### PR TITLE
Add CMake machinery to check for C++ features and optionally try to add them from external sources.

### DIFF
--- a/cmake/modules/HasCppFeature.cmake
+++ b/cmake/modules/HasCppFeature.cmake
@@ -1,0 +1,310 @@
+
+#[[
+Check for presence of C++ features against feature test macros.
+If not found, optionally use CPM to try to provide support for the feature.
+
+C++ library feature test macros may be found here:
+https://en.cppreference.com/cpp/feature_test#Library_features
+
+We provide two basic ideas: simple native presence check and a presence check that also
+tries to install support:
+
+has_cpp_feature(): checks feature-test macro, sets CMake variable with presence result;
+
+require_cpp_feature(): requires feature to be available, optionally trying to install
+it if not native.
+
+EXAMPLES:
+
+Note: all examples are assumed to have this in the cmake file, I've omitted
+it from further examples for brevity:
+include(HasCppFeature)
+
+* Simple test for the presence of a feature (uses the feature macro alone, does
+    not attempt to install anything):
+
+    has_cpp_feature(__cpp_lib_generator HAVE_CPP_LIB_GENERATOR)
+
+    if(HAVE_CPP_LIB_GENERATOR)
+     message("-- std::generator support is active")
+    endif()
+
+* Versioned test for the presence of a feature:
+    has_cpp_feature(__cpp_lib_flat_set HAVE_CPP_LIB_FLAT_SET MIN_VALUE 202207L)
+
+    if(HAVE_CPP_LIB_FLAT_SET)
+     message("-- std::flat_set support is active")
+    endif()
+
+* Require a locally available feature and define the result on a target (a more
+verbose approach, you'll see why soon):
+    add_library(bletch INTERFACE)
+    require_cpp_feature(__cpp_lib_span BLAH TARGET bletch)
+
+    if(BLAH)
+     message("-- std::span support is active")
+    endif()
+
+* Try to use an alternative target if the native feature is not found, otherwise
+fail with FATAL_ERROR. On success, the result variable name is the uppercase
+feature tag name. If TARGET is given, that target gets the result variable name
+as a preprocessor definition-- i.e.:
+  given:
+      require_cpp_feature(__cpp_lib_span MARMOT TARGET bletch)
+  ...if the feature is available, CMake sets variable MARMOT to true, and:
+      target_compile_definitions(bletch INTERFACE MARMOT)
+
+The USE_ALTERNATIVE parameter lists existing CMake targets that can provide the
+capability if the native feature check fails. If one is selected, TARGET also gets the
+generic feature preprocessor definition and a corresponding *_HAS_ALT_* or *_ALT
+preprocessor definition:
+
+    require_cpp_feature(__cpp_lib_flat_map CEPH_LIBFDB_HAS_FLAT_MAP
+        TARGET rgw_fdb
+        USE_ALTERNATIVE Boost::headers Boost::boost)
+
+    if(CEPH_LIBFDB_HAS_FLAT_MAP)
+     message("-- flat_map support is active")
+    endif()
+
+* Try to install support if feature is not found, otherwise fail with FATAL_ERROR. Extra
+arguments are passed to CPMAddPackage()-- refer to its documentation for details on
+GIT_REPOSITORY, GIT_TAG, EXCLUDE_FROM_ALL, and SYSTEM:
+
+    require_cpp_feature(__cpp_lib_generator cpp_generator
+        TARGET rgw_fdb
+        GIT_REPOSITORY https://github.com/lewissbaker/generator
+        GIT_TAG main
+        EXCLUDE_FROM_ALL YES
+        SYSTEM YES)
+
+    if(CPP_GENERATOR)
+     message("-- generator support is active")
+    endif()
+
+...if the compiler/library already supports std::generator, these extra options do nothing. If CPM
+fetches lewissbaker/generator, they keep the fallback quiet and out of the default build except
+where rgw_fdb needs it.
+
+]]#
+
+# Check for cpp_feature_macro support, set variable ${our_name} if present:
+# HAVE_CPP_LIB_GENERATOR if std::generator support is present.
+# MIN_VALUE can be used to require a minimum feature-test macro value.
+function(has_cpp_feature cpp_feature_macro our_name)
+
+  cmake_parse_arguments(PARSED "" "MIN_VALUE" "" ${ARGN})
+  set(MIN_VALUE_ARG ${PARSED_MIN_VALUE})
+  set(UNPARSED_ARGS ${PARSED_UNPARSED_ARGUMENTS})
+
+  if(UNPARSED_ARGS)
+    message(FATAL_ERROR "has_cpp_feature(): unknown arguments: ${UNPARSED_ARGS}")
+  endif()
+
+  set(feature_description "${cpp_feature_macro} / ${our_name}")
+
+  if(MIN_VALUE_ARG)
+    string(APPEND feature_description " >= ${MIN_VALUE_ARG}")
+    set(value_check "
+      #if ${MIN_VALUE_ARG} > ${cpp_feature_macro}
+       #error feature test macro does not meet MIN_VALUE
+      #endif")
+  endif()
+
+  message(STATUS "Checking for C++ feature: ${feature_description}")
+
+  set(try_compile_args)
+
+  if(DEFINED CMAKE_CXX_STANDARD)
+    list(APPEND try_compile_args CXX_STANDARD ${CMAKE_CXX_STANDARD})
+  endif()
+
+  if(DEFINED CMAKE_CXX_STANDARD_REQUIRED)
+    list(APPEND try_compile_args CXX_STANDARD_REQUIRED ${CMAKE_CXX_STANDARD_REQUIRED})
+  endif()
+
+  if(DEFINED CMAKE_CXX_EXTENSIONS)
+    list(APPEND try_compile_args CXX_EXTENSIONS ${CMAKE_CXX_EXTENSIONS})
+  endif()
+
+  set(src "
+      #include <version>
+      #ifndef ${cpp_feature_macro}
+       #error feature is not present: ${cpp_feature_macro}
+      #endif
+      ${value_check}
+      int main() {}
+    ")
+
+  unset(${our_name})
+  unset(${our_name} CACHE)
+
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.25)
+    try_compile(${our_name}
+      SOURCE_FROM_CONTENT src-check-for-${cpp_feature_macro}.cpp "${src}"
+      ${try_compile_args}
+    )
+  else()
+    # Support older versions of cmake:
+
+    set(feature_check_dir "${CMAKE_BINARY_DIR}/CMakeFiles/HasCppFeature/${cpp_feature_macro}")
+    set(feature_check_src "${feature_check_dir}/src-check-for-${cpp_feature_macro}.cpp")
+
+    file(MAKE_DIRECTORY "${feature_check_dir}")
+    file(WRITE "${feature_check_src}" "${src}")
+
+    try_compile(${our_name}
+      "${feature_check_dir}"
+      "${feature_check_src}"
+      ${try_compile_args}
+    )
+  endif()
+
+  set(${our_name} ${${our_name}} PARENT_SCOPE)
+
+  if(${our_name})
+    message(STATUS "C++ feature available: ${feature_description}")
+  else()
+    message(STATUS "C++ feature not available: ${feature_description}")
+  endif()
+
+endfunction()
+
+
+# Try to parse out the CMake target names exported by a CPM package:
+function(cpp_feature_git_repository_alternatives_detail out_name)
+
+  cmake_parse_arguments(CFG "" "GIT_REPOSITORY" "" ${ARGN})
+  set(alternatives)
+
+  if(CFG_GIT_REPOSITORY)
+    string(REGEX REPLACE "/+$" "" git_repository "${CFG_GIT_REPOSITORY}")
+    string(REGEX REPLACE "\\.git$" "" git_repository "${git_repository}")
+    get_filename_component(git_repository_name "${git_repository}" NAME)
+
+    if(git_repository_name)
+      list(APPEND alternatives
+        ${git_repository_name}
+        std${git_repository_name})
+    endif()
+  endif()
+
+  set(${out_name} ${alternatives} PARENT_SCOPE)
+
+endfunction()
+
+function(cpp_feature_alternative_target_detail out_name)
+
+  set(alternative_target)
+
+  foreach(alternative ${ARGN})
+    if(TARGET ${alternative})
+      set(alternative_target ${alternative})
+      break()
+    endif()
+  endforeach()
+
+  set(${out_name} ${alternative_target} PARENT_SCOPE)
+
+endfunction()
+
+function(cpp_feature_alternative_macro_detail out_name feature_name)
+
+  if(feature_name MATCHES "^(.+)_HAS_(.+)$")
+    set(alternative_name "${CMAKE_MATCH_1}_HAS_ALT_${CMAKE_MATCH_2}")
+  else()
+    set(alternative_name "${feature_name}_ALT")
+  endif()
+
+  set(${out_name} ${alternative_name} PARENT_SCOPE)
+
+endfunction()
+
+# Try to get the C++ feature using CPM if not already installed:
+# (MIN_VALUE is used by this helper; the extra arguments are passed to CPM.)
+function(obtain_cpp_feature_detail cpp_feature_macro feature_tag_name our_name)
+
+  cmake_parse_arguments(PARSED "" "MIN_VALUE;TARGET" "USE_ALTERNATIVE" ${ARGN})
+  set(MIN_VALUE_ARG ${PARSED_MIN_VALUE})
+  set(TARGET_ARG ${PARSED_TARGET})
+  set(USE_ALTERNATIVE_ARGS ${PARSED_USE_ALTERNATIVE})
+  set(UNPARSED_ARGS ${PARSED_UNPARSED_ARGUMENTS})
+
+  if(TARGET_ARG AND NOT TARGET ${TARGET_ARG})
+    message(FATAL_ERROR "C++ feature target does not exist: ${TARGET_ARG}")
+  endif()
+
+  set(feature_check_args)
+
+  if(MIN_VALUE_ARG)
+    list(APPEND feature_check_args MIN_VALUE ${MIN_VALUE_ARG})
+  endif()
+
+  set(feature_alternative)
+  set(feature_alternatives ${USE_ALTERNATIVE_ARGS})
+  cpp_feature_git_repository_alternatives_detail(git_repository_alternatives ${UNPARSED_ARGS})
+  list(APPEND feature_alternatives ${git_repository_alternatives})
+
+  if(feature_alternatives)
+    list(REMOVE_DUPLICATES feature_alternatives)
+  endif()
+
+  has_cpp_feature(${cpp_feature_macro} feature_found ${feature_check_args})
+
+  if(NOT feature_found)
+    cpp_feature_alternative_target_detail(feature_alternative ${feature_alternatives})
+    if(feature_alternative)
+      set(feature_found TRUE)
+    endif()
+  endif()
+
+  if(NOT feature_found AND UNPARSED_ARGS)
+    # Try to install; pass any remaining parameters to CPM and see
+    # if it can sort out the situation:
+    include(CPM)
+    CPMAddPackage(NAME ${feature_tag_name} ${UNPARSED_ARGS})
+
+    cpp_feature_alternative_target_detail(feature_alternative ${feature_alternatives})
+    if(feature_alternative)
+      set(feature_found TRUE)
+    endif()
+  endif()
+
+  if(feature_found AND TARGET_ARG)
+    target_compile_definitions(${TARGET_ARG} INTERFACE ${our_name})
+
+    if(feature_alternative)
+      cpp_feature_alternative_macro_detail(alternative_name ${our_name})
+      target_compile_definitions(${TARGET_ARG} INTERFACE ${alternative_name})
+      target_link_libraries(${TARGET_ARG} INTERFACE ${feature_alternative})
+    endif()
+  endif()
+
+  set(${our_name} ${feature_found} PARENT_SCOPE)
+
+  if(feature_found)
+    if(feature_alternative)
+      message(STATUS "C++ feature alternative target: ${cpp_feature_macro} / ${feature_alternative}")
+    endif()
+    message(STATUS "C++ feature obtained: ${cpp_feature_macro} / ${our_name}")
+  else()
+    message(STATUS "C++ feature not obtained: ${cpp_feature_macro} / ${our_name}")
+  endif()
+
+endfunction()
+
+# Require a C++ feature. The result variable is the uppercase feature_tag_name.
+# MIN_VALUE, TARGET, USE_ALTERNATIVE, and CPM package arguments are handled by
+# obtain_cpp_feature_detail(). Fail if the feature cannot be made available.
+function(require_cpp_feature cpp_feature_macro feature_tag_name)
+
+  string(TOUPPER "${feature_tag_name}" local_feature_tag_name)
+  obtain_cpp_feature_detail(${cpp_feature_macro} ${feature_tag_name} ${local_feature_tag_name} ${ARGN})
+
+  if(NOT ${local_feature_tag_name})
+    message(FATAL_ERROR "C++ feature ${cpp_feature_macro} / ${feature_tag_name} / ${local_feature_tag_name} could not be made available.")
+  endif()
+
+  set(${local_feature_tag_name} ${${local_feature_tag_name}} PARENT_SCOPE)
+
+endfunction()

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -30,7 +30,6 @@ function(gperf_generate input output)
     COMMENT "Generate ${output}"
     )
 endfunction()
-
 find_package(ICU 52.0 COMPONENTS uc REQUIRED)
 
 set(librgw_common_srcs
@@ -569,7 +568,20 @@ target_link_libraries(radosgw PRIVATE
 if(WITH_RADOSGW_FDB)
  message("FoundationDB support is active (experimental)")
 
+ include(HasCppFeature)
+
  add_library(rgw_fdb INTERFACE)
+
+ require_cpp_feature(__cpp_lib_generator CEPH_LIBFDB_HAS_GENERATOR
+   TARGET rgw_fdb
+   GIT_REPOSITORY https://github.com/lewissbaker/generator
+   GIT_TAG main
+   EXCLUDE_FROM_ALL YES
+   SYSTEM YES)
+
+ require_cpp_feature(__cpp_lib_flat_map CEPH_LIBFDB_HAS_FLAT_MAP
+   TARGET rgw_fdb
+   USE_ALTERNATIVE Boost::headers Boost::boost)
 
  target_link_libraries(rgw_fdb INTERFACE
   -lfdb_c
@@ -603,6 +615,8 @@ if(WITH_RADOSGW_FDB)
  target_include_directories(zpp_bits INTERFACE "${CMAKE_BINARY_DIR}/_deps/zpp_bits-src/")
 
  target_link_libraries(rgw_fdb INTERFACE zpp_bits)
+
+ list(APPEND rgw_libs rgw_fdb)
 
 endif(WITH_RADOSGW_FDB)
 

--- a/src/rgw/fdb/base.h
+++ b/src/rgw/fdb/base.h
@@ -39,20 +39,23 @@
 #include <iterator>
 #include <concepts>
 #include <algorithm>
-#include <generator>
 #include <exception>
 #include <functional>
 #include <filesystem>
 #include <type_traits>
 
-#ifdef __cpp_lib_flat_map
- #include <flat_map>
- template <typename ...Args>
- using flat_map = std::flat_map<Args...>;
-#else
+#if !defined(CEPH_LIBFDB_HAS_GENERATOR)
+ #error "libfdb requires generator support"
+#endif
+
+#include <generator>
+
+#if !defined(CEPH_LIBFDB_HAS_FLAT_MAP)
+ #error "libfdb requires flat_map support"
+#elif defined(CEPH_LIBFDB_HAS_ALT_FLAT_MAP)
  #include <boost/container/flat_map.hpp>
- template <typename ...Args>
- using flat_map = boost::container::flat_map<Args...>;
+#else
+ #include <flat_map>
 #endif
 
 // Wrangle some forward declarations:
@@ -67,6 +70,14 @@ using database_handle = std::shared_ptr<database>;
 using transaction_handle = std::shared_ptr<transaction>;
 
 extern transaction_handle make_transaction(database_handle dbh);
+
+#if defined(CEPH_LIBFDB_HAS_ALT_FLAT_MAP)
+ template <typename ...Args>
+ using flat_map = boost::container::flat_map<Args...>;
+#elif defined(CEPH_LIBFDB_HAS_FLAT_MAP)
+ template <typename ...Args>
+ using flat_map = std::flat_map<Args...>;
+#endif
 
 } // namespace ceph::libfdb
 

--- a/src/rgw/fdb/interface.h
+++ b/src/rgw/fdb/interface.h
@@ -16,7 +16,6 @@
 
 #include "base.h"
 #include "conversion.h"
-
 namespace ceph::libfdb {
 
 /* This should be called when the application is all done with FoundationDB: */

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -500,6 +500,7 @@ target_link_libraries(unittest_rgw_http_client
 
 if(WITH_RADOSGW_FDB)
  list(APPEND rgw_incs "${CMAKE_BINARY_DIR}/_deps/zpp_bits-src/")
+ list(APPEND rgw_libs rgw_fdb)
  add_catch2_test_rgw(rgw_hex)
  add_catch2_test_rgw(fdb NO_CATCH2_MAIN)
  add_catch2_test_rgw(fdb_ceph NO_CATCH2_MAIN)


### PR DESCRIPTION

Adds CMake machinery to check for C++ features (as per C++'s header and its macros) to provide convenient feature checks. Additionally, functions are provided to attempt to use CPM to install support, such
as reference implementations.

You may find available C++ feature test macros here:
https://en.cppreference.com/cpp/feature_test#Library_features

Signed-off-by: Jesse F. Williamson jfw@ibm.com

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
