### PR TITLE
[tentacle] bluestore, extblkdev: Now plugins can raise health warnings

### DIFF
--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -150,7 +150,7 @@ class BlockDevice {
 public:
   CephContext* cct;
   typedef void (*aio_callback_t)(void *handle, void *aio);
-  void collect_alerts(osd_alert_list_t& alerts, const std::string& device_name);
+  virtual void collect_alerts(osd_alert_list_t& alerts, const std::string& device_name);
 
 private:
   ceph::mutex ioc_reap_lock = ceph::make_mutex("BlockDevice::ioc_reap_lock");

--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -248,6 +248,9 @@ public:
   virtual int get_ebd_state(ExtBlkDevState &state) const {
     return -ENOENT;
   }
+  virtual int get_ebd_id(std::string& id) const {
+    return -ENOENT;
+  }
 
   virtual int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm) const = 0;
 

--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -248,7 +248,7 @@ public:
   virtual int get_ebd_state(ExtBlkDevState &state) const {
     return -ENOENT;
   }
-  virtual int get_ebd_id(std::string& id) const {
+  virtual int detect_ebd(std::string& id) {
     return -ENOENT;
   }
 

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -894,6 +894,11 @@ bool KernelDevice::try_discard(interval_set<uint64_t> &to_release, bool async)
   return false;
 }
 
+void KernelDevice::collect_alerts(osd_alert_list_t& alerts, const std::string& device_name)
+{
+  BlockDevice::collect_alerts(alerts, device_name);
+}
+
 void KernelDevice::_aio_log_start(
   IOContext *ioc,
   uint64_t offset,

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -292,12 +292,6 @@ int KernelDevice::open(const string& p)
       support_discard = blkdev_buffered.support_discard();
       optimal_io_size = blkdev_buffered.get_optimal_io_size();
       this->devname = devname;
-      // check if any extended block device plugin recognizes this device
-      // detect_vdo has moved into the VDO plugin
-      int rc = extblkdev::detect_device(cct, devname, ebd_impl);
-      if (rc != 0) {
-	dout(20) << __func__ << " no plugin volume maps to " << devname << dendl;
-      }
     }
   }
 
@@ -475,7 +469,16 @@ int KernelDevice::get_ebd_state(ExtBlkDevState &state) const
   return -ENOENT;
 }
 
-int KernelDevice::get_ebd_id(std::string& id) const {
+int KernelDevice::detect_ebd(std::string& id)
+{
+  // check if any extended block device plugin recognizes this device
+  // detect_vdo has moved into the VDO plugin
+  if (!ebd_impl) {
+    int rc = extblkdev::detect_device(cct, devname, ebd_impl);
+    if (rc != 0) {
+      dout(20) << __func__ << " no plugin volume maps to " << devname << dendl;
+    }
+  }
   if (ebd_impl) {
     return ebd_impl->get_plugin_id(id);
   }

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -475,6 +475,13 @@ int KernelDevice::get_ebd_state(ExtBlkDevState &state) const
   return -ENOENT;
 }
 
+int KernelDevice::get_ebd_id(std::string& id) const {
+  if (ebd_impl) {
+    return ebd_impl->get_plugin_id(id);
+  }
+  return -ENOENT;
+}
+
 int KernelDevice::choose_fd(bool buffered, int write_hint) const
 {
 #if defined(F_SET_FILE_RW_HINT)

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -897,6 +897,9 @@ bool KernelDevice::try_discard(interval_set<uint64_t> &to_release, bool async)
 void KernelDevice::collect_alerts(osd_alert_list_t& alerts, const std::string& device_name)
 {
   BlockDevice::collect_alerts(alerts, device_name);
+  if (ebd_impl) {
+    ebd_impl->collect_alerts(alerts);
+  }
 }
 
 void KernelDevice::_aio_log_start(

--- a/src/blk/kernel/KernelDevice.h
+++ b/src/blk/kernel/KernelDevice.h
@@ -98,6 +98,8 @@ private:
   bool _queue_discard(interval_set<uint64_t> &to_release);
   bool try_discard(interval_set<uint64_t> &to_release, bool async = true) override;
 
+  void collect_alerts(osd_alert_list_t& alerts, const std::string& device_name) override;
+
   int _aio_start();
   void _aio_stop();
 

--- a/src/blk/kernel/KernelDevice.h
+++ b/src/blk/kernel/KernelDevice.h
@@ -145,6 +145,7 @@ public:
   int get_devices(std::set<std::string> *ls) const override;
 
   int get_ebd_state(ExtBlkDevState &state) const override;
+  int get_ebd_id(std::string& id) const override;
 
   int read(uint64_t off, uint64_t len, ceph::buffer::list *pbl,
 	   IOContext *ioc,

--- a/src/blk/kernel/KernelDevice.h
+++ b/src/blk/kernel/KernelDevice.h
@@ -145,7 +145,7 @@ public:
   int get_devices(std::set<std::string> *ls) const override;
 
   int get_ebd_state(ExtBlkDevState &state) const override;
-  int get_ebd_id(std::string& id) const override;
+  int detect_ebd(std::string& id) override;
 
   int read(uint64_t off, uint64_t len, ceph::buffer::list *pbl,
 	   IOContext *ioc,

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -26,7 +26,6 @@
 #include "mon/MonClient.h"
 #include "include/ceph_features.h"
 #include "common/config.h"
-#include "extblkdev/ExtBlkDevPlugin.h"
 
 #include "mon/MonMap.h"
 
@@ -488,14 +487,6 @@ flushjournal_out:
       forker.exit(1);
     }
     forker.exit(0);
-  }
-  
-  {
-    int r = extblkdev::preload(g_ceph_context);
-    if (r < 0) {
-      derr << "Failed preloading extblkdev plugins, error code: " << r << dendl;
-      forker.exit(1);
-    }
   }
 
   string magic;

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4491,6 +4491,18 @@ options:
   flags:
   - create
   with_legacy: true
+- name: bluestore_use_ebd
+  type: bool
+  level: advanced
+  desc: EBD plugin used during mkfs is required for mounts.
+  long_desc: The flag has two effects, on mkfs and on mount.
+    If set for mkfs and EBD plugin did attach to the device then save plugin name to OSD metadata.
+    If set when mounting and plugin name is stored in OSD metadata then refuse to mount.
+    The flag has no meaning if the device has no associated EBD plugin.
+  default: true
+  see_also:
+  - osd_extblkdev_plugins
+  with_legacy: true
 - name: bluestore_bdev_label_multi
   type: bool
   level: advanced

--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -34,7 +34,7 @@ options:
   long_desc: When ceph switches from root to the ceph uid, all capabilities in all sets are eraseed. If
     a component that is capability aware needs a specific capability, the keepcaps flag maintains
      the permitted capability set, allowing the capabilities in the effective set to be activated as needed.
-  default: true
+  default: false
   flags:
   - startup
 - name: osd_smart_report_timeout

--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -34,7 +34,7 @@ options:
   long_desc: When ceph switches from root to the ceph uid, all capabilities in all sets are eraseed. If
     a component that is capability aware needs a specific capability, the keepcaps flag maintains
      the permitted capability set, allowing the capabilities in the effective set to be activated as needed.
-  default: false
+  default: true
   flags:
   - startup
 - name: osd_smart_report_timeout
@@ -1548,7 +1548,7 @@ options:
   type: str
   level: advanced
   desc: extended block device plugins to load, provide compression feedback at runtime
-  default: vdo
+  default: vdo fcm
   flags:
   - startup
 # minimum number of peers

--- a/src/extblkdev/CMakeLists.txt
+++ b/src/extblkdev/CMakeLists.txt
@@ -3,6 +3,7 @@
 set(extblkdev_plugin_dir ${CEPH_INSTALL_PKGLIBDIR}/extblkdev)
 
 add_subdirectory(vdo)
+add_subdirectory(fcm)
 
 add_library(extblkdev STATIC ExtBlkDevPlugin.cc)
 
@@ -12,4 +13,5 @@ if(LINUX)
 endif()
 
 add_custom_target(extblkdev_plugins DEPENDS
-    ceph_ebd_vdo)
+    ceph_ebd_vdo
+    ceph_ebd_fcm)

--- a/src/extblkdev/ExtBlkDevInterface.h
+++ b/src/extblkdev/ExtBlkDevInterface.h
@@ -34,6 +34,7 @@
 #include <map>
 #include <ostream>
 #include <memory>
+#include "osd/osd_types.h"
 #ifdef __linux__
 #include <sys/capability.h>
 #else
@@ -111,6 +112,14 @@ namespace ceph {
      * @return 0 on success or a negative errno on error.
      */
     virtual int get_plugin_id(std::string& id_str) = 0;
+
+    /**
+     * Retrieve alerts from the plugin, if any.
+     * This function is used to give plugin a way to signal health warnings.
+     *
+     * @param [out] alerts append warnings here.
+     */
+    virtual void collect_alerts(osd_alert_list_t& alerts) {}
   };
 
   typedef std::shared_ptr<ExtBlkDevInterface> ExtBlkDevInterfaceRef;

--- a/src/extblkdev/ExtBlkDevInterface.h
+++ b/src/extblkdev/ExtBlkDevInterface.h
@@ -99,6 +99,18 @@ namespace ceph {
      * @return 0 on success or a negative errno on error.
      */
     virtual int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm) = 0;
+
+    /**
+     * Retrieve the identification string of the plugin.
+     * This can be used to verify that proper plugin is loaded.
+     * It is best if id is printable string.
+     *
+     * Return 0 on success or a negative errno on error.
+     *
+     * @param [out] id_str identification of current plugin
+     * @return 0 on success or a negative errno on error.
+     */
+    virtual int get_plugin_id(std::string& id_str) = 0;
   };
 
   typedef std::shared_ptr<ExtBlkDevInterface> ExtBlkDevInterfaceRef;

--- a/src/extblkdev/ExtBlkDevPlugin.cc
+++ b/src/extblkdev/ExtBlkDevPlugin.cc
@@ -183,6 +183,17 @@ namespace ceph {
     // preload set of extblkdev plugins defined in config
     int preload(CephContext *cct)
     {
+      static bool preload_executed = false;
+      static int preload_result = -1;
+      if (preload_executed) {
+        auto registry = cct->get_plugin_registry();
+        std::lock_guard l(registry->lock);
+        dout(10) << "plugins preload done, extblkdev plugins ="
+          << registry->plugins["extblkdev"].size()
+          << " previous_result = " << preload_result << dendl;
+        return preload_result;
+      }
+      preload_executed = true;
       const auto& conf = cct->_conf;
       string plugins = conf.get_val<std::string>("osd_extblkdev_plugins");
       dout(10) << "starting preload of extblkdev plugins: " << plugins << dendl;
@@ -198,8 +209,9 @@ namespace ceph {
 	  int rc = registry->load("extblkdev", std::string("ebd_") + plg);
 	  if (rc) {
 	    derr << __func__ << " failed preloading extblkdev plugin: " << plg << dendl;
+            preload_result = rc;
 	    return rc;
-	  }else{
+	  } else {
 	    dout(10) << "successful load of extblkdev plugin: " << plg << dendl;
 	  }
 	}
@@ -208,10 +220,12 @@ namespace ceph {
       // if we are still running as root, we do not need to trim capabilities
       // as we are intended to use the privileges
       if (geteuid() == 0) {
+        preload_result = 0;
 	return 0;
       }
       return limit_caps(cct);
 #else
+      preload_result = 0;
       return 0;
 #endif
     }

--- a/src/extblkdev/ExtBlkDevPlugin.cc
+++ b/src/extblkdev/ExtBlkDevPlugin.cc
@@ -223,7 +223,8 @@ namespace ceph {
         preload_result = 0;
 	return 0;
       }
-      return limit_caps(cct);
+      preload_result = limit_caps(cct);
+      return preload_result;
 #else
       preload_result = 0;
       return 0;

--- a/src/extblkdev/fcm/CMakeLists.txt
+++ b/src/extblkdev/fcm/CMakeLists.txt
@@ -1,0 +1,8 @@
+# fcm plugin
+
+set(fcm_srcs
+  ExtBlkDevPluginFcm.cc
+)
+
+add_library(ceph_ebd_fcm SHARED ${fcm_srcs})
+install(TARGETS ceph_ebd_fcm DESTINATION ${extblkdev_plugin_dir})

--- a/src/extblkdev/fcm/ExtBlkDevPluginFcm.cc
+++ b/src/extblkdev/fcm/ExtBlkDevPluginFcm.cc
@@ -296,6 +296,9 @@ public:
     // determine device name for underlying hardware
     std::set<std::string> raw_devices;
     get_raw_devices(logdevname, &raw_devices);
+    if (raw_devices.size() > 1) {
+      ceph_abort("Device " + logdevname_a + " consist of "+ raw_devices.size() + " devices: " + raw_devices);
+    }
     for (auto& d : raw_devices) {
       std::string devpath = "/sys/block/" + d + "/device/";
       uint32_t vendor;

--- a/src/extblkdev/fcm/ExtBlkDevPluginFcm.cc
+++ b/src/extblkdev/fcm/ExtBlkDevPluginFcm.cc
@@ -1,0 +1,405 @@
+/*
+ * plugin for Ceph - scalable distributed file system
+ *
+ * (C) Copyright IBM Corporation 2022
+ * Author: Martin Ohmacht <mohmacht@us.ibm.com>
+ *
+ */
+
+#include "ceph_ver.h"
+#include "extblkdev/ExtBlkDevInterface.h"
+#include "common/blkdev.h"
+#include "include/stringify.h"
+#include "include/compat.h"
+#include "common/debug.h"
+
+//#define dout_subsys ceph_subsys_context
+#define dout_context cct
+#define dout_subsys ceph_subsys_bdev
+#undef dout_prefix
+#define dout_prefix *_dout << "fcm(" << this << ") "
+
+#include <blkid/blkid.h>
+#include <cstring>
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <iostream>
+#include <linux/nvme_ioctl.h>
+#include <set>
+#include <sstream>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/capability.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <vector>
+
+
+//! class managing one logical volume or partition, which may use one or more underlying FCM devices
+class ExtBlkDevFcm : public ceph::ExtBlkDevInterface
+{
+  //! ceph context used for logging messages
+  CephContext *cct;
+
+  //! name of the top level logical device
+  std::string logdevname;
+
+  //! class managing one underlying FCM devices
+  class fcm_dev{
+    int fd = -1; //! file descriptor for underlying device, used for issueing log queries
+    std::string fcm_devname; //! name of the underlying fcm device
+    uint64_t log[4]; //! utilization queried from device log page
+
+  public:
+    fcm_dev(const std::string& name):fcm_devname(name){}
+    ~fcm_dev(){
+      if(fd>=0)
+	VOID_TEMP_FAILURE_RETRY(::close(fd));
+    }
+    int query_log()
+    {
+      // fetch only 4 numbers from the log
+
+      // number of bytes to transfer
+      unsigned log_size=sizeof(log);
+      // number of double word (32b) blocks
+      uint32_t num_dw = (log_size >> 2) - 1;
+
+      struct nvme_passthru_cmd cmd = {
+        .opcode     = 2, // get admin log page
+        .nsid       = 0xffffffff, // nsid == all
+        .addr       = (__u64)(uintptr_t)log,
+        .data_len   = log_size,
+        .cdw10      = 202 | ((num_dw & 0xffff)<<16), // log 202 contains phys util number
+        .cdw11      = num_dw>>16,
+        .cdw12      = 280, // avail numbers start at offset 280
+        .cdw13      = 0,
+        .cdw14      = 0,
+        .timeout_ms = 0,
+      };
+
+      int rc=ioctl(fd, NVME_IOCTL_ADMIN_CMD, &cmd);
+      if(rc<0)
+	return -errno;
+      return 0;
+    }
+    int open(CephContext *cct){
+      // open file descriptor of underlying hardware device for state queries
+      std::string path = std::string("/dev/") + fcm_devname;
+      fd = ::open(path.c_str(), O_RDWR);
+      if(fd<0){
+	dout(1) << __func__ << " Can not open FCM device at path " << path << dendl;
+	return -4000-errno;
+      }
+      return 0;
+    }
+    uint64_t get_device_physical_size() const {return log[0];}
+    uint64_t get_device_physical_util() const {return log[1];}
+    uint64_t get_device_physical_avail() const {
+      int64_t avail=get_device_physical_size()-get_device_physical_util();
+      return avail<0 ? 0 : avail;}
+    uint64_t get_device_logical_size() const {return log[2];}
+    uint64_t get_device_logical_util() const {return log[3];}
+    uint64_t get_device_logical_avail() const {
+      int64_t avail=get_device_logical_size()-get_device_logical_util();
+      return avail<0 ? 0 : avail;}
+  };
+
+  std::vector<fcm_dev> fcm_devices;
+  int64_t lsize=0;  // total number of logical bytes of logical volume
+  int64_t lavail=0;  // total number of logical available bytes of logical volume
+  uint64_t psize=0; // total number of physical bytes of logical volume
+  uint64_t pavail=0; // total number of physical available bytes of logical volume
+  struct timespec last_access = {0};
+
+  uint64_t get_partition_physical_size() const {return psize;}
+  uint64_t get_partition_logical_size() const {return lsize;}
+  uint64_t get_partition_physical_avail() const {return pavail;}
+  uint64_t get_partition_logical_avail() const {return lavail;}
+
+  uint64_t get_device_physical_size() const {
+    uint64_t sum=0;
+    for (auto& d : fcm_devices) {
+      sum += d.get_device_physical_size();
+    }
+    return sum;
+  }
+  uint64_t get_device_physical_util() const {
+    uint64_t sum=0;
+    for (auto& d : fcm_devices) {
+      sum += d.get_device_physical_util();
+    }
+    return sum;
+  }
+  uint64_t get_device_logical_size() const {
+    uint64_t sum=0;
+    for (auto& d : fcm_devices) {
+      sum += d.get_device_logical_size();
+    }
+    return sum;
+  }
+  uint64_t get_device_logical_util() const {
+    uint64_t sum=0;
+    for (auto& d : fcm_devices) {
+      sum += d.get_device_logical_util();
+    }
+    return sum;
+  }
+
+
+  //! set the CAP_SYS_ADMIN in the effective capapbility set to value v
+  static int set_cap(cap_flag_value_t v)
+  {
+    int rc=0;
+    cap_t caps=cap_get_proc();
+    if (caps == NULL){
+      return -600;
+    }
+    do{
+      // does the cap already have the target value?
+      cap_flag_value_t cv;
+      if(cap_get_flag(caps, CAP_SYS_ADMIN, CAP_EFFECTIVE, &cv) == -1){
+	rc=-605;
+	break;
+      }
+      // if so, indicate a return code ==1 to caller
+      if(cv==v){
+	rc=1;
+	break;
+      }
+      cap_value_t cap_list[1];
+      cap_list[0] = CAP_SYS_ADMIN;
+      if (cap_set_flag(caps, CAP_EFFECTIVE, 1, cap_list, v) == -1){
+	rc=-601;
+	break;
+      }
+      if (cap_set_proc(caps) == -1){
+	rc=-602;
+	break;
+      }
+    }while(0);
+    if (cap_free(caps) == -1){
+      return -604;
+    }
+    return rc;
+  }
+
+
+  int get_fcm_utilization()
+  {
+    struct timespec tnow;
+    clock_gettime(CLOCK_MONOTONIC_COARSE, &tnow);
+    // have we retrieved log in past 15 seconds?
+    if(tnow.tv_sec < last_access.tv_sec + 15){
+      // just use cached numbers and indicate in return code
+      return 1;
+    }
+
+    // set SYS_ADMIN capability in effective set, needed for NVME ioctl
+    int was_set=set_cap(CAP_SET);
+    if(was_set<0){
+      return was_set;
+    }
+
+    uint64_t sum_ps=0;
+    uint64_t sum_pa=0;
+    uint64_t sum_ls=0;
+    uint64_t sum_la=0;
+
+    // accumulate status across devices
+    for (auto& dev : fcm_devices) {
+      int rc=dev.query_log();
+      if(rc<0)
+	return rc;
+      uint64_t ps=dev.get_device_physical_size(); // physical size
+      uint64_t pa=dev.get_device_physical_avail(); // physical available space
+      uint64_t ls=dev.get_device_logical_size();  // logical size
+      uint64_t la=dev.get_device_logical_avail();  // logical available space
+      if(ps==0 || ls==0){
+	return -500;
+      }
+      sum_ps+=ps;
+      sum_pa+=pa;
+      sum_ls+=ls;
+      sum_la+=la;
+    }
+
+    // restore effective capability set if we changed it
+    if(!was_set){
+      int rc=set_cap(CAP_CLEAR);
+      if(rc<0)
+	return rc;
+    }
+
+    // apportion space to OSD fractions
+    double frac=(double)get_partition_logical_size()/sum_ls;
+    psize = sum_ps*frac;
+    pavail = sum_pa*frac;
+    lavail = sum_la*frac;
+    last_access = tnow;
+    return 0;
+  }
+
+  static int fcm_get_int_property(const std::string& dev, const std::string& attr)
+  {
+    // fetch integer device attribute from sysfs
+    std::string path=std::string("/sys/block/")+dev+"/device/device/"+attr;
+    int fd=::open(path.c_str(), O_RDONLY);
+    if(fd<0)
+      return -errno;
+    int rc=-1;
+    char buf[1024];
+    int r = ::read(fd, buf, sizeof(buf) - 1);
+    if (r > 0) {
+      buf[r] = 0;
+      rc = strtol(buf,0,0);
+    }else{
+      rc=-errno;
+    }
+    TEMP_FAILURE_RETRY(::close(fd));
+    return rc;
+  }
+
+  int get_lsize()
+  {
+    // retrieve size of logical device assigned to this OSD
+    // this is used later on to apportion physical space accordingly
+
+    std::string path = std::string("/dev/") + logdevname;
+    int fd = ::open(path.c_str(), O_RDONLY);
+    if(fd<0){
+      dout(1) << __func__ << " Can not open logical device " << logdevname << dendl;
+      return -2000-errno;
+    }
+    BlkDev bdfd(fd);
+    int rc=bdfd.get_size(&lsize);
+    VOID_TEMP_FAILURE_RETRY(::close(fd));
+    if(rc<0){
+      dout(1) << __func__ << " Can not get device size of " << logdevname << dendl;
+      return -3000-errno;
+    }
+    return 0;
+  }
+
+public:
+  explicit ExtBlkDevFcm(CephContext *cct) : cct(cct) {}
+  ~ExtBlkDevFcm(){}
+  int init(const std::string& logdevname_a){
+    logdevname=logdevname_a;
+
+    // determine device name for underlying hardware
+    std::set<std::string> raw_devices;
+    get_raw_devices(logdevname, &raw_devices);
+    for (auto& d : raw_devices) {
+      // get vendor and device id of underlying hardware, compare with FCM ids
+      if(fcm_get_int_property(d, "vendor") == 0x1014 &&
+	 fcm_get_int_property(d, "device") == 0x0634){
+	fcm_devices.push_back(fcm_dev(d));
+	dout(1) << __func__ << " Found FCM vendor/device id on " << d << dendl;
+      }
+    }
+    if(fcm_devices.empty()){
+      return -1000;
+    }
+
+    // get size of logical volume/partition
+    int rc=get_lsize();
+    if(rc<0)
+      return rc;
+
+    // open file handles for FCM devices
+    for (auto& d : fcm_devices) {
+      int rc=d.open(cct);
+      if(rc<0)
+	return rc;
+    }
+
+    // do initial query for utilization to ensure query mechanism works
+    rc=get_fcm_utilization();
+    if(rc<0){
+      dout(1) << __func__ << " Can not access physical utilization log of FCM device" << dendl;
+      return rc;
+    }
+    return 0;
+  }
+  virtual const std::string& get_devname() const {return logdevname;}
+  int get_state(ExtBlkDevState& state)
+  {
+    int rc=get_fcm_utilization();
+    if(rc<0)
+      return rc;
+    if(rc==0){
+      dout(1) << __func__ << " FCM volume " << get_devname() << " physical utilization:" << dendl;
+      dout(1) << __func__ << " FCM device logical size: " << get_device_logical_size() << dendl;
+      dout(1) << __func__ << " FCM device logical util: " << get_device_logical_util() << dendl;
+      dout(1) << __func__ << " FCM device physical size: " << get_device_physical_size() << dendl;
+      dout(1) << __func__ << " FCM device physical util: " << get_device_physical_util() << dendl;
+      dout(1) << __func__ << " FCM partition logical size: " << get_partition_logical_size() << dendl;
+      dout(1) << __func__ << " FCM partition logical avail: " << get_partition_logical_avail() << dendl;
+      dout(1) << __func__ << " FCM partition physical size: " << get_partition_physical_size() << dendl;
+      dout(1) << __func__ << " FCM partition physical avail: " << get_partition_physical_avail() << dendl;
+    }
+    state.set_logical_total(get_partition_logical_size());
+    state.set_logical_avail(get_partition_logical_avail());
+    state.set_physical_total(get_partition_physical_size());
+    state.set_physical_avail(get_partition_physical_avail());
+    return 0;
+  }
+  int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm)
+  {
+    int rc=get_fcm_utilization();
+    if(rc<0)
+      return rc;
+    (*pm)[prefix + "fcm"] = "true";
+    (*pm)[prefix + "fcm_partition_physical_size"] = stringify(get_partition_physical_size());
+    (*pm)[prefix + "fcm_partition_logical_size"] = stringify(get_partition_logical_size());
+    (*pm)[prefix + "fcm_device_physical_size"] = stringify(get_device_physical_size());
+    (*pm)[prefix + "fcm_device_logical_size"] = stringify(get_device_logical_size());
+    return 0;
+  }
+};
+
+class ExtBlkDevPluginFcm : public ceph::ExtBlkDevPlugin {
+public:
+  explicit ExtBlkDevPluginFcm(CephContext *cct) : ExtBlkDevPlugin(cct) {}
+  int get_required_cap_set(cap_t caps)
+  {
+    cap_value_t adm[1];
+    adm[0]=CAP_SYS_ADMIN;
+    // set SYS_ADMIN capability in permitted set
+    return cap_set_flag(caps, CAP_PERMITTED, 1, adm, CAP_SET);
+  }
+  int factory(const std::string& logdevname,
+	      ceph::ExtBlkDevInterfaceRef& ext_blk_dev)
+  {
+    auto fcm = new ExtBlkDevFcm(cct);
+    int r = fcm->init(logdevname);
+    if (r != 0) {
+      delete fcm;
+      return r;
+    }
+    ext_blk_dev.reset(fcm);
+    return 0;
+  }
+};
+
+const char *__ceph_plugin_version() { return CEPH_GIT_NICE_VER; }
+
+int __ceph_plugin_init(CephContext *cct,
+		       const std::string& type,
+		       const std::string& name)
+{
+  auto plg=new ExtBlkDevPluginFcm(cct);
+  if(plg==0) return -ENOMEM;
+  int rc=cct->get_plugin_registry()->add(type, name, plg);
+  if(rc!=0){
+    delete plg;
+  }
+  return rc;
+}

--- a/src/extblkdev/fcm/ExtBlkDevPluginFcm.cc
+++ b/src/extblkdev/fcm/ExtBlkDevPluginFcm.cc
@@ -301,7 +301,8 @@ public:
   ~ExtBlkDevFcm(){
     unregister_perf_counters();
   }
-  int init(const std::string& logdevname_a){
+  int init(const std::string& logdevname_a) override
+  {
     logdevname=logdevname_a;
 
     // determine device name for underlying hardware
@@ -426,8 +427,8 @@ public:
     return result;
   }
 
-  virtual const std::string& get_devname() const {return logdevname;}
-  int get_state(ExtBlkDevState& state)
+  const std::string& get_devname() const override {return logdevname;}
+  int get_state(ExtBlkDevState& state) override
   {
     int rc=get_fcm_utilization();
     if(rc<0)
@@ -452,7 +453,7 @@ public:
 
     return 0;
   }
-  int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm)
+  int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm) override
   {
     int rc=get_fcm_utilization();
     if(rc<0)

--- a/src/extblkdev/fcm/ExtBlkDevPluginFcm.cc
+++ b/src/extblkdev/fcm/ExtBlkDevPluginFcm.cc
@@ -39,7 +39,14 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <vector>
+#include "common/ceph_context.h"
+#include "common/perf_counters.h"
 
+#ifdef WITH_CRIMSON
+#include "crimson/common/perf_counters_collection.h"
+#else
+#include "common/perf_counters_collection.h"
+#endif
 
 //! class managing one logical volume or partition, which may use one or more underlying FCM devices
 class ExtBlkDevFcm : public ceph::ExtBlkDevInterface
@@ -117,6 +124,7 @@ class ExtBlkDevFcm : public ceph::ExtBlkDevInterface
   uint64_t psize=0; // total number of physical bytes of logical volume
   uint64_t pavail=0; // total number of physical available bytes of logical volume
   struct timespec last_access = {0};
+  PerfCounters *perfc = nullptr;
 
   uint64_t get_partition_physical_size() const {return psize;}
   uint64_t get_partition_logical_size() const {return lsize;}
@@ -243,6 +251,7 @@ class ExtBlkDevFcm : public ceph::ExtBlkDevInterface
     pavail = sum_pa*frac;
     lavail = sum_la*frac;
     last_access = tnow;
+
     return 0;
   }
 
@@ -289,7 +298,9 @@ class ExtBlkDevFcm : public ceph::ExtBlkDevInterface
 
 public:
   explicit ExtBlkDevFcm(CephContext *cct) : cct(cct) {}
-  ~ExtBlkDevFcm(){}
+  ~ExtBlkDevFcm(){
+    unregister_perf_counters();
+  }
   int init(const std::string& logdevname_a){
     logdevname=logdevname_a;
 
@@ -336,6 +347,50 @@ public:
       return rc;
     }
     return 0;
+  }
+  enum perf_counters: uint32_t
+  {
+    l_first,
+    l_name,
+    l_dev_phy_size,
+    l_dev_log_size,
+    l_dev_phy_util,
+    l_dev_log_util,
+    l_part_phy_size,
+    l_part_log_size,
+    l_part_phy_avail,
+    l_part_log_avail,
+    l_last
+  };
+
+  void register_perf_counters()
+  {
+    auto constexpr useful = PerfCountersBuilder::PRIO_USEFUL;
+    auto constexpr unone = unit_t::UNIT_NONE;
+    auto constexpr ubytes= unit_t::UNIT_BYTES;
+
+    PerfCountersBuilder b(cct, "extblkdev", l_first, l_last);
+    b.add_u64(l_name, "fcm", "plugin type", "", useful, unone);
+    b.add_u64(l_dev_phy_size, "dev_phy_size", "FCM device physical size", "", useful, ubytes);
+    b.add_u64(l_dev_log_size, "dev_log_size", "FCM device logical size", "", useful, ubytes);
+    b.add_u64(l_dev_phy_util, "dev_phy_util", "FCM device physical util", "", useful, ubytes);
+    b.add_u64(l_dev_log_util, "dev_log_util", "FCM device logical util", "", useful, ubytes);
+    b.add_u64(l_part_phy_size, "part_phy_size", "FCM partition physical size", "", useful, ubytes);
+    b.add_u64(l_part_log_size, "part_log_size", "FCM partition logical size", "", useful, ubytes);
+    b.add_u64(l_part_phy_avail, "part_phy_avail", "FCM partition physical avail", "", useful, ubytes);
+    b.add_u64(l_part_log_avail, "part_log_avail", "FCM partition logical avail", "", useful, ubytes);
+
+    perfc = b.create_perf_counters();
+    cct->get_perfcounters_collection()->add(perfc);
+  }
+
+  void unregister_perf_counters()
+  {
+    if (perfc) {
+      cct->get_perfcounters_collection()->remove(perfc);
+      delete perfc;
+      perfc = nullptr;
+    }
   }
   /*
     Scans provided directory for entries ?/device/device and ?/device/vendor.
@@ -392,6 +447,19 @@ public:
     state.set_logical_avail(get_partition_logical_avail());
     state.set_physical_total(get_partition_physical_size());
     state.set_physical_avail(get_partition_physical_avail());
+
+    if (!perfc) {
+      register_perf_counters();
+    }
+    perfc->set(l_dev_phy_size, get_device_physical_size());
+    perfc->set(l_dev_log_size, get_device_logical_size());
+    perfc->set(l_dev_phy_util, get_device_physical_util());
+    perfc->set(l_dev_log_util, get_device_logical_util());
+    perfc->set(l_part_phy_size, get_partition_physical_size());
+    perfc->set(l_part_log_size, get_partition_logical_size());
+    perfc->set(l_part_phy_avail, get_partition_physical_avail());
+    perfc->set(l_part_log_avail, get_partition_logical_avail());
+
     return 0;
   }
   int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm)

--- a/src/extblkdev/fcm/ExtBlkDevPluginFcm.cc
+++ b/src/extblkdev/fcm/ExtBlkDevPluginFcm.cc
@@ -343,7 +343,7 @@ public:
     // do initial query for utilization to ensure query mechanism works
     rc=get_fcm_utilization();
     if(rc<0){
-      dout(1) << __func__ << " Can not access physical utilization log of FCM device" << dendl;
+      derr << __func__ << " Device detected, but FCM utilization log cannot be accessed (check capabilites!)" << dendl;
       return rc;
     }
     return 0;
@@ -432,17 +432,7 @@ public:
     int rc=get_fcm_utilization();
     if(rc<0)
       return rc;
-    if(rc==0){
-      dout(1) << __func__ << " FCM volume " << get_devname() << " physical utilization:" << dendl;
-      dout(1) << __func__ << " FCM device logical size: " << get_device_logical_size() << dendl;
-      dout(1) << __func__ << " FCM device logical util: " << get_device_logical_util() << dendl;
-      dout(1) << __func__ << " FCM device physical size: " << get_device_physical_size() << dendl;
-      dout(1) << __func__ << " FCM device physical util: " << get_device_physical_util() << dendl;
-      dout(1) << __func__ << " FCM partition logical size: " << get_partition_logical_size() << dendl;
-      dout(1) << __func__ << " FCM partition logical avail: " << get_partition_logical_avail() << dendl;
-      dout(1) << __func__ << " FCM partition physical size: " << get_partition_physical_size() << dendl;
-      dout(1) << __func__ << " FCM partition physical avail: " << get_partition_physical_avail() << dendl;
-    }
+
     state.set_logical_total(get_partition_logical_size());
     state.set_logical_avail(get_partition_logical_avail());
     state.set_physical_total(get_partition_physical_size());

--- a/src/extblkdev/fcm/ExtBlkDevPluginFcm.cc
+++ b/src/extblkdev/fcm/ExtBlkDevPluginFcm.cc
@@ -464,6 +464,11 @@ public:
     (*pm)[prefix + "fcm_device_logical_size"] = stringify(get_device_logical_size());
     return 0;
   }
+  int get_plugin_id(std::string& id_str) override
+  {
+    id_str = "fcm";
+    return 0;
+  };
 };
 
 class ExtBlkDevPluginFcm : public ceph::ExtBlkDevPlugin {

--- a/src/extblkdev/fcm/ExtBlkDevPluginFcm.cc
+++ b/src/extblkdev/fcm/ExtBlkDevPluginFcm.cc
@@ -426,6 +426,10 @@ public:
     if (r != 0) {
       delete fcm;
       return r;
+    } else {
+      if (!cct->_conf->bdev_enable_discard) {
+        derr << "FCM device in use, but bdev_enable_discard not enabled. Free space will leak." << dendl;
+      }
     }
     ext_blk_dev.reset(fcm);
     return 0;

--- a/src/extblkdev/fcm/ExtBlkDevPluginFcm.cc
+++ b/src/extblkdev/fcm/ExtBlkDevPluginFcm.cc
@@ -359,12 +359,12 @@ public:
       int device_i = fcm_get_int_property(e + entry->d_name, "device");
       if (device_i >= 0) {
         vendor_i = fcm_get_int_property(e + entry->d_name, "vendor");
-      }
-      if (vendor_i >= 0 && device_i >= 0) {
-        device = device_i;
-        vendor = vendor_i;
-        result = 0;
-        break;
+        if (vendor_i >= 0) {
+          device = device_i;
+          vendor = vendor_i;
+          result = 0;
+          break;
+        }
       }
     }
     closedir(dir);

--- a/src/extblkdev/fcm/ExtBlkDevPluginFcm.cc
+++ b/src/extblkdev/fcm/ExtBlkDevPluginFcm.cc
@@ -126,6 +126,9 @@ class ExtBlkDevFcm : public ceph::ExtBlkDevInterface
   struct timespec last_access = {0};
   PerfCounters *perfc = nullptr;
 
+  bool error_accessing_log = false;
+  bool error_multivolume = false;
+
   uint64_t get_partition_physical_size() const {return psize;}
   uint64_t get_partition_logical_size() const {return lsize;}
   uint64_t get_partition_physical_avail() const {return pavail;}
@@ -199,7 +202,7 @@ class ExtBlkDevFcm : public ceph::ExtBlkDevInterface
   }
 
 
-  int get_fcm_utilization()
+  int get_fcm_utilization_core()
   {
     struct timespec tnow;
     clock_gettime(CLOCK_MONOTONIC_COARSE, &tnow);
@@ -253,6 +256,23 @@ class ExtBlkDevFcm : public ceph::ExtBlkDevInterface
     last_access = tnow;
 
     return 0;
+  }
+
+  int get_fcm_utilization() {
+    int result = get_fcm_utilization_core();
+    if (result < 0) {
+      // raise alert status
+      error_accessing_log = true;
+    }
+    if (result == 0) {
+      // clear alert
+      error_accessing_log = false;
+    }
+    if (result > 0) {
+      // We only retrieve log every 15s.
+      // We did not retrieve it in this run, so no change on error_accessing_log.
+    }
+    return result;
   }
 
   static int fcm_get_int_property(const std::string& devpath, const std::string& attr)
@@ -325,10 +345,17 @@ public:
         }
       }
     }
+
     if(fcm_devices.empty()){
       return -1000;
+    } else {
+      if (raw_devices.size() > 1) {
+        error_multivolume = true;
+        derr << __func__ << "Device " << logdevname_a << " consist of "
+             << raw_devices.size() << " devices: " << raw_devices << dendl;
+        derr << "Multi-device volumes are unsupported for FCM plugin" << dendl;
+      }
     }
-
     // get size of logical volume/partition
     int rc=get_lsize();
     if(rc<0)
@@ -341,12 +368,8 @@ public:
 	return rc;
     }
 
-    // do initial query for utilization to ensure query mechanism works
-    rc=get_fcm_utilization();
-    if(rc<0){
-      derr << __func__ << " Device detected, but FCM utilization log cannot be accessed (check capabilites!)" << dendl;
-      return rc;
-    }
+    // do initial query for utilization to maybe raise health warning
+    get_fcm_utilization();
     return 0;
   }
   enum perf_counters: uint32_t
@@ -470,6 +493,31 @@ public:
     id_str = "fcm";
     return 0;
   };
+
+  void collect_alerts(osd_alert_list_t& alerts) override
+  {
+    if (error_accessing_log) {
+      std::string& v = alerts["EXTBLKDEV"];
+      if (!v.empty()) {
+        v += "; ";
+      }
+      v.append("failed accessing FCM utilization log");
+    }
+    if (!cct->_conf->bdev_enable_discard) {
+      std::string& v = alerts["EXTBLKDEV"];
+      if (!v.empty()) {
+        v += "; ";
+      }
+      v.append("bdev_enable_discard not enabled - free space will leak");
+    }
+    if (error_multivolume) {
+      std::string& v = alerts["EXTBLKDEV"];
+      if (!v.empty()) {
+        v += "; ";
+      }
+      v.append("multivolume fcm will not work properly");
+    }
+  }
 };
 
 class ExtBlkDevPluginFcm : public ceph::ExtBlkDevPlugin {
@@ -490,10 +538,6 @@ public:
     if (r != 0) {
       delete fcm;
       return r;
-    } else {
-      if (!cct->_conf->bdev_enable_discard) {
-        derr << "FCM device in use, but bdev_enable_discard not enabled. Free space will leak." << dendl;
-      }
     }
     ext_blk_dev.reset(fcm);
     return 0;

--- a/src/extblkdev/vdo/ExtBlkDevVdo.h
+++ b/src/extblkdev/vdo/ExtBlkDevVdo.h
@@ -47,6 +47,10 @@ public:
   virtual const std::string& get_devname() const {return name;}
   virtual int get_state(ceph::ExtBlkDevState& state);
   virtual int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm);
+  int get_plugin_id(std::string& id_str) override {
+    id_str = "vdo";
+    return 0;
+  };
 };
 
 #endif

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -3313,6 +3313,8 @@ void PGMap::get_health_checks(
         summary += " experiencing stalled read in wal device of BlueFS";
       } else if (asum.first == "DB_DEVICE_STALLED_READ_ALERT") {
         summary += " experiencing stalled read in db device of BlueFS";
+      } else if (asum.first == "EXTBLKDEV") {
+        summary += " reporting problems with ExtBlkDev plugin";
       }
 
       auto& d = checks->add(asum.first, HEALTH_WARN, summary, asum.second.first);

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -4750,10 +4750,11 @@ bool BlueFS::debug_get_is_dev_dirty(FileWriter *h, uint8_t dev)
 }
 
 void BlueFS::collect_alerts(osd_alert_list_t& alerts) {
-  if (bdev[BDEV_DB]) {
+  if (bdev[BDEV_DB] &&
+    (!is_shared_alloc(BDEV_DB) /*BlueStore is collecting alerts for its bdev*/) ) {
     bdev[BDEV_DB]->collect_alerts(alerts, "DB");
   }
-  if (bdev[BDEV_WAL]) {
+  if (bdev[BDEV_WAL] /*WAL is never shared*/) {
     bdev[BDEV_WAL]->collect_alerts(alerts, "WAL");
   }
 }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7167,14 +7167,20 @@ int BlueStore::_open_bdev(bool create)
       }
       string bdev_plugin_id;
       r = bdev->get_ebd_id(bdev_plugin_id);
+      bool is_osd = cct->get_module_type() & CEPH_ENTITY_TYPE_OSD;
       if (r != 0) {
         derr << __func__ << " plugin " << meta_plugin_id << " not loaded" << dendl;
-        goto fail_close;
-      }
-      if (meta_plugin_id != bdev_plugin_id) {
-        derr << __func__ << " plugin '" << meta_plugin_id << "' used on mkfs, "
-          << "but now uses plugin '" << bdev_plugin_id << "'" << dendl;
-        goto fail_close;
+        if (is_osd) {
+          goto fail_close;
+        }
+      } else {
+        if (meta_plugin_id != bdev_plugin_id) {
+          derr << __func__ << " plugin '" << meta_plugin_id << "' used on mkfs, "
+            << "but now uses plugin '" << bdev_plugin_id << "'" << dendl;
+          if (is_osd) {
+            goto fail_close;
+          }
+        }
       }
     }
   }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7156,6 +7156,7 @@ int BlueStore::_open_bdev(bool create)
 
   if (!create && cct->_conf->bluestore_use_ebd) {
     // for regular bdev opens check if it was deployed with plugin
+    ebd_health_alert.clear();
     string meta_plugin_id;
     r = read_meta("extblkdev", &meta_plugin_id);
     if (r == 0) {
@@ -7167,19 +7168,15 @@ int BlueStore::_open_bdev(bool create)
       }
       string bdev_plugin_id;
       r = bdev->detect_ebd(bdev_plugin_id);
-      bool is_osd = cct->get_module_type() & CEPH_ENTITY_TYPE_OSD;
       if (r != 0) {
+        ebd_health_alert = "plugin '" + meta_plugin_id + "' not loaded";
         derr << __func__ << " plugin " << meta_plugin_id << " not loaded" << dendl;
-        if (is_osd) {
-          goto fail_close;
-        }
       } else {
         if (meta_plugin_id != bdev_plugin_id) {
+          ebd_health_alert = " plugin '" + meta_plugin_id + "' used on mkfs, "
+            "but now uses plugin '" + bdev_plugin_id + "'";
           derr << __func__ << " plugin '" << meta_plugin_id << "' used on mkfs, "
             << "but now uses plugin '" << bdev_plugin_id << "'" << dendl;
-          if (is_osd) {
-            goto fail_close;
-          }
         }
       }
     }
@@ -19446,6 +19443,13 @@ void BlueStore::_log_alerts(osd_alert_list_t& alerts)
     cct->_conf.get_val<double>("bluestore_warn_on_free_fragmentation") * 1e6) {
     alerts.emplace("BLUESTORE_FREE_FRAGMENTATION",
       fmt::format("{0:.6f}", logger->get(l_bluestore_fragmentation) * 1e-6));
+  }
+  if (!ebd_health_alert.empty()) {
+    std::string& v = alerts["EXTBLKDEV"];
+    if (!v.empty()) {
+      v += "; ";
+    }
+    v.append(ebd_health_alert);
   }
 }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7166,7 +7166,7 @@ int BlueStore::_open_bdev(bool create)
         derr << "Failed preloading extblkdev plugins, error code: " << plugin_preload_r << dendl;
       }
       string bdev_plugin_id;
-      r = bdev->get_ebd_id(bdev_plugin_id);
+      r = bdev->detect_ebd(bdev_plugin_id);
       bool is_osd = cct->get_module_type() & CEPH_ENTITY_TYPE_OSD;
       if (r != 0) {
         derr << __func__ << " plugin " << meta_plugin_id << " not loaded" << dendl;
@@ -8652,7 +8652,7 @@ int BlueStore::mkfs()
   if (cct->_conf->bluestore_use_ebd) {
     // check if EBD plugin is enabled
     string plugin_id;
-    r = bdev->get_ebd_id(plugin_id);
+    r = bdev->detect_ebd(plugin_id);
     if (r == 0) {
       // retrieved name, save plugin into bdev metadata
       r = write_meta("extblkdev", plugin_id);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -60,6 +60,7 @@
 #include "Writer.h"
 #include "Compression.h"
 #include "BlueAdmin.h"
+#include "extblkdev/ExtBlkDevPlugin.h"
 
 #if defined(WITH_LTTNG)
 #define TRACEPOINT_DEFINE
@@ -7135,7 +7136,15 @@ int BlueStore::_open_bdev(bool create)
   ceph_assert(bdev == NULL);
   string p = path + "/block";
   bdev = BlockDevice::create(cct, p, aio_cb, static_cast<void*>(this), discard_cb, static_cast<void*>(this), "bluestore");
-  int r = bdev->open(p);
+  int r = 0;
+  int plugin_preload_r = 0;
+  if (cct->_conf->bluestore_use_ebd) {
+    //load plugins
+    plugin_preload_r = extblkdev::preload(cct);
+    // do not complain yet. wait until we check "extblkdev" meta.
+  }
+
+  r = bdev->open(p);
   if (r < 0)
     goto fail;
 
@@ -7143,6 +7152,31 @@ int BlueStore::_open_bdev(bool create)
     interval_set<uint64_t> whole_device;
     whole_device.insert(0, bdev->get_size());
     bdev->try_discard(whole_device, false);
+  }
+
+  if (!create && cct->_conf->bluestore_use_ebd) {
+    // for regular bdev opens check if it was deployed with plugin
+    string meta_plugin_id;
+    r = read_meta("extblkdev", &meta_plugin_id);
+    if (r == 0) {
+      // plugin selection fixed to meta, plugins must be loaded
+      if (plugin_preload_r != 0) {
+        // we will complain twice - once generally about not loading plugins,
+        // and later that specific plugin is not ready
+        derr << "Failed preloading extblkdev plugins, error code: " << plugin_preload_r << dendl;
+      }
+      string bdev_plugin_id;
+      r = bdev->get_ebd_id(bdev_plugin_id);
+      if (r != 0) {
+        derr << __func__ << " plugin " << meta_plugin_id << " not loaded" << dendl;
+        goto fail_close;
+      }
+      if (meta_plugin_id != bdev_plugin_id) {
+        derr << __func__ << " plugin '" << meta_plugin_id << "' used on mkfs, "
+          << "but now uses plugin '" << bdev_plugin_id << "'" << dendl;
+        goto fail_close;
+      }
+    }
   }
 
   if (bdev->supported_bdev_label()) {
@@ -8607,6 +8641,20 @@ int BlueStore::mkfs()
       r = write_meta("type", "bluestore");
       if (r < 0)
         return r;
+    }
+  }
+  if (cct->_conf->bluestore_use_ebd) {
+    // check if EBD plugin is enabled
+    string plugin_id;
+    r = bdev->get_ebd_id(plugin_id);
+    if (r == 0) {
+      // retrieved name, save plugin into bdev metadata
+      r = write_meta("extblkdev", plugin_id);
+      if (r < 0)
+        return r;
+    } else {
+      // Non zero result is not a problem, it just means we do not have EBD plugin.
+      r = 0;
     }
   }
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2393,6 +2393,8 @@ private:
   std::string freelist_type;
   FreelistManager *fm = nullptr;
 
+  std::string ebd_health_alert; ///< used to report ExtBlkDev plugin problem up the health chain
+
   Allocator *alloc = nullptr;   ///< allocator consumed by BlueStore
   bluefs_shared_alloc_context_t shared_alloc; ///< consumed by BlueFS (may be == alloc)
 


### PR DESCRIPTION
Backport of #68416
Includes backport of #68177

Note: based on #68024
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
