### PR TITLE
ceph-volume: utilize fast devices both for block.db and data

### DIFF
--- a/doc/ceph-volume/lvm/batch.rst
+++ b/doc/ceph-volume/lvm/batch.rst
@@ -160,6 +160,45 @@ It is also possible to provide explicit sizes to `ceph-volume` via the arguments
 this is not possible, no OSDs will be deployed.
 
 
+Collocating data OSDs on fast devices
+-------------------------------------
+In mixed HDD and NVMe deployments, NVMe devices can be used as shared
+``block.db`` devices for multiple HDD-based OSDs. This may leave remaining
+space on the NVMe that could be utilized for an additional data-only OSD
+(for example, to store metadata pools on fast storage).
+
+The ``--osd-collocate-on-fast`` flag enables this behavior. When specified,
+``ceph-volume`` will create an additional data-only OSD on each fast device
+(``--db-devices`` or ``--wal-devices``) using the remaining space after DB/WAL
+allocations::
+
+    $ ceph-volume lvm batch /dev/sdb /dev/sdc /dev/sdd --db-devices /dev/nvme0n1 --osd-collocate-on-fast
+
+This will deploy:
+
+* Three OSDs on the HDDs with their ``block.db`` on the NVMe
+* One additional data-only OSD on the NVMe using the remaining space
+
+When ``block.db`` sizes are auto-sized, enabling
+``--osd-collocate-on-fast`` sizes each ``block.db`` from the corresponding data
+OSD size (using the default 4% guideline) and leaves the remaining
+fast-device space for the collocated OSD. Explicitly configured metadata sizes
+are left unchanged.
+
+The ``--min-collocated-osd-size`` option (default: 10 GB) controls the minimum
+remaining space required to create a collocated OSD. If the remaining space on
+a fast device is less than this threshold, no collocated OSD will be created
+on that device::
+
+    $ ceph-volume lvm batch /dev/sdb /dev/sdc --db-devices /dev/nvme0n1 --osd-collocate-on-fast --min-collocated-osd-size 50G
+
+In the report output, collocated OSDs are marked with
+``(collocated on fast device)`` to distinguish them from regular OSDs.
+
+.. note:: The ``--osd-collocate-on-fast`` option requires ``--db-devices``
+          or ``--wal-devices`` to be specified.
+
+
 Idempotency and disk replacements
 =================================
 `ceph-volume lvm batch` intends to be idempotent, i.e. calling the same command

--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -14,6 +14,9 @@ from typing import Any, Dict, List, Optional, Tuple
 mlogger = terminal.MultiLogger(__name__)
 logger = logging.getLogger(__name__)
 
+DEFAULT_AUTO_BLOCK_DB_RATIO = 0.04
+UNSET_REQUESTED_SIZE = object()
+
 
 device_list_template = """
   * {path: <25} {size: <10} {state}"""
@@ -41,18 +44,19 @@ def separate_devices_from_lvs(devices: List[device.Device]) -> Tuple[List[device
     return phys, lvm
 
 
-def get_physical_fast_allocs(devices: List[device.Device], type_: str, fast_slots_per_device: int, new_osds: int, args: argparse.Namespace) -> List[Tuple[str, float, disk.Size, int]]:
+def get_physical_fast_allocs(devices: List[device.Device], type_: str, fast_slots_per_device: int, new_osds: int, args: argparse.Namespace, requested_size: Any = UNSET_REQUESTED_SIZE) -> List[Tuple[str, float, disk.Size, int]]:
     requested_slots = getattr(args, '{}_slots'.format(type_))
     if not requested_slots or requested_slots < fast_slots_per_device:
         if requested_slots:
             mlogger.info('{}_slots argument is too small, ignoring'.format(type_))
         requested_slots = fast_slots_per_device
 
-    requested_size = getattr(args, '{}_size'.format(type_), 0)
-    if not requested_size or requested_size == 0:
-        # no size argument was specified, check ceph.conf
-        get_size_fct = getattr(prepare, 'get_{}_size'.format(type_))
-        requested_size = get_size_fct(lv_format=False)
+    if requested_size is UNSET_REQUESTED_SIZE:
+        requested_size = getattr(args, '{}_size'.format(type_), 0)
+        if not requested_size or requested_size == 0:
+            # no size argument was specified, check ceph.conf
+            get_size_fct = getattr(prepare, 'get_{}_size'.format(type_))
+            requested_size = get_size_fct(lv_format=False)
 
     ret: List[Tuple[str, float, disk.Size, int]] = []
     vg_device_map = group_devices_by_vg(devices)
@@ -290,6 +294,19 @@ class Batch(object):
             default=None,
             help="Additional cryptsetup luksOpen options (use the same syntax as the cryptsetup CLI)",
         )
+        parser.add_argument(
+            '--osd-collocate-on-fast',
+            dest='osd_collocate_on_fast',
+            action='store_true',
+            help='Create an additional data-only OSD on each fast device (db/wal) using remaining space',
+        )
+        parser.add_argument(
+            '--min-collocated-osd-size',
+            dest='min_collocated_osd_size',
+            type=disk.Size.parse,
+            default=disk.Size(gb=10),
+            help='Minimum size for collocated OSD on fast device (default: 10G)',
+        )
         self.args = parser.parse_args(argv)
         if self.args.bluestore:
             self.args.objectstore = 'bluestore'
@@ -433,10 +450,12 @@ class Batch(object):
         requested_osds = self.args.osds_per_device * len(phys_devs) + len(lvm_devs)
 
         fast_type = 'block_db'
+        requested_fast_size = self._get_requested_fast_size(fast_type)
         fast_allocations = self.fast_allocations(fast_devices,
                                                  requested_osds,
                                                  num_osds,
-                                                 fast_type)
+                                                 fast_type,
+                                                 requested_fast_size)
         if fast_devices and not fast_allocations:
             mlogger.info('{} fast devices were passed, but none are available'.format(len(fast_devices)))
             return []
@@ -445,10 +464,12 @@ class Batch(object):
                 len(fast_allocations), num_osds))
             exit(1)
 
+        requested_very_fast_size = self._get_requested_fast_size('block_wal')
         very_fast_allocations = self.fast_allocations(very_fast_devices,
                                                       requested_osds,
                                                       num_osds,
-                                                      'block_wal')
+                                                      'block_wal',
+                                                      requested_very_fast_size)
         if very_fast_devices and not very_fast_allocations:
             mlogger.info('{} very fast devices were passed, but none are available'.format(len(very_fast_devices)))
             return []
@@ -459,6 +480,8 @@ class Batch(object):
 
         if fast_devices:
             fast_alloc: Optional[tuple[str, float, disk.Size, int]] = None
+            planned_fast_allocations: List[Tuple[str, float, disk.Size, int]] = []
+            fast_device_sizes = {dev.path: dev.vg_size[0] for dev in fast_devices if dev.available_lvm}
             for osd in plan:
                 if self.args.has_block_db_size_without_db_devices:
                     for i, _fast_alloc in enumerate(fast_allocations):
@@ -469,13 +492,122 @@ class Batch(object):
                     fast_alloc = fast_allocations.pop() if fast_allocations else None
 
                 if fast_alloc:
+                    fast_alloc = self._auto_size_collocated_fast_alloc(
+                        osd,
+                        fast_alloc,
+                        fast_type,
+                        requested_fast_size,
+                        fast_device_sizes,
+                    )
+                    planned_fast_allocations.append(fast_alloc)
                     osd.add_fast_device(*fast_alloc, type_=fast_type)
 
+            planned_very_fast_allocations = []
             if very_fast_devices and self.args.objectstore == 'bluestore':
-                osd.add_very_fast_device(*very_fast_allocations.pop())
+                very_fast_alloc = very_fast_allocations.pop()
+                planned_very_fast_allocations.append(very_fast_alloc)
+                osd.add_very_fast_device(*very_fast_alloc)
+        else:
+            planned_fast_allocations = []
+            planned_very_fast_allocations = []
+
+        if getattr(self.args, 'osd_collocate_on_fast', False):
+            if not fast_devices and not very_fast_devices:
+                mlogger.error('--osd-collocate-on-fast requires --db-devices or --wal-devices')
+                raise SystemExit(1)
+
+            all_fast_allocs = planned_fast_allocations + planned_very_fast_allocations
+            collocated_osds = self._create_collocated_osds(
+                fast_devices or [],
+                very_fast_devices or [],
+                all_fast_allocs
+            )
+            plan.extend(collocated_osds)
+
         return plan
 
-    def fast_allocations(self, devices: List[device.Device], requested_osds: int, new_osds: int, type_: str) -> List[Tuple[str, float, disk.Size, int]]:
+    def _create_collocated_osds(
+        self,
+        db_devices: List[device.Device],
+        wal_devices: List[device.Device],
+        fast_allocations: List[Tuple[str, float, disk.Size, int]]
+    ) -> List["OSD"]:
+        '''
+        Create data-only OSDs on fast devices using remaining space after
+        DB/WAL allocations.
+        '''
+        collocated: List["OSD"] = []
+
+        all_fast_devices = {dev.path: dev for dev in db_devices + wal_devices}
+
+        planned_usage: Dict[str, int] = {}
+        for path, _, abs_size, _ in fast_allocations:
+            if path not in planned_usage:
+                planned_usage[path] = 0
+            planned_usage[path] += int(abs_size)
+
+        for dev_path, dev in all_fast_devices.items():
+            if not dev.available_lvm:
+                continue
+
+            device_size = dev.vg_size[0]
+            used_space = planned_usage.get(dev_path, 0)
+            remaining_size = disk.Size(b=device_size - used_space)
+
+            min_size = getattr(self.args, 'min_collocated_osd_size', disk.Size(gb=10))
+            if remaining_size < min_size:
+                mlogger.warning(
+                    f'Remaining space on {dev_path} ({remaining_size}) is less than '
+                    f'minimum ({min_size}), skipping collocated OSD'
+                )
+                continue
+
+            rel_size = int(remaining_size) / device_size
+            osd_id = self.args.osd_ids.pop() if self.args.osd_ids else None
+
+            osd = Batch.OSD(
+                data_path=dev_path,
+                rel_size=rel_size,
+                abs_size=remaining_size,
+                slots=1,
+                id_=osd_id,
+                encryption='dmcrypt' if self.args.dmcrypt else None,
+                symlink=dev.symlink,
+                collocated=True
+            )
+            collocated.append(osd)
+            mlogger.info(f'Adding collocated data OSD on {dev_path} with size {remaining_size}')
+
+        return collocated
+
+    def _get_requested_fast_size(self, type_: str) -> Optional[disk.Size]:
+        requested_size = getattr(self.args, '{}_size'.format(type_), None)
+        if requested_size is not None:
+            return requested_size
+        get_size_fct = getattr(prepare, 'get_{}_size'.format(type_))
+        return get_size_fct(lv_format=False)
+
+    def _auto_size_collocated_fast_alloc(self,
+                                         osd: "OSD",
+                                         fast_alloc: Tuple[str, float, disk.Size, int],
+                                         type_: str,
+                                         requested_size: Optional[disk.Size],
+                                         fast_device_sizes: Dict[str, int]) -> Tuple[str, float, disk.Size, int]:
+        if type_ != 'block_db' or requested_size is not None:
+            return fast_alloc
+        if not getattr(self.args, 'osd_collocate_on_fast', False):
+            return fast_alloc
+        fast_path, _, abs_size, slots = fast_alloc
+        fast_device_size = fast_device_sizes.get(fast_path)
+        if fast_device_size is None:
+            return fast_alloc
+
+        target_size = disk.Size(b=int(int(osd.data.abs_size) * DEFAULT_AUTO_BLOCK_DB_RATIO))
+        target_size = min(target_size, abs_size)
+        relative_size = int(target_size) / fast_device_size
+        return (fast_path, relative_size, target_size, slots)
+
+    def fast_allocations(self, devices: List[device.Device], requested_osds: int, new_osds: int, type_: str, requested_size: Any = UNSET_REQUESTED_SIZE) -> List[Tuple[str, float, disk.Size, int]]:
         ret: List[Tuple[str, float, disk.Size, int]] = []
         if not devices:
             return ret
@@ -499,7 +631,8 @@ class Batch(object):
                                             type_,
                                             fast_slots_per_device,
                                             new_osds,
-                                            self.args))
+                                            self.args,
+                                            requested_size))
         return ret
 
     class OSD(object):
@@ -521,7 +654,8 @@ class Batch(object):
                      slots: int,
                      id_: Optional[str] = None,
                      encryption: Optional[str] = None,
-                     symlink: Optional[str] = None) -> None:
+                     symlink: Optional[str] = None,
+                     collocated: bool = False) -> None:
             self.id_ = id_
             self.data = self.VolSpec(path=data_path,
                                 rel_size=rel_size,
@@ -532,6 +666,7 @@ class Batch(object):
             self.very_fast: Optional[Any] = None
             self.encryption: Optional[str] = encryption
             self.symlink: Optional[str] = symlink
+            self.collocated: bool = collocated
 
         def add_fast_device(self, path: str, rel_size: float, abs_size: disk.Size, slots: int, type_: str) -> None:
             self.fast = self.VolSpec(path=path,
@@ -577,6 +712,8 @@ class Batch(object):
 
         def report(self) -> str:
             report = ''
+            if self.collocated:
+                report += templates.osd_collocated
             if self.id_:
                 report += templates.osd_reused_id.format(
                     id_=self.id_)

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
@@ -259,8 +259,8 @@ class TestBatch(object):
             assert fast[2] == int(dev.vg_size[0] / 2)
 
     def test_get_physical_fast_allocs_abs_size_unused_devs(self, factory,
-                                               conf_ceph_stub,
-                                               mock_devices_available):
+                                                conf_ceph_stub,
+                                                mock_devices_available):
         conf_ceph_stub('[global]\nfsid=asdf-lkjh')
         args = factory(block_db_slots=None, get_block_db_size=None)
         dev_size = 21474836480
@@ -394,3 +394,213 @@ class TestBatchOsd(object):
                                                         '5G',
                                                         1,
                                                         'block_wal')
+
+    def test_osd_collocated_flag(self):
+        osd = batch.Batch.OSD('/dev/data', 1.0, disk.Size(gb=100), 1, None, None, None, collocated=True)
+        assert osd.collocated is True
+
+    def test_osd_collocated_default_false(self):
+        osd = batch.Batch.OSD('/dev/data', 1.0, disk.Size(gb=100), 1)
+        assert osd.collocated is False
+
+
+class TestCollocatedOsds(object):
+
+    def test_collocate_flag_parsed(self):
+        b = batch.Batch(['--osd-collocate-on-fast'])
+        assert b.args.osd_collocate_on_fast is True
+
+    def test_collocate_flag_default_false(self):
+        b = batch.Batch([])
+        assert b.args.osd_collocate_on_fast is False
+
+    def test_min_collocated_size_parsed(self):
+        b = batch.Batch(['--min-collocated-osd-size', '20G'])
+        assert b.args.min_collocated_osd_size == disk.Size(gb=20)
+
+    def test_min_collocated_size_default(self):
+        b = batch.Batch([])
+        assert b.args.min_collocated_osd_size == disk.Size(gb=10)
+
+    def test_collocate_requires_db_devices(self, factory, conf_ceph_stub, mock_device_generator):
+        conf_ceph_stub('[global]\nfsid=asdf-lkjh')
+        devs = [mock_device_generator() for _ in range(2)]
+        args = factory(
+            data_slots=1,
+            osds_per_device=1,
+            osd_ids=[],
+            devices=devs,
+            db_devices=[],
+            wal_devices=[],
+            objectstore='bluestore',
+            block_db_size=None,
+            block_db_slots=None,
+            dmcrypt=False,
+            data_allocate_fraction=1.0,
+            osd_collocate_on_fast=True,
+            min_collocated_osd_size=disk.Size(gb=10),
+            has_block_db_size_without_db_devices=False
+        )
+        b = batch.Batch([])
+        b.args = args
+        with pytest.raises(SystemExit):
+            b.get_deployment_layout()
+
+    def test_collocate_creates_extra_osd(self, factory, conf_ceph_stub, mock_device_generator):
+        conf_ceph_stub('[global]\nfsid=asdf-lkjh')
+        data_devs = [mock_device_generator(path='sda'), mock_device_generator(path='sdb')]
+        db_dev = mock_device_generator(path='nvme0n1', vg_size=[107374182400])
+        db_dev.vg_free = [107374182400]
+        db_size = disk.Size(gb=10)
+        args = factory(
+            data_slots=1,
+            osds_per_device=1,
+            osd_ids=[],
+            devices=data_devs,
+            db_devices=[db_dev],
+            wal_devices=[],
+            objectstore='bluestore',
+            block_db_size=db_size,
+            block_db_slots=None,
+            dmcrypt=False,
+            data_allocate_fraction=1.0,
+            osd_collocate_on_fast=True,
+            min_collocated_osd_size=disk.Size(gb=10),
+            has_block_db_size_without_db_devices=False
+        )
+        b = batch.Batch([])
+        b.args = args
+        plan = b.get_deployment_layout()
+        assert len(plan) == 3
+        collocated_osds = [osd for osd in plan if osd.collocated]
+        assert len(collocated_osds) == 1
+        assert 'nvme0n1' in collocated_osds[0].data.path
+        assert collocated_osds[0].data.abs_size == disk.Size(b=db_dev.vg_size[0] - 2 * int(db_size))
+
+    def test_collocate_creates_extra_osd_with_auto_db_size(self, factory, conf_ceph_stub, mock_device_generator):
+        conf_ceph_stub('[global]\nfsid=asdf-lkjh')
+        data_size = int(disk.Size(tb=1))
+        data_devs = [
+            mock_device_generator(path='sda', vg_size=[data_size], vg_free=[data_size]),
+            mock_device_generator(path='sdb', vg_size=[data_size], vg_free=[data_size]),
+        ]
+        db_size = int(disk.Size(gb=100))
+        db_dev = mock_device_generator(path='nvme0n1', vg_size=[db_size], vg_free=[db_size])
+        args = factory(
+            data_slots=1,
+            osds_per_device=1,
+            osd_ids=[],
+            devices=data_devs,
+            db_devices=[db_dev],
+            wal_devices=[],
+            objectstore='bluestore',
+            block_db_size=None,
+            block_db_slots=None,
+            dmcrypt=False,
+            data_allocate_fraction=1.0,
+            osd_collocate_on_fast=True,
+            min_collocated_osd_size=disk.Size(gb=10),
+            has_block_db_size_without_db_devices=False
+        )
+        b = batch.Batch([])
+        b.args = args
+        plan = b.get_deployment_layout()
+        assert len(plan) == 3
+        collocated_osds = [osd for osd in plan if osd.collocated]
+        assert len(collocated_osds) == 1
+        db_osds = [osd for osd in plan if not osd.collocated]
+        expected_db_size = disk.Size(b=int(data_size * batch.DEFAULT_AUTO_BLOCK_DB_RATIO))
+        for osd in db_osds:
+            assert osd.fast.abs_size == expected_db_size
+        assert collocated_osds[0].data.abs_size == disk.Size(b=db_size - 2 * int(expected_db_size))
+
+    def test_collocate_skipped_insufficient_space(self, factory, conf_ceph_stub, mock_device_generator):
+        conf_ceph_stub('[global]\nfsid=asdf-lkjh')
+        data_devs = [mock_device_generator(path='sda'), mock_device_generator(path='sdb')]
+        db_dev = mock_device_generator(path='nvme0n1', vg_size=[26843545600])
+        db_dev.vg_free = [26843545600]
+        args = factory(
+            data_slots=1,
+            osds_per_device=1,
+            osd_ids=[],
+            devices=data_devs,
+            db_devices=[db_dev],
+            wal_devices=[],
+            objectstore='bluestore',
+            block_db_size=disk.Size(gb=10),
+            block_db_slots=None,
+            dmcrypt=False,
+            data_allocate_fraction=1.0,
+            osd_collocate_on_fast=True,
+            min_collocated_osd_size=disk.Size(gb=50),
+            has_block_db_size_without_db_devices=False
+        )
+        b = batch.Batch([])
+        b.args = args
+        plan = b.get_deployment_layout()
+        assert len(plan) == 2
+        collocated_osds = [osd for osd in plan if osd.collocated]
+        assert len(collocated_osds) == 0
+
+    def test_collocate_multiple_db_devices(self, factory, conf_ceph_stub, mock_device_generator):
+        conf_ceph_stub('[global]\nfsid=asdf-lkjh')
+        data_devs = [mock_device_generator(path=f'sd{c}') for c in 'abcd']
+        db_devs = [
+            mock_device_generator(path='nvme0n1', vg_size=[107374182400]),
+            mock_device_generator(path='nvme1n1', vg_size=[107374182400])
+        ]
+        for dev in db_devs:
+            dev.vg_free = [107374182400]
+        db_size = disk.Size(gb=10)
+        args = factory(
+            data_slots=1,
+            osds_per_device=1,
+            osd_ids=[],
+            devices=data_devs,
+            db_devices=db_devs,
+            wal_devices=[],
+            objectstore='bluestore',
+            block_db_size=db_size,
+            block_db_slots=None,
+            dmcrypt=False,
+            data_allocate_fraction=1.0,
+            osd_collocate_on_fast=True,
+            min_collocated_osd_size=disk.Size(gb=10),
+            has_block_db_size_without_db_devices=False
+        )
+        b = batch.Batch([])
+        b.args = args
+        plan = b.get_deployment_layout()
+        assert len(plan) == 6
+        collocated_osds = [osd for osd in plan if osd.collocated]
+        assert len(collocated_osds) == 2
+        for osd in collocated_osds:
+            assert osd.data.abs_size == disk.Size(b=db_devs[0].vg_size[0] - 2 * int(db_size))
+
+    def test_backwards_compat_no_collocate(self, factory, conf_ceph_stub, mock_device_generator):
+        conf_ceph_stub('[global]\nfsid=asdf-lkjh')
+        data_devs = [mock_device_generator(path='sda'), mock_device_generator(path='sdb')]
+        db_dev = mock_device_generator(path='nvme0n1', vg_size=[107374182400])
+        db_dev.vg_free = [107374182400]
+        args = factory(
+            data_slots=1,
+            osds_per_device=1,
+            osd_ids=[],
+            devices=data_devs,
+            db_devices=[db_dev],
+            wal_devices=[],
+            objectstore='bluestore',
+            block_db_size=disk.Size(gb=10),
+            block_db_slots=None,
+            dmcrypt=False,
+            data_allocate_fraction=1.0,
+            osd_collocate_on_fast=False,
+            min_collocated_osd_size=disk.Size(gb=10),
+            has_block_db_size_without_db_devices=False
+        )
+        b = batch.Batch([])
+        b.args = args
+        plan = b.get_deployment_layout()
+        assert len(plan) == 2
+        collocated_osds = [osd for osd in plan if osd.collocated]
+        assert len(collocated_osds) == 0

--- a/src/ceph-volume/ceph_volume/util/templates.py
+++ b/src/ceph-volume/ceph_volume/util/templates.py
@@ -19,6 +19,10 @@ osd_encryption = """
   encryption:     {enc: <15}"""
 
 
+osd_collocated = """
+  (collocated on fast device)"""
+
+
 total_osds = """
 Total OSDs: {total_osds}
 """


### PR DESCRIPTION
By default you are not able to utilize fast device (NVMe) both as a `block.db` device for HDD OSDs and as a data OSD for example for RGW metadata.

We are using this in production for some time, but we had to create a custom LVM partitioning scripts for that.

### Summary

- Adds  `--osd-collocate-on-fast` support to `ceph-volume lvm batch` while keeping the backwards compatibility
- Allows creating an additional data-only OSD on fast DB/WAL devices using space left after metadata allocations
- Size auto-generated `block.db` LVs from the corresponding data OSD size, leaving the remaining fast-device capacity for the collocated OSD
- Add report output markers and tests for collocated fast-device OSD planning

Without the `--osd-collocate-on-fast` parameter
```
sudo ceph-volume lvm batch /dev/sdc /dev/sdd /dev/sde /dev/sdf /dev/sdg --db-devices /dev/nvme0n1 --report
--> passed data devices: 5 physical, 0 LVM
--> passed block_db devices: 1 physical, 0 LVM

Total OSDs: 5

  Type            Path                                                    LV Size         % of device
----------------------------------------------------------------------------------------------------
  data            /dev/sdc                                                16.37 TB        100.00%
  block_db        /dev/nvme0n1                                            715.40 GB       20.00%
----------------------------------------------------------------------------------------------------
  data            /dev/sdd                                                16.37 TB        100.00%
  block_db        /dev/nvme0n1                                            715.40 GB       20.00%
----------------------------------------------------------------------------------------------------
  data            /dev/sde                                                16.37 TB        100.00%
  block_db        /dev/nvme0n1                                            715.40 GB       20.00%
----------------------------------------------------------------------------------------------------
  data            /dev/sdf                                                16.37 TB        100.00%
  block_db        /dev/nvme0n1                                            715.40 GB       20.00%
----------------------------------------------------------------------------------------------------
  data            /dev/sdg                                                16.37 TB        100.00%
  block_db        /dev/nvme0n1                                            715.40 GB       20.00%
```

With it.
```
sudo ceph-volume lvm batch /dev/sdc /dev/sdd /dev/sde /dev/sdf /dev/sdg --db-devices /dev/nvme0n1 --osd-collocate-on-fast --report
--> passed data devices: 5 physical, 0 LVM
--> passed block_db devices: 1 physical, 0 LVM
--> Adding collocated data OSD on /dev/nvme0n1 with size 224.18 GB

Total OSDs: 6

  Type            Path                                                    LV Size         % of device
----------------------------------------------------------------------------------------------------
  data            /dev/sdc                                                16.37 TB        100.00%
  block_db        /dev/nvme0n1                                            670.56 GB       18.75%
----------------------------------------------------------------------------------------------------
  data            /dev/sdd                                                16.37 TB        100.00%
  block_db        /dev/nvme0n1                                            670.56 GB       18.75%
----------------------------------------------------------------------------------------------------
  data            /dev/sde                                                16.37 TB        100.00%
  block_db        /dev/nvme0n1                                            670.56 GB       18.75%
----------------------------------------------------------------------------------------------------
  data            /dev/sdf                                                16.37 TB        100.00%
  block_db        /dev/nvme0n1                                            670.56 GB       18.75%
----------------------------------------------------------------------------------------------------
  data            /dev/sdg                                                16.37 TB        100.00%
  block_db        /dev/nvme0n1                                            670.56 GB       18.75%
----------------------------------------------------------------------------------------------------
  (collocated on fast device)
  data            /dev/nvme0n1                                            224.18 GB       6.27%
```

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
