### PR TITLE
mgr/dashboard: Allow moving to next when Bidirectional mode is chosen

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-group-form/nvmeof-group-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-group-form/nvmeof-group-form.component.html
@@ -106,6 +106,10 @@
             i18n-helperText>Encryption configuration
             <textarea cdsTextArea
                       id="cdsInput"
+                      cdValidate
+                      #encryptionConfig="cdValidate"
+                      [invalid]="encryptionConfig.invalid"
+                      [invalidText]="encryptionConfigError"
                       formControlName="encryptionConfig"
                       cols="100"
                       rows="4">
@@ -113,6 +117,11 @@
           </cds-textarea-label>
         </div>
       </div>
+      <ng-template #encryptionConfigError>
+        <span *ngIf="groupForm.controls.encryptionConfig.hasError('required')"
+              class="invalid-feedback"
+              i18n>This field is required.</span>
+      </ng-template>
       }
 
       <!-- Target Nodes Selection -->

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-group-form/nvmeof-group-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-group-form/nvmeof-group-form.component.ts
@@ -75,6 +75,16 @@ export class NvmeofGroupFormComponent extends CdForm implements OnInit {
       enableEncryption: new UntypedFormControl(false),
       encryptionConfig: new UntypedFormControl(null)
     });
+
+    this.groupForm.get('enableEncryption')?.valueChanges.subscribe((enabled) => {
+      const encryptionControl = this.groupForm.get('encryptionConfig');
+      if (enabled) {
+        encryptionControl?.setValidators([Validators.required]);
+      } else {
+        encryptionControl?.clearValidators();
+      }
+      encryptionControl?.updateValueAndValidity();
+    });
   }
 
   onHostsLoaded(count: number): void {
@@ -159,8 +169,8 @@ export class NvmeofGroupFormComponent extends CdForm implements OnInit {
       unmanaged: formValues.unmanaged
     };
 
-    if (formValues.enableCds && formValues.cdsInput) {
-      serviceSpec['encryption_key'] = formValues.cdsInput;
+    if (formValues.enableEncryption && formValues.encryptionConfig) {
+      serviceSpec['encryption_key'] = formValues.encryptionConfig;
     }
 
     this.taskWrapperService

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-3/nvmeof-subsystem-step-3.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-3/nvmeof-subsystem-step-3.component.html
@@ -91,6 +91,7 @@
           <p class="cds--type-label-01 text-helper"
              i18n>{{formGroup.get('authType').value === AUTHENTICATION.Bidirectional ? 'All fields are required.' : 'Optional fields.'}}</p>
         </div>
+        @if (hostDchapKeyList.controls.length) {
         @for (hostDchapKeyItem of hostDchapKeyList.controls; track $index; let i = $index) {
         <div [formGroupName]="i">
           <cds-text-label
@@ -116,6 +117,11 @@
                    [invalid]="hostKey.isInvalid">
           </cds-text-label>
         </div>
+        }
+        } @else {
+        <p
+          class="cds--type-label-01 text-helper"
+          i18ns>No hosts selected.</p>
         }
       </div>
     </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-3/nvmeof-subsystem-step-3.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-3/nvmeof-subsystem-step-3.component.spec.ts
@@ -57,6 +57,19 @@ describe('NvmeofSubsystemsStepThreeComponent', () => {
     });
 
     describe('form initialization', () => {
+      beforeEach(() => {
+        fixture = TestBed.createComponent(NvmeofSubsystemsStepThreeComponent);
+        component = fixture.componentInstance;
+
+        component.stepTwoValue = {
+          hostType: 'specific',
+          addedHosts: ['nqn.2001-07.com.ceph:1776805137618']
+        } as any;
+
+        fixture.detectChanges();
+        form = component.formGroup;
+      });
+
       it('should initialize form with default values', () => {
         expect(form).toBeTruthy();
         expect(form.get('authType')?.value).toBe(AUTHENTICATION.Unidirectional);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-3/nvmeof-subsystem-step-3.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-3/nvmeof-subsystem-step-3.component.ts
@@ -50,8 +50,6 @@ export class NvmeofSubsystemsStepThreeComponent implements OnInit, TearsheetStep
       hosts.forEach((nqn) => {
         currentList.push(this.createHostDhchapKeyFormGroup(nqn, existing.get(nqn) ?? null));
       });
-    } else {
-      currentList.push(this.createHostDhchapKeyFormGroup('', null));
     }
   }
 


### PR DESCRIPTION
- there is an issue with bi-auth , where the validation is getting empty due to some state refresh
- fixed by removing re-setting of form state

Fixes https://tracker.ceph.com/issues/76194

Before:

User cannot move forward in Bi-auth when clicking Next

After:

User can move forward


https://github.com/user-attachments/assets/7cdd8362-49d9-4df1-a357-2d63d61602f0




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
