### PR TITLE
cephadm: inject set_keepcaps=true for FCM enabled OSDs

### DIFF
--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -419,6 +419,22 @@ class OSDService(CephService):
 
     def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
         config, parent_deps = super().generate_config(daemon_spec)
+
+        # The FCM extblkdev plugin uses NVME_IOCTL_ADMIN_CMD, which requires
+        # CAP_SYS_ADMIN. The plugin only raises it briefly, but the OSD needs to
+        # keep the capability in its permitted set after dropping privileges.
+        try:
+            plugins = str(self.mgr.get_foreign_ceph_option('osd', 'osd_extblkdev_plugins') or '')
+        except KeyError:
+            logger.warning('Failed to read osd_extblkdev_plugins config option, skipping keepcaps injection')
+            plugins = ''
+        plugins = plugins.replace(';', ',').lower()
+        if any(p.strip() == 'fcm' for p in plugins.split(',')):
+            ceph_conf = config.get('config', '')
+            if isinstance(ceph_conf, str) and 'set_keepcaps' not in ceph_conf.lower():
+                logger.info('FCM extblkdev plugin enabled: injecting set_keepcaps=true into OSD config')
+                config['config'] = ceph_conf.rstrip() + '\n\n[osd]\nset_keepcaps = true\n'
+
         if daemon_spec.service_name in self.mgr.spec_store:
             svc_spec = cast(DriveGroupSpec, self.mgr.spec_store[daemon_spec.service_name].spec)
 

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -42,6 +42,7 @@ from tests import mock
 from .fixtures import wait, _run_cephadm, match_glob, with_host, \
     with_cephadm_module, with_service, make_daemons_running, async_side_effect
 from cephadm.module import CephadmOrchestrator
+from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
 
 """
 TODOs:
@@ -83,6 +84,36 @@ def with_daemon(cephadm_module: CephadmOrchestrator, spec: ServiceSpec, host: st
             return
 
     assert False, 'Daemon not found'
+
+
+@mock.patch("cephadm.module.CephadmOrchestrator.get_foreign_ceph_option")
+def test_osd_config_sets_keepcaps_when_fcm_enabled(_get_foreign_ceph_option, cephadm_module: CephadmOrchestrator):
+    cephadm_module.get_minimal_ceph_conf = lambda: "[global]\nfsid = deadbeef\n"
+    _get_foreign_ceph_option.return_value = "fcm"
+
+    daemon_spec = CephadmDaemonDeploySpec(
+        host='test',
+        daemon_id='0',
+        service_name='osd',
+        keyring='[osd.0]\nkey = dummy\n',
+    )
+    config, _deps = cephadm_module.osd_service.generate_config(daemon_spec)
+    assert 'set_keepcaps = true' in config['config']
+
+
+@mock.patch("cephadm.module.CephadmOrchestrator.get_foreign_ceph_option")
+def test_osd_config_does_not_set_keepcaps_without_fcm(_get_foreign_ceph_option, cephadm_module: CephadmOrchestrator):
+    cephadm_module.get_minimal_ceph_conf = lambda: "[global]\nfsid = deadbeef\n"
+    _get_foreign_ceph_option.return_value = ""
+
+    daemon_spec = CephadmDaemonDeploySpec(
+        host='test',
+        daemon_id='0',
+        service_name='osd',
+        keyring='[osd.0]\nkey = dummy\n',
+    )
+    config, _deps = cephadm_module.osd_service.generate_config(daemon_spec)
+    assert 'set_keepcaps' not in config['config'].lower()
 
 
 @contextmanager


### PR DESCRIPTION
**Problem:**
On clusters using NVMe drives with FCM (Flash Capacity Management), OSD daemons crash on startup with:
```
fcm init Device detected, but FCM utilization log cannot be accessed (check capabilities!)
Failed preloading extblkdev plugins, error code: -1
plugin fcm not loaded
OSD:init: unable to mount object store
```

This happens because ceph-osd drops all Linux capabilities when switching from root to the ceph user. The FCM plugin needs CAP_SYS_ADMIN to run NVMe commands, and without set_keepcaps=true, those permissions are lost, so the plugin can’t work.

When the plugin fails to load, the OSD may not start, or it falls back to reporting the logical disk size ( 30 TB) instead of the actual physical capacity (5 TB). This can make the cluster think there’s more space than there really is, leading to overfill, ENOSPC errors, and stuck backfills.

**Fix:**
Added logic to check if osd_extblkdev_plugins includes fcm. When it does, we inject set_keepcaps = true under the [osd] section of the generated config. This only affects FCM enabled deployments and any non FCM OSDs are untouched.

**Validation:**
With set_keepcaps = false in the OSD config ,the OSD crashes immediately. Logs show FCM plugin can detect the device but can't access the utilization log due to missing capabilities.
`fcm init Device detected, but FCM utilization log cannot be accessed (check capabilities!)`

With set_keepcaps = true, OSD starts cleanly, the FCM plugin loads, and ceph osd df reports physical capacity (5.1 TB).

With our changes the generated config now contains set_keepcaps = true automatically. OSD came up healthy, reporting correct physical capacity.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
