### PR TITLE
tentacle: mgr/dashboard: Difference in "path" value observed when rgw user level export created via dashboard vs cli

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/models/nfs.fsal.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/models/nfs.fsal.ts
@@ -1,3 +1,5 @@
+export const RGW_USER_EXPORT_PATH = '/';
+
 export enum SUPPORTED_FSAL {
   CEPH = 'CEPH',
   RGW = 'RGW'

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
@@ -12,7 +12,7 @@ import _ from 'lodash';
 import { forkJoin, Observable, of } from 'rxjs';
 import { catchError, debounceTime, distinctUntilChanged, map, mergeMap } from 'rxjs/operators';
 
-import { SUPPORTED_FSAL } from '~/app/ceph/nfs/models/nfs.fsal';
+import { RGW_USER_EXPORT_PATH, SUPPORTED_FSAL } from '~/app/ceph/nfs/models/nfs.fsal';
 import { Directory, NfsService } from '~/app/shared/api/nfs.service';
 import { RgwBucketService } from '~/app/shared/api/rgw-bucket.service';
 import { RgwSiteService } from '~/app/shared/api/rgw-site.service';
@@ -657,7 +657,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
       if (requestModel.rgw_export_type === 'bucket') {
         delete requestModel.fsal.user_id;
       } else {
-        requestModel.path = '';
+        requestModel.path = RGW_USER_EXPORT_PATH;
       }
     } else {
       delete requestModel.fsal.user_id;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.ts
@@ -23,7 +23,7 @@ import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { TaskListService } from '~/app/shared/services/task-list.service';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { getFsalFromRoute, getPathfromFsal } from '../utils';
-import { SUPPORTED_FSAL } from '../models/nfs.fsal';
+import { RGW_USER_EXPORT_PATH, SUPPORTED_FSAL } from '../models/nfs.fsal';
 import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 import { DeletionImpact } from '~/app/shared/enum/delete-confirmation-modal-impact.enum';
 
@@ -112,7 +112,9 @@ export class NfsListComponent extends ListWithDetails implements OnInit, OnDestr
         `/${prefix}/nfs/edit/${getNfsUri()}`,
         {
           rgw_export_type:
-            this.fsal === SUPPORTED_FSAL.RGW && !_.isEmpty(this.selection?.first()?.path)
+            this.fsal === SUPPORTED_FSAL.RGW &&
+            !_.isEmpty(this.selection?.first()?.path) &&
+            this.selection?.first()?.path !== RGW_USER_EXPORT_PATH
               ? RgwExportType.BUCKET
               : RgwExportType.USER
         }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76234

---

backport of https://github.com/ceph/ceph/pull/68541
parent tracker: https://tracker.ceph.com/issues/75425

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh