### PR TITLE
mgr/cephadm:Add NFS file logging support on host and organised log by daemon name 

### DIFF
--- a/doc/mgr/nfs.rst
+++ b/doc/mgr/nfs.rst
@@ -610,7 +610,15 @@ If the NFS service is running on a non-standard port number:
 Troubleshooting
 ===============
 
-There are two methds for examining NFS-Ganesha logs:
+Examining Logs
+--------------
+
+There are two types of logs available for troubleshooting NFS issues:
+
+NFS-Ganesha Logs
+^^^^^^^^^^^^^^^^
+
+NFS-Ganesha logs capture the NFS protocol operations and client interactions.
 
 #. ``cephadm``: List the NFS daemons by running the following command:
 
@@ -639,8 +647,25 @@ There are two methds for examining NFS-Ganesha logs:
 
        kubectl logs -n rook-ceph rook-ceph-nfs-<cluster_id>-<node_id> nfs-ganesha
 
-The NFS log level can be adjusted using the ``nfs cluster config set`` command
+The NFS-Ganesha log level can be adjusted using the ``nfs cluster config set`` command
 (see :ref:`nfs-cluster-set`).
+
+Ceph Client Logs
+^^^^^^^^^^^^^^^^
+
+Ceph client logs capture the backend communication between the NFS gateway and the Ceph storage cluster (RADOS operations).
+
+#. ``cephadm``: Ceph client logs are available on the host at:
+
+    .. prompt:: bash #
+
+      cat /var/log/ceph/<fsid>/client.nfs.<cluster_id>.*
+      # Example:
+      cat /var/log/ceph/60756928-8801-4110-9511-858524800000/client.nfs.mynfs.1.0.ceph-node-0.xkfzal.2.log
+
+   These logs show librados client operations including object reads/writes, metadata operations, and network messaging between the NFS gateway and Ceph daemons (MONs, OSDs).
+
+#. ``rook``: Ceph client logs are available within the NFS pod's logs alongside the NFS-Ganesha logs.
 
 
 .. _nfs-ganesha-config:

--- a/doc/mgr/nfs.rst
+++ b/doc/mgr/nfs.rst
@@ -624,6 +624,14 @@ There are two methds for examining NFS-Ganesha logs:
     .. prompt:: bash #
 
        cephadm logs --fsid <fsid> --name nfs.mynfs.0.0.myhost.xkfzal
+   
+   Alternatively, NFS-Ganesha logs are also available on the host at:
+
+    .. prompt:: bash #
+
+      cat /var/log/ceph/<fsid>/<daemon_name>/ganesha.log
+      # Example:
+      cat /var/log/ceph/60756928-8801-4110-9511-858524800000/nfs.mynfs.0.0.myhost.xkfzal/ganesha.log
 
 #. ``rook``:
 

--- a/src/cephadm/cephadmlib/daemons/nfs.py
+++ b/src/cephadm/cephadmlib/daemons/nfs.py
@@ -90,7 +90,7 @@ class NFSGanesha(ContainerDaemonForm):
         
         daemon_name = self.get_daemon_name()
         host_log_dir = f'/var/log/ceph/{self.fsid}/{daemon_name}'
-        mounts[host_log_dir] = '/var/log/ganesha:z'
+        mounts[host_log_dir] = '/var/log/ceph:z'
         if self.rgw:
             cluster = self.rgw.get('cluster', 'ceph')
             rgw_user = self.rgw.get('user', 'admin')

--- a/src/cephadm/cephadmlib/daemons/nfs.py
+++ b/src/cephadm/cephadmlib/daemons/nfs.py
@@ -87,6 +87,10 @@ class NFSGanesha(ContainerDaemonForm):
         mounts[os.path.join(data_dir, 'config')] = '/etc/ceph/ceph.conf:z'
         mounts[os.path.join(data_dir, 'keyring')] = '/etc/ceph/keyring:z'
         mounts[os.path.join(data_dir, 'etc/ganesha')] = '/etc/ganesha:z'
+        
+        daemon_name = self.get_daemon_name()
+        host_log_dir = f'/var/log/ceph/{self.fsid}/{daemon_name}'
+        mounts[host_log_dir] = '/var/log/ganesha:z'
         if self.rgw:
             cluster = self.rgw.get('cluster', 'ceph')
             rgw_user = self.rgw.get('user', 'admin')
@@ -180,6 +184,11 @@ class NFSGanesha(ContainerDaemonForm):
         tls_dir = os.path.join(data_dir, 'etc/ganesha/tls')
         makedirs(config_dir, uid, gid, 0o755)
         makedirs(tls_dir, uid, gid, 0o755)
+        
+        # Create log directory on host at /var/log/ceph/<fsid>/<daemon_name>
+        daemon_name = self.get_daemon_name()
+        log_dir = f'/var/log/ceph/{self.fsid}/{daemon_name}'
+        makedirs(log_dir, uid, gid, 0o755)
 
         config_files = {
             fname: content

--- a/src/cephadm/tests/test_nfs.py
+++ b/src/cephadm/tests/test_nfs.py
@@ -119,10 +119,11 @@ def test_nfsganesha_container_mounts():
             good_nfs_json(),
         )
         cmounts = nfsg._get_container_mounts("/var/tmp")
-        assert len(cmounts) == 3
+        assert len(cmounts) == 4
         assert cmounts["/var/tmp/config"] == "/etc/ceph/ceph.conf:z"
         assert cmounts["/var/tmp/keyring"] == "/etc/ceph/keyring:z"
         assert cmounts["/var/tmp/etc/ganesha"] == "/etc/ganesha:z"
+        assert cmounts[f"/var/log/ceph/{SAMPLE_UUID}/nfs.fred"] == "/var/log/ganesha:z"
 
     with with_cephadm_ctx([]) as ctx:
         nfsg = _cephadm.NFSGanesha(
@@ -132,7 +133,7 @@ def test_nfsganesha_container_mounts():
             nfs_json(pool=True, files=True, rgw=True),
         )
         cmounts = nfsg._get_container_mounts("/var/tmp")
-        assert len(cmounts) == 4
+        assert len(cmounts) == 5
         assert cmounts["/var/tmp/config"] == "/etc/ceph/ceph.conf:z"
         assert cmounts["/var/tmp/keyring"] == "/etc/ceph/keyring:z"
         assert cmounts["/var/tmp/etc/ganesha"] == "/etc/ganesha:z"
@@ -140,6 +141,7 @@ def test_nfsganesha_container_mounts():
             cmounts["/var/tmp/keyring.rgw"]
             == "/var/lib/ceph/radosgw/ceph-jsmith/keyring:z"
         )
+        assert cmounts[f"/var/log/ceph/{SAMPLE_UUID}/nfs.fred"] == "/var/log/ganesha:z"
 
 
 def test_nfsganesha_container_envs():

--- a/src/cephadm/tests/test_nfs.py
+++ b/src/cephadm/tests/test_nfs.py
@@ -123,7 +123,7 @@ def test_nfsganesha_container_mounts():
         assert cmounts["/var/tmp/config"] == "/etc/ceph/ceph.conf:z"
         assert cmounts["/var/tmp/keyring"] == "/etc/ceph/keyring:z"
         assert cmounts["/var/tmp/etc/ganesha"] == "/etc/ganesha:z"
-        assert cmounts[f"/var/log/ceph/{SAMPLE_UUID}/nfs.fred"] == "/var/log/ganesha:z"
+        assert cmounts[f"/var/log/ceph/{SAMPLE_UUID}/nfs.fred"] == "/var/log/ceph:z"
 
     with with_cephadm_ctx([]) as ctx:
         nfsg = _cephadm.NFSGanesha(
@@ -141,7 +141,7 @@ def test_nfsganesha_container_mounts():
             cmounts["/var/tmp/keyring.rgw"]
             == "/var/lib/ceph/radosgw/ceph-jsmith/keyring:z"
         )
-        assert cmounts[f"/var/log/ceph/{SAMPLE_UUID}/nfs.fred"] == "/var/log/ganesha:z"
+        assert cmounts[f"/var/log/ceph/{SAMPLE_UUID}/nfs.fred"] == "/var/log/ceph:z"
 
 
 def test_nfsganesha_container_envs():


### PR DESCRIPTION
Add NFS file logging support on the host and organize the log by daemon name.

Fixes: https://tracker.ceph.com/issues/76160
Signed-off-by: Pooja Dwivedi pooja.dwivedi@ibm.com

### Description
NFS Ganesha container does not mount any log dir. In case of debugging the Ceph client while running NFS Ganesha, one can enable debugging, but the default log file will not get created as the log dir is not defined and not available in the container. This leads to not having a Ceph client log file.
To solve this issue, the existing log directory on container is mounted on the host and is organised by daemon name.

### Testing Steps:
Create NFS cluster

Testing Logs:
```
[ceph: root@ceph-node-0 /]# ceph nfs cluster create myfs --placement="2 ceph-node-0 ceph-node-1"
Scheduled nfs.myfs update...

[ceph: root@ceph-node-0 /]# ceph orch ps --daemon-type nfs 
NAME                              HOST         PORTS   STATUS        REFRESHED  AGE  MEM USE  MEM LIM  VERSION    IMAGE ID      CONTAINER ID  
nfs.myfs.0.0.ceph-node-1.omvqmp   ceph-node-1  *:2049  running (8m)     5m ago   8m    9420k        -  7.0        c806d436f2fb  f7398643e9bb  
nfs.myfs.1.0.ceph-node-0.spaabh   ceph-node-0  *:2049  running (8m)     8m ago   8m    9286k        -  7.0        c806d436f2fb  7cc48f50958e  

[ceph: root@ceph-node-0 /]# exit
exit

[root@ceph-node-0 nfs.myfs.1.0.ceph-node-0.spaabh]# pwd
/var/log/ceph/203e8cfa-43a2-11f1-acb1-5254002f9557/nfs.myfs.1.0.ceph-node-0.spaabh

[root@ceph-node-0 nfs.myfs.1.0.ceph-node-0.spaabh]# ls
client.nfs.myfs.1.0.ceph-node-0.spaabh.2.log  ganesha.log

```



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>
[root@ceph-node-0 07817d3e-3c91-11f1-aa15-52540016f5a3]# cd nfs.mynfs.0.0.ceph-node-0.rstvum
[root@ceph-node-0 nfs.mynfs.0.0.ceph-node-0.rstvum]# ls
ganesha.log

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
