### PR TITLE
mgr/dashboard: fix CephPoolGrowthWarning false positives on mgr failover

### DIFF
--- a/monitoring/ceph-mixin/prometheus_alerts.libsonnet
+++ b/monitoring/ceph-mixin/prometheus_alerts.libsonnet
@@ -583,7 +583,8 @@
       rules: [
         {
           alert: 'CephPoolGrowthWarning',
-          expr: '(predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5) * on(%(cluster)spool_id, instance) group_right() ceph_pool_metadata) >= 95' % $.MultiClusterQuery(),
+          'for': '1h',
+          expr: '(predict_linear(avg by (%(cluster)spool_id) (ceph_pool_percent_used)[2d:], 3600 * 24 * 5) * on(%(cluster)spool_id) group_right() avg by (%(cluster)spool_id, name) (ceph_pool_metadata)) >= 95' % [$.MultiClusterQuery(), $.MultiClusterQuery(), $.MultiClusterQuery()],
           labels: { severity: 'warning', type: 'ceph_default', oid: '1.3.6.1.4.1.50495.1.2.1.9.2' },
           annotations: {
             summary: 'Pool growth rate may soon exceed capacity%(cluster)s' % $.MultiClusterSummary(),

--- a/monitoring/ceph-mixin/prometheus_alerts.yml
+++ b/monitoring/ceph-mixin/prometheus_alerts.yml
@@ -561,7 +561,8 @@ groups:
         annotations:
           description: "Pool '{{ $labels.name }}' will be full in less than 5 days assuming the average fill-up rate of the past 48 hours."
           summary: "Pool growth rate may soon exceed capacity on cluster {{ $labels.cluster }}"
-        expr: "(predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5) * on(cluster,pool_id, instance) group_right() ceph_pool_metadata) >= 95"
+        expr: "(predict_linear(avg by (cluster,pool_id) (ceph_pool_percent_used)[2d:], 3600 * 24 * 5) * on(cluster,pool_id) group_right() avg by (cluster,pool_id, name) (ceph_pool_metadata)) >= 95"
+        for: "1h"
         labels:
           oid: "1.3.6.1.4.1.50495.1.2.1.9.2"
           severity: "warning"

--- a/monitoring/ceph-mixin/tests_alerts/test_alerts.yml
+++ b/monitoring/ceph-mixin/tests_alerts/test_alerts.yml
@@ -1521,39 +1521,22 @@ tests:
           description: Reads from an OSD have used a secondary PG to return data to the client, indicating a potential failing drive.
 
 # Pools
-   # trigger percent full prediction on pools 1 and 2 only
- - interval: 12h
+   # trigger percent full prediction on pool 1 only; pool 2 stays flat
+ - interval: 1m
    input_series:
-    - series: 'ceph_pool_percent_used{pool_id="1", instance="9090", cluster="mycluster"}'
-      values: '1 1 1 1 1'
-    - series: 'ceph_pool_percent_used{pool_id="1", instance="8090", cluster="mycluster"}'
-      values: '78 89 79 98 78'
-    - series: 'ceph_pool_percent_used{pool_id="2", instance="9090", cluster="mycluster"}'
-      values: '1 1 1 1 1'
-    - series: 'ceph_pool_percent_used{pool_id="2", instance="8090", cluster="mycluster"}'
-      values: '22 22 23 23 24'
-    - series: 'ceph_pool_metadata{pool_id="1" , instance="9090" ,name="rbd",type="replicated", cluster="mycluster"}'
-      values: '1 1 1 1 1'
-    - series: 'ceph_pool_metadata{pool_id="1", instance="8090",name="default.rgw.index",type="replicated", cluster="mycluster"}'
-      values: '1 1 1 1 1'
-    - series: 'ceph_pool_metadata{pool_id="2" , instance="9090" ,name="rbd",type="replicated", cluster="mycluster"}'
-      values: '1 1 1 1 1'
-    - series: 'ceph_pool_metadata{pool_id="2", instance="8090",name="default.rgw.index",type="replicated", cluster="mycluster"}'
-      values: '1 1 1 1 1'
-   promql_expr_test:
-     - expr: |
-         (predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5) * on(cluster, pool_id, instance)
-              group_right() ceph_pool_metadata) >= 95
-       eval_time: 36h
-       exp_samples:
-         - labels: '{instance="8090",name="default.rgw.index",pool_id="1",type="replicated", cluster="mycluster"}'
-           value: 1.435E+02 # 142%
+    - series: 'ceph_pool_percent_used{pool_id="1", instance="mgr-a:9283", cluster="mycluster"}'
+      values: '50+0.02x3000'  # 50 -> 110 over 50h, slope 1.2%/h
+    - series: 'ceph_pool_percent_used{pool_id="2", instance="mgr-a:9283", cluster="mycluster"}'
+      values: '20+0x3000'
+    - series: 'ceph_pool_metadata{pool_id="1", instance="mgr-a:9283", name="default.rgw.index", type="replicated", cluster="mycluster"}'
+      values: '1+0x3000'
+    - series: 'ceph_pool_metadata{pool_id="2", instance="mgr-a:9283", name="rbd", type="replicated", cluster="mycluster"}'
+      values: '1+0x3000'
    alert_rule_test:
-    - eval_time: 48h
+    - eval_time: 49h  # for: 1h has elapsed since the alert first crossed threshold
       alertname: CephPoolGrowthWarning
       exp_alerts:
       - exp_labels:
-          instance: 8090
           name: default.rgw.index
           pool_id: 1
           severity: warning
@@ -1563,6 +1546,23 @@ tests:
         exp_annotations:
           summary: Pool growth rate may soon exceed capacity on cluster mycluster
           description: Pool 'default.rgw.index' will be full in less than 5 days assuming the average fill-up rate of the past 48 hours.
+   # regression: must NOT fire when the active mgr fails over mid-window.
+   # Per-instance series end / begin abruptly, but the pool-aggregated series
+   # is steady, so predict_linear sees zero slope.
+ - interval: 1m
+   input_series:
+    - series: 'ceph_pool_percent_used{pool_id="1", instance="mgr-a:9283", cluster="mycluster"}'
+      values: '50+0x1500'  # mgr-a active 0..25h
+    - series: 'ceph_pool_percent_used{pool_id="1", instance="mgr-b:9283", cluster="mycluster"}'
+      values: '_x1500 50+0x1500'  # mgr-b active 25h..50h
+    - series: 'ceph_pool_metadata{pool_id="1", instance="mgr-a:9283", name="rbd", type="replicated", cluster="mycluster"}'
+      values: '1+0x1500'
+    - series: 'ceph_pool_metadata{pool_id="1", instance="mgr-b:9283", name="rbd", type="replicated", cluster="mycluster"}'
+      values: '_x1500 1+0x1500'
+   alert_rule_test:
+    - eval_time: 49h
+      alertname: CephPoolGrowthWarning
+      exp_alerts: []
  - interval: 1m
    input_series:
     - series: 'ceph_health_detail{name="POOL_BACKFILLFULL", cluster="mycluster"}'


### PR DESCRIPTION
## Summary

`CephPoolGrowthWarning` fires false positives every time the active `ceph-mgr` fails over (e.g. via `ceph mgr fail`, mgr restart, or HA failover) on clusters with completely flat pool usage.

## Root cause

The rule's expression was:

```promql
(predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5)
   * on(cluster, pool_id, instance) group_right() ceph_pool_metadata) >= 95
```

`ceph_pool_percent_used` is exported by the active mgr and carries that mgr's `instance` label. When the active mgr changes, the old per-`instance` series ends abruptly (drops to staleness) and a new per-`instance` series begins. `predict_linear` over the 2-day lookback then sees an artificial 100% → 0% (or 0% → 100%) transition, fits a hugely sloped line, and projects the pool well past 95% utilisation 5 days ahead — even though the true pool fill rate is zero.

There is also no `for:` clause, so a single such transient evaluation immediately fires the alert.

## Fix

1. Aggregate `ceph_pool_percent_used` and `ceph_pool_metadata` with `avg by (cluster, pool_id[, name])` **before** `predict_linear`. The resulting per-pool series is invariant across mgr failovers (every mgr reports the same pool usage).
2. Add `for: 1h` so a single-sample anomaly cannot fire.

```promql
(predict_linear(avg by (cluster, pool_id) (ceph_pool_percent_used)[2d:], 3600 * 24 * 5)
   * on(cluster, pool_id) group_right()
   avg by (cluster, pool_id, name) (ceph_pool_metadata)) >= 95
```

## Reproducer

On any cluster with stable pool usage:

```sh
while true; do ceph mgr fail; sleep 600; done
```

Within ~48h the previous rule reliably fires `CephPoolGrowthWarning` for one or more pools despite no real growth.

## Tests

- Updated the existing positive `CephPoolGrowthWarning` unit test to feed a synthetic 1-minute-interval ramp so the new `for: 1h` debounce is exercised.
- Added a regression test that simulates an mgr failover (one `instance` series ends mid-window, another begins) on an otherwise-flat pool and asserts `exp_alerts: []`.

```
$ promtool check rules monitoring/ceph-mixin/prometheus_alerts.yml
SUCCESS: 91 rules found

$ promtool test rules monitoring/ceph-mixin/tests_alerts/test_alerts.yml
# CephPoolGrowthWarning tests pass.
# (Other failing tests are pre-existing on main and unrelated to this change —
# verified by running promtool against an unmodified checkout of upstream main.)

$ python3 monitoring/ceph-mixin/tests_alerts/validate_rules.py
No problems detected in the rule file
No problems detected in unit tests file

$ ./monitoring/ceph-mixin/lint-jsonnet.sh --test
# clean
```

## Files changed

- `monitoring/ceph-mixin/prometheus_alerts.libsonnet` — source-of-truth rule.
- `monitoring/ceph-mixin/prometheus_alerts.yml` — generated YAML (only the `CephPoolGrowthWarning` block patched; other pre-existing libsonnet/YAML drift left untouched and out of scope).
- `monitoring/ceph-mixin/tests_alerts/test_alerts.yml` — updated positive test + new mgr-failover regression test.

## Notes

- No tracker issue filed yet; happy to file one and amend a `Fixes:` trailer if reviewers prefer.
- The same pattern (predict_linear over per-instance series) does not appear elsewhere in `prometheus_alerts.libsonnet` for pool metrics; only this single rule needed the change.
