### PR TITLE
src/script: init test_stretch_crush_collisions.sh

### DIFF
--- a/doc/dev/developer_guide/tests-unit-tests.rst
+++ b/doc/dev/developer_guide/tests-unit-tests.rst
@@ -71,6 +71,31 @@ teuthology using the `cram task`_.
 .. _`cram`: https://bitheap.org/cram/
 .. _`cram task`: https://github.com/ceph/ceph/blob/master/qa/tasks/cram.py
 
+Running CLI tools tests
+-----------------------
+
+A convenience script is provided to run CLI tests easily without having to manually set up the environment.
+From the Ceph source tree root directory:
+
+  .. prompt:: bash $
+
+     # Run all CLI tests
+     ./src/script/run-cli-tests.sh
+
+     # Run with custom build directory
+     ./src/script/run-cli-tests.sh -b /path/to/build
+
+Alternatively, you can run the tests directly from the build directory by setting up your PATH:
+
+  .. prompt:: bash $
+
+     cd build
+     PATH="$PWD/bin:$PATH" ../src/test/run-cli-tests
+
+The test suite includes tests for: ``ceph-authtool``, ``ceph-conf``, 
+``ceph-kvstore-tool``, ``crushtool``, ``monmaptool``, ``osdmaptool``, 
+``radosgw-admin``, and ``rbd``.
+
 Tox-based testing of Python modules
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Some of the Python modules in Ceph use `tox <https://tox.readthedocs.io/en/latest/>`_ 

--- a/doc/man/8/crushtool.rst
+++ b/doc/man/8/crushtool.rst
@@ -151,14 +151,34 @@ pools; it only runs simulations by mapping values in the range
    Displays how many attempts were needed to find a device mapping.
    For instance::
 
-      0:     95224
-      1:      3745
-      2:      2225
+      tries 0:     95224
+      tries 1:      3745
+      tries 2:      2225
       ..
 
    shows that **95224** mappings succeeded without retries, **3745**
    mappings succeeded with one attempts, etc. There are as many rows
    as the value of the **--set-choose-total-tries** option.
+
+.. option:: --show-retry-exhaustion
+
+   Checks whether any PG mappings hit the maximum retry limit
+   (typically 50 tries) and displays a warning if retry exhaustion
+   is detected. This is useful for validating CRUSH rules, especially
+   in stretch cluster configurations with exactly
+   2 datacenters and 4 replicas can potentially fail to map some PGs due to CRUSH's
+   pseudorandom selection repeatedly choosing the same datacenter.
+   Although, the probability is extremely low, we still want to detect this.
+   
+   Outputs either a warning message if exhaustion is detected::
+
+      WARNING: Retry exhaustion detected!
+        5 PG(s) hit the maximum retry limit of 50
+        This indicates CRUSH failed to find optimal placement for some PGs.
+
+   or a success message showing the maximum tries actually needed::
+
+      No retry exhaustion detected (maximum tries needed: 7 / 50)
 
 .. option:: --output-csv
 

--- a/src/crush/CrushTester.cc
+++ b/src/crush/CrushTester.cc
@@ -475,7 +475,7 @@ int CrushTester::test(CephContext* cct)
   // make adjustments
   adjust_weights(weight);
 
-  if (output_choose_tries)
+  if (output_choose_tries || show_retry_exhaustion)
     crush.start_choose_profile();
   
   for (int r = min_rule; r < crush.get_max_rules() && r <= max_rule; r++) {
@@ -673,15 +673,42 @@ int CrushTester::test(CephContext* cct)
     }
   }
 
-  if (output_choose_tries) {
+  if (output_choose_tries || show_retry_exhaustion) {
     __u32 *v = 0;
     int n = crush.get_choose_profile(&v);
-    for (int i=0; i<n; i++) {
-      cout.setf(std::ios::right);
-      cout << std::setw(2)
-      << i << ": " << std::setw(9) << v[i];
-      cout.unsetf(std::ios::right);
-      cout << std::endl;
+    
+    if (output_choose_tries) {
+      for (int i=0; i<n; i++) {
+        cout.setf(std::ios::right);
+        cout << std::setw(2) << "tries "
+        << i+1 << ": " << std::setw(9) << v[i];
+        cout.unsetf(std::ios::right);
+        cout << std::endl;
+      }
+    }
+    
+    if (show_retry_exhaustion) {
+      // Check if the maximum retry count (n-1) has any hits
+      if (n > 0 && v[n-1] > 0) {
+        cerr << std::endl;
+        cerr << "WARNING: Retry exhaustion detected!" << std::endl;
+        cerr << "  " << v[n-1] << " PG(s) hit the maximum retry limit of " << (n) << std::endl;
+        cerr << "  This indicates CRUSH failed to find optimal placement for some PGs." << std::endl;
+        cerr << std::endl;
+      } else {
+        cout << std::endl;
+        cout << "No retry exhaustion detected (maximum tries needed: ";
+        // Find the actual maximum tries used
+        int max_tries_used = 1;
+        for (int i = n-1; i >= 0; i--) {
+          if (v[i] > 0) {
+            max_tries_used = i+1;
+            break;
+          }
+        }
+        cout << max_tries_used << " / " << (n) << ")" << std::endl;
+        cout << std::endl;
+      }
     }
 
     crush.stop_choose_profile();

--- a/src/crush/CrushTester.h
+++ b/src/crush/CrushTester.h
@@ -31,6 +31,7 @@ class CrushTester {
   bool output_mappings;
   bool output_bad_mappings;
   bool output_choose_tries;
+  bool show_retry_exhaustion;
 
   bool output_data_file;
   bool output_csv;
@@ -182,6 +183,7 @@ public:
       output_mappings(false),
       output_bad_mappings(false),
       output_choose_tries(false),
+      show_retry_exhaustion(false),
       output_data_file(false),
       output_csv(false),
       output_data_file_name("")
@@ -249,6 +251,13 @@ public:
   }
   bool get_output_choose_tries() const {
     return output_choose_tries;
+  }
+
+  void set_show_retry_exhaustion(bool b) {
+    show_retry_exhaustion = b;
+  }
+  bool get_show_retry_exhaustion() const {
+    return show_retry_exhaustion;
   }
 
   void set_batches(int b) {

--- a/src/script/run-cli-tests.sh
+++ b/src/script/run-cli-tests.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CEPH_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BUILD_DIR="${BUILD_DIR:-$CEPH_ROOT/build}"
+
+usage() {
+    cat <<EOF
+Usage: $0 [OPTIONS]
+
+Run CLI tests for Ceph tools using the cram testing framework.
+
+Options:
+    -h, --help      Show this help message
+    -b, --build     Specify build directory (default: $CEPH_ROOT/build)
+
+Examples:
+    # Run all CLI tests:
+    $0
+
+    # Run with custom build directory:
+    $0 -b /path/to/build
+
+EOF
+    exit 0
+}
+
+# Parse options
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            usage
+            ;;
+        -b|--build)
+            BUILD_DIR="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            ;;
+    esac
+done
+
+# Verify build directory exists
+if [ ! -d "$BUILD_DIR" ]; then
+    echo "Error: Build directory not found: $BUILD_DIR"
+    echo "Please build Ceph first or specify correct build directory with -b"
+    exit 1
+fi
+
+# Verify build/bin directory exists
+if [ ! -d "$BUILD_DIR/bin" ]; then
+    echo "Error: Build binaries not found in $BUILD_DIR/bin"
+    echo "Please run './do_cmake.sh && cd build && ninja' first"
+    exit 1
+fi
+
+# Change to build directory and run tests
+cd "$BUILD_DIR"
+export PATH="$PWD/bin:$PATH"
+
+echo "Running all CLI tests from build directory: $BUILD_DIR"
+echo "=================================================="
+exec "$CEPH_ROOT/src/test/run-cli-tests"

--- a/src/script/test_stretch_crush_collisions.sh
+++ b/src/script/test_stretch_crush_collisions.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+# Test script to detect CRUSH retry exhaustion in stretch mode configurations
+# Tests whether unbiased stretch rules with exactly 2 datacenters experience
+# collision retry exhaustion (hitting the 50-try limit)
+
+set -e
+
+# Find the script directory and repo root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Default to build directory at repo root, but allow override
+BUILD_DIR="${BUILD_DIR:-$REPO_ROOT/build}"
+
+# Find crushtool
+if [ -n "$CRUSHTOOL" ]; then
+    # User specified CRUSHTOOL, use it
+    :
+elif [ -x "$BUILD_DIR/bin/crushtool" ]; then
+    CRUSHTOOL="$BUILD_DIR/bin/crushtool"
+else
+    echo "Error: Cannot find crushtool. Please set BUILD_DIR or CRUSHTOOL environment variable."
+    exit 1
+fi
+
+OUTPUT_DIR="${OUTPUT_DIR:-./crush_test_results}"
+NUM_PGS="${NUM_PGS:-100000}"
+
+mkdir -p "$OUTPUT_DIR"
+
+# Function to create a CRUSH map with 2 datacenters
+create_crush_map() {
+    local filename=$1
+
+    cat > "$filename" <<'EOF'
+# CRUSH map for stretch mode with 2 datacenters
+# Matches real cluster structure
+
+# devices
+device 0 osd.0
+device 1 osd.1
+device 2 osd.2
+device 3 osd.3
+device 4 osd.4
+device 5 osd.5
+device 6 osd.6
+device 7 osd.7
+
+# types
+type 0 osd
+type 1 host
+type 2 datacenter
+type 3 root
+
+# buckets
+host host1 {
+    id -9
+    alg straw2
+    hash 0
+    item osd.0 weight 1.0
+    item osd.1 weight 1.0
+}
+
+host host2 {
+    id -10
+    alg straw2
+    hash 0
+    item osd.2 weight 1.0
+    item osd.3 weight 1.0
+}
+
+host host3 {
+    id -11
+    alg straw2
+    hash 0
+    item osd.4 weight 1.0
+    item osd.5 weight 1.0
+}
+
+host host4 {
+    id -12
+    alg straw2
+    hash 0
+    item osd.6 weight 1.0
+    item osd.7 weight 1.0
+}
+
+datacenter dc1 {
+    id -5
+    alg straw2
+    hash 0
+    item host1 weight 2.0
+    item host2 weight 2.0
+}
+
+datacenter dc2 {
+    id -7
+    alg straw2
+    hash 0
+    item host3 weight 2.0
+    item host4 weight 2.0
+}
+
+root default {
+    id -1
+    alg straw2
+    hash 0
+    item dc1 weight 4.0
+    item dc2 weight 4.0
+}
+
+# CRUSH rules
+rule stretch_replicated_rule {
+    id 0
+    type replicated
+    step take default
+    step choose firstn 0 type datacenter
+    step chooseleaf firstn 2 type host
+    step emit
+}
+EOF
+}
+
+# Function to test a CRUSH map
+test_crush_map() {
+    local map_txt=$1
+    local map_bin=$2
+    local rule_id=$3
+    local rule_name=$4
+    local iteration=$5
+    
+    if $CRUSHTOOL -i "$map_bin" --test \
+        --min-x 1 \
+        --max-x "$NUM_PGS" \
+        --rule "$rule_id" \
+        --num-rep 4 \
+        --show-statistics \
+        --set-choose-total-tries 50 \
+        --show-retry-exhaustion 2>&1 | grep -q "WARNING: Retry exhaustion detected!"; then
+        return 1  # Retry exhaustion detected - failure
+    else
+        return 0  # No retry exhaustion - success
+    fi
+}
+
+echo "Testing Unbiased Rule with 2 Datacenters"
+echo "Running 100 iterations with $NUM_PGS PGs each..."
+echo ""
+
+create_crush_map "$OUTPUT_DIR/crush_2dc.txt"
+
+echo "Compiling CRUSH map..."
+$CRUSHTOOL -c "$OUTPUT_DIR/crush_2dc.txt" -o "$OUTPUT_DIR/crush_2dc.bin"
+
+for i in $(seq 1 100); do
+    echo -n "  Iteration $i/100: "
+    
+    if test_crush_map \
+        "$OUTPUT_DIR/crush_2dc.txt" \
+        "$OUTPUT_DIR/crush_2dc.bin" \
+        0 \
+        "stretch_replicated_rule" \
+        "$i"; then
+        echo "OK"
+    else
+        echo "RETRY EXHAUSTION DETECTED"
+        exit 1
+    fi
+done
+
+

--- a/src/test/cli/crushtool/help.t
+++ b/src/test/cli/crushtool/help.t
@@ -107,6 +107,8 @@
      --show-mappings       show mappings
      --show-bad-mappings   show bad mappings
      --show-choose-tries   show choose tries histogram
+     --show-retry-exhaustion
+                           check for and report CRUSH retry exhaustion
      --output-name name
                            prepend the data file(s) generated during the
                            testing routine with name

--- a/src/test/cli/crushtool/show-choose-tries.t
+++ b/src/test/cli/crushtool/show-choose-tries.t
@@ -1,108 +1,108 @@
   $ crushtool -c "$TESTDIR/show-choose-tries.txt" -o "$TESTDIR/show-choose-tries.crushmap"
   $ FIRSTN_RULESET=0
   $ crushtool -i "$TESTDIR/show-choose-tries.crushmap" --test --show-choose-tries --rule $FIRSTN_RULESET --x 1 --num-rep 2
-   0:         1
-   1:         1
-   2:         0
-   3:         0
-   4:         0
-   5:         0
-   6:         0
-   7:         0
-   8:         0
-   9:         0
-  10:         0
-  11:         0
-  12:         0
-  13:         0
-  14:         0
-  15:         0
-  16:         0
-  17:         0
-  18:         0
-  19:         0
-  20:         0
-  21:         0
-  22:         0
-  23:         0
-  24:         0
-  25:         0
-  26:         0
-  27:         0
-  28:         0
-  29:         0
-  30:         0
-  31:         0
-  32:         0
-  33:         0
-  34:         0
-  35:         0
-  36:         0
-  37:         0
-  38:         0
-  39:         0
-  40:         0
-  41:         0
-  42:         0
-  43:         0
-  44:         0
-  45:         0
-  46:         0
-  47:         0
-  48:         0
-  49:         0
+  tries 1:         1
+  tries 2:         1
+  tries 3:         0
+  tries 4:         0
+  tries 5:         0
+  tries 6:         0
+  tries 7:         0
+  tries 8:         0
+  tries 9:         0
+  tries 10:         0
+  tries 11:         0
+  tries 12:         0
+  tries 13:         0
+  tries 14:         0
+  tries 15:         0
+  tries 16:         0
+  tries 17:         0
+  tries 18:         0
+  tries 19:         0
+  tries 20:         0
+  tries 21:         0
+  tries 22:         0
+  tries 23:         0
+  tries 24:         0
+  tries 25:         0
+  tries 26:         0
+  tries 27:         0
+  tries 28:         0
+  tries 29:         0
+  tries 30:         0
+  tries 31:         0
+  tries 32:         0
+  tries 33:         0
+  tries 34:         0
+  tries 35:         0
+  tries 36:         0
+  tries 37:         0
+  tries 38:         0
+  tries 39:         0
+  tries 40:         0
+  tries 41:         0
+  tries 42:         0
+  tries 43:         0
+  tries 44:         0
+  tries 45:         0
+  tries 46:         0
+  tries 47:         0
+  tries 48:         0
+  tries 49:         0
+  tries 50:         0
   $ INDEP_RULESET=1
   $ crushtool -i "$TESTDIR/show-choose-tries.crushmap" --test --show-choose-tries --rule $INDEP_RULESET --x 1 --num-rep 1
-   0:         0
-   1:         1
-   2:         0
-   3:         0
-   4:         0
-   5:         0
-   6:         0
-   7:         0
-   8:         0
-   9:         0
-  10:         0
-  11:         0
-  12:         0
-  13:         0
-  14:         0
-  15:         0
-  16:         0
-  17:         0
-  18:         0
-  19:         0
-  20:         0
-  21:         0
-  22:         0
-  23:         0
-  24:         0
-  25:         0
-  26:         0
-  27:         0
-  28:         0
-  29:         0
-  30:         0
-  31:         0
-  32:         0
-  33:         0
-  34:         0
-  35:         0
-  36:         0
-  37:         0
-  38:         0
-  39:         0
-  40:         0
-  41:         0
-  42:         0
-  43:         0
-  44:         0
-  45:         0
-  46:         0
-  47:         0
-  48:         0
-  49:         0
+  tries 1:         0
+  tries 2:         1
+  tries 3:         0
+  tries 4:         0
+  tries 5:         0
+  tries 6:         0
+  tries 7:         0
+  tries 8:         0
+  tries 9:         0
+  tries 10:         0
+  tries 11:         0
+  tries 12:         0
+  tries 13:         0
+  tries 14:         0
+  tries 15:         0
+  tries 16:         0
+  tries 17:         0
+  tries 18:         0
+  tries 19:         0
+  tries 20:         0
+  tries 21:         0
+  tries 22:         0
+  tries 23:         0
+  tries 24:         0
+  tries 25:         0
+  tries 26:         0
+  tries 27:         0
+  tries 28:         0
+  tries 29:         0
+  tries 30:         0
+  tries 31:         0
+  tries 32:         0
+  tries 33:         0
+  tries 34:         0
+  tries 35:         0
+  tries 36:         0
+  tries 37:         0
+  tries 38:         0
+  tries 39:         0
+  tries 40:         0
+  tries 41:         0
+  tries 42:         0
+  tries 43:         0
+  tries 44:         0
+  tries 45:         0
+  tries 46:         0
+  tries 47:         0
+  tries 48:         0
+  tries 49:         0
+  tries 50:         0
   $ rm -f "$TESTDIR/show-choose-tries.crushmap"
 # Local Variables:
 # compile-command: "cd ../../.. ; make -j4 crushtool && test/run-cli-tests"

--- a/src/tools/crushtool.cc
+++ b/src/tools/crushtool.cc
@@ -229,6 +229,8 @@ void usage()
   cout << "   --show-mappings       show mappings\n";
   cout << "   --show-bad-mappings   show bad mappings\n";
   cout << "   --show-choose-tries   show choose tries histogram\n";
+  cout << "   --show-retry-exhaustion\n";
+  cout << "                         check for and report CRUSH retry exhaustion\n";
   cout << "   --output-name name\n";
   cout << "                         prepend the data file(s) generated during the\n";
   cout << "                         testing routine with name\n";
@@ -542,6 +544,9 @@ int main(int argc, const char **argv)
     } else if (ceph_argparse_flag(args, i, "--show_choose_tries", (char*)NULL)) {
       display = true;
       tester.set_output_choose_tries(true);
+    } else if (ceph_argparse_flag(args, i, "--show-retry-exhaustion", (char*)NULL)) {
+      display = true;
+      tester.set_show_retry_exhaustion(true);
     } else if (ceph_argparse_witharg(args, i, &val, "-c", "--compile", (char*)NULL)) {
       srcfn = val;
       compile = true;


### PR DESCRIPTION
Add script to test for CRUSH retry exhaustion in stretch mode with
2 datacenters. Tests unbiased stretch rules by running 100,000
iterations of PG mappings and checking for collisions that exceed
the 50-try limit.

Also add --show-retry-exhaustion flag to crushtool to detect and
report when CRUSH mapping hits the maximum retry limit.

**Conclusion:**
Experiment with 100 iterations
suggested that for 100,000 PGs the stretch replicated rule:

```
rule stretch_replicated_rule {
    id 0
    type replicated
    step take default
    step choose firstn 0 type datacenter
    step chooseleaf firstn 2 type host
    step emit
}
```

with replica size 4 was able to
to map all 100,000 PGs within the 50 try limit.

This is the command that we ran and validate 100 times:

```
crushtool -i "$map_bin" --test \
        --min-x 1 \
        --max-x 100000 \
        --rule "$rule_id" \
        --num-rep 4 \
        --show-statistics \
        --set-choose-total-tries 50 \
        --show-retry-exhaustion
```

The result:
```
ksirivad@sockeni01:~/ceph/build$ ../src/script/test_stretch_crush_collisions.sh
Testing Unbiased Rule with 2 Datacenters
Running 100 iterations with 100000 PGs each...

Compiling CRUSH map...
  Iteration 1/100: OK
  Iteration 2/100: OK
  Iteration 3/100: OK
  Iteration 4/100: OK
  Iteration 5/100: OK
  Iteration 6/100: OK
  Iteration 7/100: OK
  Iteration 8/100: OK
  Iteration 9/100: OK
  Iteration 10/100: OK
  Iteration 11/100: OK
  Iteration 12/100: OK
  Iteration 13/100: OK
  Iteration 14/100: OK
  ...
  Iteration 87/100: OK
  Iteration 88/100: OK
  Iteration 89/100: OK
  Iteration 90/100: OK
  Iteration 91/100: OK
  Iteration 92/100: OK
  Iteration 93/100: OK
  Iteration 94/100: OK
  Iteration 95/100: OK
  Iteration 96/100: OK
  Iteration 97/100: OK
  Iteration 98/100: OK
  Iteration 99/100: OK
  Iteration 100/100: OK
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - x ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
