### PR TITLE
tentacle: ceph-volume: skip /dev/ram* devices in inventory

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_disk.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_disk.py
@@ -378,6 +378,40 @@ class TestGetBlockDevsSysfs(object):
 
         assert disk.get_block_devs_sysfs(device='sr0') == []
 
+    def test_ram_device_is_skipped(self, fake_filesystem):
+        fake_filesystem.create_file('/dev/ram0')
+        fake_filesystem.create_dir('/sys/dev/block')
+        fake_filesystem.create_dir('/sys/block/ram0/holders')
+
+        assert disk.get_block_devs_sysfs(device='ram0') == []
+
+    def test_ram_device_partitions_are_skipped(self, fake_filesystem):
+        fake_filesystem.create_file('/dev/ram0')
+        fake_filesystem.create_dir('/sys/dev/block')
+        fake_filesystem.create_dir('/sys/block/ram0/holders')
+
+        # If ram0 is skipped, skip its partition ram0p1 too.
+        with patch('ceph_volume.util.disk.get_partitions', MagicMock(return_value={"ram0p1": "ram0"})):
+            assert disk.get_block_devs_sysfs(device='ram0') == []
+
+    def test_ram_devices_are_skipped_in_full_scan(self, fake_filesystem):
+        # Common inventory path: scan /sys/block and include partitions.
+        fake_filesystem.create_dir('/sys/dev/block')
+
+        fake_filesystem.create_file('/dev/ram0')
+        fake_filesystem.create_dir('/sys/block/ram0/holders')
+
+        fake_filesystem.create_file('/dev/sda')
+        fake_filesystem.create_dir('/sys/block/sda/holders')
+
+        with patch('ceph_volume.util.disk.get_partitions', MagicMock(return_value={"ram0p1": "ram0"})):
+            result = disk.get_block_devs_sysfs()
+
+        paths = [row[0] for row in result]
+        assert '/dev/sda' in paths
+        assert '/dev/ram0' not in paths
+        assert '/dev/ram0p1' not in paths
+
     def test_regular_device_is_not_skipped(self, fake_filesystem):
         # normal disk should still be reported.
         fake_filesystem.create_file('/dev/sda')

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -721,6 +721,10 @@ def get_block_devs_sysfs(_sys_block_path: str = '/sys/block', _sys_dev_block_pat
         # These are not physical disks and are not valid OSD targets, so skip them.
         if get_file_contents(os.path.join(_sys_block_path, dev, 'device/type'), '').strip() == '5':
             continue
+        # Skip kernel RAM disks (/dev/ram*); these are not valid OSD targets.
+        # Only matches 'ram' + digits (ram0, ram1, etc.).
+        if dev.startswith('ram') and dev[3:].isdigit():
+            continue
         type_: str = 'disk'
         holders: List[str] = os.listdir(os.path.join(_sys_block_path, dev, 'holders'))
         if holder_inner_loop():
@@ -742,6 +746,10 @@ def get_block_devs_sysfs(_sys_block_path: str = '/sys/block', _sys_dev_block_pat
     # Next, look for devices that _are_ partitions
     partitions: Dict[str, str] = get_partitions()
     for partition in partitions.keys():
+        # Skip partitions that belong to kernel RAM disks (/dev/ram*).
+        parent = partitions[partition]
+        if parent.startswith('ram') and parent[3:].isdigit():
+            continue
         name = kname = os.path.join("/dev", partition)
         result.append([name, kname, "part", partitions[partition]])
     return sorted(result, key=lambda x: x[0])


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76216

backport of https://github.com/ceph/ceph/pull/68467
parent tracker: https://tracker.ceph.com/issues/76113

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh