### PR TITLE
seastore/omap_manager/btree: change omap manager funcs to coroutines

### DIFF
--- a/src/crimson/os/seastore/omap_manager.h
+++ b/src/crimson/os/seastore/omap_manager.h
@@ -75,7 +75,7 @@ public:
   virtual omap_get_value_ret omap_get_value(
     const omap_root_t &omap_root,
     Transaction &t,
-    const std::string &key) = 0;
+    std::string key) = 0;
 
   /**
    * set key value mapping in omap
@@ -91,15 +91,15 @@ public:
   virtual omap_set_key_ret omap_set_key(
     omap_root_t &omap_root,
     Transaction &t,
-    const std::string &key,
-    const ceph::bufferlist &value) = 0;
+    std::string key,
+    ceph::bufferlist value) = 0;
 
   using omap_set_keys_iertr = omap_set_key_iertr;
   using omap_set_keys_ret = omap_set_keys_iertr::future<>;
   virtual omap_set_keys_ret omap_set_keys(
     omap_root_t &omap_root,
     Transaction &t,
-    std::map<std::string, ceph::bufferlist>&& keys) = 0;
+    std::map<std::string, ceph::bufferlist> keys) = 0;
 
   /**
    * remove key value mapping in omap tree
@@ -113,14 +113,14 @@ public:
   virtual omap_rm_key_ret omap_rm_key(
     omap_root_t &omap_root,
     Transaction &t,
-    const std::string &key) = 0;
+    std::string key) = 0;
 
   using omap_rm_keys_iertr = base_iertr;
   using omap_rm_keys_ret = omap_rm_keys_iertr::future<>;
   virtual omap_rm_keys_ret omap_rm_keys(
     omap_root_t& root,
     Transaction& t,
-    std::set<std::string>& keys) = 0;
+    std::set<std::string> keys) = 0;
 
   /**
    * omap_iterate

--- a/src/crimson/os/seastore/omap_manager/btree/btree_omap_manager.cc
+++ b/src/crimson/os/seastore/omap_manager/btree/btree_omap_manager.cc
@@ -130,117 +130,79 @@ BtreeOMapManager::omap_get_value_ret
 BtreeOMapManager::omap_get_value(
   const omap_root_t &omap_root,
   Transaction &t,
-  const std::string &key)
+  std::string key)
 {
   LOG_PREFIX(BtreeOMapManager::omap_get_value);
   DEBUGT("key={}", t, key);
-  return get_omap_root(
-    get_omap_context(t, omap_root),
-    omap_root
-  ).si_then([this, &t, &key, &omap_root](auto&& extent) {
-    return extent->get_value(
-      get_omap_context(t, omap_root), key);
-  }).si_then([](auto &&e) {
-    return omap_get_value_ret(
-        interruptible::ready_future_marker{},
-        std::move(e));
-  });
+  auto extent = co_await get_omap_root(get_omap_context(t, omap_root), omap_root); 
+  co_return co_await extent->get_value(get_omap_context(t, omap_root), key);
 }
 
 BtreeOMapManager::omap_set_keys_ret
 BtreeOMapManager::omap_set_keys(
   omap_root_t &omap_root,
   Transaction &t,
-  std::map<std::string, ceph::bufferlist>&& keys)
+  std::map<std::string, ceph::bufferlist> keys)
 {
-  return seastar::do_with(std::move(keys), [&, this](auto& keys) {
-    return trans_intr::do_for_each(
-      keys.begin(),
-      keys.end(),
-      [&, this](auto &p) {
-      return omap_set_key(omap_root, t, p.first, p.second);
-    });
-  });
+  LOG_PREFIX(BtreeOMapManager::omap_set_keys);
+  for (auto &p: keys) {
+    DEBUGT("set key={}", t, p.first);
+    co_await omap_set_key(omap_root, t, p.first, p.second);
+  }
 }
 
 BtreeOMapManager::omap_set_key_ret
 BtreeOMapManager::omap_set_key(
   omap_root_t &omap_root,
   Transaction &t,
-  const std::string &key,
-  const ceph::bufferlist &value)
+  std::string key,
+  ceph::bufferlist value)
 {
   LOG_PREFIX(BtreeOMapManager::omap_set_key);
   DEBUGT("{} -> 0x{:x} value", t, key, value.length());
-  // #FIXME: heap buffer overflow during logging if value is long (e.g. 1020B)
+  // #FIXME: heap buffer overflow during logging if value is long (e.g. 1020B) 
   // https://tracker.ceph.com/issues/71524
   // DEBUGT("{} -> {}", t, key, value);
-  return get_omap_root(
-    get_omap_context(t, omap_root),
-    omap_root
-  ).si_then([this, &t, &key, &value, &omap_root](auto root) {
-    return root->insert(get_omap_context(
-      t, omap_root), key, value);
-  }).si_then([this, &omap_root, &t](auto mresult) -> omap_set_key_ret {
-    if (mresult.status == mutation_status_t::SUCCESS)
-      return seastar::now();
-    else if (mresult.status == mutation_status_t::WAS_SPLIT)
-      return handle_root_split(
-	get_omap_context(t, omap_root), omap_root, mresult);
-    else
-      return seastar::now();
-  });
+  auto root = co_await get_omap_root(get_omap_context(t, omap_root), omap_root);
+  auto mresult = co_await root->insert(get_omap_context(t, omap_root), key, value);
+  if (mresult.status == mutation_status_t::WAS_SPLIT) {
+    co_await handle_root_split(get_omap_context(t, omap_root), omap_root, mresult);
+  }
 }
 
 BtreeOMapManager::omap_rm_key_ret
 BtreeOMapManager::omap_rm_key(
   omap_root_t &omap_root,
   Transaction &t,
-  const std::string &key)
+  std::string key)
 {
   LOG_PREFIX(BtreeOMapManager::omap_rm_key);
   DEBUGT("{}", t, key);
-  return get_omap_root(
-    get_omap_context(t, omap_root),
-    omap_root
-  ).si_then([this, &t, &key, &omap_root](auto root) {
-    return root->rm_key(get_omap_context(t, omap_root), key);
-  }).si_then([this, &omap_root, &t](auto mresult) -> omap_rm_key_ret {
-    if (mresult.status == mutation_status_t::SUCCESS) {
-      return seastar::now();
-    } else if (mresult.status == mutation_status_t::WAS_SPLIT) {
-      return handle_root_split(
-        get_omap_context(t, omap_root), omap_root, mresult);
-    } else if (mresult.status == mutation_status_t::NEED_MERGE) {
-      auto root = *(mresult.need_merge);
-      if (root->get_node_size() == 1 && omap_root.depth != 1) {
-        return handle_root_merge(
-          get_omap_context(t, omap_root), omap_root, mresult);
-      } else {
-        return seastar::now(); 
-      }
-    } else {
-      return seastar::now();
+  auto root = co_await get_omap_root(get_omap_context(t, omap_root), omap_root);
+  auto mresult = co_await root->rm_key(get_omap_context(t, omap_root), key);
+  
+  if (mresult.status == mutation_status_t::WAS_SPLIT) {
+    co_await handle_root_split(get_omap_context(t, omap_root), omap_root, mresult);
+  } else if (mresult.status == mutation_status_t::NEED_MERGE) {
+    auto root = *(mresult.need_merge);
+    if (root->get_node_size() == 1 && omap_root.depth != 1) {
+      co_await handle_root_merge(get_omap_context(t, omap_root), omap_root, mresult);
     }
-  });
+  }
 }
 
 BtreeOMapManager::omap_rm_keys_ret
 BtreeOMapManager::omap_rm_keys(
   omap_root_t &omap_root,
   Transaction &t,
-  std::set<std::string>& keys)
+  std::set<std::string> keys)
 {
+  LOG_PREFIX(BtreeOMapManager::omap_rm_keys);
   auto type = omap_root.get_type();
-  return trans_intr::do_for_each(
-    keys.begin(),
-    keys.end(),
-    [&t, &omap_root, type, this](auto &p)
-  {
-    LOG_PREFIX(BtreeOMapManager::omap_rm_keys);
+  for (auto &p: keys) {
     DEBUGT("{} remove key={} ...", t, type, p);
-    return omap_rm_key(omap_root, t, p);
-  });
+    co_await omap_rm_key(omap_root, t, p);
+  }
 }
 
 BtreeOMapManager::omap_rm_key_range_ret

--- a/src/crimson/os/seastore/omap_manager/btree/btree_omap_manager.h
+++ b/src/crimson/os/seastore/omap_manager/btree/btree_omap_manager.h
@@ -72,22 +72,22 @@ public:
   omap_get_value_ret omap_get_value(
     const omap_root_t &omap_root,
     Transaction &t,
-    const std::string &key) final;
+    std::string key) final;
 
   omap_set_key_ret omap_set_key(
     omap_root_t &omap_root,
     Transaction &t,
-    const std::string &key, const ceph::bufferlist &value) final;
+    std::string key, ceph::bufferlist value) final;
 
   omap_set_keys_ret omap_set_keys(
     omap_root_t &omap_root,
     Transaction &t,
-    std::map<std::string, ceph::bufferlist>&& keys) final;
+    std::map<std::string, ceph::bufferlist> keys) final;
 
   omap_rm_key_ret omap_rm_key(
     omap_root_t &omap_root,
     Transaction &t,
-    const std::string &key) final;
+    std::string key) final;
 
   omap_rm_key_range_ret omap_rm_key_range(
     omap_root_t &omap_root,
@@ -115,7 +115,7 @@ public:
   omap_rm_keys_ret omap_rm_keys(
     omap_root_t &omap_root,
     Transaction &t,
-    std::set<std::string>& keys) final;
+    std::set<std::string> keys) final;
 };
 using BtreeOMapManagerRef = std::unique_ptr<BtreeOMapManager>;
 

--- a/src/crimson/os/seastore/omap_manager/log/log_manager.cc
+++ b/src/crimson/os/seastore/omap_manager/log/log_manager.cc
@@ -55,13 +55,12 @@ LogManager::initialize_omap(Transaction &t, laddr_t hint, omap_type_t omap_type)
 LogManager::omap_set_keys_ret
 LogManager::omap_set_keys(
   omap_root_t &log_root,
-  Transaction &t, std::map<std::string, ceph::bufferlist>&& _kvs) 
+  Transaction &t, std::map<std::string, ceph::bufferlist> kvs)
 {
   LOG_PREFIX(LogManager::omap_set_keys);
-  DEBUGT("enter kv size {}", t, _kvs.size());
+  DEBUGT("enter kv size {}", t, kvs.size());
   assert(log_root.get_type() == omap_type_t::LOG);
 
-  auto kvs = std::move(_kvs);
   auto ext = co_await log_load_extent<LogNode>(
     t, log_root.addr, BEGIN_KEY, END_KEY);
   ceph_assert(ext);
@@ -242,7 +241,7 @@ LogManager::omap_set_key_ret
 LogManager::omap_set_key(
   omap_root_t &log_root,
   Transaction &t,
-  const std::string &key, const ceph::bufferlist &value) 
+  std::string key, ceph::bufferlist value)
 {
   LOG_PREFIX(LogManager::omap_set_key);
   DEBUGT("enter k={}", t, key);
@@ -401,7 +400,7 @@ LogManager::log_load_extent(
 
 LogManager::omap_get_value_ret
 LogManager::omap_get_value(
-  const omap_root_t &log_root, Transaction &t, const std::string &key)
+  const omap_root_t &log_root, Transaction &t, std::string key)
 {
   LOG_PREFIX(LogManager::omap_get_value);
   DEBUGT("key={}", t, key);
@@ -673,7 +672,7 @@ LogManager::omap_rm_key_ret
 LogManager::omap_rm_key(
   omap_root_t &log_root,
   Transaction &t,
-  const std::string &key)
+  std::string key)
 {
   LOG_PREFIX(LogManager::omap_rm_key);
   DEBUGT("key={}", t, key);
@@ -734,7 +733,7 @@ LogManager::omap_rm_keys_ret
 LogManager::omap_rm_keys(
   omap_root_t& log_root,
   Transaction& t,
-  std::set<std::string>& keys)
+  std::set<std::string> keys)
 {
   LOG_PREFIX(LogManager::omap_rm_keys);
   DEBUGT("key size={}", t, keys.size());

--- a/src/crimson/os/seastore/omap_manager/log/log_manager.h
+++ b/src/crimson/os/seastore/omap_manager/log/log_manager.h
@@ -71,14 +71,14 @@ public:
    * @param _kvs   Batch of keys to set
    */
   omap_set_keys_ret omap_set_keys(omap_root_t &log_root,
-    Transaction &t, std::map<std::string, ceph::bufferlist>&& _kvs) final;
+    Transaction &t, std::map<std::string, ceph::bufferlist> kvs) final;
 
   // see omap_set_keys
   omap_set_key_ret omap_set_key(
     omap_root_t &log_root,
     Transaction &t,
-    const std::string &key,
-    const ceph::bufferlist &value) final;
+    std::string key,
+    ceph::bufferlist value) final;
 
   /**
    * omap_get_value
@@ -92,7 +92,7 @@ public:
    */
   omap_get_value_ret
   omap_get_value(const omap_root_t &log_root, Transaction &t,
-    const std::string &key) final;
+    std::string key) final;
 
   /**
    * omap_list
@@ -151,13 +151,13 @@ public:
   omap_rm_key_ret omap_rm_key(
     omap_root_t &log_root,
     Transaction &t,
-    const std::string &key) final;
+    std::string key) final;
 
 
   omap_rm_keys_ret omap_rm_keys(
     omap_root_t &omap_root,
     Transaction &t,
-    std::set<std::string>& keys) final;
+    std::set<std::string> keys) final;
 
   /**
    * omap_clear


### PR DESCRIPTION
This commit changes funcs in BTree OMap manager to coroutines. Apart from cleaner code that's easier to follow this is done to fix ASan heap-use-after-free asserts.

Example QA job with the error: https://pulpito.ceph.com/shraddhaag-2026-04-20_07:04:25-crimson-rados-main-distro-debug-trial/164374/

This effort is towards Rocky10 support in crimson: https://tracker.ceph.com/issues/75823. 

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [X] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
