### PR TITLE
qa/tests: ignore 'pg stuck peering' during upgrade tests

### DIFF
--- a/qa/suites/upgrade/quincy-x/parallel/0-start.yaml
+++ b/qa/suites/upgrade/quincy-x/parallel/0-start.yaml
@@ -47,6 +47,7 @@ overrides:
       - Reduced data availability
       - Degraded data redundancy
       - pg .* is stuck inactive
+      - pg .* is stuck peering
       - pg .* is .*degraded
       - FS_DEGRADED
       - OSDMAP_FLAGS

--- a/qa/suites/upgrade/quincy-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/quincy-x/stress-split/1-start.yaml
@@ -16,6 +16,7 @@ overrides:
       - Reduced data availability
       - Degraded data redundancy
       - pg .* is stuck inactive
+      - pg .* is stuck peering
       - pg .* is .*degraded
       - FS_DEGRADED
       - OSDMAP_FLAGS

--- a/qa/suites/upgrade/reef-x/parallel/0-start.yaml
+++ b/qa/suites/upgrade/reef-x/parallel/0-start.yaml
@@ -47,6 +47,7 @@ overrides:
       - Reduced data availability
       - Degraded data redundancy
       - pg .* is stuck inactive
+      - pg .* is stuck peering
       - pg .* is .*degraded
       - FS_DEGRADED
       - OSDMAP_FLAGS

--- a/qa/suites/upgrade/reef-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/reef-x/stress-split/1-start.yaml
@@ -16,6 +16,7 @@ overrides:
       - Reduced data availability
       - Degraded data redundancy
       - pg .* is stuck inactive
+      - pg .* is stuck peering
       - pg .* is .*degraded
       - FS_DEGRADED
       - OSDMAP_FLAGS


### PR DESCRIPTION
https://tracker.ceph.com/issues/70511