### PR TITLE
rgw/notifications: relax topic names validation

### DIFF
--- a/doc/radosgw/notifications.rst
+++ b/doc/radosgw/notifications.rst
@@ -195,6 +195,10 @@ generated. A successful response includes the topic's `ARN`_
 (the "Amazon Resource Name", a unique identifier used to reference the topic).
 To update a topic, use the same command that you used to create it (but when
 updating, use the name of an existing topic and different endpoint values).
+Topic names must contain only alphanumeric characters, hyphens, and underscores,
+and must be between 1 and 256 characters long. To relax these requirements, use:
+
+.. confval:: rgw_relaxed_topic_names
 
 .. tip:: Any notification already associated with the topic must be re-created
    in order for the topic to update.

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -4386,6 +4386,17 @@ options:
   flags:
   - startup
   with_legacy: true
+- name: rgw_relaxed_topic_names
+  type: bool
+  level: advanced
+  desc: RGW enable relaxed topic names
+  long_desc: RGW enable relaxed topic names to allow changing existing topics
+    that were created before validation rules were implemented. This also allows re-creating
+    topics that were deleted, but match names that are already used externally (e.g. in Kafka)
+  default: false
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_lua_max_memory_per_state
   type: uint
   level: advanced

--- a/src/rgw/rgw_rest_pubsub.cc
+++ b/src/rgw/rgw_rest_pubsub.cc
@@ -253,7 +253,10 @@ class RGWPSCreateTopicOp : public RGWOp {
 
   int get_params() {
     topic_name = s->info.args.get("Name");
-    if (!validate_topic_name(topic_name, s->err.message)) {
+    if (topic_name.empty() ||
+        (!s->get_cct()->_conf.get_val<bool>("rgw_relaxed_topic_names") &&
+        !validate_topic_name(topic_name, s->err.message))
+       ) {
       return -EINVAL;
     }
 

--- a/src/test/rgw/bucket_notification/api.py
+++ b/src/test/rgw/bucket_notification/api.py
@@ -326,7 +326,6 @@ class PSTopicS3:
     def __init__(self, conn, topic_name, region, endpoint_args=None, opaque_data=None, policy_text=None):
         self.conn = conn
         self.topic_name = topic_name.strip()
-        assert self.topic_name
         self.topic_arn = ''
         self.attributes = {}
         if endpoint_args is not None:

--- a/src/test/rgw/bucket_notification/test_bn.py
+++ b/src/test/rgw/bucket_notification/test_bn.py
@@ -904,6 +904,46 @@ def test_topic():
     list_topics(0, tenant)
 
 
+@pytest.mark.manual_test
+def test_topic_name():
+    """ test topic name validation """
+    conn = connection()
+    # make sure there are no leftover topics
+    delete_all_topics(conn, '', get_config_cluster())
+
+    zonegroup = get_config_zonegroup()
+    bucket_name = gen_bucket_name()
+    invalid_topic_name = bucket_name + '+' + TOPIC_SUFFIX
+    rgw_client = f'client.rgw.{get_config_port()}'
+
+    # fail to create topic
+    endpoint_address = 'http://127.0.0.1:7001/'
+    endpoint_args = 'push-endpoint='+endpoint_address+'&persistent=true'
+    topic_conf = PSTopicS3(conn, invalid_topic_name, zonegroup, endpoint_args=endpoint_args)
+    pytest.raises(Exception, topic_conf.set_config)
+
+    # relax topic name validation
+    set_rgw_config_option(rgw_client, 'rgw_relaxed_topic_names', 'true', get_config_cluster())
+    # create topic
+    expected_arn = 'arn:aws:sns:' + zonegroup + '::' + invalid_topic_name
+    topic_arn = topic_conf.set_config()
+    assert topic_arn == expected_arn
+
+    set_rgw_config_option(rgw_client, 'rgw_relaxed_topic_names', 'false', get_config_cluster())
+
+    # get topic (should be possible regardless of the relaxed topic name setting)
+    parsed_result = get_topic(invalid_topic_name)
+    assert parsed_result['arn'] == expected_arn
+
+    # delete topic
+    status = topic_conf.del_config()
+    assert status == 200
+
+    # maks sure that empty topic names are invalid regardless of flag
+    empty_topic_conf = PSTopicS3(conn, "", zonegroup, endpoint_args=endpoint_args)
+    pytest.raises(Exception, empty_topic_conf.set_config)
+
+
 @pytest.mark.basic_test
 def test_topic_admin():
     """ test topics set/get/delete """


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/76262


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
