### PR TITLE
mgr/dashboard: "Access Denied" being shown on overview page for read-only user

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/overview/health-card/overview-health-card.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/overview/health-card/overview-health-card.component.ts
@@ -112,15 +112,17 @@ export class OverviewHealthCardComponent {
     this.viewPGStates.emit();
   }
 
+  private readonly permissions = this.authStorageService.getPermissions();
+
   readonly data$: Observable<OverviewHealthData> = combineLatest([
     this.summaryService.summaryData$.pipe(filter((summary): summary is Summary => !!summary)),
-    this.upgradeService.listCached().pipe(
-      startWith(null as UpgradeInfoInterface | null),
-      catchError(() => of(null))
-    )
+    this.permissions?.configOpt?.read
+      ? this.upgradeService.listCached().pipe(
+          startWith(null as UpgradeInfoInterface | null),
+          catchError(() => of(null))
+        )
+      : of(null)
   ]).pipe(map(([summary, upgrade]) => ({ summary, upgrade })));
-
-  private readonly permissions = this.authStorageService.getPermissions();
 
   readonly enabled$: Observable<boolean> = this.permissions?.configOpt?.read
     ? this.mgrModuleService.getConfig('cephadm').pipe(

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/performance-card/performance-card.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/performance-card/performance-card.component.html
@@ -11,9 +11,10 @@
       <div cdsStack="horizontal"
            gap="2">
         <cd-time-picker
-          [dropdwonSize]="'sm'"
-          [label]="'Time Span'"
+          dropdownSize="sm"
+          label="Time Span"
           (selectedTime)="loadCharts($event)"
+          i18n-label
         ></cd-time-picker>
       </div>
     </ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/performance-card/performance-card.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/performance-card/performance-card.component.spec.ts
@@ -8,11 +8,12 @@ import { MgrModuleService } from '../../api/mgr-module.service';
 import { PerformanceData } from '../../models/performance-data';
 import { DatePipe } from '@angular/common';
 import { NumberFormatterService } from '../../services/number-formatter.service';
+import { AuthStorageService } from '../../services/auth-storage.service';
+import { Permissions } from '../../models/permissions';
 
 describe('PerformanceCardComponent', () => {
   let component: PerformanceCardComponent;
   let fixture: ComponentFixture<PerformanceCardComponent>;
-  let prometheusService: PrometheusService;
   let performanceCardService: PerformanceCardService;
   let mgrModuleService: MgrModuleService;
 
@@ -64,6 +65,10 @@ describe('PerformanceCardComponent', () => {
       transform: jest.fn().mockReturnValue('01 Jan, 00:00:00')
     };
 
+    const authStorageServiceMock = {
+      getPermissions: jest.fn().mockReturnValue(new Permissions({ 'config-opt': ['read'] }))
+    };
+
     await TestBed.configureTestingModule({
       imports: [HttpClientTestingModule, PerformanceCardComponent],
       providers: [
@@ -71,13 +76,13 @@ describe('PerformanceCardComponent', () => {
         { provide: PerformanceCardService, useValue: performanceCardServiceMock },
         { provide: MgrModuleService, useValue: mgrModuleServiceMock },
         { provide: NumberFormatterService, useValue: numberFormatterMock },
-        { provide: DatePipe, useValue: datePipeMock }
+        { provide: DatePipe, useValue: datePipeMock },
+        { provide: AuthStorageService, useValue: authStorageServiceMock }
       ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(PerformanceCardComponent);
     component = fixture.componentInstance;
-    prometheusService = TestBed.inject(PrometheusService);
     performanceCardService = TestBed.inject(PerformanceCardService);
     mgrModuleService = TestBed.inject(MgrModuleService);
   });
@@ -156,18 +161,18 @@ describe('PerformanceCardComponent', () => {
     flush();
   }));
 
-  it('should set emptyStateKey when prometheus is not configured', fakeAsync(() => {
-    (prometheusService.ifPrometheusConfigured as jest.Mock).mockImplementation((_fn, elseFn) => {
-      if (elseFn) {
-        elseFn();
-      }
-    });
+  it('should set emptyStateKey to empty string when user lacks configOpt read', fakeAsync(() => {
+    const auth = TestBed.inject(AuthStorageService);
+    (auth.getPermissions as jest.Mock).mockReturnValue(new Permissions({}));
+
+    fixture = TestBed.createComponent(PerformanceCardComponent);
+    component = fixture.componentInstance;
 
     const time = { start: 1000, end: 2000, step: 14 };
     component.loadCharts(time);
 
     tick();
-    expect(component.emptyStateKey()).toBe('prometheusNotAvailable');
+    expect(component.emptyStateKey()).toBe('');
   }));
 
   it('should cleanup subscriptions on ngOnDestroy', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/performance-card/performance-card.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/performance-card/performance-card.component.ts
@@ -17,7 +17,7 @@ import {
 } from '~/app/shared/models/performance-data';
 import { PerformanceCardService } from '../../api/performance-card.service';
 import { DropdownModule, GridModule, LayoutModule, ListItem } from 'carbon-components-angular';
-import { Subject, Subscription } from 'rxjs';
+import { of, Subject, Subscription } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { ProductiveCardComponent } from '../productive-card/productive-card.component';
 import { CommonModule } from '@angular/common';
@@ -25,6 +25,7 @@ import { TimePickerComponent } from '../time-picker/time-picker.component';
 import { AreaChartComponent } from '../area-chart/area-chart.component';
 import { MgrModuleService } from '../../api/mgr-module.service';
 import { toSignal } from '@angular/core/rxjs-interop';
+import { AuthStorageService } from '../../services/auth-storage.service';
 
 @Component({
   selector: 'cd-performance-card',
@@ -82,14 +83,21 @@ export class PerformanceCardComponent implements OnInit, OnDestroy {
     }
   ];
 
+  role: string = '';
+
   private prometheusService = inject(PrometheusService);
   private performanceCardService = inject(PerformanceCardService);
   private mgrModuleService = inject(MgrModuleService);
+  private readonly authStorageService = inject(AuthStorageService);
 
   time = { ...this.prometheusService.lastHourDateObject };
   private chartSub?: Subscription;
 
-  readonly list = toSignal(this.mgrModuleService.list(), { initialValue: [] });
+  private readonly permissions = this.authStorageService.getPermissions();
+
+  readonly list = this.permissions?.configOpt?.read
+    ? toSignal(this.mgrModuleService.list(), { initialValue: [] })
+    : toSignal(of([]), { initialValue: [] });
 
   ngOnInit() {
     this.loadCharts(this.time);
@@ -104,24 +112,29 @@ export class PerformanceCardComponent implements OnInit, OnDestroy {
       .getChartData(time)
       .pipe(takeUntil(this.destroy$))
       .subscribe((data) => {
-        this.chartDataSignal.set(data);
-        this.prometheusService.ifPrometheusConfigured(
-          () => {
-            let enabled$ = this.list().filter((a) => a.name === 'prometheus')[0].enabled;
-            if (enabled$) {
-              this.chartDataSignal.set(data);
-              this.emptyStateKey.set('');
-            } else if (!enabled$) {
-              this.emptyStateKey.set('prometheusDisabled');
-            } else {
-              this.emptyStateKey.set('storageNotAvailable');
-            }
-          },
-          () => {
-            this.emptyStateKey.set('prometheusNotAvailable');
-          }
-        );
+        if (this.permissions?.configOpt?.read) {
+          this.followEmptyStateMsgCheck(data);
+        } else {
+          this.skipEmptyStateMsgCheck(data);
+        }
       });
+  }
+
+  followEmptyStateMsgCheck(data: PerformanceData) {
+    let enabled$ = this.list().filter((a) => a.name === 'prometheus')[0].enabled;
+    this.chartDataSignal.set(data);
+    if (enabled$) {
+      this.emptyStateKey.set('');
+    } else if (!enabled$) {
+      this.emptyStateKey.set('prometheusDisabled');
+    } else {
+      this.emptyStateKey.set('storageNotAvailable');
+    }
+  }
+
+  skipEmptyStateMsgCheck(data: PerformanceData) {
+    this.chartDataSignal.set(data);
+    this.emptyStateKey.set('');
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
Fix: https://tracker.ceph.com/issues/76293
Signed-off-by: Devika Babrekar <devika.babrekar@ibm.com>



https://github.com/user-attachments/assets/687f4ac3-6fe2-4644-bd3e-99f08e787052

Description:
Following fix helps resolve "Access Denied" error with overview component for read-only user.
For read-only user specific scenario, Prometheus service as well as daemon check is by passed for this particular fix.
Earlier, read-only user was not able to access overview component. When he clicks on Go to overview button, it did not get redirected to new overview page. This PR fixes the issue.

How to test:
1. Create a read-only user from user management page using admin credentials.
2. Login with newly created read-only credentials. Overview page must open without any issues.
3. Navigate to any page which do not have read-only access rights, say user management, click on "Go to overview" button. This must open overview page without any issues.

Future approach:
A separate development must be considered to provide read access to certain services like Prometheus and Manager module after discussion.  

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
