### PR TITLE
smb: wildcard deletion of smb shares and clusters

### DIFF
--- a/doc/mgr/smb.rst
+++ b/doc/mgr/smb.rst
@@ -221,7 +221,7 @@ Remove Cluster
 
 .. prompt:: bash #
 
-   ceph smb cluster rm <cluster_id> [--password-filter=<password_filter>]
+   ceph smb cluster rm <cluster_id> [--recursive] [--wildcard] [--password-filter=<password_filter>]
 
 Remove a logical SMB cluster from the Ceph cluster.
 
@@ -229,6 +229,14 @@ Options:
 
 cluster_id
     A ``cluster_id`` value identifying a cluster resource.
+recursive
+    If the ``--recursive`` flag is included in the command the cluster
+    and the shares contained by that cluster will be automatically
+    removed.
+wildcard
+    If the ``--wildcard`` flag is included in the command the ``cluster_id``
+    value will be treated as a glob_ style wildcard. All clusters with an ID
+    matching the glob pattern will be removed.
 password_filter
     Optional. One of ``none``, ``base64``, or ``hidden``. If the filter is
     ``none`` the password fields in the output are emitted as plain text. If
@@ -419,9 +427,23 @@ Remove Share
 
 .. prompt:: bash #
 
-   ceph smb share rm <cluster_id> <share_id>
+   ceph smb share rm <cluster_id> <share_id> [--wildcard]
 
 Remove an SMB Share from the cluster.
+
+Options:
+
+cluster_id
+    A ``cluster_id`` value identifying a cluster resource that contains
+    the share resource.
+share_id
+    A ``share_id`` value identifying the specific share within a cluster.
+wildcard
+    If the ``--wildcard`` flag is included in the command the ``share_id``
+    value will be treated as a glob_ style wildcard. All shares with an ID
+    matching the glob pattern will be removed.
+
+.. _glob: https://docs.python.org/3/library/fnmatch.html
 
 
 List Shares

--- a/src/pybind/mgr/smb/cli.py
+++ b/src/pybind/mgr/smb/cli.py
@@ -76,6 +76,11 @@ class InvalidInputValue(object_format.ErrorResponseBase):
         return -errno.EINVAL, "", str(self)
 
 
+class NoMatchingValue(object_format.ErrorResponseBase):
+    def format_response(self) -> Tuple[int, str, str]:
+        return -errno.ENOENT, "", str(self)
+
+
 @contextlib.contextmanager
 def error_wrapper() -> Iterator[None]:
     """Context-decorator that converts between certain common exception types."""

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -15,6 +15,7 @@ from typing import (
 
 import contextlib
 import dataclasses
+import fnmatch
 import logging
 import time
 
@@ -188,6 +189,7 @@ class _Matcher:
     def __init__(self) -> None:
         self._contents: Set[Any] = set()
         self._inputs: Set[str] = set()
+        self._wildcards: Set[tuple[Any, ...]] = set()
 
     def __str__(self) -> str:
         if not self._contents:
@@ -210,9 +212,22 @@ class _Matcher:
                 len(value) == 3
                 and (value[0], value[1], None) in self._contents
             )
+            or self._wildmatch(value)
         )
 
-    def parse(self, txt: str) -> None:
+    def _wildmatch(self, value: tuple[Any]) -> bool:
+        if not self._wildcards:
+            return False
+        if not value:
+            return False
+        head, tail = value[:-1], value[-1]
+        return any(
+            fnmatch.fnmatch(tail, wild[-1])
+            for wild in self._wildcards
+            if head == wild[:-1]
+        )
+
+    def parse(self, txt: str, *, wildcard: bool = False) -> None:
         rtypes: Dict[str, Any] = {
             cast(Any, r).resource_type: r for r in self._match_resources
         }
@@ -225,19 +240,25 @@ class _Matcher:
         try:
             prefix, id_a = txt.rsplit('.', 1)
             resource_cls = rtypes[prefix]
-            self._contents.add(resource_cls)
-            self._contents.add((resource_cls, id_a))
-            self._contents.add((resource_cls, id_a, None))
             self._inputs.add(txt)
+            self._contents.add(resource_cls)
+            if wildcard:
+                self._wildcards.add((resource_cls, id_a))
+            else:
+                self._contents.add((resource_cls, id_a))
+                self._contents.add((resource_cls, id_a, None))
             return
         except (ValueError, KeyError):
             pass
         try:
             prefix, id_a, id_b = txt.rsplit('.', 2)
             resource_cls = rtypes[prefix]
-            self._contents.add(resource_cls)
-            self._contents.add((resource_cls, id_a, id_b))
             self._inputs.add(txt)
+            self._contents.add(resource_cls)
+            if wildcard:
+                self._wildcards.add((resource_cls, id_a, id_b))
+            else:
+                self._contents.add((resource_cls, id_a, id_b))
             return
         except (ValueError, KeyError):
             pass
@@ -382,10 +403,12 @@ class ClusterConfigHandler:
         with _store_transaction(self.internal_store):
             return self._search_resources(_Matcher())
 
-    def matching_resources(self, names: List[str]) -> List[SMBResource]:
+    def matching_resources(
+        self, names: List[str], *, wildcard: bool = False
+    ) -> List[SMBResource]:
         matcher = _Matcher()
         for name in names:
-            matcher.parse(name)
+            matcher.parse(name, wildcard=wildcard)
         with _store_transaction(self.internal_store):
             return self._search_resources(matcher)
 

--- a/src/pybind/mgr/smb/module.py
+++ b/src/pybind/mgr/smb/module.py
@@ -342,17 +342,105 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             password_filter_out=password_filter_out,
         ).squash(cluster)
 
+    @overload
+    def cluster_rm(
+        self,
+        cluster_id: str,
+        wildcard: Literal[False] = False,
+        recursive: bool = False,
+        password_filter: PasswordFilter = PasswordFilter.NONE,
+    ) -> results.Result:
+        ...
+
+    @overload
+    def cluster_rm(
+        self,
+        cluster_id: str,
+        wildcard: Literal[True],
+        recursive: bool = False,
+        password_filter: PasswordFilter = PasswordFilter.NONE,
+    ) -> results.ResultGroup:
+        ...
+
     @SMBCLICommand('cluster rm', perm='rw')
     def cluster_rm(
         self,
         cluster_id: str,
+        wildcard: bool = False,
+        recursive: bool = False,
         password_filter: PasswordFilter = PasswordFilter.NONE,
-    ) -> results.Result:
+    ) -> Union[results.Result, results.ResultGroup]:
         """Remove an smb cluster"""
+        if recursive or wildcard:
+            return self._cluster_multi_rm(
+                cluster_id,
+                password_filter=password_filter,
+                recursive=recursive,
+                wildcard=wildcard,
+            )
         cluster = resources.RemovedCluster(cluster_id=cluster_id)
         return self._apply_res(
             [cluster], password_filter_out=password_filter
         ).one()
+
+    def _cluster_multi_rm(
+        self,
+        cluster_id: str,
+        password_filter: PasswordFilter = PasswordFilter.NONE,
+        recursive: bool = False,
+        wildcard: bool = False,
+    ) -> results.ResultGroup:
+        """Remove >=1 cluster and optionally its shares."""
+        if wildcard:
+            # a wildcard cluster search will give 0-N matching clusters
+            matches = self._handler.matching_resources(
+                [f'ceph.smb.cluster.{cluster_id}'],
+                wildcard=True,
+            )
+            clusters = [
+                r for r in matches if isinstance(r, resources.Cluster)
+            ]
+            shares = []
+        else:
+            # a non-wildcard cluster - ids are expected to be exact
+            # belonging to the cluster
+            mixed = self._handler.matching_resources(
+                [
+                    f'ceph.smb.cluster.{cluster_id}',
+                    f'ceph.smb.share.{cluster_id}',
+                ],
+                wildcard=False,
+            )
+            clusters = [r for r in mixed if isinstance(r, resources.Cluster)]
+            shares = [r for r in mixed if isinstance(r, resources.Share)]
+        if not clusters:
+            raise cli.NoMatchingValue(f'no clusters matching "{cluster_id}"')
+        # get shares belonging to the clusters matched during wildcarding
+        if recursive and wildcard:
+            for cluster in clusters:
+                shares.extend(
+                    s
+                    for s in self._handler.matching_resources(
+                        [f'ceph.smb.share.{cluster.cluster_id}'],
+                        wildcard=False,
+                    )
+                    if isinstance(s, resources.Share)
+                )
+        # assemble the Removed{Share,Cluster} resources to submit
+        rm_res: list[resources.SMBResource] = [
+            resources.RemovedShare(
+                cluster_id=s.cluster_id, share_id=s.share_id
+            )
+            for s in shares
+        ]
+        rm_res.extend(
+            resources.RemovedCluster(cluster_id=c.cluster_id)
+            for c in clusters
+        )
+        return self._apply_res(
+            rm_res,
+            password_filter_out=password_filter,
+        )
 
     @SMBCLICommand('cluster update cephfs qos', perm='rw')
     def cluster_update_qos(

--- a/src/pybind/mgr/smb/module.py
+++ b/src/pybind/mgr/smb/module.py
@@ -1,4 +1,13 @@
-from typing import TYPE_CHECKING, Any, List, Optional, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    List,
+    Literal,
+    Optional,
+    Union,
+    cast,
+    overload,
+)
 
 import logging
 from dataclasses import replace
@@ -473,13 +482,52 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         )
         return self._apply_res([share], create_only=True).one()
 
+    @overload
+    def share_rm(
+        self, cluster_id: str, share_id: str, wildcard: Literal[False] = False
+    ) -> results.Result:
+        ...
+
+    @overload
+    def share_rm(
+        self, cluster_id: str, share_id: str, wildcard: Literal[True]
+    ) -> results.ResultGroup:
+        ...
+
     @SMBCLICommand('share rm', perm='rw')
-    def share_rm(self, cluster_id: str, share_id: str) -> results.Result:
+    def share_rm(
+        self, cluster_id: str, share_id: str, wildcard: bool = False
+    ) -> Union[results.Result, results.ResultGroup]:
         """Remove an smb share"""
+        if wildcard:
+            return self._share_wildcard_rm(cluster_id, share_id)
+        # basic mode
         share = resources.RemovedShare(
             cluster_id=cluster_id, share_id=share_id
         )
         return self._apply_res([share]).one()
+
+    def _share_wildcard_rm(
+        self, cluster_id: str, share_id: str
+    ) -> results.ResultGroup:
+        shares = self._handler.matching_resources(
+            [f'ceph.smb.share.{cluster_id}.{share_id}'],
+            wildcard=True,
+        )
+        if not shares:
+            # nothing matching the wildcard
+            raise cli.NoMatchingValue(
+                f'no shares matching "{share_id}" in {cluster_id}'
+            )
+        rm_shares: list[resources.SMBResource]
+        rm_shares = [
+            resources.RemovedShare(
+                cluster_id=s.cluster_id, share_id=s.share_id
+            )
+            for s in shares
+            if isinstance(s, resources.Share)
+        ]
+        return self._apply_res(rm_shares)
 
     @SMBCLICommand('share update cephfs qos', perm='rw')
     def share_update_qos(

--- a/src/pybind/mgr/smb/tests/test_smb.py
+++ b/src/pybind/mgr/smb/tests/test_smb.py
@@ -1279,3 +1279,26 @@ def test_share_fscrypt_config_error(tmodule, params):
     assert len(failures) == 1
     failure = failures[0]
     assert params['expected'] in failure.msg
+
+
+def test_share_rm_wildcard(tmodule):
+    _example_cfg_1(tmodule)
+
+    result = tmodule.share_rm('foo', 's*', wildcard=True)
+    assert result.success
+    assert len(list(result)) == 2
+
+
+def test_share_rm_wildcard_one_match(tmodule):
+    _example_cfg_1(tmodule)
+
+    result = tmodule.share_rm('foo', 'st*', wildcard=True)
+    assert result.success
+    assert len(list(result)) == 1
+
+
+def test_share_rm_wildcard_no_match(tmodule):
+    _example_cfg_1(tmodule)
+
+    with pytest.raises(smb.cli.NoMatchingValue):
+        tmodule.share_rm('foo', 'q*', wildcard=True)

--- a/src/pybind/mgr/smb/tests/test_smb.py
+++ b/src/pybind/mgr/smb/tests/test_smb.py
@@ -1302,3 +1302,25 @@ def test_share_rm_wildcard_no_match(tmodule):
 
     with pytest.raises(smb.cli.NoMatchingValue):
         tmodule.share_rm('foo', 'q*', wildcard=True)
+
+
+def test_cluster_rm_recursive(tmodule):
+    _example_cfg_1(tmodule)
+
+    result = tmodule.cluster_rm('foo', recursive=True)
+    assert result.success
+
+
+def test_cluster_rm_recursive_wildcard(tmodule):
+    _example_cfg_1(tmodule)
+
+    result = tmodule.cluster_rm('*', recursive=True, wildcard=True)
+    assert result.success
+    assert len(list(result)) == 3  # 1 cluster + 2 share
+
+
+def test_cluster_rm_wildcard_no_match(tmodule):
+    _example_cfg_1(tmodule)
+
+    with pytest.raises(smb.cli.NoMatchingValue):
+        tmodule.cluster_rm('gonk', wildcard=True)


### PR DESCRIPTION
Add support for the `--wildcard` option for `ceph smb share rm` and `ceph smb cluster rm`. This option causes the share_id or cluster_id argument of the corresponding command to be treated as a glob-style wildcard.

For example if you have shares "s1", "s2", "snake", and "cake" the command `ceph smb share rm --wildcard cluster1 's*'` will delete shares s1, s2 and snake (but not cake).

This PR also adds support for the --recursive flag to `cpeh smb cluster rm`. This flag causes the cluster rm command to automatically remove shares that belong to the specified cluster. For example `ceph smb cluster rm --recursive doop` deletes all shares connected to the `doop` cluster and the `doop` cluster.

These flags can be combined. `ceph smb cluster rm --wildcard --recursive '*'` will delete all clusters and shares for example.

NOTE: The normal mode of operation which assumes that when you specify a cluster and/or share id that the request was one of "make sure X doesn't exist" so it doesn't treat a "missing" ID as an error. In --wildcard mode, because the request is by nature imprecise if there are no matching items to the wildcard it returns an error. I considered an exception to this behavior for the `*` wildcard, as in "make it all go away", and treating no matches for `*` as not an error. However, that added code and added complexity. If you want that sort of behavior, just look for ENOENT errors and ignore those yourself.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
