### PR TITLE
mgr/dashboard: Validate no added hosts in second step

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-2/nvmeof-subsystem-step-2.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-2/nvmeof-subsystem-step-2.component.ts
@@ -38,9 +38,16 @@ export class NvmeofSubsystemsStepTwoComponent implements OnInit, TearsheetStep {
 
   ngOnInit() {
     this.createForm();
-    this.formGroup.get('hostType').valueChanges.subscribe(() => {
-      this.formGroup.get('hostname').updateValueAndValidity();
+
+    this.formGroup.get('hostType')?.valueChanges.subscribe(() => {
+      this.formGroup.get('hostname')?.updateValueAndValidity();
     });
+
+    this.formGroup.get('addedHosts')?.valueChanges.subscribe(() => {
+      this.formGroup.get('hostname')?.updateValueAndValidity();
+    });
+
+    this.formGroup.get('hostname')?.updateValueAndValidity();
   }
 
   isValidNQN = CdValidators.custom(
@@ -52,17 +59,16 @@ export class NvmeofSubsystemsStepTwoComponent implements OnInit, TearsheetStep {
     'duplicate',
     (input: string) =>
       !!input &&
-      (this.formGroup?.get('addedHosts')?.value.includes(input) ||
+      ((this.formGroup?.get('addedHosts')?.value ?? []).includes(input) ||
         this.existingHosts.includes(input))
   );
 
-  isRequired = CdValidators.custom(
-    'customRequired',
-    (input: string) =>
-      !input &&
-      this.addedHostsLength === 0 &&
-      this.formGroup?.get('hostType')?.value === this.HOST_TYPE.SPECIFIC
-  );
+  isRequired = CdValidators.custom('customRequired', (input: string) => {
+    const hostType = this.formGroup?.get('hostType')?.value;
+    const addedHosts = this.formGroup?.get('addedHosts')?.value ?? [];
+
+    return !input && addedHosts.length === 0 && hostType === this.HOST_TYPE.SPECIFIC;
+  });
 
   showRightInfluencer(): boolean {
     return this.formGroup.get('hostType')?.value === this.HOST_TYPE.SPECIFIC;
@@ -83,24 +89,25 @@ export class NvmeofSubsystemsStepTwoComponent implements OnInit, TearsheetStep {
     hostnameCtrl.markAsTouched();
     hostnameCtrl.updateValueAndValidity();
     if (hostnameCtrl.value && hostnameCtrl.valid) {
-      const addedHosts = this.formGroup.get('addedHosts').value;
+      const addedHosts = this.formGroup.get('addedHosts')?.value ?? [];
       const newHostList = [...addedHosts, hostnameCtrl.value];
       this.addedHostsLength = newHostList.length;
       this.formGroup.patchValue({
         addedHosts: newHostList,
         hostname: ''
       });
+      this.formGroup.get('hostname')?.updateValueAndValidity();
     }
   }
 
   removeHost(removedHost: string) {
-    const currentAddedHosts = this.formGroup.get('addedHosts').value;
+    const currentAddedHosts = this.formGroup.get('addedHosts')?.value ?? [];
     const newHostList = currentAddedHosts.filter((currentHost) => currentHost !== removedHost);
     this.addedHostsLength = newHostList.length;
     this.formGroup.patchValue({
       addedHosts: newHostList
     });
-    this.formGroup.get('hostname').updateValueAndValidity();
+    this.formGroup.get('hostname')?.updateValueAndValidity();
   }
 
   removeAll() {
@@ -108,6 +115,6 @@ export class NvmeofSubsystemsStepTwoComponent implements OnInit, TearsheetStep {
     this.formGroup.patchValue({
       addedHosts: []
     });
-    this.formGroup.get('hostname').updateValueAndValidity();
+    this.formGroup.get('hostname')?.updateValueAndValidity();
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-4/nvmeof-subsystem-step-4.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-4/nvmeof-subsystem-step-4.component.html
@@ -72,6 +72,7 @@
   }
 
   <!-- Authentication details -->
+  @if (hostType === HOST_TYPE.SPECIFIC) {
   <div cdsCol
        [columnNumbers]="{sm: 4, md: 8, lg: 12}"
        class="cds-mt-7">
@@ -113,4 +114,5 @@
        i18n>No keys added</p>
     }
   </div>
+  }
 </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-4/nvmeof-subsystem-step-4.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-4/nvmeof-subsystem-step-4.component.spec.ts
@@ -54,6 +54,11 @@ describe('NvmeofSubsystemsStepFourComponent', () => {
   });
 
   it('should return correct auth type label', () => {
+    component.hostDchapKeyCount = 0;
+    expect(component.authTypeLabel).toContain('No authentication');
+
+    component.hostDchapKeyCount = 2;
+
     component.authType = AUTHENTICATION.Bidirectional;
     expect(component.authTypeLabel).toContain('Bidirectional');
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-4/nvmeof-subsystem-step-4.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-4/nvmeof-subsystem-step-4.component.ts
@@ -45,7 +45,7 @@ export class NvmeofSubsystemsStepFourComponent implements OnInit, TearsheetStep 
   }
 
   get authTypeLabel(): string {
-    if (this.authType === AUTHENTICATION.None) return NO_AUTH;
+    if (this.authType === AUTHENTICATION.None || this.hostDchapKeyCount === 0) return NO_AUTH;
     return this.authType === AUTHENTICATION.Bidirectional
       ? $localize`Bidirectional`
       : $localize`Unidirectional`;


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/76195

Before: 

Clicking on next moves to third step when no hosts added

After: 

Next does not move forward when added hosts are empty

https://github.com/user-attachments/assets/8b6b34e6-8884-4f7b-864b-102743866551





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
