### PR TITLE
librbd/api: fix missing cleanup on group image_add failure

### DIFF
--- a/src/librbd/api/Group.cc
+++ b/src/librbd/api/Group.cc
@@ -467,7 +467,7 @@ int Group<I>::remove(librados::IoCtx& io_ctx, const char *group_name)
 
   r = io_ctx.remove(header_oid);
   if (r < 0 && r != -ENOENT) {
-    lderr(cct) << "error removing header: " << cpp_strerror(-r) << dendl;
+    lderr(cct) << "error removing header: " << cpp_strerror(r) << dendl;
     return r;
   }
 
@@ -616,7 +616,7 @@ int Group<I>::image_add(librados::IoCtx& group_ioctx, const char *group_name,
                              &image_id);
   if (r < 0) {
     lderr(cct) << "error reading image id object: "
-	       << cpp_strerror(-r) << dendl;
+	       << cpp_strerror(r) << dendl;
     return r;
   }
 
@@ -650,14 +650,14 @@ int Group<I>::image_add(librados::IoCtx& group_ioctx, const char *group_name,
 
   if (r < 0) {
     lderr(cct) << "error adding image reference to group: "
-	       << cpp_strerror(-r) << dendl;
+	       << cpp_strerror(r) << dendl;
     return r;
   }
 
   r = cls_client::image_group_add(&image_ioctx, image_header_oid, group_spec);
   if (r < 0) {
     lderr(cct) << "error adding group reference to image: "
-	       << cpp_strerror(-r) << dendl;
+	       << cpp_strerror(r) << dendl;
     cls::rbd::GroupImageSpec spec(image_id, image_ioctx.get_id());
     cls_client::group_image_remove(&group_ioctx, group_header_oid, spec);
     // Ignore errors in the clean up procedure.
@@ -676,7 +676,7 @@ int Group<I>::image_add(librados::IoCtx& group_ioctx, const char *group_name,
 				  attached_st);
   if (r < 0) {
     lderr(cct) << "error updating image reference to group: "
-	       << cpp_strerror(-r) << dendl;
+	       << cpp_strerror(r) << dendl;
     return r;
   }
 
@@ -737,7 +737,7 @@ int Group<I>::image_remove(librados::IoCtx& group_ioctx,
       &image_id);
   if (r < 0) {
     lderr(cct) << "error reading image id object: "
-      << cpp_strerror(-r) << dendl;
+      << cpp_strerror(r) << dendl;
     return r;
   }
 
@@ -1427,7 +1427,7 @@ int Group<I>::group_image_list_by_id(librados::IoCtx& group_ioctx,
 
     if (r < 0) {
       lderr(cct) << "error reading image list from group: "
-	<< cpp_strerror(-r) << dendl;
+	<< cpp_strerror(r) << dendl;
       return r;
     }
     images->insert(images->end(),
@@ -1501,7 +1501,7 @@ int Group<I>::group_image_remove(librados::IoCtx& group_ioctx, string group_id,
 
   if (r < 0) {
     lderr(cct) << "couldn't put image into removing state: "
-	       << cpp_strerror(-r) << dendl;
+	       << cpp_strerror(r) << dendl;
     return r;
   }
 
@@ -1509,7 +1509,7 @@ int Group<I>::group_image_remove(librados::IoCtx& group_ioctx, string group_id,
 				     group_spec);
   if ((r < 0) && (r != -ENOENT)) {
     lderr(cct) << "couldn't remove group reference from image"
-	       << cpp_strerror(-r) << dendl;
+	       << cpp_strerror(r) << dendl;
     return r;
   } else if (r >= 0) {
     ImageWatcher<I>::notify_header_update(image_ioctx, image_header_oid);
@@ -1518,7 +1518,7 @@ int Group<I>::group_image_remove(librados::IoCtx& group_ioctx, string group_id,
   r = cls_client::group_image_remove(&group_ioctx, group_header_oid, spec);
   if (r < 0) {
     lderr(cct) << "couldn't remove image from group"
-	       << cpp_strerror(-r) << dendl;
+	       << cpp_strerror(r) << dendl;
     return r;
   }
 

--- a/src/librbd/api/Group.cc
+++ b/src/librbd/api/Group.cc
@@ -658,10 +658,7 @@ int Group<I>::image_add(librados::IoCtx& group_ioctx, const char *group_name,
   if (r < 0) {
     lderr(cct) << "error adding group reference to image: "
 	       << cpp_strerror(r) << dendl;
-    cls::rbd::GroupImageSpec spec(image_id, image_ioctx.get_id());
-    cls_client::group_image_remove(&group_ioctx, group_header_oid, spec);
-    // Ignore errors in the clean up procedure.
-    return r;
+    goto cleanup_group_image_ref;
   }
   ImageWatcher<>::notify_header_update(image_ioctx, image_header_oid);
 
@@ -669,7 +666,9 @@ int Group<I>::image_add(librados::IoCtx& group_ioctx, const char *group_name,
   if (r < 0) {
     lderr(cct) << "error adding image to mirror group: "
                << cpp_strerror(r) << dendl;
-    return r;
+    // Mirror layer is responsible for its own cleanup, only metadata
+    // references are cleaned up here.
+    goto cleanup_image_group_ref;
   }
 
   r = cls_client::group_image_set(&group_ioctx, group_header_oid,
@@ -677,10 +676,35 @@ int Group<I>::image_add(librados::IoCtx& group_ioctx, const char *group_name,
   if (r < 0) {
     lderr(cct) << "error updating image reference to group: "
 	       << cpp_strerror(r) << dendl;
-    return r;
+    goto cleanup_image_group_ref;
   }
 
   return 0;
+
+// Fallthrough: remove image->group first, then group->image references.
+// Also, ignore errors in the clean up procedures.
+cleanup_image_group_ref:
+  int cleanup_r;
+
+  // Remove image -> group reference
+  cleanup_r = cls_client::image_group_remove(&image_ioctx,
+                                             image_header_oid, group_spec);
+  if (cleanup_r < 0) {
+    lderr(cct) << "couldn't remove group reference in image: "
+               << cpp_strerror(cleanup_r) << dendl;
+  }
+
+cleanup_group_image_ref:
+  // Remove group -> image reference
+  cls::rbd::GroupImageSpec spec(image_id, image_ioctx.get_id());
+  cleanup_r = cls_client::group_image_remove(&group_ioctx,
+                                             group_header_oid, spec);
+  if (cleanup_r < 0) {
+    lderr(cct) << "couldn't remove image reference in group: "
+               << cpp_strerror(cleanup_r) << dendl;
+  }
+
+  return r;
 }
 
 template <typename I>


### PR DESCRIPTION

In case of failure during Mirror::group_image_add(), partial references
between the image and group may remain, leading to inconsistent state.

Add cleanup logic to remove both image->group and group->image references
when the operation fails.

Note: Cleanup after validate_image() is already handled within the
GroupAddImageRequest state machine, including cleanup of partial state,
this change only fixes the missing cleanup in Group::image_add() before
the request is issued.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
