### PR TITLE
rgw/beast: dispatch connection close on strand during pause

### DIFF
--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -8,10 +8,12 @@
 #include <list>
 #include <memory>
 
+#include <boost/asio/any_io_executor.hpp>
 #include <boost/asio/bind_executor.hpp>
 #include <boost/asio/bind_cancellation_slot.hpp>
 #include <boost/asio/cancellation_signal.hpp>
 #include <boost/asio/detached.hpp>
+#include <boost/asio/dispatch.hpp>
 #include <boost/asio/error.hpp>
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
@@ -414,9 +416,14 @@ struct Connection : boost::intrusive::list_base_hook<>,
 {
   tcp::socket socket;
   parse_buffer buffer;
+  // executor of the handle_connection coroutine's strand. used so that close()
+  // from outside the strand (e.g. frontend pause) serializes with coroutine
+  // operations on the socket instead of racing the reactor
+  boost::asio::any_io_executor strand;
 
-  explicit Connection(tcp::socket&& socket) noexcept
-      : socket(std::move(socket)) {}
+  Connection(tcp::socket&& socket,
+             boost::asio::any_io_executor strand) noexcept
+      : socket(std::move(socket)), strand(std::move(strand)) {}
 
   void close(boost::system::error_code& ec) {
     socket.close(ec);
@@ -449,10 +456,19 @@ class ConnectionList {
     connections.push_back(conn);
     return Guard{this, &conn};
   }
-  void close(boost::system::error_code& ec) {
+  void close() {
     std::lock_guard lock{mutex};
     for (auto& conn : connections) {
-      conn.socket.close(ec);
+      // dispatch close() to the connection's strand so it serializes with
+      // the handle_connection coroutine. calling socket.close() from another
+      // thread can race with the coroutine's next async_read_some(), where
+      // the reactor would dereference the socket's descriptor_state after it
+      // has been deregistered
+      boost::asio::dispatch(conn.strand,
+        [c = boost::intrusive_ptr<Connection>{&conn}] {
+          boost::system::error_code ec;
+          c->socket.close(ec);
+        });
     }
     connections.clear();
   }
@@ -1194,7 +1210,8 @@ void AsioFrontend::on_accept(Listener& l, tcp::socket stream)
 #endif
     boost::asio::spawn(make_strand(context), std::allocator_arg, make_stack_allocator(),
       [this, s=std::move(stream), ssl_ctx] (boost::asio::yield_context yield) mutable {
-        auto conn = boost::intrusive_ptr{new Connection(std::move(s))};
+        auto conn = boost::intrusive_ptr{
+            new Connection(std::move(s), yield.get_executor())};
         auto c = connections.add(*conn);
         // wrap the tcp stream in an ssl stream
         boost::asio::ssl::stream<tcp::socket&> stream{conn->socket, *ssl_ctx};
@@ -1229,7 +1246,8 @@ void AsioFrontend::on_accept(Listener& l, tcp::socket stream)
 #endif // WITH_RADOSGW_BEAST_OPENSSL
     boost::asio::spawn(make_strand(context), std::allocator_arg, make_stack_allocator(),
       [this, s=std::move(stream)] (boost::asio::yield_context yield) mutable {
-        auto conn = boost::intrusive_ptr{new Connection(std::move(s))};
+        auto conn = boost::intrusive_ptr{
+            new Connection(std::move(s), yield.get_executor())};
         auto c = connections.add(*conn);
         auto timeout = timeout_timer{yield.get_executor(), request_timeout, conn};
         boost::system::error_code ec;
@@ -1274,7 +1292,7 @@ void AsioFrontend::stop()
   }
 
   // close all connections
-  connections.close(ec);
+  connections.close();
   pause_mutex.cancel();
 }
 
@@ -1300,7 +1318,7 @@ void AsioFrontend::pause()
   const bool graceful_stop{ g_ceph_context->_conf->rgw_graceful_stop };
   if (!graceful_stop) {
     // close all connections so outstanding requests fail quickly
-    connections.close(ec);
+    connections.close();
   }
 
   // pause and wait until outstanding requests complete


### PR DESCRIPTION
## Summary

Fixes a race between `AsioFrontend::pause()` and active keep-alive connections that crashes radosgw with a SIGSEGV in an `io_context_pool` thread during multisite period updates.

## Problem

When `radosgw-admin period update --commit` on one zone pushes a new period to a peer, the peer's realm reloader calls `AsioFrontend::pause()`, which invokes `ConnectionList::close()` to shut down live connections before rebuilding the driver. `close()` iterates the list and calls `socket.close()` on every connection from the reloader thread — not from the connection's asio strand.

Each close makes the reactor deregister the socket's `descriptor_state`. If a keep-alive connection is concurrently starting its next `async_read_some()` on its strand (which happens right after serving the inbound `POST /admin/realm/period` that triggered the reload), `epoll_reactor::start_op()` dereferences a `descriptor_state` that close has already freed — segfault inside the beast `read_some_op` dispatch chain.

The stack trace on the teuthology run in the tracker matches: top frames are `epoll_reactor::start_op` → `reactive_socket_service_base::async_receive` → `beast::http::detail::read_some_op`.

## Fix

Same pattern as 86ad0b891b0 (which fixed the `timeout_timer` running off the strand): anything that touches socket state from outside the strand has to be serialized with the coroutine.

- Store the coroutine's strand executor on `Connection` at construction time (via `yield.get_executor()` in `on_accept`'s spawn).
- `ConnectionList::close()` now `asio::dispatch()`es the `socket.close()` onto each connection's strand, so it runs in order with the coroutine's own socket ops.
- The dispatched lambda captures an `intrusive_ptr<Connection>` so the object outlives `connections.clear()`, which unlinks the list entry immediately.

## Testing

- Built `radosgw` with the change on a vstart multisite (2 zones, 1 zonegroup) set up via `src/test/rgw/test-rgw-multisite.sh`.
- Wrote a reproducer that alternates `zonegroup modify` endpoint lists on the master, issues `period update --commit` on the secondary, and floods the master's multisite gateway with concurrent keep-alive curls during each cycle.
- Unpatched main: SIGSEGV in `epoll_reactor::start_op` within the first few iterations, with the same signature as the tracker stack.
- With this fix: 30 iterations clean, 43 realm reload cycles ("Frontends paused" / "Resuming frontends") recorded, no crashes.

`test_period_update_commit` in `src/test/rgw/rgw_multi/tests.py` (added in 5e6a9c8f9de) already exercises this exact path — concurrent S3 writes while running multiple period-update-commit cycles. That's the test that hit this crash on Casey's 2026-04-17 trial and will gate the fix in the rgw/multisite teuthology suite.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [x] No tests

Tracker: https://tracker.ceph.com/issues/76094