### PR TITLE
crimson/osd/pg: skip replicas that's still missing the object being

### DIFF
--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -346,34 +346,6 @@ void PG::recheck_readable()
   }
 }
 
-bool PG::should_send_op(pg_shard_t peer, const hobject_t &hoid)
-{
-  if (peer == get_primary()) {
-    return true;
-  }
-  bool should_send =
-    hoid.pool != (int64_t)get_pgid().pool() ||
-    hoid <= peering_state.get_peer_info(peer).last_backfill ||
-    (recovery_handler->backfill_state &&
-      hoid <= recovery_handler->backfill_state->get_last_backfill_started());
-  if (!should_send) {
-    ceph_assert(is_backfill_target(peer));
-    logger().debug("{}: {} shipping empty opt to osd.{}, object {}"
-		   " beyond std::max(last_backfill_started,"
-		   " peer_info[peer].last_backfill {})",
-		   *this, __func__, peer, hoid,
-		   peering_state.get_peer_info(peer).last_backfill);
-    return should_send;
-  }
-  if (peering_state.is_async_recovery_target(peer) &&
-      peering_state.get_peer_missing(peer).is_missing(hoid)) {
-    should_send = false;
-    logger().info("{}: {} shipping empty opt to osd.{}, object {}"
-		  " which is pending recovery in async_recovery_targets",
-		 *this, __func__, peer, hoid);
-  }
-  return should_send;
-}
 unsigned PG::get_target_pg_log_entries() const
 {
   const unsigned local_num_pgs = shard_services.get_num_local_pgs();
@@ -1801,31 +1773,35 @@ bool PG::is_degraded_or_backfilling_object(const hobject_t& soid) const {
 
 bool PG::should_send_op(
   pg_shard_t peer,
-  const hobject_t &hoid) const
+  const hobject_t &hoid)
 {
   if (peer == get_primary())
     return true;
   bool should_send =
     (hoid.pool != (int64_t)get_info().pgid.pool() ||
-    // An object has been fully pushed to the backfill target if and only if
-    // either of the following conditions is met:
-    // 1. peer_info.last_backfill has passed "hoid"
-    // 2. last_backfill_started has passed "hoid" and "hoid" is not in the peer
-    //    missing set
-    hoid <= peering_state.get_peer_info(peer).last_backfill ||
-    (has_backfill_state() && hoid <= get_last_backfill_started() &&
-     !is_missing_on_peer(peer, hoid)));
-  if (!should_send) {
-    ceph_assert(is_backfill_target(peer));
-    logger().debug("{} issue_repop shipping empty opt to osd."
-                   "{}, object {} beyond std::max(last_backfill_started, "
-                   "peer_info[peer].last_backfill {})",
-                   __func__, peer, hoid,
-                   peering_state.get_peer_info(peer).last_backfill);
+     // An object has been fully pushed to the backfill target if and only if
+     // hoid is not in the peer's missing set and either of the following
+     // conditions is met:
+     // 1. peer_info.last_backfill has passed "hoid"
+     // 2. last_backfill_started has passed "hoid"
+     hoid <= peering_state.get_peer_info(peer).last_backfill ||
+     (has_backfill_state() && hoid <= get_last_backfill_started())) &&
+    !is_missing_on_peer(peer, hoid);
+  if (unlikely(!should_send)) {
+    if (peering_state.is_async_recovery_target(peer)) {
+      logger().info("{}: {} shipping empty opt to osd.{}, object {}"
+                    " which is pending recovery in async_recovery_targets",
+                   *this, __func__, peer, hoid);
+    } else {
+      ceph_assert(is_backfill_target(peer));
+      logger().debug("{} issue_repop shipping empty opt to osd."
+                     "{}, object {} beyond std::max(last_backfill_started, "
+                     "peer_info[peer].last_backfill {})",
+                     __func__, peer, hoid,
+                     peering_state.get_peer_info(peer).last_backfill);
+    }
   }
   return should_send;
-  // TODO: should consider async recovery cases in the future which are not supported
-  //       by crimson yet
 }
 
 void PG::op_applied(const eversion_t &applied_version)

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -171,8 +171,6 @@ public:
     return get_acting_recovery_backfill();
   }
 
-  bool should_send_op(pg_shard_t peer, const hobject_t &hoid) override;
-
   spg_t primary_spg_t() const override {
     return spg_t(get_info().pgid.pgid, get_primary().shard);
   }
@@ -696,7 +694,7 @@ public:
   bool get_need_up_thru() const {
     return peering_state.get_need_up_thru();
   }
-  bool should_send_op(pg_shard_t peer, const hobject_t &hoid) const;
+  bool should_send_op(pg_shard_t peer, const hobject_t &hoid) final;
   epoch_t get_same_interval_since() const {
     return get_info().history.same_interval_since;
   }


### PR DESCRIPTION
accessed when issuing repops

Fixes: https://tracker.ceph.com/issues/76196
Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
