### PR TITLE
tentacle: mgr/dashboard: NVMe-oF Initiator Hostname Pre-validation

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.spec.ts
@@ -2,6 +2,9 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { of } from 'rxjs';
 
 import { ToastrModule } from 'ngx-toastr';
 
@@ -9,6 +12,7 @@ import { NgbActiveModal, NgbTypeaheadModule } from '@ng-bootstrap/ng-bootstrap';
 
 import { SharedModule } from '~/app/shared/shared.module';
 import { NvmeofService } from '~/app/shared/api/nvmeof.service';
+import { HOST_TYPE } from '~/app/shared/models/nvmeof';
 
 import { NvmeofInitiatorsFormComponent } from './nvmeof-initiators-form.component';
 
@@ -17,12 +21,26 @@ describe('NvmeofInitiatorsFormComponent', () => {
   let fixture: ComponentFixture<NvmeofInitiatorsFormComponent>;
   let nvmeofService: NvmeofService;
   const mockTimestamp = 1720693470789;
+  const mockGroupName = 'default';
 
   beforeEach(async () => {
     spyOn(Date, 'now').and.returnValue(mockTimestamp);
     await TestBed.configureTestingModule({
       declarations: [NvmeofInitiatorsFormComponent],
-      providers: [NgbActiveModal],
+      schemas: [NO_ERRORS_SCHEMA],
+      providers: [
+        NgbActiveModal,
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            queryParams: of({ group: 'test-group' }),
+            params: of({ subsystem_nqn: 'nqn.test' }),
+            parent: {
+              params: of({ subsystem_nqn: 'nqn.test' })
+            }
+          }
+        }
+      ],
       imports: [
         HttpClientTestingModule,
         NgbTypeaheadModule,
@@ -37,25 +55,84 @@ describe('NvmeofInitiatorsFormComponent', () => {
     component = fixture.componentInstance;
     component.ngOnInit();
     fixture.detectChanges();
+    component.group = mockGroupName;
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should initialize with two steps (Host access control + Authentication optional)', () => {
+    expect(component.steps.length).toBe(2);
+    expect(component.steps[0].label).toBe('Host access control');
+    expect(component.steps[1].label).toBe('Authentication (optional)');
+  });
+
+  it('should hide Authentication step when showAuthStep is false', () => {
+    component.showAuthStep = false;
+    component.rebuildSteps();
+    expect(component.steps.length).toBe(1);
+    expect(component.steps[0].label).toBe('Host access control');
+  });
+
   describe('should test form', () => {
     beforeEach(() => {
       nvmeofService = TestBed.inject(NvmeofService);
-      spyOn(nvmeofService, 'addInitiators').and.stub();
+      spyOn(nvmeofService, 'addSubsystemInitiators').and.returnValue(of({}));
     });
 
     it('should be creating request correctly', () => {
-      const subsystemNQN = 'nqn.2001-07.com.ceph:' + mockTimestamp;
+      const subsystemNQN = 'nqn.test';
       component.subsystemNQN = subsystemNQN;
-      component.onSubmit();
-      expect(nvmeofService.addInitiators).toHaveBeenCalledWith(subsystemNQN, {
-        host_nqn: ''
+      component.group = 'test-group';
+
+      const payload: any = {
+        hostType: HOST_TYPE.SPECIFIC,
+        hostDchapKeyList: [{ dhchap_key: '', host_nqn: 'host1' }],
+        gw_group: 'test-group'
+      };
+
+      component.onSubmit(payload);
+      expect(nvmeofService.addSubsystemInitiators).toHaveBeenCalledWith(subsystemNQN, {
+        allow_all: false,
+        gw_group: 'test-group',
+        hosts: [{ dhchap_key: '', host_nqn: 'host1' }]
       });
+    });
+
+    it('should build hosts from addedHosts when hostDchapKeyList is absent', () => {
+      const subsystemNQN = 'nqn.test';
+      component.subsystemNQN = subsystemNQN;
+      component.group = 'test-group';
+
+      const payload: any = {
+        hostType: HOST_TYPE.SPECIFIC,
+        addedHosts: ['host2'],
+        gw_group: 'test-group'
+      };
+
+      component.onSubmit(payload);
+      expect(nvmeofService.addSubsystemInitiators).toHaveBeenCalledWith(subsystemNQN, {
+        allow_all: false,
+        gw_group: 'test-group',
+        hosts: [{ dhchap_key: '', host_nqn: 'host2' }]
+      });
+    });
+
+    it('should not submit when hostType is SPECIFIC and no host is provided', () => {
+      const subsystemNQN = 'nqn.test';
+      component.subsystemNQN = subsystemNQN;
+      component.group = 'test-group';
+
+      const payload: any = {
+        hostType: HOST_TYPE.SPECIFIC,
+        addedHosts: []
+      };
+
+      component.onSubmit(payload);
+
+      expect(nvmeofService.addSubsystemInitiators).not.toHaveBeenCalled();
+      expect(component.isSubmitLoading).toBe(false);
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.ts
@@ -1,139 +1,165 @@
-import { Component, OnInit } from '@angular/core';
-import { UntypedFormArray, UntypedFormControl, Validators } from '@angular/forms';
-
-import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
-import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
-import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
-import { CdValidators } from '~/app/shared/forms/cd-validators';
-import { Permission } from '~/app/shared/models/permissions';
-import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
-import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { Step } from 'carbon-components-angular';
+import { NvmeofService, SubsystemInitiatorRequest } from '~/app/shared/api/nvmeof.service';
 import { FinishedTask } from '~/app/shared/models/finished-task';
+import {
+  AuthStepType,
+  HOST_TYPE,
+  HostStepType,
+  NvmeofSubsystemInitiator
+} from '~/app/shared/models/nvmeof';
+import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { ActivatedRoute, Router } from '@angular/router';
-import { InitiatorRequest, NvmeofService } from '~/app/shared/api/nvmeof.service';
+import { TearsheetComponent } from '~/app/shared/components/tearsheet/tearsheet.component';
+
+type InitiatorsFormPayload = Pick<HostStepType, 'hostType' | 'addedHosts'> &
+  Partial<Pick<AuthStepType, 'hostDchapKeyList'>>;
+
+const STEP_LABELS = {
+  HOSTS: $localize`Host access control`,
+  AUTH: $localize`Authentication (optional)`
+} as const;
 
 @Component({
   selector: 'cd-nvmeof-initiators-form',
   templateUrl: './nvmeof-initiators-form.component.html',
-  styleUrls: ['./nvmeof-initiators-form.component.scss']
+  styleUrls: ['./nvmeof-initiators-form.component.scss'],
+  standalone: false
 })
 export class NvmeofInitiatorsFormComponent implements OnInit {
-  permission: Permission;
-  initiatorForm: CdFormGroup;
-  action: string;
-  resource: string;
-  pageURL: string;
-  remove: boolean = false;
-  subsystemNQN: string;
-  removeHosts: { name: string; value: boolean; id: number }[] = [];
-  group: string;
+  group!: string;
+  subsystemNQN!: string;
+  isSubmitLoading = false;
+  existingHosts: string[] = [];
+  showAuthStep = true;
+  stepTwoValue: HostStepType = null;
+
+  @ViewChild(TearsheetComponent) tearsheet!: TearsheetComponent;
+
+  steps: Step[] = [];
+
+  title = $localize`Add Initiator`;
+  description = $localize`Allow specific hosts to run NVMe/TCP commands to the NVMe subsystem.`;
+  pageURL = 'block/nvmeof/subsystems';
 
   constructor(
-    private authStorageService: AuthStorageService,
-    public actionLabels: ActionLabelsI18n,
     private nvmeofService: NvmeofService,
     private taskWrapperService: TaskWrapperService,
     private router: Router,
-    private route: ActivatedRoute,
-    private formBuilder: CdFormBuilder
-  ) {
-    this.permission = this.authStorageService.getPermissions().nvmeof;
-    this.resource = $localize`Initiator`;
-    this.pageURL = 'block/nvmeof/subsystems';
-  }
-
-  NQN_REGEX = /^nqn\.(19|20)\d\d-(0[1-9]|1[0-2])\.\D{2,3}(\.[A-Za-z0-9-]+)+(:[A-Za-z0-9-\.]+(:[A-Za-z0-9-\.]+)*)$/;
-  NQN_REGEX_UUID = /^nqn\.2014-08\.org\.nvmexpress:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
-  ALLOW_ALL_HOST = '*';
-
-  customNQNValidator = CdValidators.custom(
-    'pattern',
-    (nqnInput: string) =>
-      !!nqnInput && !(this.NQN_REGEX.test(nqnInput) || this.NQN_REGEX_UUID.test(nqnInput))
-  );
+    private route: ActivatedRoute
+  ) {}
 
   ngOnInit() {
     this.route.queryParams.subscribe((params) => {
       this.group = params?.['group'];
     });
-    this.createForm();
-    this.action = this.actionLabels.ADD;
-    this.route.params.subscribe((params: { subsystem_nqn: string }) => {
-      this.subsystemNQN = params.subsystem_nqn;
-    });
-  }
-
-  createForm() {
-    this.initiatorForm = new CdFormGroup({
-      allowAnyHost: new UntypedFormControl(false),
-      addHost: new CdFormGroup({
-        addHostCheck: new UntypedFormControl(false),
-        addedHosts: this.formBuilder.array(
-          [],
-          [
-            CdValidators.custom(
-              'duplicate',
-              (hosts: string[]) => !!hosts.length && new Set(hosts)?.size !== hosts.length
-            )
-          ]
-        )
-      })
-    });
-  }
-
-  get addedHosts(): UntypedFormArray {
-    return this.initiatorForm.get('addHost.addedHosts') as UntypedFormArray;
-  }
-
-  addHost() {
-    let newHostFormGroup;
-    newHostFormGroup = this.formBuilder.control('', [this.customNQNValidator, Validators.required]);
-    this.addedHosts.push(newHostFormGroup);
-  }
-
-  removeHost(index: number) {
-    this.addedHosts.removeAt(index);
-  }
-
-  setAddHostCheck() {
-    const addHostCheck = this.initiatorForm.get('addHost.addHostCheck').value;
-    if (!addHostCheck) {
-      while (this.addedHosts.length !== 0) {
-        this.addedHosts.removeAt(0);
+    this.route.parent.params.subscribe((params: any) => {
+      if (params.subsystem_nqn) {
+        this.subsystemNQN = params.subsystem_nqn;
       }
-    } else {
-      this.addHost();
+    });
+    this.route.params.subscribe((params: any) => {
+      if (!this.subsystemNQN && params.subsystem_nqn) {
+        this.subsystemNQN = params.subsystem_nqn;
+      }
+      this.fetchExistingHosts();
+    });
+    this.rebuildSteps();
+  }
+
+  rebuildSteps() {
+    const steps: Step[] = [{ label: STEP_LABELS.HOSTS, invalid: false }];
+
+    if (this.showAuthStep) {
+      steps.push({ label: STEP_LABELS.AUTH, invalid: false });
+    }
+
+    this.steps = steps;
+
+    if (this.tearsheet?.currentStep >= steps.length) {
+      this.tearsheet.currentStep = steps.length - 1;
     }
   }
 
-  onSubmit() {
-    const component = this;
-    const allowAnyHost: boolean = this.initiatorForm.getValue('allowAnyHost');
-    const hosts: string[] = this.addedHosts.value;
-    let taskUrl = `nvmeof/initiator/${URLVerbs.ADD}`;
+  onStepChanged() {
+    if (!this.tearsheet) return;
 
-    const request: InitiatorRequest = {
-      host_nqn: hosts.join(','),
+    const hostStep = this.tearsheet.getStepValueByLabel<HostStepType>(STEP_LABELS.HOSTS);
+
+    if (hostStep) {
+      this.stepTwoValue = hostStep;
+    }
+
+    const nextShowAuth = (hostStep?.hostType ?? HOST_TYPE.SPECIFIC) === HOST_TYPE.SPECIFIC;
+
+    if (nextShowAuth !== this.showAuthStep) {
+      this.showAuthStep = nextShowAuth;
+      this.rebuildSteps();
+    }
+  }
+
+  fetchExistingHosts() {
+    if (!this.subsystemNQN || !this.group) return;
+    this.nvmeofService
+      .getInitiators(this.subsystemNQN, this.group)
+      .subscribe((response: NvmeofSubsystemInitiator[] | { hosts: NvmeofSubsystemInitiator[] }) => {
+        const initiators = Array.isArray(response) ? response : response?.hosts || [];
+        this.existingHosts = initiators.map((i) => i.nqn);
+      });
+  }
+
+  onSubmit(payload: InitiatorsFormPayload) {
+    const taskUrl = `nvmeof/initiator/add`;
+    const hostKeyList = (payload.hostDchapKeyList || []).filter((host) => !!host?.host_nqn?.trim());
+    const addedHosts = (payload.addedHosts || []).filter((host) => !!host?.trim());
+    const hosts =
+      payload.hostType === HOST_TYPE.SPECIFIC
+        ? hostKeyList.length
+          ? hostKeyList
+          : addedHosts.map((host_nqn: string) => ({ host_nqn, dhchap_key: '' }))
+        : [];
+
+    if (payload.hostType === HOST_TYPE.SPECIFIC && hosts.length === 0) {
+      const hostStepIndex = Math.max(
+        this.tearsheet?.getStepIndexByLabel(STEP_LABELS.HOSTS) ?? 0,
+        0
+      );
+      const hostStepForm = this.tearsheet?.stepContents?.toArray()?.[hostStepIndex]?.stepComponent
+        ?.formGroup;
+
+      hostStepForm?.markAllAsTouched();
+      hostStepForm?.get('hostname')?.markAsTouched();
+      hostStepForm?.get('hostname')?.updateValueAndValidity({ emitEvent: true });
+      if (this.tearsheet) {
+        this.tearsheet.currentStep = hostStepIndex;
+      }
+      return;
+    }
+
+    this.isSubmitLoading = true;
+
+    const request: SubsystemInitiatorRequest = {
+      allow_all: payload.hostType === HOST_TYPE.ALL,
+      hosts,
       gw_group: this.group
     };
-
-    if (allowAnyHost) {
-      hosts.push('*');
-      request['host_nqn'] = hosts.join(',');
-    }
     this.taskWrapperService
       .wrapTaskAroundCall({
         task: new FinishedTask(taskUrl, {
           nqn: this.subsystemNQN
         }),
-        call: this.nvmeofService.addInitiators(this.subsystemNQN, request)
+        call: this.nvmeofService.addSubsystemInitiators(this.subsystemNQN, request)
       })
       .subscribe({
-        error() {
-          component.initiatorForm.setErrors({ cdSubmitButton: true });
+        error: () => {
+          this.isSubmitLoading = false;
         },
         complete: () => {
-          this.router.navigate([this.pageURL, { outlets: { modal: null } }]);
+          this.isSubmitLoading = false;
+          this.router.navigate([{ outlets: { modal: null } }], {
+            relativeTo: this.route.parent,
+            queryParamsHandling: 'preserve'
+          });
         }
       });
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/tearsheet/tearsheet.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/tearsheet/tearsheet.component.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectorRef,
   Component,
   ContentChildren,
   EventEmitter,
@@ -7,7 +6,12 @@ import {
   OnInit,
   Output,
   QueryList,
-  AfterViewChecked
+  AfterViewInit,
+  DestroyRef,
+  OnDestroy,
+  ChangeDetectionStrategy,
+  TemplateRef,
+  ViewEncapsulation
 } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
 import { Step } from 'carbon-components-angular';
@@ -16,20 +20,57 @@ import { ModalCdsService } from '../../services/modal-cds.service';
 import { ActivatedRoute } from '@angular/router';
 import { Location } from '@angular/common';
 import { ConfirmationModalComponent } from '../confirmation-modal/confirmation-modal.component';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Subject } from 'rxjs';
+
+/**
+<cd-tearsheet
+    [steps]="steps"
+    [title]="title"
+    [isSubmitLoading]="isSubmitLoading"
+    [description]="description"
+    (submitRequested)="onSubmit()">
+  <cd-tearsheet-step>
+      <cd-step #tearsheetStep>
+      </cds-step>
+  </cd-tearsheet-step>
+   <cd-tearsheet-step>
+      step 2 form
+  <cd-tearsheet-step>
+</cd-tearsheet>
+
+-----------------
 
 @Component({
-  selector: 'cd-tearsheet',
-  templateUrl: './tearsheet.component.html',
-  styleUrls: ['./tearsheet.component.scss']
+  selector: 'cd-step',
+  template: `<form></form>,
+  standalone: false
 })
-export class TearsheetComponent implements OnInit, AfterViewChecked {
+export class StepComponent implements TearsheetStep {
+formgroup: CdFormGroup;
+}
+**/
+@Component({
+  selector: 'cd-tearsheet',
+  standalone: false,
+  templateUrl: './tearsheet.component.html',
+  styleUrls: ['./tearsheet.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None
+})
+export class TearsheetComponent implements OnInit, AfterViewInit, OnDestroy {
   @Input() title!: string;
   @Input() steps!: Array<Step>;
   @Input() description!: string;
-  @Input() submitButtonLabel: string = $localize`Create`;
   @Input() type: 'full' | 'wide' = 'wide';
+  @Input() size: 'xs' | 'sm' | 'md' | 'lg' = 'lg';
+  @Input() submitButtonLabel: string = $localize`Create`;
+  @Input() submitButtonLoadingLabel: string = $localize`Creating`;
+  @Input() isSubmitLoading: boolean = true;
 
   @Output() submitRequested = new EventEmitter<void>();
+  @Output() closeRequested = new EventEmitter<void>();
+  @Output() stepChanged = new EventEmitter<{ current: number }>();
 
   @ContentChildren(TearsheetStepComponent)
   stepContents!: QueryList<TearsheetStepComponent>;
@@ -38,17 +79,41 @@ export class TearsheetComponent implements OnInit, AfterViewChecked {
     return this.stepContents?.toArray()[this.currentStep]?.template;
   }
 
+  get rightInfluencerTemplate(): TemplateRef<any> | null {
+    return this.stepContents?.toArray()[this.currentStep]?.rightInfluencer ?? null;
+  }
+
+  get showRightInfluencer(): boolean {
+    return this.stepContents?.toArray()[this.currentStep]?.showRightInfluencer;
+  }
+
+  getStepValue<T = any>(index: number): T | null {
+    const wrapper = this.stepContents?.toArray()?.[index];
+    return wrapper?.stepComponent?.formGroup?.value ?? null;
+  }
+
+  getStepIndexByLabel(label: string): number {
+    return this.steps?.findIndex((s) => s.label === label) ?? -1;
+  }
+
+  getStepValueByLabel<T = any>(label: string): T | null {
+    const idx = this.getStepIndexByLabel(label);
+    if (idx < 0) return null;
+    return this.getStepValue<T>(idx);
+  }
+
   currentStep: number = 0;
   lastStep: number = null;
   isOpen: boolean = true;
   hasModalOutlet: boolean = false;
+  private destroy$ = new Subject<void>();
 
   constructor(
     protected formBuilder: FormBuilder,
-    private changeDetectorRef: ChangeDetectorRef,
     private cdsModalService: ModalCdsService,
     private route: ActivatedRoute,
-    private location: Location
+    private location: Location,
+    private destroyRef: DestroyRef
   ) {}
 
   ngOnInit() {
@@ -56,8 +121,13 @@ export class TearsheetComponent implements OnInit, AfterViewChecked {
     this.hasModalOutlet = this.route.outlet === 'modal';
   }
 
+  private _updateStepInvalid(index: number, invalid: boolean) {
+    this.steps = this.steps.map((step, i) => (i === index ? { ...step, invalid } : step));
+  }
+
   onStepSelect(event: { step: Step; index: number }) {
     this.currentStep = event.index;
+    this.stepChanged.emit({ current: this.currentStep });
   }
 
   closeTearsheet() {
@@ -69,6 +139,7 @@ export class TearsheetComponent implements OnInit, AfterViewChecked {
   }
 
   closeWideTearsheet() {
+    this.closeRequested.emit();
     this.isOpen = false;
     if (this.hasModalOutlet) {
       this.location.back();
@@ -80,19 +151,46 @@ export class TearsheetComponent implements OnInit, AfterViewChecked {
   onPrevious() {
     if (this.currentStep !== 0) {
       this.currentStep = this.currentStep - 1;
+      this.stepChanged.emit({ current: this.currentStep });
     }
   }
 
   onNext() {
+    const currentForm = this.stepContents?.toArray()?.[this.currentStep]?.stepComponent?.formGroup;
+    currentForm?.markAllAsTouched();
+    currentForm?.updateValueAndValidity({ emitEvent: true });
+    if (currentForm) {
+      this._updateStepInvalid(this.currentStep, currentForm.invalid);
+    }
+
     if (this.currentStep !== this.lastStep && !this.steps[this.currentStep].invalid) {
       this.currentStep = this.currentStep + 1;
+      this.stepChanged.emit({ current: this.currentStep });
     }
   }
 
-  onSubmit() {
-    if (!this.steps[this.currentStep].invalid) {
-      this.submitRequested.emit();
-    }
+  getMergedPayload(): any {
+    return this.stepContents.toArray().reduce((acc, wrapper) => {
+      const stepFormValue = wrapper.stepComponent.formGroup.value;
+      return { ...acc, ...stepFormValue };
+    }, {});
+  }
+
+  handleSubmit() {
+    this.stepContents?.forEach((wrapper, index) => {
+      const form = wrapper.stepComponent?.formGroup;
+      if (!form) return;
+
+      form.markAllAsTouched();
+      form.updateValueAndValidity({ emitEvent: true });
+      this._updateStepInvalid(index, form.invalid);
+    });
+
+    if (this.steps.some((step) => step?.invalid)) return;
+
+    const mergedPayloads = this.getMergedPayload();
+
+    this.submitRequested.emit(mergedPayloads);
   }
 
   closeFullTearsheet() {
@@ -111,7 +209,34 @@ export class TearsheetComponent implements OnInit, AfterViewChecked {
     });
   }
 
-  ngAfterViewChecked() {
-    this.changeDetectorRef.detectChanges();
+  ngAfterViewInit() {
+    const setup = () => {
+      // keep lastStep in sync with steps input
+      this.lastStep = this.steps.length - 1;
+
+      // clamp currentStep so template lookup never goes out of range
+      if (this.currentStep > this.lastStep) {
+        this.currentStep = this.lastStep;
+      }
+
+      // subscribe to each form statusChanges
+      this.stepContents.forEach((wrapper, index) => {
+        const form = wrapper.stepComponent?.formGroup;
+        if (!form) return;
+
+        form.statusChanges
+          .pipe(takeUntilDestroyed(this.destroyRef))
+          .subscribe(() => this._updateStepInvalid(index, form.invalid));
+      });
+    };
+
+    setup();
+
+    this.stepContents.changes.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => setup());
+  }
+
+  ngOnDestroy() {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 }


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/75923

Signed-off-by: Sagar Gopale <sagar.gopale@ibm.com>
(cherry picked from commit ca99febcefb341a14ee3e077841ecdcbfc5c246b)

 Conflicts:
	src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.spec.ts
	src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.ts
	src/pybind/mgr/dashboard/frontend/src/app/shared/components/tearsheet/tearsheet.component.ts





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
