### PR TITLE
tentacle: ceph-volume: pass --set-keepcaps for FCM crush device class on mkfs

### DIFF
--- a/src/ceph-volume/ceph_volume/objectstore/baseobjectstore.py
+++ b/src/ceph-volume/ceph_volume/objectstore/baseobjectstore.py
@@ -161,6 +161,8 @@ class BaseObjectStore:
         # set bdev_enable_discard = false
         if self.skip_mkfs_discard and self.objectstore == 'bluestore':
             self.osd_mkfs_cmd.extend(['--bdev-enable-discard', 'false'])
+        if getattr(self.args, 'crush_device_class', None) == 'fcm' and self.objectstore == 'bluestore':
+            self.osd_mkfs_cmd.extend(['--set-keepcaps', 'true'])
         if self.cephx_secret is not None:
             self.osd_mkfs_cmd.extend(['--keyfile', '-'])
 

--- a/src/ceph-volume/ceph_volume/tests/objectstore/test_baseobjectstore.py
+++ b/src/ceph-volume/ceph_volume/tests/objectstore/test_baseobjectstore.py
@@ -140,6 +140,33 @@ class TestBaseObjectStore:
                           '--setuser', 'ceph',
                           '--setgroup', 'ceph']
 
+    @patch('ceph_volume.conf.cluster', 'ceph')
+    def test_build_osd_mkfs_cmd_fcm_crush_device_class_sets_keepcaps(self, factory):
+        bo = BaseObjectStore(factory(crush_device_class='fcm'))
+        bo.osd_path = '/var/lib/ceph/osd/ceph-123/'
+        bo.osd_fsid = 'abcd-1234'
+        bo.objectstore = 'bluestore'
+        bo.osd_id = '123'
+        bo.monmap = '/etc/ceph/ceph.monmap'
+        bo.osd_type = 'classic'
+        result = bo.build_osd_mkfs_cmd()
+
+        assert result == ['ceph-osd',
+                          '--cluster',
+                          'ceph',
+                          '--osd-objectstore',
+                          'bluestore',
+                          '--mkfs', '-i', '123',
+                          '--monmap',
+                          '/etc/ceph/ceph.monmap',
+                          '--set-keepcaps', 'true',
+                          '--keyfile', '-',
+                          '--osd-data',
+                          '/var/lib/ceph/osd/ceph-123/',
+                          '--osd-uuid', 'abcd-1234',
+                          '--setuser', 'ceph',
+                          '--setgroup', 'ceph']
+
     def test_osd_mkfs_ok(self, monkeypatch, fake_call, objectstore):
         args = objectstore(dmcrypt=False)
         bo = BaseObjectStore(args)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76279

---

backport of https://github.com/ceph/ceph/pull/68595
parent tracker: https://tracker.ceph.com/issues/76252

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh