### PR TITLE
RGW/Multisite: fix uninitialized LatencyMonitor causing spurious "OSD cluster is overloaded" warning

### DIFF
--- a/src/rgw/driver/rados/rgw_cr_rados.cc
+++ b/src/rgw/driver/rados/rgw_cr_rados.cc
@@ -1035,7 +1035,11 @@ int RGWContinuousLeaseCR::operate(const DoutPrefixProvider *dpp)
       current_time = ceph::coarse_mono_clock::now();
       yield call(new RGWSimpleRadosLockCR(async_rados, store, obj, lock_name, cookie, interval));
       if (latency) {
-	      latency->add_latency(ceph::coarse_mono_clock::now() - current_time);
+	      auto elapsed = ceph::coarse_mono_clock::now() - current_time;
+	      latency->add_latency(elapsed);
+	      if (counters) {
+	        counters->tinc(sync_counters::l_lock, elapsed);
+	      }
       }
       current_time = ceph::coarse_mono_clock::now();
       if (current_time - last_renew_try_time > interval_tolerance) {
@@ -1059,7 +1063,11 @@ int RGWContinuousLeaseCR::operate(const DoutPrefixProvider *dpp)
     current_time = ceph::coarse_mono_clock::now();
     yield call(new RGWSimpleRadosUnlockCR(async_rados, store, obj, lock_name, cookie));
     if (latency) {
-      latency->add_latency(ceph::coarse_mono_clock::now() - current_time);
+      auto elapsed = ceph::coarse_mono_clock::now() - current_time;
+      latency->add_latency(elapsed);
+      if (counters) {
+        counters->tinc(sync_counters::l_lock, elapsed);
+      }
     }
     return set_state(RGWCoroutine_Done);
   }

--- a/src/rgw/driver/rados/rgw_cr_rados.h
+++ b/src/rgw/driver/rados/rgw_cr_rados.h
@@ -18,6 +18,7 @@
 
 #include "services/svc_sys_obj.h"
 #include "services/svc_bucket.h"
+#include "include/common_fwd.h"
 
 struct rgw_http_param_pair;
 class RGWRESTConn;
@@ -1563,17 +1564,20 @@ class RGWContinuousLeaseCR : public RGWCoroutine {
   ceph::coarse_mono_time current_time;
 
   LatencyMonitor* latency;
+  PerfCounters* counters;
 
 public:
   RGWContinuousLeaseCR(RGWAsyncRadosProcessor* async_rados,
                        rgw::sal::RadosStore* _store,
                        rgw_raw_obj obj, std::string lock_name,
                        int interval, RGWCoroutine* caller,
-		       LatencyMonitor* const latency)
+                       LatencyMonitor* const latency,
+                       PerfCounters* counters = nullptr)
     : RGWCoroutine(_store->ctx()), async_rados(async_rados), store(_store),
       obj(std::move(obj)), lock_name(std::move(lock_name)),
       interval(interval), interval_tolerance(ceph::make_timespan(9*interval/10)),
-      ts_interval(ceph::make_timespan(interval)), caller(caller), latency(latency)
+      ts_interval(ceph::make_timespan(interval)), caller(caller), latency(latency),
+      counters(counters)
   {}
 
   virtual ~RGWContinuousLeaseCR() override;

--- a/src/rgw/driver/rados/rgw_cr_rados.h
+++ b/src/rgw/driver/rados/rgw_cr_rados.h
@@ -1523,20 +1523,30 @@ public:
 /// \warning This class is not thread safe. We do not use a mutex
 /// because all coroutines spawned by RGWDataSyncCR share a single thread.
 class LatencyMonitor {
-  ceph::timespan total;
-  std::uint64_t count = 0;
+  ceph::timespan avg{ceph::timespan::zero()};
+  bool initialized = false;
+  // Weight for new samples in running average. Recent samples matter
+  // most; after ~20 new samples a past spike decays to <4%.
+  // Example: if avg is poisoned at 30s but real latency is 0.1s,
+  // after 20 good samples the avg drops to ~1.2s (fully recovered).
+  static constexpr double alpha = 0.15;
 
 public:
 
   LatencyMonitor() = default;
   void add_latency(ceph::timespan latency) {
-    total += latency;
-    ++count;
+    if (!initialized) {
+      avg = latency;
+      initialized = true;
+    } else {
+      avg = ceph::timespan(
+        static_cast<ceph::timespan::rep>(
+          alpha * latency.count() + (1.0 - alpha) * avg.count()));
+    }
   }
 
   ceph::timespan avg_latency() {
-    using namespace std::literals;
-    return count == 0 ? 0s : total / count;
+    return avg;
   }
 };
 

--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -596,7 +596,7 @@ public:
       sc->env->async_rados, sc->env->driver,
       { sc->env->svc->zone->get_zone_params().log_pool,
 	RGWDataSyncStatusManager::sync_status_oid(sc->source_zone) },
-      string(lock_name), lock_duration, caller, &sc->lcc);
+      string(lock_name), lock_duration, caller, &sc->lcc, sc->env->counters);
   }
 
   int operate(const DoutPrefixProvider *dpp) override {
@@ -2337,7 +2337,7 @@ public:
     lease_cr.reset(new RGWContinuousLeaseCR(sync_env->async_rados, driver,
                                             rgw_raw_obj(pool, status_oid),
                                             lock_name, lock_duration, this,
-					    &sc->lcc));
+					    &sc->lcc, sync_env->counters));
     lease_stack.reset(spawn(lease_cr.get(), false));
   }
 };
@@ -5880,7 +5880,7 @@ int RGWSyncBucketCR::operate(const DoutPrefixProvider *dpp)
 
         if (!no_lease && !bucket_lease_cr) {
           bucket_lease_cr.reset(new RGWContinuousLeaseCR(env->async_rados, env->driver, status_obj,
-                lock_name, lock_duration, this, &sc->lcc));
+                lock_name, lock_duration, this, &sc->lcc, env->counters));
           yield spawn(bucket_lease_cr.get(), false);
           while (!bucket_lease_cr->is_locked()) {
             if (bucket_lease_cr->is_done()) {
@@ -5950,7 +5950,7 @@ int RGWSyncBucketCR::operate(const DoutPrefixProvider *dpp)
         // so the command is never blocked by a background sync process holding the lock.
         if (!no_lease && !bucket_lease_cr) {
           bucket_lease_cr.reset(new RGWContinuousLeaseCR(env->async_rados, env->driver, status_obj,
-							 lock_name, lock_duration, this, &sc->lcc));
+							 lock_name, lock_duration, this, &sc->lcc, env->counters));
           yield spawn(bucket_lease_cr.get(), false);
           while (!bucket_lease_cr->is_locked()) {
             if (bucket_lease_cr->is_done()) {

--- a/src/rgw/driver/rados/rgw_data_sync.h
+++ b/src/rgw/driver/rados/rgw_data_sync.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 
@@ -357,10 +358,10 @@ public:
             << "WARNING: sync lock latency elevated, halving concurrency."
             << " avg_latency_ms=" << std::chrono::duration_cast<std::chrono::milliseconds>(avg_latency()).count()
             << " threshold_ms=" << std::chrono::duration_cast<std::chrono::milliseconds>(threshold).count()
-            << " concurrency=" << (concurrency / 2) << dendl;
+            << " concurrency=" << std::max(int64_t{1}, concurrency / 2) << dendl;
         state = State::Throttled;
       }
-      return concurrency / 2;
+      return std::max(int64_t{1}, concurrency / 2);
     } else [[likely]] {
       if (state != State::Normal) [[unlikely]] {
         ldout(cct, 1)

--- a/src/rgw/driver/rados/rgw_data_sync.h
+++ b/src/rgw/driver/rados/rgw_data_sync.h
@@ -318,7 +318,10 @@ void pretty_print(const RGWDataSyncEnv* env, const S& fmt, T&& ...t) {
 /// down when latency rises.
 class LatencyConcurrencyControl : public LatencyMonitor {
   static constexpr auto dout_subsys = ceph_subsys_rgw;
-  ceph::coarse_mono_time last_warning;
+
+  enum class State { Normal, Throttled, Overloaded };
+  State state = State::Normal;
+
 public:
   CephContext* cct;
 
@@ -331,23 +334,42 @@ public:
   /// bucket), accept a number of concurrent operations to spawn and,
   /// if latency is high, cut it in half. If latency is really high,
   /// cut it to 1.
+  ///
+  /// State transitions are logged once so users can see when
+  /// concurrency is reduced and when it recovers.
   int64_t adj_concurrency(int64_t concurrency) {
     using namespace std::literals;
     auto threshold = (cct->_conf->rgw_sync_lease_period * 1s) / 12;
 
     if (avg_latency() >= 2 * threshold) [[unlikely]] {
-      auto now = ceph::coarse_mono_clock::now();
-      if (now - last_warning > 5min) {
+      if (state != State::Overloaded) [[unlikely]] {
         ldout(cct, -1)
-            << "WARNING: The OSD cluster is overloaded and struggling to "
-            << "complete ops. You need more capacity to serve this level "
-	    << "of demand." << dendl;
-	last_warning = now;
+            << "WARNING: sync lock latency is critically high, reducing concurrency."
+            << " avg_latency_ms=" << std::chrono::duration_cast<std::chrono::milliseconds>(avg_latency()).count()
+            << " threshold_ms=" << std::chrono::duration_cast<std::chrono::milliseconds>(threshold).count()
+            << " concurrency=1" << dendl;
+        state = State::Overloaded;
       }
       return 1;
     } else if (avg_latency() >= threshold) [[unlikely]] {
+      if (state != State::Throttled) [[unlikely]] {
+        ldout(cct, -1)
+            << "WARNING: sync lock latency elevated, halving concurrency."
+            << " avg_latency_ms=" << std::chrono::duration_cast<std::chrono::milliseconds>(avg_latency()).count()
+            << " threshold_ms=" << std::chrono::duration_cast<std::chrono::milliseconds>(threshold).count()
+            << " concurrency=" << (concurrency / 2) << dendl;
+        state = State::Throttled;
+      }
       return concurrency / 2;
     } else [[likely]] {
+      if (state != State::Normal) [[unlikely]] {
+        ldout(cct, 1)
+            << "sync lock latency recovered, restoring full concurrency."
+            << " avg_latency_ms=" << std::chrono::duration_cast<std::chrono::milliseconds>(avg_latency()).count()
+            << " threshold_ms=" << std::chrono::duration_cast<std::chrono::milliseconds>(threshold).count()
+            << " concurrency=" << concurrency << dendl;
+        state = State::Normal;
+      }
       return concurrency;
     }
   }

--- a/src/rgw/driver/rados/rgw_sync_counters.cc
+++ b/src/rgw/driver/rados/rgw_sync_counters.cc
@@ -21,6 +21,8 @@ PerfCountersRef build(CephContext *cct, const std::string& name)
   b.add_time_avg(l_poll, "poll_latency", "Average latency of replication log requests");
   b.add_u64_counter(l_poll_err, "poll_errors", "Number of replication log request errors");
 
+  b.add_time_avg(l_lock, "lock_latency", "Average latency of sync lock operations");
+
   auto logger = PerfCountersRef{ b.create_perf_counters(), cct };
   cct->get_perfcounters_collection()->add(logger.get());
   return logger;

--- a/src/rgw/driver/rados/rgw_sync_counters.h
+++ b/src/rgw/driver/rados/rgw_sync_counters.h
@@ -17,6 +17,8 @@ enum {
   l_poll,
   l_poll_err,
 
+  l_lock,
+
   l_last,
 };
 


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/76308

### Testing on a local mstart cluster:

After a fresh start:

```
$ceph perf dump| egrep -v "dangerous" | jq '."data-sync-from-zg1-2".lock_latency' 
{
  "avgcount": 28649,
  "sum": 183.454348314,
  "avgtime": 0.006403516
}

$ sleep 120

$ceph perf dump| egrep -v "dangerous" | jq '."data-sync-from-zg1-2".lock_latency' 
{
  "avgcount": 30277,
  "sum": 202.716489798,
  "avgtime": 0.006695395
}
```

So, normal latency is around 6 msec and no event:

```
$ egrep "sync lock latency" run/c*/out/radosgw.8*.log 
$
```

Lowering lease period `set client.rgw rgw_sync_lease_period 12` which would set the threshold to 1s given the `auto threshold = (cct->_conf->rgw_sync_lease_period * 1s) / 12`. Then, stopped osds to generate slow io scenario just for 60s on c1. That generated the events:

```
run/c1/out/radosgw.8102.log:2026-05-05T13:30:43.130+0000 7ff7ea799640 -1 WARNING: sync lock latency is critically high, reducing concurrency. avg_latency_ms=34306 threshold_ms=1000 concurrency=1
run/c1/out/radosgw.8102.log:2026-05-05T13:31:43.148+0000 7ff7ea799640  1 sync lock latency recovered, restoring full concurrency. avg_latency_ms=113 threshold_ms=1000 concurrency=20
```

Even longer outage on c2 for a couple of mins.

```
run/c2/out/radosgw.8201.log:2026-05-05T13:50:49.927+0000 7ff896fdd640 -1 WARNING: sync lock latency is critically high, reducing concurrency. avg_latency_ms=41649 threshold_ms=1000 concurrency=1
run/c2/out/radosgw.8202.log:2026-05-05T13:50:49.938+0000 7f9d84bb0640 -1 WARNING: sync lock latency is critically high, reducing concurrency. avg_latency_ms=79863 threshold_ms=1000 concurrency=1
...
run/c2/out/radosgw.8201.log:2026-05-05T13:51:32.172+0000 7ff896fdd640  1 sync lock latency recovered, restoring full concurrency. avg_latency_ms=48 threshold_ms=1000 concurrency=20
run/c2/out/radosgw.8202.log:2026-05-05T13:51:28.296+0000 7f9d84bb0640  1 sync lock latency recovered, restoring full concurrency. avg_latency_ms=720 threshold_ms=1000 concurrency=20
```

It recovered back to under < 1s real quick due to weighted average. With the old way even when you look at the average several mins later, it's still very high (2.5s); i.e., recovery back to actual latency is too slow.

```
$ date; ceph perf dump | jq '."data-sync-from-zg1-1".lock_latency' 
Tue May  5 01:54:28 PM UTC 2026
{
  "avgcount": 8011,
  "sum": 20112.442799557,
  "avgtime": 2.510603270
}
```
At this point, the EWMA method recovery of the average to 10-20 msec millisecond already.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
