### PR TITLE
tentacle: mgr/dashboard: introduce traddr for backward compatibility

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -10,7 +10,7 @@ from .. import mgr
 from ..exceptions import DashboardException
 from ..model import nvmeof as model
 from ..security import Scope
-from ..services.nvmeof_cli import NvmeofCLICommand, convert_to_bytes
+from ..services.nvmeof_cli import NvmeofCLICommand, convert_to_bytes, resolve_nvmeof_server_address
 from ..services.orchestrator import OrchClient
 from ..tools import str_to_bool
 from . import APIDoc, APIRouter, BaseController, CreatePermission, \
@@ -37,10 +37,22 @@ else:
         @NvmeofCLICommand(
             "nvmeof gateway info", model.GatewayInfo, alias="nvmeof gw info"
         )
-        @EndpointDoc("Get information about the NVMeoF gateway")
+        @EndpointDoc(
+            "Get information about the NVMeoF gateway",
+            parameters={
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
+            }
+        )
         @convert_to_model(model.GatewayInfo)
         @handle_nvmeof_error
-        def list(self, gw_group: Optional[str] = None, server_address: Optional[str] = None):
+        def list(self, gw_group: Optional[str] = None, server_address: Optional[str] = None,
+                 traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -66,10 +78,22 @@ else:
         @NvmeofCLICommand(
             "nvmeof gateway version", model.GatewayVersion, alias="nvmeof gw version"
         )
-        @EndpointDoc("Get the version of the NVMeoF gateway")
+        @EndpointDoc(
+            "Get the version of the NVMeoF gateway",
+            parameters={
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
+            }
+        )
         @convert_to_model(model.GatewayVersion)
         @handle_nvmeof_error
-        def version(self, gw_group: Optional[str] = None, server_address: Optional[str] = None):
+        def version(self, gw_group: Optional[str] = None, server_address: Optional[str] = None,
+                    traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             gw_info = NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -86,11 +110,23 @@ else:
             "nvmeof gateway get_log_level", model.GatewayLogLevelInfo,
             alias="nvmeof gw get_log_level"
         )
-        @EndpointDoc("Get NVMeoF gateway log level information")
+        @EndpointDoc(
+            "Get NVMeoF gateway log level information",
+            parameters={
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
+            }
+        )
         @convert_to_model(model.GatewayLogLevelInfo)
         @handle_nvmeof_error
         def get_log_level(self, gw_group: Optional[str] = None,
-                          server_address: Optional[str] = None):
+                          server_address: Optional[str] = None,
+                          traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             gw_log_level = NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -102,13 +138,27 @@ else:
         @ReadPermission
         @Endpoint('PUT', '/log_level')
         @NvmeofCLICommand(
-            "nvmeof gateway set_log_level", model.RequestStatus, alias="nvmeof gw set_log_level")
-        @EndpointDoc("Set NVMeoF gateway log levels")
+            "nvmeof gateway set_log_level", model.RequestStatus, alias="nvmeof gw set_log_level",
+        )
+        @EndpointDoc(
+            "Set NVMeoF gateway log levels",
+            parameters={
+                "log_level": Param(str, "Log level"),
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
+            }
+        )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def set_log_level(self, log_level: str, gw_group: Optional[str] = None,
-                          server_address: Optional[str] = None):
-            log_level = log_level.lower()
+                          server_address: Optional[str] = None,
+                          traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
+            log_level = log_level.strip().lower()
             gw_log_level = NVMeoFClient(gw_group=gw_group,
                                         server_address=server_address).stub.set_gateway_log_level(
                 NVMeoFClient.pb2.set_gateway_log_level_req(log_level=log_level)
@@ -119,11 +169,23 @@ else:
         @Endpoint('GET', '/stats')
         @NvmeofCLICommand(
             "nvmeof gateway get_stats", model.GatewayStatsInfo, alias="nvmeof gw get_stats")
-        @EndpointDoc("Get NVMeoF statistics for the gateway")
+        @EndpointDoc(
+            "Get NVMeoF statistics for the gateway",
+            parameters={
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
+            }
+        )
         @convert_to_model(model.GatewayStatsInfo)
         @handle_nvmeof_error
         def get_gw_stats(self, gw_group: Optional[str] = None,
-                         server_address: Optional[str] = None):
+                         server_address: Optional[str] = None,
+                         traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             gw_stats = NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -137,11 +199,24 @@ else:
         @NvmeofCLICommand(
             "nvmeof gateway listener_info", model.GatewayListenersInfo,
             alias="nvmeof gw listener_info")
-        @EndpointDoc("Get NVMeoF gateway's listeners info")
+        @EndpointDoc(
+            "Get NVMeoF gateway's listeners info",
+            parameters={
+                "nqn": Param(str, "NVMeoF subsystem NQN"),
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
+            }
+        )
         @convert_to_model(model.GatewayListenersInfo)
         @handle_nvmeof_error
         def listener_info(self, nqn: str, gw_group: Optional[str] = None,
-                          server_address: Optional[str] = None):
+                          server_address: Optional[str] = None,
+                          traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             gw_listener_info = NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -156,13 +231,26 @@ else:
         @ReadPermission
         @Endpoint('GET', '/log_level')
         @NvmeofCLICommand("nvmeof spdk_log_level get", model.SpdkNvmfLogFlagsAndLevelInfo)
-        @EndpointDoc("Get NVMeoF gateway spdk log levels")
+        @EndpointDoc(
+            "Get NVMeoF gateway spdk log levels",
+            parameters={
+                "all_log_flags": Param(bool, "Get all log flags", True, None),
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
+            }
+        )
         @convert_to_model(model.SpdkNvmfLogFlagsAndLevelInfo)
         @handle_nvmeof_error
         def get_spdk_log_level(
             self, all_log_flags: Optional[bool] = None,
-            gw_group: Optional[str] = None, server_address: Optional[str] = None
+            gw_group: Optional[str] = None, server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             spdk_log_level = NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -173,17 +261,35 @@ else:
 
         @ReadPermission
         @Endpoint('PUT', '/log_level')
-        @NvmeofCLICommand("nvmeof spdk_log_level set", model.RequestStatus)
-        @EndpointDoc("Set NVMeoF gateway spdk log levels")
+        @NvmeofCLICommand(
+            "nvmeof spdk_log_level set",
+            model.RequestStatus,
+        )
+        @EndpointDoc(
+            "Set NVMeoF gateway spdk log levels",
+            parameters={
+                "log_level": Param(str, "SPDK log level", True, None),
+                "print_level": Param(str, "SPDK print level", True, None),
+                "extra_log_flags": Param([str], "Extra log flags", True, None),
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
+            }
+        )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def set_spdk_log_level(self, log_level: Optional[str] = None,
                                print_level: Optional[str] = None,
                                extra_log_flags: Optional[List[str]] = None,
                                gw_group: Optional[str] = None,
-                               server_address: Optional[str] = None):
-            log_level = log_level.upper() if log_level else None
-            print_level = print_level.upper() if print_level else None
+                               server_address: Optional[str] = None,
+                               traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
+            log_level = log_level.strip().upper() if log_level else None
+            print_level = print_level.strip().upper() if print_level else None
             spdk_log_level = NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -197,14 +303,27 @@ else:
         @ReadPermission
         @Endpoint('PUT', '/log_level/disable')
         @NvmeofCLICommand("nvmeof spdk_log_level disable", model.RequestStatus)
-        @EndpointDoc("Disable NVMeoF gateway spdk log")
+        @EndpointDoc(
+            "Disable NVMeoF gateway spdk log",
+            parameters={
+                "extra_log_flags": Param([str], "Extra log flags", True, None),
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
+            }
+        )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def disable_spdk_log_level(
             self, extra_log_flags: Optional[List[str]] = None,
             gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             spdk_log_level = NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -218,10 +337,22 @@ else:
     class NVMeoFSubsystem(RESTController):
         @pick(field="subsystems")
         @NvmeofCLICommand("nvmeof subsystem list", model.SubsystemList)
-        @EndpointDoc("List all NVMeoF subsystems")
+        @EndpointDoc(
+            "List all NVMeoF subsystems",
+            parameters={
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
+            }
+        )
         @convert_to_model(model.SubsystemList)
         @handle_nvmeof_error
-        def list(self, gw_group: Optional[str] = None, server_address: Optional[str] = None):
+        def list(self, gw_group: Optional[str] = None, server_address: Optional[str] = None,
+                 traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -237,12 +368,18 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.SubsystemList)
         @handle_nvmeof_error
         def get(self, nqn: str, gw_group: Optional[str] = None,
-                server_address: Optional[str] = None):
+                server_address: Optional[str] = None,
+                traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -264,7 +401,7 @@ else:
                 "dhchap_key": Param(str, "Subsystem DH-HMAC-CHAP key", True, None),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
-                "traddr": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
                 "network_mask": Param([str],
                                       "Network mask to automatically create listeners",
                                       True, None),
@@ -282,7 +419,14 @@ else:
                    gw_group: Optional[str] = None, server_address: Optional[str] = None,
                    traddr: Optional[str] = None, network_mask: Optional[List[str]] = None,
                    port: Optional[int] = None, secure_listeners: Optional[bool] = False):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.create_subsystem(
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.create_subsystem(
                 NVMeoFClient.pb2.create_subsystem_req(
                     subsystem_nqn=nqn, serial_number=serial_number,
                     max_namespaces=max_namespaces, enable_ha=enable_ha,
@@ -301,12 +445,18 @@ else:
                 "force": Param(bool, "Force delete", True, False),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def delete(self, nqn: str, force: Optional[str] = "false", gw_group: Optional[str] = None,
-                   server_address: Optional[str] = None):
+                   server_address: Optional[str] = None,
+                   traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -323,6 +473,7 @@ else:
                 "dhchap_key": Param(str, "Subsystem DH-HMAC-CHAP key"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @empty_response
@@ -330,7 +481,12 @@ else:
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def change_key(self, nqn: str, dhchap_key: str, gw_group: Optional[str] = None,
-                       server_address: Optional[str] = None):
+                       server_address: Optional[str] = None,
+                       traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -347,6 +503,7 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @empty_response
@@ -354,7 +511,12 @@ else:
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def del_key(self, nqn: str, gw_group: Optional[str] = None,
-                    server_address: Optional[str] = None):
+                    server_address: Optional[str] = None,
+                    traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -374,16 +536,22 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "network_mask": Param(str, "Network mask to add"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "traddr": Param(str, "NVMeoF gateway address", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def add_network(self, nqn: str, network_mask: str, gw_group: Optional[str] = None,
+                        server_address: Optional[str] = None,
                         traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
-                traddr=traddr
+                server_address=server_address
             ).stub.add_subsystem_network(
                 NVMeoFClient.pb2.add_subsystem_network_req(
                     subsystem_nqn=nqn, network_mask=network_mask
@@ -400,16 +568,22 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "network_mask": Param(str, "Network mask to remove"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "traddr": Param(str, "NVMeoF gateway address", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def del_network(self, nqn: str, network_mask: str, gw_group: Optional[str] = None,
+                        server_address: Optional[str] = None,
                         traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
-                traddr=traddr
+                server_address=server_address
             ).stub.del_subsystem_network(
                 NVMeoFClient.pb2.del_subsystem_network_req(
                     subsystem_nqn=nqn, network_mask=network_mask
@@ -428,6 +602,7 @@ else:
                 "address": Param(str, "KMIP server endpoint address", True, None),
                 "port": Param(int, "KMIP server endpoint port", True, 5696),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
                 "traddr": Param(str, "NVMeoF gateway address", True, None),
             },
         )
@@ -436,11 +611,16 @@ else:
         def add_kmip_server_endpoint(self, nqn: str, server_name: str,
                                      address: Optional[str] = None,
                                      port: Optional[int] = 5696, gw_group: Optional[str] = None,
+                                     server_address: Optional[str] = None,
                                      traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             ep = NVMeoFClient.pb2.kmip_server_endpoint(address=address, port=port)
             return NVMeoFClient(
                 gw_group=gw_group,
-                traddr=traddr
+                server_address=server_address
             ).stub.add_kmip_server_endpoints(
                 NVMeoFClient.pb2.add_kmip_server_endpoints_req(
                     subsystem_nqn=nqn, server_name=server_name,
@@ -460,6 +640,7 @@ else:
                 "address": Param(str, "KMIP server endpoint address", True, None),
                 "port": Param(int, "KMIP server endpoint port", True, 5696),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
                 "traddr": Param(str, "NVMeoF gateway address", True, None),
             },
         )
@@ -468,11 +649,16 @@ else:
         def del_kmip_server_endpoint(self, nqn: str, server_name: str,
                                      address: Optional[str] = None,
                                      port: Optional[int] = 5696, gw_group: Optional[str] = None,
+                                     server_address: Optional[str] = None,
                                      traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             ep = NVMeoFClient.pb2.kmip_server_endpoint(address=address, port=port)
             return NVMeoFClient(
                 gw_group=gw_group,
-                traddr=traddr
+                server_address=server_address
             ).stub.del_kmip_server_endpoints(
                 NVMeoFClient.pb2.del_kmip_server_endpoints_req(
                     subsystem_nqn=nqn, server_name=server_name,
@@ -489,29 +675,48 @@ else:
                 "server_name": Param(str, "Only show endpoints for this KMIP server name",
                                      True, None),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
                 "traddr": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.SubsystemListKMIPEndpoints)
         @handle_nvmeof_error
         def list_eps(self, nqn: Optional[str] = None, server_name: Optional[str] = None,
-                     gw_group: Optional[str] = None, traddr: Optional[str] = None):
+                     gw_group: Optional[str] = None, server_address: Optional[str] = None,
+                     traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
-                traddr=traddr
+                server_address=server_address
             ).stub.list_kmip_server_endpoints(
                 NVMeoFClient.pb2.list_kmip_server_endpoints_req(subsystem_nqn=nqn,
                                                                 server_name=server_name)
             )
 
         @NvmeofCLICommand("nvmeof get_subsystems", model.GetSubsystems)
+        @EndpointDoc(
+            "Get NVMeoF subsystems",
+            parameters={
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
+            }
+        )
         @convert_to_model(model.GetSubsystems)
         @handle_nvmeof_error
         def get_subsystems(
             self,
             gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -530,12 +735,18 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.ListenerList)
         @handle_nvmeof_error
         def list(self, nqn: str, gw_group: Optional[str] = None,
-                 server_address: Optional[str] = None):
+                 server_address: Optional[str] = None,
+                 traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -648,12 +859,18 @@ else:
                 "nsid": Param(str, "NVMeoF Namespace ID to filter by", True, None),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.NamespaceList)
         @handle_nvmeof_error
         def list(self, nqn: Optional[str] = None, nsid: Optional[str] = None,
-                 gw_group: Optional[str] = None, server_address: Optional[str] = None):
+                 gw_group: Optional[str] = None, server_address: Optional[str] = None,
+                 traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -672,12 +889,18 @@ else:
                 "nsid": Param(str, "NVMeoF Namespace ID"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.NamespaceList)
         @handle_nvmeof_error
         def get(self, nqn: str, nsid: str, gw_group: Optional[str] = None,
-                server_address: Optional[str] = None):
+                server_address: Optional[str] = None,
+                traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -698,12 +921,18 @@ else:
                 "nsid": Param(str, "NVMeoF Namespace ID"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.NamespaceIOStats)
         @handle_nvmeof_error
         def io_stats(self, nqn: str, nsid: str, gw_group: Optional[str] = None,
-                     server_address: Optional[str] = None):
+                     server_address: Optional[str] = None,
+                     traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -717,7 +946,6 @@ else:
             parameters={
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "rados_namespace": Param(str, "RADOS namespace name", True, None),
-                "rbd_pool": Param(str, "RBD pool name"),
                 "rbd_image_name": Param(str, "RBD image name"),
                 "rbd_pool": Param(str, "RBD pool name"),
                 "nsid": Param(str, "Create RBD image", True, None),
@@ -750,6 +978,7 @@ else:
                 "read_only": Param(str, "Read only namespace", True, None),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.NamespaceCreation)
@@ -770,14 +999,18 @@ else:
             no_auto_visible: Optional[bool] = False,
             disable_auto_resize: Optional[bool] = False,
             read_only: Optional[bool] = False,
-            gw_group: Optional[str] = None,
-            traddr: Optional[str] = None,
             rados_namespace: Optional[str] = None,
             encryption_format: Optional[List[str]] = None,
             encryption_algorithm: Optional[str] = None,
             key_id: Optional[List[str]] = None,
+            gw_group: Optional[str] = None,
             server_address: Optional[str] = None,
+            traddr: Optional[str] = None,
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             encryption_format = encryption_format or []
             key_id = key_id or []
             if len(encryption_format) != len(key_id):
@@ -793,9 +1026,13 @@ else:
                     key_id=k.strip()
                 ) for f, k in zip(encryption_format, key_id)]
             enc_alg = encryption_algorithm.strip().lower() if encryption_algorithm else None
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
-                traddr=traddr
+                server_address=server_address
             ).stub.namespace_add(
                 NVMeoFClient.pb2.namespace_add_req(
                     subsystem_nqn=nqn,
@@ -856,6 +1093,7 @@ else:
                                 True, None),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "Target gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.NamespaceCreation)
@@ -876,15 +1114,19 @@ else:
             no_auto_visible: Optional[bool] = False,
             disable_auto_resize: Optional[bool] = False,
             read_only: Optional[bool] = False,
-            gw_group: Optional[str] = None,
-            traddr: Optional[str] = None,
             rados_namespace: Optional[str] = None,
             encryption_format: Optional[List[str]] = None,
             encryption_algorithm: Optional[str] = None,
             key_id: Optional[List[str]] = None,
 
+            gw_group: Optional[str] = None,
             server_address: Optional[str] = None,
+            traddr: Optional[str] = None,
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             if size and rbd_image_size:
                 raise DashboardException(
                     msg="Can use size or rbd_image_size but not both",
@@ -958,6 +1200,7 @@ else:
                 ),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -972,8 +1215,13 @@ else:
             w_mbytes_per_second: Optional[int] = None,
             force: Optional[bool] = False,
             gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -1003,6 +1251,7 @@ else:
                 "load_balancing_group": Param(int, "Load balancing group", True, None),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1013,8 +1262,13 @@ else:
             nsid: str,
             load_balancing_group: Optional[int] = None,
             gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -1034,6 +1288,7 @@ else:
                 "rbd_image_size": Param(int, "RBD image size"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1044,8 +1299,13 @@ else:
             nsid: str,
             rbd_image_size: int,
             gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             mib = 1024 * 1024
             new_size_mib = int((rbd_image_size + mib - 1) / mib)
 
@@ -1068,6 +1328,7 @@ else:
                 "rbd_image_size": Param(str, "RBD image size"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1078,8 +1339,13 @@ else:
             nsid: str,
             rbd_image_size: str,
             gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             if rbd_image_size:
                 rbd_image_size_b = convert_to_bytes(rbd_image_size, default_unit='MB')
             mib = 1024 * 1024
@@ -1112,6 +1378,7 @@ else:
                 ),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1123,8 +1390,13 @@ else:
             host_nqn: str,
             force: Optional[bool] = None,
             gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -1148,6 +1420,7 @@ else:
                 "host_nqn": Param(str, 'NVMeoF host NQN. Use "*" to allow any host.'),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1158,8 +1431,13 @@ else:
             nsid: str,
             host_nqn: str,
             gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -1186,6 +1464,7 @@ else:
                 "force": Param(bool, 'True if visible to all hosts', True, False),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1197,8 +1476,13 @@ else:
             auto_visible: str,
             force: Optional[bool] = False,
             gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -1229,6 +1513,7 @@ else:
                 ),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1239,8 +1524,13 @@ else:
             nsid: str,
             auto_resize_enabled: bool,
             gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -1267,6 +1557,7 @@ else:
                 "rbd_trash_image_on_delete": Param(bool, 'True if active'),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1277,8 +1568,13 @@ else:
             nsid: str,
             rbd_trash_image_on_delete: str,
             gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address,
@@ -1303,6 +1599,7 @@ else:
                 "nsid": Param(str, "NVMeoF Namespace ID"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1312,8 +1609,13 @@ else:
             nqn: str,
             nsid: str,
             gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -1343,6 +1645,7 @@ else:
                 "trash_image": Param(bool, "Trash RBD image after removing namespace"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.NamespaceList)
@@ -1360,7 +1663,12 @@ else:
             trash_image: Optional[bool] = None,
             gw_group: Optional[str] = None,
             server_address: Optional[str] = None,
+            traddr: Optional[str] = None,
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             contains_failure = False
 
             if rbd_image_size:
@@ -1434,6 +1742,7 @@ else:
                 "force": Param(str, "Force remove the RBD image", True, False),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1445,7 +1754,12 @@ else:
             force: Optional[str] = "false",
             gw_group: Optional[str] = None,
             server_address: Optional[str] = None,
+            traddr: Optional[str] = None,
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -1486,14 +1800,20 @@ else:
                                       True, False),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.HostsInfo, finalize=_update_hosts)
         @handle_nvmeof_error
         def list(
             self, nqn: str, clear_alerts: Optional[bool] = None,
-            gw_group: Optional[str] = None, server_address: Optional[str] = None
+            gw_group: Optional[str] = None, server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -1510,6 +1830,7 @@ else:
                 "host_nqn": Param(str, 'NVMeoF host NQN. Use "*" to allow any host.'),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1520,6 +1841,10 @@ else:
             psk: Optional[str] = None, gw_group: Optional[str] = None, traddr: Optional[str] = None,
             server_address: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -1539,12 +1864,18 @@ else:
                 "host_nqn": Param(str, 'NVMeoF host NQN. Use "*" to disallow any host.'),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def delete(self, nqn: str, host_nqn: str, gw_group: Optional[str] = None,
-                   server_address: Optional[str] = None):
+                   server_address: Optional[str] = None,
+                   traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -1566,14 +1897,20 @@ else:
                 "dhchap_key": Param(str, 'Host DH-HMAC-CHAP key'),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def change_key(
             self, nqn: str, host_nqn: str, dhchap_key: str,
-            gw_group: Optional[str] = None, server_address: Optional[str] = None
+            gw_group: Optional[str] = None, server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -1595,15 +1932,25 @@ else:
                 "host_nqn": Param(str, 'NVMeoF host NQN'),
                 "dhchap_controller_key": Param(str, 'Host DH-HMAC-CHAP controller key'),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def change_controller_key(
             self, nqn: str, host_nqn: str, dhchap_controller_key: str,
-            gw_group: Optional[str] = None, traddr: Optional[str] = None
+            gw_group: Optional[str] = None, server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.change_host_key(
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.change_host_key(
                 NVMeoFClient.pb2.change_host_key_req(subsystem_nqn=nqn,
                                                      host_nqn=host_nqn,
                                                      dhchap_key="-",
@@ -1621,14 +1968,20 @@ else:
                 "host_nqn": Param(str, 'NVMeoF host NQN.'),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def del_key(
             self, nqn: str, host_nqn: str, gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -1649,17 +2002,24 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "host_nqn": Param(str, 'NVMeoF host NQN.'),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def del_controller_key(
             self, nqn: str, host_nqn: str, gw_group: Optional[str] = None,
+            server_address: Optional[str] = None,
             traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
-                traddr=traddr
+                server_address=server_address
             ).stub.change_host_key(
                 NVMeoFClient.pb2.change_host_key_req(subsystem_nqn=nqn,
                                                      host_nqn=host_nqn,
@@ -1689,12 +2049,18 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.ConnectionList, finalize=_update_connections)
         @handle_nvmeof_error
         def list(self, nqn: Optional[str] = None,
-                 gw_group: Optional[str] = None, server_address: Optional[str] = None):
+                 gw_group: Optional[str] = None, server_address: Optional[str] = None,
+                 traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             if not nqn:
                 nqn = '*'
             return NVMeoFClient(
@@ -1728,7 +2094,9 @@ else:
                          'subsystem_nqn': (str, 'Subsystem NQN'),
                          "allow_all": Param(bool, 'Allow all hosts. Default is True.'),
                          "hosts": Param(List, 'List containg host nqn and dhchap key'),
-                         "gw_group": Param(str, "NVMeoF gateway group")
+                         "gw_group": Param(str, "NVMeoF gateway group"),
+                         "server_address": Param(str, "NVMeoF gateway address", True, None),
+                         "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
                      })
         @empty_response
         @handle_nvmeof_error
@@ -1737,12 +2105,17 @@ else:
                 gw_group: str,
                 hosts: Optional[list[dict]] = None,
                 allow_all: bool = True,
-                server_address: Optional[str] = None):
+                server_address: Optional[str] = None,
+                traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             response = None
 
             if allow_all:
                 return NVMeoFClient(gw_group=gw_group,
-                                    traddr=server_address).stub.add_host(
+                                    server_address=server_address).stub.add_host(
                     NVMeoFClient.pb2.add_host_req(
                         subsystem_nqn=subsystem_nqn,
                         host_nqn="*",
@@ -1754,7 +2127,7 @@ else:
                 key = h.get("dhchap_key")
 
                 response = NVMeoFClient(gw_group=gw_group,
-                                        traddr=server_address).stub.add_host(
+                                        server_address=server_address).stub.add_host(
                     NVMeoFClient.pb2.add_host_req(
                         subsystem_nqn=subsystem_nqn,
                         host_nqn=nqn,
@@ -1772,7 +2145,9 @@ else:
                      parameters={
                          "subsystem_nqn": Param(str, "NVMeoF subsystem NQN"),
                          "host_nqn": Param(str, 'Comma separated list of NVMeoF host NQN.'),
-                         "gw_group": Param(str, "NVMeoF gateway group")
+                         "gw_group": Param(str, "NVMeoF gateway group"),
+                         "server_address": Param(str, "NVMeoF gateway address", True, None),
+                         "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
                      })
         @empty_response
         @handle_nvmeof_error
@@ -1780,13 +2155,18 @@ else:
         def remove(self, subsystem_nqn: str,
                    host_nqn: str,
                    gw_group: str,
-                   server_address: Optional[str] = None):
+                   server_address: Optional[str] = None,
+                   traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             response = None
             to_delete_nqns = host_nqn.split(',')
 
             for del_nqn in to_delete_nqns:
                 response = NVMeoFClient(gw_group=gw_group,
-                                        traddr=server_address).stub.remove_host(
+                                        server_address=server_address).stub.remove_host(
                     NVMeoFClient.pb2.remove_host_req(subsystem_nqn=subsystem_nqn, host_nqn=del_nqn)
                 )
                 if response.status != 0:
@@ -1825,7 +2205,7 @@ else:
 
             for nqn in all_host_nqns:
                 response = NVMeoFClient(gw_group=gw_group,
-                                        traddr=server_address).stub.namespace_add_host(
+                                        server_address=server_address).stub.namespace_add_host(
                     NVMeoFClient.pb2.namespace_add_host_req(subsystem_nqn=subsystem_nqn,
                                                             nsid=int(nsid),
                                                             host_nqn=nqn,
@@ -1859,7 +2239,7 @@ else:
 
             for del_nqn in to_delete_nqns:
                 response = NVMeoFClient(gw_group=gw_group,
-                                        traddr=server_address).stub.namespace_delete_host(
+                                        server_address=server_address).stub.namespace_delete_host(
                     NVMeoFClient.pb2.namespace_delete_host_req(
                         subsystem_nqn=subsystem_nqn,
                         nsid=int(nsid),

--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -40,8 +40,11 @@ else:
         @EndpointDoc("Get information about the NVMeoF gateway")
         @convert_to_model(model.GatewayInfo)
         @handle_nvmeof_error
-        def list(self, gw_group: Optional[str] = None, traddr: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.get_gateway_info(
+        def list(self, gw_group: Optional[str] = None, server_address: Optional[str] = None):
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.get_gateway_info(
                 NVMeoFClient.pb2.get_gateway_info_req()
             )
 
@@ -66,8 +69,11 @@ else:
         @EndpointDoc("Get the version of the NVMeoF gateway")
         @convert_to_model(model.GatewayVersion)
         @handle_nvmeof_error
-        def version(self, gw_group: Optional[str] = None, traddr: Optional[str] = None):
-            gw_info = NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.get_gateway_info(
+        def version(self, gw_group: Optional[str] = None, server_address: Optional[str] = None):
+            gw_info = NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.get_gateway_info(
                 NVMeoFClient.pb2.get_gateway_info_req()
             )
             return NVMeoFClient.pb2.gw_version(status=gw_info.status,
@@ -83,9 +89,12 @@ else:
         @EndpointDoc("Get NVMeoF gateway log level information")
         @convert_to_model(model.GatewayLogLevelInfo)
         @handle_nvmeof_error
-        def get_log_level(self, gw_group: Optional[str] = None, traddr: Optional[str] = None):
-            gw_log_level = NVMeoFClient(gw_group=gw_group,
-                                        traddr=traddr).stub.get_gateway_log_level(
+        def get_log_level(self, gw_group: Optional[str] = None,
+                          server_address: Optional[str] = None):
+            gw_log_level = NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.get_gateway_log_level(
                 NVMeoFClient.pb2.get_gateway_log_level_req()
             )
             return gw_log_level
@@ -98,10 +107,10 @@ else:
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def set_log_level(self, log_level: str, gw_group: Optional[str] = None,
-                          traddr: Optional[str] = None):
+                          server_address: Optional[str] = None):
             log_level = log_level.lower()
             gw_log_level = NVMeoFClient(gw_group=gw_group,
-                                        traddr=traddr).stub.set_gateway_log_level(
+                                        server_address=server_address).stub.set_gateway_log_level(
                 NVMeoFClient.pb2.set_gateway_log_level_req(log_level=log_level)
             )
             return gw_log_level
@@ -113,9 +122,12 @@ else:
         @EndpointDoc("Get NVMeoF statistics for the gateway")
         @convert_to_model(model.GatewayStatsInfo)
         @handle_nvmeof_error
-        def get_gw_stats(self, gw_group: Optional[str] = None, traddr: Optional[str] = None):
-            gw_stats = NVMeoFClient(gw_group=gw_group,
-                                    traddr=traddr).stub.get_gateway_stats(
+        def get_gw_stats(self, gw_group: Optional[str] = None,
+                         server_address: Optional[str] = None):
+            gw_stats = NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.get_gateway_stats(
                 NVMeoFClient.pb2.get_gateway_stats_req()
             )
             return gw_stats
@@ -129,9 +141,11 @@ else:
         @convert_to_model(model.GatewayListenersInfo)
         @handle_nvmeof_error
         def listener_info(self, nqn: str, gw_group: Optional[str] = None,
-                          traddr: Optional[str] = None):
-            gw_listener_info = NVMeoFClient(gw_group=gw_group,
-                                            traddr=traddr).stub.show_gateway_listeners_info(
+                          server_address: Optional[str] = None):
+            gw_listener_info = NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.show_gateway_listeners_info(
                 NVMeoFClient.pb2.show_gateway_listeners_info_req(subsystem_nqn=nqn)
             )
             return gw_listener_info
@@ -147,10 +161,12 @@ else:
         @handle_nvmeof_error
         def get_spdk_log_level(
             self, all_log_flags: Optional[bool] = None,
-            gw_group: Optional[str] = None, traddr: Optional[str] = None
+            gw_group: Optional[str] = None, server_address: Optional[str] = None
         ):
-            spdk_log_level = NVMeoFClient(gw_group=gw_group,
-                                          traddr=traddr).stub.get_spdk_nvmf_log_flags_and_level(
+            spdk_log_level = NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.get_spdk_nvmf_log_flags_and_level(
                 NVMeoFClient.pb2.get_spdk_nvmf_log_flags_and_level_req(all_log_flags=all_log_flags)
             )
             return spdk_log_level
@@ -164,11 +180,14 @@ else:
         def set_spdk_log_level(self, log_level: Optional[str] = None,
                                print_level: Optional[str] = None,
                                extra_log_flags: Optional[List[str]] = None,
-                               gw_group: Optional[str] = None, traddr: Optional[str] = None):
+                               gw_group: Optional[str] = None,
+                               server_address: Optional[str] = None):
             log_level = log_level.upper() if log_level else None
             print_level = print_level.upper() if print_level else None
-            spdk_log_level = NVMeoFClient(gw_group=gw_group,
-                                          traddr=traddr).stub.set_spdk_nvmf_logs(
+            spdk_log_level = NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.set_spdk_nvmf_logs(
                 NVMeoFClient.pb2.set_spdk_nvmf_logs_req(log_level=log_level,
                                                         print_level=print_level,
                                                         extra_log_flags=extra_log_flags)
@@ -184,10 +203,12 @@ else:
         def disable_spdk_log_level(
             self, extra_log_flags: Optional[List[str]] = None,
             gw_group: Optional[str] = None,
-            traddr: Optional[str] = None
+            server_address: Optional[str] = None
         ):
-            spdk_log_level = NVMeoFClient(gw_group=gw_group,
-                                          traddr=traddr).stub.disable_spdk_nvmf_logs(
+            spdk_log_level = NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.disable_spdk_nvmf_logs(
                 NVMeoFClient.pb2.disable_spdk_nvmf_logs_req(extra_log_flags=extra_log_flags)
             )
             return spdk_log_level
@@ -200,8 +221,11 @@ else:
         @EndpointDoc("List all NVMeoF subsystems")
         @convert_to_model(model.SubsystemList)
         @handle_nvmeof_error
-        def list(self, gw_group: Optional[str] = None, traddr: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.list_subsystems(
+        def list(self, gw_group: Optional[str] = None, server_address: Optional[str] = None):
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.list_subsystems(
                 NVMeoFClient.pb2.list_subsystems_req()
             )
 
@@ -212,12 +236,17 @@ else:
             parameters={
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.SubsystemList)
         @handle_nvmeof_error
-        def get(self, nqn: str, gw_group: Optional[str] = None, traddr: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.list_subsystems(
+        def get(self, nqn: str, gw_group: Optional[str] = None,
+                server_address: Optional[str] = None):
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.list_subsystems(
                 NVMeoFClient.pb2.list_subsystems_req(subsystem_nqn=nqn)
             )
 
@@ -234,6 +263,7 @@ else:
                 "serial_number": Param(str, "Subsystem serial number", True, None),
                 "dhchap_key": Param(str, "Subsystem DH-HMAC-CHAP key", True, None),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
                 "traddr": Param(str, "NVMeoF gateway address", True, None),
                 "network_mask": Param([str],
                                       "Network mask to automatically create listeners",
@@ -249,8 +279,8 @@ else:
         def create(self, nqn: str, enable_ha: Optional[bool] = True,
                    max_namespaces: Optional[int] = None, no_group_append: Optional[bool] = False,
                    serial_number: Optional[str] = None, dhchap_key: Optional[str] = None,
-                   gw_group: Optional[str] = None, traddr: Optional[str] = None,
-                   network_mask: Optional[List[str]] = None,
+                   gw_group: Optional[str] = None, server_address: Optional[str] = None,
+                   traddr: Optional[str] = None, network_mask: Optional[List[str]] = None,
                    port: Optional[int] = None, secure_listeners: Optional[bool] = False):
             return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.create_subsystem(
                 NVMeoFClient.pb2.create_subsystem_req(
@@ -270,13 +300,17 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "force": Param(bool, "Force delete", True, False),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def delete(self, nqn: str, force: Optional[str] = "false", gw_group: Optional[str] = None,
-                   traddr: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.delete_subsystem(
+                   server_address: Optional[str] = None):
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.delete_subsystem(
                 NVMeoFClient.pb2.delete_subsystem_req(
                     subsystem_nqn=nqn, force=str_to_bool(force)
                 )
@@ -288,7 +322,7 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "dhchap_key": Param(str, "Subsystem DH-HMAC-CHAP key"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "traddr": Param(str, "NVMeoF gateway address", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @empty_response
@@ -296,8 +330,11 @@ else:
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def change_key(self, nqn: str, dhchap_key: str, gw_group: Optional[str] = None,
-                       traddr: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.change_subsystem_key(
+                       server_address: Optional[str] = None):
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.change_subsystem_key(
                 NVMeoFClient.pb2.change_subsystem_key_req(
                     subsystem_nqn=nqn,
                     dhchap_key=dhchap_key
@@ -309,15 +346,19 @@ else:
             parameters={
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "traddr": Param(str, "NVMeoF gateway address", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @empty_response
         @NvmeofCLICommand("nvmeof subsystem del_key", model.RequestStatus)
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
-        def del_key(self, nqn: str, gw_group: Optional[str] = None, traddr: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.change_subsystem_key(
+        def del_key(self, nqn: str, gw_group: Optional[str] = None,
+                    server_address: Optional[str] = None):
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.change_subsystem_key(
                 NVMeoFClient.pb2.change_subsystem_key_req(
                     subsystem_nqn=nqn, dhchap_key=None
                 )
@@ -466,8 +507,15 @@ else:
         @NvmeofCLICommand("nvmeof get_subsystems", model.GetSubsystems)
         @convert_to_model(model.GetSubsystems)
         @handle_nvmeof_error
-        def get_subsystems(self, gw_group: Optional[str] = None, traddr: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.get_subsystems(
+        def get_subsystems(
+            self,
+            gw_group: Optional[str] = None,
+            server_address: Optional[str] = None
+        ):
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.get_subsystems(
                 NVMeoFClient.pb2.get_subsystems_req()
             )
 
@@ -481,12 +529,17 @@ else:
             parameters={
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.ListenerList)
         @handle_nvmeof_error
-        def list(self, nqn: str, gw_group: Optional[str] = None, traddr: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.list_listeners(
+        def list(self, nqn: str, gw_group: Optional[str] = None,
+                 server_address: Optional[str] = None):
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.list_listeners(
                 NVMeoFClient.pb2.list_listeners_req(subsystem=nqn)
             )
 
@@ -501,6 +554,7 @@ else:
                 "trsvcid": Param(int, "NVMeoF transport service port", True, None),
                 "adrfam": Param(int, "NVMeoF address family (0 - IPv4, 1 - IPv6)", True, 0),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
                 "secure": Param(bool, "Use a secure channel", True, False),
                 "verify_host_name": Param(bool,
                                           "Fail if the host name doesn't match the "
@@ -518,10 +572,15 @@ else:
             trsvcid: Optional[int] = None,
             adrfam: int = 0,  # IPv4,
             gw_group: Optional[str] = None,
+            server_address: Optional[str] = None,
             secure: Optional[bool] = False,
             verify_host_name: Optional[bool] = False,
         ):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.create_listener(
+            client = NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            )
+            return client.stub.create_listener(
                 NVMeoFClient.pb2.create_listener_req(
                     nqn=nqn,
                     host_name=host_name,
@@ -544,6 +603,7 @@ else:
                 "trsvcid": Param(int, "NVMeoF transport service port"),
                 "adrfam": Param(int, "NVMeoF address family (0 - IPv4, 1 - IPv6)", True, 0),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -556,9 +616,14 @@ else:
             trsvcid: int,
             adrfam: int = 0,  # IPv4
             force: bool = False,
-            gw_group: Optional[str] = None
+            gw_group: Optional[str] = None,
+            server_address: Optional[str] = None
         ):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.delete_listener(
+            client = NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            )
+            return client.stub.delete_listener(
                 NVMeoFClient.pb2.delete_listener_req(
                     nqn=nqn,
                     host_name=host_name,
@@ -582,13 +647,17 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN", True, None),
                 "nsid": Param(str, "NVMeoF Namespace ID to filter by", True, None),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.NamespaceList)
         @handle_nvmeof_error
         def list(self, nqn: Optional[str] = None, nsid: Optional[str] = None,
-                 gw_group: Optional[str] = None, traddr: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.list_namespaces(
+                 gw_group: Optional[str] = None, server_address: Optional[str] = None):
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.list_namespaces(
                 NVMeoFClient.pb2.list_namespaces_req(subsystem=nqn,
                                                      nsid=int(nsid) if nsid else None)
             )
@@ -602,13 +671,17 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "nsid": Param(str, "NVMeoF Namespace ID"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.NamespaceList)
         @handle_nvmeof_error
         def get(self, nqn: str, nsid: str, gw_group: Optional[str] = None,
-                traddr: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.list_namespaces(
+                server_address: Optional[str] = None):
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.list_namespaces(
                 NVMeoFClient.pb2.list_namespaces_req(subsystem=nqn, nsid=int(nsid))
             )
 
@@ -624,13 +697,17 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "nsid": Param(str, "NVMeoF Namespace ID"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.NamespaceIOStats)
         @handle_nvmeof_error
         def io_stats(self, nqn: str, nsid: str, gw_group: Optional[str] = None,
-                     traddr: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.namespace_get_io_stats(
+                     server_address: Optional[str] = None):
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.namespace_get_io_stats(
                 NVMeoFClient.pb2.namespace_get_io_stats_req(
                     subsystem_nqn=nqn, nsid=int(nsid))
             )
@@ -642,16 +719,14 @@ else:
                 "rados_namespace": Param(str, "RADOS namespace name", True, None),
                 "rbd_pool": Param(str, "RBD pool name"),
                 "rbd_image_name": Param(str, "RBD image name"),
+                "rbd_pool": Param(str, "RBD pool name"),
+                "nsid": Param(str, "Create RBD image", True, None),
                 "create_image": Param(bool, "Create RBD image"),
                 "size": Param(int, "Deprecated. Use `rbd_image_size` instead"),
                 "rbd_image_size": Param(int, "RBD image size"),
                 "trash_image": Param(bool, "Trash the RBD image when namespace is removed"),
                 "block_size": Param(int, "NVMeoF namespace block size"),
                 "load_balancing_group": Param(int, "Load balancing group"),
-                "disable_auto_resize": Param(str, "Disable auto resize", True, None),
-                "read_only": Param(str, "Read only namespace", True, None),
-                "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "traddr": Param(str, "Target gateway address", True, None),
                 "force": Param(
                     bool,
                     "Force create namespace even it image is used by other namespace"
@@ -671,6 +746,10 @@ else:
                                 "Key ID(s) to use for encryption pass phrases, "
                                 "separated by commas",
                                 True, None),
+                "disable_auto_resize": Param(str, "Disable auto resize", True, None),
+                "read_only": Param(str, "Read only namespace", True, None),
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.NamespaceCreation)
@@ -697,6 +776,7 @@ else:
             encryption_format: Optional[List[str]] = None,
             encryption_algorithm: Optional[str] = None,
             key_id: Optional[List[str]] = None,
+            server_address: Optional[str] = None,
         ):
             encryption_format = encryption_format or []
             key_id = key_id or []
@@ -755,8 +835,6 @@ else:
                 "load_balancing_group": Param(int, "Load balancing group"),
                 "disable_auto_resize": Param(str, "Disable auto resize", True, None),
                 "read_only": Param(str, "Read only namespace", True, None),
-                "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "traddr": Param(str, "Target gateway address", True, None),
                 "force": Param(
                     bool,
                     "Force create namespace even it image is used by other namespace"
@@ -776,6 +854,8 @@ else:
                                 "Key ID(s) to use for encryption pass phrases, "
                                 "separated by commas",
                                 True, None),
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "Target gateway address", True, None),
             },
         )
         @convert_to_model(model.NamespaceCreation)
@@ -802,6 +882,8 @@ else:
             encryption_format: Optional[List[str]] = None,
             encryption_algorithm: Optional[str] = None,
             key_id: Optional[List[str]] = None,
+
+            server_address: Optional[str] = None,
         ):
             if size and rbd_image_size:
                 raise DashboardException(
@@ -835,7 +917,7 @@ else:
             enc_alg = encryption_algorithm.strip().lower() if encryption_algorithm else None
             return NVMeoFClient(
                 gw_group=gw_group,
-                traddr=traddr
+                server_address=server_address
             ).stub.namespace_add(
                 NVMeoFClient.pb2.namespace_add_req(
                     subsystem_nqn=nqn,
@@ -875,7 +957,7 @@ else:
                     "Set QOS limits even if they were changed by RBD"
                 ),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "traddr": Param(str, "NVMeoF gateway address", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -890,11 +972,11 @@ else:
             w_mbytes_per_second: Optional[int] = None,
             force: Optional[bool] = False,
             gw_group: Optional[str] = None,
-            traddr: Optional[str] = None
+            server_address: Optional[str] = None
         ):
             return NVMeoFClient(
                 gw_group=gw_group,
-                traddr=traddr
+                server_address=server_address
             ).stub.namespace_set_qos_limits(
                 NVMeoFClient.pb2.namespace_set_qos_req(
                     subsystem_nqn=nqn,
@@ -918,9 +1000,9 @@ else:
             parameters={
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "nsid": Param(str, "NVMeoF Namespace ID"),
-                "load_balancing_group": Param(int, "Load balancing group"),
+                "load_balancing_group": Param(int, "Load balancing group", True, None),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "traddr": Param(str, "NVMeoF gateway address", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -931,11 +1013,11 @@ else:
             nsid: str,
             load_balancing_group: Optional[int] = None,
             gw_group: Optional[str] = None,
-            traddr: Optional[str] = None
+            server_address: Optional[str] = None
         ):
             return NVMeoFClient(
                 gw_group=gw_group,
-                traddr=traddr
+                server_address=server_address
             ).stub.namespace_change_load_balancing_group(
                 NVMeoFClient.pb2.namespace_change_load_balancing_group_req(
                     subsystem_nqn=nqn, nsid=int(nsid), anagrpid=load_balancing_group
@@ -951,7 +1033,7 @@ else:
                 "nsid": Param(str, "NVMeoF Namespace ID"),
                 "rbd_image_size": Param(int, "RBD image size"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "traddr": Param(str, "NVMeoF gateway address", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -962,12 +1044,15 @@ else:
             nsid: str,
             rbd_image_size: int,
             gw_group: Optional[str] = None,
-            traddr: Optional[str] = None
+            server_address: Optional[str] = None
         ):
             mib = 1024 * 1024
             new_size_mib = int((rbd_image_size + mib - 1) / mib)
 
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.namespace_resize(
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.namespace_resize(
                 NVMeoFClient.pb2.namespace_resize_req(
                     subsystem_nqn=nqn, nsid=int(nsid), new_size=new_size_mib
                 )
@@ -982,7 +1067,7 @@ else:
                 "nsid": Param(str, "NVMeoF Namespace ID"),
                 "rbd_image_size": Param(str, "RBD image size"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "traddr": Param(str, "NVMeoF gateway address", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -993,14 +1078,17 @@ else:
             nsid: str,
             rbd_image_size: str,
             gw_group: Optional[str] = None,
-            traddr: Optional[str] = None
+            server_address: Optional[str] = None
         ):
             if rbd_image_size:
                 rbd_image_size_b = convert_to_bytes(rbd_image_size, default_unit='MB')
             mib = 1024 * 1024
             rbd_image_size_mb = rbd_image_size_b // mib
 
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.namespace_resize(
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.namespace_resize(
                 NVMeoFClient.pb2.namespace_resize_req(
                     subsystem_nqn=nqn, nsid=int(nsid), new_size=rbd_image_size_mb
                 )
@@ -1023,7 +1111,7 @@ else:
                     "has no access to the subsystem"
                 ),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "traddr": Param(str, "NVMeoF gateway address", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1035,9 +1123,12 @@ else:
             host_nqn: str,
             force: Optional[bool] = None,
             gw_group: Optional[str] = None,
-            traddr: Optional[str] = None
+            server_address: Optional[str] = None
         ):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.namespace_add_host(
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.namespace_add_host(
                 NVMeoFClient.pb2.namespace_add_host_req(subsystem_nqn=nqn,
                                                         nsid=int(nsid),
                                                         host_nqn=host_nqn,
@@ -1056,7 +1147,7 @@ else:
                 "nsid": Param(str, "NVMeoF Namespace ID"),
                 "host_nqn": Param(str, 'NVMeoF host NQN. Use "*" to allow any host.'),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "traddr": Param(str, "NVMeoF gateway address", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1067,9 +1158,12 @@ else:
             nsid: str,
             host_nqn: str,
             gw_group: Optional[str] = None,
-            traddr: Optional[str] = None
+            server_address: Optional[str] = None
         ):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.namespace_delete_host(
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.namespace_delete_host(
                 NVMeoFClient.pb2.namespace_delete_host_req(
                     subsystem_nqn=nqn,
                     nsid=int(nsid),
@@ -1089,8 +1183,9 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "nsid": Param(str, "NVMeoF Namespace ID"),
                 "auto_visible": Param(bool, 'True if visible to all hosts'),
+                "force": Param(bool, 'True if visible to all hosts', True, False),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "traddr": Param(str, "NVMeoF gateway address", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1102,9 +1197,12 @@ else:
             auto_visible: str,
             force: Optional[bool] = False,
             gw_group: Optional[str] = None,
-            traddr: Optional[str] = None
+            server_address: Optional[str] = None
         ):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.namespace_change_visibility(
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.namespace_change_visibility(
                 NVMeoFClient.pb2.namespace_change_visibility_req(
                     subsystem_nqn=nqn,
                     nsid=int(nsid),
@@ -1130,7 +1228,7 @@ else:
                     'namespace when RBD image is resized'
                 ),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "traddr": Param(str, "NVMeoF gateway address", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1141,9 +1239,12 @@ else:
             nsid: str,
             auto_resize_enabled: bool,
             gw_group: Optional[str] = None,
-            traddr: Optional[str] = None
+            server_address: Optional[str] = None
         ):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.namespace_set_auto_resize(
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.namespace_set_auto_resize(
                 NVMeoFClient.pb2.namespace_set_auto_resize_req(
                     subsystem_nqn=nqn,
                     nsid=int(nsid),
@@ -1165,7 +1266,7 @@ else:
                 "nsid": Param(str, "NVMeoF Namespace ID"),
                 "rbd_trash_image_on_delete": Param(bool, 'True if active'),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "traddr": Param(str, "NVMeoF gateway address", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1176,11 +1277,11 @@ else:
             nsid: str,
             rbd_trash_image_on_delete: str,
             gw_group: Optional[str] = None,
-            traddr: Optional[str] = None
+            server_address: Optional[str] = None
         ):
             return NVMeoFClient(
                 gw_group=gw_group,
-                traddr=traddr,
+                server_address=server_address,
             ).stub.namespace_set_rbd_trash_image(
                 NVMeoFClient.pb2.namespace_set_rbd_trash_image_req(
                     subsystem_nqn=nqn,
@@ -1201,7 +1302,7 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "nsid": Param(str, "NVMeoF Namespace ID"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "traddr": Param(str, "NVMeoF gateway address", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1211,9 +1312,12 @@ else:
             nqn: str,
             nsid: str,
             gw_group: Optional[str] = None,
-            traddr: Optional[str] = None
+            server_address: Optional[str] = None
         ):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.namespace_resize(
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.namespace_resize(
                 NVMeoFClient.pb2.namespace_resize_req(
                     subsystem_nqn=nqn,
                     nsid=int(nsid),
@@ -1236,8 +1340,9 @@ else:
                 "rw_mbytes_per_second": Param(int, "Read/Write MB/s"),
                 "r_mbytes_per_second": Param(int, "Read MB/s"),
                 "w_mbytes_per_second": Param(int, "Write MB/s"),
+                "trash_image": Param(bool, "Trash RBD image after removing namespace"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "trash_image": Param(bool, "Trash RBD image after removing namespace")
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.NamespaceList)
@@ -1252,9 +1357,9 @@ else:
             rw_mbytes_per_second: Optional[int] = None,
             r_mbytes_per_second: Optional[int] = None,
             w_mbytes_per_second: Optional[int] = None,
-            gw_group: Optional[str] = None,
-            traddr: Optional[str] = None,
             trash_image: Optional[bool] = None,
+            gw_group: Optional[str] = None,
+            server_address: Optional[str] = None,
         ):
             contains_failure = False
 
@@ -1262,7 +1367,10 @@ else:
                 mib = 1024 * 1024
                 new_size_mib = int((rbd_image_size + mib - 1) / mib)
 
-                resp = NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.namespace_resize(
+                resp = NVMeoFClient(
+                    gw_group=gw_group,
+                    server_address=server_address
+                ).stub.namespace_resize(
                     NVMeoFClient.pb2.namespace_resize_req(
                         subsystem_nqn=nqn, nsid=int(nsid), new_size=new_size_mib
                     )
@@ -1308,7 +1416,10 @@ else:
             if contains_failure:
                 cherrypy.response.status = 202
 
-            response = NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.list_namespaces(
+            response = NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.list_namespaces(
                 NVMeoFClient.pb2.list_namespaces_req(subsystem=nqn, nsid=int(nsid))
             )
             return response
@@ -1320,8 +1431,9 @@ else:
             parameters={
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "nsid": Param(str, "NVMeoF Namespace ID"),
+                "force": Param(str, "Force remove the RBD image", True, False),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "force": Param(str, "Force remove the RBD image")
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1330,11 +1442,14 @@ else:
             self,
             nqn: str,
             nsid: str,
+            force: Optional[str] = "false",
             gw_group: Optional[str] = None,
-            traddr: Optional[str] = None,
-            force: Optional[str] = "false"
+            server_address: Optional[str] = None,
         ):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.namespace_delete(
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.namespace_delete(
                 NVMeoFClient.pb2.namespace_delete_req(
                     subsystem_nqn=nqn,
                     nsid=int(nsid),
@@ -1370,15 +1485,19 @@ else:
                 "clear_alerts": Param(bool, "Clear any host alert signal after getting its value",
                                       True, False),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.HostsInfo, finalize=_update_hosts)
         @handle_nvmeof_error
         def list(
             self, nqn: str, clear_alerts: Optional[bool] = None,
-            gw_group: Optional[str] = None, traddr: Optional[str] = None
+            gw_group: Optional[str] = None, server_address: Optional[str] = None
         ):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.list_hosts(
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.list_hosts(
                 NVMeoFClient.pb2.list_hosts_req(subsystem=nqn, clear_alerts=clear_alerts)
             )
 
@@ -1390,6 +1509,7 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "host_nqn": Param(str, 'NVMeoF host NQN. Use "*" to allow any host.'),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1397,9 +1517,13 @@ else:
         def create(
             self, nqn: str, host_nqn: str, dhchap_key: Optional[str] = None,
             dhchap_controller_key: Optional[str] = None,
-            psk: Optional[str] = None, gw_group: Optional[str] = None, traddr: Optional[str] = None
+            psk: Optional[str] = None, gw_group: Optional[str] = None, traddr: Optional[str] = None,
+            server_address: Optional[str] = None
         ):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.add_host(
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.add_host(
                 NVMeoFClient.pb2.add_host_req(subsystem_nqn=nqn, host_nqn=host_nqn,
                                               dhchap_key=dhchap_key,
                                               dhchap_ctrlr_key=dhchap_controller_key,
@@ -1414,13 +1538,17 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "host_nqn": Param(str, 'NVMeoF host NQN. Use "*" to disallow any host.'),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def delete(self, nqn: str, host_nqn: str, gw_group: Optional[str] = None,
-                   traddr: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.remove_host(
+                   server_address: Optional[str] = None):
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.remove_host(
                 NVMeoFClient.pb2.remove_host_req(subsystem_nqn=nqn, host_nqn=host_nqn)
             )
 
@@ -1437,15 +1565,19 @@ else:
                 "host_nqn": Param(str, 'NVMeoF host NQN'),
                 "dhchap_key": Param(str, 'Host DH-HMAC-CHAP key'),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def change_key(
             self, nqn: str, host_nqn: str, dhchap_key: str,
-            gw_group: Optional[str] = None, traddr: Optional[str] = None
+            gw_group: Optional[str] = None, server_address: Optional[str] = None
         ):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.change_host_key(
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.change_host_key(
                 NVMeoFClient.pb2.change_host_key_req(subsystem_nqn=nqn,
                                                      host_nqn=host_nqn,
                                                      dhchap_key=dhchap_key,
@@ -1488,15 +1620,19 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "host_nqn": Param(str, 'NVMeoF host NQN.'),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def del_key(
             self, nqn: str, host_nqn: str, gw_group: Optional[str] = None,
-            traddr: Optional[str] = None
+            server_address: Optional[str] = None
         ):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.change_host_key(
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.change_host_key(
                 NVMeoFClient.pb2.change_host_key_req(subsystem_nqn=nqn,
                                                      host_nqn=host_nqn,
                                                      dhchap_key=None,
@@ -1552,15 +1688,19 @@ else:
             parameters={
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.ConnectionList, finalize=_update_connections)
         @handle_nvmeof_error
         def list(self, nqn: Optional[str] = None,
-                 gw_group: Optional[str] = None, traddr: Optional[str] = None):
+                 gw_group: Optional[str] = None, server_address: Optional[str] = None):
             if not nqn:
                 nqn = '*'
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.list_connections(
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.list_connections(
                 NVMeoFClient.pb2.list_connections_req(subsystem=nqn)
             )
 

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -9356,7 +9356,7 @@ paths:
           type: string
       - allowEmptyValue: true
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -9416,7 +9416,7 @@ paths:
           type: string
       - allowEmptyValue: true
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -9449,7 +9449,7 @@ paths:
           type: string
       - allowEmptyValue: true
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -9483,7 +9483,7 @@ paths:
                   type: string
                 log_level:
                   type: string
-                traddr:
+                server_address:
                   type: string
               required:
               - log_level
@@ -9523,7 +9523,7 @@ paths:
           type: string
       - allowEmptyValue: true
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -9556,7 +9556,7 @@ paths:
           type: string
       - allowEmptyValue: true
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -9594,7 +9594,7 @@ paths:
           type: string
       - allowEmptyValue: true
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -9632,7 +9632,7 @@ paths:
                   type: string
                 print_level:
                   type: string
-                traddr:
+                server_address:
                   type: string
               type: object
       responses:
@@ -9672,7 +9672,7 @@ paths:
                   type: string
                 gw_group:
                   type: string
-                traddr:
+                server_address:
                   type: string
               type: object
       responses:
@@ -9710,7 +9710,7 @@ paths:
           type: string
       - allowEmptyValue: true
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -9828,8 +9828,9 @@ paths:
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -9872,8 +9873,9 @@ paths:
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -9912,8 +9914,9 @@ paths:
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -9958,8 +9961,9 @@ paths:
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -10007,7 +10011,8 @@ paths:
                   type: string
                 psk:
                   type: string
-                traddr:
+                server_address:
+                  description: NVMeoF gateway address
                   type: string
               required:
               - host_nqn
@@ -10059,8 +10064,9 @@ paths:
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -10318,8 +10324,9 @@ paths:
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -10453,6 +10460,12 @@ paths:
         name: gw_group
         schema:
           type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address
+        in: query
+        name: server_address
+        schema:
+          type: string
       responses:
         '202':
           content:
@@ -10500,8 +10513,9 @@ paths:
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -10580,6 +10594,7 @@ paths:
                   description: Namespace will be visible only for the allowed hosts
                   type: boolean
                 nsid:
+                  description: Create RBD image
                   type: string
                 rados_namespace:
                   description: RADOS namespace name
@@ -10598,12 +10613,12 @@ paths:
                   default: false
                   description: Read only namespace
                   type: string
+                server_address:
+                  description: NVMeoF gateway address
+                  type: string
                 size:
                   description: Deprecated. Use `rbd_image_size` instead
                   type: integer
-                traddr:
-                  description: Target gateway address
-                  type: string
                 trash_image:
                   default: false
                   description: Trash the RBD image when namespace is removed
@@ -10651,6 +10666,12 @@ paths:
         required: true
         schema:
           type: string
+      - default: 'false'
+        description: Force remove the RBD image
+        in: query
+        name: force
+        schema:
+          type: string
       - allowEmptyValue: true
         description: NVMeoF gateway group
         in: query
@@ -10658,14 +10679,9 @@ paths:
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
-        name: traddr
-        schema:
-          type: string
-      - default: 'false'
-        description: Force remove the RBD image
-        in: query
-        name: force
+        name: server_address
         schema:
           type: string
       responses:
@@ -10714,8 +10730,9 @@ paths:
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -10775,7 +10792,8 @@ paths:
                 rw_mbytes_per_second:
                   description: Read/Write MB/s
                   type: integer
-                traddr:
+                server_address:
+                  description: NVMeoF gateway address
                   type: string
                 trash_image:
                   description: Trash RBD image after removing namespace
@@ -10834,7 +10852,7 @@ paths:
                 host_nqn:
                   description: NVMeoF host NQN. Use "*" to allow any host.
                   type: string
-                traddr:
+                server_address:
                   description: NVMeoF gateway address
                   type: string
               required:
@@ -10891,7 +10909,7 @@ paths:
                 load_balancing_group:
                   description: Load balancing group
                   type: integer
-                traddr:
+                server_address:
                   description: NVMeoF gateway address
                   type: string
               type: object
@@ -10945,11 +10963,12 @@ paths:
                   type: boolean
                 force:
                   default: false
+                  description: True if visible to all hosts
                   type: boolean
                 gw_group:
                   description: NVMeoF gateway group
                   type: string
-                traddr:
+                server_address:
                   description: NVMeoF gateway address
                   type: string
               required:
@@ -11007,7 +11026,7 @@ paths:
                 host_nqn:
                   description: NVMeoF host NQN. Use "*" to allow any host.
                   type: string
-                traddr:
+                server_address:
                   description: NVMeoF gateway address
                   type: string
               required:
@@ -11060,8 +11079,9 @@ paths:
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -11107,7 +11127,7 @@ paths:
                 gw_group:
                   description: NVMeoF gateway group
                   type: string
-                traddr:
+                server_address:
                   description: NVMeoF gateway address
                   type: string
               type: object
@@ -11162,7 +11182,7 @@ paths:
                 rbd_image_size:
                   description: RBD image size
                   type: integer
-                traddr:
+                server_address:
                   description: NVMeoF gateway address
                   type: string
               required:
@@ -11220,7 +11240,7 @@ paths:
                 gw_group:
                   description: NVMeoF gateway group
                   type: string
-                traddr:
+                server_address:
                   description: NVMeoF gateway address
                   type: string
               required:
@@ -11287,7 +11307,7 @@ paths:
                 rw_mbytes_per_second:
                   description: Read/Write MB/s
                   type: integer
-                traddr:
+                server_address:
                   description: NVMeoF gateway address
                   type: string
                 w_mbytes_per_second:
@@ -11345,7 +11365,7 @@ paths:
                 rbd_trash_image_on_delete:
                   description: True if active
                   type: boolean
-                traddr:
+                server_address:
                   description: NVMeoF gateway address
                   type: string
               required:

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -9350,13 +9350,21 @@ paths:
     get:
       parameters:
       - allowEmptyValue: true
+        description: NVMeoF gateway group
         in: query
         name: gw_group
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
         name: server_address
+        schema:
+          type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
         schema:
           type: string
       responses:
@@ -9404,19 +9412,28 @@ paths:
   /api/nvmeof/gateway/listener_info/{nqn}:
     get:
       parameters:
-      - in: path
+      - description: NVMeoF subsystem NQN
+        in: path
         name: nqn
         required: true
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway group
         in: query
         name: gw_group
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
         name: server_address
+        schema:
+          type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
         schema:
           type: string
       responses:
@@ -9443,13 +9460,21 @@ paths:
     get:
       parameters:
       - allowEmptyValue: true
+        description: NVMeoF gateway group
         in: query
         name: gw_group
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
         name: server_address
+        schema:
+          type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
         schema:
           type: string
       responses:
@@ -9480,10 +9505,16 @@ paths:
             schema:
               properties:
                 gw_group:
+                  description: NVMeoF gateway group
                   type: string
                 log_level:
+                  description: Log level
                   type: string
                 server_address:
+                  description: NVMeoF gateway address
+                  type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
                   type: string
               required:
               - log_level
@@ -9517,13 +9548,21 @@ paths:
     get:
       parameters:
       - allowEmptyValue: true
+        description: NVMeoF gateway group
         in: query
         name: gw_group
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
         name: server_address
+        schema:
+          type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
         schema:
           type: string
       responses:
@@ -9550,13 +9589,21 @@ paths:
     get:
       parameters:
       - allowEmptyValue: true
+        description: NVMeoF gateway group
         in: query
         name: gw_group
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
         name: server_address
+        schema:
+          type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
         schema:
           type: string
       responses:
@@ -9583,18 +9630,27 @@ paths:
     get:
       parameters:
       - allowEmptyValue: true
+        description: Get all log flags
         in: query
         name: all_log_flags
         schema:
-          type: string
+          type: boolean
       - allowEmptyValue: true
+        description: NVMeoF gateway group
         in: query
         name: gw_group
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
         name: server_address
+        schema:
+          type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
         schema:
           type: string
       responses:
@@ -9625,14 +9681,24 @@ paths:
             schema:
               properties:
                 extra_log_flags:
-                  type: string
+                  description: Extra log flags
+                  items:
+                    type: string
+                  type: array
                 gw_group:
+                  description: NVMeoF gateway group
                   type: string
                 log_level:
+                  description: SPDK log level
                   type: string
                 print_level:
+                  description: SPDK print level
                   type: string
                 server_address:
+                  description: NVMeoF gateway address
+                  type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
                   type: string
               type: object
       responses:
@@ -9669,10 +9735,18 @@ paths:
             schema:
               properties:
                 extra_log_flags:
-                  type: string
+                  description: Extra log flags
+                  items:
+                    type: string
+                  type: array
                 gw_group:
+                  description: NVMeoF gateway group
                   type: string
                 server_address:
+                  description: NVMeoF gateway address
+                  type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
                   type: string
               type: object
       responses:
@@ -9704,13 +9778,21 @@ paths:
     get:
       parameters:
       - allowEmptyValue: true
+        description: NVMeoF gateway group
         in: query
         name: gw_group
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
         name: server_address
+        schema:
+          type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
         schema:
           type: string
       responses:
@@ -9775,8 +9857,11 @@ paths:
                 serial_number:
                   description: Subsystem serial number
                   type: string
-                traddr:
+                server_address:
                   description: NVMeoF gateway address
+                  type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
                   type: string
               required:
               - nqn
@@ -9833,6 +9918,12 @@ paths:
         name: server_address
         schema:
           type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
+        schema:
+          type: string
       responses:
         '202':
           content:
@@ -9878,6 +9969,12 @@ paths:
         name: server_address
         schema:
           type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -9917,6 +10014,12 @@ paths:
         description: NVMeoF gateway address
         in: query
         name: server_address
+        schema:
+          type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
         schema:
           type: string
       responses:
@@ -9966,6 +10069,12 @@ paths:
         name: server_address
         schema:
           type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -10013,6 +10122,9 @@ paths:
                   type: string
                 server_address:
                   description: NVMeoF gateway address
+                  type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
                   type: string
               required:
               - host_nqn
@@ -10069,6 +10181,12 @@ paths:
         name: server_address
         schema:
           type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
+        schema:
+          type: string
       responses:
         '202':
           content:
@@ -10120,7 +10238,11 @@ paths:
                 gw_group:
                   description: NVMeoF gateway group
                   type: string
+                server_address:
+                  description: NVMeoF gateway address
+                  type: string
                 traddr:
+                  description: NVMeoF gateway address (deprecated)
                   type: string
               required:
               - dhchap_controller_key
@@ -10176,7 +10298,11 @@ paths:
                 gw_group:
                   description: NVMeoF gateway group
                   type: string
+                server_address:
+                  description: NVMeoF gateway address
+                  type: string
                 traddr:
+                  description: NVMeoF gateway address (deprecated)
                   type: string
               required:
               - dhchap_key
@@ -10229,7 +10355,11 @@ paths:
                 gw_group:
                   description: NVMeoF gateway group
                   type: string
+                server_address:
+                  description: NVMeoF gateway address
+                  type: string
                 traddr:
+                  description: NVMeoF gateway address (deprecated)
                   type: string
               type: object
       responses:
@@ -10280,7 +10410,11 @@ paths:
                 gw_group:
                   description: NVMeoF gateway group
                   type: string
+                server_address:
+                  description: NVMeoF gateway address
+                  type: string
                 traddr:
+                  description: NVMeoF gateway address (deprecated)
                   type: string
               type: object
       responses:
@@ -10327,6 +10461,12 @@ paths:
         description: NVMeoF gateway address
         in: query
         name: server_address
+        schema:
+          type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
         schema:
           type: string
       responses:
@@ -10376,6 +10516,9 @@ paths:
                   default: false
                   description: Use a secure channel
                   type: boolean
+                server_address:
+                  description: NVMeoF gateway address
+                  type: string
                 traddr:
                   description: NVMeoF transport address
                   type: string
@@ -10518,6 +10661,12 @@ paths:
         name: server_address
         schema:
           type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -10619,6 +10768,9 @@ paths:
                 size:
                   description: Deprecated. Use `rbd_image_size` instead
                   type: integer
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
+                  type: string
                 trash_image:
                   default: false
                   description: Trash the RBD image when namespace is removed
@@ -10684,6 +10836,12 @@ paths:
         name: server_address
         schema:
           type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
+        schema:
+          type: string
       responses:
         '202':
           content:
@@ -10733,6 +10891,12 @@ paths:
         description: NVMeoF gateway address
         in: query
         name: server_address
+        schema:
+          type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
         schema:
           type: string
       responses:
@@ -10795,6 +10959,9 @@ paths:
                 server_address:
                   description: NVMeoF gateway address
                   type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
+                  type: string
                 trash_image:
                   description: Trash RBD image after removing namespace
                   type: boolean
@@ -10855,6 +11022,9 @@ paths:
                 server_address:
                   description: NVMeoF gateway address
                   type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
+                  type: string
               required:
               - host_nqn
               type: object
@@ -10911,6 +11081,9 @@ paths:
                   type: integer
                 server_address:
                   description: NVMeoF gateway address
+                  type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
                   type: string
               type: object
       responses:
@@ -10971,6 +11144,9 @@ paths:
                 server_address:
                   description: NVMeoF gateway address
                   type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
+                  type: string
               required:
               - auto_visible
               type: object
@@ -11029,6 +11205,9 @@ paths:
                 server_address:
                   description: NVMeoF gateway address
                   type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
+                  type: string
               required:
               - host_nqn
               type: object
@@ -11084,6 +11263,12 @@ paths:
         name: server_address
         schema:
           type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -11129,6 +11314,9 @@ paths:
                   type: string
                 server_address:
                   description: NVMeoF gateway address
+                  type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
                   type: string
               type: object
       responses:
@@ -11184,6 +11372,9 @@ paths:
                   type: integer
                 server_address:
                   description: NVMeoF gateway address
+                  type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
                   type: string
               required:
               - rbd_image_size
@@ -11242,6 +11433,9 @@ paths:
                   type: string
                 server_address:
                   description: NVMeoF gateway address
+                  type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
                   type: string
               required:
               - auto_resize_enabled
@@ -11310,6 +11504,9 @@ paths:
                 server_address:
                   description: NVMeoF gateway address
                   type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
+                  type: string
                 w_mbytes_per_second:
                   description: Write MB/s
                   type: integer
@@ -11367,6 +11564,9 @@ paths:
                   type: boolean
                 server_address:
                   description: NVMeoF gateway address
+                  type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
                   type: string
               required:
               - rbd_trash_image_on_delete

--- a/src/pybind/mgr/dashboard/services/nvmeof_cli.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_cli.py
@@ -11,6 +11,7 @@ from mgr_module import CLICheckNonemptyFileInput, HandleCommandResult, HandlerFu
 from prettytable import PrettyTable
 
 from ..cli import DBCLICommand
+from ..exceptions import DashboardException
 from ..model.nvmeof import CliFieldTransformer, CliFlags, CliHeader
 from ..rest_client import RequestException
 from .nvmeof_conf import ManagedByOrchestratorException, \
@@ -98,6 +99,36 @@ def convert_from_bytes(num_in_bytes):
         size_str = f"{size:.1f}"
 
     return f"{size_str}{units[unit_index]}"
+
+
+def resolve_nvmeof_server_address(
+    *,
+    server_address: Optional[str] = None,
+    traddr: Optional[str] = None,
+    require: bool = False,
+) -> Optional[str]:
+    sa = (server_address or "").strip() or None
+    ta = (traddr or "").strip() or None
+
+    if sa and ta:
+        raise DashboardException(
+            msg="Pass either 'server_address' or deprecated 'traddr', not both.",
+            code="server_address_and_traddr_mutually_exclusive",
+            http_status_code=400,
+            component="nvmeof",
+        )
+
+    resolved = sa or ta
+
+    if require and not resolved:
+        raise DashboardException(
+            msg="Missing required gateway address: 'server_address' (or deprecated 'traddr').",
+            code="missing_server_address",
+            http_status_code=400,
+            component="nvmeof",
+        )
+
+    return resolved
 
 
 class OutputFormatter(ABC):

--- a/src/pybind/mgr/dashboard/services/nvmeof_client.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_client.py
@@ -33,7 +33,7 @@ else:
     class NVMeoFClient(object):
         pb2 = pb2
 
-        def __init__(self, gw_group: Optional[str] = None, traddr: Optional[str] = None):
+        def __init__(self, gw_group: Optional[str] = None, server_address: Optional[str] = None):
             logger.info("Initiating nvmeof gateway connection...")
             try:
                 if not gw_group:
@@ -51,14 +51,14 @@ else:
             self.daemon_name = ''
             # While creating listener need to direct request to the gateway
             # address where listener is supposed to be added.
-            if traddr:
+            if server_address:
                 gateways_info = NvmeofGatewaysConfig.get_gateways_config()
                 matched_gateway = next(
                     (
                         gateway
                         for gateways in gateways_info['gateways'].values()
                         for gateway in gateways
-                        if traddr in gateway['service_url']
+                        if server_address in gateway['service_url']
                     ),
                     None
                 )

--- a/src/pybind/mgr/dashboard/tests/test_nvmeof_cli.py
+++ b/src/pybind/mgr/dashboard/tests/test_nvmeof_cli.py
@@ -9,9 +9,11 @@ import pytest
 from mgr_module import CLICommandBase, HandleCommandResult
 
 from ..controllers import EndpointDoc
+from ..exceptions import DashboardException
 from ..model.nvmeof import CliFieldTransformer, CliFlags, CliHeader
 from ..services.nvmeof_cli import AnnotatedDataTextOutputFormatter, \
-    NvmeofCLICommand, convert_from_bytes, convert_to_bytes
+    NvmeofCLICommand, convert_from_bytes, convert_to_bytes, \
+    resolve_nvmeof_server_address
 from ..tests import CLICommandTestMixin
 
 
@@ -642,3 +644,57 @@ class TestConvertToBytes:
         with pytest.raises(ValueError):
             assert convert_to_bytes('5') == 5368709120
         assert convert_to_bytes('5', default_unit='GB') == 5368709120
+
+
+class TestResolveNvmeofServerAddress:
+    def test_resolve_returns_server_address_when_set(self):
+        assert resolve_nvmeof_server_address(
+            server_address="10.0.0.1",
+            traddr=None,
+            require=False,
+        ) == "10.0.0.1"
+
+    def test_resolve_uses_traddr_fallback_when_server_address_missing(self):
+        assert resolve_nvmeof_server_address(
+            server_address=None,
+            traddr="10.0.0.2",
+            require=False,
+        ) == "10.0.0.2"
+
+    def test_resolve_strips_whitespace_and_treats_empty_as_none(self):
+        assert resolve_nvmeof_server_address(
+            server_address="  ",
+            traddr=" 10.0.0.2 ",
+            require=False,
+        ) == "10.0.0.2"
+
+    def test_resolve_rejects_both_server_address_and_traddr(self):
+        with pytest.raises(DashboardException) as excinfo:
+            resolve_nvmeof_server_address(
+                server_address="10.0.0.1",
+                traddr="10.0.0.2",
+                require=False,
+            )
+
+        err = excinfo.value
+        assert err.status == 400
+        assert err.code == "server_address_and_traddr_mutually_exclusive"
+
+    def test_resolve_require_true_rejects_missing(self):
+        with pytest.raises(DashboardException) as excinfo:
+            resolve_nvmeof_server_address(
+                server_address=None,
+                traddr=None,
+                require=True,
+            )
+
+        err = excinfo.value
+        assert err.status == 400
+        assert err.code == "missing_server_address"
+
+    def test_resolve_require_false_allows_missing(self):
+        assert resolve_nvmeof_server_address(
+            server_address=None,
+            traddr=None,
+            require=False,
+        ) is None


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76143

also contains the changes from: https://github.com/ceph/ceph/pull/66822 as it depends on them
---

backport of https://github.com/ceph/ceph/pull/68393
parent tracker: https://tracker.ceph.com/issues/75978

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh