### PR TITLE
cephadm: ceph mgr fail or active ceph mgr restart causes unnecessary …

### DIFF
--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -842,7 +842,9 @@ class HostCache():
                 self.devices[host] += self.load_host_devices(host)
                 self.networks[host] = j.get('networks_and_interfaces', {})
                 self.osdspec_previews[host] = j.get('osdspec_previews', {})
-                self.last_client_files[host] = j.get('last_client_files', {})
+                self.last_client_files[host] = {
+                    path: tuple(v) for path, v in j.get('last_client_files', {}).items()
+                }
                 for name, ts in j.get('osdspec_last_applied', {}).items():
                     self.osdspec_last_applied[host][name] = str_to_datetime(ts)
 


### PR DESCRIPTION
cephadm: `ceph mgr fail or active ceph mgr` restart causes unnecessary client files recreation on _admin hosts. 

Files such as `/etc/ceph/ceph.conf` and `/etc/ceph/ceph.client.admin.keyring` are rewritten even when their content has not changed.

**Root cause:** 
`update_client_file()` stores client file metadata as a Python tuple `(digest, mode, uid, gid)`.  When `save_host() ` persists this to the `mon` store via `json.dumps()`, the tuple is serialized as a JSON array since JSON has no tuple type. 

On mgr failover or restart, `cache.load()` deserializes the data with `json.loads()`, which returns a Python list instead of a tuple.  The comparison in `_write_client_files(): match = old_files[path] == (digest, mode, uid, gid)` then compares a list (from JSON) against a tuple (freshly built), which always evaluates to False. 

This causes every client file to be rewritten on every mgr failover or restart.

**Code Fixes:**
`src/pybind/mgr/cephadm/inventory.py`:
    convert the deserialized lists back to tuples when loading last_client_files
 
**Testing:**
Test case for the issue:

On a host with the _admin label, run:

`watch ls -lrt /etc/ceph
`
to track whether `/etc/ceph/ceph.conf` or `/etc/ceph/ceph.client.admin.keyring` timestamps change (indicating a rewrite).

From a cephadm shell, run:
"ceph mgr fail"

and wait a few minutes.

Result before applying the fix: Timestamps of `/etc/ceph/ceph.conf` and `/etc/ceph/ceph.client.admin.keyring` are changed because the files are rewritten.

Expected result  - after applying the fix: Timestamps of client files are not changed and files are not rewritten.

**Steps:**
- Reproduce the bug (before fix): Run ceph mgr fail and observe that within ~30 seconds, the timestamps of both client files are updated -- confirming unnecessary rewrites.

- Apply the fix: (can be done by replace `/usr/share/ceph/mgr/cephadm/inventory.py` on each mgr host in the cluster).  Run `ceph mgr fail` again and verify that `/etc/ceph/ceph.conf` and `/etc/ceph/ceph.client.admin.keyring` timestamps remain unchanged - confirming files are no longer unnecessarily rewritten.

- Verify real changes still propagate: Modify the client admin keyring and verify that `/etc/ceph/ceph.client.admin.keyring` is updated with the new keyring content within the next serve loop cycle.


Fixes: https://tracker.ceph.com/issues/76176
Signed-off-by: Yael Azulay <yazulay@redhat.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
