### PR TITLE
crimson/os,tools,qa: fix crimson-objectstore-tool tests

### DIFF
--- a/qa/suites/crimson-rados/objectstore_tool/tasks/crimson_obejctstore_tool.yaml
+++ b/qa/suites/crimson-rados/objectstore_tool/tasks/crimson_obejctstore_tool.yaml
@@ -11,6 +11,7 @@ overrides:
 tasks:
 - ceph_objectstore_tool:
     crimson_objectstore_tool: true
+    gc_before_restart: true
     objects: 5
     pgnum: 8
 

--- a/qa/suites/crimson-rados/objectstore_tool/tasks/crimson_obejctstore_tool.yaml
+++ b/qa/suites/crimson-rados/objectstore_tool/tasks/crimson_obejctstore_tool.yaml
@@ -1,5 +1,8 @@
 overrides:
   ceph:
+    conf:
+      osd:
+        seastore_segment_size: 16777216
     log-ignorelist:
     - but it is still running
     - overall HEALTH_

--- a/qa/tasks/ceph_objectstore_tool.py
+++ b/qa/tasks/ceph_objectstore_tool.py
@@ -706,19 +706,17 @@ def test_objectstore(ctx, config, cli_remote, REP_POOL, REP_NAME, ec=False):
         if CRIMSON and config.get('gc_before_restart', False):
             # Run GC on each OSD's seastore to reclaim segments consumed
             # by repeated tool mount/unmount cycles before restarting.
-            log.info("Running GC on each OSD store...")
+            gc_timeout = config.get('gc_timeout', 120)
+            log.info("Running GC on each OSD store (timeout={})...".format(
+                gc_timeout))
             for remote in osds.remotes.keys():
                 for role in osds.remotes[remote]:
                     if not role.startswith("osd."):
                         continue
                     osdid = int(role.split('.')[1])
-                    cmd = (prefix + "--op gc").format(id=osdid)
-                    try:
-                        remote.sh(cmd, wait=True)
-                    except CommandFailedError as e:
-                        log.warning(
-                            "GC failed on osd.{id} with {ret}".format(
-                                id=osdid, ret=e.exitstatus))
+                    cmd = ("timeout {timeout} " + prefix + "--op gc").format(
+                        timeout=gc_timeout, id=osdid)
+                    remote.sh(cmd, wait=True)
 
         log.info("Restarting OSDs....")
         # They are still look to be up because of setting nodown

--- a/qa/tasks/ceph_objectstore_tool.py
+++ b/qa/tasks/ceph_objectstore_tool.py
@@ -169,6 +169,7 @@ def task(ctx, config):
           objects: 20 # <number of objects>
           pgnum: 12
           crimson_objectstore_tool: true # use crimson-objectstore-tool instead of ceph-objectstore-tool
+          gc_before_restart: true # run crimson-objectstore-tool --op gc before restarting OSDs
     """
 
     if config is None:
@@ -702,6 +703,23 @@ def test_objectstore(ctx, config, cli_remote, REP_POOL, REP_NAME, ec=False):
     ERRORS += IMP_ERRORS
 
     if EXP_ERRORS == 0 and RM_ERRORS == 0 and IMP_ERRORS == 0:
+        if CRIMSON and config.get('gc_before_restart', False):
+            # Run GC on each OSD's seastore to reclaim segments consumed
+            # by repeated tool mount/unmount cycles before restarting.
+            log.info("Running GC on each OSD store...")
+            for remote in osds.remotes.keys():
+                for role in osds.remotes[remote]:
+                    if not role.startswith("osd."):
+                        continue
+                    osdid = int(role.split('.')[1])
+                    cmd = (prefix + "--op gc").format(id=osdid)
+                    try:
+                        remote.sh(cmd, wait=True)
+                    except CommandFailedError as e:
+                        log.warning(
+                            "GC failed on osd.{id} with {ret}".format(
+                                id=osdid, ret=e.exitstatus))
+
         log.info("Restarting OSDs....")
         # They are still look to be up because of setting nodown
         for osd in manager.get_osd_status()['up']:

--- a/src/crimson/os/futurized_store.h
+++ b/src/crimson/os/futurized_store.h
@@ -258,6 +258,10 @@ public:
   virtual seastar::future<std::vector<coll_core_t>> list_collections() = 0;
 
   virtual seastar::future<std::string> get_default_device_class() = 0;
+
+  /// Run garbage collection on all shards until space ratios are acceptable.
+  /// Default implementation is a no-op (for stores that don't need GC).
+  virtual seastar::future<> do_gc() { return seastar::now(); }
 protected:
   const core_id_t primary_core;
 };

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -699,6 +699,30 @@ ExtentPlacementManager::BackgroundProcess::run_until_halt()
 }
 
 seastar::future<>
+ExtentPlacementManager::BackgroundProcess::run_cleaner_until_done()
+{
+  LOG_PREFIX(BackgroundProcess::run_cleaner_until_done);
+  ceph_assert(state == state_t::HALT);
+  assert(!is_running());
+  INFO("started...");
+  return seastar::do_until(
+    [this] {
+      return !main_cleaner->should_clean_space();
+    },
+    [this] {
+      return main_cleaner->clean_space(
+      ).handle_error(
+        crimson::ct_error::assert_all{
+          "run_cleaner_until_done encountered error in clean_space"
+        }
+      );
+    }
+  ).finally([FNAME] {
+    INFO("finished");
+  });
+}
+
+seastar::future<>
 ExtentPlacementManager::BackgroundProcess::reserve_projected_usage(
     io_usage_t usage)
 {

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -594,6 +594,10 @@ public:
     return background_process.run_until_halt();
   }
 
+  seastar::future<> run_cleaner_until_done() {
+    return background_process.run_cleaner_until_done();
+  }
+
   bool get_checksum_needed(paddr_t addr) {
     // checksum offloading only for blocks physically stored in the device
 #ifdef UNIT_TESTS_BUILT
@@ -878,7 +882,8 @@ private:
     }
 
     seastar::future<> run_until_halt();
-    
+    seastar::future<> run_cleaner_until_done();
+
     bool is_no_background() const {
       return !trimmer || !main_cleaner;
     }

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -882,6 +882,7 @@ private:
     }
 
     seastar::future<> run_until_halt();
+
     seastar::future<> run_cleaner_until_done();
 
     bool is_no_background() const {

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -413,6 +413,31 @@ base_ertr::future<> SeaStore::Shard::umount()
   onode_manager.reset();
 }
 
+seastar::future<> SeaStore::Shard::do_gc()
+{
+  LOG_PREFIX(SeaStore::Shard::do_gc);
+  if (!store_active || !transaction_manager) {
+    co_return;
+  }
+  auto *epm = transaction_manager->get_epm();
+  INFO("stopping background and running cleaner...");
+  co_await epm->stop_background();
+  co_await epm->run_cleaner_until_done();
+  INFO("done");
+}
+
+seastar::future<> SeaStore::do_gc()
+{
+  LOG_PREFIX(SeaStore::do_gc);
+  INFO("...");
+  co_await shard_stores.invoke_on_all([](auto &local_store) {
+    return seastar::do_for_each(local_store.mshard_stores, [](auto& mshard_store) {
+      return mshard_store->do_gc();
+    });
+  });
+  INFO("done");
+}
+
 seastar::future<> SeaStore::write_fsid(uuid_d new_osd_fsid)
 {
   ceph_assert(seastar::this_shard_id() == primary_core);

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -190,6 +190,7 @@ public:
   // only exposed to SeaStore
   public:
     base_ertr::future<> umount();
+    seastar::future<> do_gc();
     // init managers and mount transaction_manager
     seastar::future<> mount_managers();
 
@@ -592,6 +593,8 @@ public:
   seastar::future<std::vector<coll_core_t>> list_collections() override;
 
   seastar::future<std::string> get_default_device_class() final;
+
+  seastar::future<> do_gc() override;
 
   BackendStore get_backend_store(store_index_t store_index) override {
     assert(!shard_stores.local().mshard_stores.empty());

--- a/src/crimson/tools/objectstore/crimson_objectstore_tool.cc
+++ b/src/crimson/tools/objectstore/crimson_objectstore_tool.cc
@@ -92,6 +92,9 @@ enum class operation_type_t {
 
   // Device-inspection operations (--op)
   DUMP_SUPERBLOCK,
+
+  // Maintenance operations (--op)
+  GC,
 };
 
 std::string to_string(operation_type_t op) {
@@ -115,6 +118,7 @@ std::string to_string(operation_type_t op) {
     case operation_type_t::SET_SIZE: return "set-size";
     case operation_type_t::CLEAR_DATA_DIGEST: return "clear-data-digest";
     case operation_type_t::DUMP_SUPERBLOCK: return "dump-superblock";
+    case operation_type_t::GC: return "gc";
     default: return "unknown";
   }
 }
@@ -124,6 +128,7 @@ tl::expected<operation_type_t, std::string> parse_pg_operation(const std::string
   if (op_str == "list") return operation_type_t::LIST_OBJECTS;
   if (op_str == "info") return operation_type_t::INFO;
   if (op_str == "dump-superblock") return operation_type_t::DUMP_SUPERBLOCK;
+  if (op_str == "gc") return operation_type_t::GC;
   return tl::unexpected("Unsupported PG operation: " + op_str);
 }
 
@@ -723,7 +728,8 @@ seastar::future<int> run_tool(StoreTool& st, objectstore_config_t& config) {
 
   // Resolve object and pgid before executing operations
   if (config.operation->op != operation_type_t::LIST_PGS &&
-      config.operation->op != operation_type_t::DUMP_SUPERBLOCK) {
+      config.operation->op != operation_type_t::DUMP_SUPERBLOCK &&
+      config.operation->op != operation_type_t::GC) {
     bool resolved = co_await resolve_operation_parameters(st, config);
     if (!resolved) {
       co_return EXIT_FAILURE;
@@ -993,6 +999,11 @@ seastar::future<int> run_tool(StoreTool& st, objectstore_config_t& config) {
         fmt::println(std::cerr, "clear data digest failed");
         co_return EXIT_FAILURE;
       }
+      break;
+    }
+
+    case operation_type_t::GC: {
+      co_await st.do_gc();
       break;
     }
 

--- a/src/crimson/tools/objectstore/objectstore_tool.cc
+++ b/src/crimson/tools/objectstore/objectstore_tool.cc
@@ -26,6 +26,11 @@ seastar::future<> StoreTool::stop()
   co_return;
 }
 
+seastar::future<> StoreTool::do_gc()
+{
+  co_await store->do_gc();
+}
+
 seastar::future<std::vector<crimson::os::coll_core_t>> StoreTool::list_pgs()
 {
   co_return co_await store->list_collections();

--- a/src/crimson/tools/objectstore/objectstore_tool.h
+++ b/src/crimson/tools/objectstore/objectstore_tool.h
@@ -25,6 +25,7 @@ public:
   StoreTool(std::unique_ptr<crimson::os::FuturizedStore> store): store(std::move(store)) {}
 
   seastar::future<> stop();
+  seastar::future<> do_gc();
   void set_shard_id(seastar::shard_id shard_id) { this->shard_id = shard_id; }
   
   // PG operations


### PR DESCRIPTION
The ceph_objectstore_tool test is hitting space exhaustion on restart
due to segment pressure. In the test scenario, the GC is never given
a chance to run and free up segments.

This change add a new GC operation to Seastore and the
crimson-objectstore-tool, allowing us to trigger GC cycles
on demand. The test is updated to run GC before restarting
the OSDs.

Fixes: https://tracker.ceph.com/issues/73101