### PR TITLE
tentacle: cephadm: fix EndPoint to handle bracketed IPv6 addresses

### DIFF
--- a/src/cephadm/cephadmlib/net_utils.py
+++ b/src/cephadm/cephadmlib/net_utils.py
@@ -22,11 +22,11 @@ class EndPoint:
     """EndPoint representing an ip:port format"""
 
     def __init__(self, ip: str, port: int) -> None:
-        self.ip = ip
+        self.ip = ip.strip('[]')  # normalize: always store bare IP
         self.port = port
         self.is_ipv4 = True
         try:
-            if ip and ipaddress.ip_network(ip).version == 6:
+            if self.ip and ipaddress.ip_network(self.ip).version == 6:
                 self.is_ipv4 = False
         except Exception:
             logger.exception('Failed to check ip address version')

--- a/src/cephadm/cephadmlib/net_utils.py
+++ b/src/cephadm/cephadmlib/net_utils.py
@@ -307,7 +307,8 @@ def build_addrv_params(addrv: List[EndPoint]) -> str:
         else:
             ver = 'v2'  # default mon protocol version if port is not provided
             logger.warning(f'Using msgr2 protocol for unrecognized port {ep}')
-        addr_arg_list.append(f'{ver}:{ep.ip}:{ep.port}')
+        ip = wrap_ipv6(ep.ip) if is_ipv6(ep.ip) else ep.ip
+        addr_arg_list.append(f'{ver}:{ip}:{ep.port}')
 
     addr_arg = '[{0}]'.format(','.join(addr_arg_list))
     return addr_arg

--- a/src/cephadm/tests/test_networks.py
+++ b/src/cephadm/tests/test_networks.py
@@ -8,8 +8,43 @@ from tests.fixtures import with_cephadm_ctx, cephadm_fs, import_cephadm
 
 from cephadmlib.host_facts import _parse_ipv4_route, _parse_ipv6_route
 from cephadmlib.net_utils import get_ipv6_address
+from cephadmlib.net_utils import EndPoint
 
 _cephadm = import_cephadm()
+
+
+class TestEndPoint:
+    @pytest.mark.parametrize("ip, port, expected_str, expected_is_ipv4", [
+        # Normal IPv4
+        ('192.168.1.1', 3300, '192.168.1.1:3300', True),
+        # Normal IPv6 (bare)
+        ('fd19:8:5::11', 3300, '[fd19:8:5::11]:3300', False),
+        # Bracketed IPv6
+        ('[fd19:8:5::11]', 3300, '[fd19:8:5::11]:3300', False),
+        # Bracketed IPv6 should normalize stored ip to bare
+        ('[::1]', 6789, '[::1]:6789', False),
+    ])
+    def test_endpoint_init(self, ip, port, expected_str, expected_is_ipv4):
+        ep = EndPoint(ip, port)
+        assert str(ep) == expected_str
+        assert ep.is_ipv4 == expected_is_ipv4
+        # stored ip should always be bare (no brackets)
+        assert '[' not in ep.ip
+        assert ']' not in ep.ip
+
+    def test_endpoint_ipv4(self):
+        ep = EndPoint('10.0.0.1', 6789)
+        assert ep.is_ipv4 is True
+        assert repr(ep) == '10.0.0.1:6789'
+
+    def test_endpoint_ipv6(self):
+        ep = EndPoint('[fd19:8:5::11]', 6789)
+        assert ep.is_ipv4 is False
+        assert repr(ep) == '[fd19:8:5::11]:6789'
+
+    def test_endpoint_bracketed_ipv6_normalizes_stored_ip(self):
+        ep = EndPoint('[fd19:8:5::11]', 3300)
+        assert ep.ip == 'fd19:8:5::11'  # bare ipv6, no brackets
 
 
 class TestCommandListNetworks:

--- a/src/cephadm/tests/test_networks.py
+++ b/src/cephadm/tests/test_networks.py
@@ -285,3 +285,20 @@ fe80000000000000505400fffe04c154 03 40 20 80     eth1
             assert json.loads(capsys.readouterr().out) == {
                 '10.4.0.1/32': {'tun0': ['10.4.0.2']}
             }
+
+    def test_build_addrv_params_brackets_ipv6_endpoints_correctly(self):
+        from cephadmlib.net_utils import build_addrv_params, EndPoint
+
+        # IPv6 must be emitted as vX:[ip]:port (NOT vX:ip:port).
+        eps = [EndPoint('2001:db8:100::10', 3300), EndPoint('2001:db8:100::10', 6789)]
+        arg = build_addrv_params(eps)
+
+        assert arg == '[v2:[2001:db8:100::10]:3300,v1:[2001:db8:100::10]:6789]'
+
+    def test_build_addrv_params_ipv4_is_not_bracketed(self):
+        from cephadmlib.net_utils import build_addrv_params, EndPoint
+
+        eps = [EndPoint('192.168.100.100', 3300), EndPoint('192.168.100.100', 6789)]
+        arg = build_addrv_params(eps)
+
+        assert arg == '[v2:192.168.100.100:3300,v1:192.168.100.100:6789]'


### PR DESCRIPTION

Backport of https://github.com/ceph/ceph/pull/67530

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
