### PR TITLE
tentacle: qa: Leak_StillReachable RocksDB error_handler

### DIFF
--- a/qa/valgrind.supp
+++ b/qa/valgrind.supp
@@ -874,6 +874,17 @@
    ...
 }
 {
+   rocky10 still reachable rocksdb leak
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:_Znam
+   fun:UnknownInlinedFun
+   fun:_GLOBAL__sub_I_error_handler.cc.lto_priv.0
+   fun:_sub_I_65535_0.0
+   fun:__libc_start_main@@GLIBC_2.34
+   fun:(below main)
+}
+{
    rocksdb leak variation - ObjectLibrary PatternEntry
    Memcheck:Leak
    match-leak-kinds: reachable


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75893

---

backport of https://github.com/ceph/ceph/pull/67733
parent tracker: https://tracker.ceph.com/issues/75430

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh