### PR TITLE
squid: qa/tasks/quiescer: remove racy assertion

### DIFF
--- a/qa/tasks/quiescer.py
+++ b/qa/tasks/quiescer.py
@@ -406,7 +406,6 @@ def task(ctx, config):
     # the manager should be there
     manager = ctx.managers[cluster_name]
     manager.wait_for_clean()
-    assert manager.is_clean()
 
     mds_cluster = MDSCluster(ctx)
     for fs in mds_cluster.status().get_filesystems():


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76015

---

backport of https://github.com/ceph/ceph/pull/67555
parent tracker: https://tracker.ceph.com/issues/75201

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh