### PR TITLE
squid: rgw: read_obj_policy() consults s3:prefix when deciding between 403/404

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -435,6 +435,8 @@ static int read_obj_policy(const DoutPrefixProvider *dpp,
       return -ENOENT;
     }
 
+    s->env.emplace("s3:prefix", object->get_name());
+
     if (verify_bucket_permission(dpp, s, bucket->get_key(), s->user_acl,
                                  bucket_policy, policy, s->iam_identity_policies,
                                  s->session_policies, rgw::IAM::s3ListBucket)) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76300

---

backport of https://github.com/ceph/ceph/pull/68577
parent tracker: https://tracker.ceph.com/issues/74398

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh