### PR TITLE
rgw/cloud-tier: obfuscate secret key in RGWZoneGroupPlacementTierS3 config display

### DIFF
--- a/src/rgw/driver/rados/rgw_rest_realm.cc
+++ b/src/rgw/driver/rados/rgw_rest_realm.cc
@@ -3,6 +3,8 @@
 
 #include <optional>
 #include "common/errno.h"
+#include "common/ceph_json.h"
+#include "common/XMLFormatter.h"
 #include "rgw_rest_realm.h"
 #include "rgw_rest_s3.h"
 #include "rgw_rest_config.h"
@@ -53,10 +55,55 @@ void RGWOp_Period_Base::send_response()
   flusher.flush();
 }
 
+// Handler to mask tier S3 secrets for display (works with both JSON and XML Formatter)
+class TierS3KeysHandler : public JSONEncodeFilter::Handler<RGWZoneGroupPlacementTierS3> {
+  void encode_json(const char *name, const void *pval, ceph::Formatter *f) const override {
+    auto tier = static_cast<const RGWZoneGroupPlacementTierS3 *>(pval);
+    f->open_object_section(name);
+    tier->dump_mask_keys(f);
+    f->close_section();
+  }
+};
+
+// JSON Formatter that masks tier S3 secrets for display
+class JSONFormatter_TierS3Keys : public JSONFormatter {
+  TierS3KeysHandler tier_s3_handler;
+  JSONEncodeFilter encode_filter;
+public:
+  JSONFormatter_TierS3Keys(bool pretty) : JSONFormatter(pretty) {
+    encode_filter.register_type(&tier_s3_handler);
+  }
+  void *get_external_feature_handler(const std::string& feature) override {
+    if (feature != "JSONEncodeFilter") {
+      return nullptr;
+    }
+    return &encode_filter;
+  }
+};
+
+// XML Formatter that masks tier S3 secrets for display
+class XMLFormatter_TierS3Keys : public ceph::XMLFormatter {
+  TierS3KeysHandler tier_s3_handler;
+  JSONEncodeFilter encode_filter;
+public:
+  XMLFormatter_TierS3Keys(bool pretty) : ceph::XMLFormatter(pretty) {
+    encode_filter.register_type(&tier_s3_handler);
+  }
+  void *get_external_feature_handler(const std::string& feature) override {
+    if (feature != "JSONEncodeFilter") {
+      return nullptr;
+    }
+    return &encode_filter;
+  }
+};
+
 // GET /admin/realm/period
 class RGWOp_Period_Get : public RGWOp_Period_Base {
+  bool mask_secrets = false;
+
  public:
   void execute(optional_yield y) override;
+  void send_response() override;
   int check_caps(const RGWUserCaps& caps) override {
     return caps.check_cap("zone", RGW_CAP_READ);
   }
@@ -73,10 +120,50 @@ void RGWOp_Period_Get::execute(optional_yield y)
   RESTArgs::get_string(s, "realm_id", realm_id, &realm_id);
   RESTArgs::get_string(s, "period_id", period_id, &period_id);
   RESTArgs::get_uint32(s, "epoch", 0, &epoch);
+  RESTArgs::get_bool(s, "mask_secrets", true, &mask_secrets);
 
   op_ret = s->penv.cfgstore->read_period(this, y, period_id, std::nullopt, period);
   if (op_ret < 0)
     ldpp_dout(this, 5) << "failed to read period" << dendl;
+}
+
+void RGWOp_Period_Get::send_response()
+{
+  set_req_state_err(s, op_ret, error_stream.str());
+  dump_errno(s);
+
+  if (op_ret < 0) {
+    if (!s->err.message.empty()) {
+      ldpp_dout(this, 4) << "Request failed with " << op_ret
+          << ": " << s->err.message << dendl;
+    }
+    end_header(s);
+    return;
+  }
+
+  Formatter *original_formatter = s->formatter;
+  std::unique_ptr<Formatter> tier_formatter;
+
+  // Apply secret masking for both JSON and XML formats
+  if (mask_secrets) {
+    if (s->format == RGWFormat::XML) {
+      tier_formatter = std::make_unique<XMLFormatter_TierS3Keys>(false);
+    } else {
+      tier_formatter = std::make_unique<JSONFormatter_TierS3Keys>(false);
+    }
+    s->formatter = tier_formatter.get();
+    flusher.init(s, this);  // Re-init flusher with new formatter
+  }
+
+  encode_json("period", period, s->formatter);
+  end_header(s, NULL, "application/json", s->formatter->get_len());
+  flusher.flush();
+
+  if (mask_secrets) {
+    // Restore original formatter
+    s->formatter = original_formatter;
+    flusher.init(s, this);
+  }
 }
 
 // POST /admin/realm/period

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -2242,6 +2242,7 @@ static int do_period_pull(rgw::sal::ConfigStore* cfgstore,
     params["period_id"] = period_id;
   if (!period_epoch.empty())
     params["epoch"] = period_epoch;
+  params["mask_secrets"] = "false";
 
   bufferlist bl;
   JSONParser p;
@@ -3597,6 +3598,51 @@ public:
   }
 };
 
+// Handler to mask secret keys in S3 tier configurations for CLI display
+// This handler works with any Formatter (JSON or XML)
+class TierS3KeysHandler : public JSONEncodeFilter::Handler<RGWZoneGroupPlacementTierS3> {
+  void encode_json(const char *name, const void *pval, ceph::Formatter *f) const override {
+    auto tier = static_cast<const RGWZoneGroupPlacementTierS3 *>(pval);
+    f->open_object_section(name);
+    tier->dump_mask_keys(f);
+    f->close_section();
+  }
+};
+
+// JSON Formatter that masks secret keys in S3 tier configurations
+class JSONFormatter_TierS3Keys : public JSONFormatter {
+  TierS3KeysHandler tier_s3_type_handler;
+  JSONEncodeFilter encode_filter;
+public:
+  JSONFormatter_TierS3Keys(bool pretty_format) : JSONFormatter(pretty_format) {
+    encode_filter.register_type(&tier_s3_type_handler);
+  }
+
+  void *get_external_feature_handler(const std::string& feature) override {
+    if (feature != "JSONEncodeFilter") {
+      return nullptr;
+    }
+    return &encode_filter;
+  }
+};
+
+// XML Formatter that masks secret keys in S3 tier configurations
+class XMLFormatter_TierS3Keys : public XMLFormatter {
+  TierS3KeysHandler tier_s3_type_handler;
+  JSONEncodeFilter encode_filter;
+public:
+  XMLFormatter_TierS3Keys(bool pretty_format) : XMLFormatter(pretty_format) {
+    encode_filter.register_type(&tier_s3_type_handler);
+  }
+
+  void *get_external_feature_handler(const std::string& feature) override {
+    if (feature != "JSONEncodeFilter") {
+      return nullptr;
+    }
+    return &encode_filter;
+  }
+};
+
 void init_realm_param(CephContext *cct, string& var, std::optional<string>& opt_var, const string& conf_name)
 {
   var = cct->_conf.get_val<string>(conf_name);
@@ -3700,6 +3746,7 @@ int main(int argc, const char **argv)
   string new_bucket_name;
   std::unique_ptr<Formatter> formatter;
   std::unique_ptr<Formatter> zone_formatter;
+  std::unique_ptr<Formatter> tier_formatter;
   int purge_data = false;
   int pretty_format = false;
   int show_log_entries = true;
@@ -4848,6 +4895,14 @@ int main(int argc, const char **argv)
 
   zone_formatter = std::make_unique<JSONFormatter_PrettyZone>(pretty_format);
 
+  // Create appropriate tier formatter based on output format
+  if (format == "xml") {
+    tier_formatter = std::make_unique<XMLFormatter_TierS3Keys>(pretty_format);
+  } else {
+    tier_formatter = std::make_unique<JSONFormatter_TierS3Keys>(pretty_format);
+  }
+  Formatter* tier_display_formatter = tier_formatter.get();
+
   realm_name = g_conf()->rgw_realm;
   zone_name = g_conf()->rgw_zone;
   zonegroup_name = g_conf()->rgw_zonegroup;
@@ -4950,8 +5005,8 @@ int main(int argc, const char **argv)
 	  cerr << "failed to load period: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
-	encode_json("period", period, formatter.get());
-	formatter->flush(cout);
+	encode_json("period", period, tier_display_formatter);
+	tier_display_formatter->flush(cout);
       }
       break;
     case OPT::PERIOD_GET_CURRENT:
@@ -4995,7 +5050,7 @@ int main(int argc, const char **argv)
         int ret = update_period(cfgstore.get(), realm_id, realm_name,
                                 period_epoch, commit, remote, url,
                                 opt_region, access_key, secret_key,
-                                formatter.get(), yes_i_really_mean_it, site.get());
+                                tier_display_formatter, yes_i_really_mean_it, site.get());
 	if (ret < 0) {
 	  return -ret;
 	}
@@ -5027,8 +5082,8 @@ int main(int argc, const char **argv)
           return -ret;
         }
 
-        encode_json("period", period, formatter.get());
-        formatter->flush(cout);
+        encode_json("period", period, tier_display_formatter);
+        tier_display_formatter->flush(cout);
       }
       break;
     case OPT::GLOBAL_RATELIMIT_GET:
@@ -5629,8 +5684,8 @@ int main(int argc, const char **argv)
 	  return -ret;
 	}
 
-        encode_json("zonegroup", zonegroup, formatter.get());
-        formatter->flush(cout);
+        encode_json("zonegroup", zonegroup, tier_display_formatter);
+        tier_display_formatter->flush(cout);
       }
       break;
     case OPT::ZONEGROUP_CREATE:
@@ -5685,8 +5740,8 @@ int main(int argc, const char **argv)
           }
         }
 
-	encode_json("zonegroup", zonegroup, formatter.get());
-	formatter->flush(cout);
+	encode_json("zonegroup", zonegroup, tier_display_formatter);
+	tier_display_formatter->flush(cout);
       }
       break;
     case OPT::ZONEGROUP_DEFAULT:
@@ -5745,8 +5800,8 @@ int main(int argc, const char **argv)
 	  return -ret;
 	}
 
-	encode_json("zonegroup", zonegroup, formatter.get());
-	formatter->flush(cout);
+	encode_json("zonegroup", zonegroup, tier_display_formatter);
+	tier_display_formatter->flush(cout);
       }
       break;
     case OPT::ZONEGROUP_LIST:
@@ -5865,8 +5920,8 @@ int main(int argc, const char **argv)
           }
         }
 
-        encode_json("zonegroup", zonegroup, formatter.get());
-        formatter->flush(cout);
+        encode_json("zonegroup", zonegroup, tier_display_formatter);
+        tier_display_formatter->flush(cout);
       }
       break;
     case OPT::ZONEGROUP_SET:
@@ -5933,8 +5988,8 @@ int main(int argc, const char **argv)
           }
         }
 
-	encode_json("zonegroup", zonegroup, formatter.get());
-	formatter->flush(cout);
+	encode_json("zonegroup", zonegroup, tier_display_formatter);
+	tier_display_formatter->flush(cout);
       }
       break;
     case OPT::ZONEGROUP_REMOVE:
@@ -5980,8 +6035,8 @@ int main(int argc, const char **argv)
           return -ret;
         }
 
-        encode_json("zonegroup", zonegroup, formatter.get());
-        formatter->flush(cout);
+        encode_json("zonegroup", zonegroup, tier_display_formatter);
+        tier_display_formatter->flush(cout);
       }
       break;
     case OPT::ZONEGROUP_RENAME:
@@ -6021,8 +6076,8 @@ int main(int argc, const char **argv)
 	  return -ret;
 	}
 
-	encode_json("placement_targets", zonegroup.placement_targets, formatter.get());
-	formatter->flush(cout);
+	encode_json("placement_targets", zonegroup.placement_targets, tier_display_formatter);
+	tier_display_formatter->flush(cout);
       }
       break;
     case OPT::ZONEGROUP_PLACEMENT_GET:
@@ -6045,8 +6100,8 @@ int main(int argc, const char **argv)
 	  cerr << "failed to find a zonegroup placement target named '" << placement_id << "'" << std::endl;
 	  return -ENOENT;
 	}
-	encode_json("placement_targets", p->second, formatter.get());
-	formatter->flush(cout);
+	encode_json("placement_targets", p->second, tier_display_formatter);
+	tier_display_formatter->flush(cout);
       }
       break;
     case OPT::ZONEGROUP_PLACEMENT_ADD:
@@ -6197,8 +6252,8 @@ int main(int argc, const char **argv)
       return -ret;
     }
 
-    encode_json("placement_targets", zonegroup.placement_targets, formatter.get());
-    formatter->flush(cout);
+    encode_json("placement_targets", zonegroup.placement_targets, tier_display_formatter);
+    tier_display_formatter->flush(cout);
       }
       break;
     case OPT::ZONE_CREATE:
@@ -7128,7 +7183,7 @@ int main(int argc, const char **argv)
       int ret = update_period(cfgstore.get(), realm_id, realm_name,
                               period_epoch, commit, remote, url,
                               opt_region, access_key, secret_key,
-                              formatter.get(), yes_i_really_mean_it, site.get());
+                              tier_display_formatter, yes_i_really_mean_it, site.get());
       if (ret < 0) {
 	return -ret;
       }
@@ -7163,8 +7218,8 @@ int main(int argc, const char **argv)
         return -ret;
       }
 
-      encode_json("period", period, formatter.get());
-      formatter->flush(cout);
+      encode_json("period", period, tier_display_formatter);
+      tier_display_formatter->flush(cout);
     }
     return 0;
   case OPT::ROLE_CREATE:

--- a/src/rgw/rgw_period_puller.cc
+++ b/src/rgw/rgw_period_puller.cc
@@ -40,6 +40,7 @@ int pull_period(const DoutPrefixProvider *dpp, RGWRESTConn* conn, const std::str
   auto& params = info.args.get_params();
   params["realm_id"] = realm_id;
   params["period_id"] = period_id;
+  params["mask_secrets"] = "false";
 
   bufferlist data;
 #define MAX_REST_RESPONSE (128 * 1024)

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -789,6 +789,23 @@ void RGWZoneGroupPlacementTierS3::dump(Formatter *f) const
   encode_json("multipart_min_part_size", multipart_min_part_size, f);
 }
 
+void RGWZoneGroupPlacementTierS3::dump_mask_keys(Formatter *f) const
+{
+  encode_json("endpoint", endpoint, f);
+  encode_json("access_key", key.id, f);
+  string secret = (key.key.empty() ? "" : "******");
+  encode_json("secret", secret, f);
+  encode_json("region", region, f);
+  string s = (host_style == PathStyle ? "path" : "virtual");
+  encode_json("host_style", s, f);
+  encode_json("location_constraint", location_constraint, f);
+  encode_json("target_storage_class", target_storage_class, f);
+  encode_json("target_path", target_path, f);
+  encode_json("acl_mappings", acl_mappings, f);
+  encode_json("multipart_sync_threshold", multipart_sync_threshold, f);
+  encode_json("multipart_min_part_size", multipart_min_part_size, f);
+}
+
 void RGWTierACLMapping::dump(Formatter *f) const
 {
   string s;

--- a/src/rgw/rgw_zone_types.h
+++ b/src/rgw/rgw_zone_types.h
@@ -558,6 +558,7 @@ struct RGWZoneGroupPlacementTierS3 {
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;
+  void dump_mask_keys(Formatter *f) const;
   void decode_json(JSONObj *obj);
 };
 WRITE_CLASS_ENCODER(RGWZoneGroupPlacementTierS3)


### PR DESCRIPTION
Add dump_mask_keys() method to RGWZoneGroupPlacementTierS3 that masks
the secret key with '******' for display purposes, while keeping dump()
unchanged to output real secrets for period sync/pull.

A new JSONEncodeFilter::Handler is added for "RGWZoneGroupPlacementTierS3" to
invoke dump_mask_keys() for CLI/AdminOps display. This handler is used in both
JSON and XML formatters.

In case of adminops, a new query param "mask_secrets" is added to
GET /admin/realm/period endpoint, which is set to `true` by default.

Multisite sync operations (period pull) set this param to `false`
to read actual secret keys.

TODO:
* Update doc
* write tests (if possible)

Usage:
- GET /admin/realm/period (secrets masked by default)
- GET /admin/realm/period?mask_secrets=false (for sync operations)

Fixes: https://tracker.ceph.com/issues/76359
Signed-off-by: Soumya Koduri <skoduri@redhat.com>


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
