### PR TITLE
doc/rados: document require_osd_release and require_min_compat_client

### DIFF
--- a/doc/cephfs/administration.rst
+++ b/doc/cephfs/administration.rst
@@ -299,6 +299,8 @@ the following ``mon`` configuration:
 .. confval:: mon_fsmap_prune_threshold
 
 
+.. _cephfs_required_client_features:
+
 Required Client Features
 ------------------------
 

--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -647,6 +647,21 @@ Since migration of Filestore OSDs to BlueStore can take a considerable amount
 of time to complete, we recommend that you begin the process well in advance
 of any update to Reef or to later releases.
 
+OSD_UPGRADE_FINISHED
+____________________
+
+All up OSDs are running a release newer than ``require_osd_release``,
+which means the cluster is ready to advance the gate but the operator
+has not yet done so.
+
+Run the following command to clear the warning:
+
+.. prompt:: bash #
+
+   ceph osd require-osd-release <release>
+
+See :ref:`OSD_UPGRADE_FINISHED` for full details.
+
 OSD_UNREACHABLE
 _______________
 

--- a/doc/rados/operations/index.rst
+++ b/doc/rados/operations/index.rst
@@ -45,6 +45,7 @@ CRUSH algorithm.
         read-balancer
         balancer
 	require-min-compat-client
+	require-osd-release
 	crush-map
 	crush-map-edits
 	stretch-mode

--- a/doc/rados/operations/index.rst
+++ b/doc/rados/operations/index.rst
@@ -44,6 +44,7 @@ CRUSH algorithm.
 	upmap
         read-balancer
         balancer
+	require-min-compat-client
 	crush-map
 	crush-map-edits
 	stretch-mode

--- a/doc/rados/operations/read-balancer.rst
+++ b/doc/rados/operations/read-balancer.rst
@@ -55,6 +55,10 @@ command:
 
    ceph features
 
+See :ref:`require_min_compat_client` for what the
+``set-require-min-compat-client`` command does and how to choose an
+appropriate release argument.
+
 Balancer Module
 ---------------
 

--- a/doc/rados/operations/require-min-compat-client.rst
+++ b/doc/rados/operations/require-min-compat-client.rst
@@ -1,0 +1,142 @@
+.. _require_min_compat_client:
+
+===========================
+ Minimum Compatible Client
+===========================
+
+The ``require_min_compat_client`` field of the OSDMap declares the minimum
+Ceph client release the cluster expects of its clients. It is an
+operator-set hint that authorizes use of on-map features whose encoding
+or semantics older clients cannot parse.
+
+Setting the flag does not refuse older clients at connect time. Instead it
+gates operator commands that would place feature bits into the OSDMap which
+only newer clients understand. Once those features are in active use,
+older clients can no longer parse the OSDMap; they lose the ability to
+locate objects and will error or disconnect.
+
+Setting the flag
+================
+
+.. prompt:: bash $
+
+   ceph osd set-require-min-compat-client <release>
+
+For example, to declare that the cluster requires at least *reef*:
+
+.. prompt:: bash $
+
+   ceph osd set-require-min-compat-client reef
+
+Before committing the change, the Monitors inspect connected clients, MDSs,
+and Managers. If any advertise release-feature bits that fall short of the
+target, the command is rejected with a message like::
+
+   cannot set require_min_compat_client to reef:
+     3 connected client(s) look like luminous (missing 0x...)
+
+Pass ``--yes-i-really-mean-it`` to proceed anyway. Those clients will be
+disconnected once any feature the flag unlocks is actually enabled on the
+map.
+
+Checking the current value
+==========================
+
+.. prompt:: bash $
+
+   ceph osd get-require-min-compat-client
+
+or, for the full OSDMap context:
+
+.. prompt:: bash $
+
+   ceph osd dump | grep require_min_compat_client
+
+To see which release each connected entity advertises:
+
+.. prompt:: bash $
+
+   ceph features
+
+Lowering the flag
+=================
+
+Unlike :ref:`require_osd_release`, ``require_min_compat_client`` is not
+monotonic. Monitors accept a lower value as long as no feature
+currently on the OSDMap requires a higher one. The floor is computed from
+features in active use on the map:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 55 25
+
+   * - Feature in use
+     - Minimum release
+   * - CRUSH MSR rules
+     - ``squid``
+   * - ``pg-upmap-primary`` entries
+     - ``reef``
+   * - ``pg-upmap`` entries or CRUSH choose-args
+     - ``luminous``
+   * - CRUSH tunables level 5
+     - ``jewel``
+   * - CRUSH straw2 buckets
+     - ``hammer``
+   * - Per-OSD primary affinity, tunables level 3, or cache tiers
+     - ``firefly``
+   * - CRUSH tunables level 2 or ``OSDHASHPSPOOL`` pool flag
+     - ``dumpling``
+   * - CRUSH tunables (any non-legacy)
+     - ``argonaut``
+
+The last two rows are effectively always satisfied on modern clusters,
+since ``OSDHASHPSPOOL`` has been set by default on every pool since
+``dumpling`` and non-legacy CRUSH tunables have been the default since
+``argonaut``. They are listed for completeness; in practice the floor
+only ever sits at ``firefly`` or newer.
+
+If the command fails and prints ``osdmap current utilizes features that
+require <release>; cannot set require_min_compat_client below that``,
+remove the feature that pins the floor (for example, clear all
+``pg-upmap-primary`` entries) and retry.
+
+Features gated by the flag
+==========================
+
+Raising the flag does not enable any feature on its own. It authorizes the
+operator to run commands that would otherwise be rejected with an error
+like ``min_compat_client luminous < reef, which is required for
+pg-upmap-primary``:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 60 25
+
+   * - Command
+     - Minimum release
+   * - | ``ceph osd primary-affinity``
+       | ``ceph osd primary-temp``
+       | ``ceph osd rm-primary-temp``
+     - ``firefly``
+   * - | ``ceph osd pg-upmap``
+       | ``ceph osd rm-pg-upmap``
+       | ``ceph osd pg-upmap-items``
+       | ``ceph osd rm-pg-upmap-items``
+       | ``ceph osd crush weight-set``
+       | balancer ``upmap`` mode
+     - ``luminous``
+   * - | ``ceph osd pg-upmap-primary``
+       | ``ceph osd rm-pg-upmap-primary``
+       | ``ceph osd rm-pg-upmap-primary-all``
+       | balancer ``read`` mode
+       | balancer ``upmap-read`` mode
+     - ``reef``
+
+Note that adding CRUSH MSR rules is *not* gated at command time; however,
+once an MSR rule is in the map, the features-in-use floor rises to
+``squid`` (see the table above).
+
+See :ref:`upmap` and :ref:`read_balancer` for the operational procedures
+that depend on raising the flag. CephFS clients must satisfy both this
+flag and any per-filesystem :ref:`cephfs_required_client_features` on
+the file systems they mount.

--- a/doc/rados/operations/require-osd-release.rst
+++ b/doc/rados/operations/require-osd-release.rst
@@ -1,0 +1,138 @@
+.. _require_osd_release:
+
+=====================
+ Minimum OSD Release
+=====================
+
+The ``require_osd_release`` field of the OSDMap is the cluster-wide
+declaration that every OSD is running at least the named release. It is
+set by the operator at the tail of a cluster upgrade, once all OSDs have
+been upgraded to the new binary. Raising it unlocks features that would
+otherwise be rejected as unsafe, and it bounds how far ahead of the
+cluster a new OSD release is allowed to boot.
+
+Unlike :ref:`require_min_compat_client`, which can be lowered when
+features in use permit, ``require_osd_release`` can only move forward.
+
+Setting the flag
+================
+
+.. prompt:: bash $
+
+   ceph osd require-osd-release <release>
+
+For example, after finishing an upgrade to *tentacle*:
+
+.. prompt:: bash $
+
+   ceph osd require-osd-release tentacle
+
+Monitors only accept a small set of recent release names. The current
+accepted targets are ``squid``, ``tentacle``, and ``umbrella``; any
+older release name is rejected with ``not supported for this release``.
+The accepted set slides forward as new Ceph releases are added.
+
+The target release must be in the accepted set and must not be older
+than the current value; setting it to the current value is a no-op.
+Additionally, the Monitors verify that every Monitor in the quorum and
+every up OSD advertises the target release's feature bits. The Monitor
+feature check has no bypass; the OSD feature check can be overridden
+with ``--yes-i-really-mean-it``, but any OSD that lacks the feature
+will still be refused when it tries to boot (see `OSD boot window`_).
+
+Checking the current value
+==========================
+
+.. prompt:: bash $
+
+   ceph osd dump | grep require_osd_release
+
+What raising the flag enables
+=============================
+
+Raising ``require_osd_release`` unlocks a set of commands and features
+that the monitor refuses while the flag is below the required level.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 70
+
+   * - Required release
+     - Commands or features unlocked
+   * - ``luminous``
+     - ``ceph osd crush set-device-class``, ``ceph osd crush
+       rm-device-class``
+   * - ``nautilus``
+     - ``pg_autoscale_mode``, ``target_size_bytes``, ``target_size_ratio``,
+       new-format ``pg_num`` changes
+   * - ``tentacle``
+     - ``allow_ec_optimizations`` pool flag
+
+The gates are cumulative: a cluster whose ``require_osd_release`` is at
+``squid`` or higher satisfies the ``luminous`` and ``nautilus`` gates
+automatically. Because the current accepted-target set does not include
+releases older than ``squid``, the ``luminous`` and ``nautilus`` rows
+are historical on modern clusters and are listed for completeness.
+
+OSD boot window
+===============
+
+An OSD refuses to boot if it is running a release that is more than
+two ahead of ``require_osd_release``. For example, with
+``require_osd_release`` set to ``reef``:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 25 50
+
+   * - OSD release
+     - Boots?
+     - Notes
+   * - ``reef``
+     - yes
+     - Same release.
+   * - ``squid``
+     - yes
+     - One release ahead.
+   * - ``tentacle``
+     - yes
+     - Two releases ahead (at the edge of the window).
+   * - ``umbrella``
+     - **no**
+     - ``disallowing boot of umbrella+ OSD ... because
+       require_osd_release < squid``
+
+This sliding window forces operators to raise ``require_osd_release``
+roughly every two releases, keeping the cluster's OSD code span
+bounded.
+
+.. _OSD_UPGRADE_FINISHED:
+
+Health warning: ``OSD_UPGRADE_FINISHED``
+========================================
+
+If all up OSDs advertise the ``SERVER_<RELEASE>`` feature but
+``require_osd_release`` is still below that release, the Monitors emit
+a ``HEALTH_WARN`` check ``OSD_UPGRADE_FINISHED`` with the message::
+
+   all OSDs are running <release> or later but require_osd_release < <release>
+
+The appearance of this warning is the normal cue to run
+``ceph osd require-osd-release <release>``; the warning clears once the
+flag has been raised.
+
+Initial value on new clusters
+=============================
+
+New clusters start with ``require_osd_release`` set to the newest
+release the Monitor code knows about. On this release that is
+``umbrella``. Two developer options adjust the initial value for
+testing; neither should be used in production.
+
+.. confval:: mon_debug_no_require_umbrella
+.. confval:: mon_debug_no_require_tentacle
+
+Setting ``mon_debug_no_require_umbrella`` alone downshifts the initial
+value to ``tentacle``; setting both flags downshifts it further to
+``squid``. The ``tentacle`` flag has no effect unless the umbrella flag
+is also set.

--- a/doc/rados/operations/upmap.rst
+++ b/doc/rados/operations/upmap.rst
@@ -44,6 +44,10 @@ command:
 
    ceph features
 
+See :ref:`require_min_compat_client` for what the
+``set-require-min-compat-client`` command does and how to choose an
+appropriate release argument.
+
 Balancer Module
 ---------------
 


### PR DESCRIPTION
This changeset adds pages under `doc/rados/operations/` for the OSDMap upgrade-gate flags `require_osd_release` and `require_min_compat_client`, which are currently only covered in per-release upgrade procedures and a one-paragraph `ceph(8)` entry for the latter. Each page documents how to set and check the flag, its behavior (monotonic for `require_osd_release`, features-in-use floor for `require_min_compat_client`), and the commands it gates.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
