### PR TITLE
ceph-volume: accept dm-crypt devices as valid OSD backing stores

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -163,6 +163,30 @@ class TestDevice(object):
         assert disk.is_device is True
 
     @patch("ceph_volume.util.disk.has_bluestore_label", lambda x: False)
+    def test_crypt_device_is_device(self, fake_call, device_info):
+        data = {"/dev/mapper/luks2-r-data-0": {"foo": "bar"}}
+        lsblk = {"TYPE": "crypt", "NAME": "dm-2"}
+        device_info(devices=data, lsblk=lsblk)
+        disk = device.Device("/dev/mapper/luks2-r-data-0")
+        assert disk.is_device is True
+
+    @patch("ceph_volume.util.disk.has_bluestore_label", lambda x: False)
+    def test_crypt_device_is_acceptable(self, fake_call, device_info):
+        data = {"/dev/mapper/luks2-r-data-0": {"foo": "bar"}}
+        lsblk = {"TYPE": "crypt", "NAME": "dm-2"}
+        device_info(devices=data, lsblk=lsblk)
+        disk = device.Device("/dev/mapper/luks2-r-data-0")
+        assert disk.is_acceptable_device is True
+
+    @patch("ceph_volume.util.disk.has_bluestore_label", lambda x: False)
+    def test_crypt_device_is_available(self, fake_call, device_info):
+        data = {"/dev/mapper/luks2-r-data-0": {"ro": "0", "size": 5368709120}}
+        lsblk = {"TYPE": "crypt", "NAME": "dm-2"}
+        device_info(devices=data, lsblk=lsblk)
+        disk = device.Device("/dev/mapper/luks2-r-data-0")
+        assert disk.available
+
+    @patch("ceph_volume.util.disk.has_bluestore_label", lambda x: False)
     def test_is_not_lvm_member(self, fake_call, device_info):
         data = {"/dev/sda1": {"foo": "bar"}}
         lsblk = {"TYPE": "part", "NAME": "sda1", "PKNAME": "sda"}

--- a/src/ceph-volume/ceph_volume/tests/util/test_disk.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_disk.py
@@ -399,6 +399,46 @@ class TestGetDevices(object):
         assert result[nvme_path]['model'] == 'SSD 990 PRO'
         assert result[nvme_path]['rev'] == '1B2Q'
 
+    def test_crypt_device_is_included(self, patched_get_block_devs_sysfs, fake_filesystem):
+        dm_path = '/dev/dm-2'
+        mapper_path = '/dev/mapper/luks2-r-data-0'
+        patched_get_block_devs_sysfs.return_value = [
+            [dm_path, mapper_path, 'crypt', dm_path]
+        ]
+        fake_filesystem.create_dir('/sys/block/dm-2/slaves')
+        fake_filesystem.create_dir('/sys/block/dm-2/queue')
+        fake_filesystem.create_file('/sys/block/dm-2/size', contents='195264000')
+        fake_filesystem.create_file('/sys/block/dm-2/queue/rotational', contents='1')
+        fake_filesystem.create_file('/sys/block/dm-2/queue/hw_sector_size', contents='512')
+        with patch("ceph_volume.util.disk.UdevData") as MockUdevData:
+            mock_instance = MagicMock()
+            mock_instance.is_lvm = False
+            MockUdevData.return_value = mock_instance
+            result = disk.get_devices()
+        assert mapper_path in result
+        assert result[mapper_path]['type'] == 'crypt'
+
+    def test_crypt_device_is_not_skipped(self, patched_get_block_devs_sysfs, fake_filesystem):
+        sda_path = '/dev/sda'
+        dm_path = '/dev/dm-2'
+        mapper_path = '/dev/mapper/luks2-r-data-0'
+        patched_get_block_devs_sysfs.return_value = [
+            [sda_path, sda_path, 'disk', sda_path],
+            [dm_path, mapper_path, 'crypt', dm_path],
+        ]
+        fake_filesystem.create_dir('/sys/block/dm-2/slaves')
+        fake_filesystem.create_dir('/sys/block/dm-2/queue')
+        fake_filesystem.create_file('/sys/block/dm-2/size', contents='195264000')
+        fake_filesystem.create_file('/sys/block/dm-2/queue/rotational', contents='1')
+        fake_filesystem.create_file('/sys/block/dm-2/queue/hw_sector_size', contents='512')
+        with patch("ceph_volume.util.disk.UdevData") as MockUdevData:
+            mock_instance = MagicMock()
+            mock_instance.is_lvm = False
+            MockUdevData.return_value = mock_instance
+            result = disk.get_devices()
+        assert sda_path in result
+        assert mapper_path in result
+
 
 class TestGetBlockDevsSysfs(object):
     def test_optical_device_is_skipped(self, fake_filesystem):

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -509,7 +509,7 @@ class Device(object):
         elif self.blkid_api:
             api = self.blkid_api
         if api:
-            valid_types = ['disk', 'device', 'mpath']
+            valid_types = ['disk', 'device', 'mpath', 'crypt']
             if allow_loop_devices():
                 valid_types.append('loop')
             return self.device_type in valid_types

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -806,7 +806,7 @@ def get_devices(_sys_block_path='/sys/block', device=''):
 
     block_devs = get_block_devs_sysfs(_sys_block_path)
 
-    block_types = ['disk', 'mpath', 'lvm', 'part']
+    block_types = ['disk', 'mpath', 'lvm', 'part', 'crypt']
     if allow_loop_devices():
         block_types.append('loop')
 


### PR DESCRIPTION
Add `crypt` to accepted device types in `get_devices()` and `is_device`
so that pre-encrypted dm-crypt block devices are discoverable and usable
for OSD provisioning.

## Problem

Immutable Linux distributions (Talos Linux, Flatcar) encrypt all block
devices at the OS level using LUKS2. The unlocked dm-crypt mapper
(e.g. `/dev/mapper/luks2-r-data-0`) is a valid, empty block device but
`ceph-volume` rejects it at two gates:

1. `disk.py` `get_devices()`: `block_types` allowlist excludes `crypt`
2. `device.py` `is_device`: `valid_types` allowlist excludes `crypt`

```
ceph-volume inventory --format json /dev/mapper/luks2-r-data-0
→ "Device type is not acceptable. It should be raw device or partition"
```

This results in 0 OSDs provisioned despite Rook correctly matching the
device via `devicePathFilter`.

## Rationale

ceph-volume already has dm-crypt awareness:
- `BlockSysFs.has_active_dmcrypt_mapper` checks for active CRYPT mappers
- `objectstore/raw.py` uses it in `pre_activate_tpm2()`

An unlocked dm-crypt device is functionally identical to a raw block
device — `TYPE=crypt` describes the device-mapper target function, not
a limitation on usage.

## Evidence from a live cluster

Talos Linux node with LUKS2-encrypted Ceph data disk (KMS-backed keys):

```yaml
# Talos VolumeStatus for the Ceph data disk
spec:
  location: /dev/sdb1           # raw LUKS partition
  mountLocation: /dev/dm-2      # unlocked dm-crypt mapper
  encryptionProvider: luks2
  size: 99992207360
```

```
# lsblk from rook-discover pod
sdb                 disk              93.1G
└─sdb1              part  crypto_LUKS 93.1G
  └─luks2-r-data-0  crypt             93.1G   ← target, no filesystem
```

```
# OSD prepare log
cephosd: desiredDevices [{Name:^/dev/disk/by-id/dm-name-luks2-r-data-[0-9]+$ ...}]
cephosd: skipping device "dm-2": ["Device type is not acceptable. It should be raw device or partition"].
cephosd: 0 ceph-volume raw osd devices configured on this node
```

## Changes

- `disk.py`: add `'crypt'` to `block_types` in `get_devices()`
- `device.py`: add `'crypt'` to `valid_types` in `is_device`
- 5 unit tests covering discovery and validation of crypt devices

Fixes: https://tracker.ceph.com/issues/76323
Signed-off-by: Paul Thuriot <pth@corti.ai>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
  