### PR TITLE
rbd: defer image name publish until metadata succeeds

### DIFF
--- a/src/librbd/image/CreateRequest.cc
+++ b/src/librbd/image/CreateRequest.cc
@@ -125,13 +125,15 @@ CreateRequest<I>::CreateRequest(const ConfigProxy& config, IoCtx &ioctx,
                                 const std::string &non_primary_global_image_id,
                                 const std::string &primary_mirror_uuid,
                                 asio::ContextWQ *op_work_queue,
-                                Context *on_finish)
+                                Context *on_finish,
+                                const CreateRequestFaultInjector& fault_injector)
   : m_config(config), m_image_name(image_name), m_image_id(image_id),
     m_size(size), m_create_flags(create_flags),
     m_mirror_image_mode(mirror_image_mode),
     m_non_primary_global_image_id(non_primary_global_image_id),
     m_primary_mirror_uuid(primary_mirror_uuid),
-    m_op_work_queue(op_work_queue), m_on_finish(on_finish) {
+    m_op_work_queue(op_work_queue), m_on_finish(on_finish),
+    m_fault_injector(fault_injector) {
 
   m_io_ctx.dup(ioctx);
   m_cct = reinterpret_cast<CephContext *>(m_io_ctx.cct());
@@ -275,7 +277,7 @@ void CreateRequest<I>::validate_data_pool() {
   }
 
   if (!m_config.get_val<bool>("rbd_validate_pool")) {
-    add_image_to_directory();
+    negotiate_features();
     return;
   }
 
@@ -301,7 +303,7 @@ void CreateRequest<I>::handle_validate_data_pool(int r) {
     return;
   }
 
-  add_image_to_directory();
+  negotiate_features();
 }
 
 template<typename I>
@@ -329,21 +331,30 @@ void CreateRequest<I>::handle_add_image_to_directory(int r) {
   if (r == -EEXIST) {
     ldout(m_cct, 5) << "directory entry for image " << m_image_name
                     << " already exists" << dendl;
-    complete(r);
-    return;
   } else if (!m_io_ctx.get_namespace().empty() && r == -ENOENT) {
     ldout(m_cct, 5) << "namespace " << m_io_ctx.get_namespace()
                     << " does not exist" << dendl;
-    complete(r);
-    return;
   } else if (r < 0) {
     lderr(m_cct) << "error adding image to directory: " << cpp_strerror(r)
                  << dendl;
-    complete(r);
+  }
+
+  if (r < 0) {
+    // Roll back only the metadata created by this attempt. remove_from_dir()
+    // uses (name, id), so a pre-existing image with the same name is not
+    // unpublished if dir_add_image() collided with another image id.
+    m_r_saved = r;
+    remove_mirror_image();
     return;
   }
 
-  create_id_object();
+  m_directory_added = true;
+
+  if (check_fault_injection("after_dir_add") < 0) {
+    return;
+  }
+
+  complete(0);
 }
 
 template<typename I>
@@ -369,18 +380,27 @@ void CreateRequest<I>::handle_create_id_object(int r) {
   if (r == -EEXIST) {
     ldout(m_cct, 5) << "id object for  " << m_image_name << " already exists"
                     << dendl;
-    m_r_saved = r;
-    remove_from_dir();
-    return;
   } else if (r < 0) {
     lderr(m_cct) << "error creating RBD id object: " << cpp_strerror(r)
                  << dendl;
+  }
+
+  if (r < 0) {
+    // The create flow already owns the new header / optional metadata when
+    // create_id_object() runs, so unwind the current attempt even on EEXIST.
+    // remove_from_dir() remains scoped to this attempt's (name, id) pair.
     m_r_saved = r;
-    remove_from_dir();
+    remove_mirror_image();
     return;
   }
 
-  negotiate_features();
+  m_id_object_created = true;
+
+  if (check_fault_injection("after_id_create") < 0) {
+    return;
+  }
+
+  add_image_to_directory();
 }
 
 template<typename I>
@@ -427,6 +447,18 @@ void CreateRequest<I>::handle_negotiate_features(int r) {
 }
 
 template<typename I>
+int CreateRequest<I>::check_fault_injection(std::string_view stage) {
+  int r = m_fault_injector.check(stage);
+  if (r < 0) {
+    ldout(m_cct, 5) << "injecting create failure at stage '" << stage
+                    << "': " << cpp_strerror(r) << dendl;
+    m_r_saved = r;
+    remove_mirror_image();
+  }
+  return r;
+}
+
+template<typename I>
 void CreateRequest<I>::create_image() {
   ldout(m_cct, 15) << dendl;
   ceph_assert(m_data_pool.empty() || m_data_pool_id != -1);
@@ -439,8 +471,7 @@ void CreateRequest<I>::create_image() {
   oss << m_image_id;
   if (oss.str().length() > RBD_MAX_BLOCK_NAME_PREFIX_LENGTH) {
     lderr(m_cct) << "object prefix '" << oss.str() << "' too large" << dendl;
-    m_r_saved = -EINVAL;
-    remove_id_object();
+    complete(-EINVAL);
     return;
   }
 
@@ -467,8 +498,11 @@ void CreateRequest<I>::handle_create_image(int r) {
     return;
   } else if (r < 0) {
     lderr(m_cct) << "error writing header: " << cpp_strerror(r) << dendl;
-    m_r_saved = r;
-    remove_id_object();
+    complete(r);
+    return;
+  }
+
+  if (check_fault_injection("after_header") < 0) {
     return;
   }
 
@@ -649,7 +683,7 @@ void CreateRequest<I>::mirror_image_enable() {
   if ((m_mirror_mode != cls::rbd::MIRROR_MODE_POOL &&
        mirror_enable_flag != CREATE_FLAG_FORCE_MIRROR_ENABLE) ||
       (mirror_enable_flag == CREATE_FLAG_SKIP_MIRROR_ENABLE)) {
-    complete(0);
+    create_id_object();
     return;
   }
 
@@ -672,11 +706,12 @@ void CreateRequest<I>::handle_mirror_image_enable(int r) {
                  << dendl;
 
     m_r_saved = r;
-    journal_remove();
+    remove_mirror_image();
     return;
   }
 
-  complete(0);
+  m_mirror_image_enabled = true;
+  create_id_object();
 }
 
 template<typename I>
@@ -690,6 +725,38 @@ void CreateRequest<I>::complete(int r) {
 }
 
 // cleanup
+template<typename I>
+void CreateRequest<I>::remove_mirror_image() {
+  if (!m_mirror_image_enabled) {
+    journal_remove();
+    return;
+  }
+
+  ldout(m_cct, 15) << dendl;
+
+  librados::ObjectWriteOperation op;
+  cls_client::mirror_image_remove(&op, m_image_id);
+
+  using klass = CreateRequest<I>;
+  librados::AioCompletion *comp =
+    create_rados_callback<klass, &klass::handle_remove_mirror_image>(this);
+  int r = m_io_ctx.aio_operate(RBD_MIRRORING, comp, &op);
+  ceph_assert(r == 0);
+  comp->release();
+}
+
+template<typename I>
+void CreateRequest<I>::handle_remove_mirror_image(int r) {
+  ldout(m_cct, 15) << "r=" << r << dendl;
+
+  if (r < 0 && r != -ENOENT) {
+    lderr(m_cct) << "error cleaning up mirror image after creation failed: "
+                 << cpp_strerror(r) << dendl;
+  }
+
+  journal_remove();
+}
+
 template<typename I>
 void CreateRequest<I>::journal_remove() {
   if ((m_features & RBD_FEATURE_JOURNALING) == 0) {
@@ -717,7 +784,7 @@ template<typename I>
 void CreateRequest<I>::handle_journal_remove(int r) {
   ldout(m_cct, 15) << "r=" << r << dendl;
 
-  if (r < 0) {
+  if (r < 0 && r != -ENOENT) {
     lderr(m_cct) << "error cleaning up journal after creation failed: "
                  << cpp_strerror(r) << dendl;
   }
@@ -746,7 +813,7 @@ template<typename I>
 void CreateRequest<I>::handle_remove_object_map(int r) {
   ldout(m_cct, 15) << "r=" << r << dendl;
 
-  if (r < 0) {
+  if (r < 0 && r != -ENOENT) {
     lderr(m_cct) << "error cleaning up object map after creation failed: "
                  << cpp_strerror(r) << dendl;
   }
@@ -770,7 +837,7 @@ template<typename I>
 void CreateRequest<I>::handle_remove_header_object(int r) {
   ldout(m_cct, 15) << "r=" << r << dendl;
 
-  if (r < 0) {
+  if (r < 0 && r != -ENOENT) {
     lderr(m_cct) << "error cleaning up image header after creation failed: "
                  << cpp_strerror(r) << dendl;
   }
@@ -781,6 +848,11 @@ void CreateRequest<I>::handle_remove_header_object(int r) {
 template<typename I>
 void CreateRequest<I>::remove_id_object() {
   ldout(m_cct, 15) << dendl;
+
+  if (!m_id_object_created) {
+    remove_from_dir();
+    return;
+  }
 
   using klass = CreateRequest<I>;
   librados::AioCompletion *comp =
@@ -794,7 +866,7 @@ template<typename I>
 void CreateRequest<I>::handle_remove_id_object(int r) {
   ldout(m_cct, 15) << "r=" << r << dendl;
 
-  if (r < 0) {
+  if (r < 0 && r != -ENOENT) {
     lderr(m_cct) << "error cleaning up id object after creation failed: "
                  << cpp_strerror(r) << dendl;
   }
@@ -805,6 +877,11 @@ void CreateRequest<I>::handle_remove_id_object(int r) {
 template<typename I>
 void CreateRequest<I>::remove_from_dir() {
   ldout(m_cct, 15) << dendl;
+
+  if (!m_directory_added) {
+    complete(m_r_saved);
+    return;
+  }
 
   librados::ObjectWriteOperation op;
   cls_client::dir_remove_image(&op, m_image_name, m_image_id);
@@ -821,7 +898,7 @@ template<typename I>
 void CreateRequest<I>::handle_remove_from_dir(int r) {
   ldout(m_cct, 15) << "r=" << r << dendl;
 
-  if (r < 0) {
+  if (r < 0 && r != -ENOENT) {
     lderr(m_cct) << "error cleaning up image from rbd_directory object "
                  << "after creation failed: " << cpp_strerror(r) << dendl;
   }

--- a/src/librbd/image/CreateRequest.h
+++ b/src/librbd/image/CreateRequest.h
@@ -5,12 +5,14 @@
 #define CEPH_LIBRBD_IMAGE_CREATE_REQUEST_H
 
 #include "common/config_fwd.h"
+#include "common/fault_injector.h"
 #include "include/int_types.h"
 #include "include/buffer.h"
 #include "include/rados/librados.hpp"
 #include "include/rbd/librbd.hpp"
 #include "cls/rbd/cls_rbd_types.h"
 #include "librbd/ImageCtx.h"
+#include <string_view>
 
 class Context;
 
@@ -24,6 +26,8 @@ namespace asio { struct ContextWQ; }
 
 namespace image {
 
+using CreateRequestFaultInjector = FaultInjector<std::string_view>;
+
 template <typename ImageCtxT = ImageCtx>
 class CreateRequest {
 public:
@@ -36,11 +40,14 @@ public:
                                const std::string &non_primary_global_image_id,
                                const std::string &primary_mirror_uuid,
                                asio::ContextWQ *op_work_queue,
-                               Context *on_finish) {
+                               Context *on_finish,
+                               const CreateRequestFaultInjector& fault_injector =
+                                 {}) {
     return new CreateRequest(config, ioctx, image_name, image_id, size,
                              image_options, create_flags,
                              mirror_image_mode, non_primary_global_image_id,
-                             primary_mirror_uuid, op_work_queue, on_finish);
+                             primary_mirror_uuid, op_work_queue, on_finish,
+                             fault_injector);
   }
 
   static int validate_order(CephContext *cct, uint8_t order);
@@ -51,41 +58,56 @@ private:
   /**
    * @verbatim
    *
-   *                                  <start> . . . . > . . . . .
-   *                                     |                      .
-   *                                     v                      .
-   *                               VALIDATE DATA POOL           v (pool validation
-   *                                     |                      .  disabled)
-   *                                     v                      .
-   * (error: bottom up)         ADD IMAGE TO DIRECTORY  < . . . .
-   *  _______<_______                    |
-   * |               |                   v
-   * |               |            CREATE ID OBJECT
-   * |               |               /   |
-   * |      REMOVE FROM DIR <-------/    v
-   * |               |           NEGOTIATE FEATURES (when using default features)
-   * |               |                   |
-   * |               |                   v         (stripingv2 disabled)
-   * |               |              CREATE IMAGE. . . . > . . . .
-   * v               |               /   |                      .
-   * |      REMOVE ID OBJ <---------/    v                      .
-   * |               |          SET STRIPE UNIT COUNT           .
-   * |               |               /   |  \ . . . . . > . . . .
-   * |      REMOVE HEADER OBJ<------/    v                     /. (object-map
-   * |               |\           OBJECT MAP RESIZE . . < . . * v  disabled)
-   * |               | \              /  |  \ . . . . . > . . . .
-   * |               |  *<-----------/   v                     /. (journaling
-   * |               |             FETCH MIRROR MODE. . < . . * v  disabled)
-   * |               |                /   |                     .
-   * |     REMOVE OBJECT MAP<--------/    v                     .
-   * |               |\             JOURNAL CREATE              .
-   * |               | \               /  |                     .
-   * v               |  *<------------/   v                     .
-   * |               |           MIRROR IMAGE ENABLE            .
-   * |               |                /   |                     .
-   * |        JOURNAL REMOVE*<-------/    |                     .
-   * |                                    v                     .
-   * |_____________>___________________<finish> . . . . < . . . .
+    *           <start>
+    *              |
+    *              v
+    *      VALIDATE DATA POOL
+    *              |
+    *              v
+    *     NEGOTIATE FEATURES (optional)
+    *              |
+    *              v
+    *        CREATE IMAGE HEADER
+    *              |
+    *              v
+    *   FAIL AFTER HEADER (fault injector: "after_header")
+    *              |
+    *              v
+    *    SET STRIPE UNIT / COUNT
+    *              |
+    *              v
+    *      OBJECT MAP RESIZE (if enabled)
+    *              |
+    *              v
+    *     FETCH MIRROR MODE (if journaling)
+    *              |
+    *              v
+    *        JOURNAL CREATE (if enabled)
+    *              |
+    *              v
+    *     MIRROR IMAGE ENABLE (if requested)
+    *              |
+    *              v
+    *       CREATE rbd_id.<name>
+    *              |
+    *              v
+    *   FAIL AFTER ID CREATE (fault injector: "after_id_create")
+    *              |
+    *              v
+    *       ADD TO rbd_directory
+    *              |
+    *              v
+    *   FAIL AFTER DIR ADD (fault injector: "after_dir_add")
+    *              |
+    *              v
+    *            <finish>
+    *
+    * CreateRequestFaultInjector supports InjectError, InjectAbort, and
+    * InjectDelay at the named checkpoints above.
+    *
+    * Cleanup path: remove_mirror_image -> journal_remove -> remove_object_map
+    * -> remove_header_object -> remove_id_object -> remove_from_dir
+    * -> complete(m_r_saved).
    *
    * @endverbatim
    */
@@ -98,7 +120,8 @@ private:
                 cls::rbd::MirrorImageMode mirror_image_mode,
                 const std::string &non_primary_global_image_id,
                 const std::string &primary_mirror_uuid,
-                asio::ContextWQ *op_work_queue, Context *on_finish);
+                asio::ContextWQ *op_work_queue, Context *on_finish,
+                const CreateRequestFaultInjector& fault_injector);
 
   const ConfigProxy& m_config;
   IoCtx m_io_ctx;
@@ -128,6 +151,10 @@ private:
   int m_r_saved = 0;  // used to return actual error after cleanup
   file_layout_t m_layout;
   std::string m_id_obj, m_header_obj, m_objmap_name;
+  bool m_directory_added = false;
+  bool m_id_object_created = false;
+  bool m_mirror_image_enabled = false;
+  CreateRequestFaultInjector m_fault_injector;
 
   bufferlist m_outbl;
   cls::rbd::MirrorMode m_mirror_mode = cls::rbd::MIRROR_MODE_DISABLED;
@@ -138,6 +165,7 @@ private:
 
   void add_image_to_directory();
   void handle_add_image_to_directory(int r);
+  int check_fault_injection(std::string_view stage);
 
   void create_id_object();
   void handle_create_id_object(int r);
@@ -166,6 +194,9 @@ private:
   void complete(int r);
 
   // cleanup
+  void remove_mirror_image();
+  void handle_remove_mirror_image(int r);
+
   void journal_remove();
   void handle_journal_remove(int r);
 

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -242,3 +242,18 @@ install(TARGETS
 install(TARGETS
   ceph_test_librbd
   DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+add_executable(ceph_test_librbd_create_request
+  ceph_test_librbd_create_request.cc)
+target_link_libraries(ceph_test_librbd_create_request
+  rbd_api
+  rbd_internal
+  rbd_types
+  journal
+  cls_journal_client
+  cls_rbd_client
+  libneorados
+  librados)
+install(TARGETS
+  ceph_test_librbd_create_request
+  DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/test/librbd/ceph_test_librbd_create_request.cc
+++ b/src/test/librbd/ceph_test_librbd_create_request.cc
@@ -1,0 +1,412 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "common/Cond.h"
+#include "common/ceph_context.h"
+#include "common/errno.h"
+#include "common/strtol.h"
+#include "include/rados/librados.hpp"
+#include "include/rbd/librbd.hpp"
+#include "librbd/AsioEngine.h"
+#include "librbd/Utils.h"
+#include "librbd/api/Config.h"
+#include "librbd/image/CreateRequest.h"
+#include "librbd/image/Types.h"
+#include "librbd/internal.h"
+
+#include <chrono>
+#include <cerrno>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace {
+
+enum class InjectKind {
+  NONE,
+  ERROR,
+  ABORT,
+  DELAY,
+};
+
+struct Arguments {
+  std::string pool_name;
+  std::string image_name;
+  std::string image_id;
+  uint64_t size = 0;
+  bool pool_init = false;
+  bool skip_mirror_enable = false;
+  InjectKind inject_kind = InjectKind::NONE;
+  std::string inject_stage;
+  int inject_error = 0;
+  uint64_t inject_delay_ms = 0;
+};
+
+void usage(std::ostream& out) {
+  out << "usage: ceph_test_librbd_create_request <pool>/<image> --size <size> "
+         "[options]\n"
+      << "\n"
+      << "options:\n"
+      << "  --size <size>                image size (for example 1G)\n"
+      << "  --image-id <id>             override the generated image id\n"
+      << "  --pool-init                 run rbd pool init on the target pool\n"
+      << "  --skip-mirror-enable        pass CREATE_FLAG_SKIP_MIRROR_ENABLE\n"
+      << "  --inject-error-at <stage>   inject InjectError at a stage\n"
+      << "  --inject-error-code <errno> error code for InjectError (5 or -5)\n"
+      << "  --inject-abort-at <stage>   inject InjectAbort at a stage\n"
+      << "  --inject-delay-at <stage>   inject InjectDelay at a stage\n"
+      << "  --inject-delay-ms <ms>      delay duration in milliseconds\n"
+      << "  --help                      show this help text\n"
+      << "\n"
+      << "valid stages: after_header, after_id_create, after_dir_add\n";
+}
+
+const char* get_stage_literal(std::string_view stage) {
+  if (stage == "after_header") {
+    return "after_header";
+  }
+  if (stage == "after_id_create") {
+    return "after_id_create";
+  }
+  if (stage == "after_dir_add") {
+    return "after_dir_add";
+  }
+  return nullptr;
+}
+
+bool parse_image_spec(const std::string& spec, Arguments* args,
+                      std::string* error) {
+  auto slash = spec.find('/');
+  if (slash == std::string::npos || slash == 0 || slash == spec.size() - 1) {
+    *error = "image spec must be <pool>/<image>";
+    return false;
+  }
+
+  args->pool_name = spec.substr(0, slash);
+  args->image_name = spec.substr(slash + 1);
+  return true;
+}
+
+bool parse_size(const std::string& value, uint64_t* size, std::string* error) {
+  std::string parse_error;
+  *size = strict_iecstrtoll(value, &parse_error);
+  if (!parse_error.empty()) {
+    *error = "invalid --size value '" + value + "': " + parse_error;
+    return false;
+  }
+  return true;
+}
+
+bool parse_u64(const std::string& value, uint64_t* result,
+               std::string* error) {
+  char* end = nullptr;
+  errno = 0;
+  auto parsed = std::strtoull(value.c_str(), &end, 10);
+  if (errno != 0 || end == value.c_str() || *end != '\0') {
+    *error = "invalid integer value '" + value + "'";
+    return false;
+  }
+
+  *result = parsed;
+  return true;
+}
+
+bool parse_i32(const std::string& value, int* result, std::string* error) {
+  char* end = nullptr;
+  errno = 0;
+  auto parsed = std::strtoll(value.c_str(), &end, 10);
+  if (errno != 0 || end == value.c_str() || *end != '\0') {
+    *error = "invalid integer value '" + value + "'";
+    return false;
+  }
+
+  if (parsed < std::numeric_limits<int>::min() ||
+      parsed > std::numeric_limits<int>::max()) {
+    *error = "integer value out of range: '" + value + "'";
+    return false;
+  }
+
+  *result = static_cast<int>(parsed);
+  return true;
+}
+
+bool set_inject_kind(Arguments* args, InjectKind inject_kind,
+                     std::string* error) {
+  if (args->inject_kind != InjectKind::NONE &&
+      args->inject_kind != inject_kind) {
+    *error = "only one fault injection mode can be specified";
+    return false;
+  }
+
+  args->inject_kind = inject_kind;
+  return true;
+}
+
+bool parse_arguments(int argc, char** argv, Arguments* args,
+                     std::string* error) {
+  std::optional<std::string> image_spec;
+
+  for (int i = 1; i < argc; ++i) {
+    std::string arg = argv[i];
+
+    auto require_value = [&](const char* name) -> const char* {
+      if (i + 1 >= argc) {
+        *error = std::string("missing value for ") + name;
+        return nullptr;
+      }
+      return argv[++i];
+    };
+
+    if (arg == "--help") {
+      usage(std::cout);
+      return false;
+    } else if (arg == "--size") {
+      auto value = require_value("--size");
+      if (value == nullptr || !parse_size(value, &args->size, error)) {
+        return false;
+      }
+    } else if (arg == "--image-id") {
+      auto value = require_value("--image-id");
+      if (value == nullptr) {
+        return false;
+      }
+      args->image_id = value;
+    } else if (arg == "--pool-init") {
+      args->pool_init = true;
+    } else if (arg == "--skip-mirror-enable") {
+      args->skip_mirror_enable = true;
+    } else if (arg == "--inject-error-at") {
+      auto value = require_value("--inject-error-at");
+      if (value == nullptr || !set_inject_kind(args, InjectKind::ERROR, error)) {
+        return false;
+      }
+      args->inject_stage = value;
+    } else if (arg == "--inject-error-code") {
+      auto value = require_value("--inject-error-code");
+      if (value == nullptr ||
+          !set_inject_kind(args, InjectKind::ERROR, error) ||
+          !parse_i32(value, &args->inject_error, error)) {
+        return false;
+      }
+    } else if (arg == "--inject-abort-at") {
+      auto value = require_value("--inject-abort-at");
+      if (value == nullptr || !set_inject_kind(args, InjectKind::ABORT, error)) {
+        return false;
+      }
+      args->inject_stage = value;
+    } else if (arg == "--inject-delay-at") {
+      auto value = require_value("--inject-delay-at");
+      if (value == nullptr || !set_inject_kind(args, InjectKind::DELAY, error)) {
+        return false;
+      }
+      args->inject_stage = value;
+    } else if (arg == "--inject-delay-ms") {
+      auto value = require_value("--inject-delay-ms");
+      if (value == nullptr ||
+          !set_inject_kind(args, InjectKind::DELAY, error) ||
+          !parse_u64(value, &args->inject_delay_ms, error)) {
+        return false;
+      }
+    } else if (!arg.empty() && arg[0] == '-') {
+      *error = "unknown option '" + arg + "'";
+      return false;
+    } else if (!image_spec) {
+      image_spec = arg;
+    } else {
+      *error = "unexpected positional argument '" + arg + "'";
+      return false;
+    }
+  }
+
+  if (!image_spec) {
+    *error = "missing required <pool>/<image> argument";
+    return false;
+  }
+  if (!parse_image_spec(*image_spec, args, error)) {
+    return false;
+  }
+  if (args->size == 0) {
+    *error = "missing required --size argument";
+    return false;
+  }
+
+  if (args->inject_kind != InjectKind::NONE &&
+      get_stage_literal(args->inject_stage) == nullptr) {
+    *error = "invalid fault injection stage '" + args->inject_stage + "'";
+    return false;
+  }
+
+  if (args->inject_kind == InjectKind::ERROR) {
+    if (args->inject_stage.empty()) {
+      *error = "--inject-error-at is required when using InjectError";
+      return false;
+    }
+    if (args->inject_error == 0) {
+      *error = "--inject-error-code must be non-zero";
+      return false;
+    }
+    if (args->inject_error > 0) {
+      args->inject_error = -args->inject_error;
+    }
+  } else if (args->inject_kind == InjectKind::DELAY) {
+    if (args->inject_stage.empty()) {
+      *error = "--inject-delay-at is required when using InjectDelay";
+      return false;
+    }
+    if (args->inject_delay_ms == 0) {
+      *error = "--inject-delay-ms must be greater than zero";
+      return false;
+    }
+  } else if (args->inject_kind == InjectKind::ABORT &&
+             args->inject_stage.empty()) {
+    *error = "--inject-abort-at is required when using InjectAbort";
+    return false;
+  }
+
+  return true;
+}
+
+int connect_cluster(librados::Rados* cluster) {
+  const char* client_id = std::getenv("CEPH_CLIENT_ID");
+  int r = cluster->init(client_id);
+  if (r < 0) {
+    std::cerr << "cluster.init failed: " << cpp_strerror(r) << std::endl;
+    return r;
+  }
+
+  r = cluster->conf_read_file(nullptr);
+  if (r < 0) {
+    cluster->shutdown();
+    std::cerr << "cluster.conf_read_file failed: " << cpp_strerror(r)
+              << std::endl;
+    return r;
+  }
+
+  cluster->conf_parse_env(nullptr);
+
+  r = cluster->connect();
+  if (r < 0) {
+    cluster->shutdown();
+    std::cerr << "cluster.connect failed: " << cpp_strerror(r) << std::endl;
+    return r;
+  }
+
+  return 0;
+}
+
+int run_create_request(const Arguments& args) {
+  librados::Rados cluster;
+  int r = connect_cluster(&cluster);
+  if (r < 0) {
+    return 1;
+  }
+
+  auto exit_code = [&args, &cluster]() {
+    librados::IoCtx ioctx;
+    int r = cluster.ioctx_create(args.pool_name.c_str(), ioctx);
+    if (r < 0) {
+      std::cerr << "ioctx_create failed for pool '" << args.pool_name
+                << "': " << cpp_strerror(r) << std::endl;
+      return 1;
+    }
+
+    if (args.pool_init) {
+      librbd::RBD rbd;
+      r = rbd.pool_init(ioctx, true);
+      if (r < 0) {
+        std::cerr << "rbd pool init failed for pool '" << args.pool_name
+                  << "': " << cpp_strerror(r) << std::endl;
+        return 1;
+      }
+    }
+
+    r = librbd::detect_format(ioctx, args.image_name, nullptr, nullptr);
+    if (r != -ENOENT) {
+      if (r == 0) {
+        std::cerr << "rbd image '" << args.pool_name << "/"
+                  << args.image_name << "' already exists" << std::endl;
+      } else {
+        std::cerr << "failed to determine whether image '" << args.pool_name
+                  << "/" << args.image_name << "' exists: "
+                  << cpp_strerror(r) << std::endl;
+      }
+      return 1;
+    }
+
+    std::string image_id = args.image_id;
+    if (image_id.empty()) {
+      image_id = librbd::util::generate_image_id(ioctx);
+    }
+
+    auto cct = reinterpret_cast<CephContext*>(ioctx.cct());
+    auto config = cct->_conf;
+    librbd::api::Config<>::apply_pool_overrides(ioctx, &config);
+
+    librbd::ImageOptions opts;
+    r = opts.set(RBD_IMAGE_OPTION_FORMAT, 2);
+    if (r < 0) {
+      std::cerr << "failed to set image format option: "
+                << cpp_strerror(r) << std::endl;
+      return 1;
+    }
+
+    uint32_t create_flags = args.skip_mirror_enable ?
+      librbd::image::CREATE_FLAG_SKIP_MIRROR_ENABLE : 0U;
+
+    librbd::image::CreateRequestFaultInjector fault_injector;
+    if (args.inject_kind != InjectKind::NONE) {
+      const char* stage = get_stage_literal(args.inject_stage);
+      if (args.inject_kind == InjectKind::ERROR) {
+        fault_injector.inject(stage, InjectError{args.inject_error});
+      } else if (args.inject_kind == InjectKind::ABORT) {
+        fault_injector.inject(stage, InjectAbort{});
+      } else if (args.inject_kind == InjectKind::DELAY) {
+        fault_injector.inject(stage, InjectDelay{
+          std::chrono::milliseconds(args.inject_delay_ms)});
+      }
+    }
+
+    librbd::AsioEngine asio_engine(ioctx);
+    C_SaferCond cond;
+    auto req = librbd::image::CreateRequest<>::create(
+      config, ioctx, args.image_name, image_id, args.size, opts, create_flags,
+      cls::rbd::MIRROR_IMAGE_MODE_JOURNAL, "", "",
+      asio_engine.get_work_queue(), &cond, fault_injector);
+    req->send();
+
+    r = cond.wait();
+    if (r < 0) {
+      std::cerr << "create failed for '" << args.pool_name << "/"
+                << args.image_name << "': " << cpp_strerror(r)
+                << " (" << r << ")" << std::endl;
+    } else {
+      std::cout << "created " << args.pool_name << "/" << args.image_name
+                << " id=" << image_id << std::endl;
+      return 0;
+    }
+    return 1;
+  }();
+
+  cluster.shutdown();
+  return exit_code;
+}
+
+} // anonymous namespace
+
+int main(int argc, char** argv) {
+  Arguments args;
+  std::string error;
+  if (!parse_arguments(argc, argv, &args, &error)) {
+    if (!error.empty()) {
+      std::cerr << error << std::endl;
+      usage(std::cerr);
+      return 1;
+    }
+    return 0;
+  }
+
+  return run_create_request(args);
+}


### PR DESCRIPTION
Partial image artifacts have been observed after abnormal termination (crash, SIGKILL, client disconnect) during rbd image create. The librbd::image::CreateRequest cleanup path already unwinds cleanly on error returns -- FaultInjector coverage at after_header, after_id_create, and after_dir_add confirms this -- so error paths are not the source. The remaining exposure is the crash window during which an image is visible in rbd_directory before its backing metadata exists, which blocks subsequent create attempts with -EEXIST.

Reorder CreateRequest so the rbd_directory entry is written last: validate pool, negotiate features, create the header and optional metadata (object map, journal, mirror enable), create rbd_id.<name>, and only then add the image to rbd_directory. A crash before the directory entry is written no longer leaves a visible name; any orphaned header/id objects are no longer observable as an existing image and no longer block name reuse.

Rollback is adjusted to tolerate steps that were never reached. Track m_id_object_created and m_directory_added so cleanup skips those removals when appropriate, remove mirror-image state first when creation fails after mirror enable, and treat -ENOENT as success throughout the cleanup tail so unwind is idempotent.

Add a CreateRequestFaultInjector (defaulted, source-compatible) and the ceph_test_librbd_create_request helper to drive InjectError/InjectAbort/InjectDelay at the named checkpoints and verify the unwind path leaves no visible artifact on error.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
