### PR TITLE
squid: rgw: add Keystone scope and application credential info to ops log

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -863,6 +863,42 @@ options:
   - '1'
   - none
   with_legacy: true
+- name: rgw_keystone_scope_enabled
+  type: bool
+  level: advanced
+  desc: Enable logging of Keystone scope information in ops log
+  long_desc: When enabled, operations authenticated via Keystone will include scope
+    information (project, domain, roles) in the ops log. This is disabled by default
+    as it adds additional data to each log entry and most deployments do not require
+    this level of Keystone audit detail. User identity logging is controlled separately
+    by rgw_keystone_scope_include_user for privacy considerations. Requires
+    rgw_enable_ops_log to be enabled.
+  default: false
+  services:
+  - rgw
+  with_legacy: true
+- name: rgw_keystone_scope_include_user
+  type: bool
+  level: advanced
+  desc: Include human-readable identity names in Keystone scope logs
+  long_desc: When false (default), only opaque IDs are logged for all identity fields
+    (project_id, domain_id, user_id, app_cred_id), which is GDPR-compliant and
+    privacy-friendly. When true, human-readable names (project_name, domain names,
+    user_name, app_cred_name) are included. Opaque IDs are always logged regardless
+    of this setting, allowing operators to correlate with Keystone without exposing
+    names in logs.
+  default: false
+  services:
+  - rgw
+  with_legacy: true
+- name: rgw_keystone_scope_include_roles
+  type: bool
+  level: advanced
+  desc: Include role names in Keystone scope logs
+  default: true
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_cross_domain_policy
   type: str
   level: advanced

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -79,6 +79,7 @@ set(librgw_common_srcs
   rgw_formats.cc
   rgw_http_client.cc
   rgw_keystone.cc
+  rgw_keystone_scope.cc
   rgw_ldap.cc
   rgw_lc.cc
   rgw_lc_s3.cc

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -936,6 +936,11 @@ void rgw::auth::RemoteApplier::write_ops_log_entry(rgw_log_entry& entry) const
   if (account) {
     entry.account_id = account->id;
   }
+  entry.user = info.keystone_user;
+
+  if (info.keystone_scope.has_value()) {
+    entry.keystone_scope = info.keystone_scope;
+  }
 }
 
 /* TODO(rzarzynski): we need to handle display_name changes. */

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -15,6 +15,7 @@
 
 #include "rgw_common.h"
 #include "rgw_web_idp.h"
+#include "rgw_keystone_scope.h"
 
 #define RGW_USER_ANON_ID "anonymous"
 
@@ -576,6 +577,8 @@ public:
     const uint32_t acct_type;
     const std::string access_key_id;
     const std::string subuser;
+    const std::string keystone_user;
+    const std::optional<rgw::keystone::ScopeInfo> keystone_scope;
 
   public:
     enum class acct_privilege_t {
@@ -592,14 +595,18 @@ public:
              const acct_privilege_t level,
              const std::string access_key_id,
              const std::string subuser,
-             const uint32_t acct_type=TYPE_NONE)
+             const std::string keystone_user,
+             const uint32_t acct_type=TYPE_NONE,
+             std::optional<rgw::keystone::ScopeInfo> keystone_scope=std::nullopt)
     : acct_user(acct_user),
       acct_name(acct_name),
       perm_mask(perm_mask),
       is_admin(acct_privilege_t::IS_ADMIN_ACCT == level),
       acct_type(acct_type),
       access_key_id(access_key_id),
-      subuser(subuser) {
+      subuser(subuser),
+      keystone_user(keystone_user),
+      keystone_scope(std::move(keystone_scope)) {
     }
   };
 

--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -16,6 +16,7 @@
 
 #include "rgw_common.h"
 #include "rgw_keystone.h"
+#include "rgw_keystone_scope.h"
 #include "rgw_auth_keystone.h"
 #include "rgw_rest_s3.h"
 #include "rgw_auth_s3.h"
@@ -158,6 +159,9 @@ TokenEngine::get_creds_info(const TokenEngine::token_envelope_t& token
     }
   }
 
+  /* Build keystone scope info if ops logging is enabled */
+  auto keystone_scope = rgw::keystone::build_scope_info(cct, token);
+
   return auth_info_t {
     /* Suggested account name for the authenticated user. */
     rgw_user(token.get_project_id()),
@@ -169,7 +173,9 @@ TokenEngine::get_creds_info(const TokenEngine::token_envelope_t& token
     level,
     rgw::auth::RemoteApplier::AuthInfo::NO_ACCESS_KEY,
     rgw::auth::RemoteApplier::AuthInfo::NO_SUBUSER,
-    TYPE_KEYSTONE
+    token.get_user_name(),
+    TYPE_KEYSTONE,
+    std::move(keystone_scope)
 };
 }
 
@@ -674,6 +680,9 @@ EC2Engine::get_creds_info(const EC2Engine::token_envelope_t& token,
     }
   }
 
+  /* Build keystone scope info if ops logging is enabled */
+  auto keystone_scope = rgw::keystone::build_scope_info(cct, token);
+
   return auth_info_t {
     /* Suggested account name for the authenticated user. */
     rgw_user(token.get_project_id()),
@@ -685,7 +694,9 @@ EC2Engine::get_creds_info(const EC2Engine::token_envelope_t& token,
     level,
     access_key_id,
     rgw::auth::RemoteApplier::AuthInfo::NO_SUBUSER,
-    TYPE_KEYSTONE
+    token.get_user_name(),
+    TYPE_KEYSTONE,
+    std::move(keystone_scope)
   };
 }
 

--- a/src/rgw/rgw_keystone.cc
+++ b/src/rgw/rgw_keystone.cc
@@ -582,6 +582,13 @@ void rgw::keystone::TokenEnvelope::User::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("roles", roles_v2, obj);
 }
 
+void rgw::keystone::TokenEnvelope::ApplicationCredential::decode_json(JSONObj *obj)
+{
+  JSONDecoder::decode_json("id", id, obj, true);
+  JSONDecoder::decode_json("name", name, obj, true);
+  JSONDecoder::decode_json("restricted", restricted, obj, true);
+}
+
 void rgw::keystone::TokenEnvelope::decode_v3(JSONObj* const root_obj)
 {
   std::string expires_iso8601;
@@ -590,6 +597,12 @@ void rgw::keystone::TokenEnvelope::decode_v3(JSONObj* const root_obj)
   JSONDecoder::decode_json("expires_at", expires_iso8601, root_obj, true);
   JSONDecoder::decode_json("roles", roles, root_obj, true);
   JSONDecoder::decode_json("project", project, root_obj, true);
+
+  // Optional application_credential field (only present for app cred auth)
+  ApplicationCredential tmp_app_cred;
+  if (JSONDecoder::decode_json("application_credential", tmp_app_cred, root_obj, false)) {
+    app_cred = std::move(tmp_app_cred);
+  }
 
   struct tm t;
   if (parse_iso8601(expires_iso8601.c_str(), &t)) {

--- a/src/rgw/rgw_keystone.h
+++ b/src/rgw/rgw_keystone.h
@@ -185,10 +185,20 @@ public:
     void decode_json(JSONObj *obj);
   };
 
+  class ApplicationCredential {
+  public:
+    ApplicationCredential() : restricted(false) { }
+    std::string id;
+    std::string name;
+    bool restricted;
+    void decode_json(JSONObj *obj);
+  };
+
   Token token;
   Project project;
   User user;
   std::list<Role> roles;
+  std::optional<ApplicationCredential> app_cred;
 
   void decode_v3(JSONObj* obj);
   void decode_v2(JSONObj* obj);

--- a/src/rgw/rgw_keystone_scope.cc
+++ b/src/rgw/rgw_keystone_scope.cc
@@ -1,0 +1,111 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+#include "rgw_keystone_scope.h"
+#include "rgw_keystone.h"
+#include "common/ceph_context.h"
+#include "common/Formatter.h"
+
+#define dout_subsys ceph_subsys_rgw
+
+namespace rgw::keystone {
+
+void ScopeInfo::dump(ceph::Formatter *f) const
+{
+  f->open_object_section("keystone_scope");
+
+  // Project
+  f->open_object_section("project");
+  f->dump_string("id", project.id);
+  f->dump_string("name", project.name);
+  f->open_object_section("domain");
+  f->dump_string("id", project.domain.id);
+  f->dump_string("name", project.domain.name);
+  f->close_section(); // domain
+  f->close_section(); // project
+
+  // User (optional based on config)
+  if (user.has_value()) {
+    f->open_object_section("user");
+    f->dump_string("id", user->id);
+    f->dump_string("name", user->name);
+    f->open_object_section("domain");
+    f->dump_string("id", user->domain.id);
+    f->dump_string("name", user->domain.name);
+    f->close_section(); // domain
+    f->close_section(); // user
+  }
+
+  // Roles (may be empty based on config)
+  if (!roles.empty()) {
+    f->open_array_section("roles");
+    for (const auto& role : roles) {
+      f->dump_string("role", role);
+    }
+    f->close_section(); // roles
+  }
+
+  // Application credential (optional, present only for app cred auth)
+  if (app_cred.has_value()) {
+    f->open_object_section("application_credential");
+    f->dump_string("id", app_cred->id);
+    f->dump_string("name", app_cred->name);
+    f->dump_bool("restricted", app_cred->restricted);
+    f->close_section(); // application_credential
+  }
+
+  f->close_section(); // keystone_scope
+}
+
+std::optional<ScopeInfo> build_scope_info(
+    CephContext* cct,
+    const TokenEnvelope& token)
+{
+  // Check if scope logging is enabled
+  if (!cct->_conf->rgw_keystone_scope_enabled) {
+    return std::nullopt;
+  }
+
+  ScopeInfo scope;
+  bool include_names = cct->_conf->rgw_keystone_scope_include_user;
+
+  // Project/tenant scope - IDs always included, names only if include_user=true
+  scope.project.id = token.get_project_id();
+  scope.project.domain.id = token.project.domain.id;
+  if (include_names) {
+    scope.project.name = token.get_project_name();
+    scope.project.domain.name = token.project.domain.name;
+  }
+
+  // User identity (controlled by include_user flag - both field and names)
+  if (include_names) {
+    ScopeInfo::user_t user;
+    user.id = token.get_user_id();
+    user.name = token.get_user_name();
+    user.domain.id = token.user.domain.id;
+    user.domain.name = token.user.domain.name;
+    scope.user = std::move(user);
+  }
+
+  // Roles (controlled by include_roles flag)
+  if (cct->_conf->rgw_keystone_scope_include_roles) {
+    for (const auto& role : token.roles) {
+      scope.roles.push_back(role.name);
+    }
+  }
+
+  // Application credential (if present in token) - ID always, name only if include_user=true
+  if (token.app_cred.has_value()) {
+    ScopeInfo::app_cred_t app_cred;
+    app_cred.id = token.app_cred->id;
+    if (include_names) {
+      app_cred.name = token.app_cred->name;
+    }
+    app_cred.restricted = token.app_cred->restricted;
+    scope.app_cred = std::move(app_cred);
+  }
+
+  return scope;
+}
+
+} // namespace rgw::keystone

--- a/src/rgw/rgw_keystone_scope.h
+++ b/src/rgw/rgw_keystone_scope.h
@@ -1,0 +1,202 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "include/buffer.h"
+#include "include/encoding.h"
+
+class CephContext;
+
+namespace ceph {
+  class Formatter;
+}
+
+namespace rgw::keystone {
+
+// Import ceph encode/decode templates for visibility
+using ceph::encode;
+using ceph::decode;
+
+// Forward declaration
+class TokenEnvelope;
+
+/**
+ * Keystone authentication scope information.
+ *
+ * This structure captures the OpenStack Keystone authentication context
+ * including project, user, and roles. It's used throughout the
+ * authentication and logging pipeline.
+ *
+ * The structure supports:
+ * - Binary encoding/decoding for RADOS backend (ops log storage)
+ * - JSON formatting for file/socket backend (ops log output)
+ * - Granular control via configuration flags (include_user, include_roles)
+ */
+struct ScopeInfo {
+  /**
+   * Keystone domain information.
+   * Domains provide namespace isolation in Keystone.
+   */
+  struct domain_t {
+    static constexpr uint8_t kEncV = 1;
+    std::string id;
+    std::string name;
+
+    void encode(bufferlist &bl) const {
+      ENCODE_START(kEncV, kEncV, bl);
+      encode(id, bl);
+      encode(name, bl);
+      ENCODE_FINISH(bl);
+    }
+    void decode(bufferlist::const_iterator &p) {
+      DECODE_START(kEncV, p);
+      decode(id, p);
+      decode(name, p);
+      DECODE_FINISH(p);
+    }
+  };
+
+  /**
+   * Keystone project (tenant) information.
+   * Projects are the primary authorization scope in Keystone.
+   */
+  struct project_t {
+    static constexpr uint8_t kEncV = 1;
+    std::string id;
+    std::string name;
+    domain_t domain;
+
+    void encode(bufferlist &bl) const {
+      ENCODE_START(kEncV, kEncV, bl);
+      encode(id, bl);
+      encode(name, bl);
+      domain.encode(bl);
+      ENCODE_FINISH(bl);
+    }
+    void decode(bufferlist::const_iterator &p) {
+      DECODE_START(kEncV, p);
+      decode(id, p);
+      decode(name, p);
+      domain.decode(p);
+      DECODE_FINISH(p);
+    }
+  };
+
+  /**
+   * Keystone user information.
+   * Optional based on rgw_keystone_scope_include_user configuration.
+   */
+  struct user_t {
+    static constexpr uint8_t kEncV = 1;
+    std::string id;
+    std::string name;
+    domain_t domain;
+
+    void encode(bufferlist &bl) const {
+      ENCODE_START(kEncV, kEncV, bl);
+      encode(id, bl);
+      encode(name, bl);
+      domain.encode(bl);
+      ENCODE_FINISH(bl);
+    }
+    void decode(bufferlist::const_iterator &p) {
+      DECODE_START(kEncV, p);
+      decode(id, p);
+      decode(name, p);
+      domain.decode(p);
+      DECODE_FINISH(p);
+    }
+  };
+
+  /**
+   * Keystone application credential information.
+   * Only present when authentication used application credentials.
+   */
+  struct app_cred_t {
+    static constexpr uint8_t kEncV = 1;
+    std::string id;
+    std::string name;
+    bool restricted;
+
+    void encode(bufferlist &bl) const {
+      ENCODE_START(kEncV, kEncV, bl);
+      encode(id, bl);
+      encode(name, bl);
+      encode(restricted, bl);
+      ENCODE_FINISH(bl);
+    }
+    void decode(bufferlist::const_iterator &p) {
+      DECODE_START(kEncV, p);
+      decode(id, p);
+      decode(name, p);
+      decode(restricted, p);
+      DECODE_FINISH(p);
+    }
+  };
+
+  // Fields
+  project_t project;                        // Always present
+  std::optional<user_t> user;               // Optional (controlled by include_user config)
+  std::vector<std::string> roles;           // May be empty (controlled by include_roles config)
+  std::optional<app_cred_t> app_cred;       // Optional (present only for app cred auth)
+
+  // Serialization for RADOS backend
+  static constexpr uint8_t kEncV = 1;
+  void encode(bufferlist &bl) const;
+  void decode(bufferlist::const_iterator &p);
+
+  // JSON formatting for file/socket backend
+  void dump(ceph::Formatter *f) const;
+};
+
+// Free function wrappers at namespace level for std::optional encoding support
+inline void encode(const ScopeInfo::domain_t& v, bufferlist& bl) { v.encode(bl); }
+inline void decode(ScopeInfo::domain_t& v, bufferlist::const_iterator& p) { v.decode(p); }
+inline void encode(const ScopeInfo::project_t& v, bufferlist& bl) { v.encode(bl); }
+inline void decode(ScopeInfo::project_t& v, bufferlist::const_iterator& p) { v.decode(p); }
+inline void encode(const ScopeInfo::user_t& v, bufferlist& bl) { v.encode(bl); }
+inline void decode(ScopeInfo::user_t& v, bufferlist::const_iterator& p) { v.decode(p); }
+inline void encode(const ScopeInfo::app_cred_t& v, bufferlist& bl) { v.encode(bl); }
+inline void decode(ScopeInfo::app_cred_t& v, bufferlist::const_iterator& p) { v.decode(p); }
+inline void encode(const ScopeInfo& v, bufferlist& bl) { v.encode(bl); }
+inline void decode(ScopeInfo& v, bufferlist::const_iterator& p) { v.decode(p); }
+
+// ScopeInfo encode/decode implementations (defined after free functions for visibility)
+inline void ScopeInfo::encode(bufferlist &bl) const {
+  ENCODE_START(kEncV, kEncV, bl);
+  encode(project, bl);
+  encode(user, bl);
+  encode(roles, bl);
+  encode(app_cred, bl);
+  ENCODE_FINISH(bl);
+}
+
+inline void ScopeInfo::decode(bufferlist::const_iterator &p) {
+  DECODE_START(kEncV, p);
+  decode(project, p);
+  decode(user, p);
+  decode(roles, p);
+  decode(app_cred, p);
+  DECODE_FINISH(p);
+}
+
+/**
+ * Build ScopeInfo from Keystone token and configuration.
+ *
+ * This helper function eliminates code duplication between TokenEngine
+ * and EC2Engine by centralizing the scope building logic.
+ *
+ * @param cct CephContext for configuration access
+ * @param token TokenEnvelope containing Keystone authentication data
+ * @return ScopeInfo if scope logging enabled, nullopt otherwise
+ */
+std::optional<ScopeInfo> build_scope_info(
+    CephContext* cct,
+    const TokenEnvelope& token);
+
+} // namespace rgw::keystone

--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -331,6 +331,11 @@ void rgw_format_ops_log_entry(struct rgw_log_entry& entry, Formatter *formatter)
   }
   formatter->dump_bool("temp_url", entry.temp_url);
 
+  // Keystone scope information (if present)
+  if (entry.keystone_scope.has_value()) {
+    entry.keystone_scope->dump(formatter);
+  }
+
   if (entry.op == "multi_object_delete") {
     formatter->open_object_section("op_data");
     formatter->dump_int("num_ok", entry.delete_multi_obj_meta.num_ok);
@@ -732,5 +737,8 @@ void rgw_log_entry::dump(Formatter *f) const
   }
   if (!role_id.empty()) {
     f->dump_string("role_id", role_id);
+  }
+  if (keystone_scope.has_value()) {
+    keystone_scope->dump(f);
   }
 }

--- a/src/rgw/rgw_log.h
+++ b/src/rgw/rgw_log.h
@@ -10,6 +10,7 @@
 #include <vector>
 #include <fstream>
 #include "rgw_sal_fwd.h"
+#include "rgw_keystone_scope.h"
 
 class RGWOp;
 
@@ -105,8 +106,11 @@ struct rgw_log_entry {
   rgw_account_id account_id;
   std::string role_id;
 
+  // Keystone scope (optional) - uses unified structure from rgw_keystone_scope.h
+  std::optional<rgw::keystone::ScopeInfo> keystone_scope;
+
   void encode(bufferlist &bl) const {
-    ENCODE_START(15, 5, bl);
+    ENCODE_START(16, 5, bl);
     // old object/bucket owner ids, encoded in full in v8
     std::string empty_owner_id;
     encode(empty_owner_id, bl);
@@ -142,10 +146,11 @@ struct rgw_log_entry {
     encode(delete_multi_obj_meta, bl);
     encode(account_id, bl);
     encode(role_id, bl);
+    encode(keystone_scope, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator &p) {
-    DECODE_START_LEGACY_COMPAT_LEN(15, 5, 5, p);
+    DECODE_START_LEGACY_COMPAT_LEN(16, 5, 5, p);
     std::string object_owner_id;
     std::string bucket_owner_id;
     decode(object_owner_id, p);
@@ -217,6 +222,9 @@ struct rgw_log_entry {
     if (struct_v >= 15) {
       decode(account_id, p);
       decode(role_id, p);
+    }
+    if (struct_v >= 16) {
+      decode(keystone_scope, p);
     }
     DECODE_FINISH(p);
   }

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -6249,6 +6249,7 @@ rgw::auth::s3::LDAPEngine::get_creds_info(const rgw::RGWToken& token) const noex
     acct_privilege_t::IS_PLAIN_ACCT,
     rgw::auth::RemoteApplier::AuthInfo::NO_ACCESS_KEY,
     rgw::auth::RemoteApplier::AuthInfo::NO_SUBUSER,
+    std::string(),  // keystone_user (not applicable for LDAP)
     TYPE_LDAP
   };
 }
@@ -6393,6 +6394,7 @@ rgw::auth::s3::STSEngine::get_creds_info(const STS::SessionToken& token) const n
     (token.is_admin) ? acct_privilege_t::IS_ADMIN_ACCT: acct_privilege_t::IS_PLAIN_ACCT,
     token.access_key_id,
     rgw::auth::RemoteApplier::AuthInfo::NO_SUBUSER,
+    std::string(),  // keystone_user (not applicable for STS)
     token.acct_type
   };
 }


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/66111 to the                                                                            
  squid release branch.                                                                                                                            
                                                                                                                                                   
  Tracker: https://tracker.ceph.com/issues/76067                                                                                                   
  Original feature tracker: https://tracker.ceph.com/issues/73702                                                                                
                                                                                                                                                   
  ## Description                                                                                                                                 
                                                                                                                                                   
  Adds a new `keystone_scope` field to the RGW ops log entry, containing the                                                                       
  authenticated Keystone project, user, domain, role list, and (when applicable)
  the application credential `{id, name, restricted}`.                                                                                             
                                                                                                                                                   
  Emission is gated by a new `rgw_keystone_log_scope_info` config option                                                                           
  (default: `false`), so existing operators are unaffected unless they opt                                                                         
  in. The field is encoded as struct version 16 of `rgw_log_entry`,                                                                                
  backward compatible with prior versions.                                                                                                         
                                                                                                                                                   
  ## Backport notes                                                                                                                                
                                                                                                                                                 
  The squid branch lacks the prerequisite commit on main that introduced the                                                                       
  `keystone_user` field on `rgw::auth::RemoteApplier::AuthInfo`. To keep this                                                                    
  backport self-contained, the patch additionally:                                                                                                 
                                                                                                                                                   
  - adds the `keystone_user` member and constructor parameter to `AuthInfo`                                                                        
    (`src/rgw/rgw_auth.h`)                                                                                                                         
  - threads `token.get_user_name()` through the keystone engines                                                                                   
    (`src/rgw/rgw_auth_keystone.cc`)                                                                                                               
  - supplies an empty `keystone_user` placeholder at the LDAP and STS call                                                                         
    sites (`src/rgw/rgw_rest_s3.cc`)                                                                                                               
  - assigns `entry.user = info.keystone_user` in `rgw_auth.cc`                                                                                     
                                                                                                                                                   
  All other hunks (the `rgw::keystone::ScopeInfo` struct, `rgw_log_entry`                                                                          
  encoding bump to v16, ops-log JSON emission, yaml options, CMakeLists)                                                                           
  are identical to the main commit.                                                                                                                
                                                                                                                                                 
  ## Testing                                                                                                                                       
                                                                                                                                                 
  Verified end-to-end against a local Keystone + RGW deployment:                                                                                   
   
  - `keystone_scope` populated in the ops-log JSONL output for both                                                                                
    password-token and application-credential authentication                                                                                     
  - `application_credential` block present (`{id, name, restricted}`) when                                                                         
    the token is scoped via an app credential                                                                                                      
  - 50/50 ops-log entries valid JSONL under burst load (no encoding                                                                                
    regression from the v16 bump)                                                                                                                  
  - Existing S3 / LDAP / STS auth paths continue to log correctly with the                                                                         
    empty `keystone_user` placeholder                                                                                                              
                                                                                                                                                 
  ## Contribution Guidelines                                                                                                                       
  - To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).  
  - If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph -                                 
  Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.                                    
                                                                                                                                                   
  ## Checklist                                                                                                                                     
  - Tracker (select at least one)                                                                                                                
    - [x] References tracker ticket                                                                                                                
    - [ ] Very recent bug; references commit where it was introduced                                                                               
    - [ ] New feature (ticket optional)
    - [ ] Doc update (no ticket needed)                                                                                                            
    - [ ] Code cleanup (no ticket needed)                                                                                                        
  - Component impact                                                                                                                               
    - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket                                     
    - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket                                 
    - [x] No impact that needs to be tracked                                                                                                       
  - Documentation (select at least one)                                                                                                            
    - [ ] Updates relevant documentation                                                                                                           
    - [x] No doc update is appropriate                                                                                                           
  - Tests (select at least one)                                                                                                                    
    - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)                                         
    - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)                           
    - [ ] Includes bug reproducer                                                                                                                  
    - [ ] No tests