### PR TITLE
mgr/dashboard: allow cd-icon to project text

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/overview/health-card/overview-health-card.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/overview/health-card/overview-health-card.component.html
@@ -200,10 +200,11 @@
                [class.overview-health-card-tab-content-item]="!isLast"
                [class.border-subtle-right]="!isLast">
             <span class="overview-health-card-icon-and-text">
-              <cd-icon [type]="vm?.[item.key]?.severity"></cd-icon>
-              <span class="cds--type-body-compact-01">
-                {{ item.label }}
-              </span>
+              <cd-icon [type]="vm?.[item.key]?.severity">
+                <span class="cds--type-body-compact-01">
+                  {{ item.label }}
+                </span>
+              </cd-icon>
             </span>
             <p class="cds--type-label-01 cds-mt-3 cds-mb-0 overview-health-card-secondary-text">
               {{ vm?.[item.key]?.value }}
@@ -229,10 +230,11 @@
             @for (row of section; track row.key) {
             <div class="overview-health-card-hardware-row">
               <span class="overview-health-card-icon-and-text">
-                <cd-icon [type]="row.key"></cd-icon>
-                <span class="cds--type-body-compact-01">
-                  {{ row.label }}
-                </span>
+                <cd-icon [type]="row.key">
+                  <span class="cds--type-body-compact-01">
+                    {{ row.label }}
+                  </span>
+                </cd-icon>
               </span>
 
               <span class="overview-health-card-hardware-status">
@@ -262,10 +264,11 @@
       <div class="overview-health-card-tab-content overview-health-card-tab-content-item-row">
         <div>
           <span class="overview-health-card-icon-and-text">
-            <cd-icon [type]="vm?.resiliencyHealth?.icon"></cd-icon>
-            <span class="cds--type-body-compact-01">
-              {{vm?.resiliencyHealth?.title}}
-            </span>
+            <cd-icon [type]="vm?.resiliencyHealth?.icon">
+              <span class="cds--type-body-compact-01">
+                {{vm?.resiliencyHealth?.title}}
+              </span>
+            </cd-icon>
           </span>
           <p class="overview-health-card-secondary-text cds--type-label-01">
             {{vm?.resiliencyHealth?.description}}</p>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/overview/health-card/overview-health-card.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/overview/health-card/overview-health-card.component.scss
@@ -64,12 +64,6 @@
     margin-left: var(--cds-spacing-04);
   }
 
-  &-icon-and-text {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--cds-spacing-03);
-  }
-
   &-hardware-sections {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/icon/icon.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/icon/icon.component.html
@@ -2,3 +2,4 @@
       [size]="size"
       [ngClass]="!useDefault ? [type + '-icon', class] : []">
 </svg>
+<ng-content></ng-content>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/icon/icon.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/icon/icon.component.scss
@@ -1,5 +1,11 @@
 @use '@carbon/styles/scss/theme';
 
+cd-icon {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--cds-spacing-03);
+}
+
 /*
 !important required to override the parent component's carbon css.
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/icon/icon.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/icon/icon.component.spec.ts
@@ -1,14 +1,21 @@
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { configureTestBed } from '~/testing/unit-test-helper';
 import { IconComponent } from './icon.component';
+
+@Component({
+  template: `<cd-icon type="success">Status text</cd-icon>`,
+  standalone: false
+})
+class TestHostComponent {}
 
 describe('IconComponent', () => {
   let component: IconComponent;
   let fixture: ComponentFixture<IconComponent>;
 
   configureTestBed({
-    declarations: [IconComponent],
+    declarations: [IconComponent, TestHostComponent],
     imports: []
   });
 
@@ -20,5 +27,12 @@ describe('IconComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should render projected text', () => {
+    const hostFixture = TestBed.createComponent(TestHostComponent);
+    hostFixture.detectChanges();
+
+    expect(hostFixture.nativeElement.textContent).toContain('Status text');
   });
 });


### PR DESCRIPTION
## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Summary

Allow `cd-icon` to render projected text content so repeated icon-and-label markup can be simplified and reused consistently.

This updates the overview health card to place label text inside `cd-icon` and adds a unit test covering text projection.

Fixes: https://tracker.ceph.com/issues/75989

## Testing

```bash
npm exec -- jest src/app/shared/components/icon/icon.component.spec.ts --runInBand
npm exec -- jest src/app/ceph/overview/health-card/overview-health-card.component.spec.ts --runInBand
npm exec -- prettier --list-different src/app/shared/components/icon/icon.component.html src/app/shared/components/icon/icon.component.scss src/app/shared/components/icon/icon.component.spec.ts src/app/ceph/overview/health-card/overview-health-card.component.html src/app/ceph/overview/health-card/overview-health-card.component.scss
