### PR TITLE
mgr/dashboard: Round off y-axis value of area chart

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/overview/storage-card/overview-storage-card.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/overview/storage-card/overview-storage-card.component.html
@@ -80,6 +80,7 @@
                      [rawData]="consumptionTrendData"
                      [subHeading]="'Shows last 7 days of storage consumption trends based on recent usage'"
                      [height]="'200px'"
+                     [decimals]="2"
                      [chartType]="'area'">
       </cd-area-chart>
     </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/area-chart/area-chart.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/area-chart/area-chart.component.ts
@@ -41,6 +41,7 @@ export class AreaChartComponent implements OnChanges {
   @Input() rawData!: ChartPoint[];
   @Input() chartKey = '';
   @Input() decimals = DECIMAL;
+  @Input() axisDecimals?: number = 1;
   @Input() customOptions?: Partial<AreaChartOptions>;
   @Input() legendEnabled = true;
   @Input() subHeading = '';
@@ -150,9 +151,9 @@ export class AreaChartComponent implements OnChanges {
           ticks: {
             // Only return numeric part of the formatted string (exclude units)
             formatter: (tick: number | Date): string => {
-              const raw = this.formatValueForChart(tick, labels, divisor);
+              const raw = this.formatValueForChart(tick, labels, divisor, this.axisDecimals);
               const num = parseFloat(raw);
-              return num.toString();
+              return Number.isNaN(num) ? '' : num.toString();
             }
           }
         }
@@ -161,7 +162,7 @@ export class AreaChartComponent implements OnChanges {
         enabled: true,
         showTotal: false,
         valueFormatter: (value: number): string =>
-          (this.formatValueForChart(value, labels, divisor) || value).toString(),
+          (this.formatValueForChart(value, labels, divisor, this.decimals) || value).toString(),
         customHTML: (data, defaultHTML) => this.formatChartTooltip(defaultHTML, data)
       },
       points: {
@@ -204,7 +205,12 @@ export class AreaChartComponent implements OnChanges {
   }
 
   // Uses number formatter service to convert chart value based on unit and divisor.
-  private formatValueForChart(input: number | Date, labels: string[], divisor: number): string {
+  private formatValueForChart(
+    input: number | Date,
+    labels: string[],
+    divisor: number,
+    decimals: number
+  ): string {
     if (typeof input !== 'number') return '';
     return this.numberFormatter.formatFromTo(
       input,
@@ -212,7 +218,7 @@ export class AreaChartComponent implements OnChanges {
       this.chartDisplayUnit,
       divisor,
       labels,
-      this.decimals
+      decimals
     );
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/performance-card/performance-card.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/performance-card/performance-card.component.html
@@ -42,7 +42,8 @@
             chartTitle="Latency"
             [chartKey]="performanceTypes?.Latency"
             [dataUnit]="metricUnitMap?.latency"
-            [rawData]="chartDataSignal()?.latency">
+            [rawData]="chartDataSignal()?.latency"
+            [decimals]="2">
           </cd-area-chart>
         </div>
         <div cdsCol
@@ -52,7 +53,8 @@
             chartTitle="Throughput"
             [chartKey]="performanceTypes?.Throughput"
             [dataUnit]="metricUnitMap?.throughput"
-            [rawData]="chartDataSignal()?.throughput">
+            [rawData]="chartDataSignal()?.throughput"
+            [decimals]="2">
           </cd-area-chart>
         </div>
       </div>


### PR DESCRIPTION
- by default y-axis set to 1 for all
- the value round off for area chart is seperated from y-axis ticks
- also fixes a bug where all IOPS y-ticks being repeated 1,1,0,0

The following values are set for now:

IOPS: valueDecimals=0, axisDecimals=1
Latency: valueDecimals=2, axisDecimals=1
Throughput: valueDecimals=1, axisDecimals=1
Consumption: valueDecimals=1, axisDecimals=1

 cc @aaSharma14 @cloudbehl let know if there are any concerns with these settings.

Fixes https://tracker.ceph.com/issues/76191


Before: (notice repeating y-axis values in IOPS)

<img width="1614" height="758" alt="image" src="https://github.com/user-attachments/assets/25bf7775-d28b-490c-80b9-60684e05c202" />



After:
<img width="1614" height="758" alt="Screenshot From 2026-04-22 01-44-13" src="https://github.com/user-attachments/assets/a36482fe-97f4-48fe-ab8d-0f177d420c47" />






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
