### PR TITLE
qa: Use mount class in test_fscrypt to read/write and to compare trees

### DIFF
--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -1625,6 +1625,56 @@ class CephFSMountBase(object):
         proc = self._run_python(pyscript)
         proc.wait()
 
+    def compare_trees(self, src, dst):
+        """
+        Compare two directory trees. Compare based on file names and contents.
+
+        :param src:
+        :param dst:
+        :return:
+        """
+        pyscript = dedent("""
+            import os
+            import errno
+
+            def _md5hash_file(self, file):
+                md5 = hashlib.md5()
+                contents = ''
+                with open(file, 'r') as f:
+                    contents = f.read()
+                md5.update(contents)
+                return md5.hexdigest()
+
+            files = os.listdir('{src}')
+            for file in files:
+                src_file = '{src}/' + file
+                dst_file = '{dst}/' + file
+
+                exists = os.path.exists(dst_file)
+                lexists = os.path.lexists(dst_file)
+                if not exists and not lexists:
+                    log.debug('path_dne:=' + dst_file)
+                    raise
+
+                if os.path.islink('{src}'):
+                    #do link check
+                    if os.readlink(src_file) != os.readlink(dst_file):
+                        raise
+                elif os.path.isfile('{src}'):
+                    #check reported size
+                    rsize_match = os.path.getsize(src_file) == os.path.getsize(dst_file)
+                    if not rsize_match:
+                        raise
+
+                    #check contents
+                    src_hash = self._md5hash_file(src_file)
+                    dest_hash = self._md5hash_file(dst_file)
+                    if src_hash != dest_hash:
+                        raise
+            """).format(src=src, dst=dst)
+        proc = self._run_python(pyscript)
+        proc.wait()
+
     def touch_os(self, fs_path):
         """
         Create a dentry if it doesn't already exist. Uses the open method in the os module.

--- a/qa/tasks/cephfs/test_fscrypt.py
+++ b/qa/tasks/cephfs/test_fscrypt.py
@@ -5,7 +5,6 @@ import os
 import random
 import string
 import time
-import hashlib
 
 from logging import getLogger
 from teuthology.contextutil import safe_while
@@ -397,40 +396,6 @@ class TestFSCryptVolumes(CephFSTestCase):
         self.mount_a.run_shell_payload(f"sudo fscrypt purge --force --verbose {self.mount_a.hostfs_mntpt}")
         super().tearDown()
 
-    def _compare_trees(self, src, dst):
-        files = os.listdir(src)
-        for file in files:
-            src_file = f'{src}/{file}'
-            dst_file = f'{dst}/{file}'
-
-            exists = os.path.exists(dst_file)
-            lexists = os.path.lexists(dst_file)
-            if not exists and not lexists:
-                log.debug(f'path_dne:={dst_file}')
-                raise
-
-            if os.path.islink(src):
-                #do link check
-                if os.readlink(src_file) != os.readlink(dst_file):
-                    raise
-            elif os.path.isfile(src):
-                #check reported size
-                rsize_match = os.path.getsize(src_file) == os.path.getsize(dst_file)
-                if not rsize_match:
-                    raise
-
-                #check contents
-                src_hash = self._md5hash_file(src_file)
-                dest_hash = self._md5hash_file(dst_file)
-                if src_hash != dest_hash:
-                    raise
-
-    def _md5hash_file(self, file):
-        md5 = hashlib.md5()
-        with open(file, "rb") as f:
-            md5.update(f.read())
-        return md5.hexdigest()
-
     def _get_sv_path(self, v, sv):
         sv_path = self.get_ceph_cmd_stdout(f'fs subvolume getpath {v} {sv}')
         sv_path = sv_path.strip()
@@ -525,8 +490,7 @@ class TestFSCryptVolumes(CephFSTestCase):
                 rand_file = f'{src_path}/{i}/rand_file{j}'
                 block = ''.join(random.choice(string.ascii_letters) for _ in range(1 * 1024 * 1024))
                 contents = block * 16
-                with open(rand_file, 'w') as f:
-                    f.write(contents)
+                self.mount_a.write_file(rand_file, contents)
 
             self.mount_a.symlink(rand_file, f'{rand_file}-sym')
 
@@ -539,11 +503,11 @@ class TestFSCryptVolumes(CephFSTestCase):
         dst_path = f'{c_path}'
 
         #compare unlocked
-        self._compare_trees(src_path, dst_path)
+        self.mount_a.compare_trees(src_path, dst_path)
 
         #compare locked
         self.mount_a.run_shell_payload(f"sudo fscrypt lock --verbose {src_path}")
-        self._compare_trees(src_path, dst_path)
+        self.mount_a.compare_trees(src_path, dst_path)
 
     def test_fscrypt_clone_long_name(self):
         """ Test that an fscrypt tree with long names can be cloned """
@@ -565,8 +529,7 @@ class TestFSCryptVolumes(CephFSTestCase):
         for i in range(255):
             long_name += 'a'
 
-        with open(long_name, 'w') as f:
-            f.write('contents')
+        self.mount_a.write_file(long_name, 'contents')
 
         long_symlink = f'{src_path}/'
         for i in range(255):
@@ -583,11 +546,11 @@ class TestFSCryptVolumes(CephFSTestCase):
         dst_path = f'{c_path}'
 
         #compare unlocked
-        self._compare_trees(src_path, dst_path)
+        self.mount_a.compare_trees(src_path, dst_path)
 
         #compare locked
         self.mount_a.run_shell_payload(f"sudo fscrypt lock --verbose {src_path}")
-        self._compare_trees(src_path, dst_path)
+        self.mount_a.compare_trees(src_path, dst_path)
 
 class TestFSCryptXFS(XFSTestsDev):
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/74110





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
