### PR TITLE
seastore/omap_manager/btree: change node insert/del funcs to coroutines

### DIFF
--- a/src/crimson/os/seastore/omap_manager/btree/omap_btree_node.h
+++ b/src/crimson/os/seastore/omap_manager/btree/omap_btree_node.h
@@ -63,21 +63,21 @@ struct OMapNode : LogicalChildNode {
   using get_value_ret = OMapManager::omap_get_value_ret;
   virtual get_value_ret get_value(
     omap_context_t oc,
-    const std::string &key) = 0;
+    std::string key) = 0;
 
   using insert_iertr = base_iertr::extend<
     crimson::ct_error::value_too_large>;
   using insert_ret = insert_iertr::future<mutation_result_t>;
   virtual insert_ret insert(
     omap_context_t oc,
-    const std::string &key,
-    const ceph::bufferlist &value) = 0;
+    std::string key,
+    ceph::bufferlist value) = 0;
 
   using rm_key_iertr = base_iertr;
   using rm_key_ret = rm_key_iertr::future<mutation_result_t>;
   virtual rm_key_ret rm_key(
     omap_context_t oc,
-    const std::string &key) = 0;
+    std::string key) = 0;
 
   using rm_key_range_iertr = base_iertr;
   using rm_key_range_ret = rm_key_range_iertr::future<mutation_result_t>;

--- a/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.cc
+++ b/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.cc
@@ -146,81 +146,69 @@ OMapInnerNode::handle_split(
 OMapInnerNode::get_value_ret
 OMapInnerNode::get_value(
   omap_context_t oc,
-  const std::string &key)
+  std::string key)
 {
   LOG_PREFIX(OMapInnerNode::get_value);
   DEBUGT("key = {}, this: {}", oc.t, key, *this);
-  return get_child_node(oc, key).si_then(
-    [oc, &key] (auto extent) {
-    ceph_assert(!extent->is_btree_root());
-    return extent->get_value(oc, key);
-  }).finally([ref = OMapNodeRef(this)] {});
+  auto extent = co_await get_child_node(oc, key);
+  ceph_assert(!extent->is_btree_root());
+  co_return co_await extent->get_value(oc, key);
 }
 
 OMapInnerNode::insert_ret
 OMapInnerNode::insert(
   omap_context_t oc,
-  const std::string &key,
-  const ceph::bufferlist &value)
+  std::string key,
+  ceph::bufferlist value)
 {
   LOG_PREFIX(OMapInnerNode::insert);
   DEBUGT("{} -> 0x{:x} value, this: {}", oc.t, key, value.length(), *this);
   auto child_pt = get_containing_child(key);
   if (exceeds_max_kv_limit(key, value)) {
-    return crimson::ct_error::value_too_large::make();
+    co_await insert_iertr::future<>(crimson::ct_error::value_too_large::make());
   }
-  return get_child_node(oc, child_pt).si_then(
-    [oc, &key, &value] (auto extent) {
-    ceph_assert(!extent->is_btree_root());
-    return extent->insert(oc, key, value);
-  }).si_then([this, oc, child_pt] (auto mresult) -> insert_ret {
-    if (mresult.status == mutation_status_t::SUCCESS) {
-      return insert_iertr::make_ready_future<mutation_result_t>(mresult);
-    } else if (mresult.status == mutation_status_t::WAS_SPLIT) {
-      return handle_split(oc, child_pt, mresult);
-    } else {
-     return insert_ret(
-            interruptible::ready_future_marker{},
-            mutation_result_t(mutation_status_t::SUCCESS, std::nullopt, std::nullopt));
-    }
-  });
+  auto extent = co_await get_child_node(oc, child_pt);
+  ceph_assert(!extent->is_btree_root());
+  auto mresult = co_await extent->insert(oc, key, value);
+  if (mresult.status == mutation_status_t::SUCCESS) {
+    co_return mresult;
+  } else if (mresult.status == mutation_status_t::WAS_SPLIT) {
+    co_return co_await handle_split(oc, child_pt, mresult);
+  } else {
+    co_return mutation_result_t(mutation_status_t::SUCCESS, std::nullopt, std::nullopt);
+  }
 }
 
 OMapInnerNode::rm_key_ret
-OMapInnerNode::rm_key(omap_context_t oc, const std::string &key)
+OMapInnerNode::rm_key(omap_context_t oc, std::string key)
 {
   LOG_PREFIX(OMapInnerNode::rm_key);
   DEBUGT("key={}, this: {}", oc.t, key, *this);
   auto child_pt = get_containing_child(key);
-  return get_child_node(oc, child_pt).si_then(
-    [this, oc, &key, child_pt] (auto extent) {
-    ceph_assert(!extent->is_btree_root());
-    return extent->rm_key(oc, key)
-      .si_then([this, oc, child_pt, extent = std::move(extent)] (auto mresult) {
-      switch (mresult.status) {
-        case mutation_status_t::SUCCESS:
-        case mutation_status_t::FAIL:
-          return rm_key_iertr::make_ready_future<mutation_result_t>(mresult);
-        case mutation_status_t::NEED_MERGE: {
-          if (get_node_size() >1)
-            return merge_entry(oc, child_pt, *(mresult.need_merge));
-          else
-            return rm_key_ret(
-                   interruptible::ready_future_marker{},
-                   mutation_result_t(mutation_status_t::SUCCESS,
-                                     std::nullopt, std::nullopt));
-        }
-        case mutation_status_t::WAS_SPLIT:
-          return handle_split(oc, child_pt, mresult
-	  ).handle_error_interruptible(
-	    rm_key_iertr::pass_further{},
-	    crimson::ct_error::assert_all{"unexpected error"}
+  auto extent = co_await get_child_node(oc, child_pt);
+  ceph_assert(!extent->is_btree_root());
+  auto mresult = co_await extent->rm_key(oc, key);
+  switch (mresult.status) {
+    case mutation_status_t::SUCCESS:
+    case mutation_status_t::FAIL: {
+      co_return mresult;
+    }
+    case mutation_status_t::NEED_MERGE: {
+      if (get_node_size() >1)
+        co_return co_await merge_entry(oc, child_pt, *(mresult.need_merge));
+      else
+        co_return mutation_result_t(mutation_status_t::SUCCESS,
+                                    std::nullopt, std::nullopt);
+    }
+    case mutation_status_t::WAS_SPLIT:
+      co_return co_await handle_split(oc, child_pt, mresult
+          ).handle_error_interruptible(
+	          rm_key_iertr::pass_further{},
+	          crimson::ct_error::assert_all{"unexpected error"}
 	  );
-        default:
-          return rm_key_iertr::make_ready_future<mutation_result_t>(mresult);
-      }
-    });
-  });
+    default:
+      co_return mresult;
+  }
 }
 
 OMapInnerNode::rm_key_range_ret
@@ -728,39 +716,34 @@ std::ostream &OMapLeafNode::print_detail_l(std::ostream &out) const
 }
 
 OMapLeafNode::get_value_ret
-OMapLeafNode::get_value(omap_context_t oc, const std::string &key)
+OMapLeafNode::get_value(omap_context_t oc, std::string key)
 {
   LOG_PREFIX(OMapLeafNode::get_value);
   DEBUGT("key = {}, this: {}", oc.t, *this, key);
   auto ite = find_string_key(key);
   if (ite != iter_end()) {
-    auto value = ite->get_val();
-    return get_value_ret(
-      interruptible::ready_future_marker{},
-      value);
+    co_return ite->get_val();
   } else {
-    return get_value_ret(
-      interruptible::ready_future_marker{},
-      std::nullopt);
+    co_return std::nullopt;
   }
 }
 
 OMapLeafNode::insert_ret
 OMapLeafNode::insert(
   omap_context_t oc,
-  const std::string &key,
-  const ceph::bufferlist &value)
+  std::string key,
+  ceph::bufferlist value)
 {
   LOG_PREFIX(OMapLeafNode::insert);
   DEBUGT("{} -> 0x{:x} value, this: {}", oc.t, key, value.length(), *this);
   if (exceeds_max_kv_limit(key, value)) {
-    return crimson::ct_error::value_too_large::make();
+    co_await insert_iertr::future<>(crimson::ct_error::value_too_large::make());
   }
   bool overflow = extent_will_overflow(key.size(), value.length());
   if (!overflow) {
     if (!is_mutable()) {
       auto mut = oc.tm.get_mutable_extent(oc.t, this)->cast<OMapLeafNode>();
-      return mut->insert(oc, key, value);
+      co_return co_await mut->insert(oc, key, value);
     }
     auto replace_pt = find_string_key(key);
     if (replace_pt != iter_end()) {
@@ -773,76 +756,63 @@ OMapLeafNode::insert(
 
       DEBUGT("inserted {}, this: {}", oc.t, insert_pt.get_key(), *this);
     }
-    return insert_ret(
-           interruptible::ready_future_marker{},
-           mutation_result_t(mutation_status_t::SUCCESS, std::nullopt, std::nullopt));
+    co_return mutation_result_t(mutation_status_t::SUCCESS, std::nullopt, std::nullopt);
   } else {
-    return make_split_children(oc).si_then([this, oc, &key, &value] (auto tuple) {
-      auto [left, right, pivot] = tuple;
-      left->init_range(get_begin(), pivot);
-      right->init_range(pivot, get_end());
-      auto replace_pt = find_string_key(key);
-      if (replace_pt != iter_end()) {
-        ++(oc.t.get_omap_tree_stats().num_updates);
-        if (key < pivot) {  //left
-          auto mut_iter = left->iter_idx(replace_pt->get_offset());
-          left->journal_leaf_update(mut_iter, key, value, left->maybe_get_delta_buffer());
-        } else if (key >= pivot) { //right
-          auto mut_iter = right->iter_idx(replace_pt->get_offset() - left->get_node_size());
-          right->journal_leaf_update(mut_iter, key, value, right->maybe_get_delta_buffer());
-        }
-      } else {
-        ++(oc.t.get_omap_tree_stats().num_inserts);
-        auto insert_pt = string_lower_bound(key);
-        if (key < pivot) {  //left
-          auto mut_iter = left->iter_idx(insert_pt->get_offset());
-          left->journal_leaf_insert(mut_iter, key, value, left->maybe_get_delta_buffer());
-        } else {
-          auto mut_iter = right->iter_idx(insert_pt->get_offset() - left->get_node_size());
-          right->journal_leaf_insert(mut_iter, key, value, right->maybe_get_delta_buffer());
-        }
+    auto tuple = co_await make_split_children(oc);
+    auto [left, right, pivot] = tuple;
+    left->init_range(get_begin(), pivot);
+    right->init_range(pivot, get_end());
+    auto replace_pt = find_string_key(key);
+    if (replace_pt != iter_end()) {
+      ++(oc.t.get_omap_tree_stats().num_updates);
+      if (key < pivot) {  //left
+        auto mut_iter = left->iter_idx(replace_pt->get_offset());
+        left->journal_leaf_update(mut_iter, key, value, left->maybe_get_delta_buffer());
+      } else if (key >= pivot) { //right
+        auto mut_iter = right->iter_idx(replace_pt->get_offset() - left->get_node_size());
+        right->journal_leaf_update(mut_iter, key, value, right->maybe_get_delta_buffer());
       }
-      ++(oc.t.get_omap_tree_stats().extents_num_delta);
-      return dec_ref(oc, get_laddr())
-        .si_then([tuple = std::move(tuple)] {
-        return insert_ret(
-               interruptible::ready_future_marker{},
-               mutation_result_t(mutation_status_t::WAS_SPLIT, tuple, std::nullopt));
-      });
-    });
+    } else {
+      ++(oc.t.get_omap_tree_stats().num_inserts);
+      auto insert_pt = string_lower_bound(key);
+      if (key < pivot) {  //left
+        auto mut_iter = left->iter_idx(insert_pt->get_offset());
+        left->journal_leaf_insert(mut_iter, key, value, left->maybe_get_delta_buffer());
+      } else {
+        auto mut_iter = right->iter_idx(insert_pt->get_offset() - left->get_node_size());
+        right->journal_leaf_insert(mut_iter, key, value, right->maybe_get_delta_buffer());
+      }
+    }
+    ++(oc.t.get_omap_tree_stats().extents_num_delta);
+    co_await dec_ref(oc, get_laddr());
+    co_return mutation_result_t(mutation_status_t::WAS_SPLIT, tuple, std::nullopt);
   }
 }
 
 OMapLeafNode::rm_key_ret
-OMapLeafNode::rm_key(omap_context_t oc, const std::string &key)
+OMapLeafNode::rm_key(omap_context_t oc, std::string key)
 {
   LOG_PREFIX(OMapLeafNode::rm_key);
   DEBUGT("{}, this: {}", oc.t, key, *this);
   auto rm_pt = find_string_key(key);
   if (!is_mutable() && rm_pt != iter_end()) {
     auto mut =  oc.tm.get_mutable_extent(oc.t, this)->cast<OMapLeafNode>();
-    return mut->rm_key(oc, key);
+    co_return co_await mut->rm_key(oc, key);
   }
 
   if (rm_pt != iter_end()) {
     ++(oc.t.get_omap_tree_stats().num_erases);
     journal_leaf_remove(rm_pt, maybe_get_delta_buffer());
     if (extent_is_below_min()) {
-      return rm_key_ret(
-	interruptible::ready_future_marker{},
-	mutation_result_t(mutation_status_t::NEED_MERGE, std::nullopt,
-			  this->cast<OMapNode>()));
+      co_return mutation_result_t(mutation_status_t::NEED_MERGE, std::nullopt,
+                                  this->cast<OMapNode>());
     } else {
-      return rm_key_ret(
-	interruptible::ready_future_marker{},
-	mutation_result_t(mutation_status_t::SUCCESS, std::nullopt, std::nullopt));
+      co_return mutation_result_t(mutation_status_t::SUCCESS, std::nullopt,
+                                  std::nullopt);
     }
   } else {
-    return rm_key_ret(
-      interruptible::ready_future_marker{},
-      mutation_result_t(mutation_status_t::FAIL, std::nullopt, std::nullopt));
+    co_return mutation_result_t(mutation_status_t::FAIL, std::nullopt, std::nullopt);
   }
-
 }
 
 OMapLeafNode::rm_key_range_ret

--- a/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.h
+++ b/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.h
@@ -170,12 +170,12 @@ struct OMapInnerNode
     return is_mutation_pending() ? &delta_buffer : nullptr;
   }
 
-  get_value_ret get_value(omap_context_t oc, const std::string &key) final;
+  get_value_ret get_value(omap_context_t oc, std::string key) final;
 
   insert_ret insert(
     omap_context_t oc,
-    const std::string &key,
-    const ceph::bufferlist &value) final;
+    std::string key,
+    ceph::bufferlist value) final;
 
   bool exceeds_max_kv_limit(
     const std::string &key,
@@ -185,7 +185,7 @@ struct OMapInnerNode
 
   rm_key_ret rm_key(
     omap_context_t oc,
-    const std::string &key) final;
+    std::string key) final;
 
   rm_key_range_ret rm_key_range(
     omap_context_t oc,
@@ -434,12 +434,12 @@ struct OMapLeafNode
   }
 
   get_value_ret get_value(
-    omap_context_t oc, const std::string &key) final;
+    omap_context_t oc, std::string key) final;
 
   insert_ret insert(
     omap_context_t oc,
-    const std::string &key,
-    const ceph::bufferlist &value) final;
+    std::string key,
+    ceph::bufferlist value) final;
 
   bool exceeds_max_kv_limit(
     const std::string &key,
@@ -448,7 +448,7 @@ struct OMapLeafNode
   }
 
   rm_key_ret rm_key(
-    omap_context_t oc, const std::string &key) final;
+    omap_context_t oc, std::string key) final;
 
   rm_key_range_ret rm_key_range(
     omap_context_t oc,


### PR DESCRIPTION
This commit changes OMapLeafNode and OMapInnerNode funcs to coroutines to improve readability and prevent any ASan heap-use-after-free asserts.

This effort is towards Rocky10 support in crimson: https://tracker.ceph.com/issues/75823.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
