### PR TITLE
tentacle: python-common: fix raw OSD prepare to use osd-id instead of osd-ids

### DIFF
--- a/src/python-common/ceph/deployment/translate.py
+++ b/src/python-common/ceph/deployment/translate.py
@@ -144,7 +144,13 @@ class to_ceph_volume(object):
                 cmds[i] += " --data-allocate-fraction {}".format(self.spec.data_allocate_fraction)
 
             if self.osd_id_claims:
-                cmds[i] += " --osd-ids {}".format(" ".join(self.osd_id_claims))
+                if self.spec.method == 'raw':
+                    # raw prepare expects --osd-id (singular) for each device
+                    if i < len(self.osd_id_claims):
+                        cmds[i] += " --osd-id {}".format(self.osd_id_claims[i])
+                else:
+                    # lvm batch expects --osd-ids (plural) with all ids
+                    cmds[i] += " --osd-ids {}".format(" ".join(self.osd_id_claims))
 
             if self.spec.method != 'raw':
                 cmds[i] += " --yes"

--- a/src/python-common/ceph/tests/test_drive_group.py
+++ b/src/python-common/ceph/tests/test_drive_group.py
@@ -597,3 +597,38 @@ def test_raw_ceph_volume_command_4(test_input7):
     assert cmds[0] == 'raw prepare --bluestore --data /dev/sda --block.db /dev/sdd --block.wal /dev/sdg --crush-device-class hdd'
     assert cmds[1] == 'raw prepare --bluestore --data /dev/sdb --block.db /dev/sdf --block.wal /dev/sdi --crush-device-class nvme'
     assert cmds[2] == 'raw prepare --bluestore --data /dev/sdc --block.db /dev/sde --block.wal /dev/sdh --crush-device-class ssd'
+
+
+def test_raw_ceph_volume_command_5():
+    spec = DriveGroupSpec(placement=PlacementSpec(host_pattern='*'),
+                          service_id='foobar',
+                          data_devices=DeviceSelection(rotational=True),
+                          method='raw',
+                          osd_id_claims={'host1': ['0', '1']},
+                          )
+    spec.validate()
+    inventory = _mk_inventory(_mk_device(rotational=True) +
+                              _mk_device(rotational=True)
+                              )
+    sel = drive_selection.DriveSelection(spec, inventory)
+    cmds = translate.to_ceph_volume(sel, ['0', '1']).run()
+    assert cmds[0] == 'raw prepare --bluestore --data /dev/sda --osd-type classic --osd-id 0'
+    assert cmds[1] == 'raw prepare --bluestore --data /dev/sdb --osd-type classic --osd-id 1'
+
+
+def test_raw_ceph_volume_command_6():
+    spec = DriveGroupSpec(placement=PlacementSpec(host_pattern='*'),
+                          service_id='foobar',
+                          data_devices=DeviceSelection(rotational=True),
+                          method='raw',
+                          osd_id_claims={'host1': ['0']},
+                          )
+    spec.validate()
+    inventory = _mk_inventory(_mk_device(rotational=True) +
+                              _mk_device(rotational=True)
+                              )
+    sel = drive_selection.DriveSelection(spec, inventory)
+    cmds = translate.to_ceph_volume(sel, ['0']).run()
+    assert cmds[0] == 'raw prepare --bluestore --data /dev/sda --osd-type classic --osd-id 0'
+    assert cmds[1] == 'raw prepare --bluestore --data /dev/sdb --osd-type classic'
+


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75951

---

backport of https://github.com/ceph/ceph/pull/67842
parent tracker: https://tracker.ceph.com/issues/69284

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh