### PR TITLE
mgr/cephadm: When only the port or IP is updated in the service spec, redeploy daemon with the new config instead of remove + add

### DIFF
--- a/src/pybind/mgr/cephadm/migrations.py
+++ b/src/pybind/mgr/cephadm/migrations.py
@@ -154,7 +154,7 @@ class Migrations:
 
         def convert_to_explicit(spec: ServiceSpec) -> None:
             existing_daemons = self.mgr.cache.get_daemons_by_service(spec.service_name())
-            placements, to_add, to_remove = HostAssignment(
+            placements, to_add, to_remove, _ = HostAssignment(
                 spec=spec,
                 hosts=self.mgr.inventory.all_specs(),
                 unreachable_hosts=self.mgr.cache.get_unreachable_hosts(),

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3751,7 +3751,7 @@ Then run the following:
             rank_map=rank_map
         )
         ha.validate()
-        hosts, to_add, to_remove = ha.place()
+        hosts, to_add, to_remove, _ = ha.place()
 
         return {
             'service_name': spec.service_name(),

--- a/src/pybind/mgr/cephadm/schedule.py
+++ b/src/pybind/mgr/cephadm/schedule.py
@@ -175,6 +175,18 @@ class DaemonPlacement(NamedTuple):
                     return False
         return True
 
+    def matches_daemon_ignore_network(self, dd: DaemonDescription) -> bool:
+        """True if daemon matches this placement on type, host, and name (ignoring port/ip).
+        Used to detect when only port/ip changed so we can redeploy instead of remove+add.
+        """
+        if self.daemon_type != dd.daemon_type:
+            return False
+        if self.hostname != dd.hostname:
+            return False
+        if self.name and self.name != dd.daemon_id:
+            return False
+        return True
+
     def matches_rank_map(
             self,
             dd: DaemonDescription,
@@ -324,7 +336,7 @@ class HostAssignment(object):
         return slots, to_add, to_remove
 
     def place(self):
-        # type: () -> Tuple[List[DaemonPlacement], List[DaemonPlacement], List[orchestrator.DaemonDescription]]
+        # type: () -> Tuple[List[DaemonPlacement], List[DaemonPlacement], List[orchestrator.DaemonDescription], List[orchestrator.DaemonDescription]]
         """
         Generate a list of HostPlacementSpec taking into account:
 
@@ -382,6 +394,7 @@ class HostAssignment(object):
         existing_slots: List[DaemonPlacement] = []
         to_add: List[DaemonPlacement] = []
         to_remove: List[orchestrator.DaemonDescription] = []
+        to_redeploy: List[orchestrator.DaemonDescription] = []
         ranks: List[int] = list(range(len(candidates)))
         others: List[DaemonPlacement] = candidates.copy()
         for dd in daemons:
@@ -400,6 +413,25 @@ class HostAssignment(object):
                     existing_slots.append(p)
                     found = True
                     break
+            if not found and not self.upgrade_in_progress:
+                # Check if only port/ip changed: same daemon slot, redeploy with new config
+                for p in others:
+                    if (p.matches_daemon_ignore_network(dd) and p.matches_rank_map(dd, self.rank_map, ranks)
+                            and ((p.ports or dd.ports) and p.ports != (dd.ports or [])
+                                 or (p.ip or dd.ip) and p.ip != dd.ip)):
+                        others.remove(p)
+                        if dd.is_active:
+                            existing_active.append(dd)
+                        else:
+                            existing_standby.append(dd)
+                        if dd.rank is not None:
+                            assert dd.rank_generation is not None
+                            p = p.assign_rank(dd.rank, dd.rank_generation)
+                            ranks.remove(dd.rank)
+                        existing_slots.append(p)
+                        to_redeploy.append(dd)
+                        found = True
+                        break
             if not found:
                 to_remove.append(dd)
 
@@ -440,7 +472,8 @@ class HostAssignment(object):
             if need <= 0:
                 to_remove.extend(existing[count:])
                 del existing_slots[count:]
-                return self.place_per_host_daemons(existing_slots, [], to_remove)
+                slots, add, remove = self.place_per_host_daemons(existing_slots, [], to_remove)
+                return slots, add, remove, to_redeploy
 
             if self.related_service_daemons:
                 # prefer to put daemons on the same host(s) as daemons of the related service
@@ -480,7 +513,8 @@ class HostAssignment(object):
                 to_add[i] = to_add[i].assign_rank_generation(ranks[i], self.rank_map)
 
         logger.debug('Combine hosts with existing daemons %s + new hosts %s' % (existing, to_add))
-        return self.place_per_host_daemons(existing_slots + to_add, to_add, to_remove)
+        slots, add, remove = self.place_per_host_daemons(existing_slots + to_add, to_add, to_remove)
+        return slots, add, remove, to_redeploy
 
     def find_ip_on_host(self, hostname: str, subnets: List[str]) -> Optional[str]:
         for subnet in subnets:

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -861,10 +861,10 @@ class CephadmServe:
         )
 
         try:
-            all_slots, slots_to_add, daemons_to_remove = ha.place()
+            all_slots, slots_to_add, daemons_to_remove, daemons_to_redeploy = ha.place()
             daemons_to_remove = [d for d in daemons_to_remove if (d.hostname and self.mgr.inventory._inventory[d.hostname].get(
                 'status', '').lower() not in ['maintenance', 'offline'] and d.hostname not in self.mgr.offline_hosts)]
-            self.log.debug('Add %s, remove %s' % (slots_to_add, daemons_to_remove))
+            self.log.debug('Add %s, remove %s, redeploy %s', slots_to_add, daemons_to_remove, daemons_to_redeploy)
         except OrchestratorError as e:
             msg = f'Failed to apply {spec.service_name()} spec {spec}: {str(e)}'
             self.log.error(msg)
@@ -894,8 +894,10 @@ class CephadmServe:
             delta += [f'+{len(slots_to_add)}']
         if daemons_to_remove:
             delta += [f'-{len(daemons_to_remove)}']
+        if daemons_to_redeploy:
+            delta += [f'~{len(daemons_to_redeploy)}']
         progress_title = f'Updating {spec.service_name()} deployment ({" ".join(delta)} -> {len(all_slots)})'
-        progress_total = len(slots_to_add) + len(daemons_to_remove)
+        progress_total = len(slots_to_add) + len(daemons_to_remove) + len(daemons_to_redeploy)
         progress_done = 0
 
         def update_progress() -> None:
@@ -911,8 +913,18 @@ class CephadmServe:
 
         self.log.debug('Hosts that will receive new daemons: %s' % slots_to_add)
         self.log.debug('Daemons that will be removed: %s' % daemons_to_remove)
+        self.log.debug('Daemons that will be redeployed (port/config change): %s', daemons_to_redeploy)
 
         hosts_altered: Set[str] = set()
+
+        # Schedule redeploy for daemons that only had port/ip config change
+        for d in daemons_to_redeploy:
+            self.mgr._schedule_daemon_action(d.name(), 'redeploy')
+            progress_done += 1
+            update_progress()
+            if d.hostname:
+                hosts_altered.add(d.hostname)
+            self.mgr.spec_store.mark_needs_configuration(spec.service_name())
 
         try:
             # assign names
@@ -1300,7 +1312,7 @@ class CephadmServe:
                     daemons=[],
                     networks=self.mgr.cache.networks,
                 )
-                all_slots, _, _ = ha.place()
+                all_slots, _, _, _ = ha.place()
                 for host in {s.hostname for s in all_slots}:
                     if host not in client_files:
                         client_files[host] = {}
@@ -1331,7 +1343,7 @@ class CephadmServe:
                     daemons=[],
                     networks=self.mgr.cache.networks,
                 )
-                all_slots, _, _ = ha.place()
+                all_slots, _, _, _ = ha.place()
                 for host in {s.hostname for s in all_slots}:
                     if host not in client_files:
                         client_files[host] = {}

--- a/src/pybind/mgr/cephadm/tests/test_scheduling.py
+++ b/src/pybind/mgr/cephadm/tests/test_scheduling.py
@@ -135,7 +135,7 @@ def run_scheduler_test(results, mk_spec, hosts, daemons, key_elems):
     except IndexError:
         try:
             spec = mk_spec()
-            host_res, to_add, to_remove = HostAssignment(
+            host_res, to_add, to_remove, _ = HostAssignment(
                 spec=spec,
                 hosts=hosts,
                 unreachable_hosts=[],
@@ -152,7 +152,7 @@ def run_scheduler_test(results, mk_spec, hosts, daemons, key_elems):
     for _ in range(10):  # scheduler has a random component
         try:
             spec = mk_spec()
-            host_res, to_add, to_remove = HostAssignment(
+            host_res, to_add, to_remove, _ = HostAssignment(
                 spec=spec,
                 hosts=hosts,
                 unreachable_hosts=[],
@@ -393,10 +393,11 @@ class NodeAssignmentTest(NamedTuple):
     post_rank_map: Optional[Dict[int, Dict[int, Optional[str]]]]
     expected: List[str]
     expected_add: List[str]
-    expected_remove: List[DaemonDescription]
+    expected_remove: List[str]
+    expected_redeploy: List[str]
 
 
-@pytest.mark.parametrize("service_type,placement,hosts,daemons,rank_map,post_rank_map,expected,expected_add,expected_remove",
+@pytest.mark.parametrize("service_type,placement,hosts,daemons,rank_map,post_rank_map,expected,expected_add,expected_remove,expected_redeploy",
     [   # noqa: E128
         # just hosts
         NodeAssignmentTest(
@@ -405,7 +406,7 @@ class NodeAssignmentTest(NamedTuple):
             ['smithi060'],
             [],
             None, None,
-            ['mgr:smithi060'], ['mgr:smithi060'], []
+            ['mgr:smithi060'], ['mgr:smithi060'], [], []
         ),
         # all_hosts
         NodeAssignmentTest(
@@ -419,7 +420,7 @@ class NodeAssignmentTest(NamedTuple):
             None, None,
             ['mgr:host1', 'mgr:host2', 'mgr:host3'],
             ['mgr:host3'],
-            []
+            [], []
         ),
         # all_hosts + count_per_host
         NodeAssignmentTest(
@@ -433,7 +434,7 @@ class NodeAssignmentTest(NamedTuple):
             None, None,
             ['mds:host1', 'mds:host2', 'mds:host3', 'mds:host1', 'mds:host2', 'mds:host3'],
             ['mds:host3', 'mds:host1', 'mds:host2', 'mds:host3'],
-            []
+            [], []
         ),
         # count that is bigger than the amount of hosts. Truncate to len(hosts)
         # mgr should not be co-located to each other.
@@ -445,7 +446,7 @@ class NodeAssignmentTest(NamedTuple):
             None, None,
             ['mgr:host1', 'mgr:host2', 'mgr:host3'],
             ['mgr:host1', 'mgr:host2', 'mgr:host3'],
-            []
+            [], []
         ),
         # count that is bigger than the amount of hosts; wrap around.
         NodeAssignmentTest(
@@ -456,7 +457,7 @@ class NodeAssignmentTest(NamedTuple):
             None, None,
             ['mds:host1', 'mds:host2', 'mds:host3', 'mds:host1', 'mds:host2', 'mds:host3'],
             ['mds:host1', 'mds:host2', 'mds:host3', 'mds:host1', 'mds:host2', 'mds:host3'],
-            []
+            [], []
         ),
         # count + partial host list
         NodeAssignmentTest(
@@ -470,7 +471,7 @@ class NodeAssignmentTest(NamedTuple):
             None, None,
             ['mgr:host3'],
             ['mgr:host3'],
-            ['mgr.a', 'mgr.b']
+            ['mgr.a', 'mgr.b'], []
         ),
         # count + partial host list (with colo)
         NodeAssignmentTest(
@@ -484,7 +485,7 @@ class NodeAssignmentTest(NamedTuple):
             None, None,
             ['mds:host3', 'mds:host3', 'mds:host3'],
             ['mds:host3', 'mds:host3', 'mds:host3'],
-            ['mds.a', 'mds.b']
+            ['mds.a', 'mds.b'], []
         ),
         # count 1 + partial host list
         NodeAssignmentTest(
@@ -498,7 +499,7 @@ class NodeAssignmentTest(NamedTuple):
             None, None,
             ['mgr:host3'],
             ['mgr:host3'],
-            ['mgr.a', 'mgr.b']
+            ['mgr.a', 'mgr.b'], []
         ),
         # count + partial host list + existing
         NodeAssignmentTest(
@@ -511,7 +512,7 @@ class NodeAssignmentTest(NamedTuple):
             None, None,
             ['mgr:host3'],
             ['mgr:host3'],
-            ['mgr.a']
+            ['mgr.a'], []
         ),
         # count + partial host list + existing (deterministic)
         NodeAssignmentTest(
@@ -524,7 +525,7 @@ class NodeAssignmentTest(NamedTuple):
             None, None,
             ['mgr:host1'],
             [],
-            []
+            [], []
         ),
         # count + partial host list + existing (deterministic)
         NodeAssignmentTest(
@@ -537,7 +538,7 @@ class NodeAssignmentTest(NamedTuple):
             None, None,
             ['mgr:host1'],
             ['mgr:host1'],
-            ['mgr.a']
+            ['mgr.a'], []
         ),
         # label only
         NodeAssignmentTest(
@@ -548,7 +549,7 @@ class NodeAssignmentTest(NamedTuple):
             None, None,
             ['mgr:host1', 'mgr:host2', 'mgr:host3'],
             ['mgr:host1', 'mgr:host2', 'mgr:host3'],
-            []
+            [], []
         ),
         # label + count (truncate to host list)
         NodeAssignmentTest(
@@ -559,7 +560,7 @@ class NodeAssignmentTest(NamedTuple):
             None, None,
             ['mgr:host1', 'mgr:host2', 'mgr:host3'],
             ['mgr:host1', 'mgr:host2', 'mgr:host3'],
-            []
+            [], []
         ),
         # label + count (with colo)
         NodeAssignmentTest(
@@ -570,7 +571,7 @@ class NodeAssignmentTest(NamedTuple):
             None, None,
             ['mds:host1', 'mds:host2', 'mds:host3', 'mds:host1', 'mds:host2', 'mds:host3'],
             ['mds:host1', 'mds:host2', 'mds:host3', 'mds:host1', 'mds:host2', 'mds:host3'],
-            []
+            [], []
         ),
         # label only + count_per_hst
         NodeAssignmentTest(
@@ -583,7 +584,7 @@ class NodeAssignmentTest(NamedTuple):
              'mds:host1', 'mds:host2', 'mds:host3'],
             ['mds:host1', 'mds:host2', 'mds:host3', 'mds:host1', 'mds:host2', 'mds:host3',
              'mds:host1', 'mds:host2', 'mds:host3'],
-            []
+            [], []
         ),
         # host_pattern
         NodeAssignmentTest(
@@ -594,7 +595,7 @@ class NodeAssignmentTest(NamedTuple):
             None, None,
             ['mgr:mgrhost1', 'mgr:mgrhost2'],
             ['mgr:mgrhost1', 'mgr:mgrhost2'],
-            []
+            [], []
         ),
         # host_pattern + count_per_host
         NodeAssignmentTest(
@@ -605,7 +606,7 @@ class NodeAssignmentTest(NamedTuple):
             None, None,
             ['mds:mdshost1', 'mds:mdshost2', 'mds:mdshost1', 'mds:mdshost2', 'mds:mdshost1', 'mds:mdshost2'],
             ['mds:mdshost1', 'mds:mdshost2', 'mds:mdshost1', 'mds:mdshost2', 'mds:mdshost1', 'mds:mdshost2'],
-            []
+            [], []
         ),
         # label + count_per_host + ports
         NodeAssignmentTest(
@@ -618,9 +619,10 @@ class NodeAssignmentTest(NamedTuple):
              'rgw:host1(*:81)', 'rgw:host2(*:81)', 'rgw:host3(*:81)'],
             ['rgw:host1(*:80)', 'rgw:host2(*:80)', 'rgw:host3(*:80)',
              'rgw:host1(*:81)', 'rgw:host2(*:81)', 'rgw:host3(*:81)'],
-            []
+            [], []
         ),
         # label + count_per_host + ports (+ existing)
+        # daemon c on host1:82 is matched to slot host1:80 (port change only) -> redeploy, not remove+add
         NodeAssignmentTest(
             'rgw',
             PlacementSpec(count=6, label='foo'),
@@ -633,9 +635,8 @@ class NodeAssignmentTest(NamedTuple):
             None, None,
             ['rgw:host1(*:80)', 'rgw:host2(*:80)', 'rgw:host3(*:80)',
              'rgw:host1(*:81)', 'rgw:host2(*:81)', 'rgw:host3(*:81)'],
-            ['rgw:host1(*:80)', 'rgw:host3(*:80)',
-             'rgw:host2(*:81)', 'rgw:host3(*:81)'],
-            ['rgw.c']
+            ['rgw:host3(*:80)', 'rgw:host2(*:81)', 'rgw:host3(*:81)'],
+            [], ['rgw.c']
         ),
         # label + host pattern
         # Note all hosts will get the "foo" label, we are checking
@@ -646,7 +647,7 @@ class NodeAssignmentTest(NamedTuple):
             'mgr1 mgr2 osd1'.split(),
             [],
             None, None,
-            ['mgr:mgr1', 'mgr:mgr2'], ['mgr:mgr1', 'mgr:mgr2'], []
+            ['mgr:mgr1', 'mgr:mgr2'], ['mgr:mgr1', 'mgr:mgr2'], [], []
         ),
         # cephadm.py teuth case
         NodeAssignmentTest(
@@ -659,7 +660,7 @@ class NodeAssignmentTest(NamedTuple):
             ],
             None, None,
             ['mgr:host1(name=y)', 'mgr:host2(name=x)'],
-            [], []
+            [], [], []
         ),
 
         # note: host -> rank mapping is psuedo-random based on svc name, so these
@@ -676,7 +677,7 @@ class NodeAssignmentTest(NamedTuple):
             {0: {0: None}, 1: {0: None}, 2: {0: None}},
             ['nfs:host3(rank=0.0)', 'nfs:host2(rank=1.0)', 'nfs:host1(rank=2.0)'],
             ['nfs:host3(rank=0.0)', 'nfs:host2(rank=1.0)', 'nfs:host1(rank=2.0)'],
-            []
+            [], []
         ),
         # 21: ranked, exist
         NodeAssignmentTest(
@@ -690,7 +691,7 @@ class NodeAssignmentTest(NamedTuple):
             {0: {1: '0.1'}, 1: {0: None}, 2: {0: None}},
             ['nfs:host1(rank=0.1)', 'nfs:host3(rank=1.0)', 'nfs:host2(rank=2.0)'],
             ['nfs:host3(rank=1.0)', 'nfs:host2(rank=2.0)'],
-            []
+            [], []
         ),
         # ranked, exist, different ranks
         NodeAssignmentTest(
@@ -705,7 +706,7 @@ class NodeAssignmentTest(NamedTuple):
             {0: {1: '0.1'}, 1: {1: '1.1'}, 2: {0: None}},
             ['nfs:host1(rank=0.1)', 'nfs:host2(rank=1.1)', 'nfs:host3(rank=2.0)'],
             ['nfs:host3(rank=2.0)'],
-            []
+            [], []
         ),
         # ranked, exist, different ranks (2)
         NodeAssignmentTest(
@@ -720,7 +721,7 @@ class NodeAssignmentTest(NamedTuple):
             {0: {1: '0.1'}, 1: {1: '1.1'}, 2: {0: None}},
             ['nfs:host1(rank=0.1)', 'nfs:host3(rank=1.1)', 'nfs:host2(rank=2.0)'],
             ['nfs:host2(rank=2.0)'],
-            []
+            [], []
         ),
         # ranked, exist, extra ranks
         NodeAssignmentTest(
@@ -736,7 +737,7 @@ class NodeAssignmentTest(NamedTuple):
             {0: {5: '0.5'}, 1: {5: '1.5'}, 2: {0: None}},
             ['nfs:host1(rank=0.5)', 'nfs:host2(rank=1.5)', 'nfs:host3(rank=2.0)'],
             ['nfs:host3(rank=2.0)'],
-            ['nfs.4.5']
+            ['nfs.4.5'], []
         ),
         # 25: ranked, exist, extra ranks (scale down: kill off high rank)
         NodeAssignmentTest(
@@ -752,7 +753,7 @@ class NodeAssignmentTest(NamedTuple):
             {0: {5: '0.5'}, 1: {5: '1.5'}, 2: {5: '2.5'}},
             ['nfs:host1(rank=0.5)', 'nfs:host2(rank=1.5)'],
             [],
-            ['nfs.2.5']
+            ['nfs.2.5'], []
         ),
         # ranked, exist, extra ranks (scale down hosts)
         NodeAssignmentTest(
@@ -768,7 +769,7 @@ class NodeAssignmentTest(NamedTuple):
             {0: {5: '0.5'}, 1: {5: '1.5', 6: None}, 2: {5: '2.5'}},
             ['nfs:host1(rank=0.5)', 'nfs:host3(rank=1.6)'],
             ['nfs:host3(rank=1.6)'],
-            ['nfs.2.5', 'nfs.1.5']
+            ['nfs.2.5', 'nfs.1.5'], []
         ),
         # ranked, exist, duplicate rank
         NodeAssignmentTest(
@@ -784,7 +785,7 @@ class NodeAssignmentTest(NamedTuple):
             {0: {0: '0.0'}, 1: {2: '1.2'}, 2: {0: None}},
             ['nfs:host1(rank=0.0)', 'nfs:host3(rank=1.2)', 'nfs:host2(rank=2.0)'],
             ['nfs:host2(rank=2.0)'],
-            ['nfs.1.1']
+            ['nfs.1.1'], []
         ),
         # 28: ranked, all gens stale (failure during update cycle)
         NodeAssignmentTest(
@@ -799,7 +800,7 @@ class NodeAssignmentTest(NamedTuple):
             {0: {2: '0.2'}, 1: {2: '1.2', 3: '1.3', 4: None}},
             ['nfs:host1(rank=0.2)', 'nfs:host3(rank=1.4)'],
             ['nfs:host3(rank=1.4)'],
-            ['nfs.1.2']
+            ['nfs.1.2'], []
         ),
         # ranked, not enough hosts
         NodeAssignmentTest(
@@ -814,7 +815,7 @@ class NodeAssignmentTest(NamedTuple):
             {0: {2: '0.2'}, 1: {2: '1.2'}, 2: {0: None}},
             ['nfs:host1(rank=0.2)', 'nfs:host2(rank=1.2)', 'nfs:host3(rank=2.0)'],
             ['nfs:host3(rank=2.0)'],
-            []
+            [], []
         ),
         # ranked, scale down
         NodeAssignmentTest(
@@ -830,12 +831,12 @@ class NodeAssignmentTest(NamedTuple):
             {0: {2: '0.2', 3: None}, 1: {2: '1.2'}, 2: {2: '2.2'}},
             ['nfs:host2(rank=0.3)'],
             ['nfs:host2(rank=0.3)'],
-            ['nfs.0.2', 'nfs.1.2', 'nfs.2.2']
+            ['nfs.0.2', 'nfs.1.2', 'nfs.2.2'], []
         ),
 
     ])
 def test_node_assignment(service_type, placement, hosts, daemons, rank_map, post_rank_map,
-                         expected, expected_add, expected_remove):
+                         expected, expected_add, expected_remove, expected_redeploy):
     spec = None
     service_id = None
     allow_colo = False
@@ -856,7 +857,7 @@ def test_node_assignment(service_type, placement, hosts, daemons, rank_map, post
                            service_id=service_id,
                            placement=placement)
 
-    all_slots, to_add, to_remove = HostAssignment(
+    all_slots, to_add, to_remove, to_redeploy = HostAssignment(
         spec=spec,
         hosts=[HostSpec(h, labels=['foo']) for h in hosts],
         unreachable_hosts=[],
@@ -889,6 +890,7 @@ def test_node_assignment(service_type, placement, hosts, daemons, rank_map, post
     assert num_wildcard == len(got)
 
     assert sorted([d.name() for d in to_remove]) == sorted(expected_remove)
+    assert sorted([d.name() for d in to_redeploy]) == sorted(expected_redeploy)
 
 
 class NodeAssignmentTest5(NamedTuple):
@@ -1036,7 +1038,7 @@ class NodeAssignmentTest2(NamedTuple):
     ])
 def test_node_assignment2(service_type, placement, hosts,
                           daemons, expected_len, in_set):
-    hosts, to_add, to_remove = HostAssignment(
+    hosts, to_add, to_remove, _ = HostAssignment(
         spec=ServiceSpec(service_type, placement=placement),
         hosts=[HostSpec(h, labels=['foo']) for h in hosts],
         unreachable_hosts=[],
@@ -1071,7 +1073,7 @@ def test_node_assignment2(service_type, placement, hosts,
     ])
 def test_node_assignment3(service_type, placement, hosts,
                           daemons, expected_len, must_have):
-    hosts, to_add, to_remove = HostAssignment(
+    hosts, to_add, to_remove, _ = HostAssignment(
         spec=ServiceSpec(service_type, placement=placement),
         hosts=[HostSpec(h) for h in hosts],
         unreachable_hosts=[],
@@ -1169,7 +1171,7 @@ class NodeAssignmentTest4(NamedTuple):
     ])
 def test_node_assignment4(spec, networks, daemons,
                           expected, expected_add, expected_remove):
-    all_slots, to_add, to_remove = HostAssignment(
+    all_slots, to_add, to_remove, _ = HostAssignment(
         spec=spec,
         hosts=[HostSpec(h, labels=['foo']) for h in networks.keys()],
         unreachable_hosts=[],
@@ -1256,7 +1258,7 @@ class NodeAssignmentTestBadSpec(NamedTuple):
     ])
 def test_bad_specs(service_type, placement, hosts, daemons, expected):
     with pytest.raises(OrchestratorValidationError) as e:
-        hosts, to_add, to_remove = HostAssignment(
+        hosts, to_add, to_remove, _ = HostAssignment(
             spec=ServiceSpec(service_type, placement=placement),
             hosts=[HostSpec(h) for h in hosts],
             unreachable_hosts=[],
@@ -1433,7 +1435,7 @@ def test_active_assignment(service_type, placement, hosts, daemons, expected, ex
                        service_id=None,
                        placement=placement)
 
-    hosts, to_add, to_remove = HostAssignment(
+    hosts, to_add, to_remove, _ = HostAssignment(
         spec=spec,
         hosts=[HostSpec(h) for h in hosts],
         unreachable_hosts=[],
@@ -1531,7 +1533,7 @@ def test_unreachable_host(service_type, placement, hosts, unreachable_hosts, dae
                        service_id=None,
                        placement=placement)
 
-    hosts, to_add, to_remove = HostAssignment(
+    hosts, to_add, to_remove, _ = HostAssignment(
         spec=spec,
         hosts=[HostSpec(h) for h in hosts],
         unreachable_hosts=[HostSpec(h) for h in unreachable_hosts],
@@ -1636,7 +1638,7 @@ def test_remove_from_offline(service_type, placement, hosts, maintenance_hosts, 
         if h.hostname in maintenance_hosts:
             h.status = 'maintenance'
 
-    hosts, to_add, to_remove = HostAssignment(
+    hosts, to_add, to_remove, _ = HostAssignment(
         spec=spec,
         hosts=host_specs,
         unreachable_hosts=[h for h in host_specs if h.status],
@@ -1705,7 +1707,7 @@ def test_drain_from_explict_placement(service_type, placement, hosts, maintenanc
         if h.hostname in maintenance_hosts:
             h.status = 'maintenance'
 
-    hosts, to_add, to_remove = HostAssignment(
+    hosts, to_add, to_remove, _ = HostAssignment(
         spec=spec,
         hosts=host_specs,
         unreachable_hosts=[h for h in host_specs if h.status],
@@ -1745,7 +1747,7 @@ def test_placement_regex_host_pattern(service_type, placement, hosts, expected_a
 
     host_specs = [HostSpec(h) for h in hosts]
 
-    hosts, to_add, to_remove = HostAssignment(
+    hosts, to_add, to_remove, _ = HostAssignment(
         spec=spec,
         hosts=host_specs,
         unreachable_hosts=[],
@@ -1847,7 +1849,7 @@ def test_blocking_daemon_host(
                        service_id=None,
                        placement=placement)
 
-    hosts, to_add, to_remove = HostAssignment(
+    hosts, to_add, to_remove, _ = HostAssignment(
         spec=spec,
         hosts=[HostSpec(h) for h in hosts],
         unreachable_hosts=[HostSpec(h) for h in unreachable_hosts],

--- a/src/pybind/mgr/cephadm/tuned_profiles.py
+++ b/src/pybind/mgr/cephadm/tuned_profiles.py
@@ -41,7 +41,7 @@ class TunedProfileUtils():
                 daemons=[],
                 networks=self.mgr.cache.networks,
             )
-            all_slots, _, _ = ha.place()
+            all_slots, _, _, _ = ha.place()
             for host in {s.hostname for s in all_slots}:
                 host_profile_mapping[host].append({profile.profile_name: p_str})
 


### PR DESCRIPTION
When only the port or IP is updated in the service spec, redeploy daemon with the new config instead of remove + add

Fixes: https://tracker.ceph.com/issues/75363





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
