### PR TITLE
  rgw/lua: fix iterator invalidation when erasing last element during pairs() iteration

### DIFF
--- a/src/rgw/rgw_lua_utils.h
+++ b/src/rgw/rgw_lua_utils.h
@@ -308,8 +308,8 @@ inline const char* table_name_upvalue(lua_State* L) {
 // - since we have only one iterator per map/table we don't allow for nested loops or another iterationn
 // after breaking out of an iteration
 template<typename MapType>
-typename MapType::iterator* create_iterator_metadata(lua_State* L, const std::string_view name, 
-    const typename MapType::iterator& start_it, const typename MapType::iterator& end_it) {
+typename MapType::iterator* create_iterator_metadata(lua_State* L, const std::string_view name,
+    const typename MapType::iterator& start_it, const typename MapType::iterator& end_it, MapType* map) {
   using Iterator = typename MapType::iterator;
   // create metatable for userdata
   // metatable is created before the userdata to save on allocation if the metatable already exists
@@ -350,14 +350,21 @@ typename MapType::iterator* create_iterator_metadata(lua_State* L, const std::st
   // add "tostring" closure to metatable
   lua_pushliteral(L, "__tostring");
   lua_pushlightuserdata(L, new_it);
+  lua_pushlightuserdata(L, map);
   lua_pushcclosure(L, [](lua_State* L) {
       // the key of the table is expected to be convertible to char*
       static_assert(std::is_constructible<typename MapType::key_type, const char*>());
       auto iter = reinterpret_cast<Iterator*>(lua_touserdata(L, lua_upvalueindex(FIRST_UPVAL)));
+      auto map = reinterpret_cast<MapType*>(lua_touserdata(L, lua_upvalueindex(SECOND_UPVAL)));
       ceph_assert(iter);
+      if (*iter == map->end()) {
+        // iterator is past-the-end; return "nil" to match Lua's tostring(nil) behavior
+        lua_pushliteral(L, "nil");
+        return ONE_RETURNVAL;
+      }
       pushstring(L, (*iter)->first);
       return ONE_RETURNVAL;
-    }, ONE_UPVAL);
+    }, TWO_UPVALS);
   lua_rawset(L, metatable_pos);
   // define a finalizer of the iterator
   lua_pushliteral(L, "__gc");
@@ -447,10 +454,12 @@ int next(lua_State* L) {
     // pop the 2 nils
     lua_pop(L, 2);
     // create userdata
-    next_it = create_iterator_metadata<MapType>(L, name, map->begin(), map->end());
+    next_it = create_iterator_metadata<MapType>(L, name, map->begin(), map->end(), map);
   } else {
     next_it = reinterpret_cast<Iterator*>(lua_touserdata(L, 2));
-    *next_it = std::next(*next_it);
+    if (*next_it != map->end()) {
+      *next_it = std::next(*next_it);
+    }
   }
   ceph_assert(next_it);
 

--- a/src/test/rgw/test_rgw_lua.cc
+++ b/src/test/rgw/test_rgw_lua.cc
@@ -1274,7 +1274,7 @@ TEST(TestRGWLuaBackground, TableIterate)
   EXPECT_EQ(get_table_value<long long int>(lua_background, "size"), 5);
 }
 
-TEST(TestRGWLuaBackground, TableIterateWrite)
+TEST(TestRGWLuaBackground, TableIterateWriteMiddleElement)
 {
   DEFINE_REQ_STATE;
   TestBackground lua_background(pe.lua.manager.get());
@@ -1285,23 +1285,80 @@ TEST(TestRGWLuaBackground, TableIterateWrite)
     RGW["c"] = 3
     RGW["d"] = 4
     RGW["e"] = 5
-    counter = 0 
+    local total = #RGW
+    local middle = total // 2 + 1
+    local counter = 0
     for k, v in pairs(RGW) do
       counter = counter + 1
-      if tostring(k) == "c" then
-        RGW["c"] = nil
-        print("'c' is deleted and iterator moves")
-        assert(tostring(k) ~= "c")
+      if counter == middle then
+        local erased_key = tostring(k)
+        RGW[erased_key] = nil
+        print("middle element '" .. erased_key .. "' is deleted and iterator moves")
+        assert(tostring(k) ~= erased_key)
       end
     end
-    assert(counter == 4)
+    assert(counter == total - 1)
   )";
 
   pe.lua.background = &lua_background;
 
   const auto rc = lua::request::execute(nullptr, nullptr, &s, nullptr, request_script);
   ASSERT_EQ(rc, 0);
-  EXPECT_EQ(lua_background.get_table_value("c"), TestBackground::empty_table_value);
+}
+
+TEST(TestRGWLuaBackground, TableIterateWriteLastElement)
+{
+  DEFINE_REQ_STATE;
+  TestBackground lua_background(pe.lua.manager.get());
+
+  const std::string request_script = R"(
+    RGW["a"] = 1
+    RGW["b"] = 2
+    RGW["c"] = 3
+    RGW["d"] = 4
+    RGW["e"] = 5
+    local total = #RGW
+    local counter = 0
+    for k, v in pairs(RGW) do
+      counter = counter + 1
+      if counter == total then
+        local erased_key = tostring(k)
+        RGW[erased_key] = nil
+        print("last element '" .. erased_key .. "' is deleted and iterator becomes end")
+        assert(tostring(k) == "nil")
+      end
+    end
+    assert(counter == total)
+  )";
+
+  pe.lua.background = &lua_background;
+
+  const auto rc = lua::request::execute(nullptr, nullptr, &s, nullptr, request_script);
+  ASSERT_EQ(rc, 0);
+}
+
+TEST(TestRGWLuaBackground, TableIterateWriteOneElement)
+{
+  DEFINE_REQ_STATE;
+  TestBackground lua_background(pe.lua.manager.get());
+
+  const std::string request_script = R"(
+    RGW["a"] = 1
+    local counter = 0
+    for k, v in pairs(RGW) do
+      counter = counter + 1
+      local erased_key = tostring(k)
+      RGW[erased_key] = nil
+      print("only element '" .. erased_key .. "' is deleted and iterator becomes end")
+      assert(tostring(k) == "nil")
+    end
+    assert(counter == 1)
+  )";
+
+  pe.lua.background = &lua_background;
+
+  const auto rc = lua::request::execute(nullptr, nullptr, &s, nullptr, request_script);
+  ASSERT_EQ(rc, 0);
 }
 
 TEST(TestRGWLuaBackground, TableIncrement)


### PR DESCRIPTION
## Description

When a Lua script erases an element from the RGW background table while iterating with `pairs()`, `map->erase()` is called and its return value - the iterator to the next element - is passed to `update_erased_iterator` to keep the Lua iterator valid. If the erased element is the last in iteration order, `map->erase()` returns `map->end()` - a past-the-end iterator - which is then stored in the Lua iterator userdata by `update_erased_iterator`.

Two bugs follow:
1. `__tostring` dereferences the stored iterator without checking if it is `end()` - triggered when the script calls `tostring(k)`, where k is the Lua iterator userdata, after erasing → segfault
2. `next()` calls `std::next(end())` → undefined behavior

The existing test did not catch this because it happened to always erase a key that was not last in `std::unordered_map`'s iteration order.

## Fix

- Guard `next()` against calling `std::next` when already at `end()`
- Pass the map pointer as a second upvalue to `__tostring`, so it can detect `end()` and return `"nil"` safely

## Technical Changes

`src/rgw/rgw_lua_utils.h`:
- Added `end()` guard in `next()` before calling `std::next`
- Added map pointer as second upvalue to `__tostring` to detect past-the-end iterator

`src/test/rgw/test_rgw_lua.cc`:
- Renamed `TableIterateWrite` to `TableIterateWriteMiddleElement` and rewrote it
- Added `TableIterateWriteLastElement`
- Added `TableIterateWriteOneElement`

## Validation & Testing

Three new unit tests in `test_rgw_lua.cc`:
- `TableIterateWriteMiddleElement` - erases the middle element during iteration, verifies no crash and one element is skipped
- `TableIterateWriteLastElement` - erases the last element during iteration, verifies no crash and no element is skipped
- `TableIterateWriteOneElement` - erases the only element during iteration, verifies no crash

All 69 unit tests pass.



Fixes: https://tracker.ceph.com/issues/76111
Signed-off-by: Rotem Shapira <rotem.rs@gmail.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
