### PR TITLE
[DNM, WIP] crimson/os/seastore: LogStoreManager part 2

### DIFF
--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -468,7 +468,8 @@ void JournalTrimmerImpl::set_journal_head_sequence(
 
 void JournalTrimmerImpl::update_journal_tails(
   journal_seq_t dirty_tail,
-  journal_seq_t alloc_tail)
+  journal_seq_t alloc_tail,
+  journal_seq_t log_tail)
 {
   LOG_PREFIX(JournalTrimmerImpl::update_journal_tails);
 
@@ -507,6 +508,23 @@ void JournalTrimmerImpl::update_journal_tails(
     } else {
       INFO("journal_alloc_tail {} => {}, {}",
             alloc_tail, journal_alloc_tail, stat_printer_t{*this, false});
+    }
+  }
+
+  if (log_tail != JOURNAL_SEQ_NULL) {
+    if (journal_log_tail != JOURNAL_SEQ_NULL &&
+        journal_log_tail > log_tail) {
+      ERROR("journal_log_tail {} => {} is backwards!",
+            journal_log_tail, log_tail);
+      ceph_abort();
+    }
+    std::swap(journal_log_tail, log_tail);
+    if (journal_log_tail.segment_seq == log_tail.segment_seq) {
+      DEBUG("journal_log_tail {} => {}, {}",
+            log_tail, journal_log_tail, stat_printer_t{*this, false});
+    } else {
+      INFO("journal_log_tail {} => {}, {}",
+            log_tail, journal_log_tail, stat_printer_t{*this, false});
     }
   }
 
@@ -572,6 +590,18 @@ journal_seq_t JournalTrimmerImpl::get_alloc_tail_target() const
   return ret;
 }
 
+journal_seq_t JournalTrimmerImpl::get_log_tail_target() const
+{
+  assert(background_callback->is_ready());
+  auto ret = journal_head.add_offset(
+      backend_type,
+      // use dirty bytes
+      -static_cast<device_off_t>(config.target_journal_dirty_bytes / 2),
+      roll_start,
+      roll_size);
+  return ret;
+}
+
 std::size_t JournalTrimmerImpl::get_dirty_journal_size() const
 {
   if (!background_callback->is_ready()) {
@@ -604,6 +634,18 @@ std::size_t JournalTrimmerImpl::get_alloc_journal_size() const
 seastar::future<> JournalTrimmerImpl::trim() {
   return seastar::when_all(
     [this] {
+      if (should_trim_log()) {
+        return trim_log(
+        ).handle_error(
+          crimson::ct_error::assert_all{
+            "encountered invalid error in trim_log"
+          }
+        );
+      } else {
+        return seastar::now();
+      }
+    },
+    [this] {
       if (should_trim_alloc()) {
         return trim_alloc(
         ).handle_error(
@@ -628,6 +670,26 @@ seastar::future<> JournalTrimmerImpl::trim() {
       }
     }
   ).discard_result();
+}
+
+JournalTrimmerImpl::trim_ertr::future<>
+JournalTrimmerImpl::trim_log()
+{
+  LOG_PREFIX(JournalTrimmerImpl::trim_log);
+  assert(background_callback->is_ready());
+
+  auto& shard_stats = extent_callback->get_shard_stats();
+  ++(shard_stats.pending_bg_num);
+
+  auto target = get_log_tail_target();
+  DEBUG("start, log_tail={}, target={}",
+	 journal_log_tail, target);
+  return post_trim_callback(target
+  ).finally([this, FNAME, &shard_stats, target] {
+    DEBUG("finish, log_tail={}", journal_log_tail);
+    assert(shard_stats.pending_bg_num);
+    --(shard_stats.pending_bg_num);
+  });
 }
 
 JournalTrimmerImpl::trim_ertr::future<>
@@ -759,7 +821,8 @@ std::ostream &operator<<(
   if (stats.trimmer.background_callback->is_ready()) {
     os << "should_block_io_on_trim=" << stats.trimmer.should_block_io_on_trim()
        << ", should_(trim_dirty=" << stats.trimmer.should_start_trim_dirty()
-       << ", trim_alloc=" << stats.trimmer.should_trim_alloc() << ")";
+       << ", trim_alloc=" << stats.trimmer.should_trim_alloc() 
+       << ", trim_log=" << stats.trimmer.should_trim_log() << ")";
   } else {
     os << "not-ready";
   }

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -382,6 +382,11 @@ public:
     Transaction &t,
     std::optional<journal_seq_t> seq_to_trim = std::nullopt) = 0;
 
+  using get_next_dirty_log_node_by_oid_ret = std::vector<ghobject_t>;
+  virtual get_next_dirty_log_node_by_oid_ret get_next_dirty_log_node_by_oid(
+    journal_seq_t seq) = 0; 
+  virtual bool has_pending_lognode_deltas() = 0;
+
 private:
   template <typename Func, bool IsWeak>
   auto do_with_transaction_intr(
@@ -450,9 +455,12 @@ public:
   // get the committed journal alloc tail
   virtual journal_seq_t get_alloc_tail() const = 0;
 
+  // get the committed journal log tail
+  virtual journal_seq_t get_log_tail() const = 0;
+
   // set the committed journal tails
   virtual void update_journal_tails(
-      journal_seq_t dirty_tail, journal_seq_t alloc_tail) = 0;
+      journal_seq_t dirty_tail, journal_seq_t alloc_tail, journal_seq_t log_tail) = 0;
 
   // try reserve the projected usage in journal
   // returns if the reservation is successful
@@ -501,6 +509,8 @@ class BackrefManager;
 class LBAManager;
 class JournalTrimmerImpl;
 using JournalTrimmerImplRef = std::unique_ptr<JournalTrimmerImpl>;
+using post_trim_callback_t =
+  std::function<base_ertr::future<>(journal_seq_t)>;
 
 /**
  * Journal trimming implementation
@@ -570,8 +580,13 @@ public:
     return journal_alloc_tail;
   }
 
+  journal_seq_t get_log_tail() const final {
+    return journal_log_tail;
+  }
+
   void update_journal_tails(
-      journal_seq_t dirty_tail, journal_seq_t alloc_tail) final;
+      journal_seq_t dirty_tail, journal_seq_t alloc_tail,
+      journal_seq_t log_tail) final;
 
   std::size_t get_trim_size_per_cycle() const final {
     return config.max_backref_bytes_per_cycle +
@@ -590,15 +605,24 @@ public:
     background_callback = cb;
   }
 
+  void set_post_trim_callback(post_trim_callback_t cb) {
+    _post_trim_callback = cb;
+  }
+
+  base_ertr::future<> post_trim_callback(journal_seq_t seq) {
+    return _post_trim_callback(seq);
+  }
+
   void reset() {
     journal_head_seq = NULL_SEG_SEQ;
     journal_head = JOURNAL_SEQ_NULL;
     journal_dirty_tail = JOURNAL_SEQ_NULL;
     journal_alloc_tail = JOURNAL_SEQ_NULL;
+    journal_log_tail = JOURNAL_SEQ_NULL;
   }
 
   bool should_trim() const {
-    return should_trim_alloc() || should_start_trim_dirty();
+    return should_trim_alloc() || should_start_trim_dirty() || should_trim_log();
   }
 
   bool should_block_io_on_trim() const {
@@ -664,17 +688,27 @@ private:
     return get_alloc_tail_target() > journal_alloc_tail;
   }
 
+  bool should_trim_log() const {
+    if (!extent_callback->has_pending_lognode_deltas()) {
+      return false;
+    }
+    return (get_log_tail_target() > journal_log_tail);
+  }
+
   using trim_ertr = crimson::errorator<
     crimson::ct_error::input_output_error>;
   trim_ertr::future<> trim_dirty();
 
   trim_ertr::future<> trim_alloc();
 
+  trim_ertr::future<> trim_log();
+
   journal_seq_t get_tail_limit() const;
   journal_seq_t get_dirty_tail_min_target() const;
   journal_seq_t get_dirty_tail_target() const;
   journal_seq_t get_dirty_tail_target_per_cycle() const;
   journal_seq_t get_alloc_tail_target() const;
+  journal_seq_t get_log_tail_target() const;
   std::size_t get_dirty_journal_size() const;
   std::size_t get_alloc_journal_size() const;
   std::size_t get_journal_dirty_bytes() const {
@@ -710,10 +744,12 @@ private:
   journal_seq_t journal_head;
   journal_seq_t journal_dirty_tail;
   journal_seq_t journal_alloc_tail;
+  journal_seq_t journal_log_tail;
 
   std::size_t reserved_usage;
 
   seastar::metrics::metric_group metrics;
+  post_trim_callback_t _post_trim_callback;
 };
 
 std::ostream &operator<<(

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1775,6 +1775,41 @@ record_t Cache::prepare_record(
     record.push_back(std::move(delta));
   }
 
+  for (auto &b : t.lognode_deltas) {
+    bufferlist bl;
+    encode(b, bl);
+    delta_info_t delta;
+    delta.type = extent_types_t::LOG_NODE_INFO;
+    delta.bl = std::move(bl);
+    record.push_back(std::move(delta));
+
+    auto oid = b.oid;
+    DEBUGT("last_idx_to_delete:{} oid queue length:{}, oid:{}", t,
+      b.last_idx_to_delete, pending_lognode_deltas_by_oid[oid].size(), oid);
+    if (b.last_idx_to_delete > 0) {
+      auto &seqs_by_oid = pending_lognode_deltas_by_oid[oid];
+      ceph_assert(b.last_idx_to_delete <= seqs_by_oid.size());
+      std::optional<journal_seq_t> old_seq;
+      for (auto it = seqs_by_oid.begin();
+	   it != seqs_by_oid.begin() + b.last_idx_to_delete;
+	   ++it) {
+	const auto committed_seq = it->committed_seq;
+	if (!old_seq || *old_seq != committed_seq) {
+	  auto map_it = pending_lognode_deltas_by_seq.find(committed_seq);
+	  if (map_it != pending_lognode_deltas_by_seq.end()) {
+	    auto& oids = map_it->second;
+	    std::erase(oids, b.oid);
+	    if (oids.empty()) {
+	      pending_lognode_deltas_by_seq.erase(map_it);
+	    }
+	  }
+	  old_seq = committed_seq;
+	}
+      }
+      seqs_by_oid.erase(seqs_by_oid.begin(), seqs_by_oid.begin() + b.last_idx_to_delete);
+    }
+  }
+
   if (is_background_transaction(trans_src)) {
     assert(journal_head != JOURNAL_SEQ_NULL);
     assert(journal_dirty_tail != JOURNAL_SEQ_NULL);
@@ -2119,6 +2154,25 @@ void Cache::complete_commit(
     if (!i->is_valid()) {
       epm.mark_space_free(i->get_paddr(), i->get_length());
     }
+  }
+
+  if (t.lognode_deltas.size()) {
+    auto oid = t.lognode_deltas.begin()->oid;
+    for (auto &p : t.lognode_deltas) {
+      p.committed_seq = start_seq;
+      pending_lognode_deltas_by_seq[start_seq].push_back(oid);
+    }
+    // clear reserved
+    pending_lognode_deltas_by_oid_reserved[oid] = 0;
+    auto &seqs_by_oid = pending_lognode_deltas_by_oid[oid];
+    seqs_by_oid.insert(
+      seqs_by_oid.end(),
+      t.lognode_deltas.begin(),
+      t.lognode_deltas.end());   // copy
+    DEBUGT("lognode deltas start_seq:{}, oid:{}, oid queue length:{}, \
+      seq queue length {}", t, start_seq, t.lognode_deltas.begin()->oid, 
+      pending_lognode_deltas_by_oid[oid].size(),
+      pending_lognode_deltas_by_seq.size());
   }
 
   if (!can_drop_backref()) {

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -156,6 +156,7 @@ void Cache::register_metrics(store_index_t store_index)
     {src_t::TRIM_ALLOC, {sm::label_instance("src", "TRIM_ALLOC")}},
     {src_t::CLEANER_MAIN, {sm::label_instance("src", "CLEANER_MAIN")}},
     {src_t::CLEANER_COLD, {sm::label_instance("src", "CLEANER_COLD")}},
+    {src_t::TRIM_LOG, {sm::label_instance("src", "TRIM_LOG")}},
   };
   assert(labels_by_src.size() == (std::size_t)src_t::MAX);
 
@@ -1842,7 +1843,15 @@ record_t Cache::prepare_record(
       alloc_tail = *maybe_alloc_tail;
     }
     ceph_assert(alloc_tail != JOURNAL_SEQ_NULL);
-    auto tails = journal_tail_delta_t{alloc_tail, dirty_tail};
+    auto maybe_log_tail = get_oldest_log_dirty_from();
+    journal_seq_t log_tail;
+    if (!maybe_log_tail.has_value()) {
+      log_tail = journal_head;
+    } else {
+      log_tail = *maybe_log_tail;
+    }
+
+    auto tails = journal_tail_delta_t{alloc_tail, dirty_tail, log_tail};
     SUBDEBUGT(seastore_t, "update tails as delta {}", t, tails);
     bufferlist bl;
     encode(tails, bl);
@@ -2156,7 +2165,7 @@ void Cache::complete_commit(
     }
   }
 
-  if (t.lognode_deltas.size()) {
+  if (t.lognode_deltas.size() && t.get_src() != Transaction::src_t::TRIM_LOG) {
     auto oid = t.lognode_deltas.begin()->oid;
     for (auto &p : t.lognode_deltas) {
       p.committed_seq = start_seq;
@@ -2173,6 +2182,11 @@ void Cache::complete_commit(
       seq queue length {}", t, start_seq, t.lognode_deltas.begin()->oid, 
       pending_lognode_deltas_by_oid[oid].size(),
       pending_lognode_deltas_by_seq.size());
+  } else if (t.get_src() == Transaction::src_t::TRIM_LOG) {
+    assert(t.lognode_deltas.size() > 0);
+    auto oid = t.lognode_deltas.begin()->oid;
+    // clear reserved
+    pending_lognode_deltas_by_oid_reserved[oid] = 0;
   }
 
   if (!can_drop_backref()) {
@@ -2257,6 +2271,7 @@ Cache::replay_delta(
   const delta_info_t &delta,
   const journal_seq_t &dirty_tail,
   const journal_seq_t &alloc_tail,
+  const journal_seq_t &log_tail,
   sea_time_point modify_time)
 {
   LOG_PREFIX(Cache::replay_delta);
@@ -2297,6 +2312,21 @@ Cache::replay_delta(
     // this delta should have been dealt with during segment cleaner mounting
     return replay_delta_ertr::make_ready_future<std::pair<bool, CachedExtentRef>>(
       std::make_pair(false, nullptr));
+  }
+  
+  // replay log
+  if (delta.type == extent_types_t::LOG_NODE_INFO) {
+    if (journal_seq < log_tail) {
+      DEBUG("journal_seq {} < log_tail {}, don't replay {}",
+	journal_seq, log_tail, delta);
+      return replay_delta_ertr::make_ready_future<std::pair<bool, CachedExtentRef>>(
+	std::make_pair(false, nullptr));
+    }
+    lognode_delta_t d;
+    auto iter = delta.bl.cbegin();
+    decode(d, iter);
+    pending_lognode_deltas_by_seq[journal_seq].push_back(d.oid);
+    pending_lognode_deltas_by_oid[d.oid].emplace_back(std::move(d));
   }
 
   // replay alloc
@@ -2447,6 +2477,27 @@ Cache::replay_delta(
 	std::make_pair(true, extent));
     });
   }
+}
+
+std::vector<ghobject_t>
+Cache::get_next_dirty_log_node_by_oid(
+  journal_seq_t seq)
+{
+  LOG_PREFIX(Cache::get_next_dirty_log_node_by_oid);
+  std::vector<ghobject_t> cand;
+  for (auto& [entry_seq, oids] : pending_lognode_deltas_by_seq) {
+    if (entry_seq > seq) {
+      break;
+    }
+    DEBUG(
+      "entry_seq={}, target_seq={}, oids={}, first oid={}",
+      entry_seq,
+      seq,
+      oids.size()
+    );
+    cand.insert(cand.end(), oids.begin(), oids.end());
+  }
+  return cand;
 }
 
 Cache::get_next_dirty_extents_ret Cache::get_next_dirty_extents(

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1382,6 +1382,7 @@ public:
     const delta_info_t &delta,
     const journal_seq_t &dirty_tail,
     const journal_seq_t &alloc_tail,
+    const journal_seq_t &log_tail,
     sea_time_point modify_time);
 
   /**
@@ -1501,6 +1502,26 @@ public:
     Transaction &t,
     journal_seq_t seq,
     size_t max_bytes);
+
+  std::vector<ghobject_t> get_next_dirty_log_node_by_oid(
+    journal_seq_t seq);
+
+  std::optional<journal_seq_t> get_oldest_log_dirty_from() const {
+    LOG_PREFIX(Cache::get_oldest_log_dirty_from);
+    if (pending_lognode_deltas_by_seq.size()) {
+      SUBDEBUG(seastore_cache, "dirty_log_oldest: {}", pending_lognode_deltas_by_seq.begin()->first);
+      return pending_lognode_deltas_by_seq.begin()->first;
+    } 
+    return std::nullopt;
+  }
+
+  bool has_pending_lognode_deltas() const {
+    return pending_lognode_deltas_by_seq.size() > 0;
+  }
+
+  std::optional<size_t> pending_lognode_delta_size(ghobject_t oid) {
+    return pending_lognode_deltas_by_oid[oid].size();
+  }
 
 #define PENDING_MAX_NODE_DELTAS 18
   std::optional<std::pair<lognode_deltas_t, size_t>> get_pending_lognode_delta_by_oid(

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1018,6 +1018,10 @@ private:
   backref_entryrefs_by_seq_t backref_entryrefs_by_seq;
   backref_entry_mset_t backref_entry_mset;
 
+  std::map<journal_seq_t, std::vector<ghobject_t>> pending_lognode_deltas_by_seq;
+  std::map<ghobject_t, lognode_deltas_t> pending_lognode_deltas_by_oid;
+  std::map<ghobject_t, size_t> pending_lognode_deltas_by_oid_reserved;
+
   using backref_entry_query_mset_t = std::multiset<
       backref_entry_t, backref_entry_t::cmp_t>;
   backref_entry_query_mset_t get_backref_entries_in_range(
@@ -1497,6 +1501,53 @@ public:
     Transaction &t,
     journal_seq_t seq,
     size_t max_bytes);
+
+#define PENDING_MAX_NODE_DELTAS 18
+  std::optional<std::pair<lognode_deltas_t, size_t>> get_pending_lognode_delta_by_oid(
+    ghobject_t oid, bool force = false) {
+    LOG_PREFIX(Cache::get_pending_lognode_delta_by_oid);
+    auto oid_iter = pending_lognode_deltas_by_oid.find(oid);
+    if (oid_iter == pending_lognode_deltas_by_oid.end()) {
+      return std::nullopt;
+    }
+    if (oid_iter->second.size() < PENDING_MAX_NODE_DELTAS && force == false) {
+      return std::nullopt;
+    }
+    // If the transaction fails, reissue the conflicting transaction with reserved set to 1. 
+    // This causes it to be handled as a normal transaction, after which reserved is reset to 0
+    // in complete_commit
+    if (pending_lognode_deltas_by_oid_reserved[oid] >= 1) {
+      return std::nullopt;
+    }
+    lognode_deltas_t d;
+    bool prev_has_delete = false;
+    bool prev_has_insert = false;
+    size_t idx = 1, last_idx_to_delete = 0;
+    transaction_id_t prev_id = oid_iter->second.begin()->trans_id;
+    for (auto &p : oid_iter->second) {
+      if (prev_has_delete && p.op == lognode_delta_t::op_t::INSERT) {
+	break;
+      }
+      if (prev_has_insert && p.op == lognode_delta_t::op_t::DELETE &&
+	  prev_id < p.trans_id) {
+	break;
+      }
+      if (p.op == lognode_delta_t::op_t::DELETE) {
+	prev_has_delete = true;
+      }
+      if (p.op == lognode_delta_t::op_t::INSERT) {
+	prev_has_insert = true;
+      }
+      d.push_back(p);
+      last_idx_to_delete = idx++;
+      prev_id = p.trans_id;
+      SUBDEBUG(seastore_cache, "oid:{}, oid queue size:{}, tid:{}, commit_seq:{}", oid,
+	pending_lognode_deltas_by_oid[oid].size(),  p.trans_id, p.committed_seq);
+    }
+    ceph_assert(d.size() > 0);
+    pending_lognode_deltas_by_oid_reserved[oid] = 1;
+    return std::make_pair(std::move(d), last_idx_to_delete);
+  }
 
   /// returns std::nullopt if no pending alloc-infos
   std::optional<journal_seq_t> get_oldest_backref_dirty_from() const {

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -598,6 +598,18 @@ public:
     return !devices_by_id[addr.get_device_id()]->is_end_to_end_data_protection();
   }
 
+  using post_trim_callback_t =
+    std::function<base_ertr::future<>(journal_seq_t target)>;
+  void set_post_trim_callback(post_trim_callback_t cb)
+  {
+    background_process.set_post_trim_callback(std::move(cb));
+  }
+
+  base_ertr::future<> post_trim_callback(journal_seq_t target)
+  {
+    return background_process.post_trim_callback(target);
+  }
+
 private:
   rewrite_gen_t adjust_generation(
       data_category_t category,
@@ -874,6 +886,14 @@ private:
     
     bool is_no_background() const {
       return !trimmer || !main_cleaner;
+    }
+    
+    void set_post_trim_callback(post_trim_callback_t cb) {
+      trimmer->set_post_trim_callback(cb);
+    }
+
+    base_ertr::future<> post_trim_callback(journal_seq_t target) {
+      return trimmer->post_trim_callback(target);
     }
 
   protected:

--- a/src/crimson/os/seastore/journal.h
+++ b/src/crimson/os/seastore/journal.h
@@ -97,6 +97,7 @@ public:
       const delta_info_t&,
       const journal_seq_t&, // dirty_tail
       const journal_seq_t&, // alloc_tail
+      const journal_seq_t&, // log_tail
       sea_time_point modify_time)>;
   virtual replay_ret replay(
     delta_handler_t &&delta_handler) = 0;

--- a/src/crimson/os/seastore/journal/circular_bounded_journal.cc
+++ b/src/crimson/os/seastore/journal/circular_bounded_journal.cc
@@ -136,7 +136,8 @@ CircularBoundedJournal::submit_record(
   if (is_trim_transaction(t_src)) {
     co_await update_journal_tail(
       trimmer.get_dirty_tail(),
-      trimmer.get_alloc_tail());
+      trimmer.get_alloc_tail(),
+      trimmer.get_log_tail());
   }
 }
 
@@ -365,6 +366,7 @@ Journal::replay_ret CircularBoundedJournal::replay(
 	}
 	return replay_ertr::make_ready_future<bool>(true);
       };
+      assert(get_dirty_tail <= get_log_tail());
       auto tail = get_dirty_tail() <= get_alloc_tail() ?
 	get_dirty_tail() : get_alloc_tail();
       set_written_to(tail);
@@ -384,6 +386,7 @@ Journal::replay_ret CircularBoundedJournal::replay(
 	      e,
 	      get_dirty_tail(),
 	      get_alloc_tail(),
+	      get_log_tail(),
 	      modify_time
 	    ).safe_then([&e, &crc_info](auto ret) {
 	      auto [applied, ext] = ret;
@@ -417,7 +420,8 @@ Journal::replay_ret CircularBoundedJournal::replay(
       }
       trimmer.update_journal_tails(
 	get_dirty_tail(),
-	get_alloc_tail());
+	get_alloc_tail(),
+	get_log_tail());
     });
   });
 }

--- a/src/crimson/os/seastore/journal/circular_bounded_journal.h
+++ b/src/crimson/os/seastore/journal/circular_bounded_journal.h
@@ -110,14 +110,18 @@ public:
 
   seastar::future<> update_journal_tail(
     journal_seq_t dirty,
-    journal_seq_t alloc) {
-    return cjs.update_journal_tail(dirty, alloc);
+    journal_seq_t alloc,
+    journal_seq_t log) {
+    return cjs.update_journal_tail(dirty, alloc, log);
   }
   journal_seq_t get_dirty_tail() const {
     return cjs.get_dirty_tail();
   }
   journal_seq_t get_alloc_tail() const {
     return cjs.get_alloc_tail();
+  }
+  journal_seq_t get_log_tail() const {
+    return cjs.get_log_tail();
   }
 
   void set_write_pipeline(WritePipeline *_write_pipeline) final {

--- a/src/crimson/os/seastore/journal/circular_journal_space.h
+++ b/src/crimson/os/seastore/journal/circular_journal_space.h
@@ -122,12 +122,14 @@ class CircularJournalSpace : public JournalAllocator {
     // start offset of CircularBoundedJournal in the device
     journal_seq_t dirty_tail;
     journal_seq_t alloc_tail;
+    journal_seq_t log_tail;
     segment_nonce_t magic;
 
     DENC(cbj_header_t, v, p) {
       DENC_START(1, 1, p);
       denc(v.dirty_tail, p);
       denc(v.alloc_tail, p);
+      denc(v.log_tail, p);
       denc(v.magic, p);
       DENC_FINISH(p);
     }
@@ -162,6 +164,9 @@ class CircularJournalSpace : public JournalAllocator {
   }
   journal_seq_t get_alloc_tail() const {
     return header.alloc_tail;
+  }
+  journal_seq_t get_log_tail() const {
+    return header.log_tail;
   }
 
   /* 
@@ -222,9 +227,11 @@ class CircularJournalSpace : public JournalAllocator {
 
   seastar::future<> update_journal_tail(
     journal_seq_t dirty,
-    journal_seq_t alloc) {
+    journal_seq_t alloc,
+    journal_seq_t log) {
     header.dirty_tail = dirty;
     header.alloc_tail = alloc;
+    header.log_tail = log;
     return write_header(
     ).handle_error(
       crimson::ct_error::assert_all{

--- a/src/crimson/os/seastore/journal/segment_allocator.cc
+++ b/src/crimson/os/seastore/journal/segment_allocator.cc
@@ -71,26 +71,32 @@ SegmentAllocator::do_open(bool is_mkfs)
     segment_id_t segment_id = sref->get_segment_id();
     journal_seq_t dirty_tail;
     journal_seq_t alloc_tail;
+    journal_seq_t log_tail;
     if (type == segment_type_t::JOURNAL) {
       dirty_tail = trimmer->get_dirty_tail();
       alloc_tail = trimmer->get_alloc_tail();
+      log_tail = trimmer->get_log_tail();
       if (is_mkfs) {
         ceph_assert(dirty_tail == JOURNAL_SEQ_NULL);
         ceph_assert(alloc_tail == JOURNAL_SEQ_NULL);
+        ceph_assert(log_tail == JOURNAL_SEQ_NULL);
         auto mkfs_seq = journal_seq_t{
           new_segment_seq,
           paddr_t::make_seg_paddr(segment_id, 0)
         };
         dirty_tail = mkfs_seq;
         alloc_tail = mkfs_seq;
+        log_tail = mkfs_seq;
       } else {
         ceph_assert(dirty_tail != JOURNAL_SEQ_NULL);
         ceph_assert(alloc_tail != JOURNAL_SEQ_NULL);
+        ceph_assert(log_tail != JOURNAL_SEQ_NULL);
       }
     } else { // OOL
       ceph_assert(!is_mkfs);
       dirty_tail = JOURNAL_SEQ_NULL;
       alloc_tail = JOURNAL_SEQ_NULL;
+      log_tail = JOURNAL_SEQ_NULL;
     }
     auto header = segment_header_t{
       timepoint_to_mod(seastar::lowres_system_clock::now()),
@@ -98,6 +104,7 @@ SegmentAllocator::do_open(bool is_mkfs)
       segment_id,
       dirty_tail,
       alloc_tail,
+      log_tail,
       current_segment_nonce,
       type,
       category,

--- a/src/crimson/os/seastore/journal/segmented_journal.cc
+++ b/src/crimson/os/seastore/journal/segmented_journal.cc
@@ -107,9 +107,10 @@ SegmentedJournal::prep_replay_segments(
   auto last_header = segments.rbegin()->second;
   return scan_last_segment(last_segment_id, last_header
   ).safe_then([this, FNAME, segments=std::move(segments)] {
-    INFO("dirty_tail={}, alloc_tail={}",
+    INFO("dirty_tail={}, alloc_tail={}, log_tail={}",
          trimmer.get_dirty_tail(),
-         trimmer.get_alloc_tail());
+         trimmer.get_alloc_tail(),
+	 trimmer.get_log_tail());
     auto journal_tail = trimmer.get_journal_tail();
     auto journal_tail_paddr = journal_tail.offset;
     ceph_assert(journal_tail != JOURNAL_SEQ_NULL);
@@ -156,7 +157,7 @@ SegmentedJournal::scan_last_segment(
   LOG_PREFIX(SegmentedJournal::scan_last_segment);
   assert(segment_id == segment_header.physical_segment_id);
   trimmer.update_journal_tails(
-      segment_header.dirty_tail, segment_header.alloc_tail);
+      segment_header.dirty_tail, segment_header.alloc_tail, segment_header.log_tail);
   auto seq = journal_seq_t{
     segment_header.segment_seq,
     paddr_t::make_seg_paddr(segment_id, 0)
@@ -206,8 +207,9 @@ SegmentedJournal::scan_last_segment(
               DEBUG("got {}, at {}", tail_delta, start_seq);
               ceph_assert(tail_delta.dirty_tail != JOURNAL_SEQ_NULL);
               ceph_assert(tail_delta.alloc_tail != JOURNAL_SEQ_NULL);
+              ceph_assert(tail_delta.log_tail != JOURNAL_SEQ_NULL);
               trimmer.update_journal_tails(
-                  tail_delta.dirty_tail, tail_delta.alloc_tail);
+                  tail_delta.dirty_tail, tail_delta.alloc_tail, tail_delta.log_tail);
             }
           }
         }
@@ -292,6 +294,7 @@ SegmentedJournal::replay_segment(
 	      delta,
 	      trimmer.get_dirty_tail(),
 	      trimmer.get_alloc_tail(),
+	      trimmer.get_log_tail(),
               modify_time
             ).safe_then([&stats, delta_type=delta.type](auto ret) {
 	      auto [is_applied, ext] = ret;

--- a/src/crimson/os/seastore/omap_manager/log/log_manager.cc
+++ b/src/crimson/os/seastore/omap_manager/log/log_manager.cc
@@ -107,6 +107,31 @@ LogManager::merge_deltas(
 }
 
 LogManager::omap_set_keys_ret
+LogManager::flush_logs(
+  omap_root_t &log_root,
+  Transaction &t) 
+{
+  LOG_PREFIX(LogManager::flush_logs);
+  auto pending = tm.get_pending_lognode_delta_by_oid(*log_root.associated_oid, true);
+  size_t last_idx_to_delete = 0;
+  if (pending) {
+    auto& deltas = pending->first;
+    last_idx_to_delete = pending->second;
+    co_await merge_deltas(log_root, t, deltas);
+  }
+  lognode_delta_t delta;
+  assert(log_root.associated_oid);
+  delta.oid = *log_root.associated_oid;
+  delta.op = lognode_delta_t::op_t::FLUSH;
+  if (last_idx_to_delete > 0) {
+    delta.last_idx_to_delete = last_idx_to_delete;
+  }
+  delta.trans_id = t.get_trans_id();
+  t.add_lognode_delta(std::move(delta));
+  co_return;
+}
+
+LogManager::omap_set_keys_ret
 LogManager::omap_set_keys(
   omap_root_t &log_root,
   Transaction &t, std::map<std::string, ceph::bufferlist>&& _kvs) 

--- a/src/crimson/os/seastore/omap_manager/log/log_manager.cc
+++ b/src/crimson/os/seastore/omap_manager/log/log_manager.cc
@@ -53,6 +53,60 @@ LogManager::initialize_omap(Transaction &t, laddr_t hint, omap_type_t omap_type)
 }
 
 LogManager::omap_set_keys_ret
+LogManager::merge_deltas(
+  omap_root_t &log_root,
+  Transaction &t,
+  lognode_deltas_t &deltas)
+{
+  LOG_PREFIX(LogManager::merge_deltas);
+  std::map<std::string, ceph::bufferlist> merged_kvs;
+  std::vector<std::pair<std::string, std::string>> merged_ranges;
+  for (auto &delta : deltas) {
+    if (delta.op == lognode_delta_t::op_t::INSERT) {
+      std::map<std::string, ceph::bufferlist> __kvs;
+      auto iter = delta.buffer.cbegin();
+      decode(__kvs, iter);
+      for (auto &[k, v] : __kvs) {
+	merged_kvs.insert_or_assign(k, std::move(v));
+      }
+    } else {
+      assert(delta.op == lognode_delta_t::op_t::DELETE);
+      std::vector<std::pair<std::string, std::string>> range;
+      auto iter = delta.buffer.cbegin();
+      decode(range, iter);
+      for (auto &p : range) {
+	if (merged_ranges.empty()) {
+	  merged_ranges.emplace_back(std::move(p));
+	  continue;
+	}
+	auto& last = merged_ranges.back();
+	std::set<std::string> can_merge{
+	  last.second,
+	  p.first
+	};
+	if (is_continuous_fixed_width(can_merge)) {
+	  last.second = std::move(p.second);
+	} else {
+	  merged_ranges.emplace_back(std::move(p));
+	}
+      }
+    }
+  }
+  ceph_assert(merged_kvs.size() || merged_ranges.size());
+  if (merged_kvs.size()) {
+    DEBUGT("oid:{} insert op kv size:{} ", t, *log_root.associated_oid, merged_kvs.size());
+    co_await _omap_set_keys(log_root, t, std::move(merged_kvs));
+  }
+  if (merged_ranges.size()) {
+    for (auto &p : merged_ranges) {
+      DEBUGT("oid:{} delete op:{} ~ {}", t, *log_root.associated_oid, p.first, p.second);
+      co_await _omap_rm_key_range(log_root, t, p.first, p.second);
+    }
+  }
+  co_return;
+}
+
+LogManager::omap_set_keys_ret
 LogManager::omap_set_keys(
   omap_root_t &log_root,
   Transaction &t, std::map<std::string, ceph::bufferlist>&& _kvs) 
@@ -60,7 +114,33 @@ LogManager::omap_set_keys(
   LOG_PREFIX(LogManager::omap_set_keys);
   DEBUGT("enter kv size {}", t, _kvs.size());
   assert(log_root.get_type() == omap_type_t::LOG);
+  auto kvs = std::move(_kvs);
 
+  auto pending = tm.get_pending_lognode_delta_by_oid(*log_root.associated_oid);
+  size_t last_idx_to_delete = 0;
+  if (pending) {
+    auto& deltas = pending->first;
+    last_idx_to_delete = pending->second;
+    co_await merge_deltas(log_root, t, deltas);
+  }
+  lognode_delta_t delta;
+  assert(log_root.associated_oid);
+  delta.oid = *log_root.associated_oid;
+  delta.op = lognode_delta_t::op_t::INSERT;
+  if (last_idx_to_delete > 0) {
+    delta.last_idx_to_delete = last_idx_to_delete;
+  }
+  delta.trans_id = t.get_trans_id();
+  encode(kvs, delta.buffer);
+  t.add_lognode_delta(std::move(delta));
+  co_return;
+}
+
+LogManager::omap_set_keys_ret
+LogManager::_omap_set_keys(
+  omap_root_t &log_root,
+  Transaction &t, std::map<std::string, ceph::bufferlist>&& _kvs) 
+{
   auto kvs = std::move(_kvs);
   auto ext = co_await log_load_extent<LogNode>(
     t, log_root.addr, BEGIN_KEY, END_KEY);
@@ -759,16 +839,31 @@ LogManager::omap_rm_keys(
 
     bool continuous = is_continuous_fixed_width(key_set);
     if (continuous) {
-      // fast path
-      co_await remove_kvs(
-	t, addr,
-	*key_set.begin(),
-	*key_set.rbegin(),
-	nullptr);
+      lognode_delta_t delta;
+      assert(log_root.associated_oid);
+      delta.oid = *log_root.associated_oid;
+      delta.op = lognode_delta_t::op_t::DELETE;
+      delta.trans_id = t.get_trans_id();
+      std::vector<std::pair<std::string, std::string>> keys;
+      auto pair = std::make_pair(*key_set.begin(), *key_set.rbegin());
+      keys.emplace_back(pair);
+      encode(keys, delta.buffer);
+      t.add_lognode_delta(std::move(delta));
+      co_return;
     } else {
+      lognode_delta_t delta;
+      assert(log_root.associated_oid);
+      delta.oid = *log_root.associated_oid;
+      delta.op = lognode_delta_t::op_t::DELETE;
+      delta.trans_id = t.get_trans_id();
+      std::vector<std::pair<std::string, std::string>> keys;
       for (auto& p : key_set) {
-	co_await remove_kv(t, log_root.addr, p, nullptr);
+	auto pair = std::make_pair(p, p);
+	keys.emplace_back(pair);
       }
+      encode(keys, delta.buffer);
+      t.add_lognode_delta(std::move(delta));
+      co_return;
     }
   };
   co_await remove_key_set(keys, log_root.addr);
@@ -787,6 +882,31 @@ LogManager::omap_rm_key_range(
   LOG_PREFIX(LogManager::omap_rm_key_range);
   DEBUGT("first={}, last={}", t, first, last);
   assert(log_root.get_type() == omap_type_t::LOG);
+
+  lognode_delta_t delta;
+  assert(log_root.associated_oid);
+  delta.oid = *log_root.associated_oid;
+  delta.op = lognode_delta_t::op_t::DELETE;
+  delta.trans_id = t.get_trans_id();
+  auto p = std::make_pair(first, last);
+  std::vector<std::pair<std::string, std::string>> keys;
+  keys.emplace_back(p);
+  encode(keys, delta.buffer);
+  t.add_lognode_delta(std::move(delta));
+  co_return;
+}
+
+LogManager::omap_rm_key_range_ret 
+LogManager::_omap_rm_key_range(
+  omap_root_t &log_root,
+  Transaction &t,
+  const std::string &first,
+  const std::string &last)
+{
+  LOG_PREFIX(LogManager::omap_rm_key_range);
+  DEBUGT("first={}, last={}", t, first, last);
+  assert(log_root.get_type() == omap_type_t::LOG);
+
   co_await remove_kvs(t, log_root.addr, first, last, nullptr);
   // for dup list
   co_await remove_kvs(t, 

--- a/src/crimson/os/seastore/omap_manager/log/log_manager.h
+++ b/src/crimson/os/seastore/omap_manager/log/log_manager.h
@@ -351,6 +351,7 @@ public:
     Transaction &t, LogNodeRef tail,
     const std::string &key, const ceph::bufferlist &value);
 
+  omap_set_keys_ret flush_logs(omap_root_t &log_root, Transaction &t);
   omap_set_keys_ret merge_deltas(omap_root_t &log_root, Transaction &t,
     lognode_deltas_t &deltas);
 

--- a/src/crimson/os/seastore/omap_manager/log/log_manager.h
+++ b/src/crimson/os/seastore/omap_manager/log/log_manager.h
@@ -73,6 +73,9 @@ public:
   omap_set_keys_ret omap_set_keys(omap_root_t &log_root,
     Transaction &t, std::map<std::string, ceph::bufferlist>&& _kvs) final;
 
+  omap_set_keys_ret _omap_set_keys(omap_root_t &log_root,
+    Transaction &t, std::map<std::string, ceph::bufferlist>&& _kvs);
+
   // see omap_set_keys
   omap_set_key_ret omap_set_key(
     omap_root_t &log_root,
@@ -133,6 +136,12 @@ public:
     Transaction &t,
     const std::string &first,
     const std::string &last) final;
+
+  omap_rm_key_range_ret _omap_rm_key_range(
+    omap_root_t &log_root,
+    Transaction &t,
+    const std::string &first,
+    const std::string &last);
 
   /**
    * omap_rm_key
@@ -342,6 +351,8 @@ public:
     Transaction &t, LogNodeRef tail,
     const std::string &key, const ceph::bufferlist &value);
 
+  omap_set_keys_ret merge_deltas(omap_root_t &log_root, Transaction &t,
+    lognode_deltas_t &deltas);
 
   TransactionManager &tm;
 };

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -1422,6 +1422,58 @@ omap_root_t SeaStore::Shard::select_log_omap_root(Onode& onode) const
   return get_omap_root(omap_type_t::OMAP, onode);
 }
 
+template <typename Result, typename ReadFunc>
+SeaStore::Shard::read_errorator::future<Result>
+SeaStore::Shard::repeat_with_onode_after_lognode_flush(
+  CollectionRef ch,
+  const ghobject_t& oid,
+  Transaction::src_t src,
+  const char* op_name,
+  op_type_t op_type,
+  uint32_t op_flags,
+  ReadFunc&& read_func)
+{
+  using read_func_t = std::decay_t<ReadFunc>;
+  using checked_result_t = std::optional<Result>;
+  return seastar::do_with(
+    read_func_t(std::forward<ReadFunc>(read_func)),
+    [this, ch, oid, src, op_name, op_type, op_flags](auto& read_func) {
+      return repeat_with_onode<checked_result_t>(
+        ch, oid, src, op_name, op_type, op_flags,
+        [this, &read_func](
+          auto& t,
+          auto& onode) -> base_iertr::future<checked_result_t> {
+          auto root = select_log_omap_root(onode);
+          if (root.get_type() == omap_type_t::LOG &&
+              transaction_manager->has_pending_lognode_deltas()) {
+            return base_iertr::make_ready_future<
+              checked_result_t>(std::nullopt);
+          }
+          return read_func(t, onode
+          ).si_then([](Result result) {
+	    return checked_result_t{std::move(result)};
+          });
+        }
+      ).safe_then(
+        [this, ch, oid, src, op_name, op_type, op_flags, &read_func](
+          checked_result_t result) mutable -> read_errorator::future<Result> {
+          if (result) {
+            return read_errorator::make_ready_future<Result>(
+              std::move(*result));
+          }
+	  return pgoid_log_flush(oid
+          ).safe_then(
+            [this, ch, oid, src, op_name, op_type, op_flags, &read_func]() mutable {
+              return repeat_with_onode<Result>(
+                ch, oid, src, op_name, op_type, op_flags, [this, &read_func](
+                  auto& t, auto& onode) {
+                  return read_func(t, onode);
+              });
+          });
+      });
+  });
+}
+
 SeaStore::Shard::read_errorator::future<SeaStore::Shard::omap_values_t>
 SeaStore::Shard::omap_get_values(
   CollectionRef ch,
@@ -1433,7 +1485,7 @@ SeaStore::Shard::omap_get_values(
   ++(shard_stats.read_num);
   ++(shard_stats.pending_read_num);
 
-  return repeat_with_onode<omap_values_t>(
+  return repeat_with_onode_after_lognode_flush<omap_values_t>(
     ch,
     oid,
     Transaction::src_t::READ,
@@ -1469,7 +1521,7 @@ SeaStore::Shard::omap_iterate(
     [this, ch, &oid, callback, op_flags, on_conflict] (
     auto &start_from, auto &conflict_counter)
   {
-    return repeat_with_onode<ObjectStore::omap_iter_ret_t>(
+    return repeat_with_onode_after_lognode_flush<ObjectStore::omap_iter_ret_t>(
       ch,
       oid,
       Transaction::src_t::READ,

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -1869,6 +1869,9 @@ SeaStore::Shard::_do_transaction_step(
 	auto root = select_log_omap_root(*onode);
         DEBUGT("op OMAP_SETKEYS, oid={}, omap size={}, type={} ...",
                *ctx.transaction, oid, aset.size(), root.get_type());
+	if (root.get_type() == omap_type_t::LOG) {
+	  root.associated_oid = oid;
+	}
         return omaptree_set_keys(
           *ctx.transaction,
           std::move(root),
@@ -1890,6 +1893,9 @@ SeaStore::Shard::_do_transaction_step(
 	auto root = select_log_omap_root(*onode);
         DEBUGT("op OMAP_RMKEYS, oid={}, omap size={}, type={} ...",
                *ctx.transaction, oid, keys.size(), root.get_type());
+	if (root.get_type() == omap_type_t::LOG) {
+	  root.associated_oid = oid;
+	}
         return omaptree_rm_keys(
           *ctx.transaction,
           std::move(root),
@@ -1904,6 +1910,9 @@ SeaStore::Shard::_do_transaction_step(
 	auto root = select_log_omap_root(*onode);
         DEBUGT("op OMAP_RMKEYRANGE, oid={}, first={}, last={}, type={}...",
                *ctx.transaction, oid, first, last, root.get_type());
+	if (root.get_type() == omap_type_t::LOG) {
+	  root.associated_oid = oid;
+	}
         return omaptree_rm_keyrange(
           *ctx.transaction,
           std::move(root),

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -2625,6 +2625,11 @@ void SeaStore::Shard::init_managers()
       *transaction_manager);
   onode_manager = std::make_unique<crimson::os::seastore::onode::FLTreeOnodeManager>(
       *transaction_manager);
+  transaction_manager->get_epm()->set_post_trim_callback(
+    [this] (journal_seq_t target) {
+      return handle_log_flush(target);
+    }
+  );
 }
 
 double SeaStore::Shard::reset_report_interval() const
@@ -3215,6 +3220,90 @@ SeaStore::Shard::omaptree_rm_key(
   } else {
     return run(BtreeOMapManager(*transaction_manager));
   }
+}
+
+base_iertr::future<>
+SeaStore::Shard::pgoid_do_handle_log_flush(
+  Transaction& t, const ghobject_t oid)
+{
+  LOG_PREFIX(SeaStoreS::pgoid_do_handle_log_flush);
+  auto onode = co_await onode_manager->get_onode(t, oid
+  ).handle_error_interruptible(
+    crimson::ct_error::assert_all(
+      "Invalid error in onode_manager->get_onode"
+  ));
+  DEBUG("enter with oid:{}", oid);
+  auto root = select_log_omap_root(*onode);
+  assert(root.get_type() == omap_type_t::LOG);
+  root.associated_oid = oid;
+  LogManager log_manager(*transaction_manager);
+  co_await log_manager.flush_logs(root, t
+  ).handle_error_interruptible(
+    crimson::ct_error::assert_all(
+      "Invalid error in log_manager.sync_log"
+    )
+  );
+  if (root.must_update()) {
+    omaptree_update_root(t, root, *onode);
+  }
+  co_await transaction_manager->submit_transaction(t);
+}
+
+base_ertr::future<> SeaStore::Shard::pgoid_log_flush(const ghobject_t oid)
+{
+  assert(store_active);
+  LOG_PREFIX(SeaStoreS::pgoid_log_flush);
+  return ::crimson::repeat([this, FNAME, oid] {
+    auto entries = transaction_manager->pending_lognode_delta_size(oid);
+    if (!entries || *entries == 0) {
+      return base_ertr::make_ready_future<
+	seastar::stop_iteration>(seastar::stop_iteration::yes);
+    }
+    DEBUG("pendings:{}", *entries);
+    return repeat_eagain([this, FNAME, oid] {
+      return transaction_manager->with_transaction_intr(
+	Transaction::src_t::TRIM_LOG,
+	"trim_log",
+	CACHE_HINT_NOCACHE,
+	[this, FNAME, oid](auto& t) -> base_iertr::future<>  {
+	return pgoid_do_handle_log_flush(t, oid);
+      });
+    }).safe_then([] {
+      return seastar::stop_iteration::no;
+    });
+  });
+}
+
+base_ertr::future<> SeaStore::Shard::handle_log_flush(journal_seq_t target)
+{
+  assert(store_active);
+  LOG_PREFIX(SeaStoreS::handle_log_flush);
+  std::optional<journal_seq_t> completed_seq;
+  return seastar::do_with(
+    completed_seq,
+    [this, FNAME, target](auto& completed_seq) {
+    return ::crimson::repeat([this, FNAME, &completed_seq, target] {
+      auto oids =
+	transaction_manager->get_next_dirty_log_node_by_oid(
+	target);
+      DEBUG("the number of oids {} target {}", oids.size(), target);
+      if (oids.size() == 0) {
+	return base_ertr::make_ready_future<
+	  seastar::stop_iteration>(seastar::stop_iteration::yes);
+      }
+      return seastar::do_with(
+	std::move(oids),
+        [this, FNAME](auto& oids) {
+	return crimson::do_for_each(
+	  oids,
+	  [this, FNAME](auto &oid) {
+	  return pgoid_log_flush(oid);
+	}).safe_then([] {
+          return seastar::stop_iteration::no;
+        });
+      });
+    });
+  });
 }
 
 }

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -187,6 +187,10 @@ public:
 
     omap_root_t select_log_omap_root(Onode& onode) const;
 
+    base_iertr::future<> pgoid_do_handle_log_flush(Transaction& t, const ghobject_t oid);
+    base_ertr::future<> pgoid_log_flush(const ghobject_t oid);
+    base_ertr::future<> handle_log_flush(journal_seq_t target);
+
   // only exposed to SeaStore
   public:
     base_ertr::future<> umount();

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -190,6 +190,16 @@ public:
     base_iertr::future<> pgoid_do_handle_log_flush(Transaction& t, const ghobject_t oid);
     base_ertr::future<> pgoid_log_flush(const ghobject_t oid);
     base_ertr::future<> handle_log_flush(journal_seq_t target);
+    template <typename Result, typename ReadFunc>
+    read_errorator::future<Result>
+    repeat_with_onode_after_lognode_flush(
+      CollectionRef ch,
+      const ghobject_t& oid,
+      Transaction::src_t src,
+      const char* op_name,
+      op_type_t op_type,
+      uint32_t op_flags,
+      ReadFunc&& read_func);
 
   // only exposed to SeaStore
   public:

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -365,6 +365,7 @@ std::ostream &operator<<(std::ostream &out, const journal_tail_delta_t &delta)
   return out << "journal_tail_delta_t("
              << "alloc_tail=" << delta.alloc_tail
              << ", dirty_tail=" << delta.dirty_tail
+             << ", log_tail=" << delta.log_tail
              << ")";
 }
 
@@ -447,6 +448,8 @@ std::ostream &operator<<(std::ostream &os, transaction_type_t type)
     return os << "TRIM_DIRTY";
   case transaction_type_t::TRIM_ALLOC:
     return os << "TRIM_ALLOC";
+  case transaction_type_t::TRIM_LOG:
+    return os << "TRIM_LOG";
   case transaction_type_t::CLEANER_MAIN:
     return os << "CLEANER_MAIN";
   case transaction_type_t::CLEANER_COLD:

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -571,6 +571,26 @@ std::ostream& operator<<(std::ostream& out, const record_group_t& rg)
              << ")";
 }
 
+void lognode_delta_t::encode(ceph::buffer::list& bl) const {
+  ENCODE_START(1, 1, bl);
+  encode(op, bl);
+  encode(buffer, bl);
+  encode(oid, bl);
+  encode(committed_seq, bl);
+  encode(trans_id, bl);
+  ENCODE_FINISH(bl);
+}
+
+void lognode_delta_t::decode(ceph::buffer::list::const_iterator& p) {
+  DECODE_START(1, p);
+  decode(op, p);
+  decode(buffer, p);
+  decode(oid, p);
+  decode(committed_seq, p);
+  decode(trans_id, p);
+  DECODE_FINISH(p);
+}
+
 ceph::bufferlist encode_record(
   record_t&& record,
   extent_len_t block_size,

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -23,6 +23,7 @@
 #include "include/rados.h"
 
 #include "crimson/common/errorator.h"
+#include "common/hobject.h"
 
 namespace crimson::os::seastore {
 
@@ -1481,8 +1482,9 @@ enum class extent_types_t : uint8_t {
   BACKREF_INTERNAL = 15,
   BACKREF_LEAF = 16,
   LOG_NODE = 17,
+  LOG_NODE_INFO = 18,
   // None and the number of valid extent_types_t
-  NONE = 18,
+  NONE = 19,
 };
 using extent_types_le_t = uint8_t;
 constexpr auto EXTENT_TYPES_MAX = static_cast<uint8_t>(extent_types_t::NONE);
@@ -1862,6 +1864,7 @@ struct omap_root_t {
   laddr_t hint = L_ADDR_MIN;
   bool mutated = false;
   omap_type_t type = omap_type_t::NONE;
+  std::optional<ghobject_t> associated_oid;
 
   omap_root_t() = default;
   omap_root_t(laddr_t addr, depth_t depth, laddr_t addr_min, omap_type_t type)
@@ -2139,6 +2142,22 @@ struct alloc_delta_t {
     DENC_FINISH(p);
   }
 };
+
+struct lognode_delta_t {
+  enum class op_t : uint_fast8_t {
+    INSERT,
+    DELETE,
+  } op;
+  bufferlist buffer;
+  ghobject_t oid;
+  journal_seq_t committed_seq;
+  transaction_id_t trans_id = 0;
+  uint64_t last_idx_to_delete = 0; // indicate the last index to be deleted
+
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator& p);
+};
+using lognode_deltas_t = std::vector<lognode_delta_t>;
 
 struct extent_info_t {
   extent_types_t type = extent_types_t::NONE;
@@ -3134,6 +3153,7 @@ WRITE_CLASS_DENC_BOUNDED(crimson::os::seastore::segment_header_t)
 WRITE_CLASS_DENC_BOUNDED(crimson::os::seastore::alloc_blk_t)
 WRITE_CLASS_DENC_BOUNDED(crimson::os::seastore::alloc_delta_t)
 WRITE_CLASS_DENC_BOUNDED(crimson::os::seastore::segment_tail_t)
+WRITE_CLASS_ENCODER(crimson::os::seastore::lognode_delta_t)
 
 #if FMT_VERSION >= 90000
 template <> struct fmt::formatter<crimson::os::seastore::cache_access_stats_printer_t> : fmt::ostream_formatter {};

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1771,11 +1771,13 @@ std::ostream &operator<<(std::ostream &out, const delta_info_t &delta);
 struct journal_tail_delta_t {
   journal_seq_t alloc_tail;
   journal_seq_t dirty_tail;
+  journal_seq_t log_tail;
 
   DENC(journal_tail_delta_t, v, p) {
     DENC_START(1, 1, p);
     denc(v.alloc_tail, p);
     denc(v.dirty_tail, p);
+    denc(v.log_tail, p);
     DENC_FINISH(p);
   }
 };
@@ -2147,6 +2149,7 @@ struct lognode_delta_t {
   enum class op_t : uint_fast8_t {
     INSERT,
     DELETE,
+    FLUSH,
   } op;
   bufferlist buffer;
   ghobject_t oid;
@@ -2200,6 +2203,7 @@ struct segment_header_t {
 
   journal_seq_t dirty_tail;
   journal_seq_t alloc_tail;
+  journal_seq_t log_tail;
   segment_nonce_t segment_nonce;
 
   segment_type_t type;
@@ -2218,6 +2222,7 @@ struct segment_header_t {
     denc(v.physical_segment_id, p);
     denc(v.dirty_tail, p);
     denc(v.alloc_tail, p);
+    denc(v.log_tail, p);
     denc(v.segment_nonce, p);
     denc(v.type, p);
     denc(v.category, p);
@@ -2262,6 +2267,7 @@ enum class transaction_type_t : uint8_t {
   TRIM_ALLOC,
   CLEANER_MAIN,
   CLEANER_COLD,
+  TRIM_LOG,
   MAX
 };
 
@@ -2293,7 +2299,8 @@ constexpr bool is_rewrite_transaction(transaction_type_t type) {
 
 constexpr bool is_trim_transaction(transaction_type_t type) {
   return (type == transaction_type_t::TRIM_DIRTY ||
-      type == transaction_type_t::TRIM_ALLOC);
+      type == transaction_type_t::TRIM_ALLOC ||
+      type == transaction_type_t::TRIM_LOG);
 }
 
 constexpr bool is_modify_transaction(transaction_type_t type) {

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -579,6 +579,7 @@ public:
     }
     get_handle().exit();
     views.clear();
+    lognode_deltas.clear();
   }
 
   bool did_reset() const {
@@ -687,6 +688,10 @@ public:
 
   cache_hint_t get_cache_hint() const {
     return cache_hint;
+  }
+
+  void add_lognode_delta(lognode_delta_t &&delta) {
+    lognode_deltas.emplace_back(std::move(delta));
   }
 
   btree_cursor_stats_t cursor_stats;
@@ -919,6 +924,8 @@ private:
   backref_entry_refs_t backref_entries;
 
   cache_hint_t cache_hint = CACHE_HINT_TOUCH;
+
+  lognode_deltas_t lognode_deltas;
 };
 using TransactionRef = Transaction::Ref;
 

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -53,7 +53,7 @@ TransactionManager::mkfs_ertr::future<> TransactionManager::mkfs()
   ).safe_then([this] {
     return journal->open_for_mkfs();
   }).safe_then([this](auto start_seq) {
-    journal->get_trimmer().update_journal_tails(start_seq, start_seq);
+    journal->get_trimmer().update_journal_tails(start_seq, start_seq, start_seq);
     journal->get_trimmer().set_journal_head(start_seq);
     return epm->open_for_write();
   }).safe_then([this, FNAME]() {
@@ -115,6 +115,7 @@ TransactionManager::mount()
 	const auto &e,
 	const journal_seq_t &dirty_tail,
 	const journal_seq_t &alloc_tail,
+	const journal_seq_t &log_tail,
 	sea_time_point modify_time)
       {
 	auto start_seq = offsets.write_result.start_seq;
@@ -124,6 +125,7 @@ TransactionManager::mount()
 	  e,
 	  dirty_tail,
 	  alloc_tail,
+	  log_tail,
 	  modify_time);
       });
   }).safe_then([this] {
@@ -578,7 +580,8 @@ TransactionManager::do_submit_transaction(
       start_seq);
     journal->get_trimmer().update_journal_tails(
       cache->get_oldest_dirty_from().value_or(start_seq),
-      cache->get_oldest_backref_dirty_from().value_or(start_seq));
+      cache->get_oldest_backref_dirty_from().value_or(start_seq),
+      cache->get_oldest_log_dirty_from().value_or(start_seq));
     }).handle_error(
       submit_transaction_iertr::pass_further{},
       crimson::ct_error::assert_all{"Hit error submitting to journal"}
@@ -615,6 +618,15 @@ TransactionManager::get_next_dirty_extents(
   LOG_PREFIX(TransactionManager::get_next_dirty_extents);
   DEBUGT("max_bytes=0x{:x}B, seq={}", t, max_bytes, seq);
   return cache->get_next_dirty_extents(t, seq, max_bytes);
+}
+
+TransactionManager::get_next_dirty_log_node_by_oid_ret
+TransactionManager::get_next_dirty_log_node_by_oid(
+  journal_seq_t seq)
+{
+  LOG_PREFIX(TransactionManager::get_next_dirty_log_node_by_oid);
+  DEBUG("seq={}", seq);
+  return cache->get_next_dirty_log_node_by_oid(seq);
 }
 
 TransactionManager::rewrite_extent_ret

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -742,6 +742,18 @@ public:
     return cache->get_pending_lognode_delta_by_oid(oid, force);
   }
 
+  using ExtentCallbackInterface::get_next_dirty_log_node_by_oid_ret;
+  get_next_dirty_log_node_by_oid_ret get_next_dirty_log_node_by_oid(
+    journal_seq_t seq) final;
+
+  bool has_pending_lognode_deltas() final {
+    return cache->has_pending_lognode_deltas();
+  }
+
+  std::optional<size_t> pending_lognode_delta_size(ghobject_t oid) {
+    return cache->pending_lognode_delta_size(oid); 
+  }
+
   using ExtentCallbackInterface::rewrite_extent_ret;
   rewrite_extent_ret rewrite_extent(
     Transaction &t,

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -736,6 +736,11 @@ public:
     Transaction &t,
     journal_seq_t seq,
     size_t max_bytes) final;
+  
+  std::optional<std::pair<lognode_deltas_t, size_t>> get_pending_lognode_delta_by_oid(
+    ghobject_t oid, bool force = false) {
+    return cache->get_pending_lognode_delta_by_oid(oid, force);
+  }
 
   using ExtentCallbackInterface::rewrite_extent_ret;
   rewrite_extent_ret rewrite_extent(


### PR DESCRIPTION
Based on this discussion (https://github.com/ceph/ceph/pull/64439#issuecomment-3615012225
), this PR further improves random write performance by storing set/rm keys related to `pgmeta_oid` as operation logs in the journal. These keys are then replayed/applied together during replay, minimizing the overhead of processing key-value pairs in the hot path.

Based on my observations, this improves 4 KiB random write performance from 107K IOPS to up to 120K IOPS or more (16 cores, 1 OSD, RBM enabled, delta-overwrite, RBD, fio 16 thread with 32 depth).

- [x] Write log path to store logs to journal 
- [x] Replay path and trim_log
- [x] Read path after log flush



single crimson OSD, 16 reactors pinned to 16 cores, fio rbd engine on 16 disjoint cores, 25 GiB prefilled image, PS 1030 SSD.

4K randwrite QD32, 120s, `RANDOM_BLOCK_SSD` (circular-bounded journal):

| metric                  | before | after         |
|-------------------------|-------:|--------------:|
| IOPS                    |  106K  | 116K |
| latency  (ms)                  |  4.75 | 4.4 |


 Signed-off-by: Myoungwon Oh <ohmyoungwon@gmail.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
