### PR TITLE
mgr/dashboard: Fix service form to take into account labels

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group.component.ts
@@ -228,6 +228,7 @@ export class NvmeofGatewayGroupComponent implements OnInit {
       }
     });
   }
+
   private checkNodesAvailability(): void {
     forkJoin([this.nvmeofService.listGatewayGroups(), this.hostService.getAllHosts()]).subscribe(
       ([groups, hosts]: [GatewayGroup[][], any[]]) => {
@@ -236,6 +237,15 @@ export class NvmeofGatewayGroupComponent implements OnInit {
         groupList.forEach((group: CephServiceSpec) => {
           const placementHosts = group.placement?.hosts || [];
           placementHosts.forEach((hostname: string) => usedHosts.add(hostname));
+
+          const placementLabel = group.placement?.label;
+          if (placementLabel) {
+            (hosts || []).forEach((host) => {
+              if (host.labels?.includes(placementLabel)) {
+                usedHosts.add(host.hostname);
+              }
+            });
+          }
         });
 
         const availableHosts = (hosts || []).filter((host) => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-node/nvmeof-gateway-node.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-node/nvmeof-gateway-node.component.ts
@@ -303,8 +303,16 @@ export class NvmeofGatewayNodeComponent implements OnInit, OnDestroy {
     groupList.forEach((group: CephServiceSpec) => {
       const hosts = group.placement?.hosts || group.spec?.placement?.hosts || [];
       hosts.forEach((hostname: string) => allUsedHostnames.add(hostname));
-    });
 
+      const label = group.placement?.label || group.spec?.placement?.label;
+      if (label) {
+        (hostList || []).forEach((host: Host) => {
+          if (host.labels?.includes(label as string)) {
+            allUsedHostnames.add(host.hostname);
+          }
+        });
+      }
+    });
     this.usedHostnames = allUsedHostnames;
 
     // Check if there are any available hosts globally (not used by any group)
@@ -328,11 +336,19 @@ export class NvmeofGatewayNodeComponent implements OnInit, OnDestroy {
     } else {
       const placementHosts =
         this.serviceSpec.placement?.hosts || this.serviceSpec.spec?.placement?.hosts || [];
-      const currentGroupHosts = new Set<string>(placementHosts);
+      const placementLabel =
+        this.serviceSpec.placement?.label || this.serviceSpec.spec?.placement?.label;
 
-      this.hosts = (hostList || []).filter((host: Host) => {
-        return currentGroupHosts.has(host.hostname);
-      });
+      if (placementHosts.length > 0) {
+        const currentGroupHosts = new Set<string>(placementHosts);
+        this.hosts = (hostList || []).filter((host: Host) => currentGroupHosts.has(host.hostname));
+      } else if (placementLabel) {
+        this.hosts = (hostList || []).filter((host: Host) =>
+          host.labels?.includes(placementLabel as string)
+        );
+      } else {
+        this.hosts = [];
+      }
     }
 
     this.count = this.hosts.length;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
@@ -322,7 +322,7 @@
       @if (hostsAndLabels$ | async; as data) {
       @if (!serviceForm.controls.unmanaged.value && serviceForm.controls.placement.value === 'label') {
       <div class="form-item">
-        <cds-combo-box type="multi"
+        <cds-combo-box type="single"
                        selectionFeedback="top-after-reopen"
                        label="Label"
                        cdRequiredField="Label"
@@ -331,9 +331,7 @@
                        [appendInline]="true"
                        [items]="data.labels"
                        [invalid]="serviceForm.controls.label.invalid && serviceForm.controls.label.dirty"
-                       [invalidText]="requiredFieldLabel"
-                       (selected)="multiSelector($event, 'label')"
-                       i18n>
+                       [invalidText]="requiredFieldLabel">
           <cds-dropdown-list></cds-dropdown-list>
         </cds-combo-box>
         <ng-template #requiredFieldLabel>
@@ -354,7 +352,7 @@
                        id="hosts"
                        [appendInline]="true"
                        [items]="data.hosts"
-                       (selected)="multiSelector($event, 'hosts')"
+                       (selected)="multiSelector($event)"
                        i18n>
           <cds-dropdown-list></cds-dropdown-list>
         </cds-combo-box>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.spec.ts
@@ -109,7 +109,7 @@ describe('ServiceFormComponent', () => {
       // placement labels take only single value
       formHelper.setValue('service_type', 'mgr');
       formHelper.setValue('placement', 'label');
-      formHelper.setValue('label', "{content: 'foo', selected:  true}");
+      formHelper.setValue('label', { content: 'foo', selected: true });
 
       component.onSubmit();
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.spec.ts
@@ -105,15 +105,18 @@ describe('ServiceFormComponent', () => {
       });
     });
 
-    it('should test placement (label)', () => {
+    it('should test placement (label) with single select value', () => {
+      // placement labels take only single value
       formHelper.setValue('service_type', 'mgr');
       formHelper.setValue('placement', 'label');
-      formHelper.setValue('label', [{ content: 'foo', selected: true }]);
+      formHelper.setValue('label', 'foo');
+
       component.onSubmit();
+
       expect(cephServiceService.create).toHaveBeenCalledWith({
         service_type: 'mgr',
         placement: {
-          label: ['foo']
+          label: 'foo'
         },
         unmanaged: false
       });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.spec.ts
@@ -109,7 +109,7 @@ describe('ServiceFormComponent', () => {
       // placement labels take only single value
       formHelper.setValue('service_type', 'mgr');
       formHelper.setValue('placement', 'label');
-      formHelper.setValue('label', 'foo');
+      formHelper.setValue('label', "{content: 'foo', selected:  true}");
 
       component.onSubmit();
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
@@ -743,8 +743,17 @@ export class ServiceFormComponent extends CdForm implements OnInit {
               : (placementValue = 'hosts');
             this.serviceForm.get('placement').setValue(placementValue);
             this.serviceForm.get('count').setValue(response[0]['placement']['count']);
-            if (response[0]?.placement[placementValue]) {
-              this.serviceForm.get(placementValue).setValue(response[0]?.placement[placementValue]);
+            if (placementValue === 'hosts' && response[0]?.placement?.hosts) {
+              this.serviceForm.get('hosts').setValue(
+                response[0].placement.hosts.map((host: string) => ({
+                  content: host,
+                  selected: true
+                }))
+              );
+            } else if (placementValue === 'label' && response[0]?.placement?.label) {
+              this.serviceForm
+                .get('label')
+                .setValue({ content: response[0].placement.label, selected: true });
             }
           }
           switch (this.serviceType) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
@@ -80,7 +80,6 @@ export class ServiceFormComponent extends CdForm implements OnInit {
   resource: string;
   serviceTypes: string[] = [];
   serviceIds: string[] = [];
-  selectedLabels: string[] = [];
   selectedHosts: string[] = [];
   labels: string[];
   labelClick = new Subject<string>();
@@ -1355,9 +1354,9 @@ export class ServiceFormComponent extends CdForm implements OnInit {
           }
           break;
         case 'label':
-          serviceSpec['placement']['label'] = values['label']
-            .filter((label: { content: string; selected: boolean }) => label.selected)
-            .map((label: { content: string }) => label.content);
+          if (!_.isEmpty(values['label'])) {
+            serviceSpec['placement']['label'] = values['label']?.content;
+          }
           break;
       }
       if (_.isNumber(values['count']) && values['count'] > 0) {
@@ -1499,9 +1498,8 @@ export class ServiceFormComponent extends CdForm implements OnInit {
     });
   }
 
-  multiSelector(event: any, field: 'label' | 'hosts') {
-    if (field === 'hosts') this.selectedHosts = event.map((host: any) => host.content);
-    else this.selectedLabels = event.map((label: any) => label.content);
+  multiSelector(event: any) {
+    this.selectedHosts = event.map((host: any) => host.content);
   }
 
   get isPrefixedNamedService(): boolean {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.spec.ts
@@ -340,22 +340,6 @@ describe('NvmeofService', () => {
       req.flush(mockGroups);
     });
 
-    it('should filter hosts by array label placement', (done) => {
-      const mockGroups = [
-        [{ spec: { group: 'default' }, placement: { hosts: [], label: ['nvmeof', 'storage'] } }]
-      ];
-      mockHostService.getAllHosts.mockReturnValue(of(allHosts));
-
-      service.getHostsForGroup('default').subscribe((hosts: any[]) => {
-        expect(hosts.length).toBe(1);
-        expect(hosts[0].hostname).toBe('host3');
-        done();
-      });
-
-      const req = httpTesting.expectOne(`${API_PATH}/gateway/group`);
-      req.flush(mockGroups);
-    });
-
     it('should return empty array when group not found', (done) => {
       const mockGroups = [
         [{ spec: { group: 'other' }, placement: { hosts: ['host1'], label: [] } }]

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
@@ -90,9 +90,22 @@ export class NvmeofService {
     }).pipe(
       map(({ groups, hosts }) => {
         const usedHosts = new Set<string>();
+
         (groups?.[0] ?? []).forEach((group: CephServiceSpec) => {
-          group.placement?.hosts?.forEach((hostname: string) => usedHosts.add(hostname));
+          const placementHosts = group.placement?.hosts || [];
+          const placementLabel = group.placement?.label;
+
+          placementHosts.forEach((hostname: string) => usedHosts.add(hostname));
+
+          if (placementLabel) {
+            (hosts || []).forEach((host: Host) => {
+              if (host.labels?.includes(placementLabel as string)) {
+                usedHosts.add(host.hostname);
+              }
+            });
+          }
         });
+
         return (hosts || []).filter((host: Host) => {
           const isAvailable =
             host.status === HostStatus.AVAILABLE || host.status === HostStatus.RUNNING;
@@ -130,15 +143,8 @@ export class NvmeofService {
 
         if (hosts?.length) {
           return allHosts.filter((host: Host) => hosts.includes(host.hostname));
-        } else if (label?.length) {
-          if (typeof label === 'string') {
-            return allHosts.filter((host: Host) => host?.labels?.includes(label));
-          }
-          return allHosts.filter(
-            (host: Host) =>
-              host?.labels?.length === label?.length &&
-              _.isEqual([...host.labels].sort(), [...label].sort())
-          );
+        } else if (label) {
+          return allHosts.filter((host: Host) => host?.labels?.includes(label as string));
         }
         return [];
       })

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
@@ -210,7 +210,9 @@ export class NvmeofService {
     return this.getSubsystem(subsystemNqn, group).pipe(
       mapTo(true),
       catchError((e) => {
-        e?.preventDefault();
+        if (_.isFunction(e?.preventDefault)) {
+          e.preventDefault();
+        }
         return observableOf(false);
       })
     );


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/76215

- placement label for services takes only a single label
- when multiple labels or an array of labels is passed the service was not getting created
- also fixes https://tracker.ceph.com/issues/75280
- Also fixes https://github.com/ceph/ceph/pull/68549#issuecomment-4303900115

**Before**:

Try creating any service with labels, nothing will be created.

**After:**


https://github.com/user-attachments/assets/1510b451-3354-4e7c-af59-3053930efad3





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
