### PR TITLE
qa/lsan.supp: suppress CPython 3.10 interpreter shutdown leaks

### DIFF
--- a/qa/lsan.supp
+++ b/qa/lsan.supp
@@ -27,6 +27,16 @@ leak:^PyMem_Calloc
 leak:^PyUnicode_New
 # python3.9, 3.10, 3.11
 leak:^PyMem_Malloc
+leak:^PyDict_Copy
+leak:^_PyObject_GC_NewVar
+# Catch unsymbolised interpreter frames in both the standalone
+# /usr/bin/python3.10 binary (used by the bin/ceph wrapper) and the
+# /lib/.../libpython3.10.so.1.0 embedded by C++ unittests such as
+# unittest_mgr_pyformatter / unittest_mgr_pyutil.  Not all CPython
+# 3.10 internal helpers are exported in .dynsym, so function-name
+# matches above don't cover everything; this substring-matches the
+# module path in the stack frame.  Remove when CI moves to >= 3.12.
+leak:python3.10
 # python3.12 doesn't leak anything
 # python3.13
 leak:^PyModule_ExecDef


### PR DESCRIPTION
When building with ASan, it reports leaks in five tests that exercise CPython 3.10 either as an external process (bin/ceph) or embedded in unittests:
```
   #36  smoke.sh                    (timeout, via bin/ceph)
  #205  unittest_mgr_pyformatter    (libpython3.10.so embedded)
  #206  unittest_mgr_pyutil         (libpython3.10.so embedded)
  #210  mgr-dashboard-smoke.sh      (via bin/ceph)
  #225  safe-to-destroy.sh          (via bin/ceph)
```
A representative stack from `#210`:
```
  Direct leak of 25846 byte(s) in 28 object(s) allocated from:
    #0  malloc
    #1  /usr/bin/python3.10+0x16d7be
  Direct leak of 20456 byte(s) in 29 object(s):
    #1  PyDict_Copy /usr/bin/python3.10+0x16ae06
  Direct leak of 8456 byte(s) in 14 object(s):
    #1  _PyObject_GC_NewVar /usr/bin/python3.10+0x14fc57
```
The unittests show the same shape against /lib/.../libpython3.10.so.

These are CPython 3.10 runtime artefacts, not Ceph bugs.  In CPython 3.10, Py_FinalizeEx() leaves a set of interpreter-internal allocations (module namespace dict copies, GC-tracked variable-size containers, type-method caches, interned strings) heap-allocated until process exit; the OS reclaims them.  PEP 683 (Immortal Objects, accepted for Python 3.12) extends pylifecycle.c::finalize_modules() to deallocate these remaining objects during runtime shutdown:

>   "During runtime shutdown, the strategy will be to first let the
>   runtime try to do its best effort of deallocating these instances
>   normally.  Most of the module deallocation will now be handled by
>   pylifecycle.c:finalize_modules() where we clean up the remaining
>   modules as best as we can."

PEP 683, https://peps.python.org/pep-0683/

The qa/lsan.supp file has carried the empirical note "python3.12 doesn't leak anything" since the file was introduced (commit 8c099a534044bf, "asan: add qa/lsan.supp for leak sanitizer suppressions", Mar 2023).  An empirical reproduction with a minimal Py_Initialize()/Py_FinalizeEx() program built against Python 3.13 under -fsanitize=address reports zero leaks; the same minimal test against Python 3.10 (CI environment) reports the leaks shown above.

Add three suppressions to qa/lsan.supp's existing 3.9-3.11 block:

 - leak:^PyDict_Copy and leak:^_PyObject_GC_NewVar match the two exported CPython functions visible in the leak stacks.
 - leak:python3.10 substring-matches the module path in the stack frame, catching unsymbolised offsets in both the /usr/bin/python3.10 binary and the libpython3.10.so.1.0 shared object.  Mirrors the existing leak:libsqlite3.so pattern earlier in the file.

The whole block (including the existing PyMem_Malloc entry above) can be removed once CI runs on Python >= 3.12.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
