### PR TITLE
squid: ceph-volume: fix vendor detection for nvme devices

### DIFF
--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -800,14 +800,6 @@ def get_devices(_sys_block_path='/sys/block', device=''):
         if is_ceph_rbd(diskname):
             continue
 
-        # If the mapper device is a logical volume it gets excluded
-        try:
-            if UdevData(diskname).is_lvm:
-                continue
-        except RuntimeError:
-            logger.debug("get_devices(): device {} couldn't be found.".format(diskname))
-            continue
-
         # all facts that have no defaults
         # (<name>, <path relative to _sys_block_path>)
         facts = [('removable', 'removable'),


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75793

---

backport of https://github.com/ceph/ceph/pull/67996
parent tracker: https://tracker.ceph.com/issues/75708

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh