### PR TITLE
mgr: enrich `ceph osd perf` with per-OSD latency KPIs

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -285,6 +285,15 @@
   on a devdax namespace (a character device such as ``/dev/dax0.0``) will no
   longer start, because no remaining backend can open one; reconfigure the
   namespace to fsdax with ``ndctl`` or re-provision them before upgrading.
+* MGR: ``ceph osd perf`` now reports per-OSD latency KPIs pulled from the
+  Manager's cached perf counters: ``op_latency``, ``op_r_latency``,
+  ``op_w_latency``, ``bluestore_w_latency``, ``bluestore_r_latency`` and
+  ``kv_sync``. The old ``commit_latency_ms`` and ``apply_latency_ms`` columns
+  (and their JSON keys, including the ``*_ns`` variants) are gone from this
+  command. On BlueStore both always reported the same number, so they were
+  redundant. Prometheus and the Dashboard read ``os_perf_stat`` from the PG map
+  directly rather than from this CLI, so ``ceph_osd_commit_latency_ms``,
+  ``ceph_osd_apply_latency_ms`` and the matching Grafana panels keep working.
 
 >=20.0.0
 

--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -321,6 +321,15 @@
   read-only fsck, gated by the new ``bluestore_accept_corrupted_onode_recovery``
   option (``never`` or ``read-only``, default ``read-only``); mount, repair, and
   ``ceph-bluestore-tool trim`` still abort.
+* MGR: ``ceph osd perf`` now reports per-OSD latency KPIs pulled from the
+  Manager's cached perf counters: ``op_latency``, ``op_r_latency``,
+  ``op_w_latency``, ``bluestore_w_latency``, ``bluestore_r_latency`` and
+  ``kv_sync``. The old ``commit_latency_ms`` and ``apply_latency_ms`` columns
+  (and their JSON keys, including the ``*_ns`` variants) are gone from this
+  command. On BlueStore both always reported the same number, so they were
+  redundant. Prometheus and the Dashboard read ``os_perf_stat`` from the PG map
+  directly rather than from this CLI, so ``ceph_osd_commit_latency_ms``,
+  ``ceph_osd_apply_latency_ms`` and the matching Grafana panels keep working.
 
 >=20.0.0
 

--- a/qa/standalone/mon/osd-perf.sh
+++ b/qa/standalone/mon/osd-perf.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
+
+function run() {
+    local dir=$1
+    shift
+
+    export CEPH_MON="127.0.0.1:7114" # git grep '\<7114\>' : there must be only one
+    export CEPH_ARGS
+    CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
+    CEPH_ARGS+="--mon-host=$CEPH_MON "
+
+    local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
+    for func in $funcs ; do
+        setup $dir || return 1
+        $func $dir || return 1
+        teardown $dir || return 1
+    done
+}
+
+function TEST_osd_perf() {
+    local dir=$1
+    setup $dir || return 1
+
+    run_mon $dir a || return 1
+    run_mgr $dir x || return 1
+    run_osd $dir 0 || return 1
+    run_osd $dir 1 || return 1
+
+    # Drive a mix of read and write IO so every per-OSD KPI
+    # (op_latency / op_r_latency / op_w_latency / bluestore_w_latency /
+    # bluestore_r_latency / kv_sync) has at least one sample by the time
+    # we query the command.
+    ceph osd pool create testpool 8 || return 1
+    rados bench -p testpool 10 write --no-cleanup >/dev/null 2>&1
+    rados bench -p testpool 5 rand >/dev/null 2>&1
+    sleep 10
+
+    # Plain text output: the legacy commit/apply columns were dropped;
+    # prometheus and the dashboard read pg_map.osd_stat directly.
+    local out
+    out=$(ceph osd perf) || return 1
+    echo "$out" | grep -q "commit_latency(ms)" && return 1
+    echo "$out" | grep -q "apply_latency(ms)" && return 1
+    echo "$out" | grep -q "op_latency(ms)" || return 1
+    echo "$out" | grep -q "op_r_latency(ms)" || return 1
+    echo "$out" | grep -q "op_w_latency(ms)" || return 1
+    echo "$out" | grep -q "bluestore_w_latency(ms)" || return 1
+    echo "$out" | grep -q "bluestore_r_latency(ms)" || return 1
+    echo "$out" | grep -q "kv_sync(ms)" || return 1
+
+    # JSON output: same shape, legacy keys removed.
+    local json
+    json=$(ceph osd perf -f json) || return 1
+    echo "$json" | grep -q '"commit_latency_ms"' && return 1
+    echo "$json" | grep -q '"apply_latency_ms"' && return 1
+    echo "$json" | grep -q '"osd_perf_infos"' || return 1
+    echo "$json" | grep -q '"op_latency_ms"' || return 1
+
+    teardown $dir || return 1
+}
+
+main osd-perf "$@"

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -16,6 +16,7 @@
 #include "DaemonState.h"
 #include "Mgr.h"
 #include "MgrSession.h"
+#include "PerfCounterInstance.h"
 
 #include "include/stringify.h"
 #include "include/str_list.h"
@@ -54,8 +55,11 @@
 
 #include <iomanip>
 
+#include <array>
 #include <list>
 #include <map>
+#include <optional>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -2023,6 +2027,144 @@ bool DaemonServer::_handle_command(
 			      &on_finish->from_mon, &on_finish->outs, on_finish);
       return true;
     }
+  } else if (prefix == "osd perf") {
+    // Per-OSD latency KPIs pulled from the mgr's cached perf counters.
+    // Crimson OSDs use seastar metrics rather than PerfCounters, so the
+    // paths below won't be present in their daemon_state; the plain-text
+    // table omits a column entirely if no OSD has data for it, and the
+    // JSON output skips missing fields per-OSD.
+    //
+    // The previous commit/apply latency columns/JSON keys were dropped
+    // here. Prometheus and the dashboard read pg_map.osd_stat.os_perf_stat
+    // directly, not the CLI, so ceph_osd_commit_latency_ms /
+    // ceph_osd_apply_latency_ms continue to work unchanged.
+    struct extra_col {
+      const char* path;        // mgr perf counter path
+      const char* json_field;  // JSON key
+      const char* column;      // plain-table column header
+    };
+    static const std::array<extra_col, 6> extra = {{
+      {"osd.op_latency",         "op_latency_ms",          "op_latency(ms)"},
+      {"osd.op_r_latency",       "op_r_latency_ms",        "op_r_latency(ms)"},
+      {"osd.op_w_latency",       "op_w_latency_ms",        "op_w_latency(ms)"},
+      {"bluestore.write_lat",    "bluestore_w_latency_ms", "bluestore_w_latency(ms)"},
+      {"bluestore.read_lat",     "bluestore_r_latency_ms", "bluestore_r_latency(ms)"},
+      {"bluestore.kv_sync_lat",  "kv_sync_lat_ms",         "kv_sync(ms)"},
+    }};
+
+    // Bound the per-op avg walk-back so a long idle stretch can't drag
+    // a stale "busy" reference point into the displayed value.
+    const utime_t avg_max_age{60, 0};
+
+    auto lookup_ns = [this, &avg_max_age](int osd_id, const std::string& path)
+        -> std::optional<uint64_t> {
+      DaemonKey key{"osd", std::to_string(osd_id)};
+      if (!daemon_state.exists(key)) {
+        return std::nullopt;
+      }
+      auto daemon = daemon_state.get(key);
+      std::lock_guard l(daemon->lock);
+      auto it = daemon->perf_counters.instances.find(path);
+      if (it == daemon->perf_counters.instances.end()) {
+        return std::nullopt;
+      }
+      return it->second.get_current_avg(avg_max_age);
+    };
+
+    // Render a nanosecond latency as milliseconds. >=1 ms is integer
+    // milliseconds; sub-millisecond shows three decimals so fast
+    // storage does not render as "0".
+    auto format_ms = [](uint64_t ns) -> std::string {
+      if (ns >= 1000000ULL) {
+        return std::to_string(ns / 1000000ULL);
+      }
+      std::ostringstream oss;
+      oss << std::fixed << std::setprecision(3) << (ns / 1000000.0);
+      return oss.str();
+    };
+
+    // Pull the OSD list out of pg_map under its lock; do all
+    // perf-counter lookups + formatting outside so daemon->lock is
+    // never acquired while pg_map's lock is held.
+    std::vector<int> osd_ids;
+    r = cluster_state.with_pgmap([&](const PGMap& pg_map) {
+      osd_ids.reserve(pg_map.osd_stat.size());
+      for (const auto& [osd_id, _] : pg_map.osd_stat) {
+        osd_ids.push_back(osd_id);
+      }
+      return 0;
+    });
+
+    if (f) {
+      f->open_object_section("osdstats");
+      f->open_array_section("osd_perf_infos");
+      for (int osd_id : osd_ids) {
+        f->open_object_section("osd");
+        f->dump_int("id", osd_id);
+        f->open_object_section("perf_stats");
+        for (const auto& e : extra) {
+          if (auto ns = lookup_ns(osd_id, e.path); ns) {
+            // Three decimals keeps the JSON compact and matches the
+            // plain-text table; double precision would leak
+            // "0.056222000000000001"-style noise via
+            // JSONFormatter::dump_float.
+            f->dump_format_unquoted(e.json_field, "%.3f",
+                                    *ns / 1000000.0);
+          }
+        }
+        f->close_section();
+        f->close_section();
+      }
+      f->close_section();
+      f->close_section();
+      f->flush(cmdctx->odata);
+    } else {
+      // First pass: record which columns have data for any OSD. Drop
+      // columns with nothing to report (typical on pure-crimson
+      // clusters) so the table isn't padded with `-` placeholders.
+      std::vector<std::vector<std::optional<uint64_t>>> rows;
+      rows.reserve(osd_ids.size());
+      std::array<bool, extra.size()> has_data{};
+      for (int osd_id : osd_ids) {
+        std::vector<std::optional<uint64_t>> vals;
+        vals.reserve(extra.size());
+        for (size_t i = 0; i < extra.size(); ++i) {
+          auto v = lookup_ns(osd_id, extra[i].path);
+          if (v) {
+            has_data[i] = true;
+          }
+          vals.push_back(v);
+        }
+        rows.push_back(std::move(vals));
+      }
+
+      TextTable tab;
+      tab.define_column("osd", TextTable::LEFT, TextTable::RIGHT);
+      for (size_t i = 0; i < extra.size(); ++i) {
+        if (has_data[i]) {
+          tab.define_column(extra[i].column, TextTable::LEFT, TextTable::RIGHT);
+        }
+      }
+      for (size_t row_idx = 0; row_idx < osd_ids.size(); ++row_idx) {
+        tab << osd_ids[row_idx];
+        for (size_t i = 0; i < extra.size(); ++i) {
+          if (!has_data[i]) {
+            continue;
+          }
+          if (rows[row_idx][i]) {
+            tab << format_ms(*rows[row_idx][i]);
+          } else {
+            tab << "-";
+          }
+        }
+        tab << TextTable::endrow;
+      }
+      std::ostringstream os;
+      os << tab;
+      cmdctx->odata.append(os.str());
+    }
+    cmdctx->reply(r, ss);
+    return true;
   } else if (prefix == "osd df") {
     string method, filter;
     cmd_getval(cmdctx->cmdmap, "output_method", method);

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -16,6 +16,7 @@
 #include "DaemonState.h"
 #include "Mgr.h"
 #include "MgrSession.h"
+#include "PerfCounterInstance.h"
 
 #include "include/stringify.h"
 #include "include/str_list.h"
@@ -54,8 +55,11 @@
 
 #include <iomanip>
 
+#include <array>
 #include <list>
 #include <map>
+#include <optional>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -2042,6 +2046,144 @@ bool DaemonServer::_handle_command(
 			      &on_finish->from_mon, &on_finish->outs, on_finish);
       return true;
     }
+  } else if (prefix == "osd perf") {
+    // Per-OSD latency KPIs pulled from the mgr's cached perf counters.
+    // Crimson OSDs use seastar metrics rather than PerfCounters, so the
+    // paths below won't be present in their daemon_state; the plain-text
+    // table omits a column entirely if no OSD has data for it, and the
+    // JSON output skips missing fields per-OSD.
+    //
+    // The previous commit/apply latency columns/JSON keys were dropped
+    // here. Prometheus and the dashboard read pg_map.osd_stat.os_perf_stat
+    // directly, not the CLI, so ceph_osd_commit_latency_ms /
+    // ceph_osd_apply_latency_ms continue to work unchanged.
+    struct extra_col {
+      const char* path;        // mgr perf counter path
+      const char* json_field;  // JSON key
+      const char* column;      // plain-table column header
+    };
+    static const std::array<extra_col, 6> extra = {{
+      {"osd.op_latency",         "op_latency_ms",          "op_latency(ms)"},
+      {"osd.op_r_latency",       "op_r_latency_ms",        "op_r_latency(ms)"},
+      {"osd.op_w_latency",       "op_w_latency_ms",        "op_w_latency(ms)"},
+      {"bluestore.write_lat",    "bluestore_w_latency_ms", "bluestore_w_latency(ms)"},
+      {"bluestore.read_lat",     "bluestore_r_latency_ms", "bluestore_r_latency(ms)"},
+      {"bluestore.kv_sync_lat",  "kv_sync_lat_ms",         "kv_sync(ms)"},
+    }};
+
+    // Bound the per-op avg walk-back so a long idle stretch can't drag
+    // a stale "busy" reference point into the displayed value.
+    const utime_t avg_max_age{60, 0};
+
+    auto lookup_ns = [this, &avg_max_age](int osd_id, const std::string& path)
+        -> std::optional<uint64_t> {
+      DaemonKey key{"osd", std::to_string(osd_id)};
+      if (!daemon_state.exists(key)) {
+        return std::nullopt;
+      }
+      auto daemon = daemon_state.get(key);
+      std::lock_guard l(daemon->lock);
+      auto it = daemon->perf_counters.instances.find(path);
+      if (it == daemon->perf_counters.instances.end()) {
+        return std::nullopt;
+      }
+      return it->second.get_current_avg(avg_max_age);
+    };
+
+    // Render a nanosecond latency as milliseconds. >=1 ms is integer
+    // milliseconds; sub-millisecond shows three decimals so fast
+    // storage does not render as "0".
+    auto format_ms = [](uint64_t ns) -> std::string {
+      if (ns >= 1000000ULL) {
+        return std::to_string(ns / 1000000ULL);
+      }
+      std::ostringstream oss;
+      oss << std::fixed << std::setprecision(3) << (ns / 1000000.0);
+      return oss.str();
+    };
+
+    // Pull the OSD list out of pg_map under its lock; do all
+    // perf-counter lookups + formatting outside so daemon->lock is
+    // never acquired while pg_map's lock is held.
+    std::vector<int> osd_ids;
+    r = cluster_state.with_pgmap([&](const PGMap& pg_map) {
+      osd_ids.reserve(pg_map.osd_stat.size());
+      for (const auto& [osd_id, _] : pg_map.osd_stat) {
+        osd_ids.push_back(osd_id);
+      }
+      return 0;
+    });
+
+    if (f) {
+      f->open_object_section("osdstats");
+      f->open_array_section("osd_perf_infos");
+      for (int osd_id : osd_ids) {
+        f->open_object_section("osd");
+        f->dump_int("id", osd_id);
+        f->open_object_section("perf_stats");
+        for (const auto& e : extra) {
+          if (auto ns = lookup_ns(osd_id, e.path); ns) {
+            // Three decimals keeps the JSON compact and matches the
+            // plain-text table; double precision would leak
+            // "0.056222000000000001"-style noise via
+            // JSONFormatter::dump_float.
+            f->dump_format_unquoted(e.json_field, "%.3f",
+                                    *ns / 1000000.0);
+          }
+        }
+        f->close_section();
+        f->close_section();
+      }
+      f->close_section();
+      f->close_section();
+      f->flush(cmdctx->odata);
+    } else {
+      // First pass: record which columns have data for any OSD. Drop
+      // columns with nothing to report (typical on pure-crimson
+      // clusters) so the table isn't padded with `-` placeholders.
+      std::vector<std::vector<std::optional<uint64_t>>> rows;
+      rows.reserve(osd_ids.size());
+      std::array<bool, extra.size()> has_data{};
+      for (int osd_id : osd_ids) {
+        std::vector<std::optional<uint64_t>> vals;
+        vals.reserve(extra.size());
+        for (size_t i = 0; i < extra.size(); ++i) {
+          auto v = lookup_ns(osd_id, extra[i].path);
+          if (v) {
+            has_data[i] = true;
+          }
+          vals.push_back(v);
+        }
+        rows.push_back(std::move(vals));
+      }
+
+      TextTable tab;
+      tab.define_column("osd", TextTable::LEFT, TextTable::RIGHT);
+      for (size_t i = 0; i < extra.size(); ++i) {
+        if (has_data[i]) {
+          tab.define_column(extra[i].column, TextTable::LEFT, TextTable::RIGHT);
+        }
+      }
+      for (size_t row_idx = 0; row_idx < osd_ids.size(); ++row_idx) {
+        tab << osd_ids[row_idx];
+        for (size_t i = 0; i < extra.size(); ++i) {
+          if (!has_data[i]) {
+            continue;
+          }
+          if (rows[row_idx][i]) {
+            tab << format_ms(*rows[row_idx][i]);
+          } else {
+            tab << "-";
+          }
+        }
+        tab << TextTable::endrow;
+      }
+      std::ostringstream os;
+      os << tab;
+      cmdctx->odata.append(os.str());
+    }
+    cmdctx->reply(r, ss);
+    return true;
   } else if (prefix == "osd df") {
     string method, filter;
     cmd_getval(cmdctx->cmdmap, "output_method", method);

--- a/src/mgr/PerfCounterInstance.h
+++ b/src/mgr/PerfCounterInstance.h
@@ -15,6 +15,7 @@
 #define PERF_COUNTER_INSTANCE_H_
 
 #include <cstdint>
+#include <optional>
 
 #include <boost/circular_buffer.hpp>
 
@@ -70,6 +71,39 @@ class PerfCounterInstance
   }
   void push(utime_t t, uint64_t const &v);
   void push_avg(utime_t t, uint64_t const &s, uint64_t const &c);
+
+  // Compute a per-op average latency for display. Prefers the delta
+  // between the two most recent samples in which the op count advanced
+  // (walking back through the buffer past any idle samples), since that
+  // reflects current behavior. `max_age` bounds the walk-back: samples
+  // older than `latest.t - max_age` are ignored, so a long idle stretch
+  // can't drag a stale "busy" reference point into the displayed value.
+  // Pass a zero utime_t to disable the bound.
+  //
+  // Falls back to the lifetime cumulative `s/c` only when a single
+  // sample is buffered (right after a mgr restart, before any delta is
+  // possible). When multiple samples are buffered but none within the
+  // window show op activity, returns nullopt - the counter is currently
+  // idle and the caller can render a dash rather than a stale value.
+  std::optional<uint64_t> get_current_avg(utime_t max_age = utime_t()) const {
+    if (avg_buffer.empty()) {
+      return std::nullopt;
+    }
+    const auto& latest = avg_buffer.back();
+    for (size_t i = avg_buffer.size() - 1; i-- > 0; ) {
+      const auto& prev = avg_buffer[i];
+      if (!max_age.is_zero() && (latest.t - prev.t) > max_age) {
+        break;
+      }
+      if (latest.c > prev.c) {
+        return (latest.s - prev.s) / (latest.c - prev.c);
+      }
+    }
+    if (avg_buffer.size() == 1 && latest.c > 0) {
+      return latest.s / latest.c;
+    }
+    return std::nullopt;
+  }
 
   PerfCounterInstance(enum perfcounter_type_d type)
   {

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -2102,49 +2102,6 @@ int PGMap::dump_stuck_pg_stats(
   return 0;
 }
 
-std::vector<std::pair<int32_t, osd_stat_t>> PGMap::get_sorted_osd_stats() const
-{
-  std::vector<std::pair<int32_t, osd_stat_t>> sorted_stats(osd_stat.begin(), osd_stat.end());
-
-  std::sort(sorted_stats.begin(), sorted_stats.end(), [](const auto& a, const auto& b) {
-    return a.first < b.first;
-  });
-
-  return sorted_stats;
-}
-
-void PGMap::dump_osd_perf_stats(ceph::Formatter *f) const
-{
-  f->open_array_section("osd_perf_infos");
-
-  for (const auto& [osd_id, stat] : get_sorted_osd_stats()) {
-    f->open_object_section("osd");
-    f->dump_int("id", osd_id);
-    {
-      f->open_object_section("perf_stats");
-      stat.os_perf_stat.dump(f);
-      f->close_section();
-    }
-    f->close_section();
-  }
-  f->close_section();
-}
-void PGMap::print_osd_perf_stats(std::ostream *ss) const
-{
-  TextTable tab;
-  tab.define_column("osd", TextTable::LEFT, TextTable::RIGHT);
-  tab.define_column("commit_latency(ms)", TextTable::LEFT, TextTable::RIGHT);
-  tab.define_column("apply_latency(ms)", TextTable::LEFT, TextTable::RIGHT);
-
-  for (const auto& [osd_id, stat] : get_sorted_osd_stats()) {
-    tab << osd_id;
-    tab << stat.os_perf_stat.os_commit_latency_ns / 1000000ull;
-    tab << stat.os_perf_stat.os_apply_latency_ns / 1000000ull;
-    tab << TextTable::endrow;
-  }
-  (*ss) << tab;
-}
-
 void PGMap::dump_osd_blocked_by_stats(ceph::Formatter *f) const
 {
   f->open_array_section("osd_blocked_by_infos");
@@ -3796,19 +3753,6 @@ int process_pg_map_command(
       odata->append(ds);
       return 0;
     }
-  }
-
-  if (prefix == "osd perf") {
-    if (f) {
-      f->open_object_section("osdstats");
-      pg_map.dump_osd_perf_stats(f);
-      f->close_section();
-      f->flush(ds);
-    } else {
-      pg_map.print_osd_perf_stats(&ds);
-    }
-    odata->append(ds);
-    return 0;
   }
 
   if (prefix == "osd blocked-by") {

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -385,7 +385,6 @@ public:
                              const utime_t ts,
                              const int64_t pool,
                              const pool_stat_t& old_pool_sum);
-  std::vector<std::pair<int32_t, osd_stat_t>> get_sorted_osd_stats() const;
 
  public:
 
@@ -521,9 +520,6 @@ public:
   void dump_osd_stats(std::ostream& ss) const;
   void dump_osd_sum_stats(std::ostream& ss) const;
   void dump_filtered_pg_stats(std::ostream& ss, std::set<pg_t>& pgs) const;
-
-  void dump_osd_perf_stats(ceph::Formatter *f) const;
-  void print_osd_perf_stats(std::ostream *ss) const;
 
   void dump_osd_blocked_by_stats(ceph::Formatter *f) const;
   void print_osd_blocked_by_stats(std::ostream *ss) const;

--- a/src/test/mgr/CMakeLists.txt
+++ b/src/test/mgr/CMakeLists.txt
@@ -81,6 +81,13 @@ add_ceph_unittest(unittest_mgr_map_cache)
 target_link_libraries(unittest_mgr_map_cache ceph-common
   Python3::Python ${CMAKE_DL_LIBS} ${GSSAPI_LIBRARIES})
 
+# unittest_mgr_perf_counter_instance
+add_executable(unittest_mgr_perf_counter_instance
+  test_perf_counter_instance.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/PerfCounterInstance.cc)
+add_ceph_unittest(unittest_mgr_perf_counter_instance)
+target_link_libraries(unittest_mgr_perf_counter_instance ceph-common)
+
 #scripts
 if(WITH_MGR_DASHBOARD_FRONTEND)
   if(NOT CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64|arm|ARM")

--- a/src/test/mgr/test_perf_counter_instance.cc
+++ b/src/test/mgr/test_perf_counter_instance.cc
@@ -1,0 +1,108 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#include "mgr/PerfCounterInstance.h"
+#include "gtest/gtest.h"
+
+namespace {
+utime_t tp(double s) {
+  utime_t t;
+  t.set_from_double(s);
+  return t;
+}
+}
+
+TEST(PerfCounterInstance, CurrentAvgEmptyBuffer)
+{
+  PerfCounterInstance inst{PERFCOUNTER_LONGRUNAVG};
+  EXPECT_FALSE(inst.get_current_avg().has_value());
+}
+
+TEST(PerfCounterInstance, CurrentAvgSingleSampleFallsBackToCumulative)
+{
+  // Right after a mgr restart, only the first report is buffered. We
+  // fall back to the lifetime cumulative average so the command has
+  // something to show instead of a dash.
+  PerfCounterInstance inst{PERFCOUNTER_LONGRUNAVG};
+  inst.push_avg(tp(1.0), /*sum_ns=*/1'000'000, /*count=*/10);
+  auto avg = inst.get_current_avg();
+  ASSERT_TRUE(avg.has_value());
+  EXPECT_EQ(100'000ULL, *avg); // 1ms / 10 ops = 100us per op
+}
+
+TEST(PerfCounterInstance, CurrentAvgSingleSampleZeroCount)
+{
+  // Lifetime count is zero - no ops ever observed, no meaningful avg.
+  PerfCounterInstance inst{PERFCOUNTER_LONGRUNAVG};
+  inst.push_avg(tp(1.0), 0, 0);
+  EXPECT_FALSE(inst.get_current_avg().has_value());
+}
+
+TEST(PerfCounterInstance, CurrentAvgDelta)
+{
+  PerfCounterInstance inst{PERFCOUNTER_LONGRUNAVG};
+  // First observation: 1 ms total across 10 ops.
+  inst.push_avg(tp(1.0), 1'000'000, 10);
+  // Second observation: 10 new ops took 20 ms total (2 ms each).
+  inst.push_avg(tp(2.0), 1'000'000 + 20'000'000, 20);
+  auto avg = inst.get_current_avg();
+  ASSERT_TRUE(avg.has_value());
+  EXPECT_EQ(2'000'000ULL, *avg);
+}
+
+TEST(PerfCounterInstance, CurrentAvgNoNewOpsReturnsNullopt)
+{
+  PerfCounterInstance inst{PERFCOUNTER_LONGRUNAVG};
+  // All buffered samples share the same count - no recent activity.
+  // The lifetime cumulative would mix in ops from arbitrarily long ago,
+  // so the helper returns nullopt and the caller renders a dash.
+  inst.push_avg(tp(1.0), 21'000'000, 7);
+  inst.push_avg(tp(2.0), 21'000'000, 7);
+  inst.push_avg(tp(3.0), 21'000'000, 7);
+  EXPECT_FALSE(inst.get_current_avg().has_value());
+}
+
+TEST(PerfCounterInstance, CurrentAvgWalksBackPastIdleSamples)
+{
+  PerfCounterInstance inst{PERFCOUNTER_LONGRUNAVG};
+  // Activity happened a few intervals ago; most recent samples are idle.
+  // The helper should still report the recent-activity delta rather
+  // than the lifetime cumulative, because the cluster just stopped
+  // doing IO moments ago.
+  inst.push_avg(tp(1.0), 0, 0);
+  inst.push_avg(tp(2.0), 10'000'000, 5);       // 2 ms/op during this burst
+  inst.push_avg(tp(3.0), 10'000'000, 5);       // idle
+  inst.push_avg(tp(4.0), 10'000'000, 5);       // idle
+  auto avg = inst.get_current_avg();
+  ASSERT_TRUE(avg.has_value());
+  EXPECT_EQ(2'000'000ULL, *avg);
+}
+
+TEST(PerfCounterInstance, CurrentAvgOnlyUsesLastTwo)
+{
+  PerfCounterInstance inst{PERFCOUNTER_LONGRUNAVG};
+  // Older sample should be ignored once a newer pair is available.
+  inst.push_avg(tp(1.0), 0, 0);
+  inst.push_avg(tp(2.0), 1'000'000'000, 100); // would yield 10 ms/op
+  inst.push_avg(tp(3.0), 1'000'000'000 + 5'000'000, 105); // 1 ms/op since prev
+  auto avg = inst.get_current_avg();
+  ASSERT_TRUE(avg.has_value());
+  EXPECT_EQ(1'000'000ULL, *avg);
+}
+
+TEST(PerfCounterInstance, CurrentAvgRespectsMaxAge)
+{
+  PerfCounterInstance inst{PERFCOUNTER_LONGRUNAVG};
+  // A burst of activity 30s ago, then idle. Without max_age the helper
+  // would fold the old burst's delta into the displayed value.
+  inst.push_avg(tp(0.0), 0, 0);
+  inst.push_avg(tp(1.0), 10'000'000, 5);   // 2 ms/op during the burst
+  inst.push_avg(tp(31.0), 10'000'000, 5);  // idle 30s later
+  // 5s window: prev sample at tp(1.0) is too old, walk-back stops.
+  // Buffer has >1 sample, so no lifetime fallback - return nullopt.
+  EXPECT_FALSE(inst.get_current_avg(utime_t(5, 0)).has_value());
+  // 60s window covers both samples - delta from the burst is reported.
+  auto avg = inst.get_current_avg(utime_t(60, 0));
+  ASSERT_TRUE(avg.has_value());
+  EXPECT_EQ(2'000'000ULL, *avg);
+}


### PR DESCRIPTION
## Summary

`ceph osd perf` has shipped just `commit_latency` and `apply_latency`
for years. On any BlueStore cluster those two columns are literally
the same number (`BSPerfTracker::update_from_perfcounters` feeds
`l_bluestore_commit_lat` into both fields), and neither maps cleanly
to a counter in `perf dump`. [Dan filed #74247](https://tracker.ceph.com/issues/74247)
(dup of [#67968](https://tracker.ceph.com/issues/67968)) asking for
more useful KPIs.

Replaces the two legacy columns with six per-OSD KPIs joined in from
the mgr's cached perf counters:

- `op_latency`, `op_r_latency`, `op_w_latency` (client op durations)
- `bluestore_w_latency`, `bluestore_r_latency` (store-layer)
- `kv_sync` (RocksDB commit flush)

`commit_latency_ms` / `apply_latency_ms` / `*_ns` columns and JSON
keys are dropped from the CLI here. Prometheus and the dashboard read
`pg_map.osd_stat.os_perf_stat` directly via `PGMap::dump_osd_stats`,
not the CLI, so `ceph_osd_commit_latency_ms` /
`ceph_osd_apply_latency_ms` and the corresponding Grafana queries
keep working unchanged.

## Notes

- `osd perf` moves from the (now-unreachable) branch in
  `mon/PGMap.cc` to `DaemonServer::_handle_command`, where
  `daemon_state` is in scope. Dead PGMap branch and the now-unused
  `dump_osd_perf_stats` / `print_osd_perf_stats` helpers removed.
- The handler collects the OSD list under `ClusterState`'s pg_map
  lock, releases it, and only then walks `daemon_state`.
  `DaemonState::lock` is never acquired while the pg_map lock is
  held.
- `PerfCounterInstance::get_current_avg()` walks back through the
  buffered samples so the value stays meaningful when the cluster
  just went idle. Walk-back is time-bounded (handler passes 60s) so
  a long idle stretch can't fold a stale "busy" reference into the
  displayed average. When multiple samples are buffered but none in
  the window show op activity, the helper returns nullopt and the
  column renders as `-`. The single-sample post-restart fallback to
  the lifetime cumulative is preserved so a freshly (re)started mgr
  produces a value immediately instead of dashes.
- Sub-ms values render with 3 decimals (`0.056`) in plain text so
  fast storage doesn't collapse to `0`. JSON uses `%.3f` via
  `dump_format_unquoted` to avoid `0.056222000000000001`-style
  noise.
- Crimson OSDs publish seastar metrics, not PerfCounters, so the
  paths are absent in their `daemon_state`. Columns with no data on
  any OSD get dropped from the plain-text table, so pure-crimson
  clusters fall back cleanly to a single `osd` column instead of a
  table padded with `-`. JSON output omits missing fields per-OSD.

## Example output

3-OSD BlueStore vstart, sustained 64K rados bench writes + 8-thread
rand reads:

```
osd  op_latency(ms)  op_r_latency(ms)  op_w_latency(ms)  bluestore_w_latency(ms)  bluestore_r_latency(ms)  kv_sync(ms)
  2               4                 1                10                    0.165                    0.637            2
  1               5                 2                11                    0.182                    0.771            2
  0               4                 1                10                    0.173                    0.643            2
```

JSON, single OSD:

```json
{
  "id": 0,
  "perf_stats": {
    "op_latency_ms": 5.237,
    "op_r_latency_ms": 2.164,
    "op_w_latency_ms": 12.042,
    "bluestore_w_latency_ms": 0.179,
    "bluestore_r_latency_ms": 0.791,
    "kv_sync_lat_ms": 2.113
  }
}
```

## Tests

- `unittest_mgr_perf_counter_instance` (8 cases): empty, single
  sample with cumulative fallback, single sample with zero count,
  delta, idle multi-sample (returns nullopt), walk-back past idle
  samples, only-last-two, and the `max_age` bound.
- `qa/standalone/mon/osd-perf.sh`: mon+mgr+2 OSDs, mixed read/write
  rados bench, asserts each new column and JSON key is present and
  the legacy ones are gone.
- Verified end-to-end on a 3-OSD BlueStore vstart under sustained
  rados bench.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes unit test(s)
  - [x] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [ ] No tests

Fixes: https://tracker.ceph.com/issues/74247
Fixes: https://tracker.ceph.com/issues/67968
Signed-off-by: Lumir Sliva <61183145+lumir-sliva@users.noreply.github.com>

