### PR TITLE
Correct: ceph orch daemon incorrectly setting container image to force

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -62,7 +62,7 @@ from mgr_module import (
     NotifyType,
     MonCommandFailed,
 )
-from mgr_util import build_url, NvmeofMetadataPoolHelper
+from mgr_util import build_url, is_valid_container_image_ref, NvmeofMetadataPoolHelper
 import orchestrator
 from orchestrator.module import to_format, Format
 
@@ -2722,6 +2722,9 @@ Then run the following:
                 raise OrchestratorError(
                     f'Cannot redeploy {daemon_type}.{daemon_id} with a new image: Supported '
                     f'types are: {", ".join(CEPH_IMAGE_TYPES)}')
+            if not is_valid_container_image_ref(image):
+                raise OrchestratorError(
+                    f'Invalid container image {image!r} (not a valid container image reference)')
 
             self.check_mon_command({
                 'prefix': 'config set',

--- a/src/pybind/mgr/mgr_util.py
+++ b/src/pybind/mgr/mgr_util.py
@@ -17,6 +17,7 @@ import errno
 import socket
 import time
 import logging
+import re
 import sys
 from ipaddress import ip_address
 from threading import Lock, Condition
@@ -61,6 +62,67 @@ BOLD_SEQ = "\033[1m"
 UNDERLINE_SEQ = "\033[4m"
 
 logger = logging.getLogger(__name__)
+
+# NAME and TAG are taken verbatim from the OCI distribution spec:
+#   https://github.com/opencontainers/distribution-spec/blob/main/spec.md
+# DIGEST is based on the OCI image-spec descriptor grammar:
+#   https://github.com/opencontainers/image-spec/blob/main/descriptor.md
+# REGISTRY is a practical heuristic, not defined by either spec.
+#
+# Catches malformed input.
+# Not a full OCI image reference parser.
+
+# distribution-spec, verbatim:
+NAME = r"[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*(\/[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*)*"
+
+# distribution-spec, verbatim:
+TAG = r"[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}"
+
+# image-spec descriptor grammar translated literally:
+GENERIC_DIGEST_RE = re.compile(
+    r"^[a-z0-9]+(?:[+._-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$",
+    re.ASCII,
+)
+
+# Practical heuristic for hostname[:port].
+REGISTRY = r"(?:[a-zA-Z0-9.-]+(?::[0-9]+)?)"
+
+STRICT_KNOWN_DIGESTS = {
+    "sha256": re.compile(r"^[a-f0-9]{64}$", re.ASCII),
+    "sha512": re.compile(r"^[a-f0-9]{128}$", re.ASCII),
+    "blake3": re.compile(r"^[a-f0-9]{64}$", re.ASCII),
+}
+
+IMAGE_RE = re.compile(
+    rf"""
+        ^
+        (?:{REGISTRY}/)?
+        {NAME}
+        (?::{TAG})?
+        (?:@(?P<digest>[a-z0-9]+(?:[+._-][a-z0-9]+)*:[a-zA-Z0-9=_-]+))?
+        $
+    """,
+    re.VERBOSE | re.ASCII,
+)
+
+
+def is_valid_digest(digest: str) -> bool:
+    if not GENERIC_DIGEST_RE.fullmatch(digest):
+        return False
+    algorithm, encoded = digest.split(":", 1)
+    checker = STRICT_KNOWN_DIGESTS.get(algorithm)
+    if checker is None:
+        return True
+    return checker.fullmatch(encoded) is not None
+
+
+def is_valid_container_image_ref(ref: str) -> bool:
+    """Basic sanity check for OCI/Docker-style container image references."""
+    m = IMAGE_RE.fullmatch(ref)
+    if m is None:
+        return False
+    digest = m.group("digest")
+    return digest is None or is_valid_digest(digest)
 
 
 class PortAlreadyInUse(Exception):

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -22,7 +22,13 @@ from ceph.deployment.hostspec import SpecValidationError
 from ceph.deployment.utils import unwrap_ipv6
 from ceph.utils import datetime_now
 from ceph.cephadm.images import NonCephImageServiceTypes
-from mgr_util import to_pretty_timedelta, format_bytes, parse_combined_pem_file, NvmeofMetadataPoolHelper
+from mgr_util import (
+    is_valid_container_image_ref,
+    to_pretty_timedelta,
+    format_bytes,
+    parse_combined_pem_file,
+    NvmeofMetadataPoolHelper,
+)
 from mgr_module import MgrModule, HandleCommandResult, Option
 from object_format import Format
 
@@ -1791,11 +1797,16 @@ Usage:
     @OrchestratorCLICommand.Write('orch daemon redeploy')
     def _daemon_action_redeploy(self,
                                 name: str,
-                                image: Optional[str] = None) -> HandleCommandResult:
+                                image: Optional[str] = None,
+                                force: bool = False) -> HandleCommandResult:
         """Redeploy a daemon (with a specific image)"""
         if '.' not in name:
             raise OrchestratorError('%s is not a valid daemon name' % name)
-        completion = self.daemon_action("redeploy", name, image=image)
+        if image is not None and not is_valid_container_image_ref(image):
+            raise OrchestratorError(
+                f'Invalid container image {image!r} (not a valid container image reference)'
+            )
+        completion = self.daemon_action("redeploy", name, image=image, force=force)
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 

--- a/src/pybind/mgr/tests/test_mgr_util.py
+++ b/src/pybind/mgr/tests/test_mgr_util.py
@@ -85,3 +85,71 @@ class TestCephFsEarmarkResolver:
         mock_parse_earmark.side_effect = mgr_util.EarmarkParseError
         result = resolver.check_earmark("error.test", mgr_util.EarmarkTopScope.SMB)
         assert result is False
+
+
+_SHA256_OK = "a" * 64
+_SHA256_BAD_HEX = "g" * 64
+_SHA256_SHORT = "a" * 63
+_SHA512_OK = "b" * 128
+_SHA512_SHORT = "b" * 127
+_BLAKE3_OK = "c" * 64
+
+
+@pytest.mark.parametrize(
+    "digest, expected",
+    [
+        (f"sha256:{_SHA256_OK}", True),
+        (f"sha512:{_SHA512_OK}", True),
+        (f"blake3:{_BLAKE3_OK}", True),
+        (f"sha256:{_SHA256_BAD_HEX}", False),
+        (f"sha256:{_SHA256_SHORT}", False),
+        (f"sha512:{_SHA512_SHORT}", False),
+        ("notadigest", False),
+        ("", False),
+        ("nocolon", False),
+        # Unknown algorithm: generic descriptor grammar only (no length check).
+        ("foo:bar", True),
+        ("acme:encoded-value_1", True),
+    ],
+)
+def test_is_valid_digest(digest: str, expected: bool):
+    assert mgr_util.is_valid_digest(digest) is expected
+
+
+@pytest.mark.parametrize(
+    "ref, expected",
+    [
+        # Typical registry + path + tag
+        ("quay.io/ceph/ceph", True),
+        ("quay.io/ceph/ceph:v18.2.0", True),
+        ("registry.example.com:5000/foo/bar:latest", True),
+        ("docker.io/library/nginx:1.25", True),
+        ("gcr.io/google-containers/pause:3.1", True),
+        ("mcr.microsoft.com/devcontainers/base:debian", True),
+        (f"quay.io/foo/bar@sha256:{_SHA256_OK}", True),
+        (f"localhost:5000/myapp/service@sha512:{_SHA512_OK}", True),
+        (f"127.0.0.1:5000/img/name@blake3:{_BLAKE3_OK}", True),
+        # Shorthand names (no registry)
+        ("ceph/ceph", True),
+        ("library/nginx:1", True),
+        ("alpine", True),
+        ("postgres:16-alpine", True),
+        # Tag charset (OCI distribution-spec tag)
+        ("quay.io/x/img:v1.2.3-rc.1", True),
+        ("registry.io/a/b/c/d/e:1", True),
+        # Reject common CLI/flag confusions
+        ("--force", False),
+        ("-f", False),
+        ("--image", False),
+        ("", False),
+        # Path traversal–looking strings can still match the permissive REGISTRY/NAME
+        # heuristic (e.g. ".."/"escape"). Use characters NAME/TAG reject instead:
+        ("quay.io/ceph/ceph:bad tag", False),
+        ("!not/valid", False),
+        # Malformed or wrong-length digest
+        (f"quay.io/foo@sha256:{_SHA256_BAD_HEX}", False),
+        (f"docker.io/lib/img@sha256:{_SHA256_SHORT}", False),
+    ],
+)
+def test_is_valid_container_image_ref(ref: str, expected: bool):
+    assert mgr_util.is_valid_container_image_ref(ref) is expected


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/75967
Signed-off-by: Kobi Ginon <kginon@redhat.com>

test result with the fix
```
[ceph: root@ceph-node-0 /]# ceph orch ps --daemon_type=osd
NAME   HOST         PORTS  STATUS        REFRESHED  AGE  MEM USE  MEM LIM  VERSION               IMAGE ID      CONTAINER ID
osd.0  ceph-node-0         running (3m)     3m ago   3m    50.7M    4096M  21.0.0-810-g21bad98f  28558c3b2fb4  402349a5dd47
osd.1  ceph-node-1         running (3m)    41s ago   3m    53.9M    4096M  21.0.0-810-g21bad98f  28558c3b2fb4  24dec7eb2542
osd.2  ceph-node-2         running (2m)    41s ago   2m    52.2M    2987M  21.0.0-810-g21bad98f  28558c3b2fb4  869880b3ce2a
[ceph: root@ceph-node-0 /]# ceph orch daemon redeploy osd.0 --force
Scheduled to redeploy osd.0 on host 'ceph-node-0'
[ceph: root@ceph-node-0 /]# ceph config dump | grep osd
osd     host:ceph-node-2  basic     osd_memory_target                      3132318924
osd                       advanced  osd_memory_target_autotune             true
[ceph: root@ceph-node-0 /]#  ceph config get osd.0 container_image
192.168.100.254:5000/ceph/ceph@sha256:af702caf35b9837f20d3c4a25eff22bdf86a6fdef9dcdc109b77c6866004bd4c
```

Unit tests Passsed

```
tests/test_mgr_util.py::test_pretty_timedelta[delta0-90m] PASSED                                                                                                                                            [  3%]
tests/test_mgr_util.py::test_pretty_timedelta[delta1-3h] PASSED                                                                                                                                             [  7%]
tests/test_mgr_util.py::test_pretty_timedelta[delta2-3d] PASSED                                                                                                                                             [ 11%]
tests/test_mgr_util.py::test_pretty_timedelta[delta3-3h] PASSED                                                                                                                                             [ 15%]
tests/test_mgr_util.py::test_pretty_timedelta[delta4-3y] PASSED                                                                                                                                             [ 19%]
tests/test_mgr_util.py::test_pretty_timedelta[delta5-90m] PASSED                                                                                                                                            [ 23%]
tests/test_mgr_util.py::TestCephFsEarmarkResolver::test_get_earmark PASSED                                                                                                                                  [ 26%]
tests/test_mgr_util.py::TestCephFsEarmarkResolver::test_set_earmark PASSED                                                                                                                                  [ 30%]
tests/test_mgr_util.py::TestCephFsEarmarkResolver::test_check_earmark PASSED                                                                                                                                [ 34%]
tests/test_mgr_util.py::test_is_valid_digest[sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-True] PASSED                                                                           [ 38%]
tests/test_mgr_util.py::test_is_valid_digest[sha512:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-True] PASSED           [ 42%]
tests/test_mgr_util.py::test_is_valid_digest[sha256:gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg-False] PASSED                                                                          [ 46%]
tests/test_mgr_util.py::test_is_valid_digest[notadigest-False] PASSED                                                                                                                                       [ 50%]
tests/test_mgr_util.py::test_is_valid_digest[foo:bar-True] PASSED                                                                                                                                           [ 53%]
tests/test_mgr_util.py::test_is_valid_container_image_ref[quay.io/ceph/ceph-True] PASSED                                                                                                                    [ 57%]
tests/test_mgr_util.py::test_is_valid_container_image_ref[quay.io/ceph/ceph:v18.2.0-True] PASSED                                                                                                            [ 61%]
tests/test_mgr_util.py::test_is_valid_container_image_ref[registry.example.com:5000/foo/bar:latest-True] PASSED                                                                                             [ 65%]
tests/test_mgr_util.py::test_is_valid_container_image_ref[quay.io/foo/bar@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-True] PASSED                                              [ 69%]
tests/test_mgr_util.py::test_is_valid_container_image_ref[ceph/ceph-True] PASSED                                                                                                                            [ 73%]
tests/test_mgr_util.py::test_is_valid_container_image_ref[library/nginx:1-True] PASSED                                                                                                                      [ 76%]
tests/test_mgr_util.py::test_is_valid_container_image_ref[--force-False] PASSED                                                                                                                             [ 80%]
tests/test_mgr_util.py::test_is_valid_container_image_ref[-f-False] PASSED                                                                                                                                  [ 84%]
tests/test_mgr_util.py::test_is_valid_container_image_ref[-False] PASSED                                                                                                                                    [ 88%]
tests/test_mgr_util.py::test_is_valid_container_image_ref[quay.io/ceph/ceph:bad tag-False] PASSED                                                                                                           [ 92%]
tests/test_mgr_util.py::test_is_valid_container_image_ref[!not/valid-False] PASSED                                                                                                                          [ 96%]
tests/test_mgr_util.py::test_is_valid_container_image_ref[quay.io/foo@sha256:gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg-False] PASSED                                                 [100%]

=============================================================================================== 26 passed in 0.05s ================================================================================================
  py3: OK (0.29=setup[0.03]+cmd[0.26] seconds)
  congratulations :) (0.32 seconds)
root@C-PF4513NK:~/ceph-adm-projects/ceph/src/pybind/mgr# tox -e py3 -- tests/test_mgr_util.py -v
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
