### PR TITLE
cephadm: During the upgrade, when inspecting the new ceph image for t…

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2044,7 +2044,7 @@ def _pull_image(ctx, image, insecure=False):
 @infer_image
 def command_inspect_image(ctx):
     # type: (CephadmContext) -> int
-    out, err, ret = call_throws(ctx, [
+    out, err, ret = call(ctx, [
         ctx.container_engine.path, 'inspect',
         '--format', '{{.ID}},{{.RepoDigests}}',
         ctx.image])


### PR DESCRIPTION

During the upgrade, when inspecting the new ceph image for the first time, an error is printed
to the ceph-mgr log instead of displaying a user-friendly message.

---

## Root Cause

During an upgrade, `inspect-image` is called on each node to check if the target image exists
locally before pulling it. This flow — where `inspect-image` always precedes the pull — occurs
on nodes other than the first.

---

## Code Fixes

### `src/cephadm/cephadm.py`

Replace `call_throws` with `call` in `command_inspect_image`.

- `call_throws` raises a `RuntimeError` on any non-zero exit code, producing a full traceback in the logs.
- `call` returns the exit code instead of raising, so the function exits cleanly with `errno.ENOENT` when the image is not found.

---

## Testing

### Steps to Reproduce

1. Install a cluster with `quay.io/ceph/ceph:v20.1.0`
2. Open a `cephadm` shell
3. Run `ceph config set mgr log_to_file true` so logs can be seen in `ceph-mgr` files
4. Upgrade the Ceph container to `quay.io/ceph/ceph:v20.2.0` by running:

```
   ceph orch upgrade start --image quay.io/ceph/ceph:v20.2.0
```

### Result Before the Fix

An error message with a full stack trace (as reported in the ticket) is written to the active
mgr log file, even though the upgrade finishes successfully.

### Expected Result After the Fix

The upgrade finishes successfully and the error message with the full stack trace is **not**
written to the active mgr log file.

---

## Reproduction Details

**Before the fix:** The error message with full stack trace appeared in the active mgr log file
as soon as the image was pulled for the second node:

~~~
[cephadm DEBUG cephadm.serve] err: Non-zero exit code 125 from /usr/bin/podman inspect --format {{.ID}},{{.RepoDigests}} quay.io/ceph/ceph@sha256:1228c3d...
/usr/bin/podman: stderr Error: no such object: "quay.io/ceph/ceph@sha256:1228c3d..."
Traceback (most recent call last):
  ...
  File ".../__main__.py", line 1809, in command_inspect_image
    out, err, ret = call_throws(ctx, [
  File ".../call_wrappers.py", line 307, in call_throws
    raise RuntimeError(...)
RuntimeError: Failed command: /usr/bin/podman inspect ...
~~~

**After the fix:** By replacing the `cephadm` binary, the upgrade finished successfully and the
full stack trace of the error was not seen in the log.

 
Fixes: https://tracker.ceph.com/issues/75448
Signed-off-by: Yael Azulay <yazulay@redhat.com>


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
