### PR TITLE
rgw: Storage class enforcebility

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -19,6 +19,8 @@
 #include "include/compat.h"
 #include <boost/lexical_cast.hpp>
 
+#include "cls_rgw_types.h"
+
 using std::pair;
 using std::list;
 using std::map;
@@ -751,6 +753,16 @@ int rgw_bucket_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   }
 } // rgw_bucket_list
 
+static void initialize_storage_class(rgw_bucket_dir_header *header) {
+  for (auto kiter = header->stats.begin(); kiter != header->stats.end(); ++kiter) {
+    auto s = kiter->second;
+    if (s.num_entries > 0) {
+      return;
+    }
+  }
+  header->storage_class_stats.emplace();
+}
+
 static int write_bucket_header(cls_method_context_t hctx, rgw_bucket_dir_header *header)
 {
   header->ver++;
@@ -839,6 +851,20 @@ int rgw_bucket_update_stats(cls_method_context_t hctx, bufferlist *in, bufferlis
     }
   }
 
+  if (header.storage_class_stats.has_value()) {
+    for (auto& s : op.storage_class_stats.value()) {
+      auto& dest = header.storage_class_stats.value()[s.first];
+      if (op.absolute) {
+        dest = s.second;
+      } else {
+        dest.total_size += s.second.total_size;
+        dest.total_size_rounded += s.second.total_size_rounded;
+        dest.num_entries += s.second.num_entries;
+        dest.actual_size += s.second.actual_size;
+      }
+    }
+  }
+
   return write_bucket_header(hctx, &header);
 }
 
@@ -863,6 +889,7 @@ int rgw_bucket_init_index(cls_method_context_t hctx, bufferlist *in, bufferlist 
   }
 
   rgw_bucket_dir dir;
+  dir.header.storage_class_stats.emplace();
 
   return write_bucket_header(hctx, &dir.header);
 }
@@ -1026,12 +1053,24 @@ static void unaccount_entry(rgw_bucket_dir_header& header,
 			    rgw_bucket_dir_entry& entry)
 {
   if (entry.exists) {
+    auto& storage_class = rgw_placement_rule::get_canonical_storage_class(entry.meta.storage_class);
     rgw_bucket_category_stats& stats = header.stats[entry.meta.category];
+
     stats.num_entries--;
     stats.total_size -= entry.meta.accounted_size;
     stats.total_size_rounded -=
       cls_rgw_get_rounded_size(entry.meta.accounted_size);
     stats.actual_size -= entry.meta.size;
+    if (header.storage_class_stats.has_value()) {
+      rgw_bucket_category_stats &sc_stats = header.storage_class_stats.value()[storage_class];
+      sc_stats.num_entries--;
+      sc_stats.total_size -= entry.meta.accounted_size;
+      sc_stats.total_size_rounded -=
+              cls_rgw_get_rounded_size(entry.meta.accounted_size);
+      sc_stats.actual_size -= entry.meta.size;
+    } else {
+      initialize_storage_class(&header);
+    }
   }
 }
 
@@ -1314,16 +1353,29 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
     unaccount_entry(header, entry);
 
     rgw_bucket_dir_entry_meta& meta = op.meta;
+    auto& storage_class = rgw_placement_rule::get_canonical_storage_class(meta.storage_class);
     rgw_bucket_category_stats& stats = header.stats[meta.category];
     entry.meta = meta;
     entry.key = op.key;
     entry.exists = true;
     entry.tag = op.tag;
     // account for new entry
+    if (!header.storage_class_stats.has_value()) {
+      // initialize storage class stats if the bucket was the empty
+      initialize_storage_class(&header);
+    }
     stats.num_entries++;
     stats.total_size += meta.accounted_size;
     stats.total_size_rounded += cls_rgw_get_rounded_size(meta.accounted_size);
     stats.actual_size += meta.size;
+    if (header.storage_class_stats.has_value()) {
+      rgw_bucket_category_stats& sc_stats = header.storage_class_stats.value()[storage_class];
+      sc_stats.num_entries++;
+      sc_stats.total_size += meta.accounted_size;
+      sc_stats.total_size_rounded += cls_rgw_get_rounded_size(meta.accounted_size);
+      sc_stats.actual_size += meta.size;
+    }
+
     CLS_LOG_BITX(bitx_inst, 20,
 		 "INFO: %s: setting map entry at key=%s",
 		 __func__, escape_str(idx).c_str());
@@ -2512,15 +2564,27 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx,
     if (cur_disk.pending_map.empty()) {
       CLS_LOG_BITX(bitx_inst, 10, "INFO: %s: cur_disk.pending_map is empty", __func__);
       if (cur_disk.exists) {
-        rgw_bucket_category_stats& old_stats = header.stats[cur_disk.meta.category];
+          auto& storage_class = rgw_placement_rule::get_canonical_storage_class(cur_disk.meta.storage_class);
+          rgw_bucket_category_stats& old_stats = header.stats[cur_disk.meta.category];
 	CLS_LOG_BITX(bitx_inst, 10, "INFO: %s: stats.num_entries: %ld -> %ld",
 		     __func__, old_stats.num_entries, old_stats.num_entries - 1);
         old_stats.num_entries--;
         old_stats.total_size -= cur_disk.meta.accounted_size;
         old_stats.total_size_rounded -= cls_rgw_get_rounded_size(cur_disk.meta.accounted_size);
         old_stats.actual_size -= cur_disk.meta.size;
+        if (header.storage_class_stats.has_value()) {
+          rgw_bucket_category_stats &old_sc_stats = header.storage_class_stats.value()[storage_class];
+          old_sc_stats.num_entries--;
+          old_sc_stats.total_size -= cur_disk.meta.accounted_size;
+          old_sc_stats.total_size_rounded -= cls_rgw_get_rounded_size(cur_disk.meta.accounted_size);
+          old_sc_stats.actual_size -= cur_disk.meta.size;
+        } else {
+          initialize_storage_class(&header);
+        }
         header_changed = true;
       }
+      auto& storage_class = rgw_placement_rule::get_canonical_storage_class(cur_change.meta.storage_class);
+      std::optional<std::unordered_map<std::string, rgw_bucket_category_stats>> storage_class_stats = header.storage_class_stats;
       rgw_bucket_category_stats& stats = header.stats[cur_change.meta.category];
 
       switch(op) {
@@ -2559,6 +2623,13 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx,
         stats.total_size += cur_change.meta.accounted_size;
         stats.total_size_rounded += cls_rgw_get_rounded_size(cur_change.meta.accounted_size);
         stats.actual_size += cur_change.meta.size;
+        if (storage_class_stats.has_value()) {
+          rgw_bucket_category_stats sc_stats = storage_class_stats.value()[storage_class];
+          sc_stats.num_entries++;
+          sc_stats.total_size += cur_change.meta.accounted_size;
+          sc_stats.total_size_rounded += cls_rgw_get_rounded_size(cur_change.meta.accounted_size);
+          sc_stats.actual_size += cur_change.meta.size;
+        }
         header_changed = true;
         cur_change.index_ver = header.ver;
 
@@ -2941,7 +3012,8 @@ static int rgw_bi_put_entries(cls_method_context_t hctx, bufferlist *in, bufferl
       cls_rgw_obj_key key;
       RGWObjCategory category;
       rgw_bucket_category_stats stats;
-      const bool account = entry.get_info(&key, &category, &stats);
+      string storage_class;
+      const bool account = entry.get_info(&key, &category, &stats, &storage_class);
       if (account) {
         auto& dest = header.stats[category];
         dest.total_size -= stats.total_size;
@@ -2967,7 +3039,8 @@ static int rgw_bi_put_entries(cls_method_context_t hctx, bufferlist *in, bufferl
     cls_rgw_obj_key key;
     RGWObjCategory category;
     rgw_bucket_category_stats stats;
-    const bool account = entry.get_info(&key, &category, &stats);
+    string storage_class;
+    const bool account = entry.get_info(&key, &category, &stats, &storage_class);
     if (account) {
       auto& dest = header.stats[category];
       dest.total_size += stats.total_size;
@@ -3445,11 +3518,19 @@ static int check_index(cls_method_context_t hctx,
       }
 
       if (entry.exists && entry.flags == 0) {
+        auto& storage_class = rgw_placement_rule::get_canonical_storage_class(entry.meta.storage_class);
         rgw_bucket_category_stats& stats = calc_header->stats[entry.meta.category];
         stats.num_entries++;
         stats.total_size += entry.meta.accounted_size;
         stats.total_size_rounded += cls_rgw_get_rounded_size(entry.meta.accounted_size);
         stats.actual_size += entry.meta.size;
+        if (calc_header->storage_class_stats.has_value()) {
+          rgw_bucket_category_stats& sc_stats = calc_header->storage_class_stats.value()[storage_class];
+          sc_stats.num_entries++;
+          sc_stats.total_size += entry.meta.accounted_size;
+          sc_stats.total_size_rounded += cls_rgw_get_rounded_size(entry.meta.accounted_size);
+          sc_stats.actual_size += entry.meta.size;
+        }
       }
       start_obj = bientry.idx;
     }
@@ -3474,11 +3555,19 @@ static int check_index(cls_method_context_t hctx,
       }
 
       if (entry.exists) {
+        auto& storage_class = rgw_placement_rule::get_canonical_storage_class(entry.meta.storage_class);
         rgw_bucket_category_stats& stats = calc_header->stats[entry.meta.category];
         stats.num_entries++;
         stats.total_size += entry.meta.accounted_size;
         stats.total_size_rounded += cls_rgw_get_rounded_size(entry.meta.accounted_size);
         stats.actual_size += entry.meta.size;
+        if (calc_header->storage_class_stats.has_value()) {
+          rgw_bucket_category_stats& sc_stats = calc_header->storage_class_stats.value()[storage_class];
+          sc_stats.num_entries++;
+          sc_stats.total_size += entry.meta.accounted_size;
+          sc_stats.total_size_rounded += cls_rgw_get_rounded_size(entry.meta.accounted_size);
+          sc_stats.actual_size += entry.meta.size;
+        }
       }
       start_obj = bientry.idx;
     }
@@ -5369,3 +5458,4 @@ CLS_INIT(rgw)
 
   return;
 }
+

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -72,12 +72,14 @@ void cls_rgw_bucket_set_tag_timeout(librados::ObjectWriteOperation& op,
 
 void cls_rgw_bucket_update_stats(librados::ObjectWriteOperation& o,
 				 bool absolute,
-                                 const map<RGWObjCategory, rgw_bucket_category_stats>& stats,
-                                 const map<RGWObjCategory, rgw_bucket_category_stats>* dec_stats)
+                 const map<RGWObjCategory, rgw_bucket_category_stats>& stats,
+                 const std::unordered_map<std::string, rgw_bucket_category_stats>& storage_class_stats,
+                 const std::map<RGWObjCategory, rgw_bucket_category_stats>* dec_stats)
 {
   rgw_cls_bucket_update_stats_op call;
   call.absolute = absolute;
   call.stats = stats;
+  call.storage_class_stats = storage_class_stats;
   if (dec_stats != NULL)
     call.dec_stats = *dec_stats;
   bufferlist in;

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -135,6 +135,7 @@ void cls_rgw_bucket_set_tag_timeout(librados::ObjectWriteOperation& op,
 void cls_rgw_bucket_update_stats(librados::ObjectWriteOperation& o,
                                  bool absolute,
                                  const std::map<RGWObjCategory, rgw_bucket_category_stats>& stats,
+                                 const std::unordered_map<std::string, rgw_bucket_category_stats>& storage_class_stats,
                                  const std::map<RGWObjCategory, rgw_bucket_category_stats>* dec_stats = nullptr);
 
 void cls_rgw_bucket_prepare_op(librados::ObjectWriteOperation& o, RGWModifyOp op, const std::string& tag,

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -499,22 +499,27 @@ struct rgw_cls_bucket_update_stats_op
   bool absolute{false};
   std::map<RGWObjCategory, rgw_bucket_category_stats> stats;
   std::map<RGWObjCategory, rgw_bucket_category_stats> dec_stats;
+  std::optional<std::unordered_map<std::string, rgw_bucket_category_stats>> storage_class_stats;
 
   rgw_cls_bucket_update_stats_op() {}
 
   void encode(ceph::buffer::list &bl) const {
-    ENCODE_START(2, 1, bl);
+    ENCODE_START(3, 1, bl);
     encode(absolute, bl);
     encode(stats, bl);
     encode(dec_stats, bl);
+    encode(storage_class_stats, bl);
     ENCODE_FINISH(bl);
   }
   void decode(ceph::buffer::list::const_iterator &bl) {
-    DECODE_START(2, bl);
+    DECODE_START(3, bl);
     decode(absolute, bl);
     decode(stats, bl);
     if (struct_v >= 2)
       decode(dec_stats, bl);
+    if (struct_v >= 3) {
+      decode(storage_class_stats, bl);
+    }
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -413,7 +413,8 @@ void rgw_cls_bi_entry::dump(Formatter *f) const
 
 bool rgw_cls_bi_entry::get_info(cls_rgw_obj_key *key,
                                 RGWObjCategory *category,
-                                rgw_bucket_category_stats *accounted_stats) const
+                                rgw_bucket_category_stats *accounted_stats,
+                                string *storage_class) const
 {
   using ceph::decode;
   auto iter = data.cbegin();
@@ -433,6 +434,7 @@ bool rgw_cls_bi_entry::get_info(cls_rgw_obj_key *key,
   rgw_bucket_dir_entry entry;
   decode(entry, iter);
   *key = entry.key;
+  *storage_class = entry.meta.storage_class;
   *category = entry.meta.category;
   accounted_stats->num_entries++;
   accounted_stats->total_size += entry.meta.accounted_size;

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -505,7 +505,7 @@ struct rgw_cls_bi_entry {
   void decode_json(JSONObj *obj, cls_rgw_obj_key *effective_key = NULL);
   static std::list<rgw_cls_bi_entry> generate_test_instances();
   bool get_info(cls_rgw_obj_key *key, RGWObjCategory *category,
-		rgw_bucket_category_stats *accounted_stats) const;
+		rgw_bucket_category_stats *accounted_stats, std::string *storage_class) const;
 };
 WRITE_CLASS_ENCODER(rgw_cls_bi_entry)
 
@@ -842,12 +842,13 @@ struct rgw_bucket_dir_header {
   cls_rgw_bucket_instance_entry new_instance;
   bool syncstopped;
   uint32_t reshardlog_entries;
+  std::optional<std::unordered_map<std::string, rgw_bucket_category_stats>> storage_class_stats;
 
   rgw_bucket_dir_header() : tag_timeout(0), ver(0), master_ver(0), syncstopped(false),
                             reshardlog_entries(0) {}
 
   void encode(ceph::buffer::list &bl) const {
-    ENCODE_START(8, 2, bl);
+    ENCODE_START(9, 2, bl);
     encode(stats, bl);
     encode(tag_timeout, bl);
     encode(ver, bl);
@@ -856,10 +857,11 @@ struct rgw_bucket_dir_header {
     encode(new_instance, bl);
     encode(syncstopped,bl);
     encode(reshardlog_entries, bl);
+    encode(storage_class_stats, bl);
     ENCODE_FINISH(bl);
   }
   void decode(ceph::buffer::list::const_iterator &bl) {
-    DECODE_START_LEGACY_COMPAT_LEN(8, 2, 2, bl);
+    DECODE_START_LEGACY_COMPAT_LEN(9, 2, 2, bl);
     decode(stats, bl);
     if (struct_v > 2) {
       decode(tag_timeout, bl);
@@ -888,6 +890,10 @@ struct rgw_bucket_dir_header {
     } else {
       reshardlog_entries = 0;
     }
+    if (struct_v >= 9) {
+      decode(storage_class_stats, bl);
+    }
+
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;
@@ -966,25 +972,32 @@ struct rgw_usage_data {
   uint64_t bytes_received;
   uint64_t ops;
   uint64_t successful_ops;
+  std::optional<std::string> storage_class;
 
-  rgw_usage_data() : bytes_sent(0), bytes_received(0), ops(0), successful_ops(0) {}
-  rgw_usage_data(uint64_t sent, uint64_t received) : bytes_sent(sent), bytes_received(received), ops(0), successful_ops(0) {}
+  rgw_usage_data() : bytes_sent(0), bytes_received(0), ops(0), successful_ops(0), storage_class({}) {}
+  rgw_usage_data(uint64_t sent, uint64_t received) : bytes_sent(sent), bytes_received(received), ops(0), successful_ops(0), storage_class({}) {}
+  rgw_usage_data(uint64_t sent, uint64_t received, std::string stg_cls) : bytes_sent(sent), bytes_received(received), ops(0), successful_ops(0), storage_class(stg_cls) {}
 
-  void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(1, 1, bl);
+
+    void encode(ceph::buffer::list& bl) const {
+    ENCODE_START(2, 1, bl);
     encode(bytes_sent, bl);
     encode(bytes_received, bl);
     encode(ops, bl);
     encode(successful_ops, bl);
+    encode(storage_class, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START(1, bl);
+    DECODE_START(2, bl);
     decode(bytes_sent, bl);
     decode(bytes_received, bl);
     decode(ops, bl);
     decode(successful_ops, bl);
+    if (struct_v >= 2) {
+      decode(storage_class, bl);
+    }
     DECODE_FINISH(bl);
   }
 
@@ -993,6 +1006,9 @@ struct rgw_usage_data {
     bytes_received += usage.bytes_received;
     ops += usage.ops;
     successful_ops += usage.successful_ops;
+    if (!storage_class && usage.storage_class){
+      storage_class = { *usage.storage_class };
+    }
   }
   void dump(ceph::Formatter *f) const;
   static std::list<rgw_usage_data> generate_test_instances();
@@ -1008,13 +1024,14 @@ struct rgw_usage_log_entry {
   rgw_usage_data total_usage; /* this one is kept for backwards compatibility */
   std::map<std::string, rgw_usage_data> usage_map;
   rgw_s3select_usage_data s3select_usage;
+  std::unordered_map<std::string, std::map<std::string, rgw_usage_data>> usage_by_storage_class_map;
 
   rgw_usage_log_entry() : epoch(0) {}
   rgw_usage_log_entry(std::string& o, std::string& b) : owner(o), bucket(b), epoch(0) {}
   rgw_usage_log_entry(std::string& o, std::string& p, std::string& b) : owner(o), payer(p), bucket(b), epoch(0) {}
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(4, 1, bl);
+    ENCODE_START(5, 1, bl);
     encode(owner.to_str(), bl);
     encode(bucket, bl);
     encode(epoch, bl);
@@ -1025,12 +1042,14 @@ struct rgw_usage_log_entry {
     encode(usage_map, bl);
     encode(payer.to_str(), bl);
     encode(s3select_usage, bl);
+    encode(total_usage.storage_class, bl);
+    encode(usage_by_storage_class_map, bl);
     ENCODE_FINISH(bl);
   }
 
 
    void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START(4, bl);
+    DECODE_START(5, bl);
     std::string s;
     decode(s, bl);
     owner.from_str(s);
@@ -1053,6 +1072,10 @@ struct rgw_usage_log_entry {
     if (struct_v >= 4) {
       decode(s3select_usage, bl);
     }
+    if (struct_v >= 5) {
+      decode(total_usage.storage_class, bl);
+      decode(usage_by_storage_class_map, bl);
+    }
     DECODE_FINISH(bl);
   }
 
@@ -1065,9 +1088,12 @@ struct rgw_usage_log_entry {
       payer = e.payer;
     }
 
-    for (auto iter = e.usage_map.begin(); iter != e.usage_map.end(); ++iter) {
-      if (!categories || !categories->size() || categories->count(iter->first)) {
-        add_usage(iter->first, iter->second);
+    for (auto iter = e.usage_by_storage_class_map.begin(); iter != e.usage_by_storage_class_map.end(); ++iter) {
+      for (auto iter2 = iter->second.begin(); iter2 != iter->second.end(); ++iter2) {
+        if (!categories || !categories->size() || categories->count(iter2->first)) {
+          add_usage(iter->first, iter2->first, iter2->second);
+          add_usage(iter2->first, iter2->second);
+        }
       }
     }
 
@@ -1088,6 +1114,11 @@ struct rgw_usage_log_entry {
 
   void add_usage(const std::string& category, const rgw_usage_data& data) {
     usage_map[category].aggregate(data);
+    total_usage.aggregate(data);
+  }
+
+  void add_usage(const std::string &storage_class, const std::string &category, const rgw_usage_data &data) {
+    usage_by_storage_class_map[storage_class][category].aggregate(data);
     total_usage.aggregate(data);
   }
 

--- a/src/cls/user/cls_user.cc
+++ b/src/cls/user/cls_user.cc
@@ -138,18 +138,58 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
     return ret;
   }
 
+  if (op.reset) {
+    for (auto &new_entry: op.entries) {
+      std::optional<std::string> storage_class = new_entry.storage_class;
+      string key;
+      get_key_by_bucket_name(new_entry.bucket.name, &key);
+      cls_user_bucket_entry old_entry;
+      if (storage_class.has_value() && !storage_class.value().empty()) {
+        key += "-" + storage_class.value();
+      }
+      ret = get_existing_bucket_entry(hctx, key, old_entry);
+      if (ret == -ENOENT) {
+        continue;
+      }
+      old_entry.size = 0;
+      old_entry.size_rounded = 0;
+      old_entry.count = 0;
+      ret = write_entry(hctx, key, old_entry);
+      if (ret < 0)
+        return ret;
+
+    }
+    header.stats.total_entries = 0;
+    header.stats.total_bytes = 0;
+    header.stats.total_bytes_rounded = 0;
+    header.storage_class_stats.emplace();
+    bufferlist bl;
+    encode(header, bl);
+    ret = cls_cxx_map_write_header(hctx, &bl);
+    if (ret < 0)
+      return ret;
+    return 0;
+  }
+
   for (auto iter = op.entries.begin(); iter != op.entries.end(); ++iter) {
     cls_user_bucket_entry& update_entry = *iter;
-
+    std::optional<std::string> storage_class = update_entry.storage_class;
+    if (!storage_class.has_value()) {
+      header.storage_class_stats.reset();
+      continue;
+    }
     string key;
 
     get_key_by_bucket_name(update_entry.bucket.name, &key);
-
+    string old_key = key;
     cls_user_bucket_entry entry;
+    if (!storage_class.value().empty()) {
+      key += "-" + storage_class.value();
+    }
     ret = get_existing_bucket_entry(hctx, key, entry);
 
     if (ret == -ENOENT) {
-     if (!op.add)
+     if (!op.add && !storage_class)
       continue; /* racing bucket removal */
 
      entry = update_entry;
@@ -160,13 +200,41 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
       entry.bucket.bucket_id = update_entry.bucket.bucket_id;
       // creation date may have changed (ie delete/recreate bucket)
       entry.creation_time = update_entry.creation_time;
+      // updating bucket id for storage classes entries
+      if (header.storage_class_stats.has_value()) {
+        for (auto& idx: header.storage_class_stats.value()) {
+          cls_user_bucket_entry storage_class_entry;
+          string storage_class_key = old_key + "-" + idx.first;
+          int s_ret = get_existing_bucket_entry(hctx, storage_class_key, storage_class_entry);
+          if (s_ret < 0) {
+            CLS_LOG(0, "WARNING: cannot update bucket id for bucket %s and storage class %s. ret: %d.",
+                    old_key.c_str(), idx.first.c_str(), s_ret);
+            continue;
+          }
+          storage_class_entry.bucket.bucket_id = update_entry.bucket.bucket_id;
+          storage_class_entry.creation_time = update_entry.creation_time;
+          s_ret = write_entry(hctx, storage_class_key, storage_class_entry);
+          if (s_ret < 0) {
+            CLS_LOG(0, "WARNING: cannot update bucket id for bucket %s and storage class %s. ret: %d.",
+                    old_key.c_str(), idx.first.c_str(), s_ret);
+          }
+        }
+      }
     }
 
     if (ret < 0) {
       CLS_LOG(0, "ERROR: get_existing_bucket_entry() key=%s returned %d", key.c_str(), ret);
       return ret;
     } else if (ret >= 0 && entry.user_stats_sync) {
-      dec_header_stats(&header.stats, entry);
+      if (!storage_class.value().empty()){
+        if (header.storage_class_stats.has_value()) {
+          header.storage_class_stats.value()[storage_class.value()].total_entries -= entry.count;
+          header.storage_class_stats.value()[storage_class.value()].total_bytes -= entry.size;
+          header.storage_class_stats.value()[storage_class.value()].total_bytes_rounded -= entry.size_rounded;
+        }
+      } else {
+        dec_header_stats(&header.stats, entry);
+      }
     }
 
     CLS_LOG(20, "storing entry for key=%s size=%lld count=%lld",
@@ -184,7 +252,15 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
     if (ret < 0)
       return ret;
 
-    add_header_stats(&header.stats, entry);
+    if (!storage_class.value().empty()){
+      if (header.storage_class_stats.has_value()) {
+        header.storage_class_stats.value()[storage_class.value()].total_entries += entry.count;
+        header.storage_class_stats.value()[storage_class.value()].total_bytes += entry.size;
+        header.storage_class_stats.value()[storage_class.value()].total_bytes_rounded += entry.size_rounded;
+      }
+    } else {
+      add_header_stats(&header.stats, entry);
+    }
   }
 
   bufferlist bl;
@@ -193,6 +269,10 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
 
   if (header.last_stats_update < op.time)
     header.last_stats_update = op.time;
+
+  if (header.stats.total_entries == 0) {
+    header.storage_class_stats.emplace();
+  }
 
   encode(header, bl);
   
@@ -268,7 +348,13 @@ static int cls_user_remove_bucket(cls_method_context_t hctx, bufferlist *in, buf
     CLS_LOG(0, "ERROR: get existing bucket entry, key=%s ret=%d", key.c_str(), ret);
     return ret;
   }
-
+  if (header.storage_class_stats.has_value()) {
+    for(auto it = header.storage_class_stats.value().begin(); it != header.storage_class_stats.value().end(); ++it){
+      auto new_key = key + "-" + it->first;
+      CLS_LOG(20, "removing entry at %s", new_key.c_str());
+      remove_entry(hctx, new_key);
+    }
+  }
   CLS_LOG(20, "removing entry at %s", key.c_str());
 
   ret = remove_entry(hctx, key);

--- a/src/cls/user/cls_user_client.cc
+++ b/src/cls/user/cls_user_client.cc
@@ -16,12 +16,13 @@ using librados::IoCtx;
 using librados::ObjectOperationCompletion;
 using librados::ObjectReadOperation;
 
-void cls_user_set_buckets(librados::ObjectWriteOperation& op, list<cls_user_bucket_entry>& entries, bool add)
+void cls_user_set_buckets(librados::ObjectWriteOperation& op, list<cls_user_bucket_entry>& entries, bool add, bool reset)
 {
   bufferlist in;
   cls_user_set_buckets_op call;
   call.entries = entries;
   call.add = add;
+  call.reset = reset;
   call.time = real_clock::now();
   encode(call, in);
   op.exec("user", "set_buckets_info", in);

--- a/src/cls/user/cls_user_client.h
+++ b/src/cls/user/cls_user_client.h
@@ -18,7 +18,7 @@ public:
  * user objclass
  */
 
-void cls_user_set_buckets(librados::ObjectWriteOperation& op, std::list<cls_user_bucket_entry>& entries, bool add);
+void cls_user_set_buckets(librados::ObjectWriteOperation& op, std::list<cls_user_bucket_entry>& entries, bool add, bool reset);
 void cls_user_complete_stats_sync(librados::ObjectWriteOperation& op);
 void cls_user_remove_bucket(librados::ObjectWriteOperation& op,  const cls_user_bucket& bucket);
 void cls_user_bucket_list(librados::ObjectReadOperation& op,

--- a/src/cls/user/cls_user_ops.h
+++ b/src/cls/user/cls_user_ops.h
@@ -9,23 +9,28 @@
 struct cls_user_set_buckets_op {
   std::list<cls_user_bucket_entry> entries;
   bool add;
+  bool reset;
   ceph::real_time time; /* op time */
 
-  cls_user_set_buckets_op() : add(false) {}
+  cls_user_set_buckets_op() : add(false), reset(false) {}
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 1, bl);
     encode(entries, bl);
     encode(add, bl);
     encode(time, bl);
+    encode(reset, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START(1, bl);
+    DECODE_START(2, bl);
     decode(entries, bl);
     decode(add, bl);
     decode(time, bl);
+    if (struct_v >= 2) {
+        decode(reset, bl);
+    }
     DECODE_FINISH(bl);
   }
 

--- a/src/cls/user/cls_user_types.h
+++ b/src/cls/user/cls_user_types.h
@@ -104,11 +104,12 @@ struct cls_user_bucket_entry {
   ceph::real_time creation_time;
   uint64_t count;
   bool user_stats_sync;
+  std::optional<std::string> storage_class;
 
-  cls_user_bucket_entry() : size(0), size_rounded(0), count(0), user_stats_sync(false) {}
+  cls_user_bucket_entry() : size(0), size_rounded(0), count(0), user_stats_sync(false), storage_class({}) {}
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(9, 5, bl);
+    ENCODE_START(10, 5, bl);
     uint64_t s = size;
     __u32 mt = ceph::real_clock::to_time_t(creation_time);
     std::string empty_str;  // originally had the bucket name here, but we encode bucket later
@@ -122,10 +123,11 @@ struct cls_user_bucket_entry {
     encode(user_stats_sync, bl);
     encode(creation_time, bl);
     //::encode(placement_rule, bl); removed in v9
+    encode(storage_class, bl);
     ENCODE_FINISH(bl);
   }
   void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START_LEGACY_COMPAT_LEN(9, 5, 5, bl);
+    DECODE_START_LEGACY_COMPAT_LEN(10, 5, 5, bl);
     __u32 mt;
     uint64_t s;
     std::string empty_str;  // backward compatibility
@@ -150,6 +152,9 @@ struct cls_user_bucket_entry {
     if (struct_v == 8) { // added in v8, removed in v9
       std::string placement_rule;
       decode(placement_rule, bl);
+    }
+    if (struct_v >= 10) {
+      decode(storage_class, bl);
     }
     DECODE_FINISH(bl);
   }
@@ -193,21 +198,26 @@ WRITE_CLASS_ENCODER(cls_user_stats)
  */
 struct cls_user_header {
   cls_user_stats stats;
+  std::optional<std::unordered_map<std::string, cls_user_stats>> storage_class_stats;
   ceph::real_time last_stats_sync;     /* last time a full stats sync completed */
   ceph::real_time last_stats_update;   /* last time a stats update was done */
 
   void encode(ceph::buffer::list& bl) const {
-     ENCODE_START(1, 1, bl);
+     ENCODE_START(2, 1, bl);
     encode(stats, bl);
     encode(last_stats_sync, bl);
     encode(last_stats_update, bl);
+    encode(storage_class_stats, bl);
     ENCODE_FINISH(bl);
   }
   void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START(1, bl);
+    DECODE_START(2, bl);
     decode(stats, bl);
     decode(last_stats_sync, bl);
     decode(last_stats_update, bl);
+    if (struct_v >= 2) {
+      decode(storage_class_stats, bl);
+    }
     DECODE_FINISH(bl);
   }
 

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -86,6 +86,7 @@ set(librgw_common_srcs
   rgw_pubsub.cc
   rgw_cr_rest.cc
   rgw_op.cc
+  rgw_sc_quota_checker.cc
   rgw_policy_s3.cc
   rgw_public_access.cc
   rgw_putobj.cc

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -2705,6 +2705,7 @@ int POSIXBucket::read_stats_async(const DoutPrefixProvider *dpp,
 }
 
 int POSIXBucket::sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y,
+                                  bool reset,
                                   RGWBucketEnt* ent)
 {
   return 0;

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -903,7 +903,7 @@ public:
   virtual int read_stats_async(const DoutPrefixProvider *dpp,
 			       const bucket_index_layout_generation& idx_layout,
 			       int shard_id, boost::intrusive_ptr<ReadStatsCB> ctx) override;
-  virtual int sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y,
+  virtual int sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y, bool reset,
                                RGWBucketEnt* ent) override;
   virtual int check_bucket_shards(const DoutPrefixProvider* dpp,
                                   uint64_t num_objs, optional_yield y) override;

--- a/src/rgw/driver/rados/buckets.cc
+++ b/src/rgw/driver/rados/buckets.cc
@@ -26,11 +26,30 @@ namespace rgwrados::buckets {
 
 static int set(const DoutPrefixProvider* dpp, optional_yield y,
                librados::Rados& rados, const rgw_raw_obj& obj,
-               cls_user_bucket_entry&& entry, bool add)
+               cls_user_bucket_entry&& entry, bool add, bool reset,
+               const RGWBucketEnt* ent)
 {
   std::list<cls_user_bucket_entry> entries;
-  entries.push_back(std::move(entry));
-
+  cls_user_bucket_entry main_entry = std::move(entry);
+  main_entry.storage_class = "";
+  entries.push_back(main_entry);
+  if (ent != nullptr) {
+    std::string placement_target = ent->placement_rule.name;
+    if (main_entry.count > 0 && ent->storage_class_ents.empty()) {
+      cls_user_bucket_entry do_not_initialize_storage_classes;
+      ent->convert(&do_not_initialize_storage_classes);
+      do_not_initialize_storage_classes.storage_class.reset();
+      entries.push_back(do_not_initialize_storage_classes);
+    }
+    for (auto it = ent->storage_class_ents.begin(); it != ent->storage_class_ents.end(); ++it) {
+      std::string storage_class = it->first;
+      RGWBucketEnt bent = it->second;
+      cls_user_bucket_entry en;
+      bent.convert(&en);
+      en.storage_class = placement_target + "::" + storage_class;
+      entries.push_back(en);
+    }
+  }
   rgw_rados_ref ref;
   int r = rgw_get_rados_ref(dpp, &rados, obj, &ref);
   if (r < 0) {
@@ -38,7 +57,7 @@ static int set(const DoutPrefixProvider* dpp, optional_yield y,
   }
 
   librados::ObjectWriteOperation op;
-  ::cls_user_set_buckets(op, entries, add);
+  ::cls_user_set_buckets(op, entries, add, reset);
   return ref.operate(dpp, std::move(op), y);
 }
 
@@ -56,7 +75,7 @@ int add(const DoutPrefixProvider* dpp, optional_yield y,
   }
 
   constexpr bool add = true; // create/update entry
-  return set(dpp, y, rados, obj, std::move(entry), add);
+  return set(dpp, y, rados, obj, std::move(entry), add, false, nullptr);
 }
 
 int remove(const DoutPrefixProvider* dpp, optional_yield y,
@@ -141,13 +160,13 @@ int list(const DoutPrefixProvider* dpp, optional_yield y,
 
 int write_stats(const DoutPrefixProvider* dpp, optional_yield y,
                 librados::Rados& rados, const rgw_raw_obj& obj,
-                const RGWBucketEnt& ent)
+                const RGWBucketEnt& ent, bool reset)
 {
   cls_user_bucket_entry entry;
   ent.convert(&entry);
 
   constexpr bool add = false; // bucket entry must exist
-  return set(dpp, y, rados, obj, std::move(entry), add);
+  return set(dpp, y, rados, obj, std::move(entry), add, reset, &ent);
 }
 
 int read_stats(const DoutPrefixProvider* dpp, optional_yield y,
@@ -174,6 +193,18 @@ int read_stats(const DoutPrefixProvider* dpp, optional_yield y,
   stats.size = header.stats.total_bytes;
   stats.size_rounded = header.stats.total_bytes_rounded;
   stats.num_objects = header.stats.total_entries;
+  if (header.storage_class_stats.has_value()) {
+    if (!stats.storage_class_stats.has_value()) {
+      stats.storage_class_stats.emplace();
+    }
+    for (auto it = header.storage_class_stats.value().begin(); it != header.storage_class_stats.value().end(); ++it) {
+      std::string storage_class = it->first;
+      stats.storage_class_stats.value()[storage_class].size = it->second.total_bytes;
+      stats.storage_class_stats.value()[storage_class].size_rounded = it->second.total_bytes_rounded;
+      stats.storage_class_stats.value()[storage_class].num_objects = it->second.total_entries;
+    }
+  }
+
   if (last_synced) {
     *last_synced = header.last_stats_sync;
   }

--- a/src/rgw/driver/rados/buckets.h
+++ b/src/rgw/driver/rados/buckets.h
@@ -64,7 +64,8 @@ int write_stats(const DoutPrefixProvider* dpp,
                 optional_yield y,
                 librados::Rados& rados,
                 const rgw_raw_obj& obj,
-                const RGWBucketEnt& bucket);
+                const RGWBucketEnt& bucket,
+                bool reset);
 
 /// Read the total usage stats of all buckets.
 int read_stats(const DoutPrefixProvider* dpp,

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -312,6 +312,30 @@ static void dump_bucket_usage(map<RGWObjCategory, RGWStorageStats>& stats, Forma
   formatter->close_section();
 }
 
+static void dump_bucket_storage_classes_usage(map<RGWObjCategory, RGWStorageStats>& stats, std::optional<map<std::string, RGWStorageStats>> sc_stats, Formatter *formatter)
+{
+  formatter->open_object_section("usage");
+  for (auto it = stats.begin(); it != stats.end(); ++it) {
+    RGWStorageStats& s = it->second;
+    formatter->open_object_section(to_string(it->first));
+    s.dump(formatter);
+    formatter->close_section();
+  }
+  if (sc_stats.has_value()) {
+    formatter->open_array_section("rgw.storage-classes");
+    for (auto it = sc_stats.value().begin(); it != sc_stats.value().end(); ++it){
+      RGWStorageStats& s = it->second;
+      std::string storage_class = it->first;
+      formatter->open_object_section(storage_class);
+      formatter->dump_string("name", storage_class);
+      s.dump(formatter);
+      formatter->close_section();
+    }
+    formatter->close_section();
+  }
+  formatter->close_section();
+}
+
 static void dump_index_check(map<RGWObjCategory, RGWStorageStats> existing_stats,
         map<RGWObjCategory, RGWStorageStats> calculated_stats,
         Formatter *formatter)
@@ -1580,6 +1604,8 @@ static int bucket_stats(rgw::sal::Driver* driver,
                         const DoutPrefixProvider* dpp, optional_yield y) {
   std::unique_ptr<rgw::sal::Bucket> bucket;
   map<RGWObjCategory, RGWStorageStats> stats;
+  std::optional<map<string, RGWStorageStats>> sc_stats;
+  sc_stats.emplace();
 
   int ret = driver->load_bucket(dpp, rgw_bucket(tenant_name, bucket_name),
                                 &bucket, y);
@@ -1601,6 +1627,20 @@ static int bucket_stats(rgw::sal::Driver* driver,
   ret = bucket->read_stats(dpp, y, index, RGW_NO_SHARD, &bucket_ver, &master_ver, stats, &max_marker);
   if (ret < 0) {
     cerr << "error getting bucket stats bucket=" << bucket->get_name() << " ret=" << ret << std::endl;
+    return ret;
+  }
+
+  auto radosdriver = static_cast<rgw::sal::RadosStore*>(driver);
+  if (!radosdriver) {
+    cerr << "rados store only" << std::endl;
+    return -ENOTSUP;
+  }
+
+  ret = radosdriver->getRados()->get_bucket_storage_classes_stats(dpp, y, bucket_info, RGW_NO_SHARD,
+                                                            &bucket_ver, &master_ver, sc_stats,
+                                                            &max_marker, index);
+  if (ret < 0) {
+    cerr << "error getting bucket storage class stats bucket=" << bucket->get_name() << " ret=" << ret << std::endl;
     return ret;
   }
 
@@ -1634,7 +1674,7 @@ static int bucket_stats(rgw::sal::Driver* driver,
   ut.gmtime(formatter->dump_stream("mtime"));
   ctime_ut.gmtime(formatter->dump_stream("creation_time"));
   formatter->dump_string("max_marker", max_marker);
-  dump_bucket_usage(stats, formatter);
+  dump_bucket_storage_classes_usage(stats, sc_stats, formatter);
   encode_json("bucket_quota", bucket_info.quota, formatter);
 
   // bucket tags
@@ -3618,6 +3658,7 @@ int RGWBucketCtl::sync_owner_stats(const DoutPrefixProvider *dpp,
                                    const rgw_owner& owner,
                                    const RGWBucketInfo& bucket_info,
                                    optional_yield y,
+                                   bool reset,
                                    RGWBucketEnt* pent)
 {
   RGWBucketEnt ent;
@@ -3639,7 +3680,7 @@ int RGWBucketCtl::sync_owner_stats(const DoutPrefixProvider *dpp,
         const RGWZoneParams& zone = svc.zone->get_zone_params();
         return rgwrados::account::get_buckets_obj(zone, id);
       }), owner);
-  return rgwrados::buckets::write_stats(dpp, y, rados, obj, *pent);
+  return rgwrados::buckets::write_stats(dpp, y, rados, obj, *pent, reset);
 }
 
 int RGWBucketCtl::get_sync_policy_handler(std::optional<rgw_zone_id> zone,

--- a/src/rgw/driver/rados/rgw_bucket.h
+++ b/src/rgw/driver/rados/rgw_bucket.h
@@ -702,6 +702,7 @@ public:
                        const rgw_owner& owner,
                        const RGWBucketInfo& bucket_info,
                        optional_yield y,
+                       bool reset,
                        RGWBucketEnt* pent);
 
   /* bucket sync */

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -6261,6 +6261,18 @@ void RGWRados::delete_objs_inline(const DoutPrefixProvider *dpp, cls_rgw_obj_cha
   std::ignore = rgw::check_for_errors(completed);
 }
 
+
+static bool is_empty_stats(const rgw_bucket_dir_header& header) {
+  for (const auto& pair : header.stats) {
+    const rgw_bucket_category_stats& header_stats = pair.second;
+    if (header_stats.num_entries > 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+
 static void accumulate_raw_stats(const rgw_bucket_dir_header& header,
                                  map<RGWObjCategory, RGWStorageStats>& stats)
 {
@@ -9928,6 +9940,64 @@ int RGWRados::raw_obj_stat(const DoutPrefixProvider *dpp,
     rgw_filter_attrset(unfiltered_attrset, RGW_ATTR_PREFIX, attrs);
   }
 
+  return 0;
+}
+
+int RGWRados::get_bucket_storage_classes_stats(const DoutPrefixProvider *dpp, optional_yield y, const RGWBucketInfo& bucket_info, int shard_id, string *bucket_ver, string *master_ver,
+                                               std::optional<map<std::string, RGWStorageStats>>& sc_stats, string *max_marker,
+                                               const rgw::bucket_index_layout_generation& idx_layout, bool *syncstopped)
+{
+  vector<rgw_bucket_dir_header> headers;
+  map<int, string> bucket_instance_ids;
+  int r = svc.bi_rados->cls_bucket_head(dpp, bucket_info, idx_layout, shard_id, &headers, &bucket_instance_ids, y);
+  if (r < 0) {
+    return r;
+  }
+
+  ceph_assert(headers.size() == bucket_instance_ids.size());
+
+  auto iter = headers.begin();
+  map<int, string>::iterator viter = bucket_instance_ids.begin();
+  bool has_storage_class = true;
+  BucketIndexShardsManager ver_mgr;
+  BucketIndexShardsManager master_ver_mgr;
+  BucketIndexShardsManager marker_mgr;
+  for(; iter != headers.end(); ++iter, ++viter) {
+    if (is_empty_stats(*iter)) {
+      iter->storage_class_stats.emplace();
+    }
+    if (has_storage_class && iter->storage_class_stats.has_value()) {
+      for (auto it = iter->storage_class_stats.value().begin(); it != iter->storage_class_stats.value().end(); ++it) {
+        std::string storage_class = it->first;
+        rgw_bucket_category_stats stats = it->second;
+        RGWStorageStats& s = sc_stats.value()[storage_class];
+
+        s.size += stats.total_size;
+        s.size_rounded += stats.total_size_rounded;
+        s.size_utilized += stats.actual_size;
+        s.num_objects += stats.num_entries;
+      }
+    } else {
+      has_storage_class = false;
+    }
+    if (!has_storage_class) {
+      sc_stats.reset();
+    }
+    ver_mgr.add(viter->first, fmt::format("%lu", (unsigned long)iter->ver));
+    master_ver_mgr.add(viter->first, fmt::format("%lu", (unsigned long)iter->master_ver));
+    if (shard_id >= 0) {
+      *max_marker = iter->max_marker;
+    } else {
+      marker_mgr.add(viter->first, iter->max_marker);
+    }
+    if (syncstopped != NULL)
+      *syncstopped = iter->syncstopped;
+  }
+  ver_mgr.to_string(bucket_ver);
+  master_ver_mgr.to_string(master_ver);
+  if (shard_id < 0) {
+    marker_mgr.to_string(max_marker);
+  }
   return 0;
 }
 

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -9983,8 +9983,8 @@ int RGWRados::get_bucket_storage_classes_stats(const DoutPrefixProvider *dpp, op
     if (!has_storage_class) {
       sc_stats.reset();
     }
-    ver_mgr.add(viter->first, fmt::format("%lu", (unsigned long)iter->ver));
-    master_ver_mgr.add(viter->first, fmt::format("%lu", (unsigned long)iter->master_ver));
+    ver_mgr.add(viter->first, std::to_string(iter->ver));
+    master_ver_mgr.add(viter->first, std::to_string(iter->master_ver));
     if (shard_id >= 0) {
       *max_marker = iter->max_marker;
     } else {

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1500,6 +1500,10 @@ public:
     rctx->set_compressed(obj);
   }
   int decode_policy(const DoutPrefixProvider *dpp, bufferlist& bl, ACLOwner *owner);
+  int get_bucket_storage_classes_stats(const DoutPrefixProvider *dpp, optional_yield y, const RGWBucketInfo& bucket_info,
+                                       int shard_id, std::string *bucket_ver, std::string *master_ver,
+                                       std::optional<std::map<std::string, RGWStorageStats>>& sc_stats, std::string *max_marker,
+                                       const rgw::bucket_index_layout_generation& idx_layout, bool* syncstopped = NULL);
   int get_bucket_stats(const DoutPrefixProvider *dpp, optional_yield y,
                        RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout, int shard_id, std::string *bucket_ver, std::string *master_ver,
       std::map<RGWObjCategory, RGWStorageStats>& stats, std::string *max_marker, bool* syncstopped = NULL);

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -156,6 +156,7 @@ class BucketReshardShard {
   RGWRados::BucketShard bs;
   vector<rgw_cls_bi_entry> entries;
   map<RGWObjCategory, rgw_bucket_category_stats> stats;
+  unordered_map<string, rgw_bucket_category_stats> storage_class_stats;
   deque<librados::AioCompletion *>& aio_completions;
   uint64_t max_aio_completions;
   uint64_t reshard_shard_batch_size;
@@ -212,11 +213,17 @@ public:
   }
 
   int add_entry(rgw_cls_bi_entry& entry, bool account, RGWObjCategory category,
-                const rgw_bucket_category_stats& entry_stats,
+                const rgw_bucket_category_stats& entry_stats, string& storage_class,
                 bool process_log = false) {
     entries.push_back(entry);
     if (account) {
       rgw_bucket_category_stats& target = stats[category];
+      storage_class = rgw_placement_rule::get_canonical_storage_class(storage_class);
+      rgw_bucket_category_stats& sc_target = storage_class_stats[storage_class];
+      sc_target.num_entries += entry_stats.num_entries;
+      sc_target.total_size += entry_stats.total_size;
+      sc_target.total_size_rounded += entry_stats.total_size_rounded;
+      sc_target.actual_size += entry_stats.actual_size;
       target.num_entries += entry_stats.num_entries;
       target.total_size += entry_stats.total_size;
       target.total_size_rounded += entry_stats.total_size_rounded;
@@ -248,7 +255,7 @@ public:
       for (auto& entry : entries) {
         store->getRados()->bi_put(op, bs, entry, null_yield);
       }
-      cls_rgw_bucket_update_stats(op, false, stats);
+      cls_rgw_bucket_update_stats(op, false, stats, storage_class_stats);
     }
 
     librados::AioCompletion *c;
@@ -263,7 +270,7 @@ public:
     }
     entries.clear();
     stats.clear();
-
+    storage_class_stats.clear();
     return 0;
   }
 
@@ -313,9 +320,10 @@ public:
   int add_entry(int shard_index,
                 rgw_cls_bi_entry& entry, bool account, RGWObjCategory category,
                 const rgw_bucket_category_stats& entry_stats,
+                string& storage_class,
                 bool process_log = false) {
     int ret = target_shards[shard_index].add_entry(entry, account, category,
-						   entry_stats, process_log);
+						   entry_stats, storage_class, process_log);
     if (ret < 0) {
       derr << "ERROR: target_shards.add_entry(" << entry.idx <<
 	") returned error: " << cpp_strerror(-ret) << dendl;
@@ -1136,7 +1144,8 @@ int RGWBucketReshard::reshard_process(const rgw::bucket_index_layout_generation&
         cls_rgw_obj_key cls_key;
         RGWObjCategory category;
         rgw_bucket_category_stats stats;
-        bool account = entry.get_info(&cls_key, &category, &stats);
+        string storage_class;
+        bool account = entry.get_info(&cls_key, &category, &stats, &storage_class);
         rgw_obj_key key(cls_key);
         if (entry.type == BIIndexType::OLH && key.empty()) {
           // bogus entry created by https://tracker.ceph.com/issues/46456
@@ -1153,7 +1162,7 @@ int RGWBucketReshard::reshard_process(const rgw::bucket_index_layout_generation&
         }
 
         ret = target_shards_mgr.add_entry(shard_index, entry, account,
-                  category, stats, process_log);
+                  category, stats, storage_class, process_log);
         if (ret < 0) {
           return ret;
         }

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -449,7 +449,7 @@ int RadosBucket::remove(const DoutPrefixProvider* dpp,
 
   librados::Rados& rados = *store->getRados()->get_rados_handle();
   if (own_bucket) {
-    ret = store->ctl()->bucket->sync_owner_stats(dpp, rados, info.owner, info, y, nullptr);
+    ret = store->ctl()->bucket->sync_owner_stats(dpp, rados, info.owner, info, y, false, nullptr);
     if (ret < 0) {
       ldout(store->ctx(), 1) << "WARNING: failed sync user stats before bucket delete. ret=" <<  ret << dendl;
     }
@@ -609,7 +609,7 @@ int RadosBucket::remove_bypass_gc(int concurrent_max, bool
     return ret;
   }
 
-  sync_owner_stats(dpp, y, nullptr);
+  sync_owner_stats(dpp, y, false, nullptr);
   if (ret < 0) {
      ldpp_dout(dpp, 1) << "WARNING: failed sync user stats before bucket delete. ret=" <<  ret << dendl;
   }
@@ -671,10 +671,11 @@ int RadosBucket::read_stats_async(const DoutPrefixProvider *dpp,
 }
 
 int RadosBucket::sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y,
+                                  bool reset,
                                   RGWBucketEnt* ent)
 {
   librados::Rados& rados = *store->getRados()->get_rados_handle();
-  return store->ctl()->bucket->sync_owner_stats(dpp, rados, info.owner, info, y, ent);
+  return store->ctl()->bucket->sync_owner_stats(dpp, rados, info.owner, info, y, reset, ent);
 }
 
 int RadosBucket::check_bucket_shards(const DoutPrefixProvider* dpp,

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -744,7 +744,7 @@ class RadosBucket : public StoreBucket {
                                  const bucket_index_layout_generation& idx_layout,
                                  int shard_id, boost::intrusive_ptr<ReadStatsCB> ctx) override;
     int sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y,
-                         RGWBucketEnt* ent) override;
+						 bool reset, RGWBucketEnt* ent) override;
     int check_bucket_shards(const DoutPrefixProvider* dpp, uint64_t num_objs,
                             optional_yield y) override;
     virtual int chown(const DoutPrefixProvider* dpp,

--- a/src/rgw/driver/rados/rgw_user.cc
+++ b/src/rgw/driver/rados/rgw_user.cc
@@ -169,6 +169,13 @@ static void dump_user_info(Formatter *f, RGWUserInfo &info,
   encode_json("group_ids", info.group_ids, f);
   if (stats) {
     encode_json("stats", *stats, f);
+    if (stats->storage_class_stats.has_value()) {
+      f->open_object_section("stats.storage-classes");
+      for(auto it = stats->storage_class_stats.value().begin(); it != stats->storage_class_stats.value().end(); ++it){
+        encode_json(it->first.c_str(), it->second, f);
+      }
+      f->close_section();
+    }
   }
   f->close_section();
 }
@@ -2321,7 +2328,7 @@ int RGWUserAdminOp_User::info(const DoutPrefixProvider *dpp,
   }
 
   if (op_state.sync_stats) {
-    ret = rgw_sync_all_stats(dpp, y, driver, owner, ruser->get_tenant());
+    ret = rgw_sync_all_stats(dpp, y, driver, owner, false, ruser->get_tenant());
     if (ret < 0) {
       return ret;
     }

--- a/src/rgw/driver/rados/rgw_user.h
+++ b/src/rgw/driver/rados/rgw_user.h
@@ -80,7 +80,7 @@ struct bucket_meta_entry {
 
 int rgw_sync_all_stats(const DoutPrefixProvider *dpp,
                        optional_yield y, rgw::sal::Driver* driver,
-                       const rgw_owner& owner, const std::string& tenant);
+                       const rgw_owner& owner, bool reset, const std::string& tenant);
 extern int rgw_user_get_all_buckets_stats(const DoutPrefixProvider *dpp,
   rgw::sal::Driver* driver, rgw::sal::User* user,
   std::map<std::string, bucket_meta_entry>& buckets_usage_map, optional_yield y);

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -9707,7 +9707,7 @@ next:
           cerr << "ERROR: could not init bucket: " << cpp_strerror(-ret) << std::endl;
           return -ret;
         }
-        ret = bucket->sync_owner_stats(dpp(), null_yield, nullptr);
+        ret = bucket->sync_owner_stats(dpp(), null_yield, false, nullptr);
         if (ret < 0) {
           cerr << "ERROR: could not sync bucket stats: " <<
 	    cpp_strerror(-ret) << std::endl;
@@ -9715,7 +9715,16 @@ next:
         }
       } else {
         int ret = rgw_sync_all_stats(dpp(), null_yield, driver,
-                                     user->get_id(), user->get_tenant());
+                                   user->get_id(), fix, user->get_tenant());
+        if (ret < 0) {
+          cerr << "ERROR: could not sync user stats: " <<
+               cpp_strerror(-ret) << std::endl;
+          return -ret;
+        }
+        if (fix) {
+          ret = rgw_sync_all_stats(dpp(), null_yield, driver,
+                                       user->get_id(), false, user->get_tenant());
+        }
         if (ret < 0) {
           cerr << "ERROR: could not sync user stats: " <<
 	    cpp_strerror(-ret) << std::endl;
@@ -9756,6 +9765,13 @@ next:
     {
       Formatter::ObjectSection os(*formatter, "result");
       encode_json("stats", stats, formatter.get());
+      if (stats.storage_class_stats.has_value()) {
+        formatter->open_object_section("stats.storage-classes");
+        for(auto it = stats.storage_class_stats.value().begin(); it != stats.storage_class_stats.value().end(); ++it){
+          encode_json(it->first.c_str(), it->second, formatter.get());
+        }
+        formatter->close_section();
+      }
       utime_t last_sync_ut(last_stats_sync);
       encode_json("last_stats_sync", last_sync_ut, formatter.get());
       utime_t last_update_ut(last_stats_update);

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -1527,7 +1527,7 @@ void set_quota_info(RGWQuotaInfo& quota, OPT opt_cmd, int64_t max_size, int64_t 
     case OPT::GLOBAL_QUOTA_DISABLE:
       quota.enabled = false;
       break;
-    default:
+    default:f
       break;
   }
 }
@@ -3714,6 +3714,7 @@ int main(int argc, const char **argv)
   string object_version;
   string placement_id;
   std::optional<string> opt_storage_class;
+  std::string opt_placement_target;
   list<string> tags;
   list<string> tags_add;
   list<string> tags_rm;
@@ -4276,6 +4277,8 @@ int main(int argc, const char **argv)
       placement_id = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--storage-class", (char*)NULL)) {
       opt_storage_class = val;
+    } else if (ceph_argparse_witharg(args, i, &val, "--placement-target", (char*)NULL)) {
+      opt_placement_target = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--tags", (char*)NULL)) {
       get_str_list(val, ",", tags);
     } else if (ceph_argparse_witharg(args, i, &val, "--tags-add", (char*)NULL)) {
@@ -11407,14 +11410,88 @@ next:
         cerr << "ERROR: invalid quota scope specification." << std::endl;
         return EINVAL;
       }
-      set_bucket_quota(driver, opt_cmd, tenant, bucket_name,
-                       max_size, max_objects, have_max_size, have_max_objects);
+      if (opt_cmd == OPT::QUOTA_SET && opt_storage_class && !opt_placement_target.empty()) {
+        std::unique_ptr<rgw::sal::Bucket> bkt;
+        int r = driver->load_bucket(dpp(), rgw_bucket(tenant, bucket_name), &bkt, null_yield);
+        if (r < 0) {
+          cerr << "could not get bucket info for bucket=" << bucket_name
+               << ": " << cpp_strerror(-r) << std::endl;
+          return -r;
+        }
+        RGWQuotaInfo& bq = bkt->get_info().quota;
+        const std::string sc_key = rgw_sc_quota_key(opt_placement_target, *opt_storage_class);
+        RGWStorageClassQuota& scq = bq.storage_class_quotas[sc_key];
+        if (have_max_size)    scq.max_size    = max_size < 0 ? -1 : max_size;
+        if (have_max_objects) scq.max_objects = max_objects < 0 ? -1 : max_objects;
+        scq.enabled = true;
+        if (bq.enforcement_mode == RGWQuotaEnforcementMode::LEGACY) {
+          bq.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+        }
+        r = bkt->put_info(dpp(), false, real_time(), null_yield);
+        if (r < 0) {
+          cerr << "ERROR: failed writing bucket quota: " << cpp_strerror(-r) << std::endl;
+          return -r;
+        }
+      } else {
+        set_bucket_quota(driver, opt_cmd, tenant, bucket_name,
+                         max_size, max_objects, have_max_size, have_max_objects);
+      }
     } else if (!rgw::sal::User::empty(user)) {
       if (quota_scope == "bucket") {
-        return set_user_bucket_quota(opt_cmd, ruser, user_op, max_size, max_objects, have_max_size, have_max_objects);
-      } else if (quota_scope == "user") {
-        return set_user_quota(opt_cmd, ruser, user_op, max_size, max_objects, have_max_size, have_max_objects);
-      } else {
+        if (opt_cmd == OPT::QUOTA_SET && opt_storage_class && !opt_placement_target.empty()) {
+          int r = user->load_user(dpp(), null_yield);
+          if (r < 0) {
+            cerr << "could not load user: " << cpp_strerror(-r) << std::endl;
+            return -r;
+          }
+          RGWQuotaInfo& bq = user->get_info().quota.bucket_quota;
+          const std::string sc_key = rgw_sc_quota_key(opt_placement_target, *opt_storage_class);
+          RGWStorageClassQuota& scq = bq.storage_class_quotas[sc_key];
+          if (have_max_size)    scq.max_size    = max_size < 0 ? -1 : max_size;
+          if (have_max_objects) scq.max_objects = max_objects < 0 ? -1 : max_objects;
+          scq.enabled = true;
+          if (bq.enforcement_mode == RGWQuotaEnforcementMode::LEGACY) {
+            bq.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+          }
+          user_op.set_bucket_quota(bq);
+          string err;
+          r = ruser.modify(dpp(), user_op, null_yield, &err);
+          if (r < 0) {
+            cerr << "ERROR: failed updating user info: " << cpp_strerror(-r) << ": " << err << std::endl;
+            return -r;
+          }
+        } else {
+          return set_user_bucket_quota(opt_cmd, ruser, user_op, max_size, max_objects, have_max_size, have_max_objects);
+        }
+      } 
+        else if (quota_scope == "user") {
+        if (opt_cmd == OPT::QUOTA_SET && opt_storage_class && !opt_placement_target.empty()) {
+          int r = user->load_user(dpp(), null_yield);
+          if (r < 0) {
+            cerr << "could not load user: " << cpp_strerror(-r) << std::endl;
+            return -r;
+          }
+          RGWQuotaInfo& uq = user->get_info().quota.user_quota;
+          const std::string sc_key = rgw_sc_quota_key(opt_placement_target, *opt_storage_class);
+          RGWStorageClassQuota& scq = uq.storage_class_quotas[sc_key];
+          if (have_max_size)    scq.max_size    = max_size < 0 ? -1 : max_size;
+          if (have_max_objects) scq.max_objects = max_objects < 0 ? -1 : max_objects;
+          scq.enabled = true;
+          if (uq.enforcement_mode == RGWQuotaEnforcementMode::LEGACY) {
+            uq.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+          }
+          user_op.set_user_quota(uq);
+          string err;
+          r = ruser.modify(dpp(), user_op, null_yield, &err);
+          if (r < 0) {
+            cerr << "ERROR: failed updating user info: " << cpp_strerror(-r) << ": " << err << std::endl;
+            return -r;
+          }
+        } else {
+          return set_user_quota(opt_cmd, ruser, user_op, max_size, max_objects, have_max_size, have_max_objects);
+        }
+      } 
+        else {
         cerr << "ERROR: invalid quota scope specification. Please specify either --quota-scope=bucket, or --quota-scope=user" << std::endl;
         return EINVAL;
       }

--- a/src/rgw/rgw_account.cc
+++ b/src/rgw/rgw_account.cc
@@ -523,7 +523,7 @@ int stats(const DoutPrefixProvider* dpp,
   const rgw_owner owner = rgw_account_id{info.id};
 
   if (sync_stats) {
-    ret = rgw_sync_all_stats(dpp, y, driver, owner, info.tenant);
+    ret = rgw_sync_all_stats(dpp, y, driver, owner, false, info.tenant);
     if (ret < 0) {
       err_msg = "failed to sync account stats";
       return ret;

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1239,6 +1239,7 @@ struct RGWStorageStats
   uint64_t num_objects;
   uint64_t size_utilized{0}; //< size after compression, encryption
   bool dump_utilized;        // whether dump should include utilized values
+  std::optional<std::map<std::string, RGWStorageStats>> storage_class_stats;
 
   RGWStorageStats(bool _dump_utilized=true)
     : category(RGWObjCategory::None),
@@ -1486,6 +1487,7 @@ struct RGWBucketEnt {
    * of the Swift API. Although the info available in RGWBucketInfo, we need
    * to duplicate it here to not affect the performance of buckets listing. */
   rgw_placement_rule placement_rule;
+  std::map<std::string, RGWBucketEnt> storage_class_ents;
 
   RGWBucketEnt()
     : size(0),
@@ -1513,7 +1515,7 @@ struct RGWBucketEnt {
   }
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(7, 5, bl);
+    ENCODE_START(8, 5, bl);
     uint64_t s = size;
     // issue tracked here: https://tracker.ceph.com/issues/61160
     // coverity[store_truncates_time_t:SUPPRESS]
@@ -1528,10 +1530,11 @@ struct RGWBucketEnt {
     encode(s, bl);
     encode(creation_time, bl);
     encode(placement_rule, bl);
+    encode(storage_class_ents, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START_LEGACY_COMPAT_LEN(7, 5, 5, bl);
+    DECODE_START_LEGACY_COMPAT_LEN(8, 5, 5, bl);
     __u32 mt;
     uint64_t s;
     std::string empty_str;  // backward compatibility
@@ -1553,6 +1556,8 @@ struct RGWBucketEnt {
       decode(creation_time, bl);
     if (struct_v >= 7)
       decode(placement_rule, bl);
+    if (struct_v >= 8)
+      decode(storage_class_ents, bl);
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1,5 +1,5 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
-// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
 
 /*
  * Ceph - scalable distributed file system
@@ -27,8 +27,6 @@
 #include <boost/container/flat_set.hpp>
 
 #include "common/dout_fmt.h"
-#include "include/neorados/RADOS.hpp"
-
 #include "common/ceph_crypto.h"
 #include "common/random_string.h"
 #include "common/tracer.h"
@@ -43,7 +41,6 @@
 #include "common/async/yield_context.h"
 #include "rgw_website.h"
 #include "rgw_object_lock.h"
-#include "rgw_object_ownership.h"
 #include "rgw_tag.h"
 #include "rgw_op_type.h"
 #include "rgw_sync_policy.h"
@@ -88,8 +85,7 @@ using ceph::crypto::MD5;
 #define RGW_ATTR_LC		RGW_ATTR_PREFIX "lc"
 #define RGW_ATTR_CORS		RGW_ATTR_PREFIX "cors"
 #define RGW_ATTR_ETAG RGW_ATTR_PREFIX "etag"
-#define RGW_ATTR_CKSUM          RGW_ATTR_PREFIX "cksum"
-#define RGW_ATTR_BLAKE3         RGW_ATTR_PREFIX "blake3"
+#define RGW_ATTR_CKSUM    	RGW_ATTR_PREFIX "cksum"
 #define RGW_ATTR_BUCKETS	RGW_ATTR_PREFIX "buckets"
 #define RGW_ATTR_META_PREFIX	RGW_ATTR_PREFIX RGW_AMZ_META_PREFIX
 #define RGW_ATTR_CONTENT_TYPE	RGW_ATTR_PREFIX "content_type"
@@ -104,7 +100,6 @@ using ceph::crypto::MD5;
 #define RGW_ATTR_SHADOW_OBJ    	RGW_ATTR_PREFIX "shadow_name"
 #define RGW_ATTR_MANIFEST    	RGW_ATTR_PREFIX "manifest"
 #define RGW_ATTR_USER_MANIFEST  RGW_ATTR_PREFIX "user_manifest"
-#define RGW_ATTR_SHARE_MANIFEST RGW_ATTR_PREFIX "shared_manifest"
 #define RGW_ATTR_AMZ_WEBSITE_REDIRECT_LOCATION	RGW_ATTR_PREFIX RGW_AMZ_WEBSITE_REDIRECT_LOCATION
 #define RGW_ATTR_SLO_MANIFEST   RGW_ATTR_PREFIX "slo_manifest"
 /* Information whether an object is SLO or not must be exposed to
@@ -113,16 +108,12 @@ using ceph::crypto::MD5;
 #define RGW_ATTR_X_ROBOTS_TAG	RGW_ATTR_PREFIX "x-robots-tag"
 #define RGW_ATTR_STORAGE_CLASS  RGW_ATTR_PREFIX "storage_class"
 #define RGW_ATTR_BUCKET_LOGGING RGW_ATTR_PREFIX "logging"
-#define RGW_ATTR_BUCKET_LOGGING_MTIME RGW_ATTR_PREFIX "logging-mtime"
-#define RGW_ATTR_BUCKET_LOGGING_SOURCES RGW_ATTR_PREFIX "logging-sources"
 
 /* S3 Object Lock*/
 #define RGW_ATTR_OBJECT_LOCK        RGW_ATTR_PREFIX "object-lock"
 #define RGW_ATTR_OBJECT_RETENTION   RGW_ATTR_PREFIX "object-retention"
 #define RGW_ATTR_OBJECT_LEGAL_HOLD  RGW_ATTR_PREFIX "object-legal-hold"
 
-// S3 Object Ownership
-#define RGW_ATTR_OWNERSHIP_CONTROLS RGW_ATTR_PREFIX "ownership-controls"
 
 #define RGW_ATTR_PG_VER 	RGW_ATTR_PREFIX "pg_ver"
 #define RGW_ATTR_SOURCE_ZONE    RGW_ATTR_PREFIX "source_zone"
@@ -133,8 +124,6 @@ using ceph::crypto::MD5;
 #define RGW_ATTR_RESTORE_TYPE   RGW_ATTR_PREFIX "restore-type"
 #define RGW_ATTR_RESTORE_TIME   RGW_ATTR_PREFIX "restored-at"
 #define RGW_ATTR_RESTORE_EXPIRY_DATE   RGW_ATTR_PREFIX "restore-expiry-date"
-#define RGW_ATTR_TRANSITION_TIME RGW_ATTR_PREFIX "transition-at"
-#define RGW_ATTR_RESTORE_VERSIONED_EPOCH RGW_ATTR_PREFIX "restore-versioned-epoch"
 
 #define RGW_ATTR_TEMPURL_KEY1   RGW_ATTR_META_PREFIX "temp-url-key"
 #define RGW_ATTR_TEMPURL_KEY2   RGW_ATTR_META_PREFIX "temp-url-key-2"
@@ -173,11 +162,10 @@ using ceph::crypto::MD5;
 #define RGW_ATTR_OBJ_REPLICATION_TIMESTAMP RGW_ATTR_PREFIX "replicated-at"
 
 /* IAM Policy */
-#define RGW_ATTR_IAM_POLICY                    RGW_ATTR_PREFIX "iam-policy"
-#define RGW_ATTR_USER_POLICY                   RGW_ATTR_PREFIX "user-policy"
-#define RGW_ATTR_MANAGED_POLICY                RGW_ATTR_PREFIX "managed-policy"
-#define RGW_ATTR_PUBLIC_ACCESS                 RGW_ATTR_PREFIX "public-access"
-#define RGW_ATTR_IAM_POLICY_REMOVE_SELF_ACCESS RGW_ATTR_PREFIX "iam-policy-remove-self-access"
+#define RGW_ATTR_IAM_POLICY	RGW_ATTR_PREFIX "iam-policy"
+#define RGW_ATTR_USER_POLICY    RGW_ATTR_PREFIX "user-policy"
+#define RGW_ATTR_MANAGED_POLICY RGW_ATTR_PREFIX "managed-policy"
+#define RGW_ATTR_PUBLIC_ACCESS  RGW_ATTR_PREFIX "public-access"
 
 /* RGW File Attributes */
 #define RGW_ATTR_UNIX_KEY1      RGW_ATTR_PREFIX "unix-key1"
@@ -200,8 +188,6 @@ using ceph::crypto::MD5;
 #define RGW_ATTR_TRACE RGW_ATTR_PREFIX "trace"
 
 #define RGW_ATTR_BUCKET_NOTIFICATION RGW_ATTR_PREFIX "bucket-notification"
-
-#define RGW_ATTR_INTERNAL_MTIME RGW_ATTR_PREFIX "rgw-internal-mtime"
 
 enum class RGWFormat : int8_t {
   BAD_FORMAT = -1,
@@ -352,9 +338,6 @@ inline constexpr const char* RGW_REST_STS_XMLNS =
 #define ERR_PRESIGNED_URL_DISABLED     2224
 #define ERR_AUTHORIZATION        2225 // SNS 403 AuthorizationError
 #define ERR_ILLEGAL_LOCATION_CONSTRAINT_EXCEPTION 2226
-#define ERR_ACLS_NOT_SUPPORTED   2227 // 400 AccessControlListNotSupported
-#define ERR_INVALID_BUCKET_ACL   2228 // 400 InvalidBucketAclWithObjectOwnership
-#define ERR_NO_SUCH_OWNERSHIP_CONTROLS 2229 // 404 OwnershipControlsNotFoundError
 
 #define ERR_BUSY_RESHARDING      2300 // also in cls_rgw_types.h, don't change!
 #define ERR_NO_SUCH_ENTITY       2301
@@ -366,9 +349,7 @@ inline constexpr const char* RGW_REST_STS_XMLNS =
 
 #define ERR_NO_SUCH_TAG_SET 2402
 #define ERR_ACCOUNT_EXISTS 2403
-
-#define ERR_RESTORE_ALREADY_IN_PROGRESS 2500
-#define ERR_EXPIRED_TOKEN 2501
+#define ERR_BUCKET_NOT_CONVERTED 2404  // Bucket not converted for SC stats
 
 #ifndef UINT32_MAX
 #define UINT32_MAX (0xffffffffu)
@@ -575,40 +556,26 @@ class RateLimiter;
 struct RGWRateLimitInfo {
   int64_t max_write_ops;
   int64_t max_read_ops;
-  int64_t max_list_ops;
-  int64_t max_delete_ops;
   int64_t max_write_bytes;
   int64_t max_read_bytes;
   bool enabled = false;
   RGWRateLimitInfo()
-    : max_write_ops(0), max_read_ops(0), max_list_ops(0), max_delete_ops(0), max_write_bytes(0), max_read_bytes(0)  {}
+    : max_write_ops(0), max_read_ops(0), max_write_bytes(0), max_read_bytes(0)  {}
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(2, 1, bl);
+    ENCODE_START(1, 1, bl);
     encode(max_write_ops, bl);
     encode(max_read_ops, bl);
-    encode(max_list_ops, bl);
-    encode(max_delete_ops, bl);
     encode(max_write_bytes, bl);
     encode(max_read_bytes, bl);
     encode(enabled, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START(2, bl);
-    decode(max_write_ops, bl);
+    DECODE_START(1, bl);
+    decode(max_write_ops,bl);
     decode(max_read_ops, bl);
-    if (struct_v >= 2) {
-      decode(max_list_ops, bl);
-    } else {
-      max_list_ops = 0;
-    }
-    if (struct_v >= 2) {
-      decode(max_delete_ops, bl);
-    } else {
-      max_delete_ops = 0;
-    }
-    decode(max_write_bytes, bl);
+    decode(max_write_bytes,bl);
     decode(max_read_bytes, bl);
     decode(enabled, bl);
     DECODE_FINISH(bl);
@@ -820,7 +787,7 @@ struct RGWUserInfo
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;
-  static std::list<RGWUserInfo> generate_test_instances();
+  static void generate_test_instances(std::list<RGWUserInfo*>& o);
 
   void decode_json(JSONObj *obj);
 };
@@ -886,7 +853,7 @@ struct RGWAccountInfo {
 
   void dump(Formatter* f) const;
   void decode_json(JSONObj* obj);
-  static std::list<RGWAccountInfo> generate_test_instances();
+  static void generate_test_instances(std::list<RGWAccountInfo*>& o);
 };
 WRITE_CLASS_ENCODER(RGWAccountInfo)
 
@@ -920,7 +887,7 @@ struct RGWGroupInfo {
 
   void dump(Formatter* f) const;
   void decode_json(JSONObj* obj);
-  static std::list<RGWGroupInfo> generate_test_instances();
+  static void generate_test_instances(std::list<RGWGroupInfo*>& o);
 };
 WRITE_CLASS_ENCODER(RGWGroupInfo)
 
@@ -1006,14 +973,6 @@ struct RGWObjVersionTracker {
   /// This function is defined in `rgw_rados.cc` rather than `rgw_common.cc`.
   void prepare_op_for_read(librados::ObjectReadOperation* op);
 
-  /// This function is to be called on any read operation. If we have
-  /// a non-empty `read_version`, assert on the OSD that the object
-  /// has the same version. Also reads the version into `read_version`.
-  ///
-  /// This function is defined in `rgw_rados.cc` rather than
-  /// `rgw_common.cc`.
-  void prepare_read(neorados::ReadOp& op);
-
   /// This function is to be called on any write operation. If we have
   /// a non-empty read operation, assert on the OSD that the object
   /// has the same version. If we have a non-empty `write_version`,
@@ -1022,15 +981,6 @@ struct RGWObjVersionTracker {
   /// This function is defined in `rgw_rados.cc` rather than
   /// `rgw_common.cc`.
   void prepare_op_for_write(librados::ObjectWriteOperation* op);
-
-  /// This function is to be called on any write operation. If we have
-  /// a non-empty read operation, assert on the OSD that the object
-  /// has the same version. If we have a non-empty `write_version`,
-  /// set the object to it. Otherwise increment the version on the OSD.
-  ///
-  /// This function is defined in `rgw_rados.cc` rather than
-  /// `rgw_common.cc`.
-  void prepare_write(neorados::WriteOp& op);
 
   /// This function is to be called after the completion of any write
   /// operation on which `prepare_op_for_write` was called. If we did
@@ -1067,6 +1017,12 @@ struct RGWObjVersionTracker {
   void generate_new_write_ver(CephContext* cct);
 };
 
+inline std::ostream& operator<<(std::ostream& out, const obj_version &v)
+{
+  out << v.tag << ":" << v.ver;
+  return out;
+}
+
 inline std::ostream& operator<<(std::ostream& out, const RGWObjVersionTracker &ot)
 {
   out << "{r=" << ot.read_version << ",w=" << ot.write_version << "}";
@@ -1080,16 +1036,12 @@ enum RGWBucketFlags {
   BUCKET_DATASYNC_DISABLED = 0X8,
   BUCKET_MFA_ENABLED = 0X10,
   BUCKET_OBJ_LOCK_ENABLED = 0X20,
-  BUCKET_DELETED = 0X40,
 };
 
 class RGWSI_Zone;
 
 #include "rgw_cksum.h"
 
-
-// this represents the at-rest bucket instance object and is stored as
-// a system object
 struct RGWBucketInfo {
   rgw_bucket bucket;
   rgw_owner owner;
@@ -1130,7 +1082,7 @@ struct RGWBucketInfo {
   void encode(bufferlist& bl) const;
   void decode(bufferlist::const_iterator& bl);
   void dump(Formatter *f) const;
-  static std::list<RGWBucketInfo> generate_test_instances();
+  static void generate_test_instances(std::list<RGWBucketInfo*>& o);
 
   void decode_json(JSONObj *obj);
 
@@ -1140,7 +1092,6 @@ struct RGWBucketInfo {
   bool mfa_enabled() const { return (versioning_status() & BUCKET_MFA_ENABLED) != 0; }
   bool datasync_flag_enabled() const { return (flags & BUCKET_DATASYNC_DISABLED) == 0; }
   bool obj_lock_enabled() const { return (flags & BUCKET_OBJ_LOCK_ENABLED) != 0; }
-  bool bucket_deleted() const { return (flags & BUCKET_DELETED) != 0; }
 
   bool has_swift_versioning() const {
     /* A bucket may be versioned through one mechanism only. */
@@ -1227,7 +1178,7 @@ struct RGWBucketEntryPoint
 
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static std::list<RGWBucketEntryPoint> generate_test_instances();
+  static void generate_test_instances(std::list<RGWBucketEntryPoint*>& o);
 };
 WRITE_CLASS_ENCODER(RGWBucketEntryPoint)
 
@@ -1239,7 +1190,6 @@ struct RGWStorageStats
   uint64_t num_objects;
   uint64_t size_utilized{0}; //< size after compression, encryption
   bool dump_utilized;        // whether dump should include utilized values
-  std::optional<std::map<std::string, RGWStorageStats>> storage_class_stats;
 
   RGWStorageStats(bool _dump_utilized=true)
     : category(RGWObjCategory::None),
@@ -1277,7 +1227,7 @@ struct req_info {
   meta_map_t crypt_attribute_map;
 
   std::string host;
-  const char *method = nullptr;
+  const char *method;
   std::string script_uri;
   std::string request_uri;
   std::string request_uri_aws4;
@@ -1403,7 +1353,6 @@ struct req_state : DoutPrefixProvider {
   rgw::IAM::Environment env;
   boost::optional<rgw::IAM::Policy> iam_policy;
   boost::optional<PublicAccessBlockConfiguration> bucket_access_conf;
-  rgw::s3::ObjectOwnership bucket_object_ownership = rgw::s3::ObjectOwnership::ObjectWriter;
   std::vector<rgw::IAM::Policy> iam_identity_policies;
 
   /* Is the request made by an user marked as a system one?
@@ -1412,7 +1361,6 @@ struct req_state : DoutPrefixProvider {
 
   std::string canned_acl;
   bool has_acl_header{false};
-  bool granted_by_acl{false};
   bool local_source{false}; /* source is local */
 
   int prot_flags{0};
@@ -1480,14 +1428,12 @@ struct RGWBucketEnt {
   size_t size;
   size_t size_rounded;
   ceph::real_time creation_time;
-  ceph::real_time modification_time;
   uint64_t count;
 
   /* The placement_rule is necessary to calculate per-storage-policy statics
    * of the Swift API. Although the info available in RGWBucketInfo, we need
    * to duplicate it here to not affect the performance of buckets listing. */
   rgw_placement_rule placement_rule;
-  std::map<std::string, RGWBucketEnt> storage_class_ents;
 
   RGWBucketEnt()
     : size(0),
@@ -1515,7 +1461,7 @@ struct RGWBucketEnt {
   }
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(8, 5, bl);
+    ENCODE_START(7, 5, bl);
     uint64_t s = size;
     // issue tracked here: https://tracker.ceph.com/issues/61160
     // coverity[store_truncates_time_t:SUPPRESS]
@@ -1530,11 +1476,10 @@ struct RGWBucketEnt {
     encode(s, bl);
     encode(creation_time, bl);
     encode(placement_rule, bl);
-    encode(storage_class_ents, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START_LEGACY_COMPAT_LEN(8, 5, 5, bl);
+    DECODE_START_LEGACY_COMPAT_LEN(7, 5, 5, bl);
     __u32 mt;
     uint64_t s;
     std::string empty_str;  // backward compatibility
@@ -1556,12 +1501,10 @@ struct RGWBucketEnt {
       decode(creation_time, bl);
     if (struct_v >= 7)
       decode(placement_rule, bl);
-    if (struct_v >= 8)
-      decode(storage_class_ents, bl);
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;
-  static std::list<RGWBucketEnt> generate_test_instances();
+  static void generate_test_instances(std::list<RGWBucketEnt*>& o);
 };
 WRITE_CLASS_ENCODER(RGWBucketEnt)
 
@@ -1585,10 +1528,9 @@ struct multipart_upload_info
   RGWObjectRetention obj_retention;
   RGWObjectLegalHold obj_legal_hold;
   rgw::cksum::Type cksum_type {rgw::cksum::Type::none};
-  uint16_t cksum_flags{rgw::cksum::Cksum::FLAG_CKSUM_NONE};
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(4, 1, bl);
+    ENCODE_START(3, 1, bl);
     encode(dest_placement, bl);
     encode(obj_retention_exist, bl);
     encode(obj_legal_hold_exist, bl);
@@ -1596,12 +1538,11 @@ struct multipart_upload_info
     encode(obj_legal_hold, bl);
     uint16_t ct{uint16_t(cksum_type)};
     encode(ct, bl);
-    encode(cksum_flags, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START_LEGACY_COMPAT_LEN(4, 1, 1, bl);
+    DECODE_START_LEGACY_COMPAT_LEN(3, 1, 1, bl);
     decode(dest_placement, bl);
     if (struct_v >= 2) {
       decode(obj_retention_exist, bl);
@@ -1612,9 +1553,6 @@ struct multipart_upload_info
 	uint16_t ct;
 	decode(ct, bl);
 	cksum_type = rgw::cksum::Type(ct);
-	if (struct_v >= 4) {
-	  decode(cksum_flags, bl);
-	}
       }
     } else {
       obj_retention_exist = false;
@@ -1627,13 +1565,11 @@ struct multipart_upload_info
     dest_placement.dump(f);
   }
 
-  static std::list<multipart_upload_info> generate_test_instances() {
-    std::list<multipart_upload_info> o;
-    o.emplace_back();
-    o.emplace_back();
-    o.back().dest_placement.name = "dest_placement";
-    o.back().dest_placement.storage_class = "dest_storage_class";
-    return o;
+  static void generate_test_instances(std::list<multipart_upload_info*>& o) {
+    o.push_back(new multipart_upload_info);
+    o.push_back(new multipart_upload_info);
+    o.back()->dest_placement.name = "dest_placement";
+    o.back()->dest_placement.storage_class = "dest_storage_class";
   }
 };
 WRITE_CLASS_ENCODER(multipart_upload_info)
@@ -1722,7 +1658,6 @@ struct perm_state_base {
   const rgw::IAM::Environment& env;
   rgw::auth::Identity *identity;
   const RGWBucketInfo bucket_info;
-  rgw::s3::ObjectOwnership bucket_object_ownership;
   int perm_mask;
   bool defer_to_bucket_acls;
   boost::optional<PublicAccessBlockConfiguration> bucket_access_conf;
@@ -1731,7 +1666,6 @@ struct perm_state_base {
                   const rgw::IAM::Environment& _env,
                   rgw::auth::Identity *_identity,
                   const RGWBucketInfo& _bucket_info,
-                  rgw::s3::ObjectOwnership bucket_object_ownership,
                   int _perm_mask,
                   bool _defer_to_bucket_acls,
                   boost::optional<PublicAccessBlockConfiguration> _bucket_access_conf = boost::none) :
@@ -1739,7 +1673,6 @@ struct perm_state_base {
                                                 env(_env),
                                                 identity(_identity),
                                                 bucket_info(_bucket_info),
-                                                bucket_object_ownership(bucket_object_ownership),
                                                 perm_mask(_perm_mask),
                                                 defer_to_bucket_acls(_defer_to_bucket_acls),
                                                 bucket_access_conf(_bucket_access_conf)
@@ -1762,7 +1695,6 @@ struct perm_state : public perm_state_base {
              const rgw::IAM::Environment& _env,
              rgw::auth::Identity *_identity,
              const RGWBucketInfo& _bucket_info,
-             rgw::s3::ObjectOwnership bucket_object_ownership,
              int _perm_mask,
              bool _defer_to_bucket_acls,
              const char *_referer,
@@ -1770,7 +1702,6 @@ struct perm_state : public perm_state_base {
                                                     _env,
                                                     _identity,
                                                     _bucket_info,
-                                                    bucket_object_ownership,
                                                     _perm_mask,
                                                     _defer_to_bucket_acls),
                                     referer(_referer),
@@ -1789,10 +1720,10 @@ struct perm_state : public perm_state_base {
  * to do the requested action  */
 bool verify_bucket_permission_no_policy(
   const DoutPrefixProvider* dpp,
-  const perm_state_base * const s,
+  struct perm_state_base * const s,
   const RGWAccessControlPolicy& user_acl,
   const RGWAccessControlPolicy& bucket_acl,
-  const int perm, bool* granted_by_acl = nullptr);
+  const int perm);
 
 bool verify_user_permission_no_policy(const DoutPrefixProvider* dpp,
                                       struct perm_state_base * const s,
@@ -1804,8 +1735,7 @@ bool verify_object_permission_no_policy(const DoutPrefixProvider* dpp,
 					const RGWAccessControlPolicy& user_acl,
 					const RGWAccessControlPolicy& bucket_acl,
 					const RGWAccessControlPolicy& object_acl,
-					const int perm,
-                                        bool *granted_by_acl = nullptr);
+					const int perm);
 
 // determine whether a request is allowed or denied within an account
 rgw::IAM::Effect evaluate_iam_policies(
@@ -1826,7 +1756,7 @@ bool verify_user_permission_no_policy(const DoutPrefixProvider* dpp,
                                       req_state * const s,
                                       int perm);
 bool verify_bucket_permission(const DoutPrefixProvider* dpp,
-                              const perm_state_base * const s,
+                              struct perm_state_base * const s,
                               const rgw::ARN& arn,
                               bool account_root,
                               const RGWAccessControlPolicy& user_acl,
@@ -1834,7 +1764,7 @@ bool verify_bucket_permission(const DoutPrefixProvider* dpp,
 			      const boost::optional<rgw::IAM::Policy>& bucket_policy,
                               const std::vector<rgw::IAM::Policy>& identity_policies,
                               const std::vector<rgw::IAM::Policy>& session_policies,
-                              const uint64_t op, bool *granted_by_acl = nullptr);
+                              const uint64_t op);
 bool verify_bucket_permission(
   const DoutPrefixProvider* dpp,
   req_state * const s,
@@ -1870,6 +1800,13 @@ extern bool verify_object_permission(
   const std::vector<rgw::IAM::Policy>& session_policies,
   const uint64_t op);
 extern bool verify_object_permission(const DoutPrefixProvider* dpp, req_state *s, uint64_t op);
+extern bool verify_object_permission_no_policy(
+  const DoutPrefixProvider* dpp,
+  req_state * const s,
+  const RGWAccessControlPolicy& user_acl,
+  const RGWAccessControlPolicy& bucket_acl,
+  const RGWAccessControlPolicy& object_acl,
+  int perm);
 extern bool verify_object_permission_no_policy(const DoutPrefixProvider* dpp, req_state *s,
 					       int perm);
 extern int verify_object_lock(
@@ -1965,7 +1902,9 @@ extern std::string calc_hash_sha256_restart_stream(ceph::crypto::SHA256** phash)
 extern int rgw_parse_op_type_list(const std::string& str, uint32_t *perm);
 
 static constexpr uint32_t MATCH_POLICY_ACTION = 0x01;
-static constexpr uint32_t MATCH_POLICY_ARN = 0x02;
+static constexpr uint32_t MATCH_POLICY_RESOURCE = 0x02;
+static constexpr uint32_t MATCH_POLICY_ARN = 0x04;
+static constexpr uint32_t MATCH_POLICY_STRING = 0x08;
 
 extern bool match_policy(const std::string& pattern, const std::string& input,
                          uint32_t flag);
@@ -2078,26 +2017,3 @@ extern boost::optional<rgw::IAM::Policy>
 get_iam_policy_from_attr(CephContext* cct,
                          const std::map<std::string, bufferlist>& attrs,
                          const std::string& tenant);
-
-static inline void prepend_bucket_marker(const rgw_bucket& bucket, const std::string& orig_oid, std::string& oid)
-{
-  if (bucket.marker.empty() || orig_oid.empty()) {
-    oid = orig_oid;
-  } else {
-    oid = bucket.marker;
-    oid.append("_");
-    oid.append(orig_oid);
-  }
-}
-
-static inline void get_obj_bucket_and_oid_loc(const rgw_obj& obj, std::string& oid, std::string& locator)
-{
-  const rgw_bucket& bucket = obj.bucket;
-  prepend_bucket_marker(bucket, obj.get_oid(), oid);
-  const std::string& loc = obj.key.get_loc();
-  if (!loc.empty()) {
-    prepend_bucket_marker(bucket, loc, locator);
-  } else {
-    locator.clear();
-  }
-}

--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -229,7 +229,7 @@ static void log_usage(req_state *s, const string& op_name)
   uint64_t bytes_sent = ACCOUNTING_IO(s)->get_bytes_sent();
   uint64_t bytes_received = ACCOUNTING_IO(s)->get_bytes_received();
 
-  rgw_usage_data data(bytes_sent, bytes_received);
+  rgw_usage_data data(bytes_sent, bytes_received, s->dest_placement.get_storage_class());
 
   data.ops = 1;
   if (!s->is_err())
@@ -242,7 +242,7 @@ static void log_usage(req_state *s, const string& op_name)
 	<< ", bytes_processed=" << s->s3select_usage.bytes_processed
 	<< ", bytes_returned=" << s->s3select_usage.bytes_returned << dendl;
 
-  entry.add_usage(op_name, data);
+  entry.add_usage(s->dest_placement.name + "::" + s->dest_placement.get_storage_class(), op_name, data);
   entry.s3select_usage = s->s3select_usage;
 
   utime_t ts = ceph_clock_now();

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3028,7 +3028,7 @@ void RGWGetUsage::execute(optional_yield y)
   }
 
   op_ret = rgw_sync_all_stats(this, y, driver, s->user->get_id(),
-                              s->user->get_tenant());
+                              false, s->user->get_tenant());
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "ERROR: failed to sync user stats" << dendl;
     return;
@@ -4181,7 +4181,7 @@ void RGWDeleteBucket::execute(optional_yield y)
 
   if (own_bucket) {
     // only if we own the bucket
-    op_ret = s->bucket->sync_owner_stats(this, y, nullptr);
+    op_ret = s->bucket->sync_owner_stats(this, y, false, nullptr);
     if (op_ret < 0) {
       ldpp_dout(this, 1) << "WARNING: failed to sync user stats before bucket delete: op_ret= " << op_ret << dendl;
     }

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -61,6 +61,7 @@
 #ifdef WITH_RADOSGW_RADOS
 #include "rgw_sal_rados.h"
 #endif
+#include "rgw_sc_quota_checker.h"
 #include "rgw_torrent.h"
 #include "rgw_cksum_pipe.h"
 #include "rgw_lua_data_filter.h"
@@ -4625,6 +4626,23 @@ void RGWPutObj::execute(optional_yield y)
       ldpp_dout(this, 20) << "check_quota() returned ret=" << op_ret << dendl;
       return;
     }
+
+    op_ret = rgw_check_storage_class_quota(
+      this,
+      driver,
+      s->bucket.get(),
+      s->user.get(),
+      s->dest_placement.name,
+      s->dest_placement.storage_class,
+      static_cast<uint64_t>(s->content_length),
+      1,
+      y);
+
+    if (op_ret < 0) {
+      ldpp_dout(this, 5) << "rgw_check_storage_class_quota() returned ret="
+                        << op_ret << dendl;
+      return;
+    }
   }
 
   if (supplied_etag) {
@@ -4893,6 +4911,23 @@ void RGWPutObj::execute(optional_yield y)
   op_ret = s->bucket->check_quota(this, quota, s->obj_size, y);
   if (op_ret < 0) {
     ldpp_dout(this, 20) << "second check_quota() returned op_ret=" << op_ret << dendl;
+    return;
+  }
+
+  op_ret = rgw_check_storage_class_quota(
+    this,
+    driver,
+    s->bucket.get(),
+    s->user.get(),
+    s->dest_placement.name,
+    s->dest_placement.storage_class,
+    s->obj_size,
+    1,
+    y);
+  
+    if (op_ret < 0) {
+    ldpp_dout(this, 5) << "second rgw_check_storage_class_quota() returned ret="
+                      << op_ret << dendl;
     return;
   }
 
@@ -6386,6 +6421,18 @@ void RGWCopyObj::execute(optional_yield y)
       if (op_ret < 0) {
         return;
       }
+      op_ret = rgw_check_storage_class_quota(
+          this, driver,
+          s->bucket.get(), s->user.get(),
+          s->dest_placement.name,
+          s->dest_placement.storage_class,
+          s->src_object->get_accounted_size(),
+          1, y);
+      if (op_ret < 0) {
+        ldpp_dout(this, 5) << "SC quota exceeded for copy operation ret="
+                           << op_ret << dendl;
+        return;
+      }
     }
   }
 
@@ -7557,6 +7604,43 @@ void RGWCompleteMultipart::execute(optional_yield y)
     op_ret = -ERR_INTERNAL_ERROR;
     s->err.message = "This multipart completion is already in progress";
     return;
+  }
+
+  // Parts are already loaded into upload->get_parts() if cksum_type != none
+  // (try_sum_part_cksums called list_parts). If cksum_type == none they haven't
+  // been listed yet, so we do it now.
+  {
+    if (upload->get_parts().empty()) {
+      bool trunc = false;
+      int marker = 0;
+      int r = upload->list_parts(this, s->cct,
+                                static_cast<int>(parts->parts.size()),
+                                marker, &marker, &trunc, y);
+      if (r < 0) {
+        ldpp_dout(this, 1) << "WARNING: list_parts for SC quota check returned "
+                          << r << " — allowing upload (fail-open)" << dendl;
+      }
+    }
+
+    uint64_t total_size = 0;
+    for (const auto& [num, part] : upload->get_parts()) {
+      total_size += part->get_size();
+    }
+
+    if (total_size > 0 && dest_placement != nullptr) {
+      int r = rgw_check_storage_class_quota(
+          this, driver,
+          s->bucket.get(), s->user.get(),
+          dest_placement->name,
+          dest_placement->storage_class,
+          total_size, 1, y);
+      if (r < 0) {
+        ldpp_dout(this, 5) << "SC quota exceeded for multipart upload ret="
+                          << r << dendl;
+        op_ret = r;
+        return;
+      }
+    }
   }
 
   op_ret =

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -610,7 +610,7 @@ int RGWOwnerStatsCache::sync_bucket(const rgw_owner& owner, const rgw_bucket& b,
   }
 
   RGWBucketEnt ent;
-  r = bucket->sync_owner_stats(dpp, y, &ent);
+  r = bucket->sync_owner_stats(dpp, y, false, &ent);
   if (r < 0) {
     ldpp_dout(dpp, 0) << "ERROR: sync_owner_stats() for bucket=" << bucket << " returned " << r << dendl;
     return r;
@@ -676,7 +676,7 @@ int RGWOwnerStatsCache::sync_owner(const DoutPrefixProvider *dpp,
     return ret;
   }
 
-  ret = rgw_sync_all_stats(dpp, y, driver, owner, tenant);
+  ret = rgw_sync_all_stats(dpp, y, driver, owner, false, tenant);
   if (ret < 0) {
     ldpp_dout(dpp, 0) << "ERROR: failed user stats sync, ret=" << ret << dendl;
     return ret;

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -1031,6 +1031,34 @@ void rgw_apply_default_account_quota(RGWQuotaInfo& quota, const ConfigProxy& con
   }
 }
 
+void RGWStorageClassQuota::dump(Formatter *f) const
+{
+  f->dump_bool("enabled",     enabled);
+  f->dump_int ("max_size",    max_size);
+  f->dump_int ("max_size_kb", rgw_rounded_kb(max_size));
+  f->dump_int ("max_objects", max_objects);
+}
+
+void RGWStorageClassQuota::decode_json(JSONObj *obj)
+{
+  JSONDecoder::decode_json("enabled",     enabled,     obj);
+  JSONDecoder::decode_json("max_objects", max_objects, obj);
+  if (!JSONDecoder::decode_json("max_size", max_size, obj)) {
+    int64_t max_size_kb = 0;
+    JSONDecoder::decode_json("max_size_kb", max_size_kb, obj);
+    max_size = max_size_kb * 1024;
+  }
+}
+
+std::list<RGWStorageClassQuota> RGWStorageClassQuota::generate_test_instances()
+{
+  RGWStorageClassQuota q;
+  q.enabled     = true;
+  q.max_size    = 1024LL * 1024 * 1024;  // 1 GiB
+  q.max_objects = 1000;
+  return {q, RGWStorageClassQuota{}};
+}
+
 void RGWQuotaInfo::dump(Formatter *f) const
 {
   f->dump_bool("enabled", enabled);
@@ -1039,6 +1067,19 @@ void RGWQuotaInfo::dump(Formatter *f) const
   f->dump_int("max_size", max_size);
   f->dump_int("max_size_kb", rgw_rounded_kb(max_size));
   f->dump_int("max_objects", max_objects);
+
+  if (!storage_class_quotas.empty()) {
+    f->open_object_section("storage_class_quotas");
+    for (const auto& [key, scq] : storage_class_quotas) {
+      f->open_object_section(key.c_str());
+      scq.dump(f);
+      f->close_section();
+    }
+    f->close_section();
+
+    f->dump_unsigned("enforcement_mode",
+                     static_cast<uint8_t>(enforcement_mode));
+  }
 }
 
 std::list<RGWQuotaInfo> RGWQuotaInfo::generate_test_instances()
@@ -1050,6 +1091,20 @@ std::list<RGWQuotaInfo> RGWQuotaInfo::generate_test_instances()
   o.back().check_on_raw = true;
   o.back().max_size = 1024;
   o.back().max_objects = 1;
+
+  // v4 addition: instance with storage class quotas
+  RGWQuotaInfo q_sc;
+  q_sc.enabled = true;
+  q_sc.max_size = 1024;
+  q_sc.max_objects = 1;
+  q_sc.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  RGWStorageClassQuota scq;
+  scq.enabled     = true;
+  scq.max_size    = 512 * 1024 * 1024;
+  scq.max_objects = 500;
+  q_sc.storage_class_quotas["default-placement::SSD"] = scq;
+  o.push_back(q_sc);
+
   return o;
 }
 
@@ -1066,5 +1121,21 @@ void RGWQuotaInfo::decode_json(JSONObj *obj)
 
   JSONDecoder::decode_json("check_on_raw", check_on_raw, obj);
   JSONDecoder::decode_json("enabled", enabled, obj);
+  
+  JSONObj *scq_obj = obj->find_obj("storage_class_quotas");
+  if (scq_obj) {
+    JSONObjIter it = scq_obj->find_first();
+    for (; !it.end(); ++it) {
+      JSONObj *entry = *it;
+      RGWStorageClassQuota scq;
+      scq.decode_json(entry);
+      storage_class_quotas[entry->get_name()] = std::move(scq);
+    }
+  }
+
+  uint8_t mode_raw = 0;
+  if (JSONDecoder::decode_json("enforcement_mode", mode_raw, obj)) {
+    enforcement_mode = static_cast<RGWQuotaEnforcementMode>(mode_raw);
+  }
 }
 

--- a/src/rgw/rgw_quota_types.h
+++ b/src/rgw/rgw_quota_types.h
@@ -19,6 +19,7 @@
  */
 
 #pragma once
+#include "rgw_sc_quota_types.h"
 
 static inline int64_t rgw_rounded_kb(int64_t bytes)
 {
@@ -34,16 +35,19 @@ struct RGWQuotaInfo {
   /* Do we want to compare with raw, not rounded RGWStorageStats::size (true)
    * or maybe rounded-to-4KiB RGWStorageStats::size_rounded (false)? */
   bool check_on_raw;
+  std::unordered_map<std::string, RGWStorageClassQuota> storage_class_quotas;
+  RGWQuotaEnforcementMode enforcement_mode;
 
   RGWQuotaInfo()
     : max_size(-1),
       max_objects(-1),
       enabled(false),
-      check_on_raw(false) {
+      check_on_raw(false),
+      enforcement_mode(RGWQuotaEnforcementMode::LEGACY) {
   }
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(3, 1, bl);
+    ENCODE_START(4, 1, bl);
     if (max_size < 0) {
       encode(-rgw_rounded_kb(abs(max_size)), bl);
     } else {
@@ -53,10 +57,14 @@ struct RGWQuotaInfo {
     encode(enabled, bl);
     encode(max_size, bl);
     encode(check_on_raw, bl);
+    // version 4 parameters
+    encode(storage_class_quotas, bl);
+    encode(static_cast<uint8_t>(enforcement_mode), bl);
     ENCODE_FINISH(bl);
   }
+
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START_LEGACY_COMPAT_LEN(3, 1, 1, bl);
+    DECODE_START_LEGACY_COMPAT_LEN(4, 1, 1, bl);
     int64_t max_size_kb;
     decode(max_size_kb, bl);
     decode(max_objects, bl);
@@ -69,7 +77,18 @@ struct RGWQuotaInfo {
     if (struct_v >= 3) {
       decode(check_on_raw, bl);
     }
+    if (struct_v >= 4) {
+      decode(storage_class_quotas, bl);
+      uint8_t mode_raw;
+      decode(mode_raw, bl);
+      enforcement_mode = static_cast<RGWQuotaEnforcementMode>(mode_raw);
+    }
     DECODE_FINISH(bl);
+  }
+  
+  const RGWStorageClassQuota* get_sc_quota(const std::string& sc_key) const {
+    auto it = storage_class_quotas.find(sc_key);
+    return (it != storage_class_quotas.end()) ? &it->second : nullptr;
   }
 
   void dump(Formatter *f) const;

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -955,6 +955,7 @@ class Bucket {
 				 int shard_id, boost::intrusive_ptr<ReadStatsCB> cb) = 0;
     /** Sync this bucket's stats to the owning user's stats in the backing store */
     virtual int sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y,
+                                 bool reset,
                                  RGWBucketEnt* optional_ent) = 0;
     /** Check if this bucket needs resharding, and schedule it if it does */
     virtual int check_bucket_shards(const DoutPrefixProvider* dpp,

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -219,6 +219,7 @@ namespace rgw::sal {
   }
 
   int DBBucket::sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y,
+                                 bool reset,
                                  RGWBucketEnt* ent)
   {
     return 0;

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -160,7 +160,7 @@ protected:
           std::string *max_marker = nullptr,
           bool *syncstopped = nullptr) override;
       virtual int read_stats_async(const DoutPrefixProvider *dpp, const bucket_index_layout_generation& idx_layout, int shard_id, boost::intrusive_ptr<ReadStatsCB> ctx) override;
-      int sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y,
+      int sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y, bool reset,
                            RGWBucketEnt* ent) override;
       int check_bucket_shards(const DoutPrefixProvider *dpp,
                               uint64_t num_objs, optional_yield y) override;

--- a/src/rgw/rgw_sal_filter.cc
+++ b/src/rgw/rgw_sal_filter.cc
@@ -874,9 +874,10 @@ int FilterBucket::read_stats_async(const DoutPrefixProvider *dpp,
 }
 
 int FilterBucket::sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y,
+                                   bool reset,
                                    RGWBucketEnt* ent)
 {
-  return next->sync_owner_stats(dpp, y, ent);
+  return next->sync_owner_stats(dpp, y, reset, ent);
 }
 
 int FilterBucket::check_bucket_shards(const DoutPrefixProvider* dpp,

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -595,7 +595,7 @@ public:
   virtual int read_stats_async(const DoutPrefixProvider *dpp,
 			       const bucket_index_layout_generation& idx_layout,
 			       int shard_id, boost::intrusive_ptr<ReadStatsCB> ctx) override;
-  int sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y,
+  int sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y, bool reset,
                        RGWBucketEnt* ent) override;
   int check_bucket_shards(const DoutPrefixProvider* dpp,
                           uint64_t num_objs, optional_yield y) override;

--- a/src/rgw/rgw_sc_quota_checker.cc
+++ b/src/rgw/rgw_sc_quota_checker.cc
@@ -1,0 +1,274 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+#include "rgw_sc_quota_checker.h"
+#include "rgw_sal.h"
+#include "rgw_bucket.h"
+#include "cls/rgw/cls_rgw_types.h"
+#include "cls/rgw/cls_rgw_client.h"
+#include "common/errno.h"
+#include "common/dout.h"
+
+#include <fmt/format.h>
+
+#define dout_subsys ceph_subsys_rgw
+
+using namespace rgw::quota;
+
+StorageClassQuotaChecker::StorageClassQuotaChecker(
+    CephContext* cct,
+    rgw::sal::Driver* driver)
+  : cct_(cct), driver_(driver)
+{
+}
+
+std::string StorageClassQuotaChecker::make_cache_key(const rgw_bucket& bucket) const
+{
+  return bucket.get_key();
+}
+
+int StorageClassQuotaChecker::get_quota_info(
+    const DoutPrefixProvider* dpp,
+    const rgw_bucket& bucket,
+    RGWQuotaInfo* quota_info)
+{
+  std::string cache_key = make_cache_key(bucket);
+  uint32_t expiry = cct_->_conf->rgw_storage_class_quota_cache_expiry_sec;
+
+  // Try cache first
+  {
+    std::lock_guard lock(cache_mutex_);
+    auto it = quota_cache_.find(cache_key);
+    if (it != quota_cache_.end() && !it->second.is_stale(expiry)) {
+      *quota_info = it->second.quota;
+      ldpp_dout(dpp, 20) << __func__ << " cache hit for bucket=" << bucket << dendl;
+      return 0;
+    }
+  }
+
+  // Cache miss - read from bucket metadata
+  std::unique_ptr<rgw::sal::Bucket> sal_bucket;
+  int ret = driver_->get_bucket(dpp, nullptr, bucket, &sal_bucket, null_yield);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: " << __func__ << " failed to get bucket: " 
+                      << bucket << " ret=" << ret << dendl;
+    return ret;
+  }
+
+  // Get bucket info (contains quota_info)
+  RGWBucketInfo& info = sal_bucket->get_info();
+  *quota_info = info.quota;
+
+  // Update cache
+  {
+    std::lock_guard lock(cache_mutex_);
+    QuotaCacheEntry entry;
+    entry.quota = *quota_info;
+    entry.cached_at = ceph::real_clock::now();
+    quota_cache_[cache_key] = entry;
+  }
+
+  ldpp_dout(dpp, 20) << __func__ << " loaded quota for bucket=" << bucket << dendl;
+  return 0;
+}
+
+int StorageClassQuotaChecker::get_current_usage(
+    const DoutPrefixProvider* dpp,
+    const rgw_bucket& bucket,
+    const std::string& sc_key,
+    uint64_t* out_size,
+    uint64_t* out_objects)
+{
+  // Get bucket
+  std::unique_ptr<rgw::sal::Bucket> sal_bucket;
+  int ret = driver_->get_bucket(dpp, nullptr, bucket, &sal_bucket, null_yield);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: " << __func__ << " failed to get bucket: " 
+                      << bucket << " ret=" << ret << dendl;
+    return ret;
+  }
+
+  // Read bucket index header (contains PR #66501 storage_class_stats)
+  rgw_bucket_dir_header header;
+  ret = sal_bucket->read_bucket_stats(dpp, null_yield, &header);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: " << __func__ << " failed to read bucket stats: "
+                      << bucket << " ret=" << ret << dendl;
+    return ret;
+  }
+
+  // Check if bucket has SC stats (PR #66501)
+  if (!header.storage_class_stats) {
+    ldpp_dout(dpp, 5) << "NOTICE: " << __func__ << " bucket not converted for SC stats: "
+                      << bucket << dendl;
+    return -ENOTSUP;
+  }
+
+  // Find SC-specific stats
+  auto it = header.storage_class_stats->find(sc_key);
+  if (it == header.storage_class_stats->end()) {
+    // No objects in this storage class yet - return 0
+    *out_size = 0;
+    *out_objects = 0;
+    ldpp_dout(dpp, 20) << __func__ << " no usage for sc_key=" << sc_key << dendl;
+    return 0;
+  }
+
+  *out_size = it->second.total_size;
+  *out_objects = it->second.num_entries;
+
+  ldpp_dout(dpp, 20) << __func__ << " sc_key=" << sc_key
+                     << " size=" << *out_size
+                     << " objects=" << *out_objects << dendl;
+
+  return 0;
+}
+
+int StorageClassQuotaChecker::check_bucket_quota(
+    const DoutPrefixProvider* dpp,
+    const rgw_bucket& bucket,
+    const RGWQuotaInfo& quota_info,
+    const std::string& sc_key,
+    uint64_t obj_size,
+    uint64_t num_objs)
+{
+  // Get SC quota for this storage class
+  const RGWStorageClassQuota* sc_quota = quota_info.get_sc_quota(sc_key);
+  if (!sc_quota || !sc_quota->enabled) {
+    ldpp_dout(dpp, 20) << __func__ << " no quota configured for sc_key=" << sc_key << dendl;
+    return 0;  // No quota configured
+  }
+
+  // Get current usage from PR #66501 data
+  uint64_t current_size = 0;
+  uint64_t current_objects = 0;
+  int ret = get_current_usage(dpp, bucket, sc_key, &current_size, &current_objects);
+  if (ret < 0) {
+    if (ret == -ENOTSUP) {
+      ldpp_dout(dpp, 1) << "ERROR: " << __func__ 
+                        << " bucket not converted for SC quota: " << bucket << dendl;
+      // Return specific error for unconverted bucket
+      return -ENOTSUP;
+    }
+
+    // Fail-safe: allow operation if stats unavailable (configurable)
+    if (cct_->_conf->rgw_storage_class_quota_fail_safe) {
+      ldpp_dout(dpp, 1) << "WARNING: " << __func__ 
+                        << " stats unavailable, allowing (fail-safe)" << dendl;
+      return 0;
+    }
+    return ret;
+  }
+
+  // Check size quota
+  if (sc_quota->max_size >= 0) {
+    uint64_t new_total = current_size + obj_size;
+    if (new_total > (uint64_t)sc_quota->max_size) {
+      ldpp_dout(dpp, 1) << "QUOTA EXCEEDED: " << __func__
+                        << " sc_key=" << sc_key
+                        << " current_size=" << current_size
+                        << " limit=" << sc_quota->max_size
+                        << " requested=" << obj_size
+                        << " would_be=" << new_total << dendl;
+      return -ERR_QUOTA_EXCEEDED;
+    }
+  }
+
+  // Check object count quota
+  if (sc_quota->max_objects >= 0) {
+    uint64_t new_total = current_objects + num_objs;
+    if (new_total > (uint64_t)sc_quota->max_objects) {
+      ldpp_dout(dpp, 1) << "QUOTA EXCEEDED: " << __func__
+                        << " sc_key=" << sc_key
+                        << " current_objects=" << current_objects
+                        << " limit=" << sc_quota->max_objects
+                        << " requested=" << num_objs
+                        << " would_be=" << new_total << dendl;
+      return -ERR_QUOTA_EXCEEDED;
+    }
+  }
+
+  ldpp_dout(dpp, 20) << __func__ << " quota check passed for sc_key=" << sc_key << dendl;
+  return 0;
+}
+
+int StorageClassQuotaChecker::check_quota(
+    const DoutPrefixProvider* dpp,
+    const rgw_bucket& bucket,
+    const std::string& storage_class,
+    const std::string& placement,
+    uint64_t obj_size,
+    uint64_t num_objs)
+{
+  // Check if feature enabled
+  if (!cct_->_conf->rgw_storage_class_quota_enabled) {
+    ldpp_dout(dpp, 20) << __func__ << " SC quota disabled" << dendl;
+    return 0;
+  }
+
+  // Get quota info
+  RGWQuotaInfo quota_info;
+  int ret = get_quota_info(dpp, bucket, &quota_info);
+  if (ret < 0) {
+    if (cct_->_conf->rgw_storage_class_quota_fail_safe) {
+      ldpp_dout(dpp, 1) << "WARNING: " << __func__ 
+                        << " failed to get quota info, allowing (fail-safe)" << dendl;
+      return 0;  // Fail-open
+    }
+    return ret;
+  }
+
+  // Build storage class key (same format as PR #66501)
+  std::string sc_key = fmt::format("{}::{}", placement, storage_class);
+
+  ldpp_dout(dpp, 20) << __func__ 
+                     << " bucket=" << bucket
+                     << " sc_key=" << sc_key
+                     << " obj_size=" << obj_size
+                     << " num_objs=" << num_objs
+                     << " enforcement_mode=" << (int)quota_info.enforcement_mode << dendl;
+
+  // Determine what to check based on enforcement mode
+  bool check_sc_quota = false;
+  bool check_global_quota = false;
+
+  switch (quota_info.enforcement_mode) {
+    case RGWQuotaEnforcementMode::LEGACY:
+    case RGWQuotaEnforcementMode::GLOBAL_ONLY:
+      check_global_quota = true;
+      break;
+    case RGWQuotaEnforcementMode::STORAGE_CLASS:
+      check_sc_quota = true;
+      break;
+    case RGWQuotaEnforcementMode::HYBRID:
+      check_sc_quota = true;
+      check_global_quota = true;
+      break;
+  }
+
+  // Check SC quota if enabled
+  if (check_sc_quota) {
+    ret = check_bucket_quota(dpp, bucket, quota_info, sc_key, obj_size, num_objs);
+    if (ret < 0) {
+      return ret;  // SC quota exceeded
+    }
+  }
+
+  // Check global quota if enabled
+  // NOTE: This would call existing RGW global quota check function
+  // For now, we skip this to avoid dependency issues call: rgw_check_quota(...)
+  if (check_global_quota && quota_info.enabled) {
+    ldpp_dout(dpp, 20) << __func__ << " would also check global quota here" << dendl;
+    // HSTTODO: Call existing global quota check
+  }
+
+  return 0;  // All quota checks passed
+}
+
+void StorageClassQuotaChecker::invalidate_cache(const rgw_bucket& bucket)
+{
+  std::lock_guard lock(cache_mutex_);
+  std::string cache_key = make_cache_key(bucket);
+  quota_cache_.erase(cache_key);
+  ldpp_dout(nullptr, 20) << __func__ << " invalidated cache for bucket=" << bucket << dendl;
+}

--- a/src/rgw/rgw_sc_quota_checker.h
+++ b/src/rgw/rgw_sc_quota_checker.h
@@ -1,0 +1,104 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+#ifndef CEPH_RGW_SC_QUOTA_CHECKER_H
+#define CEPH_RGW_SC_QUOTA_CHECKER_H
+
+#include "rgw_quota_types.h"
+#include "rgw_common.h"
+#include "common/ceph_time.h"
+#include <mutex>
+#include <memory>
+#include <string>
+
+class CephContext;
+class DoutPrefixProvider;
+struct rgw_bucket;
+
+namespace rgw {
+namespace sal {
+  class Driver;
+  class Bucket;
+}
+}
+
+namespace rgw { namespace quota {
+
+/**
+ * Storage Class Quota Checker
+ * 
+ * Enforces per-storage-class quota limits by reading usage data
+ * from PR #66501 (storage_class_stats in bucket index).
+ */
+class StorageClassQuotaChecker {
+private:
+  CephContext* cct_;
+  rgw::sal::Driver* driver_;
+
+  // Cache entry for quota info
+  struct QuotaCacheEntry {
+    RGWQuotaInfo quota;
+    ceph::real_time cached_at;
+
+    bool is_stale(uint32_t expiry_sec) const {
+      auto age = ceph::real_clock::now() - cached_at;
+      return std::chrono::duration_cast<std::chrono::seconds>(age).count() > expiry_sec;
+    }
+  };
+
+  mutable std::mutex cache_mutex_;
+  std::unordered_map<std::string, QuotaCacheEntry> quota_cache_;
+
+  // Helpers
+  std::string make_cache_key(const rgw_bucket& bucket) const;
+  
+  int get_quota_info(
+      const DoutPrefixProvider* dpp,
+      const rgw_bucket& bucket,
+      RGWQuotaInfo* quota_info);
+
+  int get_current_usage(
+      const DoutPrefixProvider* dpp,
+      const rgw_bucket& bucket,
+      const std::string& sc_key,
+      uint64_t* out_size,
+      uint64_t* out_objects);
+
+  int check_bucket_quota(
+      const DoutPrefixProvider* dpp,
+      const rgw_bucket& bucket,
+      const RGWQuotaInfo& quota_info,
+      const std::string& sc_key,
+      uint64_t obj_size,
+      uint64_t num_objs);
+
+public:
+  StorageClassQuotaChecker(CephContext* cct, rgw::sal::Driver* driver);
+  ~StorageClassQuotaChecker() = default;
+
+  /**
+   * Check quota before object write
+   * 
+   * @param dpp Debug prefix provider
+   * @param bucket Bucket being written to
+   * @param storage_class Storage class (e.g., "STANDARD", "SSD")
+   * @param placement Placement target (e.g., "default-placement")
+   * @param obj_size Size of object being written
+   * @param num_objs Number of objects (usually 1)
+   * @return 0 on success, negative error code on quota exceeded
+   */
+  int check_quota(
+      const DoutPrefixProvider* dpp,
+      const rgw_bucket& bucket,
+      const std::string& storage_class,
+      const std::string& placement,
+      uint64_t obj_size,
+      uint64_t num_objs = 1);
+
+  // Invalidate cached quota info
+  void invalidate_cache(const rgw_bucket& bucket);
+};
+
+}} // namespace rgw::quota
+
+#endif // CEPH_RGW_SC_QUOTA_CHECKER_H

--- a/src/rgw/rgw_sc_quota_types.h
+++ b/src/rgw/rgw_sc_quota_types.h
@@ -1,0 +1,62 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+#ifndef CEPH_RGW_SC_QUOTA_TYPES_H
+#define CEPH_RGW_SC_QUOTA_TYPES_H
+
+#include "include/encoding.h"
+#include <cstdint>
+#include <string>
+
+// Per-storage-class quota limits
+struct RGWStorageClassQuota {
+  int64_t max_size;      // -1 = unlimited
+  int64_t max_objects;   // -1 = unlimited
+  bool enabled;
+
+  RGWStorageClassQuota()
+    : max_size(-1),
+      max_objects(-1),
+      enabled(false) {
+  }
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(max_size, bl);
+    encode(max_objects, bl);
+    encode(enabled, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(max_size, bl);
+    decode(max_objects, bl);
+    decode(enabled, bl);
+    DECODE_FINISH(bl);
+  }
+
+  void dump(Formatter *f) const;
+  void decode_json(JSONObj *obj);
+};
+WRITE_CLASS_ENCODER(RGWStorageClassQuota)
+
+// Quota enforcement modes
+enum class RGWQuotaEnforcementMode : uint32_t {
+  LEGACY = 0,         // Backward compat - only global quotas
+  GLOBAL_ONLY = 1,    // Enforce only global quotas
+  STORAGE_CLASS = 2,  // Enforce only per-SC quotas
+  HYBRID = 3          // Enforce both (most restrictive wins)
+};
+
+inline void encode(RGWQuotaEnforcementMode mode, bufferlist& bl) {
+  encode((uint32_t)mode, bl);
+}
+
+inline void decode(RGWQuotaEnforcementMode& mode, bufferlist::const_iterator& bl) {
+  uint32_t val;
+  decode(val, bl);
+  mode = (RGWQuotaEnforcementMode)val;
+}
+
+#endif // CEPH_RGW_SC_QUOTA_TYPES_H

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -15,7 +15,7 @@ using namespace std;
 
 int rgw_sync_all_stats(const DoutPrefixProvider *dpp,
                        optional_yield y, rgw::sal::Driver* driver,
-                       const rgw_owner& owner, const std::string& tenant)
+                       const rgw_owner& owner, bool reset, const std::string& tenant)
 {
   size_t max_entries = dpp->get_cct()->_conf->rgw_list_buckets_max_chunk;
 
@@ -36,7 +36,7 @@ int rgw_sync_all_stats(const DoutPrefixProvider *dpp,
         ldpp_dout(dpp, 0) << "ERROR: could not read bucket info: bucket=" << bucket << " ret=" << ret << dendl;
         continue;
       }
-      ret = bucket->sync_owner_stats(dpp, y, &ent);
+      ret = bucket->sync_owner_stats(dpp, y, reset, &ent);
       if (ret < 0) {
         ldpp_dout(dpp, 0) << "ERROR: could not sync bucket stats: ret=" << ret << dendl;
         return ret;

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -584,6 +584,17 @@ int RGWSI_BucketIndex_RADOS::read_stats(const DoutPrefixProvider *dpp,
       result->size += stats.total_size;
       result->size_rounded += stats.total_size_rounded;
     }
+    if (hiter->storage_class_stats.has_value()) {
+      for(auto it = hiter->storage_class_stats.value().begin(); it != hiter->storage_class_stats.value().end(); ++it){
+        std::string storage_class = it->first;
+        struct rgw_bucket_category_stats& stats = it->second;
+        result->storage_class_ents[storage_class].count += stats.num_entries;
+        result->storage_class_ents[storage_class].size += stats.total_size;
+        result->storage_class_ents[storage_class].size_rounded += stats.total_size_rounded;
+        result->storage_class_ents[storage_class].bucket = result->bucket;
+      }
+    }
+
   }
 
   result->placement_rule = std::move(bucket_info.placement_rule);

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -426,6 +426,18 @@ target_link_libraries(ceph_test_datalog
 install(TARGETS ceph_test_datalog DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
+# Test for storage class stats with std::optional
+add_executable(unittest_rgw_storage_class_stats
+               test_rgw_storage_class_stats.cc
+              )
+target_link_libraries(unittest_rgw_storage_class_stats
+                      cls_rgw_client
+                      cls_user_client
+                      global
+                      ${UNITTEST_LIBS}
+                      )
+add_ceph_unittest(unittest_rgw_storage_class_stats)
+
 #
 # Helper for adding RGW tests built with Catch2:
 # Note: to define a test that does not use Catch2::main(), use:

--- a/src/test/rgw/test_rgw_storage_class_stats.cc
+++ b/src/test/rgw/test_rgw_storage_class_stats.cc
@@ -1,0 +1,753 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <gtest/gtest.h>
+#include "cls/rgw/cls_rgw_types.h"
+#include "cls/user/cls_user_types.h"
+#include <chrono>
+
+using namespace std;
+
+TEST(StorageClassStats, OptionalInitialization) {
+  rgw_bucket_dir_header header;
+  
+  // New buckets should initialize storage_class_stats as nullopt initially
+  EXPECT_FALSE(header.storage_class_stats.has_value());
+  
+  // After initialization, should have value
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  EXPECT_TRUE(header.storage_class_stats.has_value());
+  EXPECT_TRUE(header.storage_class_stats->empty());
+}
+
+TEST(StorageClassStats, OptionalEmptyVsNull) {
+  rgw_bucket_dir_header legacy_header;
+  rgw_bucket_dir_header new_empty_header;
+  rgw_bucket_dir_header converted_header;
+  
+  // Legacy bucket - nullopt (not converted)
+  EXPECT_FALSE(legacy_header.storage_class_stats.has_value());
+  
+  // New empty bucket - empty map (converted)
+  new_empty_header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  EXPECT_TRUE(new_empty_header.storage_class_stats.has_value());
+  EXPECT_TRUE(new_empty_header.storage_class_stats->empty());
+  
+  // Converted bucket with data
+  converted_header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  rgw_bucket_category_stats stats;
+  stats.num_entries = 10;
+  stats.total_size = 1024;
+  (*converted_header.storage_class_stats)["STANDARD"] = stats;
+  
+  EXPECT_TRUE(converted_header.storage_class_stats.has_value());
+  EXPECT_FALSE(converted_header.storage_class_stats->empty());
+  EXPECT_EQ((*converted_header.storage_class_stats)["STANDARD"].num_entries, 10);
+}
+
+TEST(StorageClassStats, OptionalAfterDeletion) {
+  rgw_bucket_dir_header header;
+  
+  // Initialize with data
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  rgw_bucket_category_stats stats;
+  stats.num_entries = 5;
+  stats.total_size = 2048;
+  (*header.storage_class_stats)["HDD"] = stats;
+  
+  EXPECT_TRUE(header.storage_class_stats.has_value());
+  EXPECT_EQ((*header.storage_class_stats)["HDD"].num_entries, 5);
+  
+  // Simulate deletion - set to 0 but keep entry
+  (*header.storage_class_stats)["HDD"].num_entries = 0;
+  (*header.storage_class_stats)["HDD"].total_size = 0;
+  
+  // Field should still have value (not nullopt)
+  EXPECT_TRUE(header.storage_class_stats.has_value());
+  EXPECT_EQ((*header.storage_class_stats)["HDD"].num_entries, 0);
+  EXPECT_EQ((*header.storage_class_stats)["HDD"].total_size, 0);
+}
+
+TEST(StorageClassStats, UserHeaderOptional) {
+  cls_user_header header;
+  
+  // Should start as nullopt
+  EXPECT_FALSE(header.storage_class_stats.has_value());
+  
+  // Initialize
+  header.storage_class_stats = std::unordered_map<std::string, cls_user_stats>();
+  EXPECT_TRUE(header.storage_class_stats.has_value());
+  
+  // Add stats
+  cls_user_stats user_stats;
+  user_stats.total_entries = 100;
+  user_stats.total_bytes = 10240;
+  (*header.storage_class_stats)["default-placement::STANDARD"] = user_stats;
+  
+  EXPECT_EQ((*header.storage_class_stats)["default-placement::STANDARD"].total_entries, 100);
+}
+
+TEST(StorageClassStats, MultipleStorageClasses) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Add multiple storage classes
+  rgw_bucket_category_stats standard_stats;
+  standard_stats.num_entries = 10;
+  standard_stats.total_size = 5120;
+  
+  rgw_bucket_category_stats hdd_stats;
+  hdd_stats.num_entries = 20;
+  hdd_stats.total_size = 10240;
+  
+  (*header.storage_class_stats)["STANDARD"] = standard_stats;
+  (*header.storage_class_stats)["HDD"] = hdd_stats;
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 2);
+  EXPECT_EQ((*header.storage_class_stats)["STANDARD"].num_entries, 10);
+  EXPECT_EQ((*header.storage_class_stats)["HDD"].num_entries, 20);
+}
+
+TEST(StorageClassStats, SafeAccess) {
+  rgw_bucket_dir_header header;
+  
+  // Accessing without initialization should be safe with has_value check
+  if (header.storage_class_stats.has_value()) {
+    // This should not execute
+    FAIL() << "Should not have value before initialization";
+  }
+  
+  // Initialize
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Now access is safe
+  if (header.storage_class_stats.has_value()) {
+    EXPECT_TRUE(header.storage_class_stats->empty());
+  } else {
+    FAIL() << "Should have value after initialization";
+  }
+}
+
+TEST(StorageClassStats, ResetToNullopt) {
+  rgw_bucket_dir_header header;
+  
+  // Initialize with value
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  (*header.storage_class_stats)["STANDARD"].num_entries = 10;
+  EXPECT_TRUE(header.storage_class_stats.has_value());
+  
+  // Reset to nullopt (simulate legacy bucket state)
+  header.storage_class_stats = std::nullopt;
+  EXPECT_FALSE(header.storage_class_stats.has_value());
+  
+  // Re-initialize
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  EXPECT_TRUE(header.storage_class_stats.has_value());
+  EXPECT_TRUE(header.storage_class_stats->empty()); // Should be empty after reset
+}
+
+TEST(StorageClassStats, EmptyStringStorageClassName) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Test with empty string as storage class name (edge case)
+  rgw_bucket_category_stats stats;
+  stats.num_entries = 5;
+  stats.total_size = 1024;
+  (*header.storage_class_stats)[""] = stats;
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 1);
+  EXPECT_EQ((*header.storage_class_stats)[""].num_entries, 5);
+}
+
+TEST(StorageClassStats, VeryLongStorageClassName) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Test with very long storage class name (1000 characters)
+  std::string long_name(1000, 'A');
+  rgw_bucket_category_stats stats;
+  stats.num_entries = 10;
+  (*header.storage_class_stats)[long_name] = stats;
+  
+  EXPECT_EQ((*header.storage_class_stats)[long_name].num_entries, 10);
+}
+
+TEST(StorageClassStats, SpecialCharactersInName) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Test with special characters
+  std::vector<std::string> special_names = {
+    "STANDARD-IA",
+    "storage_class_1",
+    "storage.class.dots",
+    "storage:class:colons",
+    "UTF8-名称",
+    "with spaces",
+    "with\ttabs",
+    "with\nnewlines"
+  };
+  
+  for (const auto& name : special_names) {
+    rgw_bucket_category_stats stats;
+    stats.num_entries = 1;
+    (*header.storage_class_stats)[name] = stats;
+  }
+  
+  EXPECT_EQ(header.storage_class_stats->size(), special_names.size());
+}
+
+TEST(StorageClassStats, MaximumValues) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Test with maximum uint64_t values
+  rgw_bucket_category_stats stats;
+  stats.num_entries = UINT64_MAX;
+  stats.total_size = UINT64_MAX;
+  stats.total_size_rounded = UINT64_MAX;
+  stats.actual_size = UINT64_MAX;
+  
+  (*header.storage_class_stats)["STANDARD"] = stats;
+  
+  EXPECT_EQ((*header.storage_class_stats)["STANDARD"].num_entries, UINT64_MAX);
+  EXPECT_EQ((*header.storage_class_stats)["STANDARD"].total_size, UINT64_MAX);
+}
+
+TEST(StorageClassStats, ManyStorageClasses) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Test with 100 different storage classes
+  for (int i = 0; i < 100; i++) {
+    std::string name = "SC_" + std::to_string(i);
+    rgw_bucket_category_stats stats;
+    stats.num_entries = i;
+    stats.total_size = i * 1024;
+    (*header.storage_class_stats)[name] = stats;
+  }
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 100);
+  EXPECT_EQ((*header.storage_class_stats)["SC_50"].num_entries, 50);
+  EXPECT_EQ((*header.storage_class_stats)["SC_50"].total_size, 50 * 1024);
+}
+
+TEST(StorageClassStats, OverwriteExistingEntry) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Add entry
+  rgw_bucket_category_stats stats1;
+  stats1.num_entries = 10;
+  stats1.total_size = 1024;
+  (*header.storage_class_stats)["STANDARD"] = stats1;
+  
+  // Overwrite with new values
+  rgw_bucket_category_stats stats2;
+  stats2.num_entries = 20;
+  stats2.total_size = 2048;
+  (*header.storage_class_stats)["STANDARD"] = stats2;
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 1);
+  EXPECT_EQ((*header.storage_class_stats)["STANDARD"].num_entries, 20);
+  EXPECT_EQ((*header.storage_class_stats)["STANDARD"].total_size, 2048);
+}
+
+TEST(StorageClassStats, EraseEntry) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Add multiple entries
+  (*header.storage_class_stats)["STANDARD"].num_entries = 10;
+  (*header.storage_class_stats)["HDD"].num_entries = 20;
+  (*header.storage_class_stats)["GLACIER"].num_entries = 30;
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 3);
+  
+  // Erase one entry
+  header.storage_class_stats->erase("HDD");
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 2);
+  EXPECT_EQ(header.storage_class_stats->count("STANDARD"), 1);
+  EXPECT_EQ(header.storage_class_stats->count("HDD"), 0);
+  EXPECT_EQ(header.storage_class_stats->count("GLACIER"), 1);
+}
+
+TEST(StorageClassStats, ClearAll) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Add entries
+  (*header.storage_class_stats)["STANDARD"].num_entries = 10;
+  (*header.storage_class_stats)["HDD"].num_entries = 20;
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 2);
+  
+  // Clear all entries
+  header.storage_class_stats->clear();
+  
+  EXPECT_TRUE(header.storage_class_stats.has_value()); // Still has_value
+  EXPECT_TRUE(header.storage_class_stats->empty());    // But is empty
+  EXPECT_EQ(header.storage_class_stats->size(), 0);
+}
+
+// ============================================================================
+// COPY/MOVE SEMANTICS TESTS
+// ============================================================================
+
+TEST(StorageClassStats, CopyConstruction) {
+  rgw_bucket_dir_header header1;
+  header1.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  (*header1.storage_class_stats)["STANDARD"].num_entries = 10;
+  
+  // Copy construct
+  rgw_bucket_dir_header header2 = header1;
+  
+  EXPECT_TRUE(header2.storage_class_stats.has_value());
+  EXPECT_EQ((*header2.storage_class_stats)["STANDARD"].num_entries, 10);
+  
+  // Modify copy - original should not change
+  (*header2.storage_class_stats)["STANDARD"].num_entries = 20;
+  EXPECT_EQ((*header1.storage_class_stats)["STANDARD"].num_entries, 10);
+  EXPECT_EQ((*header2.storage_class_stats)["STANDARD"].num_entries, 20);
+}
+
+TEST(StorageClassStats, MoveConstruction) {
+  rgw_bucket_dir_header header1;
+  header1.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  (*header1.storage_class_stats)["STANDARD"].num_entries = 10;
+  
+  // Move construct
+  rgw_bucket_dir_header header2 = std::move(header1);
+  
+  EXPECT_TRUE(header2.storage_class_stats.has_value());
+  EXPECT_EQ((*header2.storage_class_stats)["STANDARD"].num_entries, 10);
+}
+
+TEST(StorageClassStats, CopyAssignment) {
+  rgw_bucket_dir_header header1, header2;
+  header1.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  (*header1.storage_class_stats)["STANDARD"].num_entries = 10;
+  
+  // Copy assign
+  header2 = header1;
+  
+  EXPECT_TRUE(header2.storage_class_stats.has_value());
+  EXPECT_EQ((*header2.storage_class_stats)["STANDARD"].num_entries, 10);
+}
+
+TEST(StorageClassStats, AssignNulloptToValue) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  (*header.storage_class_stats)["STANDARD"].num_entries = 10;
+  
+  EXPECT_TRUE(header.storage_class_stats.has_value());
+  
+  // Assign nullopt (e.g., during legacy bucket handling)
+  header.storage_class_stats = std::nullopt;
+  
+  EXPECT_FALSE(header.storage_class_stats.has_value());
+}
+
+// ============================================================================
+// SERIALIZATION TESTS (Ceph encoding/decoding)
+// ============================================================================
+
+TEST(StorageClassStats, EncodeDecodeWithValue) {
+  rgw_bucket_dir_header original;
+  original.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  (*original.storage_class_stats)["STANDARD"].num_entries = 10;
+  (*original.storage_class_stats)["HDD"].num_entries = 20;
+  
+  // Encode
+  bufferlist bl;
+  encode(original, bl);
+  
+  // Decode
+  rgw_bucket_dir_header decoded;
+  auto iter = bl.cbegin();
+  decode(decoded, iter);
+  
+  // Verify
+  EXPECT_TRUE(decoded.storage_class_stats.has_value());
+  EXPECT_EQ(decoded.storage_class_stats->size(), 2);
+  EXPECT_EQ((*decoded.storage_class_stats)["STANDARD"].num_entries, 10);
+  EXPECT_EQ((*decoded.storage_class_stats)["HDD"].num_entries, 20);
+}
+
+TEST(StorageClassStats, EncodeDecodeNullopt) {
+  rgw_bucket_dir_header original;
+  // Leave storage_class_stats as nullopt
+  
+  // Encode
+  bufferlist bl;
+  encode(original, bl);
+  
+  // Decode
+  rgw_bucket_dir_header decoded;
+  auto iter = bl.cbegin();
+  decode(decoded, iter);
+  
+  // Verify nullopt is preserved
+  EXPECT_FALSE(decoded.storage_class_stats.has_value());
+}
+
+TEST(StorageClassStats, EncodeDecodeEmpty) {
+  rgw_bucket_dir_header original;
+  original.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  // Leave map empty
+  
+  // Encode
+  bufferlist bl;
+  encode(original, bl);
+  
+  // Decode
+  rgw_bucket_dir_header decoded;
+  auto iter = bl.cbegin();
+  decode(decoded, iter);
+  
+  // Verify empty map is preserved (not nullopt)
+  EXPECT_TRUE(decoded.storage_class_stats.has_value());
+  EXPECT_TRUE(decoded.storage_class_stats->empty());
+}
+
+// ============================================================================
+// USER STATS TESTS
+// ============================================================================
+
+TEST(StorageClassStats, UserStatsMultiplePlacements) {
+  cls_user_header header;
+  header.storage_class_stats = std::unordered_map<std::string, cls_user_stats>();
+  
+  // Add stats for multiple placements and storage classes
+  std::vector<std::string> keys = {
+    "default-placement::STANDARD",
+    "default-placement::HDD",
+    "archive-placement::GLACIER",
+    "fast-placement::SSD"
+  };
+  
+  for (size_t i = 0; i < keys.size(); i++) {
+    cls_user_stats stats;
+    stats.total_entries = (i + 1) * 10;
+    stats.total_bytes = (i + 1) * 1024;
+    (*header.storage_class_stats)[keys[i]] = stats;
+  }
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 4);
+  EXPECT_EQ((*header.storage_class_stats)["archive-placement::GLACIER"].total_entries, 30);
+}
+
+// ============================================================================
+// ITERATOR SAFETY TESTS
+// ============================================================================
+
+TEST(StorageClassStats, IterationWhileModifying) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Add initial entries
+  for (int i = 0; i < 10; i++) {
+    (*header.storage_class_stats)["SC_" + std::to_string(i)].num_entries = i;
+  }
+  
+  // Iterate and collect keys
+  std::vector<std::string> keys;
+  for (const auto& [key, value] : *header.storage_class_stats) {
+    keys.push_back(key);
+  }
+  
+  EXPECT_EQ(keys.size(), 10);
+}
+
+TEST(StorageClassStats, SafeIterationWithHasValue) {
+  rgw_bucket_dir_header header;
+
+  // Should be nullopt initially
+  EXPECT_FALSE(header.storage_class_stats.has_value());
+
+  // Initialize and iterate
+  header.storage_class_stats =
+      std::unordered_map<std::string, rgw_bucket_category_stats>();
+  (*header.storage_class_stats)["STANDARD"].num_entries = 10;
+
+  ASSERT_TRUE(header.storage_class_stats.has_value());
+
+  int count = 0;
+  for (const auto& [key, value] : *header.storage_class_stats) {
+    count++;
+    EXPECT_EQ(key, "STANDARD");
+    EXPECT_EQ(value.num_entries, 10);
+  }
+
+  EXPECT_EQ(count, 1);
+}
+
+// ============================================================================
+// THREAD SAFETY TESTS (Basic)
+// ============================================================================
+
+TEST(StorageClassStats, ConcurrentReads) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  (*header.storage_class_stats)["STANDARD"].num_entries = 100;
+  (*header.storage_class_stats)["HDD"].num_entries = 200;
+  
+  // Multiple threads reading simultaneously
+  std::vector<std::thread> threads;
+  std::atomic<int> success_count{0};
+  
+  for (int i = 0; i < 10; i++) {
+    threads.emplace_back([&header, &success_count]() {
+      if (header.storage_class_stats.has_value()) {
+        if (header.storage_class_stats->count("STANDARD") > 0) {
+          auto val = (*header.storage_class_stats)["STANDARD"].num_entries;
+          if (val == 100) {
+            success_count++;
+          }
+        }
+      }
+    });
+  }
+  
+  for (auto& t : threads) {
+    t.join();
+  }
+  
+  EXPECT_EQ(success_count, 10);
+}
+
+// ============================================================================
+// BOUNDARY CONDITION TESTS
+// ============================================================================
+
+TEST(StorageClassStats, ZeroValues) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // All zero values
+  rgw_bucket_category_stats stats;
+  stats.num_entries = 0;
+  stats.total_size = 0;
+  stats.total_size_rounded = 0;
+  stats.actual_size = 0;
+  
+  (*header.storage_class_stats)["STANDARD"] = stats;
+  
+  EXPECT_EQ((*header.storage_class_stats)["STANDARD"].num_entries, 0);
+  EXPECT_TRUE(header.storage_class_stats.has_value()); // Still has_value even with 0
+}
+
+TEST(StorageClassStats, ValueOrAlternative) {
+  rgw_bucket_dir_header header1, header2;
+  
+  // header1 is nullopt
+  auto map1 = header1.storage_class_stats.value_or(
+    std::unordered_map<std::string, rgw_bucket_category_stats>()
+  );
+  EXPECT_TRUE(map1.empty());
+  
+  // header2 has value
+  header2.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  (*header2.storage_class_stats)["STANDARD"].num_entries = 10;
+  
+  auto map2 = header2.storage_class_stats.value_or(
+    std::unordered_map<std::string, rgw_bucket_category_stats>()
+  );
+  EXPECT_EQ(map2.size(), 1);
+  EXPECT_EQ(map2["STANDARD"].num_entries, 10);
+}
+
+// ============================================================================
+// REGRESSION TESTS
+// ============================================================================
+
+TEST(StorageClassStats, DereferenceSafety) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Test all dereference operators work correctly
+  EXPECT_NO_THROW({
+    (*header.storage_class_stats)["STANDARD"].num_entries = 10;  // operator*
+    header.storage_class_stats->size();                          // operator->
+  });
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 1);
+  EXPECT_EQ((*header.storage_class_stats)["STANDARD"].num_entries, 10);
+}
+
+// ============================================================================
+// PERFORMANCE BENCHMARK TESTS
+// ============================================================================
+
+TEST(StorageClassStats, BenchmarkLargeScale) {
+  using namespace std::chrono;
+  
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  auto start = high_resolution_clock::now();
+  
+  // Add 10,000 storage classes
+  for (int i = 0; i < 10000; i++) {
+    std::string name = "STORAGE_CLASS_" + std::to_string(i);
+    rgw_bucket_category_stats stats;
+    stats.num_entries = i;
+    stats.total_size = i * 1024;
+    (*header.storage_class_stats)[name] = stats;
+  }
+  
+  auto end = high_resolution_clock::now();
+  auto duration = duration_cast<microseconds>(end - start).count();
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 10000);
+  std::cout << "Added 10,000 storage classes in " << duration << " µs" << std::endl;
+  
+  // Should complete in under 100ms
+  EXPECT_LT(duration, 100000); // 100ms in microseconds
+}
+
+TEST(StorageClassStats, BenchmarkIteration) {
+  using namespace std::chrono;
+  
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Setup: 1000 storage classes
+  for (int i = 0; i < 1000; i++) {
+    (*header.storage_class_stats)["SC_" + std::to_string(i)].num_entries = i;
+  }
+  
+  auto start = high_resolution_clock::now();
+  
+  // Iterate 1000 times
+  uint64_t sum = 0;
+  for (int iteration = 0; iteration < 1000; iteration++) {
+    if (header.storage_class_stats.has_value()) {
+      for (const auto& [key, value] : *header.storage_class_stats) {
+        sum += value.num_entries;
+      }
+    }
+  }
+  
+  auto end = high_resolution_clock::now();
+  auto duration = duration_cast<microseconds>(end - start).count();
+  
+  std::cout << "1000 iterations over 1000 entries in " << duration << " µs" << std::endl;
+  EXPECT_LT(duration, 50000); // Should be under 50ms
+  EXPECT_GT(sum, 0); // Make sure loop ran
+}
+
+TEST(StorageClassStats, BenchmarkSerialization) {
+  using namespace std::chrono;
+  
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Add 100 storage classes
+  for (int i = 0; i < 100; i++) {
+    (*header.storage_class_stats)["SC_" + std::to_string(i)].num_entries = i * 100;
+    (*header.storage_class_stats)["SC_" + std::to_string(i)].total_size = i * 1024 * 1024;
+  }
+  
+  auto start = high_resolution_clock::now();
+  
+  // Encode/decode 100 times
+  for (int i = 0; i < 100; i++) {
+    bufferlist bl;
+    encode(header, bl);
+    
+    rgw_bucket_dir_header decoded;
+    auto iter = bl.cbegin();
+    decode(decoded, iter);
+  }
+  
+  auto end = high_resolution_clock::now();
+  auto duration = duration_cast<microseconds>(end - start).count();
+  
+  std::cout << "100 encode/decode cycles in " << duration << " µs" << std::endl;
+  EXPECT_LT(duration, 10000); // Should be under 10ms
+}
+
+TEST(StorageClassStats, BenchmarkMemoryUsage) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  size_t initial_size = sizeof(header);
+  std::cout << "Header base size: " << initial_size << " bytes" << std::endl;
+  
+  // Add varying numbers of storage classes and measure
+  std::vector<int> sizes = {1, 10, 100, 1000};
+  
+  for (int size : sizes) {
+    rgw_bucket_dir_header test_header;
+    test_header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+    
+    for (int i = 0; i < size; i++) {
+      (*test_header.storage_class_stats)["SC_" + std::to_string(i)].num_entries = i;
+    }
+    
+    bufferlist bl;
+    encode(test_header, bl);
+    
+    std::cout << "  " << size << " storage classes: " << bl.length() << " bytes encoded" << std::endl;
+  }
+  
+  SUCCEED(); // Informational test
+}
+
+// ============================================================================
+// STRESS TESTS
+// ============================================================================
+
+TEST(StorageClassStats, StressTestRapidChanges) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Rapidly add and remove storage classes
+  for (int cycle = 0; cycle < 100; cycle++) {
+    // Add 50
+    for (int i = 0; i < 50; i++) {
+      std::string name = "SC_" + std::to_string(cycle) + "_" + std::to_string(i);
+      (*header.storage_class_stats)[name].num_entries = i;
+    }
+    
+    // Remove half
+    int removed = 0;
+    for (auto it = header.storage_class_stats->begin(); 
+         it != header.storage_class_stats->end() && removed < 25; ) {
+      it = header.storage_class_stats->erase(it);
+      removed++;
+    }
+  }
+  
+  // Should still be valid
+  EXPECT_TRUE(header.storage_class_stats.has_value());
+  std::cout << "Final size after stress test: " 
+            << header.storage_class_stats->size() << " entries" << std::endl;
+}
+
+TEST(StorageClassStats, StressTestDeepCopy) {
+  rgw_bucket_dir_header original;
+  original.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Add 100 entries
+  for (int i = 0; i < 100; i++) {
+    (*original.storage_class_stats)["SC_" + std::to_string(i)].num_entries = i;
+  }
+  
+  // Make 1000 copies
+  std::vector<rgw_bucket_dir_header> copies;
+  for (int i = 0; i < 1000; i++) {
+    copies.push_back(original);
+  }
+  
+  // Verify all copies are valid
+  for (const auto& copy : copies) {
+    EXPECT_TRUE(copy.storage_class_stats.has_value());
+    EXPECT_EQ(copy.storage_class_stats->size(), 100);
+  }
+  
+  std::cout << "Successfully created 1000 deep copies" << std::endl;
+}


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
