### PR TITLE
mgr/nfs: restrict CephfsClient instances per nfs module

### DIFF
--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -504,8 +504,7 @@ class ExportMgr:
 
     # This method is used by the dashboard module (../dashboard/controllers/nfs.py)
     # Do not change interface without updating the Dashboard code
-    def apply_export(self, cluster_id: str, export_config: str,
-                     earmark_resolver: Optional[CephFSEarmarkResolver] = None) -> AppliedExportResults:
+    def apply_export(self, cluster_id: str, export_config: str) -> AppliedExportResults:
         try:
             exports = self._read_export_config(cluster_id, export_config)
         except Exception as e:
@@ -514,7 +513,7 @@ class ExportMgr:
 
         aeresults = AppliedExportResults()
         for export in exports:
-            changed_export = self._change_export(cluster_id, export, earmark_resolver)
+            changed_export = self._change_export(cluster_id, export)
             # This will help figure out which export blocks in conf/json file
             # are problematic.
             if changed_export.get("state", "") == "error":
@@ -543,10 +542,9 @@ class ExportMgr:
             return j  # j is already a list object
         return [j]  # return a single object list, with j as the only item
 
-    def _change_export(self, cluster_id: str, export: Dict,
-                       earmark_resolver: Optional[CephFSEarmarkResolver] = None) -> Dict[str, Any]:
+    def _change_export(self, cluster_id: str, export: Dict) -> Dict[str, Any]:
         try:
-            return self._apply_export(cluster_id, export, earmark_resolver)
+            return self._apply_export(cluster_id, export)
         except NotImplementedError:
             # in theory, the NotImplementedError here may be raised by a hook back to
             # an orchestration module. If the orchestration module supports it the NFS
@@ -622,8 +620,10 @@ class ExportMgr:
         log.info(f"Export user created is {json_res[0]['entity']}")
         return json_res[0]['key']
 
-    def _check_earmark(self, earmark_resolver: CephFSEarmarkResolver, path: str,
-                       fs_name: str) -> None:
+    def _check_earmark(self, path: str, fs_name: str) -> None:
+        """Apply NFS earmark for a CephFS path. Not used for RGW exports."""
+        earmark_resolver = CephFSEarmarkResolver(
+            self.mgr, client=self._get_cephfs_client())
         earmark = earmark_resolver.get_earmark(
             path,
             fs_name,
@@ -647,8 +647,7 @@ class ExportMgr:
     def create_export_from_dict(self,
                                 cluster_id: str,
                                 ex_id: int,
-                                ex_dict: Dict[str, Any],
-                                earmark_resolver: Optional[CephFSEarmarkResolver] = None
+                                ex_dict: Dict[str, Any]
                                 ) -> Export:
         pseudo_path = ex_dict.get("pseudo")
         if not pseudo_path:
@@ -674,8 +673,7 @@ class ExportMgr:
             self.validate_cephfs_path(fs_name, path)
 
             # Check if earmark is set for the path, given path is of subvolume
-            if earmark_resolver:
-                self._check_earmark(earmark_resolver, path, fs_name)
+            self._check_earmark(path, fs_name)
 
             if fsal["cmount_path"] != "/":
                 _validate_cmount_path(fsal["cmount_path"], path)  # type: ignore
@@ -717,8 +715,7 @@ class ExportMgr:
                              sectype: Optional[List[str]] = None,
                              xprtsec: Optional[str] = None,
                              cmount_path: Optional[str] = "/",
-                             transports: Optional[List[str]] = None,
-                             earmark_resolver: Optional[CephFSEarmarkResolver] = None
+                             transports: Optional[List[str]] = None
                              ) -> Dict[str, Any]:
 
         self.validate_cephfs_path(fs_name, path)
@@ -750,8 +747,7 @@ class ExportMgr:
             export = self.create_export_from_dict(
                 cluster_id,
                 self._gen_export_id(cluster_id),
-                export_dict,
-                earmark_resolver
+                export_dict
             )
             log.debug("creating cephfs export %s", export)
             self._ensure_cephfs_export_user(export)
@@ -824,8 +820,7 @@ class ExportMgr:
     def _apply_export(
             self,
             cluster_id: str,
-            new_export_dict: Dict,
-            earmark_resolver: Optional[CephFSEarmarkResolver] = None
+            new_export_dict: Dict
     ) -> Dict[str, str]:
         for k in ['path', 'pseudo']:
             if k not in new_export_dict:
@@ -869,8 +864,7 @@ class ExportMgr:
         new_export = self.create_export_from_dict(
             cluster_id,
             new_export_dict.get('export_id', self._gen_export_id(cluster_id)),
-            new_export_dict,
-            earmark_resolver
+            new_export_dict
         )
 
         if not old_export:

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -2,6 +2,7 @@ import errno
 import hashlib
 import json
 import logging
+import stat
 from typing import (
     List,
     Any,
@@ -12,11 +13,12 @@ from typing import (
     Callable,
     Set,
     cast)
+from threading import Lock
 from os.path import normpath
 from ceph.fs.earmarking import EarmarkTopScope
 import cephfs
 
-from mgr_util import CephFSEarmarkResolver
+from mgr_util import CephFSEarmarkResolver, CephfsClient, open_filesystem
 from rados import TimedOut, ObjectNotFound
 
 from object_format import ErrorResponse
@@ -43,8 +45,7 @@ from .utils import (
     available_clusters,
     check_fs,
     get_nfs_spec_for_cluster,
-    restart_nfs_service,
-    cephfs_path_is_dir)
+    restart_nfs_service)
 from .rados_utils import NFSRados
 
 if TYPE_CHECKING:
@@ -73,17 +74,6 @@ def normalize_path(path: str) -> str:
         if path[:2] == "//":
             path = path[1:]
     return path
-
-
-def validate_cephfs_path(mgr: 'Module', fs_name: str, path: str) -> None:
-    try:
-        cephfs_path_is_dir(mgr, fs_name, path)
-    except NotADirectoryError:
-        raise NFSException(f"path {path} is not a dir", -errno.ENOTDIR)
-    except cephfs.ObjectNotFound:
-        raise NFSObjectNotFound(f"path {path} does not exist")
-    except cephfs.Error as e:
-        raise NFSException(e.args[1], -e.args[0])
 
 
 def _validate_cmount_path(cmount_path: str, path: str) -> None:
@@ -161,6 +151,8 @@ class ExportMgr:
         self.rados_pool = POOL_NAME
         self._exports: Optional[Dict[str, List[Export]]] = export_ls
         self.skip_notify_nfs_server = False
+        self._cephfs_client_lock = Lock()
+        self._cephfs_client: Optional[CephfsClient] = None
 
     def _get_cluster_protocols(self, cluster_id: str) -> List[int]:
         """Get the list of supported NFS protocols for a cluster.
@@ -373,6 +365,25 @@ class ExportMgr:
         if cluster_id not in clusters:
             raise ErrorResponse(f"Cluster {cluster_id!r} does not exist",
                                 return_value=-errno.ENOENT)
+
+    def _get_cephfs_client(self) -> CephfsClient:
+        with self._cephfs_client_lock:
+            if self._cephfs_client is None:
+                self._cephfs_client = CephfsClient(self.mgr)
+        return self._cephfs_client
+
+    def validate_cephfs_path(self, fs_name: str, path: str) -> None:
+        try:
+            cephfs_client = self._get_cephfs_client()
+            with open_filesystem(cephfs_client, fs_name) as fs_handle:
+                stx = fs_handle.statx(path.encode('utf-8'), cephfs.CEPH_STATX_MODE,
+                                      cephfs.AT_SYMLINK_NOFOLLOW)
+                if not stat.S_ISDIR(stx.get('mode')):
+                    raise NotADirectoryError(f"path {path} is not a dir")
+        except cephfs.ObjectNotFound:
+            raise NFSObjectNotFound(f"path {path} does not exist")
+        except cephfs.Error as e:
+            raise NFSException(e.args[1], -e.args[0])
 
     def create_export(self, addr: Optional[List[str]] = None, **kwargs: Any) -> Dict[str, Any]:
         self._validate_cluster_id(kwargs['cluster_id'])
@@ -660,7 +671,7 @@ class ExportMgr:
             if not check_fs(self.mgr, fs_name):
                 raise FSNotFound(fs_name)
 
-            validate_cephfs_path(self.mgr, fs_name, path)
+            self.validate_cephfs_path(fs_name, path)
 
             # Check if earmark is set for the path, given path is of subvolume
             if earmark_resolver:
@@ -710,7 +721,7 @@ class ExportMgr:
                              earmark_resolver: Optional[CephFSEarmarkResolver] = None
                              ) -> Dict[str, Any]:
 
-        validate_cephfs_path(self.mgr, fs_name, path)
+        self.validate_cephfs_path(fs_name, path)
         if cmount_path != "/":
             _validate_cmount_path(cmount_path, path)  # type: ignore
 

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -9,11 +9,9 @@ from mgr_module import MgrModule, Option, CLICheckNonemptyFileInput
 import object_format
 import orchestrator
 from orchestrator.module import IngressType
-from mgr_util import CephFSEarmarkResolver
-
 from .export import ExportMgr, AppliedExportResults
 from .cluster import NFSCluster
-from .utils import available_clusters, cephfs_client_for_mgr
+from .utils import available_clusters
 from .qos_conf import QOSType, QOSBandwidthControl, UserQoSType, QOSOpsControl
 
 log = logging.getLogger(__name__)
@@ -51,8 +49,6 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     ) -> Dict[str, Any]:
         """Create a CephFS export"""
         self.export_mgr.skip_notify_nfs_server = skip_notify_nfs_server
-        earmark_resolver = CephFSEarmarkResolver(
-            self, client=cephfs_client_for_mgr(self))
         return self.export_mgr.create_export(
             fsal_type='cephfs',
             fs_name=fsname,
@@ -66,7 +62,6 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             xprtsec=xprtsec,
             cmount_path=cmount_path,
             transports=transports,
-            earmark_resolver=earmark_resolver
         )
 
     @NFSCLICommand('nfs export create rgw', perm='rw')
@@ -147,11 +142,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                               inbuf: str,
                               skip_notify_nfs_server: bool = False) -> AppliedExportResults:
         """Create or update an export by `-i <json_or_ganesha_export_file>`"""
-        earmark_resolver = CephFSEarmarkResolver(
-            self, client=cephfs_client_for_mgr(self))
         self.export_mgr.skip_notify_nfs_server = skip_notify_nfs_server
-        return self.export_mgr.apply_export(cluster_id, export_config=inbuf,
-                                            earmark_resolver=earmark_resolver)
+        return self.export_mgr.apply_export(cluster_id, export_config=inbuf)
 
     @NFSCLICommand('nfs cluster create', perm='rw')
     @object_format.EmptyResponder()
@@ -269,10 +261,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     def export_apply(self, cluster_id: str, export_config: str) -> AppliedExportResults:
         """Create or update an export by `export_config` which can be json string or ganesha export specification"""
-        earmark_resolver = CephFSEarmarkResolver(
-            self, client=cephfs_client_for_mgr(self))
-        return self.export_mgr.apply_export(cluster_id, export_config=export_config,
-                                            earmark_resolver=earmark_resolver)
+        return self.export_mgr.apply_export(cluster_id, export_config=export_config)
 
     def export_ls(self, cluster_id: Optional[str] = None, detailed: bool = False) -> List[Dict[Any, Any]]:
         if not (cluster_id):

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -357,7 +357,7 @@ QOS_BLOCK {
                 mock.patch('nfs.ganesha_conf.check_fs', return_value=True), \
                 mock.patch('nfs.export.ExportMgr._create_user_key',
                            return_value='thekeyforclientabc'), \
-                mock.patch('nfs.export.cephfs_path_is_dir'):
+                mock.patch('nfs.export.ExportMgr.cephfs_path_is_dir'):
 
             rados.open_ioctx.return_value.__enter__.return_value = self.io_mock
             rados.open_ioctx.return_value.__exit__ = mock.Mock(return_value=None)

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -6,7 +6,6 @@ from typing import Optional, Tuple, Iterator, List, Any
 from contextlib import contextmanager
 from unittest import mock
 from unittest.mock import MagicMock
-import mgr_util
 from mgr_module import MgrModule, NFS_POOL_NAME
 
 from rados import ObjectNotFound
@@ -15,7 +14,6 @@ from ceph.deployment.service_spec import NFSServiceSpec, PlacementSpec
 from ceph.utils import with_units_to_int, bytes_to_human
 from nfs import Module
 from nfs.export import ExportMgr, normalize_path
-from nfs.utils import cephfs_client_for_mgr
 from nfs.ganesha_conf import GaneshaConfParser, Export
 from nfs.qos_conf import (
     RawBlock,
@@ -357,7 +355,8 @@ QOS_BLOCK {
                 mock.patch('nfs.ganesha_conf.check_fs', return_value=True), \
                 mock.patch('nfs.export.ExportMgr._create_user_key',
                            return_value='thekeyforclientabc'), \
-                mock.patch('nfs.export.ExportMgr.cephfs_path_is_dir'):
+                mock.patch('nfs.export.ExportMgr.validate_cephfs_path'), \
+                mock.patch('nfs.export.ExportMgr._check_earmark'):
 
             rados.open_ioctx.return_value.__enter__.return_value = self.io_mock
             rados.open_ioctx.return_value.__exit__ = mock.Mock(return_value=None)
@@ -1859,28 +1858,75 @@ def test_ganesha_validate_access_type():
         _validate_access_type("any")
 
 
-class TestCephfsClientForMgr:
-    @pytest.fixture(autouse=True)
-    def clear_cephfs_client_cache(self):
-        cephfs_client_for_mgr.cache_clear()
-        yield
-        cephfs_client_for_mgr.cache_clear()
-
-    def test_cephfs_client_for_mgr_returns_same_instance(self):
+class TestExportMgrCephfsClient:
+    def test_get_cephfs_client_returns_same_instance(self):
         mgr = MagicMock()
-        with mock.patch('nfs.utils.CephfsClient') as mock_cephfs_cls:
+        export_mgr = ExportMgr(mgr, export_ls={})
+        with mock.patch('nfs.export.CephfsClient') as mock_cephfs_cls:
             mock_cephfs_cls.return_value = MagicMock()
-            first = cephfs_client_for_mgr(mgr)
-            second = cephfs_client_for_mgr(mgr)
+            first = export_mgr._get_cephfs_client()
+            second = export_mgr._get_cephfs_client()
             assert first is second
             mock_cephfs_cls.assert_called_once_with(mgr)
 
-    def test_multiple_earmark_resolvers_share_cached_cephfs_client(self):
+    def test_cephfs_export_uses_shared_client_for_earmark(self):
         mgr = MagicMock()
-        with mock.patch('nfs.utils.CephfsClient') as mock_cephfs_cls:
-            mock_cephfs_cls.return_value = MagicMock()
-            cached = cephfs_client_for_mgr(mgr)
-            r1 = mgr_util.CephFSEarmarkResolver(mgr=mgr, client=cached)
-            r2 = mgr_util.CephFSEarmarkResolver(mgr=mgr, client=cephfs_client_for_mgr(mgr))
-            assert r1._cephfs_client is r2._cephfs_client
-            mock_cephfs_cls.assert_called_once_with(mgr)
+        export_mgr = ExportMgr(mgr, export_ls={})
+        shared_client = MagicMock()
+        export_dict = {
+            'pseudo': '/foo',
+            'path': '/volumes/group/subvol',
+            'fsal': {
+                'name': 'CEPH',
+                'fs_name': 'cephfs',
+                'cmount_path': '/',
+            },
+        }
+        with mock.patch.object(export_mgr, '_get_cephfs_client',
+                               return_value=shared_client), \
+                mock.patch.object(export_mgr, 'validate_cephfs_path'), \
+                mock.patch('nfs.export.check_fs', return_value=True), \
+                mock.patch('nfs.export.get_nfs_spec_for_cluster',
+                           return_value=None), \
+                mock.patch('nfs.export.CephFSEarmarkResolver') as mock_resolver_cls, \
+                mock.patch.object(export_mgr, '_ensure_cephfs_export_user'), \
+                mock.patch('nfs.export.Export.from_dict') as mock_from_dict:
+            mock_export = MagicMock()
+            mock_export.fsal.name = 'CEPH'
+            mock_from_dict.return_value = mock_export
+            mock_resolver = MagicMock()
+            mock_resolver.get_earmark.return_value = None
+            mock_resolver_cls.return_value = mock_resolver
+
+            export_mgr.create_export_from_dict('cluster1', 1, export_dict)
+
+            mock_resolver_cls.assert_called_once_with(
+                mgr, client=shared_client)
+            mock_resolver.get_earmark.assert_called_once_with(
+                '/volumes/group/subvol', 'cephfs')
+            mock_resolver.set_earmark.assert_called_once()
+
+    def test_rgw_export_skips_earmark(self):
+        mgr = MagicMock()
+        export_mgr = ExportMgr(mgr, export_ls={})
+        export_dict = {
+            'pseudo': '/rgw',
+            'path': 'bucket',
+            'fsal': {
+                'name': 'RGW',
+                'user_id': 'nfs.foo.bucket',
+            },
+        }
+        with mock.patch.object(export_mgr, '_check_earmark') as mock_check, \
+                mock.patch.object(export_mgr, '_get_cephfs_client') as mock_client, \
+                mock.patch('nfs.export.get_nfs_spec_for_cluster',
+                           return_value=None), \
+                mock.patch('nfs.export.Export.from_dict') as mock_from_dict:
+            mock_export = MagicMock()
+            mock_export.fsal.name = 'RGW'
+            mock_from_dict.return_value = mock_export
+
+            export_mgr.create_export_from_dict('cluster1', 1, export_dict)
+
+            mock_check.assert_not_called()
+            mock_client.assert_not_called()

--- a/src/pybind/mgr/nfs/utils.py
+++ b/src/pybind/mgr/nfs/utils.py
@@ -1,13 +1,9 @@
-import functools
 import logging
-import stat
 from typing import List, Optional, Tuple, Any, TYPE_CHECKING
 
 from object_format import ErrorResponseBase
 import orchestrator
 from orchestrator import NoOrchestrator
-import cephfs
-from mgr_util import CephfsClient, open_filesystem
 from mgr_module import NFS_POOL_NAME as POOL_NAME
 
 from rados import Rados, LIBRADOS_ALL_NSPACES, ObjectNotFound
@@ -136,18 +132,3 @@ def check_fs(mgr: 'Module', fs_name: str) -> bool:
     '''
     fs_map = mgr.get('fs_map')
     return fs_name in [fs['mdsmap']['fs_name'] for fs in fs_map['filesystems']]
-
-
-@functools.lru_cache(maxsize=1)
-def cephfs_client_for_mgr(mgr: 'Module') -> CephfsClient:
-    return CephfsClient(mgr)
-
-
-def cephfs_path_is_dir(mgr: 'Module', fs: str, path: str) -> None:
-    cephfs_client = cephfs_client_for_mgr(mgr)
-
-    with open_filesystem(cephfs_client, fs) as fs_handle:
-        stx = fs_handle.statx(path.encode('utf-8'), cephfs.CEPH_STATX_MODE,
-                              cephfs.AT_SYMLINK_NOFOLLOW)
-        if not stat.S_ISDIR(stx.get('mode')):
-            raise NotADirectoryError()


### PR DESCRIPTION
by having a class level CephfsClient object

This prevents issues like https://tracker.ceph.com/issues/76278 where
creating cephfs exports lead to having proportional amount of
CephfsClient objects and that means multiple RTimer objects scanning
for idle connections and flooding mgr logs.

Fixes: https://tracker.ceph.com/issues/76290
Regression-of: https://github.com/ceph/ceph/commit/1356992c1c13
Signed-off-by: Dhairya Parmar <dparmar@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
