### PR TITLE
Mgr: Allow autoscaling for overlapped roots

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,3 +1,7 @@
+* RADOS: PG autoscaler allows overlapping roots. Each root receives a PG target based
+  on its OSDs, with OSDs shared across multiple roots contributing proportionally
+  less to each root's allocation.
+  
 * librados/neorados: The C++ APIs for executing Ceph Class (CLS) methods
   have undergone a breaking change to enforce compile-time type safety, replacing
   legacy string-based parameters with strongly-typed ClsMethod structs. C++

--- a/doc/rados/operations/placement-groups.rst
+++ b/doc/rados/operations/placement-groups.rst
@@ -232,28 +232,48 @@ command:
 For all but the very smallest deployments a value of 200 is recommended.
 A value above 500 may result in excessive peering traffic and RAM usage.
 
-The autoscaler analyzes pools and adjusts on a per-subtree basis.  Because each
-pool might map to a different CRUSH rule, and each rule might distribute data
-across different and possibly overlapping sets of devices,
-Ceph will consider the utilization of each subtree of
-the CRUSH hierarchy independently. For example, a pool that maps to OSDs of class
-``ssd`` and a pool that maps to OSDs of class ``hdd`` will each have calculated PG
-counts that are determined by how many OSDs of these two different device types
-there are.
+.. _overlapping_crush_roots:
 
-If a pool uses OSDs under two or more CRUSH roots (for example, shadow trees
-with both ``ssd`` and ``hdd`` devices), the autoscaler issues a warning to the
-user in the manager log. The warning states the name of the pool and the set of
-roots that overlap each other. The autoscaler does not scale any pools with
-overlapping roots because this condition can cause problems with the scaling
-process. We recommend constraining each pool so that it belongs to only one
-root (that is, one device OSD class) to silence the warning and ensure successful
-scaling.
+Overlapping CRUSH Roots PG Budget
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When OSDs are distributed across multiple CRUSH roots, each root receives a PG target based
+on its OSDs, with OSDs shared across multiple roots contributing proportionally less to each
+root's allocation. The budget assigned to each root is:
+
+.. math::
+
+   \sum_{\text{OSD}_i \in R} \frac{\text{mon_target_pg_per_osd}}{|\text{roots}(\text{OSD}_i)|}
+
+This ensures that the total PG budget is distributed proportionally across all roots.
+
+Consider a cluster with the following topology:
+
+.. prompt:: bash #
+
+   mon_target_pg_per_osd = 300
+
+- **rootid -1**: Contains OSDs {0, 1, 2, 3}
+- **rootid -2**: Contains OSDs {0, 1}
+- **rootid -3**: Contains OSDs {2, 3}
+
+OSD membership:
+
+- **OSD 0**: Belongs to roots {-1, -2}
+- **OSD 1**: Belongs to roots {-1, -2}
+- **OSD 2**: Belongs to roots {-1, -3}
+- **OSD 3**: Belongs to roots {-1, -3}
+
+The PG target allocation for each root is calculated as follows:
+
+- Root -1: pg_target = 600 = (300 / 2 roots for OSD 0) + (300 / 2 roots for OSD 1) + (300 / 2 roots for OSD 2) + (300 / 2 roots for OSD 3)
+- Root -2: pg_target = 300 = (300 / 2 roots for OSD 0) + (300 / 2 roots for OSD 1)
+- Root -3: pg_target = 300 = (300 / 2 roots for OSD 2) + (300 / 2 roots for OSD 3)
 
 .. _allocation_algorithm:
 
 Allocation Algorithm
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 The autoscaler sets each pool's ``final_pool_pg_target`` to be rounded to the
 nearest power of two while ensuring that the number of PGs to be placed on each OSD

--- a/qa/workunits/mon/pg_autoscaler.sh
+++ b/qa/workunits/mon/pg_autoscaler.sh
@@ -139,7 +139,6 @@ function test_autoscaler_basic() {
     wait_for 60 "ceph health detail | grep POOL_HAS_TARGET_SIZE_BYTES_AND_RATIO"
 
     # test autoscale warn
-
     ceph osd pool create warn0 1 --autoscale-mode=warn
     wait_for 120 "ceph health detail | grep POOL_TOO_FEW_PGS"
 
@@ -212,14 +211,161 @@ function test_exact_budget() {
     ceph osd pool rm data1 data1 --yes-i-really-really-mean-it
 }
 
+function test_overlapping_roots() {
+    # Create custom CRUSH rules for zone-based placement
+    MON_TARGET_PG_PER_OSD=100
+    ceph config set global mon_target_pg_per_osd $MON_TARGET_PG_PER_OSD
+
+    ceph osd crush add-bucket us-east region
+    ceph osd crush move us-east root=default
+
+    ceph osd crush add-bucket us-east-1 zone
+    ceph osd crush add-bucket us-east-2 zone
+    ceph osd crush add-bucket us-east-3 zone
+    ceph osd crush move us-east-1 region=us-east
+    ceph osd crush move us-east-2 region=us-east
+    ceph osd crush move us-east-3 region=us-east
+
+    ceph osd crush add-bucket host0 host
+    ceph osd crush add-bucket host1 host
+    ceph osd crush add-bucket host2 host
+    ceph osd crush add-bucket host3 host
+    ceph osd crush add-bucket host4 host
+    ceph osd crush add-bucket host5 host
+
+    ceph osd crush move host0 zone=us-east-1
+    ceph osd crush move host1 zone=us-east-1
+    ceph osd crush move host2 zone=us-east-2
+    ceph osd crush move host3 zone=us-east-2
+    ceph osd crush move host4 zone=us-east-3
+    ceph osd crush move host5 zone=us-east-3
+
+    ceph osd crush set osd.0 1.0 host=host0
+    ceph osd crush set osd.1 1.0 host=host1
+    ceph osd crush set osd.2 1.0 host=host2
+    ceph osd crush set osd.3 1.0 host=host3
+    ceph osd crush set osd.4 1.0 host=host4
+    ceph osd crush set osd.5 1.0 host=host5
+
+    ceph osd crush move us-east root=default
+
+    # Add zone-based CRUSH rules
+    hostname=$(hostname -s)
+    ceph osd crush remove $hostname
+
+    ceph osd getcrushmap > crushmap
+    crushtool --decompile crushmap > crushmap.txt
+    sed 's/^# end crush map$//' crushmap.txt > crushmap_modified.txt
+    cat >> crushmap_modified.txt << EOF
+rule zone-1-only {
+        id 1
+        type replicated
+        step take us-east-1
+        step chooseleaf firstn 3 type host
+        step emit
+}
+
+rule zone-2-only {
+        id 2
+        type replicated
+        step take us-east-2
+        step chooseleaf firstn 3 type host
+        step emit
+}
+
+rule zone-3-only {
+        id 3
+        type replicated
+        step take us-east-3
+        step chooseleaf firstn 3 type host
+        step emit
+}
+
+rule default {
+        id 4
+        type replicated
+        step take default
+        step chooseleaf firstn 3 type host
+        step emit
+}
+# end crush map
+EOF
+
+    # compile the modified crushmap and set it
+    crushtool --compile crushmap_modified.txt -o crushmap.bin
+    ceph osd setcrushmap -i crushmap.bin
+
+
+    ceph osd pool create data0 --size=1
+    ceph osd pool create data1 --size=1
+    ceph osd pool create data2 --size=1
+    ceph osd pool create data3 --size=3
+
+    ceph osd pool set data0 pg_autoscale_mode on
+    ceph osd pool set data1 pg_autoscale_mode on
+    ceph osd pool set data2 pg_autoscale_mode on
+    ceph osd pool set data3 pg_autoscale_mode on
+    
+
+    ceph osd pool set data0 crush_rule zone-1-only
+    ceph osd pool set data1 crush_rule zone-2-only
+    ceph osd pool set data2 crush_rule zone-3-only
+    ceph osd pool set data3 crush_rule default
+
+    ceph osd pool set data0 target_size_ratio 1.0
+    ceph osd pool set data1 target_size_ratio 1.0
+    ceph osd pool set data2 target_size_ratio 1.0
+    ceph osd pool set data3 target_size_ratio 1.0
+
+    # expect
+    #  -1         6.00000  root default
+    #  -8         6.00000      region us-east
+    #  -5         2.00000          zone us-east-1
+    # -13         1.00000              host host0
+    #   0    ssd  1.00000                  osd.0
+    # -14         1.00000              host host1
+    #   1    ssd  1.00000                  osd.1
+    #  -6         2.00000          zone us-east-2
+    # -15         1.00000              host host2
+    #   2    ssd  1.00000                  osd.2
+    # -16         1.00000              host host3
+    #   3    ssd  1.00000                  osd.3
+    #  -7         2.00000          zone us-east-3
+    # -17         1.00000              host host4
+    #   4    ssd  1.00000                  osd.4
+    # -18         1.00000              host host5
+    #   5    ssd  1.00000                  osd.5
+
+    # -1: pg_target = 300
+    # -5: pg_target = 100
+    # -6  pg_target = 100
+    # -7: pg_target = 100
+
+    TARGET_PG_1=$(power2_floor $MON_TARGET_PG_PER_OSD)
+    TARGET_PG_2=$(power2_floor $(( ($NUM_OSDS - 3) * $MON_TARGET_PG_PER_OSD )))
+
+
+    wait_for 300 "ceph osd pool get data0 pg_num | grep $TARGET_PG_1"
+    wait_for 300 "ceph osd pool get data1 pg_num | grep $TARGET_PG_1"
+    wait_for 300 "ceph osd pool get data2 pg_num | grep $TARGET_PG_1"
+    wait_for 300 "ceph osd pool get data3 pg_num | grep $TARGET_PG_2"
+
+    ceph osd pool rm data0 data0 --yes-i-really-really-mean-it
+    ceph osd pool rm data1 data1 --yes-i-really-really-mean-it
+    ceph osd pool rm data2 data2 --yes-i-really-really-mean-it
+    ceph osd pool rm data3 data3 --yes-i-really-really-mean-it
+}
 
 # enable
 ceph config set mgr mgr/pg_autoscaler/sleep_interval 60
 ceph mgr module enable pg_autoscaler
+ceph osd pool set threshold 1.0
+
 
 test_autoscaler_basic || return 1
 test_pool_starvation || return 1
 test_exact_budget || return 1
+test_overlapping_roots || exit 1
 
 echo OK
 

--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -19,8 +19,6 @@ Some terminology is made up for the purposes of this module:
  - "raw pgs": pg count after applying replication, i.e. the real resource
               consumption of a pool.
  - "grow/shrink" - increase/decrease the pg_num in a pool
- - "crush subtree" - non-overlapping domains in crush hierarchy: used as
-                     units of resource management.
 """
 
 INTERVAL = 5
@@ -113,12 +111,12 @@ class PgAdjustmentProgress(object):
                       refs=[("pool", self.pool_id)])
 
 
-class CrushSubtreeResourceStatus:
+class CrushRootResourceStatus:
     def __init__(self) -> None:
-        self.root_ids: List[int] = []
+        self.root_id: int
         self.osds: Set[int] = set()
         self.osd_count: Optional[int] = None  # Number of OSDs
-        self.pg_target: Optional[int] = None  # Ideal full-capacity PG count?
+        self.pg_target = 0 # Ideal full-capacity PG count?
         self.pg_current = 0  # How many PGs already?
         self.pg_left = 0
         self.capacity: Optional[int] = None  # Total capacity of OSDs in subtree
@@ -425,17 +423,18 @@ class PgAutoscaler(MgrModule):
         self.log.info('Stopping pg_autoscaler')
         self._shutdown.set()
 
-    def identify_subtrees_and_overlaps(self,
-                                       osdmap: OSDMap,
-                                       pools: Dict[str, Dict[str, Any]],
-                                       crush: CRUSHMap,
-                                       result: Dict[int, CrushSubtreeResourceStatus],
-                                       overlapped_roots: Set[int],
-                                       roots: List[CrushSubtreeResourceStatus]) -> \
-        Tuple[List[CrushSubtreeResourceStatus],
-              Set[int]]:
+    def identify_subtrees(self,
+                          osdmap: OSDMap,
+                          pools: Dict[str, Dict[str, Any]],
+                          crush: CRUSHMap,
+                          result: Dict[int, CrushRootResourceStatus],
+                          roots: List[CrushRootResourceStatus],
+                          osd_uses_by_root: Dict[int, Set[int]]) -> \
+        Tuple[List[CrushRootResourceStatus],
+              Dict[int, Set[int]]]:
 
-        # We identify subtrees and overlapping roots from osdmap
+        # We identify subtrees from osdmap
+
         for pool_name, pool in pools.items():
             crush_rule = crush.get_rule_by_id(pool['crush_rule'])
             assert crush_rule is not None
@@ -443,26 +442,15 @@ class PgAutoscaler(MgrModule):
             root_id = crush.get_rule_root(cr_name)
             assert root_id is not None
             osds = set(crush.get_osds_under(root_id))
-
-            # Are there overlapping roots?
+            for osd in osds:
+                osd_uses_by_root[osd].add(root_id)
             s = None
-            for prev_root_id, prev in result.items():
-                if osds & prev.osds:
-                    s = prev
-                    if prev_root_id != root_id:
-                        overlapped_roots.add(prev_root_id)
-                        overlapped_roots.add(root_id)
-                        self.log.warning("pool %s won't scale due to overlapping roots: %s",
-                                      pool_name, overlapped_roots)
-                        self.log.warning("Please See: https://docs.ceph.com/en/"
-                                         "latest/rados/operations/placement-groups"
-                                         "/#automated-scaling")
-                    break
-            if not s:
-                s = CrushSubtreeResourceStatus()
+            if root_id not in result:
+                s = CrushRootResourceStatus()
                 roots.append(s)
-            result[root_id] = s
-            s.root_ids.append(root_id)
+                result[root_id] = s
+                s.root_id = root_id
+            s = result[root_id]
             s.osds |= osds
             s.pool_ids.append(pool['pool'])
             s.pool_names.append(pool_name)
@@ -474,32 +462,33 @@ class PgAutoscaler(MgrModule):
                 target_bytes = pool['options'].get('target_size_bytes', 0)
                 if target_bytes:
                     s.total_target_bytes += target_bytes * osdmap.pool_raw_used_rate(pool['pool'])
-        return roots, overlapped_roots
+        return roots, osd_uses_by_root
 
     def get_subtree_resource_status(self,
                                     osdmap: OSDMap,
                                     pools: Dict[str, Dict[str, Any]],
-                                    crush: CRUSHMap) -> Tuple[Dict[int, CrushSubtreeResourceStatus],
-                                                              Set[int]]:
+                                    crush: CRUSHMap) -> Dict[int, CrushRootResourceStatus]:
         """
         For each CRUSH subtree of interest (i.e. the roots under which
         we have pools), calculate the current resource usages and targets,
         such as how many PGs there are, vs. how many PGs we would
         like there to be.
         """
-        result: Dict[int, CrushSubtreeResourceStatus] = {}
-        roots: List[CrushSubtreeResourceStatus] = []
-        overlapped_roots: Set[int] = set()
-        # identify subtrees and overlapping roots
-        roots, overlapped_roots = self.identify_subtrees_and_overlaps(
-            osdmap, pools, crush, result, overlapped_roots, roots
+        result: Dict[int, CrushRootResourceStatus] = {}
+        roots: List[CrushRootResourceStatus] = []
+        osd_uses_by_root: Dict[int, Set[int]] = defaultdict(set[int])
+        # identify subtrees and roots
+        roots, osd_uses_by_root = self.identify_subtrees(
+            osdmap, pools, crush, result, roots, osd_uses_by_root
         )
         # finish subtrees
         all_stats = self.get('osd_stats')
+        for osd, root_ids in osd_uses_by_root.items():
+            for root_id in root_ids:
+                result[root_id].pg_target += self.mon_target_pg_per_osd // len(root_ids)
         for s in roots:
             assert s.osds is not None
             s.osd_count = len(s.osds)
-            s.pg_target = s.osd_count * self.mon_target_pg_per_osd
             s.pg_left = s.pg_target
             s.pool_count = len(s.pool_ids)
             capacity = 0
@@ -512,13 +501,12 @@ class PgAutoscaler(MgrModule):
                     capacity += osd_stats['kb'] * 1024
 
             s.capacity = capacity
-            self.log.debug('root_ids %s pools %s with %d osds, pg_target %d',
-                           s.root_ids,
+            self.log.debug('root_id %s pools %s with %d osds, pg_target %d',
+                           s.root_id,
                            s.pool_ids,
                            s.osd_count,
                            s.pg_target)
-
-        return result, overlapped_roots
+        return result
 
     def _append_result (
             self,
@@ -568,7 +556,7 @@ class PgAutoscaler(MgrModule):
 
     def _find_optimal_pg_distribution (
             self,
-            root_map: Dict[int, CrushSubtreeResourceStatus],
+            root_map: Dict[int, CrushRootResourceStatus],
             root_id: int,
             base: int,
             cost: int,
@@ -617,7 +605,7 @@ class PgAutoscaler(MgrModule):
 
     def _calculate_final_pool_pg_target(
             self,
-            root_map: Dict[int, CrushSubtreeResourceStatus],
+            root_map: Dict[int, CrushRootResourceStatus],
             root_id: int,
             func_pass: 'PassT',
             pool_group: Dict[GroupKey, PoolGroup],
@@ -736,7 +724,7 @@ class PgAutoscaler(MgrModule):
     def _calculate_pool_metrics(
             self,
             osdmap: OSDMap,
-            root_map: Dict[int, CrushSubtreeResourceStatus],
+            root_map: Dict[int, CrushRootResourceStatus],
             root_id: int,
             pool_id: int,
             pool_stats: Dict[int, Dict[str, int]],
@@ -781,7 +769,7 @@ class PgAutoscaler(MgrModule):
 
     def _get_pool_pg_targets(
             self,
-            root_map: Dict[int, CrushSubtreeResourceStatus],
+            root_map: Dict[int, CrushRootResourceStatus],
             ret: List[Dict[str, Any]],
             threshold: float,
             func_pass: 'PassT',
@@ -879,9 +867,8 @@ class PgAutoscaler(MgrModule):
         osdmap: OSDMap,
         pools: Dict[str, Dict[str, Any]],
         crush_map: CRUSHMap,
-        root_map: Dict[int, CrushSubtreeResourceStatus],
+        root_map: Dict[int, CrushRootResourceStatus],
         pool_stats: Dict[int, Dict[str, int]],
-        overlapped_roots: Set[int],
         pool_groups_by_root: Dict[int, Dict[GroupKey, PoolGroup]],
         pool_metrics: Dict[str, Dict[str, Any]],
     ) -> None:
@@ -901,12 +888,6 @@ class PgAutoscaler(MgrModule):
             cr_name = crush_rule['rule_name']
             root_id = crush_map.get_rule_root(cr_name)
             assert root_id is not None
-            if root_id in overlapped_roots:
-                # skip pools
-                # with overlapping roots
-                self.log.warn("pool %d contains an overlapping root %d"
-                              "... skipping scaling", pool_id, root_id)
-                continue
             capacity = root_map[root_id].capacity
             assert capacity is not None
             if capacity == 0:
@@ -944,12 +925,12 @@ class PgAutoscaler(MgrModule):
             osdmap: OSDMap,
             pools: Dict[str, Dict[str, Any]],
     ) -> Tuple[List[Dict[str, Any]],
-               Dict[int, CrushSubtreeResourceStatus]]:
+               Dict[int, CrushRootResourceStatus]]:
         threshold = self.threshold
         assert threshold >= 1.0
 
         crush_map = osdmap.get_crush()
-        root_map, overlapped_roots = self.get_subtree_resource_status(osdmap, pools, crush_map)
+        root_map = self.get_subtree_resource_status(osdmap, pools, crush_map)
         df = self.get('df')
         pool_stats = dict([(p['id'], p['stats']) for p in df['pools']])
 
@@ -977,7 +958,7 @@ class PgAutoscaler(MgrModule):
         #     'target_ratio': float
         #     'bulk': bool
         # }
-        self._compute_pool_group_metrics(osdmap, pools, crush_map, root_map, pool_stats, overlapped_roots, pool_groups_by_root, pool_metrics)
+        self._compute_pool_group_metrics(osdmap, pools, crush_map, root_map, pool_stats, pool_groups_by_root, pool_metrics)
 
         ret = self._get_pool_pg_targets(root_map, ret, threshold, 'first', pool_groups_by_root, pool_metrics)
         ret = self._get_pool_pg_targets(root_map, ret, threshold, 'second', pool_groups_by_root, pool_metrics)

--- a/src/pybind/mgr/pg_autoscaler/tests/test_overlapping_roots.py
+++ b/src/pybind/mgr/pg_autoscaler/tests/test_overlapping_roots.py
@@ -3,7 +3,9 @@ import unittest
 from tests import mock
 import pytest
 import json
+from collections import defaultdict
 from pg_autoscaler import module
+from pg_autoscaler.module import CrushRootResourceStatus
 
 
 class OSDMAP:
@@ -45,17 +47,16 @@ class TestPgAutoscaler(object):
     def setup_method(self):
         # a bunch of attributes for testing.
         self.autoscaler = module.PgAutoscaler('module_name', 0, 0)
+        self.autoscaler.mon_target_pg_per_osd = 100
 
-    def helper_test(self, osd_dic, rules, pools, expected_overlapped_roots):
-        result = {}
-        roots = []
-        overlapped_roots = set()
+    def helper_test(self, osd_dic, rules, pools, expected_result):
         osdmap = OSDMAP(pools)
         crush = CRUSH(rules, osd_dic)
-        roots, overlapped_roots = self.autoscaler.identify_subtrees_and_overlaps(
-            osdmap, pools, crush, result, overlapped_roots, roots
+        result = self.autoscaler.get_subtree_resource_status(
+            osdmap, pools, crush
         )
-        assert overlapped_roots == expected_overlapped_roots
+        for root_id in result:
+            assert result[root_id].pg_target == expected_result[root_id].pg_target
 
     def test_subtrees_and_overlaps(self):
         osd_dic = {
@@ -282,8 +283,13 @@ class TestPgAutoscaler(object):
                 "expected_final_pg_target": 128,
             },
         }
-        expected_overlapped_roots = {-40, -1, -5}
-        self.helper_test(osd_dic, rules, pools, expected_overlapped_roots)
+        expected_result = defaultdict(CrushRootResourceStatus)
+        for root in osd_dic:
+            expected_result[root] = CrushRootResourceStatus()
+        expected_result[-1].pg_target = 550
+        expected_result[-40].pg_target = 250
+        expected_result[-5].pg_target = 800
+        self.helper_test(osd_dic, rules, pools, expected_result)
 
     def test_no_overlaps(self):
         osd_dic = {
@@ -510,5 +516,10 @@ class TestPgAutoscaler(object):
                 "expected_final_pg_target": 128,
             },
         }
-        expected_overlapped_roots = set()
-        self.helper_test(osd_dic, rules, pools, expected_overlapped_roots)
+        expected_result = defaultdict(CrushRootResourceStatus)
+        for root in osd_dic:
+            expected_result[root] = CrushRootResourceStatus()
+        expected_result[-1].pg_target = 1100
+        expected_result[-40].pg_target = 500
+        expected_result[-5].pg_target = 300
+        self.helper_test(osd_dic, rules, pools, expected_result)


### PR DESCRIPTION
Problem:

- If crush roots have overlapping roots, they do not autoscale.

Solution:

- Do not check for overlapping roots and allow all roots to autoscale. PG budget assigned for root is sum(mon_target_pg_per_osd/ #roots containing osd). Changed CrushSubtreeResourceStatus to be unique for each crush root instead of shared across overlapping roots.

Fixes: https://tracker.ceph.com/issues/73892

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
