### PR TITLE
squid: qa: ignore expected MON_DOWN

### DIFF
--- a/qa/suites/fs/multiclient/tasks/cephfs_misc_tests.yaml
+++ b/qa/suites/fs/multiclient/tasks/cephfs_misc_tests.yaml
@@ -12,3 +12,4 @@ overrides:
       - MDS_CLIENT_LATE_RELEASE
       - responding to mclientcaps
       - RECENT_CRASH
+      - MON_DOWN


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76013

---

backport of https://github.com/ceph/ceph/pull/68360
parent tracker: https://tracker.ceph.com/issues/75992

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh