### PR TITLE
tentacle: ceph-volume: make TPM2 PCR policy configurable (default to PCR 7)

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -216,6 +216,14 @@ class Batch(object):
             action='store_true'
         )
         parser.add_argument(
+            '--tpm2-pcrs',
+            dest='tpm2_pcrs',
+            help=('PCRs for systemd-cryptenroll --tpm2-pcrs when using --with-tpm '
+                  '(default binds to Secure Boot policy, see systemd-cryptenroll(1)).'),
+            default='7',
+            type=str,
+        )
+        parser.add_argument(
             '--crush-device-class',
             dest='crush_device_class',
             help='Crush device class to assign this OSD to',
@@ -389,6 +397,7 @@ class Batch(object):
             'bluestore',
             'dmcrypt',
             'with_tpm',
+            'tpm2_pcrs',
             'crush_device_class',
             'no_systemd',
             'dmcrypt_format_opts',

--- a/src/ceph-volume/ceph_volume/devices/lvm/common.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/common.py
@@ -97,6 +97,13 @@ common_args: Dict[str, Any] = {
         'help': 'Whether encrypted OSDs should be enrolled with TPM.',
         'action': 'store_true'
     },
+    '--tpm2-pcrs': {
+        'dest': 'tpm2_pcrs',
+        'help': ('PCRs for systemd-cryptenroll --tpm2-pcrs when using --with-tpm '
+                 '(default binds to Secure Boot policy, see systemd-cryptenroll(1)).'),
+        'default': '7',
+        'type': str,
+    },
     '--no-systemd': {
         'dest': 'no_systemd',
         'action': 'store_true',

--- a/src/ceph-volume/ceph_volume/devices/raw/common.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/common.py
@@ -65,6 +65,14 @@ def create_parser(prog: str, description: str) -> argparse.ArgumentParser:
         action='store_true'
     ),
     parser.add_argument(
+        '--tpm2-pcrs',
+        dest='tpm2_pcrs',
+        help=('PCRs for systemd-cryptenroll --tpm2-pcrs when using --with-tpm '
+              '(default binds to Secure Boot policy, see systemd-cryptenroll(1)).'),
+        default='7',
+        type=str,
+    ),
+    parser.add_argument(
         '--osd-id',
         help='Reuse an existing OSD id',
         default=None,

--- a/src/ceph-volume/ceph_volume/objectstore/baseobjectstore.py
+++ b/src/ceph-volume/ceph_volume/objectstore/baseobjectstore.py
@@ -37,6 +37,7 @@ class BaseObjectStore:
         self.block_device_path: str = ''
         self.dmcrypt_key: str = encryption_utils.create_dmcrypt_key()
         self.with_tpm: int = int(getattr(self.args, 'with_tpm', False))
+        self.tpm2_pcrs: str = getattr(self.args, 'tpm2_pcrs', '7')
         self.method: str = ''
         self.osd_path: str = ''
         self.key: Optional[str] = None
@@ -223,6 +224,7 @@ class BaseObjectStore:
         """
         Enrolls a device with TPM2 (Trusted Platform Module 2.0) using systemd-cryptenroll.
         This method creates a temporary file to store the dmcrypt key and uses it to enroll the device.
+        PCR selection follows `--tpm2-pcrs` on the ceph-volume CLI (`self.tpm2_pcrs`, default is "7").
 
         Args:
             device (str): The device path to be enrolled with TPM2.
@@ -236,7 +238,7 @@ class BaseObjectStore:
                 temp_file_name: str = temp_file.name.replace('/rootfs', '', 1)
                 cmd: List[str] = ['systemd-cryptenroll', '--tpm2-device=auto',
                                   device, '--unlock-key-file', temp_file_name,
-                                  '--tpm2-pcrs', '9+12', '--wipe-slot', 'tpm2']
+                                  '--tpm2-pcrs', self.tpm2_pcrs, '--wipe-slot', 'tpm2']
                 process.call(cmd, run_on_host=True, show_command=True)
 
     def add_label(self, key: str,

--- a/src/ceph-volume/ceph_volume/tests/objectstore/test_baseobjectstore.py
+++ b/src/ceph-volume/ceph_volume/tests/objectstore/test_baseobjectstore.py
@@ -212,6 +212,39 @@ class TestBaseObjectStore:
         with pytest.raises(NotImplementedError):
             BaseObjectStore([]).activate()
 
+    def test_enroll_tpm2_default_pcrs(self, monkeypatch, factory):
+        captured: dict = {}
+
+        def fake_call(cmd, **kwargs):
+            captured['cmd'] = cmd
+            return ([], '', 0)
+
+        monkeypatch.setattr(
+            'ceph_volume.objectstore.baseobjectstore.process.call', fake_call)
+        args = factory(with_tpm=True)
+        bo = BaseObjectStore(args)
+        bo.dmcrypt_key = 'sekrit'
+        bo.enroll_tpm2('/dev/sdz')
+        assert '--tpm2-pcrs' in captured['cmd']
+        i = captured['cmd'].index('--tpm2-pcrs')
+        assert captured['cmd'][i + 1] == '7'
+
+    def test_enroll_tpm2_custom_pcrs(self, monkeypatch, factory):
+        captured: dict = {}
+
+        def fake_call(cmd, **kwargs):
+            captured['cmd'] = cmd
+            return ([], '', 0)
+
+        monkeypatch.setattr(
+            'ceph_volume.objectstore.baseobjectstore.process.call', fake_call)
+        args = factory(with_tpm=True, tpm2_pcrs='9+12')
+        bo = BaseObjectStore(args)
+        bo.dmcrypt_key = 'sekrit'
+        bo.enroll_tpm2('/dev/sdz')
+        i = captured['cmd'].index('--tpm2-pcrs')
+        assert captured['cmd'][i + 1] == '9+12'
+
     @patch('ceph_volume.objectstore.baseobjectstore.prepare_utils.create_key', Mock(return_value=['AQCee6ZkzhOrJRAAZWSvNC3KdXOpC2w8ly4AZQ==']))
     def setup_method(self, m_create_key):
         self.b = BaseObjectStore([])


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76351

---

backport of https://github.com/ceph/ceph/pull/68670
parent tracker: https://tracker.ceph.com/issues/76318

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh