### PR TITLE
rgw: multisite sync data_log error handling broken in tentacle

### DIFF
--- a/src/rgw/driver/rados/rgw_datalog.cc
+++ b/src/rgw/driver/rados/rgw_datalog.cc
@@ -210,13 +210,14 @@ public:
 			 << err.what() << dendl;
       throw;
     } catch (const sys::system_error& e) {
-      if (e.code() == sys::errc::no_such_file_or_directory) {
-	co_return std::make_tuple(entries.first(0), std::string{});
+      if (e.code() == sys::errc::no_such_file_or_directory ||
+          e.code() == ceph::buffer::errc::end_of_buffer) {
+        co_return std::make_tuple(entries.first(0), std::string{});
       } else {
-	ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
-			   << ": failed to list " << oids[shard]
-			   << ": " << e.what() << dendl;
-	throw;
+        ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
+              << ": failed to list " << oids[shard]
+              << ": " << e.what() << dendl;
+	      throw;
       }
     }
   }
@@ -228,7 +229,8 @@ public:
       co_return RGWDataChangesLogInfo{.marker = header.max_marker,
 				      .last_update = header.max_time};
     } catch (const sys::system_error& e) {
-      if (e.code() == sys::errc::no_such_file_or_directory) {
+      if (e.code() == sys::errc::no_such_file_or_directory || 
+          e.code() == ceph::buffer::errc::end_of_buffer) {
 	co_return RGWDataChangesLogInfo{};
       }
       ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
@@ -244,7 +246,8 @@ public:
 			  asio::use_awaitable);
       co_return;
     } catch (const sys::system_error& e) {
-      if (e.code() == sys::errc::no_such_file_or_directory) {
+      if (e.code() == sys::errc::no_such_file_or_directory || 
+          e.code() == ceph::buffer::errc::end_of_buffer) {
 	co_return;
       } else {
 	ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
@@ -268,7 +271,8 @@ public:
 	  co_return false;
 	}
       } catch (const sys::system_error& e) {
-	if (e.code() == sys::errc::no_such_file_or_directory) {
+	if (e.code() == sys::errc::no_such_file_or_directory || 
+      e.code() == ceph::buffer::errc::end_of_buffer) {
 	  continue;
 	}
       }
@@ -1474,7 +1478,8 @@ RGWDataChangesLog::read_sems(int index, std::string cursor) {
 				       &out, &cursor)),
       nullptr, asio::use_awaitable);
   } catch (const sys::system_error& e) {
-    if (e.code() != sys::errc::no_such_file_or_directory) {
+    if (e.code() != sys::errc::no_such_file_or_directory || 
+        e.code() == ceph::buffer::errc::end_of_buffer) {
       throw;
     }
   }
@@ -1705,7 +1710,8 @@ RGWDataChangesLog::admin_sem_list(std::optional<int> req_shard,
 	mkeep = marker;
       }
     } catch (const sys::system_error& e) {
-      if (e.code() == sys::errc::no_such_file_or_directory) {
+      if (e.code() == sys::errc::no_such_file_or_directory || 
+          e.code() == ceph::buffer::errc::end_of_buffer) {
 	if (!req_shard) {
 	  begin_next = true;
 	  ++shard;


### PR DESCRIPTION
The data_log error handling was broken in a recent refactor such that it
is not tolerant of missing data_log rados objects. This restores the tolerant 
behaviour.

I didn't go looking for instances of this out-with the file, it may be worth doing that too. 

Fixes: https://tracker.ceph.com/issues/76253
Signed-off-by: Alexander Hussein-Kershaw <alexander.husseinkershaw@alianza.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
