### PR TITLE
crimson/os/seastore/journal: switch CircularJournalSpace to coroutines

### DIFF
--- a/src/crimson/os/seastore/journal/circular_journal_space.cc
+++ b/src/crimson/os/seastore/journal/circular_journal_space.cc
@@ -114,25 +114,21 @@ CircularJournalSpace::open_ret CircularJournalSpace::open(bool is_mkfs) {
     DEBUG(
       "initialize header block in CircularJournalSpace length {}, head: {}",
       bl.length(), header);
-    return write_header(
-    ).safe_then([this]() {
-      return open_ret(
-	open_ertr::ready_future_marker{},
-	get_written_to());
-    }).handle_error(
+    co_await write_header(
+    ).handle_error(
       open_ertr::pass_further{},
       crimson::ct_error::assert_all{
-	"Invalid error write_header"
+        "Invalid error write_header"
       }
     );
+
+    co_return get_written_to();
   }
   ceph_assert(initialized);
   if (written_to.segment_seq == NULL_SEG_SEQ) {
     written_to.segment_seq = 0;
   }
-  return open_ret(
-    open_ertr::ready_future_marker{},
-    get_written_to());
+  co_return get_written_to();
 }
 
 ceph::bufferlist CircularJournalSpace::encode_header()
@@ -161,13 +157,13 @@ CircularJournalSpace::device_write_bl(
   LOG_PREFIX(CircularJournalSpace::device_write_bl);
   auto length = bl.length();
   if (offset + length >= get_journal_end()) {
-    return crimson::ct_error::erange::make();
+    co_return co_await submit_ertr::future<>(crimson::ct_error::erange::make());
   }
   DEBUG(
     "overwrite in CircularJournalSpace, offset {}, length {}",
     offset,
     length);
-  return device->writev(offset, bl
+  co_await device->writev(offset, bl
   ).handle_error(
     submit_ertr::pass_further{},
     crimson::ct_error::assert_all{ "Invalid error device->write" }
@@ -182,39 +178,36 @@ CircularJournalSpace::read_header()
   auto bptr = bufferptr(ceph::buffer::create_page_aligned(
 			device->get_block_size()));
   DEBUG("reading {}", device->get_shard_journal_start());
-  return device->read(device->get_shard_journal_start(), bptr
-  ).safe_then([bptr, FNAME, this]() mutable
-    -> read_header_ret {
-    bufferlist bl;
-    bl.append(bptr);
-    auto bp = bl.cbegin();
-    cbj_header_t cbj_header;
-    try {
-      decode(cbj_header, bp);
-    } catch (ceph::buffer::error &e) {
-      ERROR("unable to read header block");
-      return crimson::ct_error::enoent::make();
+  co_await device->read(device->get_shard_journal_start(), bptr);
+  
+  bufferlist bl;
+  bl.append(bptr);
+  auto bp = bl.cbegin();
+  cbj_header_t cbj_header;
+  bool decode_failed = false;
+  try {
+    decode(cbj_header, bp);
+  } catch (ceph::buffer::error &e) {
+    ERROR("unable to read header block");
+    decode_failed = true;
+  }
+  if (decode_failed) {
+    co_return co_await read_header_ret(crimson::ct_error::enoent::make());
+  }
+  if (!device->is_end_to_end_data_protection()) {
+    auto bliter = bl.cbegin();
+    auto test_crc = bliter.crc32c(
+      ceph::encoded_sizeof_bounded<cbj_header_t>(),
+      -1);
+    ceph_le32 recorded_crc_le;
+    decode(recorded_crc_le, bliter);
+    uint32_t recorded_crc = recorded_crc_le;
+    if (test_crc != recorded_crc) {
+      ERROR("error, header crc mismatch.");
+      co_return std::nullopt;
     }
-    if (!device->is_end_to_end_data_protection()) {
-      auto bliter = bl.cbegin();
-      auto test_crc = bliter.crc32c(
-	ceph::encoded_sizeof_bounded<cbj_header_t>(),
-	-1);
-      ceph_le32 recorded_crc_le;
-      decode(recorded_crc_le, bliter);
-      uint32_t recorded_crc = recorded_crc_le;
-      if (test_crc != recorded_crc) {
-	ERROR("error, header crc mismatch.");
-	return read_header_ret(
-	  read_header_ertr::ready_future_marker{},
-	  std::nullopt);
-      }
-    }
-    return read_header_ret(
-      read_header_ertr::ready_future_marker{},
-      std::make_pair(cbj_header, bl)
-    );
-  });
+  }
+  co_return std::make_pair(cbj_header, bl);
 }
 
 CircularJournalSpace::submit_ertr::future<>
@@ -231,7 +224,7 @@ CircularJournalSpace::write_header()
   assert(bl.length() < get_block_size());
   bufferptr bp = bufferptr(ceph::buffer::create_page_aligned(get_block_size()));
   iter.copy(bl.length(), bp.c_str());
-  return device->write(device->get_shard_journal_start(), std::move(bp)
+  co_await device->write(device->get_shard_journal_start(), std::move(bp)
   ).handle_error(
     submit_ertr::pass_further{},
     crimson::ct_error::assert_all{ "Invalid error device->write" }


### PR DESCRIPTION

Signed-off-by: Myoungwon Oh <ohmyoungwon@gmail.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
