### PR TITLE
qa/tests: bump squid-p2p starting version from v19.2.0 to v19.2.1

### DIFF
--- a/qa/suites/upgrade/squid-p2p/squid-p2p-parallel/point-to-point-upgrade.yaml
+++ b/qa/suites/upgrade/squid-p2p/squid-p2p-parallel/point-to-point-upgrade.yaml
@@ -70,12 +70,12 @@ openstack:
     count: 3
     size: 30 # GB
 tasks:
-- print: "****  done squid about to install v19.2.0"
+- print: "****  done squid about to install v19.2.1"
 - install:
-    tag: v19.2.0
+    tag: v19.2.1
     # line below can be removed its from jewel test
     #exclude_packages: ['ceph-mgr','libcephfs2','libcephfs-devel','libcephfs-dev', 'librgw2']
-- print: "**** done v19.2.0 install"
+- print: "**** done v19.2.1 install"
 - ceph:
    fs: xfs
    add_osds_to_crush: true

--- a/qa/suites/upgrade/squid-p2p/squid-p2p-stress-split/1-ceph-install/squid.yaml
+++ b/qa/suites/upgrade/squid-p2p/squid-p2p-stress-split/1-ceph-install/squid.yaml
@@ -1,13 +1,13 @@
 meta:
 - desc: |
-   install ceph/squid v19.2.0
+   install ceph/squid v19.2.1
    Overall upgrade path is - squid-latest.point -1 => squid-latest
 tasks:
 - install:
-    tag: v19.2.0
+    tag: v19.2.1
     exclude_packages: ['librados3']
     extra_packages: ['librados2']
-- print: "**** done install squid v19.2.0"
+- print: "**** done install squid v19.2.1"
 - ceph:
 - exec:
     osd.0:


### PR DESCRIPTION
## Summary

- `v19.2.0` lacks the fix from tracker [#66019](https://tracker.ceph.com/issues/66019), causing `NeoRadosCls.RemoteReads` to fail during P2P upgrade tests
- Bump the starting version to `v19.2.1` in both `squid-p2p-parallel` and `squid-p2p-stress-split` test suites
- New upgrade path: `v19.2.1 -> v19.2.3 -> squid-latest`

Fixes: https://tracker.ceph.com/issues/76030

Signed-off-by: Yuri Weinstein <yweinste@redhat.com>