### PR TITLE
cephadm, mgr/cephadm: resolve FIXME comments and clean up dead code

### DIFF
--- a/src/cephadm/cephadmlib/context.py
+++ b/src/cephadm/cephadmlib/context.py
@@ -1,7 +1,10 @@
 # context.py - cephadm application context support classes
 
 import argparse
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+if TYPE_CHECKING:
+    from .container_engine_base import ContainerEngine
 
 from .constants import (
     CONTAINER_INIT,
@@ -33,8 +36,7 @@ class BaseConfig:
         self.log_to_journald: Optional[bool] = None
 
         self.container_init: bool = CONTAINER_INIT
-        # FIXME(refactor) : should be Optional[ContainerEngine]
-        self.container_engine: Any = None
+        self.container_engine: Optional['ContainerEngine'] = None
 
     def set_from_args(self, args: argparse.Namespace) -> None:
         argdict: Dict[str, Any] = vars(args)

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -156,7 +156,6 @@ class CephadmDaemonDeploySpec:
                  service_name: str,
                  network: Optional[str] = None,
                  keyring: Optional[str] = None,
-                 extra_args: Optional[List[str]] = None,
                  ceph_conf: str = '',
                  extra_files: Optional[Dict[str, Any]] = None,
                  daemon_type: Optional[str] = None,
@@ -184,11 +183,6 @@ class CephadmDaemonDeploySpec:
 
         # for run_cephadm.
         self.keyring: Optional[str] = keyring
-
-        # FIXME: finish removing this
-        # For run_cephadm. Would be great to have more expressive names.
-        # self.extra_args: List[str] = extra_args or []
-        assert not extra_args
 
         self.ceph_conf = ceph_conf
         self.extra_files = extra_files or {}
@@ -269,10 +263,6 @@ class CephadmDaemonDeploySpec:
             extra_container_args=cast(GeneralArgList, self.extra_container_args),
             extra_entrypoint_args=cast(GeneralArgList, self.extra_entrypoint_args),
         )
-
-    @property
-    def extra_args(self) -> List[str]:
-        return []
 
 
 class CephadmService(metaclass=ABCMeta):


### PR DESCRIPTION
This PR addresses a few long-standing FIXME comments in the Python codebase:

1. Removes the deprecated `extra_args` variable from `CephadmDaemonDeploySpec`, clearing up dead code as requested by the FIXME.
2. Uses `TYPE_CHECKING` to properly annotate `self.container_engine` with `Optional['ContainerEngine']` instead of `Any`, fixing a typing FIXME.