### PR TITLE
mgr/dashboard : Fixes EC profile used pool empty

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -405,7 +405,6 @@
           >
             <cds-select
               formControlName="erasureProfile"
-              (change)="erasureProfileChange()"
               label="Erasure code profile"
               i18n-label
               [helperText]="'Policy used for compression algorithm'"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
@@ -4,6 +4,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 
 import { NgbNav } from '@ng-bootstrap/ng-bootstrap';
 import _ from 'lodash';
+import { startWith } from 'rxjs/operators';
 import { Observable, ReplaySubject, Subscription } from 'rxjs';
 
 import { DashboardNotFoundError } from '~/app/core/error/error';
@@ -459,16 +460,14 @@ export class PoolFormComponent extends CdForm implements OnInit {
       this.pgCalc();
     });
 
-    this.form.get('erasureProfile').valueChanges.subscribe((profile) => {
-      // The ec profile can only be changed if type 'erasure' is set.
-      if (!profile) {
-        return;
-      }
-      this.data.erasureInfo = false;
-      this.erasureProfileChange();
-      this.ecpIsUsedBy(profile);
-      this.pgCalc();
-    });
+    this.form
+      .get('erasureProfile')
+      .valueChanges.pipe(startWith(this.form.getValue('erasureProfile')))
+      .subscribe((profile) => {
+        // The ec profile can only be changed if type 'erasure' is set.
+        this.erasureProfileChange(profile);
+        this.pgCalc();
+      });
     this.form.get('mode').valueChanges.subscribe(() => {
       ['minBlobSize', 'maxBlobSize', 'ratio'].forEach((name) => {
         this.form.get(name).updateValueAndValidity({ emitEvent: false });
@@ -1093,16 +1092,27 @@ export class PoolFormComponent extends CdForm implements OnInit {
     this.form.get('name').updateValueAndValidity({ emitEvent: false, onlySelf: true });
   }
 
-  erasureProfileChange() {
+  erasureProfileChange(selectedName?: string) {
     if (!this.ecProfiles || this.ecProfiles.length === 0) {
       return;
     }
-    const selectedName = this.form.get('erasureProfile').value;
-    this.selectedEcp = this.ecProfiles.find((ecp: ErasureCodeProfile) => ecp.name === selectedName);
-    if (this.selectedEcp) {
+    const formSelectedName = this.form.get('erasureProfile')?.value;
+    const resolvedName = selectedName ?? formSelectedName ?? this.ecProfiles[0]?.name;
+    const selectedEcp = this.ecProfiles.find(
+      (ecp: ErasureCodeProfile) => ecp.name === resolvedName
+    );
+    this.ecpIsUsedBy(resolvedName);
+    if (resolvedName) {
+      this.data.erasureInfo = false;
+    }
+    if (selectedEcp) {
+      this.selectedEcp = selectedEcp;
       this.msrCrush =
-        this.selectedEcp['crush-num-failure-domains'] > 0 ||
-        this.selectedEcp['crush-osds-per-failure-domain'] > 0;
+        (selectedEcp['crush-num-failure-domains'] ?? 0) > 0 ||
+        (selectedEcp['crush-osds-per-failure-domain'] ?? 0) > 0;
+    } else {
+      this.selectedEcp = undefined as any;
+      this.msrCrush = false;
     }
   }
 }


### PR DESCRIPTION
fixes : https://tracker.ceph.com/issues/76288
Signed-off-by: Abhishek Desai <abhishek.desai1@ibm.com>

PS : 
```
Dashboard does not show the pools which use a particular EC profile
```
UTC : 
```
While creating a new pool. user should be able to see ec profile's info correctly.
Earlier it was populated blank due to initialization  issue. 
```

https://github.com/user-attachments/assets/4e4e28f8-dca9-4476-9d2f-615e453d95ea





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
