### PR TITLE
tentacle: test: rados singleton-bluestore missing mds for cephtool tests

### DIFF
--- a/qa/suites/rados/singleton-bluestore/all/cephtool.yaml
+++ b/qa/suites/rados/singleton-bluestore/all/cephtool.yaml
@@ -3,6 +3,7 @@ roles:
   - mon.b
   - mon.c
   - mgr.x
+  - mds.a
   - osd.0
   - osd.1
   - osd.2


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76349

---

backport of https://github.com/ceph/ceph/pull/67640
parent tracker: https://tracker.ceph.com/issues/74607

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh