### PR TITLE
crimson/os/seastore: drop dead PRESENT assert in LogManager::resync_node

### DIFF
--- a/src/crimson/os/seastore/omap_manager/log/log_manager.cc
+++ b/src/crimson/os/seastore/omap_manager/log/log_manager.cc
@@ -70,10 +70,13 @@ LogManager::omap_set_keys(
   auto resync_node = [&](LogNodeRef e)
     -> log_load_extent_iertr::future<CachedExtentRef> {
     CachedExtentRef node;
-    [[maybe_unused]] Transaction::get_extent_ret ret;
-    // To find mutable extent in the same transaction
-    ret = t.get_extent(e->get_paddr(), &node);
-    assert(ret == Transaction::get_extent_ret::PRESENT);
+    // Look for a mutable version already tracked by this transaction.
+    auto ret = t.get_extent(e->get_paddr(), &node);
+    // ABSENT is expected when the target LogNode was newly created and is
+    // not yet tracked in the transaction's extent cache; fall through to a
+    // full reload below. RETIRED would mean the caller is resyncing an
+    // extent already removed in this transaction, which is a real logic bug.
+    ceph_assert(ret != Transaction::get_extent_ret::RETIRED);
     if (!node) {
       // Do full reload if not cached
       node = co_await log_load_extent<LogNode>(


### PR DESCRIPTION
## Summary

`LogManager::omap_set_keys` crashes a crimson OSD with
`Assertion 'ret == Transaction::get_extent_ret::PRESENT' failed`
inside `resync_node` during a pgmeta write.

Commit 8f95695e ("crimson/os/seastore: ensure extent is loaded if
missing from cache", Feb 2026) added a fallback reload for the case
where the extent isn't tracked by the transaction:

    if (!node) {
      node = co_await log_load_extent<LogNode>(
        t, e->get_laddr(), BEGIN_KEY, END_KEY);
    }

but left the pre-existing `assert(ret == PRESENT)` right above it. In
debug builds the assert fires before the fallback can run, so any
legitimately absent extent takes the OSD down.

Drops the PRESENT assert so the reload path actually runs, and keeps
a weaker guard against RETIRED. RETIRED here would mean the caller is
resyncing an extent it already removed in the same transaction —
that's a real logic bug worth catching.

Tracker: https://tracker.ceph.com/issues/75521
Tracker: https://tracker.ceph.com/issues/75520

## Test plan

- Built `crimson-osd`, `unittest-seastore`, `unittest-omap-manager` on
  a vstart dev box
- `unittest-seastore` passes (113s) — covers `pgmeta_io`, which
  exercises `LogManager::omap_set_keys` batching and multi-node chains
- `unittest-omap-manager` passes (314s)

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [x] No tests
