### PR TITLE
mds: use __func__ to log function name

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -5768,18 +5768,18 @@ void MDCache::prepare_realm_merge(SnapRealm *realm, SnapRealm *parent_realm,
 
 void MDCache::send_snaps(map<client_t,ref_t<MClientSnap>>& splits)
 {
-  dout(10) << "send_snaps" << dendl;
+  dout(10) << __func__ << dendl;
   
   for (auto &p : splits) {
     Session *session = mds->sessionmap.get_session(entity_name_t::CLIENT(p.first.v));
     if (session) {
-      dout(10) << " client." << p.first
+      dout(10) << __func__ << " client." << p.first
 	       << " split " << p.second->head.split
 	       << " inos " << p.second->split_inos
 	       << dendl;
       mds->send_message_client_counted(p.second, session);
     } else {
-      dout(10) << " no session for client." << p.first << dendl;
+      dout(10) << __func__ << " no session for client." << p.first << dendl;
     }
   }
   splits.clear();

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -227,7 +227,7 @@ void SessionMap::_load_finish(
     bool more_session_vals)
 {
   if (operation_r < 0) {
-    derr << "_load_finish got " << cpp_strerror(operation_r) << dendl;
+    derr << __func__ << " got " << cpp_strerror(operation_r) << dendl;
     mds->clog->error() << "error reading sessionmap '" << get_object_name()
                        << "' " << operation_r << " ("
                        << cpp_strerror(operation_r) << ")";
@@ -319,7 +319,7 @@ void SessionMap::_load_finish(
  */
 void SessionMap::load(MDSContext *onload)
 {
-  dout(10) << "load" << dendl;
+  dout(10) << "__func__" << dendl;
 
   if (onload)
     waiting_for_load.push_back(onload);
@@ -373,12 +373,12 @@ void SessionMap::_load_legacy_finish(int r, bufferlist &bl)
 { 
   auto blp = bl.cbegin();
   if (r < 0) {
-    derr << "_load_finish got " << cpp_strerror(r) << dendl;
+    derr << __func__ << " got " << cpp_strerror(r) << dendl;
     ceph_abort_msg("failed to load sessionmap");
   }
   dump();
   decode_legacy(blp);  // note: this sets last_cap_renew = now()
-  dout(10) << "_load_finish v " << version 
+  dout(10) << __func__ << " v " << version
 	   << ", " << session_map.size() << " sessions, "
 	   << bl.length() << " bytes"
 	   << dendl;

--- a/src/mds/SnapRealm.cc
+++ b/src/mds/SnapRealm.cc
@@ -84,7 +84,7 @@ SnapRealm::SnapRealm(MDCache *c, CInode *in) :
  */
 void SnapRealm::build_snap_set() const
 {
-  dout(10) << "build_snap_set on " << *this << dendl;
+  dout(10) << __func__ << " on " << *this << dendl;
 
   cached_snaps.clear();
 
@@ -156,7 +156,7 @@ void SnapRealm::check_cache() const
 
   build_snap_trace();
   
-  dout(10) << "check_cache rebuilt " << cached_snaps
+  dout(10) << __func__ << " rebuilt " << cached_snaps
 	   << " seq " << seq
 	   << " cached_seq " << cached_seq
 	   << " cached_last_created " << cached_last_created
@@ -169,7 +169,7 @@ void SnapRealm::check_cache() const
 const set<snapid_t>& SnapRealm::get_snaps() const
 {
   check_cache();
-  dout(10) << "get_snaps " << cached_snaps
+  dout(10) << __func__ << " " << cached_snaps
 	   << " (seq " << srnode.seq << " cached_seq " << cached_seq << ")"
 	   << dendl;
   return cached_snaps;
@@ -198,7 +198,7 @@ const SnapContext& SnapRealm::get_snap_context() const
 void SnapRealm::get_snap_info(map<snapid_t, const SnapInfo*>& infomap, snapid_t first, snapid_t last)
 {
   const set<snapid_t>& snaps = get_snaps();
-  dout(10) << "get_snap_info snaps " << snaps << dendl;
+  dout(10) << __func__ << " snaps " << snaps << dendl;
 
   // include my snaps within interval [first,last]
   for (auto p = srnode.snaps.lower_bound(first); // first element >= first
@@ -253,7 +253,7 @@ std::string_view SnapRealm::get_snapname(snapid_t snapid, inodeno_t atino)
 snapid_t SnapRealm::resolve_snapname(std::string_view n, inodeno_t atino, snapid_t first, snapid_t last)
 {
   // first try me
-  dout(10) << "resolve_snapname '" << n << "' in [" << first << "," << last << "]" << dendl;
+  dout(10) << __func__ << " '" << n << "' in [" << first << "," << last << "]" << dendl;
 
   bool actual = (atino == inode->ino());
   string pname;
@@ -315,7 +315,7 @@ void SnapRealm::adjust_parent()
     newparent = pdn ? pdn->get_dir()->get_inode()->find_snaprealm() : NULL;
   }
   if (newparent != parent) {
-    dout(10) << "adjust_parent " << parent << " -> " << newparent << dendl;
+    dout(10) << __func__ << " " << parent << " -> " << newparent << dendl;
     if (parent)
       parent->open_children.erase(this);
     parent = newparent;


### PR DESCRIPTION
Submitting improvements to log messages for few places that I noticed while working on MDS recently.

---

Use `__func__` instead of typing full function name everytime. This
reduces the effort and the chance of error when a function name is
changed.
    






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>