### PR TITLE
tentacle: mgr/dashboard : add stretch cluster validation for pools form

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form-data.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form-data.ts
@@ -1,7 +1,7 @@
 import { Validators } from '@angular/forms';
 
 import { SelectMessages } from '~/app/shared/components/select/select-messages.model';
-import { Pool } from '../pool';
+import { Pool, PoolType } from '../pool';
 
 export class PoolFormData {
   poolTypes: string[];
@@ -10,13 +10,13 @@ export class PoolFormData {
   applications: any;
 
   readonly APP_LABELS: Record<string, string> = {
-    cephfs: $localize`Filesystem (CephFS)`,
+    cephfs: $localize`File system (CephFS)`,
     rbd: $localize`Block (RBD)`,
     rgw: $localize`Object (RGW)`
   };
 
   constructor() {
-    this.poolTypes = ['erasure', 'replicated'];
+    this.poolTypes = [PoolType.ERASURE, PoolType.REPLICATED];
     this.applications = {
       selected: [],
       default: ['cephfs', 'rbd', 'rgw'],

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form-data.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form-data.ts
@@ -10,9 +10,9 @@ export class PoolFormData {
   applications: any;
 
   readonly APP_LABELS: Record<string, string> = {
-    cephfs: 'Filesystem',
-    rbd: 'Block',
-    rgw: 'Object'
+    cephfs: $localize`Filesystem (CephFS)`,
+    rbd: $localize`Block (RBD)`,
+    rgw: $localize`Object (RGW)`
   };
 
   constructor() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -15,6 +15,11 @@
         class="form-header"
       >
         {{ action | titlecase }} {{ resource | upperFirst }}
+      @if (isStretchMode) {
+      <cd-help-text>
+        Stretch cluster is enabled. Only replicated pool type is supported in Stretch mode.
+      </cd-help-text>
+      }
       </div>
       <!-- Name -->
       <div
@@ -93,6 +98,32 @@
           >
             Pool type
           </legend>
+          @if (isStretchMode) {
+          <cds-tooltip
+            description="In stretch mode, only replicated pool type is supported."
+            placement="right"
+            [highContrast]="true"
+            [caret]="true"
+          >
+            <cds-radio-group
+              formControlName="poolType"
+              cdRequiredField="Pool type"
+              data-testid="pool-type-select"
+            >
+              @for (poolType of data.poolTypes; track poolType) {
+              <cds-radio
+                [value]="poolType"
+                [id]="poolType"
+                [disabled]="isStretchMode && !editing && poolType === 'erasure'"
+                (change)="data.erasureInfo = false; data.crushInfo = false;"
+                i18n
+              >
+                {{ poolType | upperFirst }}
+              </cds-radio>
+              }
+            </cds-radio-group>
+          </cds-tooltip>
+          } @else {
           <cds-radio-group
             formControlName="poolType"
             cdRequiredField="Pool type"
@@ -102,6 +133,7 @@
             <cds-radio
               [value]="poolType"
               [id]="poolType"
+              [disabled]="isStretchMode && !editing && poolType === 'erasure'"
               (change)="data.erasureInfo = false; data.crushInfo = false;"
               i18n
             >
@@ -109,6 +141,7 @@
             </cds-radio>
             }
           </cds-radio-group>
+          }
           @if (form.showError('poolType', formDir, 'required')) {
           <span
             class="cds--form-requirement invalid-feedback"
@@ -262,6 +295,11 @@
               }
             </ng-template>
             <ng-template #sizeWarning>
+              @if (isStretchMode) {
+              <span i18n>
+                The replicated size value is predefined for stretch cluster
+              </span>
+              }
               @if (form.getValue('size') === 1) {
               <span
                 class="text-warning-dark"
@@ -620,10 +658,14 @@
             [columnNumbers]="{ lg: 13 }"
           >
             <cds-select
+              cdValidate
+              #crushRuleRef="cdValidate"
               formControlName="crushRule"
               label="Crush ruleset"
               i18n-label
               id="crushRule"
+              [invalid]="crushRuleRef.isInvalid"
+              [invalidText]="crushRuleError"
             >
               <option [value]="null"
                       i18n>-- Select a crush rule --
@@ -634,6 +676,16 @@
               </option>
               }
             </cds-select>
+            <ng-template #crushRuleError>
+              @if (form.showError('crushRule', formDir, 'required')) {
+              <span
+                class="invalid-feedback"
+                i18n
+              >
+                This field is required!
+              </span>
+              }
+            </ng-template>
           </div>
           } @else {
           <div cdsCol>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -269,28 +269,12 @@
             </cds-number>
             <ng-template #sizeError>
               @if (form.showError('size', formDir)) {
-              <span class="invalid-feedback">
-                <ul class="list-inline">
-                  <li
-                    i18n
-                  >
-                    Minimum: {{ getMinSize() }}
-                  </li>
-                  <li
-                    i18n
-                  >
-                    Maximum: {{ getMaxSize() }}
-                  </li>
-                </ul>
-              </span>
-              }
-              @if (form.showError('size', formDir)) {
               <span
                 class="invalid-feedback"
                 i18n
               >
-                The size specified is out of range. A value from {{ getMinSize() }} to
-                {{ getMaxSize() }} is usable.
+                Invalid input. Replicated size must be between {{ getMinSize() }} and
+                {{ getMaxSize() }}.
               </span>
               }
             </ng-template>
@@ -667,9 +651,6 @@
               [invalid]="crushRuleRef.isInvalid"
               [invalidText]="crushRuleError"
             >
-              <option [value]="null"
-                      i18n>-- Select a crush rule --
-              </option>
               @for (rule of current.rules; track rule.rule_name) {
               <option [value]="rule.rule_name">
                 {{ rule.rule_name }}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
@@ -26,7 +26,7 @@ import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { SharedModule } from '~/app/shared/shared.module';
 import { configureTestBed, FixtureHelper, FormHelper, Mocks } from '~/testing/unit-test-helper';
-import { Pool } from '../pool';
+import { Pool, PoolType } from '../pool';
 import { PoolModule } from '../pool.module';
 import { PoolFormComponent } from './pool-form.component';
 
@@ -228,8 +228,8 @@ describe('PoolFormComponent', () => {
       expect(form.valid).toBeFalsy();
       // With default poolType 'replicated', expect 'name' required.
       ['name'].forEach((name) => formHelper.expectError(name, 'required'));
-      // For replicated type with multiple crush rules, 'crushRule' is required.
-      formHelper.expectError('crushRule', 'required');
+      // crushRule is auto-selected when replicated rules exist, so it is valid.
+      formHelper.expectValid('crushRule');
       // Other fields are valid by default.
       ['size', 'erasureProfile', 'ecOverwrites'].forEach((name) => formHelper.expectValid(name));
       expect(component.form.get('compression').valid).toBeTruthy();
@@ -249,13 +249,18 @@ describe('PoolFormComponent', () => {
     });
 
     it('validates poolType', () => {
-      // Default is 'replicated' now, so just verify switching remains valid
+      // Default is replicated; the control is not empty, so there is no required error.
+      formHelper.expectValid('poolType');
+      expect(form.getValue('poolType')).toBe(PoolType.REPLICATED);
       formHelper.expectValidChange('poolType', 'erasure');
       formHelper.expectValidChange('poolType', 'replicated');
     });
 
     it('validates that pgNum is required creation mode', () => {
-      formHelper.setValue('pgNum', '');
+      // After getInfo(), pgCalc() fills pgNum automatically; clear and mark dirty so
+      // auto-calc does not overwrite empty (see poolTypeChange / pgCalc guards).
+      formHelper.setValue('pgNum', '', true);
+      fixture.detectChanges();
       formHelper.expectError(form.get('pgNum'), 'required');
     });
 
@@ -279,10 +284,13 @@ describe('PoolFormComponent', () => {
       expect(form.valid).toBeTruthy();
     });
 
-    it('validates crushRule with multiple crush rules', () => {
+    it('auto-selects `crushRule` with multiple crush rules', () => {
       formHelper.expectValidChange('poolType', 'replicated');
       form.get('crushRule').updateValueAndValidity();
-      formHelper.expectError('crushRule', 'required'); // As multiple rules exist
+      expect(form.getValue('crushRule')).toEqual(
+        component.info.crush_rules_replicated[0].rule_name
+      );
+      formHelper.expectValid('crushRule');
     });
 
     it('validates crushRule with no crush rules', () => {
@@ -513,10 +521,22 @@ describe('PoolFormComponent', () => {
         expect(control.disabled).toBe(true);
       });
 
-      it('does not select the first rule if more than one exist', () => {
+      it('selects the first rule if `replicated_rule` does not exist', () => {
         formHelper.setValue('poolType', 'replicated');
         const control = form.get('crushRule');
-        expect(control.value).toEqual(null);
+        expect(control.value).toEqual(component.info.crush_rules_replicated[0].rule_name);
+        expect(control.disabled).toBe(false);
+      });
+
+      it('selects `replicated_rule` by default when available', () => {
+        infoReturn.crush_rules_replicated = [
+          Mocks.getCrushRule({ id: 0, name: 'rep1', type: 'replicated' }),
+          Mocks.getCrushRule({ id: 1, name: 'replicated_rule', type: 'replicated' }),
+          Mocks.getCrushRule({ id: 2, name: 'rep2', type: 'replicated' })
+        ];
+        setUpPoolComponent();
+        const control = form.get('crushRule');
+        expect(control.value).toEqual('replicated_rule');
         expect(control.disabled).toBe(false);
       });
 
@@ -546,6 +566,7 @@ describe('PoolFormComponent', () => {
     });
 
     it('returns 1 as minimum and 3 as maximum if no crush rule is available', () => {
+      component.selectedCrushRule = undefined;
       expect(component.getMinSize()).toBe(1);
       expect(component.getMaxSize()).toBe(3);
     });
@@ -746,7 +767,7 @@ describe('PoolFormComponent', () => {
       });
 
       const getValidCase = () => ({
-        type: 'replicated',
+        type: PoolType.REPLICATED,
         osds: OSDS,
         size: 4,
         ecp: {
@@ -777,7 +798,7 @@ describe('PoolFormComponent', () => {
         form.get('pgNum').markAsPristine();
         fixture.detectChanges();
 
-        if (type === 'replicated') {
+        if (type === PoolType.REPLICATED) {
           // Set a valid crush rule for replicated pools
           if (
             component.info.crush_rules_replicated &&
@@ -791,7 +812,7 @@ describe('PoolFormComponent', () => {
           // Explicitly call pgCalc() to ensure calculation happens with new values
           component['pgCalc']();
           fixture.detectChanges();
-        } else if (type === 'erasure') {
+        } else if (type === PoolType.ERASURE) {
           // For erasure code, initialize an ECP with the given k/m values
           if (ecp) {
             component['initEcp']([
@@ -814,7 +835,7 @@ describe('PoolFormComponent', () => {
 
       // TODO: These tests have state pollution from parent beforeEach that sets invalid crushRule
       it.skip('does not change anything if type is not valid', () => {
-        const test = getValidCase();
+        const test: Record<string, any> = getValidCase();
         test.type = '';
         test.expected = PGS;
         testPgCalc(test);
@@ -823,7 +844,7 @@ describe('PoolFormComponent', () => {
       it.skip('does not change anything if ecp is not valid', () => {
         const test = getValidCase();
         test.expected = PGS;
-        test.type = 'erasure';
+        test.type = PoolType.ERASURE;
         test.ecp = null;
         testPgCalc(test);
       });
@@ -851,14 +872,14 @@ describe('PoolFormComponent', () => {
       it('calculates erasure code values even if selection is disabled', () => {
         component['initEcp']([{ k: 2, m: 2, name: 'bla', plugin: '', technique: '' }]);
         const test = getValidCase();
-        test.type = 'erasure';
+        test.type = PoolType.ERASURE;
         testPgCalc(test);
         expect(form.get('erasureProfile').disabled).toBeTruthy();
       });
 
       it('calculates some erasure code values', () => {
         const test = getValidCase();
-        test.type = 'erasure';
+        test.type = PoolType.ERASURE;
         testPgCalc(test);
         test.osds = 16;
         test.ecp.m = 5;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
@@ -367,7 +367,7 @@ export class PoolFormComponent extends CdForm implements OnInit {
     const selectedApps = this.data.applications.selected || [];
     this.data.applications.available = _.uniq(apps.sort()).map((x: string) => {
       const option = new SelectOption(selectedApps.includes(x), x, this.data.APP_LABELS?.[x] || x);
-      (option as any).content = x;
+      (option as any).content = this.data.APP_LABELS?.[x] || x;
       return option;
     });
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
@@ -27,7 +27,6 @@ import { CrushRule } from '~/app/shared/models/crush-rule';
 import { CrushStep } from '~/app/shared/models/crush-step';
 import { ErasureCodeProfile } from '~/app/shared/models/erasure-code-profile';
 import { FinishedTask } from '~/app/shared/models/finished-task';
-import { Permission } from '~/app/shared/models/permissions';
 import { PoolFormInfo } from '~/app/shared/models/pool-form-info';
 import { DimlessBinaryPipe } from '~/app/shared/pipes/dimless-binary.pipe';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
@@ -41,6 +40,7 @@ import { PoolEditModeResponseModel } from '../../block/mirroring/pool-edit-mode-
 import { RbdMirroringService } from '~/app/shared/api/rbd-mirroring.service';
 import { MonitorService } from '~/app/shared/api/monitor.service';
 import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
+import { Permissions } from '~/app/shared/models/permissions';
 
 interface FormFieldDescription {
   externalFieldName: string;
@@ -72,7 +72,7 @@ export class PoolFormComponent extends CdForm implements OnInit {
 
   isFormSubmitted = false;
 
-  permission: Permission;
+  permissions: Permissions;
   form: CdFormGroup;
   ecProfiles: ErasureCodeProfile[];
   selectedEcp: ErasureCodeProfile;
@@ -138,11 +138,11 @@ export class PoolFormComponent extends CdForm implements OnInit {
   }
 
   authenticate() {
-    this.permission = this.authStorageService.getPermissions().pool;
+    this.permissions = this.authStorageService.getPermissions();
     if (
-      !this.permission.read ||
-      (!this.permission.update && this.editing) ||
-      (!this.permission.create && !this.editing)
+      !this.permissions?.pool?.read ||
+      (!this.permissions?.pool?.update && this.editing) ||
+      (!this.permissions?.pool?.create && !this.editing)
     ) {
       throw new DashboardNotFoundError();
     }
@@ -221,13 +221,15 @@ export class PoolFormComponent extends CdForm implements OnInit {
   }
 
   ngOnInit() {
-    this.monitorService.getMonitor().subscribe((data: MonitorResponse) => {
-      this.isStretchMode = data?.mon_status?.stretch_mode || false;
-      if (this.isStretchMode) {
-        this.applyStretchModeRestrictions();
-      }
-      this.replicatedRuleChange();
-    });
+    if (this.permissions?.monitor?.read) {
+      this.monitorService.getMonitor().subscribe((data: MonitorResponse) => {
+        this.isStretchMode = data?.mon_status?.stretch_mode || false;
+        if (this.isStretchMode) {
+          this.applyStretchModeRestrictions();
+        }
+        this.replicatedRuleChange();
+      });
+    }
     this.poolService.getInfo().subscribe((info: PoolFormInfo) => {
       this.initInfo(info);
       if (this.editing) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
@@ -39,6 +39,7 @@ import { Pool } from '../pool';
 import { PoolFormData } from './pool-form-data';
 import { PoolEditModeResponseModel } from '../../block/mirroring/pool-edit-mode-modal/pool-edit-mode-response.model';
 import { RbdMirroringService } from '~/app/shared/api/rbd-mirroring.service';
+import { MonitorService } from '~/app/shared/api/monitor.service';
 import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 
 interface FormFieldDescription {
@@ -48,6 +49,12 @@ interface FormFieldDescription {
   replaceFn?: Function;
   editable?: boolean;
   resetValue?: any;
+}
+
+interface MonitorResponse {
+  mon_status?: {
+    stretch_mode?: boolean;
+  };
 }
 
 @Component({
@@ -95,6 +102,12 @@ export class PoolFormComponent extends CdForm implements OnInit {
   DEFAULT_RATIO = 0.875;
   isApplicationsSelected = true;
   msrCrush: boolean = false;
+  isStretchMode: boolean = false;
+
+  readonly DEFAULT_REPLICATED_MIN_SIZE = 1;
+  readonly DEFAULT_REPLICATED_MAX_SIZE = 3;
+  readonly STRETCH_REPLICATED_MIN_SIZE = 2;
+  readonly STRETCH_REPLICATED_MAX_SIZE = 4;
 
   private modalSubscription: Subscription;
 
@@ -111,6 +124,7 @@ export class PoolFormComponent extends CdForm implements OnInit {
     private crushRuleService: CrushRuleService,
     public actionLabels: ActionLabelsI18n,
     private rbdMirroringService: RbdMirroringService,
+    private monitorService: MonitorService,
     private cdr: ChangeDetectorRef
   ) {
     super();
@@ -205,6 +219,13 @@ export class PoolFormComponent extends CdForm implements OnInit {
   }
 
   ngOnInit() {
+    this.monitorService.getMonitor().subscribe((data: MonitorResponse) => {
+      this.isStretchMode = data?.mon_status?.stretch_mode || false;
+      if (this.isStretchMode) {
+        this.applyStretchModeRestrictions();
+      }
+      this.replicatedRuleChange();
+    });
     this.poolService.getInfo().subscribe((info: PoolFormInfo) => {
       this.initInfo(info);
       if (this.editing) {
@@ -457,7 +478,29 @@ export class PoolFormComponent extends CdForm implements OnInit {
       this.setListControlStatus('crushRule', rules);
     }
     this.replicatedRuleChange();
+    if (this.isStretchMode) {
+      this.applyStretchModeRestrictions();
+    }
     this.pgCalc();
+  }
+
+  private applyStretchModeRestrictions() {
+    if (!this.editing && this.form.getValue('poolType') === 'erasure') {
+      this.form.silentSet('poolType', 'replicated');
+      this.poolTypeChange('replicated');
+      return;
+    }
+    if (this.editing) {
+      return;
+    }
+    const sizeControl = this.form.get('size');
+    if (this.isStretchMode) {
+      if (sizeControl.enabled) {
+        sizeControl.disable({ emitEvent: false });
+      }
+    } else if (sizeControl.disabled) {
+      sizeControl.enable({ emitEvent: false });
+    }
   }
 
   private setTypeBooleans(replicated: boolean, erasure: boolean) {
@@ -470,7 +513,9 @@ export class PoolFormComponent extends CdForm implements OnInit {
       return;
     }
     const control = this.form.get('size');
-    let size = this.form.getValue('size') || 3;
+    let size =
+      this.form.getValue('size') ||
+      (this.isStretchMode ? this.STRETCH_REPLICATED_MAX_SIZE : this.DEFAULT_REPLICATED_MAX_SIZE);
     const min = this.getMinSize();
     const max = this.getMaxSize();
     if (size < min) {
@@ -487,7 +532,7 @@ export class PoolFormComponent extends CdForm implements OnInit {
     if (!this.info || this.info.osd_count < 1) {
       return 0;
     }
-    return 1;
+    return this.isStretchMode ? this.STRETCH_REPLICATED_MIN_SIZE : this.DEFAULT_REPLICATED_MIN_SIZE;
   }
 
   getMaxSize(): number {
@@ -495,10 +540,9 @@ export class PoolFormComponent extends CdForm implements OnInit {
     if (!this.info) {
       return 0;
     }
+    if (this.isStretchMode) return this.STRETCH_REPLICATED_MAX_SIZE;
     if (!rule) {
-      const osds = this.info.osd_count;
-      const defaultSize = 3;
-      return Math.min(osds, defaultSize);
+      return Math.min(this.info.osd_count, this.DEFAULT_REPLICATED_MAX_SIZE);
     }
     return rule.usable_size;
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
@@ -35,7 +35,7 @@ import { FormatterService } from '~/app/shared/services/formatter.service';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { CrushRuleFormModalComponent } from '../crush-rule-form-modal/crush-rule-form-modal.component';
 import { ErasureCodeProfileFormModalComponent } from '../erasure-code-profile-form/erasure-code-profile-form-modal.component';
-import { Pool } from '../pool';
+import { Pool, PoolType } from '../pool';
 import { PoolFormData } from './pool-form-data';
 import { PoolEditModeResponseModel } from '../../block/mirroring/pool-edit-mode-modal/pool-edit-mode-response.model';
 import { RbdMirroringService } from '~/app/shared/api/rbd-mirroring.service';
@@ -63,6 +63,8 @@ interface MonitorResponse {
   styleUrls: ['./pool-form.component.scss']
 })
 export class PoolFormComponent extends CdForm implements OnInit {
+  private static readonly DEFAULT_RULE_NAME = 'replicated_rule';
+
   @ViewChild('crushInfoTabs') crushInfoTabs: NgbNav;
   @ViewChild('ecpInfoTabs') ecpInfoTabs: NgbNav;
   @ViewChild(FormGroupDirective)
@@ -185,7 +187,7 @@ export class PoolFormComponent extends CdForm implements OnInit {
             })
           ]
         }),
-        poolType: new UntypedFormControl('replicated', {
+        poolType: new UntypedFormControl(PoolType.REPLICATED, {
           validators: [Validators.required]
         }),
         crushRule: new UntypedFormControl(null, {
@@ -236,7 +238,7 @@ export class PoolFormComponent extends CdForm implements OnInit {
       }
       this.listenToChanges();
       this.setComplexValidators();
-      this.poolTypeChange('replicated');
+      this.poolTypeChange(PoolType.REPLICATED);
     });
     this.loadingReady();
   }
@@ -266,23 +268,45 @@ export class PoolFormComponent extends CdForm implements OnInit {
   private setListControlStatus(controlName: string, arr: any[]) {
     const control = this.form.get(controlName);
     const value = control.value;
-    if (arr.length === 1 && (!value || !_.isEqual(value, arr[0]))) {
-      if (controlName === 'erasureProfile') {
+
+    if (controlName === 'erasureProfile') {
+      if (arr.length === 1 && (!value || !_.isEqual(value, arr[0]))) {
         control.setValue(arr[0].name);
-      } else {
-        control.setValue(arr[0].rule_name);
+      } else if (arr.length === 0 && value) {
+        control.setValue(null);
+      }
+    } else {
+      const selectedRule = this.validateCrushRule(value, arr);
+      if (arr.length > 0 && selectedRule) {
+        control.setValue(selectedRule);
         this.replicatedRuleChange();
+      } else if (arr.length === 0 && value) {
+        control.setValue(null);
       }
-    } else if (arr.length === 0 && value) {
-      control.setValue(null);
     }
-    if (arr.length <= 1) {
-      if (control.enabled) {
-        control.disable();
-      }
-    } else if (control.disabled) {
-      control.enable();
+
+    arr.length <= 1 ? control.disable() : control.enable();
+  }
+
+  private validateCrushRule(
+    value: string | { rule_name?: string; name?: string } | null,
+    arr: CrushRule[]
+  ): string | undefined {
+    type CrushRuleWithOptionalName = CrushRule & { name?: string };
+    const selectedName = typeof value === 'string' ? value : value?.rule_name || value?.name;
+    const isSelected =
+      selectedName &&
+      arr.some(
+        (rule: CrushRuleWithOptionalName) =>
+          rule.rule_name === selectedName || rule.name === selectedName
+      );
+    if (isSelected) {
+      return undefined;
     }
+    const defaultRule =
+      arr.find((rule: CrushRule) => rule.rule_name === PoolFormComponent.DEFAULT_RULE_NAME) ||
+      arr[0];
+    return defaultRule?.rule_name;
   }
 
   private initEditMode() {
@@ -364,10 +388,15 @@ export class PoolFormComponent extends CdForm implements OnInit {
   }
 
   private setAvailableApps(apps: string[] = this.data.applications.default) {
+    type SelectOptionWithContent = SelectOption & { content?: string };
     const selectedApps = this.data.applications.selected || [];
     this.data.applications.available = _.uniq(apps.sort()).map((x: string) => {
-      const option = new SelectOption(selectedApps.includes(x), x, this.data.APP_LABELS?.[x] || x);
-      (option as any).content = this.data.APP_LABELS?.[x] || x;
+      const option: SelectOptionWithContent = new SelectOption(
+        selectedApps.includes(x),
+        x,
+        this.data.APP_LABELS?.[x] || x
+      );
+      option.content = this.data.APP_LABELS?.[x] || x;
       return option;
     });
   }
@@ -417,7 +446,7 @@ export class PoolFormComponent extends CdForm implements OnInit {
       this.data.crushInfo = false;
 
       rule = (this.current.rules || []).find(
-        (r: CrushRule) => r.rule_name === rule || (r as any).name === rule
+        (r: CrushRule & { name?: string }) => r.rule_name === rule || r.name === rule
       );
       this.selectedCrushRule = rule;
       this.setCorrectMaxSize(rule);
@@ -458,9 +487,9 @@ export class PoolFormComponent extends CdForm implements OnInit {
   }
 
   private poolTypeChange(poolType: string) {
-    if (poolType === 'replicated') {
+    if (poolType === PoolType.REPLICATED) {
       this.setTypeBooleans(true, false);
-    } else if (poolType === 'erasure') {
+    } else if (poolType === PoolType.ERASURE) {
       this.setTypeBooleans(false, true);
     } else {
       this.setTypeBooleans(false, false);
@@ -536,11 +565,11 @@ export class PoolFormComponent extends CdForm implements OnInit {
   }
 
   getMaxSize(): number {
-    const rule = this.selectedCrushRule;
-    if (!this.info) {
+    if (!this.info || this.info.osd_count < 1) {
       return 0;
     }
     if (this.isStretchMode) return this.STRETCH_REPLICATED_MAX_SIZE;
+    const rule = this.selectedCrushRule;
     if (!rule) {
       return Math.min(this.info.osd_count, this.DEFAULT_REPLICATED_MAX_SIZE);
     }
@@ -816,7 +845,7 @@ export class PoolFormComponent extends CdForm implements OnInit {
       getInfo: () => this.poolService.getInfo(),
       initInfo: (info) => {
         this.initInfo(info);
-        this.poolTypeChange('replicated');
+        this.poolTypeChange(PoolType.REPLICATED);
       },
       findNewItem: () =>
         this.info.crush_rules_replicated.find((rule) => rule.rule_name === ruleName),

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
@@ -308,6 +308,7 @@ describe('PoolListComponent', () => {
     const getPoolData = (o: object) => [
       _.merge(
         _.merge(Mocks.getPool('a', 0), {
+          application_metadata: ['Block'],
           cdIsBinary: true,
           pg_status: '',
           stats: {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.ts
@@ -265,6 +265,11 @@ export class PoolListComponent extends ListWithDetails implements OnInit {
       'wr'
     ];
     const emptyStat: PoolStat = { latest: 0, rate: 0, rates: [] };
+    const applicationLabels: Record<string, string> = {
+      cephfs: $localize`filesystem`,
+      rbd: $localize`block`,
+      rgw: $localize`object`
+    };
 
     _.forEach(pools, (pool: Pool) => {
       pool['pg_status'] = this.transformPgStatus(pool['pg_status']);
@@ -294,6 +299,10 @@ export class PoolListComponent extends ListWithDetails implements OnInit {
       if (pool['type'] === 'replicated') {
         pool['data_protection'] = `replica: ×${pool['size']}`;
       }
+
+      pool['application_metadata'] = (pool.application_metadata || []).map(
+        (application: string) => applicationLabels[application] || application
+      );
     });
 
     return pools;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.ts
@@ -27,7 +27,7 @@ import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { TaskListService } from '~/app/shared/services/task-list.service';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { URLBuilderService } from '~/app/shared/services/url-builder.service';
-import { Pool } from '../pool';
+import { Pool, PoolType } from '../pool';
 import { PoolStat, PoolStats } from '../pool-stat';
 import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 import { DeletionImpact } from '~/app/shared/enum/delete-confirmation-modal-impact.enum';
@@ -266,9 +266,9 @@ export class PoolListComponent extends ListWithDetails implements OnInit {
     ];
     const emptyStat: PoolStat = { latest: 0, rate: 0, rates: [] };
     const applicationLabels: Record<string, string> = {
-      cephfs: $localize`filesystem`,
-      rbd: $localize`block`,
-      rgw: $localize`object`
+      cephfs: $localize`File system`,
+      rbd: $localize`Block`,
+      rgw: $localize`Object`
     };
 
     _.forEach(pools, (pool: Pool) => {
@@ -292,11 +292,11 @@ export class PoolListComponent extends ListWithDetails implements OnInit {
       });
       pool.cdIsBinary = true;
 
-      if (pool['type'] === 'erasure') {
+      if (pool['type'] === PoolType.ERASURE) {
         const erasureCodeProfile = pool['erasure_code_profile'];
         pool['data_protection'] = this.getErasureCodeProfile(erasureCodeProfile);
       }
-      if (pool['type'] === 'replicated') {
+      if (pool['type'] === PoolType.REPLICATED) {
         pool['data_protection'] = `replica: ×${pool['size']}`;
       }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool.ts
@@ -1,6 +1,11 @@
 import { ExecutingTask } from '~/app/shared/models/executing-task';
 import { PoolStats } from './pool-stat';
 
+export enum PoolType {
+  ERASURE = 'erasure',
+  REPLICATED = 'replicated'
+}
+
 export class Pool {
   cache_target_full_ratio_micro: number;
   fast_read: boolean;


### PR DESCRIPTION
This is a batch backport PR for pool form related changes and includes following PRs:

https://github.com/ceph/ceph/pull/67952
https://github.com/ceph/ceph/pull/67841
https://github.com/ceph/ceph/pull/68658
