### PR TITLE
qa/erasure-code: Add test scenarios which enable allow_ec_optimizations on pools mid-test

### DIFF
--- a/qa/suites/rados/thrash-erasure-code-big/ec_optimizations/ec_optimizations_off_then_on.yaml
+++ b/qa/suites/rados/thrash-erasure-code-big/ec_optimizations/ec_optimizations_off_then_on.yaml
@@ -1,0 +1,11 @@
+overrides:
+  ceph:
+    conf:
+      global:
+        enable experimental unrecoverable data corrupting features: '*'
+        osd_pool_default_flag_ec_optimizations: false
+  thrashosds:
+    ec_optimizations_off_then_on: true
+  rados:
+    ops: 400000
+    max_seconds: 1800

--- a/qa/suites/rados/thrash-erasure-code-crush-4-nodes/ec_optimizations/ec_optimizations_off_then_on.yaml
+++ b/qa/suites/rados/thrash-erasure-code-crush-4-nodes/ec_optimizations/ec_optimizations_off_then_on.yaml
@@ -1,0 +1,11 @@
+overrides:
+  ceph:
+    conf:
+      global:
+        enable experimental unrecoverable data corrupting features: '*'
+        osd_pool_default_flag_ec_optimizations: false
+  thrashosds:
+    ec_optimizations_off_then_on: true
+  rados:
+    ops: 400000
+    max_seconds: 1800

--- a/qa/suites/rados/thrash-erasure-code-isa/ec_optimizations/ec_optimizations_off_then_on.yaml
+++ b/qa/suites/rados/thrash-erasure-code-isa/ec_optimizations/ec_optimizations_off_then_on.yaml
@@ -1,0 +1,11 @@
+overrides:
+  ceph:
+    conf:
+      global:
+        enable experimental unrecoverable data corrupting features: '*'
+        osd_pool_default_flag_ec_optimizations: false
+  thrashosds:
+    ec_optimizations_off_then_on: true
+  rados:
+    ops: 400000
+    max_seconds: 1800

--- a/qa/suites/rados/thrash-erasure-code-overwrites/ec_optimizations/ec_optimizations_off_then_on.yaml
+++ b/qa/suites/rados/thrash-erasure-code-overwrites/ec_optimizations/ec_optimizations_off_then_on.yaml
@@ -1,0 +1,11 @@
+overrides:
+  ceph:
+    conf:
+      global:
+        enable experimental unrecoverable data corrupting features: '*'
+        osd_pool_default_flag_ec_optimizations: false
+  thrashosds:
+    ec_optimizations_off_then_on: true
+  rados:
+    ops: 400000
+    max_seconds: 1800

--- a/qa/suites/rados/thrash-erasure-code-shec/ec_optimizations/ec_optimizations_off_then_on.yaml
+++ b/qa/suites/rados/thrash-erasure-code-shec/ec_optimizations/ec_optimizations_off_then_on.yaml
@@ -1,0 +1,11 @@
+overrides:
+  ceph:
+    conf:
+      global:
+        enable experimental unrecoverable data corrupting features: '*'
+        osd_pool_default_flag_ec_optimizations: false
+  thrashosds:
+    ec_optimizations_off_then_on: true
+  rados:
+    ops: 400000
+    max_seconds: 1800

--- a/qa/suites/rados/thrash-erasure-code/ec_optimizations/ec_optimizations_off_then_on.yaml
+++ b/qa/suites/rados/thrash-erasure-code/ec_optimizations/ec_optimizations_off_then_on.yaml
@@ -1,0 +1,11 @@
+overrides:
+  ceph:
+    conf:
+      global:
+        enable experimental unrecoverable data corrupting features: '*'
+        osd_pool_default_flag_ec_optimizations: false
+  thrashosds:
+    ec_optimizations_off_then_on: true
+  rados:
+    ops: 400000
+    max_seconds: 1800

--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -238,6 +238,8 @@ class OSDThrasher(Thrasher):
         self.chance_force_recovery = self.config.get('chance_force_recovery', 0.3)
         self.chance_reset_purged_snaps_last = self.config.get('chance_reset_purged_snaps_last', 0.3)
         self.chance_trim_stale_osdmaps = self.config.get('chance_trim_stale_osdmaps', 0.3)
+        self.ec_opts_enable = self.config.get('ec_optimizations_off_then_on', False)
+        self.ec_opts_delay = self.config.get('ec_optimizations_delay', random.uniform(300, 900))
 
         num_osds = self.in_osds + self.out_osds
         self.max_pgs = self.config.get("max_pgs_per_pool_osd", 1200) * len(num_osds)
@@ -283,6 +285,10 @@ class OSDThrasher(Thrasher):
             self.dump_ops_thread = gevent.spawn(self.do_dump_ops)
         if self.noscrub_toggle_delay:
             self.noscrub_toggle_thread = gevent.spawn(self.do_noscrub_toggle)
+        if self.ec_opts_enable:
+            # need delay to let some objects be written before enabling optimizations
+            self.ec_opts_enable_thread = gevent.spawn_later(self.ec_opts_delay,
+                                                            self.do_ec_opts_enable)
 
     def log(self, msg, *args, **kwargs):
         self.logger.info(msg, *args, **kwargs)
@@ -893,6 +899,9 @@ class OSDThrasher(Thrasher):
         if self.noscrub_toggle_delay:
             self.log("joining the do_noscrub_toggle greenlet")
             self.noscrub_toggle_thread.join()
+        if self.ec_opts_enable:
+            self.log("joining the do_ec_opts_enable greenlet")
+            self.ec_opts_enable_thread.join()
 
     def stop_and_join(self):
         """
@@ -1469,6 +1478,25 @@ class OSDThrasher(Thrasher):
             gevent.sleep(delay)
         self.ceph_manager.raw_cluster_cmd('osd', 'unset', 'noscrub')
         self.ceph_manager.raw_cluster_cmd('osd', 'unset', 'nodeep-scrub')
+
+    @log_exc
+    def do_ec_opts_enable(self):
+        """
+        Loop through pools and enable allow_ec_optimizations on
+        any EC pools with optimizations disabled.
+        """
+        pools_json = self.ceph_manager.get_osd_dump_json()['pools']
+        enabled_count = 0
+        for pool_json in pools_json:
+            pool = pool_json['pool_name']
+            pool_type = pool_json['type']
+            if pool_type != PoolType.ERASURE_CODED:
+                continue
+            pool_ec_opts = self.ceph_manager.get_pool_property(pool, 'allow_ec_optimizations')
+            if pool_ec_opts == 'false':
+                self.ceph_manager.set_pool_property(pool, 'allow_ec_optimizations', 1)
+                enabled_count += 1
+        assert enabled_count > 0
 
     @log_exc
     def _do_thrash(self):


### PR DESCRIPTION
Our existing testing of allow_ec_optimizations does not sufficiently cover enabling allow_ec_optimizations on an EC pool with existing objects. This commit adds a new ec_optimizations_off_then_on setting in the thrasher which will turn optimizations on any existing EC pools after a small time delay, either random or set by config value.

ceph_test_rados will perform an IO workload on an EC pool, then the thrasher will attempt to turn on optimizations for every EC pool which does not already have optimizations on. The thrasher will assert if this fails or if it does not find any pools which can have optimizations turned on.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
