### PR TITLE
Issue 76185 enable mgmt gateway on a fips cluster failed

### DIFF
--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1343,7 +1343,7 @@ class RgwService(CephService):
         if ssl_cert:
             if isinstance(ssl_cert, list):
                 ssl_cert = '\n'.join(ssl_cert)
-            deps.append(f'ssl-cert:{str(utils.md5_hash(ssl_cert))}')
+            deps.append(f'ssl-cert:{utils.config_hash(ssl_cert)}')
 
         return sorted(deps)
 

--- a/src/pybind/mgr/cephadm/services/ingress.py
+++ b/src/pybind/mgr/cephadm/services/ingress.py
@@ -121,7 +121,7 @@ class IngressService(CephService):
             ssl_cert_key = getattr(ingress_spec, attr, None)
             if ssl_cert_key:
                 assert isinstance(ssl_cert_key, str)
-                deps.append(f'ssl-cert-key:{str(utils.md5_hash(ssl_cert_key))}')
+                deps.append(f'ssl-cert-key:{utils.config_hash(ssl_cert_key)}')
         backend_spec = mgr.spec_store[ingress_spec.backend_service].spec
         if backend_spec.service_type == 'nfs':
             hosts = get_placement_hosts(spec, mgr.cache.get_schedulable_hosts(), mgr.cache.get_draining_hosts())

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -113,7 +113,7 @@ class GrafanaService(CephadmService):
         # in case security is enabled we have to reconfig when prom user/pass changes
         prometheus_user, prometheus_password = mgr._get_prometheus_credentials()
         if security_enabled and prometheus_user and prometheus_password:
-            deps.append(f'cred:{utils.md5_hash(prometheus_user + prometheus_password)}')
+            deps.append(f'cred:{utils.config_hash(prometheus_user + prometheus_password)}')
 
         # adding a dependency for mgmt-gateway because the usage of url_prefix relies on its presence.
         # another dependency is added for oauth-proxy as Grafana login is delegated to this service when enabled.
@@ -307,7 +307,7 @@ class AlertmanagerService(CephadmService):
         if security_enabled:
             alertmanager_user, alertmanager_password = mgr._get_alertmanager_credentials()
             if alertmanager_user and alertmanager_password:
-                alertmgr_cred_hash = f'cred:{utils.md5_hash(alertmanager_user + alertmanager_password)}'
+                alertmgr_cred_hash = f'cred:{utils.config_hash(alertmanager_user + alertmanager_password)}'
                 deps.append(alertmgr_cred_hash)
 
         if not mgmt_gw_enabled:
@@ -667,9 +667,9 @@ class PrometheusService(CephadmService):
             alertmanager_user, alertmanager_password = mgr._get_alertmanager_credentials()
             prometheus_user, prometheus_password = mgr._get_prometheus_credentials()
             if prometheus_user and prometheus_password:
-                deps.append(f'prom-cred:{utils.md5_hash(prometheus_user + prometheus_password)}')
+                deps.append(f'prom-cred:{utils.config_hash(prometheus_user + prometheus_password)}')
             if alertmanager_user and alertmanager_password:
-                deps.append(f'alert-cred:{utils.md5_hash(alertmanager_user + alertmanager_password)}')
+                deps.append(f'alert-cred:{utils.config_hash(alertmanager_user + alertmanager_password)}')
 
         # Adding other services as deps (with corresponding justification):
         # mgmt-gateway : url_prefix depends on the existence of mgmt-gateway

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -132,9 +132,9 @@ class NFSService(CephService):
         nfs_spec = cast(NFSServiceSpec, spec)
         # add dependency of tls fields
         if (spec.ssl and spec.ssl_cert and spec.ssl_key and spec.ssl_ca_cert):
-            deps.append(f'ssl_cert: {str(utils.md5_hash(spec.ssl_cert))}')
-            deps.append(f'ssl_key: {str(utils.md5_hash(spec.ssl_key))}')
-            deps.append(f'ssl_ca_cert: {str(utils.md5_hash(spec.ssl_ca_cert))}')
+            deps.append(f'ssl_cert: {utils.config_hash(spec.ssl_cert)}')
+            deps.append(f'ssl_key: {utils.config_hash(spec.ssl_key)}')
+            deps.append(f'ssl_ca_cert: {utils.config_hash(spec.ssl_ca_cert)}')
         deps.append(f'tls_ktls: {nfs_spec.tls_ktls}')
         deps.append(f'tls_debug: {nfs_spec.tls_debug}')
         deps.append(f'tls_min_version: {nfs_spec.tls_min_version}')

--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -187,10 +187,13 @@ def file_mode_to_str(mode: int) -> str:
     return r
 
 
-def md5_hash(input_value: str) -> str:
-    input_str = str(input_value).encode('utf-8')
-    hash_object = hashlib.md5(input_str)
-    return hash_object.hexdigest()
+def config_hash(input_value: str) -> str:
+    """
+    Short stable digest for config/dependency change detection.
+    Uses SHA-256 so this works on FIPS-enabled systems (MD5 may be blocked).
+    """
+    input_str = input_value.encode('utf-8')
+    return hashlib.sha256(input_str).hexdigest()[:8]
 
 
 def get_node_proxy_status_value(data: Any, key: str, lower: bool = False) -> str:


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/76185
Signed-off-by: Kobi Ginon <kginon@redhat.com>

**tested on almalinux9 with fips mode enabled**

```
[root@ceph-node-0 ~]# cat /proc/sys/crypto/fips_enabled
1

```

**After fix was applied then the Error has been fixed**
```
[ceph: root@ceph-node-0 /]# ceph -s
  cluster:
    id:     f291f758-4255-11f1-92f9-525400121784
    health: HEALTH_OK
            
  services:
    mon: 3 daemons, quorum ceph-node-0,ceph-node-2,ceph-node-1 (age 43m) [leader: ceph-node-0]
    mgr: ceph-node-0.hfiqzj(active, since 5m), standbys: ceph-node-2.pljryk
    osd: 3 osds: 3 up (since 43m), 3 in (since 43m)

  data:
    pools:   1 pools, 1 pgs
    objects: 2 objects, 449 KiB
    usage:   80 MiB used, 30 GiB / 30 GiB avail
    pgs:     1 active+clean

```

```
tox passed:
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================ 1334 passed, 1 skipped, 140 warnings in 180.25s (0:03:00) ============================================================================
  py3: OK (181.07=setup[0.03]+cmd[181.04] seconds)
  congratulations :) (181.09 seconds)
root@C-PF4513NK:~/ceph-adm-projects/ceph/src/pybind/mgr# tox -e py3 -- cephadm/tests/

root@C-PF4513NK:~/ceph-adm-projects/ceph/src/pybind/mgr# tox -e mypy
mypy: commands[0]> mypy --config-file=../../mypy.ini -m alerts -m balancer -m cephadm -m crash -m dashboard -m devicehealth -m diskprediction_local -m hello -m nvmeof -m influx -m iostat -m localpool -m mds_autoscaler -m mgr_module -m mgr_util -m mirroring -m nfs -m orchestrator -m pg_autoscaler -m progress -m prometheus -m rbd_support -m rgw -m rook -m selftest -m smb -m snap_schedule -m stats -m status -m telegraf -m telemetry -m test_orchestrator -m volumes
Success: no issues found in 33 source files
  mypy: OK (7.27=setup[0.03]+cmd[7.23] seconds)
  congratulations :) (7.29 seconds)
root@C-PF4513NK:~/ceph-adm-projects/ceph/src/pybind/mgr# echo $?
0
root@C-PF4513NK:~/ceph-adm-projects/ceph/src/pybind/mgr# tox -e mypy

```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
