### PR TITLE
tentacle: mgr: fix continous smb MgrDBNotReady

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/smb.py
+++ b/src/pybind/mgr/dashboard/controllers/smb.py
@@ -451,6 +451,9 @@ class SMBStatus(RESTController):
     def status(self):
         status = {'available': False, 'message': None}
         try:
+            if not mgr.remote('smb', 'db_ready'):
+                status['message'] = 'SMB DB not ready. SMB module is unavailable.'
+                return status
             mgr.remote('smb', 'show', ['ceph.smb.cluster'])
             status['available'] = True
         except (ImportError, RuntimeError):

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -1874,6 +1874,16 @@ class Module(MgrModule, OrchestratorClientMixin):
                 self.log.debug("Orchestrator not available")
                 return
 
+            try:
+                if not self.remote('smb', 'db_ready'):
+                    self.log.debug(
+                        "SMB DB not ready, skipping SMB metadata collection"
+                    )
+                    return
+            except Exception as e:
+                self.log.debug(f"SMB DB readiness check failed: {str(e)}")
+                return
+
             smb_version = ""
 
             try:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76251

---

backport of https://github.com/ceph/ceph/pull/68483
parent tracker: https://tracker.ceph.com/issues/76151

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh