### PR TITLE
rgw/lc: Implementation of the LC guardrails

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -570,6 +570,17 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_lc_dry_run
+  type: bool
+  level: advanced
+  desc: Enable dry-run mode for lifecycle processing - log what would be deleted without actually deleting
+  long_desc: When enabled, lifecycle processing will log all objects that match
+    expiration rules but will not actually delete them. Useful for testing LC rules
+    and debugging. Can be changed at runtime without RGW restart.
+  default: false
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_mp_lock_max_time
   type: int
   level: advanced

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -5588,7 +5588,7 @@ int RGWRados::restore_obj_from_cloud(RGWLCCloudTierCtx& tier_ctx,
   uint64_t olh_epoch = 0; // read it from attrs fetched from cloud below
   rgw::putobj::AtomicObjectProcessor processor(aio.get(), this, dest_bucket_info, nullptr,
                                   owner, obj_ctx, dest_obj_bi, olh_epoch, tag, dpp, y, no_trace);
- 
+
   void (*progress_cb)(off_t, void *) = NULL;
   void *progress_data = NULL;
   bool cb_processed = false;
@@ -9337,7 +9337,7 @@ int RGWRados::apply_olh_log(const DoutPrefixProvider *dpp,
                      << (entry.delete_marker ? "(delete)" : "") << dendl;
 
       if (link_epoch == entry.epoch)
-        ldpp_dout(dpp, 1) << "apply_olh_log epoch collision detected for " << entry.key
+        ldpp_dout(dpp, 1) << "apply_olh_log epoch collision detected for " << entry.key << "(" << entry.epoch << ")"
                           << "; incoming op: " << entry.op << "(" << entry.op_tag << ")" << dendl;
 
       switch (entry.op) {

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -358,122 +358,6 @@ static bool should_list_unordered(const rgw::bucket_index_layout_generation& cur
   return current_index.layout.type == rgw::BucketIndexType::Normal
     && rgw::num_shards(current_index.layout.normal) > threshold;
 }
-class LCObjsLister {
-  rgw::sal::Driver* driver;
-  rgw::sal::Bucket* bucket;
-  rgw::sal::Bucket::ListParams list_params;
-  rgw::sal::Bucket::ListResults list_results;
-  string prefix;
-  vector<rgw_bucket_dir_entry>::iterator obj_iter;
-  rgw_bucket_dir_entry pre_obj;
-  uint64_t num_noncurrent{0};
-  int64_t delay_ms;
-
-public:
-  LCObjsLister(rgw::sal::Driver* _driver, rgw::sal::Bucket* _bucket) :
-      driver(_driver), bucket(_bucket) {
-    list_params.list_versions = bucket->versioned();
-
-    CephContext* cct = driver->ctx();
-    uint64_t threshold = cct->_conf.get_val<uint64_t>("rgw_lc_ordered_list_threshold");
-
-    const auto& current_index = bucket->get_info().layout.current_index;
-    list_params.allow_unordered = should_list_unordered(current_index, threshold);
-
-    delay_ms = driver->ctx()->_conf.get_val<int64_t>("rgw_lc_thread_delay");
-  }
-
-  void set_prefix(const string& p) {
-    prefix = p;
-    list_params.prefix = prefix;
-  }
-
-  int init(const DoutPrefixProvider *dpp, optional_yield y) {
-    return fetch(dpp, y);
-  }
-
-  int fetch(const DoutPrefixProvider *dpp, optional_yield y) {
-    CephContext* cct = dpp->get_cct();
-    int cnt = cct->_conf.get_val<uint64_t>("rgw_lc_list_cnt");
-    int ret = bucket->list(dpp, list_params, cnt, list_results, y);
-    if (ret < 0) {
-      return ret;
-    }
-
-    obj_iter = list_results.objs.begin();
-
-    return 0;
-  }
-
-  void delay(const DoutPrefixProvider* dpp) {
-    if (delay_ms) {
-      maybe_warn_about_blocking(dpp);
-      std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
-    }
-  }
-
-  bool get_obj(const DoutPrefixProvider *dpp, optional_yield y,
-	       rgw_bucket_dir_entry **obj,
-	       std::function<void(void)> fetch_barrier
-	       = []() { /* nada */}) {
-    if (obj_iter == list_results.objs.end()) {
-      if (!list_results.is_truncated) {
-        delay(dpp);
-        return false;
-      } else {
-	fetch_barrier();
-        list_params.marker = pre_obj.key;
-        int ret = fetch(dpp, y);
-        if (ret < 0) {
-          ldpp_dout(dpp, 0) << "ERROR: list_op returned ret=" << ret
-				 << dendl;
-          return false;
-        }
-      }
-      delay(dpp);
-    }
-
-    if (obj_iter->key.name == pre_obj.key.name) {
-      ++num_noncurrent;
-    } else {
-      num_noncurrent = 0; // XXX the first element must be current or a delete marker (?)
-    }
-
-    /* returning address of entry in objs */
-    *obj = &(*obj_iter);
-    return obj_iter != list_results.objs.end();
-  }
-
-  rgw_bucket_dir_entry get_prev_obj() {
-    return pre_obj;
-  }
-
-  void next() {
-    pre_obj = *obj_iter;
-    ++obj_iter;
-  }
-
-  boost::optional<std::string> next_key_name() {
-    if (obj_iter == list_results.objs.end()) {
-      return boost::none;
-    }
-    if ((obj_iter + 1) == list_results.objs.end()) {
-      /* At the last object in the current page */
-      if (list_results.is_truncated) {
-        /* More pages exist. Cannot determine if next object has same name
-         * without fetching next page. Return current object name to indicate
-         * uncertainty and prevent incorrect DM deletion at page boundaries. */
-        return obj_iter->key.name;
-      }
-      /* No more pages, definitively no next object */
-      return boost::none;
-    }
-
-    return ((obj_iter + 1)->key.name);
-  }
-
-  uint64_t get_num_noncurrent() { return num_noncurrent; }
-}; /* LCObjsLister */
 
 struct op_env {
 
@@ -638,6 +522,22 @@ static int remove_expired_obj(const DoutPrefixProvider* dpp,
   auto obj_key = o.key;
   auto& meta = o.meta;
   auto version_id = obj_key.instance; // deep copy, so not cleared below
+
+  /* DRY-RUN mode: log what would be deleted without actually deleting */
+  if (oc.cct->_conf->rgw_lc_dry_run) {
+    ldpp_dout(dpp, 5)
+        << "DRY-RUN: would delete "
+        << "bucket=" << oc.bucket->get_name() << " obj=" << o.key
+        /* event_types contains duplicate events with different prefixes
+         * (s3:ObjectLifecycle:* and s3:LifecycleExpiration:*) for
+         * backward compatibility; printing only the first */
+        << (!event_types.empty()
+                ? " rule=" + rgw::notify::to_string(event_types.front())
+                : "")
+        << " is_delete_marker=" << o.is_delete_marker() << " flags=" << o.flags
+        << dendl;
+    return 0;
+  }
 
   /* per discussion w/Daniel, Casey,and Eric, we *do need*
    * a new sal object handle, based on the following decision
@@ -1613,6 +1513,210 @@ int LCOpRule::process(rgw_bucket_dir_entry& o,
 
 }
 
+
+LCObjsLister::LCObjsLister(ILCBucketLister *_backend,
+                           bool list_versions,
+                           bool allow_unordered,
+                           int64_t delay,
+                           const DoutPrefixProvider *_dpp) :
+  backend(_backend), dpp(_dpp) {
+  list_params.list_versions = list_versions;
+  list_params.allow_unordered = allow_unordered;
+  delay_ms = delay;
+}
+
+int LCObjsLister::init(boost::asio::yield_context y) {
+  int res = fetch(y);
+  if (res < 0)
+    return  res;
+
+  obj_iter = skip_to_the_first_current(obj_iter, y);
+
+  return 0;
+}
+
+int LCObjsLister::fetch(boost::asio::yield_context y) {
+  if (!list_results.objs.empty()) {
+    list_params.marker = list_results.objs.back().key;
+  }
+  int ret = backend->list(list_params, PAGE_SIZE, list_results, y);
+  if (ret < 0)
+    return ret;
+
+  obj_iter = list_results.objs.begin();
+  ++page_index;
+  return 0;
+}
+
+void LCObjsLister::delay() {
+  if (delay_ms) {
+    maybe_warn_about_blocking(dpp);
+    std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));      
+  }
+}
+
+LCObjsLister::obj_iter_type LCObjsLister::skip_to_the_first_current(obj_iter_type from, boost::asio::yield_context y) {
+  if (list_results.objs.empty())
+    return list_results.objs.end();
+
+  // if the @from already pointing at the current just return it and increment the counter;
+  auto first = *from;
+  if (first.is_current()) {
+    num_noncurrent=0;
+    num_current = 1;
+    return from;
+  }
+
+  ldpp_dout(dpp, 20) << "LCObjsLister::next(): skipping " << from->key << " (newer than the current)" <<  dendl;
+
+  pre_obj = first;
+  num_noncurrent=1;
+  num_current=0;
+  ++from;
+  do {
+    for (auto i=from; i!=list_results.objs.end(); ++i) {
+      // are we still on the same object?
+      if (i->key.name==pre_obj.key.name) {
+        // are we now pointing at the current instance?
+        if (i->is_current() && num_current==0) {
+          num_current = 1;
+          // log the number of non-current elements newer than the current ;
+          ldpp_dout(dpp, 1) << "WARNING: bucket " << backend->get_bucket_key() << " "
+                            << "object " << i->key.name << ": found " << num_noncurrent
+                            << " version(s) newer than the current" << dendl;
+          return  i;
+        }
+        ++num_noncurrent;
+      } else {
+        // we have now advanced to a new object
+        if (i->is_current()) {
+          num_noncurrent = 0;
+          num_current = 1;
+          return i;
+        }
+        num_noncurrent = 1;
+        pre_obj = *i;
+      }
+      ldpp_dout(dpp, 1) << "WARNING: LCObjsLister::next(): skipping " << i->key << " (newer than the current)" <<  dendl;
+    }
+
+    // we reached the end of the current list results batch;
+    // need to fetch the next page and start over;
+    if (list_results.is_truncated && fetch(y)==0) {
+      // fetch() sets obj_iter to the beginning of the new results page
+      from = obj_iter;
+    } else {
+      break;
+    }
+  } while (true);
+
+  return list_results.objs.end();
+}
+
+bool LCObjsLister::get_obj(rgw_bucket_dir_entry *obj) const {
+  ceph_assert(obj!=nullptr);
+
+  /* returning address of entry in objs */
+  if (obj_iter != list_results.objs.end()) {
+    *obj = *obj_iter;
+    return  true;
+  }
+
+  return false;
+}
+
+bool LCObjsLister::next(boost::asio::yield_context y) {
+  if (obj_iter == list_results.objs.end())
+    return false;
+
+  pre_obj = *obj_iter++;
+  if (obj_iter == list_results.objs.end()) {
+    if (!list_results.is_truncated) {
+      delay();
+      return false;
+    } else {
+      int ret = fetch(y);
+      if (ret < 0) {
+        ldpp_dout(dpp, 0) << "ERROR: list_op returned ret=" << ret << dendl;
+        return false;
+      }
+    }
+    delay();
+  }
+
+  if (obj_iter->key.name == pre_obj.key.name) {
+    if (!obj_iter->is_current())
+      ++num_noncurrent;
+    else {
+      // looks like we have multiple currents in a row;
+      obj_iter = skip_currents(obj_iter, y);
+    }
+  }
+  else
+    obj_iter = skip_to_the_first_current(obj_iter, y);
+
+  if (obj_iter != list_results.objs.end()) {
+    ldpp_dout(dpp, 20) << "LCObjsLister::next(): advanced to " << obj_iter->key << " at position " << get_entry_pos() << dendl;
+  }
+
+  return obj_iter != list_results.objs.end();
+}
+
+LCObjsLister::obj_iter_type LCObjsLister::skip_currents(obj_iter_type from, boost::asio::yield_context y) {
+  ceph_assert(from!=list_results.objs.end());
+
+  auto cur_obj = *from;
+  ceph_assert(cur_obj.is_current());
+  ldpp_dout(dpp, 20) << "LCObjsLister::next(): skipping " << from->key << " (multiple currents)" <<  dendl;
+  ++num_current;
+  auto i=from+1;
+  do {
+    for (; i!=list_results.objs.end(); ++i) {
+      if (cur_obj.key.name==i->key.name) {
+        if (i->is_current()) {
+          ++num_current;
+          ldpp_dout(dpp, 20) << "LCObjsLister::next(): skipping " << i->key << " (multiple currents)" <<  dendl;
+        }
+        else {
+          ++num_noncurrent;
+          return i;
+        }
+      }
+      else
+        return skip_to_the_first_current(i, y);
+    }
+
+    // we reached the end of the current list results batch;
+    // need to fetch the next page and start over;
+    if (list_results.is_truncated && fetch(y)==0) {
+      i = obj_iter;
+    } else {
+      break;
+    }
+  } while (true);
+
+  return i;
+}
+
+boost::optional<std::string> LCObjsLister::next_key_name() const {
+  if (obj_iter == list_results.objs.end()) {
+    return boost::none;
+  }
+  if ((obj_iter + 1) == list_results.objs.end()) {
+    /* At the last object in the current page */
+    if (list_results.is_truncated) {
+      /* More pages exist. Cannot determine if next object has same name
+       * without fetching next page. Return current object name to indicate
+       * uncertainty and prevent incorrect DM deletion at page boundaries. */
+      return obj_iter->key.name;
+    }
+    /* No more pages, definitely no next object */
+    return boost::none;
+  }
+
+  return ((obj_iter + 1)->key.name);
+}
+
 int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker,
 			     time_t stop_at, bool once,
 			     boost::asio::yield_context yield)
@@ -1725,7 +1829,16 @@ int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker,
       pre_marker = next_marker;
     }
 
-    LCObjsLister ol(driver, bucket.get());
+    rgw::sal::BucketLister bl(bucket.get(), this);
+    CephContext* cct = driver->ctx();
+    auto delay_ms = cct->_conf.get_val<int64_t>("rgw_lc_thread_delay");
+    uint64_t threshold = cct->_conf.get_val<uint64_t>("rgw_lc_ordered_list_threshold");
+    const auto& current_index = bucket->get_info().layout.current_index;
+    LCObjsLister ol(&bl, 
+      bucket->versioned(), 
+      should_list_unordered(current_index, threshold), 
+      delay_ms, 
+      this);
     ol.set_prefix(prefix_iter->first);
 
     std::vector<lc_op*> active_ops;
@@ -1746,7 +1859,7 @@ int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker,
       continue;
     }
 
-    ret = ol.init(this, yield);
+    ret = ol.init(yield);
     if (ret < 0) {
       if (ret == (-ENOENT))
         return 0;
@@ -1762,9 +1875,9 @@ int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker,
       rules.back().build(); // why can't ctor do it?
     }
 
-    rgw_bucket_dir_entry* o{nullptr};
-    for (auto offset = 0; ol.get_obj(this, yield, &o /* , fetch_barrier */); ++offset, ol.next()) {
-      const auto obj = *o;
+    rgw_bucket_dir_entry e;
+    for (auto offset = 0; ol.get_obj(&e); ++offset, ol.next(yield)) {
+      const auto obj = e;
 
       // Update all rules to capture current lister state before spawning
       for (auto& rule : rules) {

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -564,6 +564,103 @@ WRITE_CLASS_ENCODER(RGWLifecycleConfiguration)
 
 namespace ceph::async { class spawn_throttle; }
 
+/**
+ * Interface for a bucket listing backend.
+ */
+struct ILCBucketLister {
+  virtual ~ILCBucketLister() = default;
+
+  virtual rgw_bucket get_bucket_key () const noexcept = 0;
+
+  virtual int list(rgw::sal::Bucket::ListParams& params,
+                   int max_entries,
+                   rgw::sal::Bucket::ListResults& results,
+                   optional_yield y) = 0;
+};
+
+/**
+ * @brief Presents a sanitized view of the bucket index for the LC to operate on.
+ *
+ * Lists objects in a bucket for the LC to process.
+ * Relies on a bucket lister backend as the source of objects data.
+ * Accumulates per-object data such as the number of current/non-current
+ * instances per-object (which a specific LC rule might act upon).
+ * It also detects and sanitizes (filters out) any object versions/instances which are inconsistent
+ * with a valid object state to protect from a potential data loss such as:
+ * - multiple-non-current versions newer than the current:
+ *      skip non-current versions which are newer than the current;
+ * - no current version:
+ *      skip (exclude) all non-current versions;
+ * - multiple current versions:
+ *      only let LC process the first current version and skip to the first non-current.
+ */
+class LCObjsLister {
+
+  using obj_iter_type = std::vector<rgw_bucket_dir_entry>::iterator;
+
+  ILCBucketLister* backend;
+  const DoutPrefixProvider *dpp;
+
+  rgw::sal::Bucket::ListParams list_params;
+  rgw::sal::Bucket::ListResults list_results;
+  std::string prefix;
+  obj_iter_type obj_iter;
+  rgw_bucket_dir_entry pre_obj;
+  uint64_t num_noncurrent{0}, num_current{0};
+  int64_t delay_ms;
+  int64_t page_index{-1};
+
+  static const uint PAGE_SIZE = 1000;
+
+ public:
+
+  LCObjsLister(ILCBucketLister *backend,
+               bool list_versions = true,
+               bool allow_unordered = true,
+               int64_t delay = 0,
+               const DoutPrefixProvider *_dpp = nullptr);
+
+  void set_prefix(const std::string &p) {
+    prefix = p;
+    list_params.prefix = prefix;
+  }
+
+  int init(boost::asio::yield_context y);
+
+  int fetch(boost::asio::yield_context y);
+
+  void delay();
+
+  bool get_obj(rgw_bucket_dir_entry *obj) const;
+
+  rgw_bucket_dir_entry get_prev_obj() const noexcept { return pre_obj; }
+
+  bool next(boost::asio::yield_context y);
+
+  boost::optional<std::string> next_key_name() const;
+
+  uint64_t get_num_noncurrent() const noexcept { return num_noncurrent; }
+
+  uint64_t get_num_current() const noexcept { return num_current; }
+
+  uint64_t get_entry_pos() const noexcept {
+    return (page_index * PAGE_SIZE) + (obj_iter - list_results.objs.begin());
+  }
+
+ private:
+
+  // assuming obj_iter points to a non-current version for object foo skip ahead until either:
+  // - a current version for the same object is found;
+  // - we reach a version for a different object;
+  obj_iter_type skip_to_the_first_current(obj_iter_type from, boost::asio::yield_context y);
+
+  // assuming obj_iter points to a current version for object foo skip ahead until either:
+  // - a non-current version for the same object is found;
+  // - we reach a version for a different object;
+  obj_iter_type skip_currents(obj_iter_type from, boost::asio::yield_context y);
+
+}; /* LCObjsLister */
+
 class RGWLC : public DoutPrefixProvider {
   CephContext *cct;
   rgw::sal::Driver* driver;
@@ -678,7 +775,38 @@ public:
 				  LCWorker* worker, time_t stop_at, bool once);
 };
 
-namespace rgw::lc {
+namespace rgw {
+namespace  sal {
+
+  class BucketLister : public  ILCBucketLister {
+
+    rgw::sal::Bucket *bucket;
+    const DoutPrefixProvider* dpp;
+
+   public:
+
+    BucketLister (rgw::sal::Bucket *_bucket,
+                  const DoutPrefixProvider *_dpp)
+        : bucket{_bucket},
+          dpp{_dpp} {
+      ceph_assert(bucket);
+    }
+
+    rgw_bucket get_bucket_key () const noexcept override {
+      return bucket->get_key();
+    }
+
+    int list(rgw::sal::Bucket::ListParams& params,
+             int max_entries,
+             rgw::sal::Bucket::ListResults& results,
+             optional_yield y) override {
+      return bucket->list(dpp, params, max_entries, results, y);
+    }
+  };
+
+}
+
+namespace lc {
 
 int fix_lc_shard_entry(const DoutPrefixProvider *dpp,
                        rgw::sal::Driver* driver,
@@ -701,3 +829,4 @@ bool s3_multipart_abort_header(
   std::string& rule_id);
 
 } // namespace rgw::lc
+}

--- a/src/test/rgw/test_rgw_lc.cc
+++ b/src/test/rgw/test_rgw_lc.cc
@@ -234,7 +234,7 @@ struct LCWorkTimeTests : ::testing::Test
 protected:
 
    void SetUp() override {
-      cct.reset(new CephContext(CEPH_ENTITY_TYPE_ANY), false);
+     cct.reset(new CephContext(CEPH_ENTITY_TYPE_ANY), false);
 
       cct->_conf->set_value("rgw_lc_max_wp_worker", 0, 0); // no need to create a real workpool
       worker = std::make_unique<RGWLC::LCWorker>(nullptr, cct.get(), nullptr, 0);
@@ -419,3 +419,722 @@ TEST_F(LCWorkTimeTests, ScheduleNextStartTime)
 
    run_schedule_next_start_time_test(test_values_to_expectations);
 }
+
+namespace {
+
+  rgw_bucket_dir_entry make_entry(const std::string &name,
+                                  const std::string &instance,
+                                  uint16_t flags) {
+    rgw_bucket_dir_entry e;
+    e.key.name = name;
+    e.key.instance = instance;
+    e.flags = flags;
+    return e;
+  }
+
+  struct Page {
+    std::vector<rgw_bucket_dir_entry> objs;
+    bool truncated{false};
+  };
+
+  struct Call {
+    std::string prefix;
+    rgw_obj_key marker;
+    bool list_versions{false};
+    int max_entries{0};
+  };
+
+  class FakeBucketLister : public ILCBucketLister {
+   public:
+
+    std::vector<Page> pages;
+    std::vector<Call> calls;
+    size_t idx{0};
+
+    rgw_bucket get_bucket_key () const noexcept override {
+      return rgw_bucket("test", "me");
+    }
+
+    int list(rgw::sal::Bucket::ListParams &params,
+             int max_entries,
+             rgw::sal::Bucket::ListResults &out,
+             optional_yield /*y*/) override {
+      calls.push_back(Call{params.prefix, params.marker, params.list_versions, max_entries});
+      if (idx >= pages.size())
+        return -EINVAL;
+
+      out.objs = pages[idx].objs;
+      out.is_truncated = pages[idx].truncated;
+      ++idx;
+      return 0;
+    }
+  };
+
+  auto non_curr_flags = rgw_bucket_dir_entry::FLAG_VER;
+  auto curr_flags = non_curr_flags | rgw_bucket_dir_entry::FLAG_CURRENT;
+
+
+} // anonymous namespace
+
+TEST(LCObjsLister, BaseCase_2Objs_5Vers) {
+  boost::asio::io_context io;
+  boost::asio::spawn(io, [&](boost::asio::yield_context yield) {
+    FakeBucketLister fbl;
+    fbl.pages = {
+        {
+            .objs = {
+                make_entry("objA", "cur", curr_flags),   // 1
+                make_entry("objA", "v1", non_curr_flags),    // 2
+                make_entry("objA", "v2", non_curr_flags),    // 3
+                make_entry("objB", "cur", curr_flags),   // 4
+                make_entry("objB", "v1", non_curr_flags),    // 5
+            },
+            .truncated = false
+        }
+    };
+    LCObjsLister l(&fbl);
+    ASSERT_EQ(l.init(yield), 0);
+
+    rgw_bucket_dir_entry e;
+
+    ASSERT_TRUE(l.get_obj(&e));
+    EXPECT_EQ(e.key.name, "objA");
+    EXPECT_EQ(e.key.instance, "cur");
+    EXPECT_TRUE(e.is_current());
+    EXPECT_EQ(l.get_num_noncurrent(), 0);
+    EXPECT_EQ(l.get_num_current(), 1);
+
+    ASSERT_TRUE(l.next(yield));
+    ASSERT_TRUE(l.get_obj(&e));
+    EXPECT_EQ(e.key.name, "objA");
+    EXPECT_EQ(e.key.instance, "v1");
+    EXPECT_FALSE(e.is_current());
+    EXPECT_EQ(l.get_num_noncurrent(), 1);
+    EXPECT_EQ(l.get_num_current(), 1);
+
+    ASSERT_TRUE(l.next(yield));
+    ASSERT_TRUE(l.get_obj(&e));
+    EXPECT_EQ(e.key.name, "objA");
+    EXPECT_EQ(e.key.instance, "v2");
+    EXPECT_FALSE(e.is_current());
+    EXPECT_EQ(l.get_num_noncurrent(), 2);
+    EXPECT_EQ(l.get_num_current(), 1);
+
+    ASSERT_TRUE(l.next(yield));
+    ASSERT_TRUE(l.get_obj(&e));
+    EXPECT_EQ(e.key.name, "objB");
+    EXPECT_EQ(e.key.instance, "cur");
+    EXPECT_TRUE(e.is_current());
+    EXPECT_EQ(l.get_num_noncurrent(), 0);
+    EXPECT_EQ(l.get_num_current(), 1);
+
+    ASSERT_TRUE(l.next(yield));
+    ASSERT_TRUE(l.get_obj(&e));
+    EXPECT_EQ(e.key.name, "objB");
+    EXPECT_EQ(e.key.instance, "v1");
+    EXPECT_FALSE(e.is_current());
+    EXPECT_EQ(l.get_num_noncurrent(), 1);
+    EXPECT_EQ(l.get_num_current(), 1);
+
+    ASSERT_FALSE(l.next(yield));
+    ASSERT_FALSE(l.get_obj(&e));
+  }, boost::asio::detached);
+  io.run();
+}
+
+TEST(LCObjsLister, BaseCase_1Obj_3Vers) {
+  boost::asio::io_context io;
+  boost::asio::spawn(io, [&](boost::asio::yield_context yield) {
+    FakeBucketLister fbl;
+    fbl.pages = {
+        {
+            .objs = {
+                make_entry("objA", "cur", curr_flags),     // 1
+                make_entry("objA", "v1", non_curr_flags),  // 2
+                make_entry("objA", "v2", non_curr_flags),  // 3
+            },
+            .truncated = false
+        }
+    };
+
+    LCObjsLister l(&fbl);
+    ASSERT_EQ(l.init(yield), 0);
+
+    rgw_bucket_dir_entry e;
+
+    ASSERT_TRUE(l.get_obj(&e));
+    EXPECT_EQ(e.key.name, "objA");
+    EXPECT_EQ(e.key.instance, "cur");
+    EXPECT_TRUE(e.is_current());
+    EXPECT_EQ(l.get_num_noncurrent(), 0);
+    EXPECT_EQ(l.get_num_current(), 1);
+
+    // doing multiple get_obj() should yield the same object and there should be no changes in the state of the lister;
+    ASSERT_TRUE(l.get_obj(&e));
+    EXPECT_EQ(e.key.name, "objA");
+    EXPECT_EQ(e.key.instance, "cur");
+    EXPECT_TRUE(e.is_current());
+    EXPECT_EQ(l.get_num_noncurrent(), 0);
+    EXPECT_EQ(l.get_num_current(), 1);
+
+    ASSERT_TRUE(l.next(yield));
+    ASSERT_TRUE(l.get_obj(&e));
+    EXPECT_EQ(e.key.name, "objA");
+    EXPECT_EQ(e.key.instance, "v1");
+    EXPECT_FALSE(e.is_current());
+    EXPECT_EQ(l.get_num_noncurrent(), 1);
+    EXPECT_EQ(l.get_num_current(), 1);
+
+    ASSERT_TRUE(l.next(yield));
+    ASSERT_TRUE(l.get_obj(&e));
+    EXPECT_EQ(e.key.name, "objA");
+    EXPECT_EQ(e.key.instance, "v2");
+    EXPECT_FALSE(e.is_current());
+    EXPECT_EQ(l.get_num_noncurrent(), 2);
+    EXPECT_EQ(l.get_num_current(), 1);
+
+    ASSERT_FALSE(l.next(yield));
+    ASSERT_FALSE(l.get_obj(&e));
+  }, boost::asio::detached);
+  io.run();
+}
+
+
+TEST(LCObjsLister, 1NonCur_1Cur_2NonCur) {
+  boost::asio::io_context io;
+  boost::asio::spawn(io, [&](boost::asio::yield_context yield) {
+    FakeBucketLister fbl;
+    fbl.pages = {
+        {
+            .objs = {
+                make_entry("objA", "v0", non_curr_flags),  // skip (newer than the current)
+                make_entry("objA", "cur", curr_flags),     // 1
+                make_entry("objA", "v1", non_curr_flags),  // 2
+                make_entry("objA", "v2", non_curr_flags),  // 3
+            },
+            .truncated = false
+        }
+    };
+
+    LCObjsLister l(&fbl);
+    ASSERT_EQ(l.init(yield), 0);
+
+  rgw_bucket_dir_entry e;
+
+  ASSERT_TRUE(l.get_obj(&e));
+  EXPECT_EQ(e.key.name, "objA");
+  EXPECT_EQ(e.key.instance, "cur");
+  EXPECT_TRUE(e.is_current());
+  EXPECT_EQ(l.get_num_noncurrent(), 1);
+  EXPECT_EQ(l.get_num_current(), 1);
+
+  ASSERT_TRUE(l.next(yield));
+  ASSERT_TRUE(l.get_obj(&e));
+  EXPECT_EQ(e.key.name, "objA");
+  EXPECT_EQ(e.key.instance, "v1");
+  EXPECT_FALSE(e.is_current());
+  EXPECT_EQ(l.get_num_noncurrent(), 2);
+  EXPECT_EQ(l.get_num_current(), 1);
+
+  ASSERT_TRUE(l.next(yield));
+  ASSERT_TRUE(l.get_obj(&e));
+  EXPECT_EQ(e.key.name, "objA");
+  EXPECT_EQ(e.key.instance, "v2");
+  EXPECT_FALSE(e.is_current());
+  EXPECT_EQ(l.get_num_noncurrent(), 3);
+  EXPECT_EQ(l.get_num_current(), 1);
+
+    ASSERT_FALSE(l.next(yield));
+    ASSERT_FALSE(l.get_obj(&e));
+  }, boost::asio::detached);
+  io.run();
+}
+
+TEST(LCObjsLister, 2NonCur_1Cur_1NonCur) {
+  boost::asio::io_context io;
+  boost::asio::spawn(io, [&](boost::asio::yield_context yield) {
+    FakeBucketLister fbl;
+    fbl.pages = {
+        {
+            .objs = {
+                make_entry("objA", "v0", non_curr_flags),  // skip (newer than the current)
+                make_entry("objA", "v1", non_curr_flags),  // skip (newer than the current)
+                make_entry("objA", "cur", curr_flags),  // 1
+                make_entry("objA", "v2", non_curr_flags)  // 2
+            },
+            .truncated = false
+        }
+    };
+
+    LCObjsLister l(&fbl);
+    ASSERT_EQ(l.init(yield), 0);
+
+  rgw_bucket_dir_entry e;
+
+  ASSERT_TRUE(l.get_obj(&e));
+  EXPECT_EQ(e.key.name, "objA");
+  EXPECT_EQ(e.key.instance, "cur");
+  EXPECT_TRUE(e.is_current());
+  EXPECT_EQ(l.get_num_noncurrent(), 2);
+  EXPECT_EQ(l.get_num_current(), 1);
+
+  ASSERT_TRUE(l.next(yield));
+  ASSERT_TRUE(l.get_obj(&e));
+  EXPECT_EQ(e.key.name, "objA");
+  EXPECT_EQ(e.key.instance, "v2");
+  EXPECT_FALSE(e.is_current());
+  EXPECT_EQ(l.get_num_noncurrent(), 3);
+  EXPECT_EQ(l.get_num_current(), 1);
+
+    ASSERT_FALSE(l.next(yield));
+    ASSERT_FALSE(l.get_obj(&e));
+  }, boost::asio::detached);
+  io.run();
+}
+
+TEST(LCObjsLister, AllNonCurr) {
+  boost::asio::io_context io;
+  boost::asio::spawn(io, [&](boost::asio::yield_context yield) {
+    FakeBucketLister fbl;
+    fbl.pages = {
+        {
+            .objs = {
+                make_entry("objA", "v0", non_curr_flags),  // skip (newer than the current)
+                make_entry("objA", "v1", non_curr_flags),  // skip (newer than the current)
+                make_entry("objA", "v2", non_curr_flags)  // skip (newer than the current)
+            },
+            .truncated = false
+        }
+    };
+
+    LCObjsLister l(&fbl);
+    ASSERT_EQ(l.init(yield), 0);
+
+    rgw_bucket_dir_entry e;
+
+    ASSERT_FALSE(l.get_obj(&e));
+    ASSERT_FALSE(l.next(yield));
+  }, boost::asio::detached);
+  io.run();
+}
+
+TEST(LCObjsLister, AllNonCurr_1Obj_2Pages) {
+  boost::asio::io_context io;
+  boost::asio::spawn(io, [&](boost::asio::yield_context yield) {
+    FakeBucketLister fbl;
+    fbl.pages = {
+        {
+            .objs = {
+                make_entry("objA", "v0", non_curr_flags),  // skip (newer than the current)
+                make_entry("objA", "v1", non_curr_flags),  // skip (newer than the current)
+                make_entry("objA", "v2", non_curr_flags)   // skip (newer than the current)
+            },
+            .truncated = false
+        },
+        {
+            .objs = {
+                make_entry("objA", "v3", non_curr_flags),  // skip (newer than the current)
+                make_entry("objA", "v4", non_curr_flags),  // skip (newer than the current)
+                make_entry("objA", "v5", non_curr_flags)   // skip (newer than the current)
+            },
+            .truncated = false
+        }
+    };
+
+    LCObjsLister l(&fbl);
+    ASSERT_EQ(l.init(yield), 0);
+
+    rgw_bucket_dir_entry e;
+
+    ASSERT_FALSE(l.get_obj(&e));
+    ASSERT_FALSE(l.next(yield));
+  }, boost::asio::detached);
+  io.run();
+}
+
+TEST(LCObjsLister, AllNonCurr_2Objs_2Pages) {
+  boost::asio::io_context io;
+  boost::asio::spawn(io, [&](boost::asio::yield_context yield) {
+    FakeBucketLister fbl;
+    fbl.pages = {
+        {
+            .objs = {
+                make_entry("objA", "v0", non_curr_flags),  // skip (newer than the current)
+                make_entry("objA", "v1", non_curr_flags),   // skip (newer than the current)
+                make_entry("objA", "v2", non_curr_flags)   // skip (newer than the current)
+            },
+            .truncated = true
+        },
+        {
+            .objs = {
+                make_entry("objB", "v0", non_curr_flags),  // skip (newer than the current)
+                make_entry("objB", "v1", non_curr_flags),   // skip (newer than the current)
+                make_entry("objB", "v2", non_curr_flags)   // skip (newer than the current)
+            },
+            .truncated = false
+        }
+    };
+
+    LCObjsLister l(&fbl);
+    ASSERT_EQ(l.init(yield), 0);
+
+    rgw_bucket_dir_entry e;
+
+    ASSERT_FALSE(l.get_obj(&e));
+    ASSERT_FALSE(l.next(yield));
+  }, boost::asio::detached);
+  io.run();
+}
+
+TEST(LCObjsLister, AllNonCurrPage1_1Cur_1NonCur_Page2) {
+  boost::asio::io_context io;
+  boost::asio::spawn(io, [&](boost::asio::yield_context yield) {
+    FakeBucketLister fbl;
+    fbl.pages = {{
+           .objs = {
+               make_entry("objA", "v0", non_curr_flags),  // skip (newer than the current)
+               make_entry("objA", "v1", non_curr_flags),  // skip (newer than the current)
+               make_entry("objA", "v2", non_curr_flags)   // skip (newer than the current)
+           },
+           .truncated = true
+       },
+       {
+           .objs = {
+               make_entry("objA", "cur", curr_flags),     // 1
+               make_entry("objA", "v4", non_curr_flags),  // 2
+           },
+           .truncated = false
+       }
+    };
+
+    LCObjsLister l(&fbl);
+    ASSERT_EQ(l.init(yield), 0);
+
+  rgw_bucket_dir_entry e;
+
+  ASSERT_TRUE(l.get_obj(&e));
+  ASSERT_EQ(e.key.name, "objA");
+  ASSERT_EQ(e.key.instance, "cur");
+  ASSERT_TRUE(e.is_current());
+  ASSERT_EQ(l.get_num_noncurrent(), 3);
+  ASSERT_EQ(l.get_num_current(), 1);
+
+  ASSERT_TRUE(l.next(yield));
+  ASSERT_TRUE(l.get_obj(&e));
+  ASSERT_EQ(e.key.name, "objA");
+  ASSERT_EQ(e.key.instance, "v4");
+  ASSERT_FALSE(e.is_current());
+  ASSERT_EQ(l.get_num_noncurrent(), 4);
+  ASSERT_EQ(l.get_num_current(), 1);
+
+    ASSERT_FALSE(l.next(yield));
+    ASSERT_FALSE(l.get_obj(&e));
+  }, boost::asio::detached);
+  io.run();
+}
+
+TEST(LCObjsLister, AllNonCurr_Page1_AllNonCurr_Page2) {
+  boost::asio::io_context io;
+  boost::asio::spawn(io, [&](boost::asio::yield_context yield) {
+    FakeBucketLister fbl;
+    fbl.pages = {
+        {
+            .objs = {
+                make_entry("objA", "v0", non_curr_flags),  // skip (newer than the current)
+                make_entry("objA", "v1", non_curr_flags),  // skip (newer than the current)
+                make_entry("objB", "v0", non_curr_flags),  // skip (newer than the current)
+            },
+            .truncated = true
+        },
+        {
+            .objs = {
+                make_entry("objB", "v1", non_curr_flags),  // skip (newer than the current)
+                make_entry("objB", "v2", non_curr_flags),  // skip (newer than the current)
+            },
+            .truncated = false
+        }
+    };
+
+    LCObjsLister l(&fbl);
+    ASSERT_EQ(l.init(yield), 0);
+
+    rgw_bucket_dir_entry e;
+
+    ASSERT_FALSE(l.get_obj(&e));
+    ASSERT_FALSE(l.next(yield));
+  }, boost::asio::detached);
+  io.run();
+}
+
+TEST(LCObjsLister, 2Curr_1NonCur_Page1_1Curr_1NonCurr_Page2) {
+  boost::asio::io_context io;
+  boost::asio::spawn(io, [&](boost::asio::yield_context yield) {
+    FakeBucketLister fbl;
+    fbl.pages = {
+        {
+            .objs = {
+                make_entry("objA", "cur0", curr_flags),    // 1
+                make_entry("objA", "cur1", curr_flags),    // skip (second current)
+                make_entry("objB", "v0", non_curr_flags),  // skip (newer than the current)
+            },
+            .truncated = true
+        },
+        {
+            .objs = {
+                make_entry("objB", "cur", curr_flags),     // 2
+                make_entry("objB", "v2", non_curr_flags),  // 3
+            },
+            .truncated = false
+        }
+    };
+
+    LCObjsLister l(&fbl);
+    ASSERT_EQ(l.init(yield), 0);
+
+    rgw_bucket_dir_entry e;
+
+    ASSERT_TRUE(l.get_obj(&e));
+    ASSERT_EQ(e.key.name, "objA");
+    ASSERT_EQ(e.key.instance, "cur0");
+    ASSERT_TRUE(e.is_current());
+    ASSERT_EQ(l.get_num_noncurrent(), 0);
+    ASSERT_EQ(l.get_num_current(), 1);
+
+    ASSERT_TRUE(l.next(yield));
+    ASSERT_TRUE(l.get_obj(&e));
+    ASSERT_EQ(e.key.name, "objB");
+    ASSERT_EQ(e.key.instance, "cur");
+    ASSERT_TRUE(e.is_current());
+    ASSERT_EQ(l.get_num_noncurrent(), 1);
+    ASSERT_EQ(l.get_num_current(), 1);
+
+    ASSERT_TRUE(l.next(yield));
+    ASSERT_TRUE(l.get_obj(&e));
+    ASSERT_EQ(e.key.name, "objB");
+    ASSERT_EQ(e.key.instance, "v2");
+    ASSERT_FALSE(e.is_current());
+    ASSERT_EQ(l.get_num_noncurrent(), 2);
+    ASSERT_EQ(l.get_num_current(), 1);
+
+    // check number of calls to the backend
+    ASSERT_EQ(fbl.calls.size(), 2);
+
+    ASSERT_FALSE(l.next(yield));
+    ASSERT_FALSE(l.get_obj(&e));
+  }, boost::asio::detached);
+  io.run();
+}
+
+TEST(LCObjsLister, AllCurr_Page1_1NonCurr_Page2) {
+  boost::asio::io_context io;
+  boost::asio::spawn(io, [&](boost::asio::yield_context yield) {
+    FakeBucketLister fbl;
+    fbl.pages = {
+        {
+            .objs = {
+                make_entry("objA", "cur0", curr_flags),    // 1
+                make_entry("objA", "cur1", curr_flags),     // skip (2-nd current)
+                make_entry("objA", "cur2", curr_flags),    // skip (3-rd current)
+            },
+            .truncated = true
+        },
+        {
+            .objs = {
+                make_entry("objA", "v0", non_curr_flags)     // 2
+            },
+            .truncated = false
+        }
+    };
+
+    LCObjsLister ol(&fbl);
+    ASSERT_EQ(ol.init(yield), 0);
+
+    rgw_bucket_dir_entry e;
+
+    ASSERT_TRUE(ol.get_obj(&e));
+    ASSERT_EQ(e.key.name, "objA");
+    ASSERT_EQ(e.key.instance, "cur0");
+    ASSERT_TRUE(e.is_current());
+    ASSERT_EQ(ol.get_num_noncurrent(), 0);
+    ASSERT_EQ(ol.get_num_current(), 1);
+
+    ASSERT_TRUE(ol.next(yield));
+    ASSERT_TRUE(ol.get_obj(&e));
+    ASSERT_EQ(e.key.name, "objA");
+    ASSERT_EQ(e.key.instance, "v0");
+    ASSERT_FALSE(e.is_current());
+    ASSERT_EQ(ol.get_num_noncurrent(), 1);
+    ASSERT_EQ(ol.get_num_current(), 3);
+
+    ASSERT_FALSE(ol.next(yield));
+    ASSERT_FALSE(ol.get_obj(&e));
+  }, boost::asio::detached);
+  io.run();
+}
+
+TEST(LCObjsLister, AllCurr_ObjA_Page1_1NonCurr_1Curr_ObjB_Page2) {
+  boost::asio::io_context io;
+  boost::asio::spawn(io, [&](boost::asio::yield_context yield) {
+    FakeBucketLister fbl;
+    fbl.pages = {
+        {
+            .objs = {
+                make_entry("objA", "cur0", curr_flags),    // 1
+                make_entry("objA", "cur1", curr_flags),     // skip (2-nd current)
+                make_entry("objA", "cur2", curr_flags),    // skip (3-rd current)
+            },
+            .truncated = true
+        },
+        {
+            .objs = {
+                // tricky path: the first entry on the next page is a different object - but it is non-current!
+                make_entry("objB", "v0", non_curr_flags),  // skip (newer than the current)
+                make_entry("objB", "cur", curr_flags)       // 2
+            },
+            .truncated = false
+        }
+    };
+
+    LCObjsLister ol(&fbl);
+    ASSERT_EQ(ol.init(yield), 0);
+
+    rgw_bucket_dir_entry e;
+
+    ASSERT_TRUE(ol.get_obj(&e));
+    ASSERT_EQ(e.key.name, "objA");
+    ASSERT_EQ(e.key.instance, "cur0");
+    ASSERT_TRUE(e.is_current());
+    ASSERT_EQ(ol.get_num_noncurrent(), 0);
+    ASSERT_EQ(ol.get_num_current(), 1);
+
+    ASSERT_TRUE(ol.next(yield));
+    ASSERT_TRUE(ol.get_obj(&e));
+    ASSERT_EQ(e.key.name, "objB");
+    ASSERT_EQ(e.key.instance, "cur");
+    ASSERT_TRUE(e.is_current());
+    ASSERT_EQ(ol.get_num_noncurrent(), 1);
+    ASSERT_EQ(ol.get_num_current(), 1);
+
+    ASSERT_FALSE(ol.next(yield));
+    ASSERT_FALSE(ol.get_obj(&e));
+  }, boost::asio::detached);
+  io.run();
+}
+
+TEST(LCObjsLister, AllNonCurr_ObjA_Page1_1CurrObjA_1Curr_ObjB_Page2) {
+  boost::asio::io_context io;
+  boost::asio::spawn(io, [&](boost::asio::yield_context yield) {
+    FakeBucketLister fbl;
+    fbl.pages = {
+          {
+              .objs = {
+                  make_entry("objA", "v0", non_curr_flags),    // skip (newer than the current)
+                  make_entry("objA", "v1", non_curr_flags),    // skip (newer than the current)
+                  make_entry("objA", "v2", non_curr_flags),    // skip (newer than the current)
+              },
+              .truncated = true
+          },
+          {
+              .objs = {
+                  make_entry("objB", "cur", curr_flags)         // 1
+              },
+              .truncated = false
+          }
+    };
+
+    LCObjsLister ol(&fbl);
+    ASSERT_EQ(ol.init(yield), 0);
+
+    rgw_bucket_dir_entry e;
+
+    ASSERT_TRUE(ol.get_obj(&e));
+    ASSERT_EQ(e.key.name, "objB");
+    ASSERT_EQ(e.key.instance, "cur");
+    ASSERT_TRUE(e.is_current());
+    ASSERT_EQ(ol.get_num_noncurrent(), 0);
+    ASSERT_EQ(ol.get_num_current(), 1);
+
+    ASSERT_FALSE(ol.next(yield));
+    ASSERT_FALSE(ol.get_obj(&e));
+  }, boost::asio::detached);
+  io.run();
+}
+
+TEST(LCObjsLister, BasicIteration) {
+  boost::asio::io_context io;
+  boost::asio::spawn(io, [&](boost::asio::yield_context yield) {
+    FakeBucketLister fbl;
+    fbl.pages = {
+      {
+        .objs = {
+            make_entry("objA", "cur", curr_flags),      // 1
+            make_entry("objA", "v1", non_curr_flags),   // 2
+            make_entry("objA", "v2", non_curr_flags),   // 3
+            make_entry("objB", "cur", curr_flags),     // 4
+            make_entry("objB", "v1", non_curr_flags),  // 5
+        },
+        .truncated = true,
+      },
+      {
+        .objs = {
+            make_entry("objC", "cur", curr_flags) // 6
+        },
+        .truncated = true
+      },
+      {
+          .objs = {
+              make_entry("objC", "cur", curr_flags),      //skip (2-nd current)
+              make_entry("objD", "v0", non_curr_flags),     // skip (latest non-current)
+          },
+          .truncated = true
+      },
+      {
+          .objs = {
+              make_entry("objD", "cur", curr_flags),      // 7
+              make_entry("objD", "v1", non_curr_flags),     // 8
+          },
+          .truncated = false
+      }
+    };
+
+    LCObjsLister ol(&fbl);
+    ASSERT_EQ(ol.init(yield), 0);
+
+  cls_rgw_obj_key expected[] = {
+      {"objA", "cur"},
+      {"objA", "v1"},
+      {"objA", "v2"},
+      {"objB", "cur"},
+      {"objB", "v1"},
+      {"objC", "cur"},
+      {"objD", "cur"},
+      {"objD", "v1"}
+  };
+  rgw_bucket_dir_entry e;
+  auto total=0;
+  for (; ol.get_obj(&e); ++total, ol.next(yield)) {
+    ASSERT_EQ(expected[total].name, e.key.name);
+    ASSERT_EQ(expected[total].instance, e.key.instance);
+  }
+
+    // we must have processed 8 objects in total
+    ASSERT_EQ(total, 8);
+    //we must have visited all 4 pages
+    ASSERT_EQ(fbl.calls.size(), 4);
+  }, boost::asio::detached);
+  io.run();
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/75991

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
