### PR TITLE
rgw/radosgw-admin: [POC][NOT READY] CLI11 hybrid for bucket list, usage show, object rm

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -32,7 +32,7 @@ function(gperf_generate input output)
 endfunction()
 
 find_package(ICU 52.0 COMPONENTS uc REQUIRED)
-find_package(CLI11 REQUIRED)
+find_package(CLI11 QUIET)
 
 set(librgw_common_srcs
   spdk/crc64.c
@@ -539,13 +539,16 @@ add_executable(radosgw-admin ${radosgw_admin_srcs})
 target_link_libraries(radosgw-admin
   legacy-option-headers
   ${rgw_libs} librados
-  CLI11::CLI11
   cls_rgw_client cls_otp_client cls_lock_client cls_refcount_client
   cls_log_client cls_timeindex_client
   cls_version_client cls_user_client
   global ${LIB_RESOLV}
   OATH::OATH
   ${CURL_LIBRARIES} ${EXPAT_LIBRARIES} ${BLKID_LIBRARIES})
+if(CLI11_FOUND)
+  target_compile_definitions(radosgw-admin PRIVATE HAVE_CLI11)
+  target_link_libraries(radosgw-admin PRIVATE CLI11::CLI11)
+endif()
 endif()
 
 # this is unsatisfying and hopefully temporary; ARROW should not be

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -32,6 +32,7 @@ function(gperf_generate input output)
 endfunction()
 
 find_package(ICU 52.0 COMPONENTS uc REQUIRED)
+find_package(CLI11 REQUIRED)
 
 set(librgw_common_srcs
   spdk/crc64.c
@@ -538,6 +539,7 @@ add_executable(radosgw-admin ${radosgw_admin_srcs})
 target_link_libraries(radosgw-admin
   legacy-option-headers
   ${rgw_libs} librados
+  CLI11::CLI11
   cls_rgw_client cls_otp_client cls_lock_client cls_refcount_client
   cls_log_client cls_timeindex_client
   cls_version_client cls_user_client

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -13,6 +13,7 @@
 
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/use_awaitable.hpp>
+#include <CLI/CLI.hpp>
 
 extern "C" {
 #include <liboath/oath.h>
@@ -3604,6 +3605,84 @@ void init_realm_param(CephContext *cct, string& var, std::optional<string>& opt_
   }
 }
 
+struct Cli11PocParseResult {
+  bool matched = false;
+  OPT opt_cmd = OPT::NO_CMD;
+};
+
+static int try_parse_cli11_poc(const std::vector<const char*>& args,
+                               Cli11PocParseResult* out,
+                               std::string* err)
+{
+  if (!out) {
+    return -EINVAL;
+  }
+  *out = {};
+  if (err) {
+    err->clear();
+  }
+  if (args.empty()) {
+    return 0;
+  }
+
+  std::vector<std::string> string_args;
+  string_args.reserve(args.size());
+  for (const auto* arg : args) {
+    string_args.emplace_back(arg);
+  }
+
+  std::vector<char*> cli11_argv;
+  cli11_argv.reserve(string_args.size() + 1);
+  static char program_name[] = "radosgw-admin";
+  cli11_argv.push_back(program_name);
+  for (auto& arg : string_args) {
+    cli11_argv.push_back(arg.data());
+  }
+
+  CLI::App app{"radosgw-admin CLI11 POC"};
+  app.allow_extras(false);
+  app.set_help_flag("");
+  app.require_subcommand(1);
+
+  auto* bucket = app.add_subcommand("bucket");
+  auto* buckets = app.add_subcommand("buckets");
+  auto* usage = app.add_subcommand("usage");
+  auto* object = app.add_subcommand("object");
+
+  bucket->require_subcommand(1);
+  buckets->require_subcommand(1);
+  usage->require_subcommand(1);
+  object->require_subcommand(1);
+
+  auto* bucket_list = bucket->add_subcommand("list");
+  auto* buckets_list = buckets->add_subcommand("list");
+  auto* usage_show = usage->add_subcommand("show");
+  auto* object_rm = object->add_subcommand("rm");
+
+  int cli11_argc = static_cast<int>(cli11_argv.size());
+  try {
+    app.parse(cli11_argc, cli11_argv.data());
+  } catch (const CLI::ParseError& e) {
+    if (err) {
+      *err = e.what();
+    }
+    return 0;
+  }
+
+  if (bucket_list->parsed() || buckets_list->parsed()) {
+    out->matched = true;
+    out->opt_cmd = OPT::BUCKETS_LIST;
+  } else if (usage_show->parsed()) {
+    out->matched = true;
+    out->opt_cmd = OPT::USAGE_SHOW;
+  } else if (object_rm->parsed()) {
+    out->matched = true;
+    out->opt_cmd = OPT::OBJECT_RM;
+  }
+
+  return 0;
+}
+
 // This has an uncaught exception. Even if the exception is caught, the program
 // would need to be terminated, so the warning is simply suppressed.
 // coverity[root_function:SUPPRESS]
@@ -4518,44 +4597,55 @@ int main(int argc, const char **argv)
     exit(1);
   }
   else {
-    std::vector<string> extra_args;
-    std::vector<string> expected;
-
-    std::any _opt_cmd;
-
-    if (!cmd.find_command(args, &_opt_cmd, &extra_args, &err, &expected)) {
-      if (!expected.empty()) {
-        cerr << err << std::endl;
-        cerr << "Expected one of the following:" << std::endl;
-        for (auto& exp : expected) {
-          if (exp == "*" || exp == "[*]") {
-            continue;
-          }
-          cerr << "  " << exp << std::endl;
-        }
-      } else {
-        cerr << "Command not found:";
-        for (auto& arg : args) {
-          cerr << " " << arg;
-        }
-        cerr << std::endl;
-      }
-      exit(1);
+    Cli11PocParseResult cli11_poc;
+    std::string cli11_poc_err;
+    const int cli11_poc_ret = try_parse_cli11_poc(args, &cli11_poc, &cli11_poc_err);
+    if (cli11_poc_ret < 0) {
+      return -cli11_poc_ret;
     }
 
-    opt_cmd = std::any_cast<OPT>(_opt_cmd);
+    if (cli11_poc.matched) {
+      opt_cmd = cli11_poc.opt_cmd;
+    } else {
+      std::vector<string> extra_args;
+      std::vector<string> expected;
 
-    /* some commands may have an optional extra param */
-    if (!extra_args.empty()) {
-      switch (opt_cmd) {
-        case OPT::METADATA_GET:
-        case OPT::METADATA_PUT:
-        case OPT::METADATA_RM:
-        case OPT::METADATA_LIST:
-          metadata_key = extra_args[0];
-          break;
-        default:
-          break;
+      std::any _opt_cmd;
+
+      if (!cmd.find_command(args, &_opt_cmd, &extra_args, &err, &expected)) {
+        if (!expected.empty()) {
+          cerr << err << std::endl;
+          cerr << "Expected one of the following:" << std::endl;
+          for (auto& exp : expected) {
+            if (exp == "*" || exp == "[*]") {
+              continue;
+            }
+            cerr << "  " << exp << std::endl;
+          }
+        } else {
+          cerr << "Command not found:";
+          for (auto& arg : args) {
+            cerr << " " << arg;
+          }
+          cerr << std::endl;
+        }
+        exit(1);
+      }
+
+      opt_cmd = std::any_cast<OPT>(_opt_cmd);
+
+      /* some commands may have an optional extra param */
+      if (!extra_args.empty()) {
+        switch (opt_cmd) {
+          case OPT::METADATA_GET:
+          case OPT::METADATA_PUT:
+          case OPT::METADATA_RM:
+          case OPT::METADATA_LIST:
+            metadata_key = extra_args[0];
+            break;
+          default:
+            break;
+        }
       }
     }
 

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -13,7 +13,9 @@
 
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/use_awaitable.hpp>
+#ifdef HAVE_CLI11
 #include <CLI/CLI.hpp>
+#endif
 
 extern "C" {
 #include <liboath/oath.h>
@@ -3610,17 +3612,14 @@ struct Cli11PocParseResult {
   OPT opt_cmd = OPT::NO_CMD;
 };
 
+#ifdef HAVE_CLI11
 static int try_parse_cli11_poc(const std::vector<const char*>& args,
-                               Cli11PocParseResult* out,
-                               std::string* err)
+                               Cli11PocParseResult* out)
 {
   if (!out) {
     return -EINVAL;
   }
   *out = {};
-  if (err) {
-    err->clear();
-  }
   if (args.empty()) {
     return 0;
   }
@@ -3662,10 +3661,7 @@ static int try_parse_cli11_poc(const std::vector<const char*>& args,
   int cli11_argc = static_cast<int>(cli11_argv.size());
   try {
     app.parse(cli11_argc, cli11_argv.data());
-  } catch (const CLI::ParseError& e) {
-    if (err) {
-      *err = e.what();
-    }
+  } catch (const CLI::ParseError&) {
     return 0;
   }
 
@@ -3682,6 +3678,7 @@ static int try_parse_cli11_poc(const std::vector<const char*>& args,
 
   return 0;
 }
+#endif // HAVE_CLI11
 
 // This has an uncaught exception. Even if the exception is caught, the program
 // would need to be terminated, so the warning is simply suppressed.
@@ -4597,16 +4594,20 @@ int main(int argc, const char **argv)
     exit(1);
   }
   else {
+    bool cli11_poc_matched = false;
+#ifdef HAVE_CLI11
     Cli11PocParseResult cli11_poc;
-    std::string cli11_poc_err;
-    const int cli11_poc_ret = try_parse_cli11_poc(args, &cli11_poc, &cli11_poc_err);
+    const int cli11_poc_ret = try_parse_cli11_poc(args, &cli11_poc);
     if (cli11_poc_ret < 0) {
       return -cli11_poc_ret;
     }
-
     if (cli11_poc.matched) {
       opt_cmd = cli11_poc.opt_cmd;
-    } else {
+      cli11_poc_matched = true;
+    }
+#endif // HAVE_CLI11
+
+    if (!cli11_poc_matched) {
       std::vector<string> extra_args;
       std::vector<string> expected;
 


### PR DESCRIPTION
## Status
- Draft POC only (not production-ready)
- Not merge-ready until parity testing is added and validated
- Intended as a scoped exploration for 3 commands only

## Motivation
radosgw-admin currently uses a legacy/manual command parse path. This patch introduces a minimal hybrid CLI11 proof-of-concept to modernize parse/dispatch incrementally without changing handler logic.

## Scope
This draft is intentionally limited to 3 commands:
- bucket list (and existing alias buckets list)
- usage show
- object rm

All other commands remain on the existing SimpleCmd path.

## Design
- Add a small CLI11 adapter that matches only the 3 commands above.
- Run this adapter before SimpleCmd resolution.
- On match: set opt_cmd to existing enums (OPT::BUCKETS_LIST, OPT::USAGE_SHOW, OPT::OBJECT_RM) and keep downstream execution unchanged.
- On no-match: fall back to existing command resolution unchanged.
- Add CLI11 dependency wiring scoped to radosgw-admin target.

## Compatibility
- No intended behavior change outside the 3-command POC scope.
- Existing command handlers and option parsing/execution blocks are reused.
- Existing alias compatibility for bucket list/buckets list is preserved.

## Commits
1. rgw/radosgw-admin: wire CLI11 dependency for POC
2. rgw/radosgw-admin: add CLI11 hybrid parser POC for 3 commands

## Tests run
- Not run locally in this draft submission.

## Follow-up plan
- Expand command coverage in follow-up PRs after validating parity and behavior.
- Add focused CLI tests for success/error parity for the migrated command set.
