### PR TITLE
mgr/dashboard: Inconsistent tooltip timestamp format on performance card

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/jest.config.cjs
+++ b/src/pybind/mgr/dashboard/frontend/jest.config.cjs
@@ -14,6 +14,7 @@ const jestConfig = {
     '~/(.*)$': '<rootDir>/src/$1',
     '^@carbon/icons/es/(.*)$': '@carbon/icons/lib/$1.js',
     '^lodash-es$': 'lodash',
+    '^@carbon/charts$': '<rootDir>/node_modules/@carbon/charts/dist/index.mjs'
   },
   moduleFileExtensions: ['ts', 'html', 'js', 'json', 'mjs', 'cjs'],
   preset: 'jest-preset-angular',

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/area-chart/area-chart.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/area-chart/area-chart.component.spec.ts
@@ -10,7 +10,6 @@ describe('AreaChartComponent', () => {
   let component: AreaChartComponent;
   let fixture: ComponentFixture<AreaChartComponent>;
   let numberFormatterService: NumberFormatterService;
-  let datePipe: DatePipe;
 
   const mockData: ChartPoint[] = [
     {
@@ -41,23 +40,15 @@ describe('AreaChartComponent', () => {
       unitlessLabels: ['', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y']
     };
 
-    const datePipeMock = {
-      transform: jest.fn().mockReturnValue('01 Jan, 00:00:00')
-    };
-
     await TestBed.configureTestingModule({
       imports: [ChartsModule, AreaChartComponent],
-      providers: [
-        { provide: NumberFormatterService, useValue: numberFormatterMock },
-        { provide: DatePipe, useValue: datePipeMock }
-      ],
+      providers: [DatePipe, { provide: NumberFormatterService, useValue: numberFormatterMock }],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
 
     fixture = TestBed.createComponent(AreaChartComponent);
     component = fixture.componentInstance;
     numberFormatterService = TestBed.inject(NumberFormatterService);
-    datePipe = TestBed.inject(DatePipe);
   });
 
   it('should mount', () => {
@@ -133,23 +124,36 @@ describe('AreaChartComponent', () => {
     expect(component.chartOptions?.tooltip?.enabled).toBe(true);
   });
 
-  it('should format tooltip with custom date format', () => {
-    const testDate = new Date('2024-01-01T12:30:45Z');
-    const formattedDate = '01 Jan, 12:30:45';
-    const defaultHTML = '<div><p class="value">2024-01-01T12:30:45Z</p></div>';
+  it('should wire tooltip customHTML with arity 2', () => {
+    component.chartTitle = 'Test Chart';
+    component.dataUnit = 'B/s';
+    component.rawData = mockData;
 
-    (datePipe.transform as jest.Mock).mockReturnValue(formattedDate);
+    (numberFormatterService.formatFromTo as jest.Mock).mockReturnValue('4.00 KiB/s');
 
-    const result = component.formatChartTooltip(defaultHTML, [{ date: testDate }]);
+    fixture.detectChanges();
+    component.ngOnChanges({
+      rawData: new SimpleChange(null, mockData, false)
+    });
 
-    expect(datePipe.transform).toHaveBeenCalledWith(testDate, 'dd MMM, HH:mm:ss');
-    expect(result).toContain(formattedDate);
-    expect(result).not.toContain('2024-01-01T12:30:45Z');
+    expect(component.chartOptions?.tooltip?.customHTML?.length).toBe(2);
   });
 
-  it('should return default HTML if tooltip data is empty', () => {
+  it('should replace x-value label with Time in tooltip HTML', () => {
+    const defaultHTML =
+      '<ul class="multi-tooltip"><li><div class="datapoint-tooltip">' +
+      '<div class="label"><p>x-value</p></div><p class="value">ignored</p></div></li></ul>';
+
+    const result = component.formatChartTooltip(defaultHTML);
+
+    expect(result).toContain('<p>Time</p>');
+    expect(result).not.toContain('x-value');
+    expect(result).toContain('<p class="value">ignored</p>');
+  });
+
+  it('should return default HTML if tooltip has no x-value label', () => {
     const defaultHTML = '<div><p>Default</p></div>';
-    const result = component.formatChartTooltip(defaultHTML, []);
+    const result = component.formatChartTooltip(defaultHTML);
     expect(result).toBe(defaultHTML);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/area-chart/area-chart.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/area-chart/area-chart.component.ts
@@ -13,11 +13,11 @@ import {
   ChartTabularData,
   ToolbarControlTypes,
   ScaleTypes,
-  ChartsModule
+  ChartsModule,
+  TickRotations
 } from '@carbon/charts-angular';
 import merge from 'lodash.merge';
 import { NumberFormatterService } from '../../services/number-formatter.service';
-import { DatePipe } from '@angular/common';
 import { ChartPoint } from '../../models/area-chart-point';
 import {
   DECIMAL,
@@ -26,6 +26,12 @@ import {
   getDivisor,
   getLabels
 } from '../../helpers/unit-format-utils';
+import { DatePipe } from '@angular/common';
+
+const DEFAULT_TICKS_COUNT = 4;
+const FIVE_MINUTE_SPAN_SECONDS = 300;
+const TIME_SPAN_TOLERANCE_SECONDS = 30;
+const TOOLTIP_TIME_FORMAT = 'MMM d, hh:mm a';
 
 @Component({
   selector: 'cd-area-chart',
@@ -59,8 +65,9 @@ export class AreaChartComponent implements OnChanges {
 
   private cdr = inject(ChangeDetectorRef);
   private numberFormatter: NumberFormatterService = inject(NumberFormatterService);
-  private datePipe = inject(DatePipe);
   private lastEmittedRawValues?: Record<string, number>;
+
+  private datePipe = inject(DatePipe);
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['rawData'] && this.rawData?.length) {
@@ -129,7 +136,22 @@ export class AreaChartComponent implements OnChanges {
     this.lastEmittedRawValues = { ...latestEntry.values };
   }
 
+  // Calculate time span in seconds from raw data timestamps
+  private getTimeSpanInSeconds(): number {
+    if (!this.rawData || this.rawData.length < 2) {
+      return 0;
+    }
+    const firstTimestamp = new Date(this.rawData[0].timestamp).getTime();
+    const lastTimestamp = new Date(this.rawData[this.rawData.length - 1].timestamp).getTime();
+    return (lastTimestamp - firstTimestamp) / 1000;
+  }
+
   private getChartOptions(max: number, labels: string[], divisor: number): AreaChartOptions {
+    const timeSpan = this.getTimeSpanInSeconds();
+    const isFiveMinuteSpan =
+      timeSpan > 0 &&
+      timeSpan >= FIVE_MINUTE_SPAN_SECONDS - TIME_SPAN_TOLERANCE_SECONDS &&
+      timeSpan <= FIVE_MINUTE_SPAN_SECONDS + TIME_SPAN_TOLERANCE_SECONDS;
     return {
       legend: {
         enabled: this.legendEnabled
@@ -139,8 +161,8 @@ export class AreaChartComponent implements OnChanges {
           mapsTo: 'date',
           scaleType: ScaleTypes.TIME,
           ticks: {
-            number: 4,
-            rotateIfSmallerThan: 0
+            number: DEFAULT_TICKS_COUNT,
+            rotation: isFiveMinuteSpan ? TickRotations.ALWAYS : TickRotations.AUTO
           }
         },
         left: {
@@ -161,9 +183,18 @@ export class AreaChartComponent implements OnChanges {
       tooltip: {
         enabled: true,
         showTotal: false,
-        valueFormatter: (value: number): string =>
-          (this.formatValueForChart(value, labels, divisor, this.decimals) || value).toString(),
-        customHTML: (data, defaultHTML) => this.formatChartTooltip(defaultHTML, data)
+        truncation: {
+          type: 'none'
+        },
+        valueFormatter: (value: number | Date, label: string): string => {
+          if (value instanceof Date && label === 'x-value') {
+            return this.datePipe.transform(value, TOOLTIP_TIME_FORMAT) ?? '';
+          }
+          return (
+            this.formatValueForChart(value, labels, divisor, this.decimals) || value
+          ).toString();
+        },
+        customHTML: (_data, defaultHTML) => this.formatChartTooltip(defaultHTML)
       },
       points: {
         enabled: false
@@ -193,15 +224,8 @@ export class AreaChartComponent implements OnChanges {
     };
   }
 
-  // Custom tooltip formatter to replace default timestamp with a formatted one.
-  formatChartTooltip(defaultHTML: string, data: { date: Date }[]): string {
-    if (!data?.length) return defaultHTML;
-
-    const formattedTime = this.datePipe.transform(data[0].date, 'dd MMM, HH:mm:ss');
-    return defaultHTML.replace(
-      /<p class="value">.*?<\/p>/,
-      `<p class="value">${formattedTime}</p>`
-    );
+  formatChartTooltip(defaultHTML: string): string {
+    return defaultHTML.replace(/<p>x-value<\/p>/i, `<p>${$localize`Time`}</p>`);
   }
 
   // Uses number formatter service to convert chart value based on unit and divisor.


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/76169

Signed-off by: Devika Babrekar <devika.babrekar@ibm.com>

<img width="3840" height="1978" alt="image" src="https://github.com/user-attachments/assets/cec3fd08-525f-45f5-a1dd-ad41d5c5bd13" />


Description:
1. Sets tool-tip timestamp format same as X-axes.
2. Auto-rotation for ticks in enabled.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
