### PR TITLE
mgr/tox: adding coverage target to the main tox.ini

### DIFF
--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -7,6 +7,7 @@ envlist =
     check-black
     check-isort
     py3
+    coverage
 skipsdist = true
 skip_missing_interpreters = true
 
@@ -45,6 +46,12 @@ addopts =
     --recursive \
     --ignore-local-config
 
+[coverage:report]
+omit =
+    */tests/*
+    */test_*.py
+    */templates/*
+
 [testenv]
 setenv =
     UNITTEST = true
@@ -64,6 +71,23 @@ deps =
     -rrequirements.txt
 commands =
     pytest {posargs:cephadm/tests/test_ssh.py}
+
+
+[testenv:coverage]
+setenv =
+    UNITTEST = true
+    PYTHONPATH = $PYTHONPATH:..
+deps =
+    {[base]deps}
+    pytest-cov
+# Default: percentages only
+# To show uncovered line numbers:
+#   COVERAGE_REPORT=term-missing tox -e coverage -- <module>
+# To generate a nice html with visual uncovered line numbers:
+#   COVERAGE_REPORT=html tox -e coverage -- <module>
+#   <your-browser> htmlcov/index.html
+commands =
+    pytest --cov={posargs:.} --cov-report={env:COVERAGE_REPORT:term} {posargs:.}
 
 
 [testenv:{,py37-,py38-,py39-,py310-}mypy]


### PR DESCRIPTION

Let's add a `coverage` target so we can measure this metric for mgr modules.

**Usage examples:**

- Run coverage for a single module (percentages only):
>   tox -e coverage -- cephadm
>   tox -e coverage -- smb

- Show uncovered line numbers:
>   COVERAGE_REPORT=term-missing tox -e coverage -- cephadm


- Generate a visual HTML report:
>   COVERAGE_REPORT=html tox -e coverage -- cephadm
>   firefox htmlcov/index.html
> 

**Current numbers:**

**Cephadm**: `tox -e coverage -- cephadm`

```
---------- coverage: platform linux, python 3.10.6-final-0 -----------
Name                                    Stmts   Miss  Cover
-----------------------------------------------------------
cephadm/__init__.py                         6      0   100%
cephadm/agent.py                          586    298    49%
cephadm/autotune.py                        44      1    98%
cephadm/ceph_volume.py                     92      0   100%
cephadm/cert_mgr.py                       408    103    75%
cephadm/cli.py                              2      0   100%
cephadm/configchecks.py                   451     37    92%
cephadm/exchange.py                        80      3    96%
cephadm/http_server.py                    112     74    34%
cephadm/inventory.py                     1205    278    77%
cephadm/migrations.py                     320    107    67%
cephadm/module.py                        2321    934    60%
cephadm/offline_watcher.py                 47     22    53%
cephadm/registry.py                        52     41    21%
cephadm/schedule.py                       307     10    97%
cephadm/serve.py                         1170    311    73%
cephadm/services/__init__.py                0      0   100%
cephadm/services/cephadmservice.py        986    244    75%
cephadm/services/container.py              20      0   100%
cephadm/services/ingress.py               321     40    88%
cephadm/services/iscsi.py                 118     28    76%
cephadm/services/jaeger.py                 75      0   100%
cephadm/services/mgmt_gateway.py           85      1    99%
cephadm/services/monitoring.py            517    112    78%
cephadm/services/nfs.py                   292     92    68%
cephadm/services/node_proxy.py            126    103    18%
cephadm/services/nvmeof.py                196     72    63%
cephadm/services/oauth2_proxy.py           49      1    98%
cephadm/services/osd.py                   621    164    74%
cephadm/services/rgw_d3n.py                81     65    20%
cephadm/services/service_discovery.py     179     47    74%
cephadm/services/service_registry.py       37      1    97%
cephadm/services/smb.py                   253    128    49%
cephadm/ssh.py                            302    100    67%
cephadm/ssl_cert_utils.py                 176     46    74%
cephadm/template.py                        55      7    87%
cephadm/tlsobject_store.py                159     21    87%
cephadm/tlsobject_types.py                 92     15    84%
cephadm/tuned_profiles.py                  64      1    98%
cephadm/upgrade.py                        771    311    60%
cephadm/utils.py                          121     25    79%
-----------------------------------------------------------
TOTAL                                   12899   3843    70%

```

**SMB**: `tox -e coverage -- smb`

```
---------- coverage: platform linux, python 3.10.6-final-0 -----------
Name                  Stmts   Miss  Cover
-----------------------------------------
smb/__init__.py           5      0   100%
smb/cli.py               39      4    90%
smb/clustermeta.py      117    117     0%
smb/config_store.py     107     20    81%
smb/enums.py             88      0   100%
smb/external.py          45      3    93%
smb/fs.py               100      0   100%
smb/handler.py          697     85    88%
smb/internal.py         144      9    94%
smb/module.py           186     44    76%
smb/mon_store.py        135     85    37%
smb/proto.py             26      0   100%
smb/rados_store.py      171     50    71%
smb/resourcelib.py      330     23    93%
smb/resources.py        666     71    89%
smb/results.py           84      6    93%
smb/sqlite_store.py     312    218    30%
smb/staging.py          320     62    81%
smb/utils.py             20      0   100%
smb/validation.py        85     12    86%
-----------------------------------------
TOTAL                  3677    809    78%

```




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
