### PR TITLE
tentacle: mgr/dashboard: NVMeoF namespace create form should show subsystem selection first

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.html
@@ -1,115 +1,336 @@
-<cd-modal [pageURL]="pageURL"
-          [modalRef]="activeModal">
-  <span class="modal-title"
-        i18n>{{ action | titlecase }} {{ resource | upperFirst }}</span>
-  <ng-container class="modal-content">
-    <form name="nsForm"
-          #formDir="ngForm"
-          [formGroup]="nsForm"
-          novalidate>
-      <div class="modal-body">
-        <!-- Block Pool -->
-        <div class="form-group row">
-          <label class="cd-col-form-label"
-                 for="pool">
-            <span [ngClass]="{'required': !edit}"
-                  i18n>Pool</span>
-          </label>
-          <div class="cd-col-form-input">
-            <input *ngIf="edit"
-                   class="form-control"
-                   type="text"
-                   id="pool-edit"
-                   formControlName="pool">
-            <select *ngIf="!edit"
-                    id="pool-create"
-                    class="form-select"
-                    formControlName="pool">
-              <option *ngIf="rbdPools === null"
-                      [ngValue]="null"
-                      i18n>Loading...</option>
-              <option *ngIf="rbdPools && rbdPools.length === 0"
-                      [ngValue]="null"
-                      i18n>-- No block pools available --</option>
-              <option *ngIf="rbdPools && rbdPools.length > 0"
-                      [ngValue]="null"
-                      i18n>-- Select a pool --</option>
-              <option *ngFor="let pool of rbdPools"
-                      [value]="pool.pool_name">{{ pool.pool_name }}</option>
-            </select>
-            <cd-help-text i18n>
-              An RBD application-enabled pool where the image will be created.
-            </cd-help-text>
-            <span class="invalid-feedback"
-                  *ngIf="nsForm.showError('pool', formDir, 'required')"
-                  i18n>This field is required.</span>
+<form
+  name="nsForm"
+  #formDir="ngForm"
+  [formGroup]="nsForm"
+  novalidate>
+  <div cdsGrid
+       [useCssGrid]="true"
+       [narrow]="true"
+       [fullWidth]="true">
+
+    <div cdsCol
+         [columnNumbers]="{sm: 4, md: 8}">
+      <div cdsRow
+           class="form-heading form-item">
+        <h3>{{ title }}</h3>
+        <cd-help-text>
+          <span>
+            {{ description }}
+          </span>
+        </cd-help-text>
+      </div>
+
+      <!-- Subsystem -->
+      <div cdsRow
+           class="form-item">
+        <div cdsCol>
+          <cds-select
+            formControlName="subsystem"
+            cdValidate
+            #subsystemRef="cdValidate"
+            label="Select subsystem"
+            [invalid]="subsystemRef.isInvalid"
+            invalidText="This field is required"
+            i18n-label
+            i18n-invalidText>
+            @if (!subsystems) {
+            <option
+              [ngValue]="null"
+              disabled>Loading...</option>
+            }
+            @if (subsystems && subsystems.length === 0) {
+            <option
+              [ngValue]="null"
+              disabled>-- No subsystems available --</option>
+            }
+            @if (subsystems && subsystems.length > 0) {
+            <option
+              selectionFeedback="top-after-reopen"
+              value=""
+              selected>Select a subsystem</option>
+            }
+            @for (subsystem of subsystems; track subsystem.nqn) {
+            <option
+              [value]="subsystem.nqn">{{ subsystem.nqn }}</option>
+            }
+          </cds-select>
+        </div>
+      </div>
+
+      <!-- Namespace Count (Create only) -->
+      <div cdsRow
+           class="form-item">
+        <div cdsCol>
+          <cds-number
+            formControlName="nsCount"
+            cdValidate
+            #nsCountRef="cdValidate"
+            label="Number of namespaces"
+            helperText="No. of namespaces to generate. Value must be between 1 and 5."
+            [min]="MIN_NAMESPACE_CREATE"
+            [max]="MAX_NAMESPACE_CREATE"
+            [invalid]="nsCountRef.isInvalid"
+            [invalidText]="nsForm.getError('required', 'nsCount') ? requiredInvalidText : nsCountInvalidText"
+            i18n-label
+            i18n-helperText>
+          </cds-number>
+        </div>
+      </div>
+
+      <!-- Namespace Size (UI only) -->
+      <div cdsRow
+           class="form-item">
+        <div cdsCol>
+          <cds-number
+            formControlName="namespace_size"
+            cdValidate
+            #namespaceSizeRef="cdValidate"
+            label="Namespace size (GiB)"
+            helperText="Specify the size to expose to hosts. Leave blank for full device/file."
+            placeholder="e.g. 100"
+            [min]="0"
+            [invalid]="namespaceSizeRef.isInvalid"
+            [invalidText]="namespaceSizeError"
+            i18n-label
+            i18n-helperText>
+          </cds-number>
+          <ng-template #namespaceSizeError>
+            @if (nsForm.controls['namespace_size'].hasError('blockSizeMultiple')) {
+            <span
+              i18n>Size must be a multiple of the block size (typically 512 or 4096 bytes).</span>
+            }
+          </ng-template>
+        </div>
+      </div>
+
+      <!-- Host Access (UI only) -->
+      <div cdsRow
+           class="form-item">
+        <div cdsCol>
+          <legend
+            class="cds--type-label-01"
+            i18n>Host access (Initiators)</legend>
+          <div class="form-item">
+            <cds-radio-group
+              formControlName="host_access"
+              orientation="horizontal">
+              <cds-radio
+                value="all"
+                [checked]="true">
+                <div>
+                  <span
+                    class="cds--type-body-compact-01"
+                    i18n>All hosts on the subsystem</span>
+                  <span
+                    class="cds--type-helper-text-01 cds-ml-1 d-block"
+                    i18n>Allow all hosts associated with the selected subsystem to access the namespace.</span>
+                </div>
+              </cds-radio>
+              <cds-radio value="specific">
+                <div>
+                  <span
+                    class="cds--type-body-compact-01"
+                    i18n>Select specific hosts</span>
+                  <span
+                    class="cds--type-helper-text-01 cds-ml-1 d-block"
+                    i18n>Only the selected hosts will be able to access this namespace.</span>
+                </div>
+              </cds-radio>
+            </cds-radio-group>
           </div>
         </div>
-        <!-- Namespace Count -->
-        <div *ngIf="!edit"
-             class="form-group row"
-             id="namespace-count">
-          <label class="cd-col-form-label"
-                 for="nsCount">
-            <span [ngClass]="{'required': !edit}"
-                  i18n>Namespace Count</span>
-          </label>
-          <div class="cd-col-form-input">
-            <cds-number
-              formControlName="nsCount"
-              helperText="The number of namespaces to create"
+      </div>
+
+      <!-- Host Selection (Visible only when 'specific' is selected) -->
+      @if (nsForm.getValue('host_access') === 'specific') {
+      <div cdsRow
+           class="form-item">
+        <div cdsCol>
+          <div class="form-item">
+            <cds-combo-box
+              type="multi"
+              selectionFeedback="top-after-reopen"
+              label="Select hosts"
+              i18n-label
+              placeholder="Select one or more hosts"
+              [appendInline]="true"
+              [items]="initiatorCandidates"
+              (selected)="onInitiatorSelection($event)"
+              [invalid]="nsForm.controls['initiators'].invalid && (nsForm.controls['initiators'].dirty || nsForm.controls['initiators'].touched)"
+              invalidText="This field is required"
+              i18n-invalidText
+              i18n-placeholder>
+              <cds-dropdown-list></cds-dropdown-list>
+            </cds-combo-box>
+          </div>
+        </div>
+      </div>
+      }
+
+      <!-- Pool -->
+      <div cdsRow
+           class="form-item">
+        <div cdsCol>
+          <cds-select
+            formControlName="pool"
+            cdValidate
+            #poolRef="cdValidate"
+            label="RBD image pool"
+            [invalid]="poolRef.isInvalid"
+            invalidText="This field is required"
+            helperText="Pool where the backing Ceph block device resides."
+            i18n-label
+            i18n-invalidText
+            i18n-helperText>
+            @if (rbdPools === null) {
+            <option
+              [ngValue]="null"
+              disabled>Loading...</option>
+            }
+            @if (rbdPools && rbdPools.length === 0) {
+            <option
+              [ngValue]="null"
+              disabled>-- No block pools available --</option>
+            }
+            @if (rbdPools && rbdPools.length > 0) {
+            <option
+              value=""
+              selected>Select a RBD image pool</option>
+            }
+            @for (pool of rbdPools; track pool.pool_name) {
+            <option
+              [value]="pool.pool_name">{{ pool.pool_name }}</option>
+            }
+          </cds-select>
+        </div>
+      </div>
+
+      <!-- RBD image creation (UI only) -->
+      <div cdsRow
+           class="form-item">
+        <div cdsCol>
+          <legend
+            class="cds--type-label-01"
+            i18n>RBD image creation</legend>
+          <cds-radio-group
+            formControlName="rbd_image_creation"
+            orientation="vertical">
+            <cds-radio
+              value="gateway_provisioned"
+              i18n>Gateway-provisioned image</cds-radio>
+            <cds-radio
+              value="externally_managed"
+              [disabled]="nsForm.getValue('nsCount') > 1"
+              [title]="nsForm.getValue('nsCount') > 1 ? 'Unavailable during bulk creation. RBD images are created automatically.' : ''"
+              i18n>Externally managed image</cds-radio>
+          </cds-radio-group>
+        </div>
+      </div>
+
+      <!-- Image Name (Visible only when 'gateway_provisioned' is selected) -->
+      @if (nsForm.getValue('rbd_image_creation') === 'gateway_provisioned' && nsForm.getValue('nsCount') > 1) {
+      <div cdsRow
+           class="form-item">
+        <div cdsCol>
+          <cd-alert-panel
+            type="info"
+            [dismissible]="false"
+            [showTitle]="false">
+            <strong i18n>For bulk namespace creation, RBD images are provisioned automatically.</strong>
+          </cd-alert-panel>
+
+          <div class="form-item">
+            <label
+              class="cds--type-label-01"
+              i18n>Image name (optional)</label>
+            <cds-text-label
+              helperText="Provide a name for the images. For bulk creation, this will be used as the base prefix with numeric suffixes (e.g., img-1, img-2). Leave blank to auto-generate."
+              [invalid]="rbdImageNameRef.isInvalid"
+              [invalidText]="nsForm.getError('rbdImageName', 'rbd_image_name') ? 'Image name contains invalid characters' : ''"
               i18n-helperText
-              [min]="MIN_NAMESPACE_CREATE"
-              [max]="MAX_NAMESPACE_CREATE"
-              [invalid]="nsForm.showError('nsCount', formDir, 'max') || nsForm.showError('nsCount', formDir, 'min') || nsForm.showError('nsCount', formDir, 'required')"
-              [invalidText]="nsForm.get('nsCount').hasError('required') ? requiredInvalidText: nsCountInvalidText"
-              size="sm"></cds-number>
-          </div>
-        </div>
-        <!-- Image Size -->
-        <div class="form-group row">
-          <label class="cd-col-form-label"
-                 for="image_size">
-            <span [ngClass]="{'required': edit}"
-                  i18n>Image Size</span>
-          </label>
-          <div class="cd-col-form-input">
-            <div class="input-group">
-              <input id="size"
-                     class="form-control"
-                     type="text"
-                     formControlName="image_size">
-              <select id="unit"
-                      class="form-input form-select"
-                      formControlName="unit">
-                <option *ngFor="let u of units"
-                        [value]="u"
-                        i18n>{{ u }}</option>
-              </select>
-              <span class="invalid-feedback"
-                    *ngIf="nsForm.showError('image_size', formDir, 'pattern')">
-                <ng-container i18n>Enter a positive integer.</ng-container>
-              </span>
-              <span class="invalid-feedback"
-                    *ngIf="edit && nsForm.showError('image_size', formDir, 'required')">
-                <ng-container i18n>This field is required</ng-container>
-              </span>
-              <span class="invalid-feedback"
-                    id="image-size-invalid"
-                    *ngIf="edit && invalidSizeError">
-                <ng-container i18n>Enter a value above than previous. A block device image can be expanded but not reduced.</ng-container>
-              </span>
-            </div>
+              i18n-invalidText>
+              <input cdsText
+                     cdValidate
+                     #rbdImageNameRef="cdValidate"
+                     placeholder="Enter a name"
+                     formControlName="rbd_image_name" />
+            </cds-text-label>
           </div>
         </div>
       </div>
-      <div class="modal-footer">
-        <div class="text-right">
-          <cd-form-button-panel (submitActionEvent)="onSubmit()"
-                                [form]="nsForm"
-                                [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"></cd-form-button-panel>
+      }
+
+      <!-- Image Selection (Visible only when 'externally_managed' is selected) -->
+      @if (nsForm.getValue('rbd_image_creation') === 'externally_managed') {
+      <div cdsRow
+           class="form-item">
+        <div cdsCol>
+          <cds-select
+            formControlName="rbd_image_name"
+            cdValidate
+            #rbdImageSelectRef="cdValidate"
+            label="RBD Image"
+            [invalid]="rbdImageSelectRef.isInvalid"
+            invalidText="This field is required"
+            helperText="Select an existing RBD image from the pool to expose as a namespace."
+            i18n-label
+            i18n-invalidText
+            i18n-helperText>
+            <option
+              [ngValue]="null"
+              disabled
+              selected>Select an image</option>
+            @for (img of rbdImages; track img.name) {
+            <option
+              [value]="img.name">{{ img.name }} ({{ img.size | dimlessBinary }})</option>
+            }
+          </cds-select>
         </div>
       </div>
-    </form>
-  </ng-container>
-</cd-modal>
+      }
+
+      <!-- Image Size -->
+      <div cdsRow
+           class="form-item">
+        <div
+          cdsCol
+          [columnNumbers]="{md: 4}">
+          <cds-text-label
+            label="Image size (GiB)"
+            helperText="The size of the namespace image."
+            [invalid]="imageSizeRef.isInvalid"
+            [invalidText]="sizeError"
+            cdRequiredField="Image Size"
+            i18n-label
+            i18n-helperText>
+            <input cdsText
+                   cdValidate
+                   #imageSizeRef="cdValidate"
+                   type="text"
+                   placeholder="e.g. 100 GiB"
+                   id="image_size"
+                   formControlName="image_size"
+                   defaultUnit="GiB"
+                   [min]="0"
+                   [invalid]="imageSizeRef.isInvalid"
+                   cdDimlessBinary>
+          </cds-text-label>
+          <ng-template #sizeError>
+            <span
+              i18n>Enter a valid size (e.g., 10GiB).</span>
+          </ng-template>
+        </div>
+      </div>
+
+      <div cdsRow>
+        <cd-form-button-panel
+          (submitActionEvent)="onSubmit()"
+          [form]="nsForm"
+          [submitText]="(action | titlecase) + ' ' + (resource | titlecase)"
+          wrappingClass="text-right form-button">
+        </cd-form-button-panel>
+      </div>
+
+    </div>
+  </div>
+</form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.ts
@@ -1,16 +1,19 @@
-import { Component, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, OnInit } from '@angular/core';
 import { UntypedFormControl, Validators } from '@angular/forms';
-import { ActivatedRoute, Router } from '@angular/router';
-import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { ActivatedRoute, Params, Router } from '@angular/router';
 import {
   NamespaceCreateRequest,
-  NamespaceUpdateRequest,
+  NamespaceInitiatorRequest,
   NvmeofService
 } from '~/app/shared/api/nvmeof.service';
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { FinishedTask } from '~/app/shared/models/finished-task';
-import { NvmeofSubsystemNamespace } from '~/app/shared/models/nvmeof';
+import {
+  NvmeofSubsystem,
+  NvmeofSubsystemInitiator,
+  NvmeofSubsystemNamespace
+} from '~/app/shared/models/nvmeof';
 import { Permission } from '~/app/shared/models/permissions';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
@@ -18,7 +21,8 @@ import { Pool } from '../../pool/pool';
 import { PoolService } from '~/app/shared/api/pool.service';
 import { RbdService } from '~/app/shared/api/rbd.service';
 import { FormatterService } from '~/app/shared/services/formatter.service';
-import { forkJoin, Observable } from 'rxjs';
+import { forkJoin, Observable, of } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
 import { CdValidators } from '~/app/shared/forms/cd-validators';
 import { DimlessBinaryPipe } from '~/app/shared/pipes/dimless-binary.pipe';
 import { HttpResponse } from '@angular/common/http';
@@ -26,7 +30,8 @@ import { HttpResponse } from '@angular/common/http';
 @Component({
   selector: 'cd-nvmeof-namespaces-form',
   templateUrl: './nvmeof-namespaces-form.component.html',
-  styleUrls: ['./nvmeof-namespaces-form.component.scss']
+  styleUrls: ['./nvmeof-namespaces-form.component.scss'],
+  standalone: false
 })
 export class NvmeofNamespacesFormComponent implements OnInit {
   action: string;
@@ -34,14 +39,19 @@ export class NvmeofNamespacesFormComponent implements OnInit {
   poolPermission: Permission;
   resource: string;
   pageURL: string;
-  edit: boolean = false;
+
+  title: string = '';
+  description: string = '';
+
   nsForm: CdFormGroup;
   subsystemNQN: string;
-  rbdPools: Array<Pool> = null;
-  units: Array<string> = ['MiB', 'GiB', 'TiB'];
+  subsystems: NvmeofSubsystem[] | null = null;
+  rbdPools: Array<Pool> | null = null;
+  rbdImages: any[] = [];
+  initiatorCandidates: { content: string; selected: boolean }[] = [];
+
   nsid: string;
-  currentBytes: number;
-  invalidSizeError: boolean;
+
   group: string;
   MAX_NAMESPACE_CREATE: number = 5;
   MIN_NAMESPACE_CREATE: number = 1;
@@ -57,167 +67,378 @@ export class NvmeofNamespacesFormComponent implements OnInit {
     private rbdService: RbdService,
     private router: Router,
     private route: ActivatedRoute,
-    public activeModal: NgbActiveModal,
+    private cdr: ChangeDetectorRef,
     public formatterService: FormatterService,
     public dimlessBinaryPipe: DimlessBinaryPipe
   ) {
     this.permission = this.authStorageService.getPermissions().nvmeof;
     this.poolPermission = this.authStorageService.getPermissions().pool;
     this.resource = $localize`Namespace`;
-    this.pageURL = 'block/nvmeof/subsystems';
+    this.pageURL = 'block/nvmeof/namespaces';
   }
 
   init() {
-    this.route.queryParams.subscribe((params) => {
-      this.group = params?.['group'];
-    });
     this.createForm();
     this.action = this.actionLabels.CREATE;
-    this.route.params.subscribe((params: { subsystem_nqn: string; nsid: string }) => {
-      this.subsystemNQN = params.subsystem_nqn;
-      this.nsid = params?.nsid;
-    });
-  }
+    this.title = this.action + ' ' + this.resource;
+    this.description = $localize`Namespaces define the storage volumes that subsystems present to hosts.`;
 
-  initForEdit() {
-    this.edit = true;
-    this.action = this.actionLabels.EDIT;
-    this.nvmeofService
-      .getNamespace(this.subsystemNQN, this.nsid, this.group)
-      .subscribe((res: NvmeofSubsystemNamespace) => {
-        const convertedSize = this.dimlessBinaryPipe.transform(res.rbd_image_size).split(' ');
-        this.currentBytes = res.rbd_image_size;
-        this.nsForm.get('pool').setValue(res.rbd_pool_name);
-        this.nsForm.get('unit').setValue(convertedSize[1]);
-        this.nsForm.get('image_size').setValue(convertedSize[0]);
-        this.nsForm.get('image_size').addValidators(Validators.required);
-        this.nsForm.get('pool').disable();
-      });
+    this.route.params.subscribe((params: Params) => {
+      if (params['subsystem_nqn']) {
+        this.subsystemNQN = params['subsystem_nqn'];
+      }
+      this.nsid = params['nsid'];
+      if (params['group']) {
+        this.group = params['group'];
+      }
+      if (this.subsystemNQN && this.group) {
+        this.pageURL = `block/nvmeof/subsystems/${this.subsystemNQN}/namespaces`;
+        this.action = this.actionLabels.ADD;
+        this.title = this.action + ' ' + this.resource;
+        this.description = $localize`Create a new namespace associated with this subsystem.`;
+      }
+    });
+    this.route.queryParams.subscribe((params: Params) => {
+      if (params['group']) {
+        this.group = params['group'];
+      }
+      if (params['subsystem_nqn']) {
+        this.subsystemNQN = params['subsystem_nqn'];
+      }
+      if (this.subsystemNQN && this.group) {
+        this.pageURL = `block/nvmeof/subsystems/${this.subsystemNQN}/namespaces`;
+        this.action = this.actionLabels.ADD;
+        this.title = this.action + ' ' + this.resource;
+        this.description = $localize`Create a new namespace associated with this subsystem.`;
+      }
+    });
   }
 
   initForCreate() {
     this.poolService.getList().subscribe((resp: Pool[]) => {
       this.rbdPools = resp.filter(this.rbdService.isRBDPool);
-      if (this.rbdPools?.length) {
-        this.nsForm.get('pool').setValue(this.rbdPools[0].pool_name);
-      }
     });
+    if (this.group) {
+      this.fetchUsedImages();
+      this.nvmeofService
+        .listSubsystems(this.group)
+        .subscribe((res: NvmeofSubsystem[] | NvmeofSubsystem) => {
+          this.subsystems = Array.isArray(res) ? res : [res];
+          this.cdr.detectChanges();
+          if (this.subsystemNQN) {
+            const selectedSubsystem = this.subsystems.find((s) => s.nqn === this.subsystemNQN);
+            if (selectedSubsystem) {
+              this.nsForm.get('subsystem').setValue(selectedSubsystem.nqn);
+            }
+          }
+        });
+    }
   }
 
   ngOnInit() {
     this.init();
-    if (this.router.url.includes('subsystems/(modal:edit')) {
-      this.initForEdit();
-    } else {
-      this.initForCreate();
+    this.initForCreate();
+    const subsystemControl = this.nsForm.get('subsystem');
+    if (subsystemControl) {
+      subsystemControl.valueChanges.subscribe((nqn: string) => {
+        this.onSubsystemChange(nqn);
+      });
     }
+  }
+
+  // Stores all RBD images fetched for the selected pool
+  private allRbdImages: { name: string; size: number }[] = [];
+  // Maps pool name to a Set of used image names for O(1) lookup
+  private usedRbdImages: Map<string, Set<string>> = new Map();
+
+  onPoolChange(): void {
+    const pool = this.nsForm.getValue('pool');
+    if (!pool) return;
+
+    this.rbdService
+      .list({ pool_name: pool, offset: '0', limit: '-1' })
+      .subscribe((pools: { pool_name: string; value: { name: string; size: number }[] }[]) => {
+        const selectedPool = pools.find((p) => p.pool_name === pool);
+        this.allRbdImages = selectedPool?.value ?? [];
+        this.filterImages();
+
+        const imageControl = this.nsForm.get('rbd_image_name');
+        const currentImage = this.nsForm.getValue('rbd_image_name');
+        if (currentImage && !this.rbdImages.some((img) => img.name === currentImage)) {
+          imageControl.setValue(null);
+        }
+        imageControl.markAsUntouched();
+        imageControl.markAsPristine();
+      });
+  }
+
+  fetchUsedImages(): void {
+    if (!this.group) return;
+
+    this.nvmeofService.listNamespaces(this.group).subscribe((response: any) => {
+      const namespaces: NvmeofSubsystemNamespace[] = Array.isArray(response)
+        ? response
+        : response?.namespaces ?? [];
+      this.usedRbdImages = namespaces.reduce((map, ns) => {
+        if (!map.has(ns.rbd_pool_name)) {
+          map.set(ns.rbd_pool_name, new Set<string>());
+        }
+        map.get(ns.rbd_pool_name)!.add(ns.rbd_image_name);
+        return map;
+      }, new Map<string, Set<string>>());
+      this.filterImages();
+    });
+  }
+
+  onSubsystemChange(nqn: string): void {
+    if (!nqn) return;
+    this.nvmeofService
+      .getInitiators(nqn, this.group)
+      .subscribe((response: NvmeofSubsystemInitiator[] | { hosts: NvmeofSubsystemInitiator[] }) => {
+        const initiators = Array.isArray(response) ? response : response?.hosts || [];
+        this.initiatorCandidates = initiators.map((initiator) => ({
+          content: initiator.nqn,
+          selected: false
+        }));
+      });
+  }
+
+  onInitiatorSelection(event: any) {
+    // Carbon ComboBox (selected) emits the full array of selected items
+    const selectedInitiators = Array.isArray(event) ? event.map((e: any) => e.content) : [];
+    this.nsForm
+      .get('initiators')
+      .setValue(selectedInitiators.length > 0 ? selectedInitiators : null);
+    this.nsForm.get('initiators').markAsDirty();
+    this.nsForm.get('initiators').markAsTouched();
+  }
+
+  private filterImages(): void {
+    const pool = this.nsForm.getValue('pool');
+    if (!pool) {
+      this.rbdImages = [];
+      return;
+    }
+    const usedInPool = this.usedRbdImages.get(pool);
+    this.rbdImages = usedInPool
+      ? this.allRbdImages.filter((img) => !usedInPool.has(img.name))
+      : [...this.allRbdImages];
   }
 
   createForm() {
     this.nsForm = new CdFormGroup({
-      pool: new UntypedFormControl(null, {
+      pool: new UntypedFormControl('', {
         validators: [Validators.required]
       }),
-      image_size: new UntypedFormControl(1, [CdValidators.number(false), Validators.min(1)]),
-      unit: new UntypedFormControl(this.units[1]),
+      subsystem: new UntypedFormControl('', {
+        validators: [Validators.required]
+      }),
+      image_size: new UntypedFormControl(null, {
+        validators: [Validators.required]
+      }),
       nsCount: new UntypedFormControl(this.MAX_NAMESPACE_CREATE, [
         Validators.required,
         Validators.max(this.MAX_NAMESPACE_CREATE),
         Validators.min(this.MIN_NAMESPACE_CREATE)
-      ])
-    });
-  }
+      ]),
+      rbd_image_creation: new UntypedFormControl('gateway_provisioned'),
 
-  buildUpdateRequest(rbdImageSize: number): Observable<HttpResponse<Object>> {
-    const request: NamespaceUpdateRequest = {
-      gw_group: this.group,
-      rbd_image_size: rbdImageSize
-    };
-    return this.nvmeofService.updateNamespace(
-      this.subsystemNQN,
-      this.nsid,
-      request as NamespaceUpdateRequest
-    );
+      rbd_image_name: new UntypedFormControl(null, [
+        CdValidators.custom('rbdImageName', (value: any) => {
+          if (!value) return null;
+          return /^[^@/]+$/.test(value) ? null : { rbdImageName: true };
+        })
+      ]),
+      namespace_size: new UntypedFormControl(null), // UI only - not sent to backend
+      host_access: new UntypedFormControl('all'), // UI only - determines visibility
+      initiators: new UntypedFormControl([]) // UI only - selected hosts
+    });
+
+    this.nsForm.get('pool').valueChanges.subscribe(() => {
+      this.onPoolChange();
+    });
+
+    this.nsForm.get('nsCount').valueChanges.subscribe((count: number) => {
+      if (count > 1) {
+        const creationControl = this.nsForm.get('rbd_image_creation');
+        if (creationControl.value === 'externally_managed') {
+          creationControl.setValue('gateway_provisioned');
+        }
+      }
+    });
+
+    this.nsForm.get('rbd_image_creation').valueChanges.subscribe((mode: string) => {
+      const nameControl = this.nsForm.get('rbd_image_name');
+      const sizeControl = this.nsForm.get('image_size');
+      const countControl = this.nsForm.get('nsCount');
+
+      if (mode === 'externally_managed') {
+        countControl.setValue(1);
+        countControl.disable();
+        this.onPoolChange();
+        nameControl.addValidators(Validators.required);
+        sizeControl.removeValidators(Validators.required);
+        sizeControl.disable();
+      } else {
+        sizeControl.enable();
+        countControl.enable();
+        nameControl.removeValidators(Validators.required);
+        sizeControl.addValidators(Validators.required);
+      }
+      nameControl.updateValueAndValidity();
+      sizeControl.updateValueAndValidity();
+    });
+
+    this.nsForm.get('host_access').valueChanges.subscribe((mode: string) => {
+      const initiatorsControl = this.nsForm.get('initiators');
+      if (mode === 'specific') {
+        initiatorsControl.addValidators(Validators.required);
+      } else {
+        initiatorsControl.removeValidators(Validators.required);
+        initiatorsControl.setValue([]);
+        this.initiatorCandidates.forEach((i) => (i.selected = false));
+      }
+      initiatorsControl.updateValueAndValidity();
+    });
   }
 
   randomString() {
     return Math.random().toString(36).substring(2);
   }
 
-  buildCreateRequest(rbdImageSize: number, nsCount: number): Observable<HttpResponse<Object>>[] {
+  private normalizeImageSizeInput(value: string | number): string {
+    const input = String(value ?? '').trim();
+    if (!input) {
+      return input;
+    }
+    if (typeof value === 'number') {
+      return input;
+    }
+    // Accept plain numeric values as GiB (e.g. "45" => "45GiB").
+    return /^\d+(\.\d+)?$/.test(input) ? `${input}GiB` : input;
+  }
+
+  buildCreateRequest(
+    rbdImageSize: number | null,
+    nsCount: number,
+    noAutoVisible: boolean
+  ): Observable<HttpResponse<Object>>[] {
     const pool = this.nsForm.getValue('pool');
     const requests: Observable<HttpResponse<Object>>[] = [];
+    const creationMode = this.nsForm.getValue('rbd_image_creation');
+    const isGatewayProvisioned = creationMode === 'gateway_provisioned';
 
-    for (let i = 1; i <= nsCount; i++) {
+    const loopCount = isGatewayProvisioned ? nsCount : 1;
+
+    for (let i = 1; i <= loopCount; i++) {
       const request: NamespaceCreateRequest = {
         gw_group: this.group,
-        rbd_image_name: `nvme_${pool}_${this.group}_${this.randomString()}`,
         rbd_pool: pool,
-        create_image: true
+        create_image: isGatewayProvisioned,
+        no_auto_visible: noAutoVisible
       };
-      if (rbdImageSize) {
-        request['rbd_image_size'] = rbdImageSize;
+
+      if (isGatewayProvisioned) {
+        const rbdImageName = this.nsForm.getValue('rbd_image_name');
+        if (rbdImageName) {
+          request.rbd_image_name = loopCount > 1 ? `${rbdImageName}-${i}` : rbdImageName;
+        } else {
+          request.rbd_image_name = `nvme_${pool}_${this.group}_${this.randomString()}`;
+        }
+        if (rbdImageSize) {
+          request['rbd_image_size'] = rbdImageSize;
+        }
+      } else {
+        const rbdImageName = this.nsForm.getValue('rbd_image_name');
+        if (rbdImageName) {
+          request['rbd_image_name'] = rbdImageName;
+        }
       }
-      requests.push(this.nvmeofService.createNamespace(this.subsystemNQN, request));
+
+      const subsystemNQN = this.nsForm.getValue('subsystem') || this.subsystemNQN;
+      requests.push(this.nvmeofService.createNamespace(subsystemNQN, request));
     }
 
     return requests;
   }
 
-  validateSize() {
-    const unit = this.nsForm.getValue('unit');
-    const image_size = this.nsForm.getValue('image_size');
-    if (image_size && unit) {
-      const bytes = this.formatterService.toBytes(image_size + unit);
-      return bytes <= this.currentBytes;
-    }
-    return null;
-  }
-
   onSubmit() {
-    if (this.validateSize()) {
-      this.invalidSizeError = true;
+    if (this.nsForm.invalid) {
       this.nsForm.setErrors({ cdSubmitButton: true });
-    } else {
-      this.invalidSizeError = false;
-      const component = this;
-      const taskUrl: string = `nvmeof/namespace/${this.edit ? URLVerbs.EDIT : URLVerbs.CREATE}`;
-      const image_size = this.nsForm.getValue('image_size');
-      const nsCount = this.nsForm.getValue('nsCount');
-      let action: Observable<HttpResponse<Object>>;
-      let rbdImageSize: number = null;
-
-      if (image_size) {
-        const image_size_unit = this.nsForm.getValue('unit');
-        const value: number = this.formatterService.toBytes(image_size + image_size_unit);
-        rbdImageSize = value;
-      }
-      if (this.edit) {
-        action = this.taskWrapperService.wrapTaskAroundCall({
-          task: new FinishedTask(taskUrl, {
-            nqn: this.subsystemNQN,
-            nsid: this.nsid
-          }),
-          call: this.buildUpdateRequest(rbdImageSize)
-        });
-      } else {
-        action = this.taskWrapperService.wrapTaskAroundCall({
-          task: new FinishedTask(taskUrl, {
-            nqn: this.subsystemNQN,
-            nsCount
-          }),
-          call: forkJoin(this.buildCreateRequest(rbdImageSize, nsCount))
-        });
-      }
-
-      action.subscribe({
-        error() {
-          component.nsForm.setErrors({ cdSubmitButton: true });
-        },
-        complete: () => {
-          this.router.navigate([this.pageURL, { outlets: { modal: null } }]);
-        }
-      });
+      this.nsForm.markAllAsTouched();
+      return;
     }
+
+    const component = this;
+    const taskUrl: string = `nvmeof/namespace/${URLVerbs.CREATE}`;
+    const image_size = this.nsForm.getValue('image_size');
+    const nsCount = this.nsForm.getValue('nsCount');
+    const hostAccess = this.nsForm.getValue('host_access');
+    const selectedHosts: string[] = this.nsForm.getValue('initiators') || [];
+    const noAutoVisible = hostAccess === 'specific';
+    let action: Observable<any>;
+    let rbdImageSize: number | null = null;
+
+    if (image_size) {
+      const normalizedSize = this.normalizeImageSizeInput(image_size);
+      rbdImageSize = this.formatterService.toBytes(normalizedSize);
+      if (rbdImageSize === null) {
+        this.nsForm.get('image_size').setErrors({ invalid: true });
+        this.nsForm.setErrors({ cdSubmitButton: true });
+        return;
+      }
+    }
+
+    const subsystemNQN = this.nsForm.getValue('subsystem');
+
+    // Step 1: Create namespaces
+    // Step 2: If specific hosts selected, chain addNamespaceInitiators calls
+    const createObs = forkJoin(this.buildCreateRequest(rbdImageSize, nsCount, noAutoVisible));
+
+    const combinedObs = createObs.pipe(
+      switchMap((responses: HttpResponse<Object>[]) => {
+        if (noAutoVisible && selectedHosts.length > 0) {
+          const initiatorObs: Observable<any>[] = [];
+
+          responses.forEach((res) => {
+            const body: any = res.body;
+            if (body && body.nsid) {
+              selectedHosts.forEach((host: string) => {
+                const req: NamespaceInitiatorRequest = {
+                  gw_group: this.group,
+                  subsystem_nqn: subsystemNQN || this.subsystemNQN,
+                  host_nqn: host
+                };
+                initiatorObs.push(this.nvmeofService.addNamespaceInitiators(body.nsid, req));
+              });
+            }
+          });
+
+          if (initiatorObs.length > 0) {
+            return forkJoin(initiatorObs);
+          }
+        }
+        return of(responses);
+      })
+    );
+
+    action = this.taskWrapperService.wrapTaskAroundCall({
+      task: new FinishedTask(taskUrl, {
+        nqn: subsystemNQN,
+        nsCount
+      }),
+      call: combinedObs
+    });
+
+    action.subscribe({
+      error: () => {
+        component.nsForm.setErrors({ cdSubmitButton: true });
+      },
+      complete: () => {
+        this.router.navigate([this.pageURL], {
+          queryParams: { group: this.group }
+        });
+      }
+    });
   }
 }


### PR DESCRIPTION
mgr/dashboard: NVMeoF namespace create form should show subsystem selection first

Fixes: https://tracker.ceph.com/issues/75846

Signed-off-by: Sagar Gopale <sagar.gopale@ibm.com>
(cherry picked from commit 0457ac58b6eb4b5557f01d4a5c23e0d5fc3ab36a)

 Conflicts:
	src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.html
	src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.ts





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
