### PR TITLE
rgw: account presigned POST bytes_received in usage log

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1233,7 +1233,9 @@ int RGWPostObj_ObjStore::read_with_boundary(ceph::bufferlist& bl,
 
     bufferptr bp(need_to_read);
 
+    ACCOUNTING_IO(s)->set_account(true);
     const auto read_len = recv_body(s, bp.c_str(), need_to_read);
+    ACCOUNTING_IO(s)->set_account(false);
     if (read_len < 0) {
       return read_len;
     }
@@ -1265,7 +1267,9 @@ int RGWPostObj_ObjStore::read_with_boundary(ceph::bufferlist& bl,
     if (left < skip + 2) {
       int need = skip + 2 - left;
       bufferptr boundary_bp(need);
+      ACCOUNTING_IO(s)->set_account(true);
       const int r = recv_body(s, boundary_bp.c_str(), need);
+      ACCOUNTING_IO(s)->set_account(false);
       if (r < 0) {
         return r;
       }


### PR DESCRIPTION
## Problem

Presigned POST uploads report `bytes_received=0` in the usage log (`radosgw-admin usage show`), while equivalent PUT uploads report the full object size. Operators using the usage log for bandwidth accounting or billing undercount any traffic uploaded via presigned POST (browser form uploads, JavaScript SDKs, etc.).

## Cause

The `AccountingFilter` (`src/rgw/rgw_client_io_filters.h`) starts with `enabled=false`, so any `recv_body` call made while it is off contributes nothing to `total_received`. The PUT path explicitly toggles it on around its body read in `RGWPutObj_ObjStore::get_data`. The POST path does not. All POST body bytes pass through `RGWPostObj_ObjStore::read_with_boundary`, whose two `recv_body` call sites run with accounting off, so every byte pulled off the wire during multipart parsing is silently dropped by the accounter.

## Fix

Wrap the two `recv_body` calls in `read_with_boundary` with `ACCOUNTING_IO(s)->set_account(true/false)`, mirroring the PUT pattern. POST uploads now account correctly; PUT behavior is unchanged.

## Test

Reproduced and verified the fix on a vstart cluster (bluestore, `rgw_enable_usage_log=true`) by uploading the same 1 MiB body to the same bucket twice, once via `put_object` and once via `generate_presigned_post` + multipart form POST.

Before the patch:
```
post_obj  ops=1  bytes_received=0
put_obj   ops=1  bytes_received=1048576
```

After the patch:
```
post_obj  ops=1  bytes_received=1049891
put_obj   ops=1  bytes_received=1048576
```

The POST total matches the 1 MiB file body plus the ~1.3 KiB of multipart boundaries and part headers that the wire actually carried.

Tracker: https://tracker.ceph.com/issues/76157

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [x] No tests
