### PR TITLE
cephadm: include IPv4 host-scoped routes in list-networks

### DIFF
--- a/src/cephadm/cephadmlib/host_facts.py
+++ b/src/cephadm/cephadmlib/host_facts.py
@@ -922,17 +922,19 @@ def _list_ipv4_networks(
 def _parse_ipv4_route(out: str) -> Dict[str, Dict[str, Set[str]]]:
     r = {}  # type: Dict[str, Dict[str, Set[str]]]
     p = re.compile(
-        r'^(\S+) (?:via \S+)? ?dev (\S+) (.*)scope link (.*)src (\S+)'
+        r'^(?P<net>\S+)(?: via \S+)? dev (?P<iface>\S+).*?(?:\ssrc\s(?P<src>\S+))(?:\s|$)'
     )
     for line in out.splitlines():
-        m = p.findall(line)
+        m = p.search(line)
         if not m:
             continue
-        net = m[0][0]
+        net = m.group('net')
+        if net.lower() == 'default':
+            continue
         if '/' not in net:  # aggregate /32 mask for single host sub-networks
             net += '/32'
-        iface = m[0][1]
-        ip = m[0][4]
+        iface = m.group('iface')
+        ip = m.group('src')
         if net not in r:
             r[net] = {}
         if iface not in r[net]:

--- a/src/cephadm/tests/test_networks.py
+++ b/src/cephadm/tests/test_networks.py
@@ -1,10 +1,14 @@
+# flake8: noqa: Q000, W291
+# This test file includes large multiline `ip`/`ip -6` fixtures copied from real
+# host output; keep them byte-stable (including occasional trailing spaces in the
+# captured text) and allow legacy double-quoted dict literals in expectations.
 import json
 from textwrap import dedent
 from unittest import mock
 
 import pytest
 
-from tests.fixtures import with_cephadm_ctx, cephadm_fs, import_cephadm
+from tests.fixtures import with_cephadm_ctx, cephadm_fs, import_cephadm  # noqa: F401
 
 from cephadmlib.host_facts import _parse_ipv4_route, _parse_ipv6_route
 from cephadmlib.net_utils import get_ipv6_address
@@ -103,6 +107,15 @@ class TestCommandListNetworks:
                 '10.88.0.0/16': {'cni-podman0': {'10.88.0.1'}},
                 '172.21.3.1/32': {'tun0': {'172.21.3.2'}},
                 '192.168.122.0/24': {'virbr0': {'192.168.122.1'}}
+            }
+        ), (
+            dedent("""
+            10.1.0.40 dev dummy0 proto kernel scope host src 10.1.0.40
+            10.123.166.0/24 dev bond0 proto kernel scope link src 10.123.166.1
+            """),
+            {
+                '10.1.0.40/32': {'dummy0': {'10.1.0.40'}},
+                '10.123.166.0/24': {'bond0': {'10.123.166.1'}},
             }
         ),
     ])
@@ -277,7 +290,7 @@ fe80000000000000505400fffe04c154 03 40 20 80     eth1
 
     @mock.patch('cephadmlib.host_facts.call_throws')
     @mock.patch('cephadmlib.host_facts.find_executable')
-    def test_command_list_networks(self, _find_exe, _call_throws, cephadm_fs, capsys):
+    def test_command_list_networks(self, _find_exe, _call_throws, cephadm_fs, capsys):  # noqa: F811
         _call_throws.return_value = ('10.4.0.1 dev tun0 proto kernel scope link src 10.4.0.2 metric 50\n', '', '')
         _find_exe.return_value = 'ip'
         with with_cephadm_ctx([]) as ctx:


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/76229
Signed-off-by: Kobi Ginon <kginon@redhat.com>


tested on the below setup
[root@ceph-node-0 ~]# ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host noprefixroute
       valid_lft forever preferred_lft forever
2: ens3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 52:54:00:fb:0c:43 brd ff:ff:ff:ff:ff:ff
    altname enp0s3
    altname enx525400fb0c43
    inet 192.168.100.100/24 brd 192.168.100.255 scope global dynamic noprefixroute ens3
       valid_lft 3177sec preferred_lft 3177sec
    inet6 fe80::5054:ff:fefb:c43/64 scope link noprefixroute
       valid_lft forever preferred_lft forever
3: dummy0: <BROADCAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN group default qlen 1000
    link/ether 72:ab:b5:3a:dc:84 brd ff:ff:ff:ff:ff:ff
    inet 10.1.0.40/32 scope global dummy0
       valid_lft forever preferred_lft forever
       
       
   [root@ceph-node-0 ~]# cephadm list-networks
{
    "10.1.0.40/32": {
        "dummy0": [
            "10.1.0.40"
        ]
    },
    "192.168.100.0/24": {
        "ens3": [
            "192.168.100.100"
        ]
    },
    "fe80::/64": {
        "ens3": [
            "fe80::5054:ff:fefb:c43"
        ]
    }
}

**Tests validation pass indication **
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================= 422 passed, 20 warnings in 17.66s =================================================
  py3: OK (18.20=setup[0.07]+cmd[18.14] seconds)
  congratulations :) (18.26 seconds)
root@C-PF4513NK:~/ceph-adm-projects/ceph/src/cephadm# echo $?
0
root@C-PF4513NK:~/ceph-adm-projects/ceph/src/cephadm# tox -e py3 -- tests/


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
