### PR TITLE
wip, enable user-txn no conflict support 

### DIFF
--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -2128,14 +2128,14 @@ void Cache::complete_commit(
       auto &committer = *i->committer;
       committer.commit_state();
       committer.sync_checksum();
-      committer.unblock_trans(t);
       auto &prior = *i->prior_instance;
       prior.pending_for_transaction = TRANS_ID_NULL;
       ceph_assert(prior.is_valid());
-      if (is_lba_backref_node(i->get_type())) {
-        committer.commit_data();
-      }
+      committer.commit_and_share_paddr();
+      committer.commit_data();
       committer.sync_version();
+      DEBUGT("commit unblocking (mutated blocks) {}", t, *i);
+      committer.unblock_trans(t);
       prior.complete_io();
       prior.clear_delta();
       i->committer.reset();

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1644,11 +1644,18 @@ record_t Cache::prepare_record(
 	  i->get_length(),
 	  i->get_type()));
     }
+
+    // No-conflict handoff for *fresh extents* only applies to rewrite extents.
+    // User-created fresh LBA nodes have no prior_instance, so there is nothing to hand off from.
+    const bool do_handoff =
+      should_use_no_conflict_publish(t.get_src(), i->get_type()) &&
+      i->get_prior_instance(); // only rewrite-style fresh extents have a prior
+
     i->set_io_wait(CachedExtent::extent_state_t::CLEAN,
-                   should_use_no_conflict_publish(t.get_src(), i->get_type()));
+                   do_handoff);
     // Note, paddr is known until complete_commit(),
     // so add_extent() later.
-    if (should_use_no_conflict_publish(t.get_src(), i->get_type())) {
+    if (do_handoff) {
       assert(i->get_prior_instance());
       assert(!i->committer);
       assert(!i->get_prior_instance()->committer);
@@ -1657,7 +1664,7 @@ record_t Cache::prepare_record(
       auto &committer = *i->committer;
       committer.block_trans(t);
       i->get_prior_instance()->set_io_wait(
-        CachedExtent::extent_state_t::CLEAN, should_use_no_conflict_publish(t.get_src(), i->get_type()));
+        CachedExtent::extent_state_t::CLEAN, true);
     }
   }
 
@@ -2009,7 +2016,14 @@ void Cache::complete_commit(
     i->pending_for_transaction = TRANS_ID_NULL;
     i->on_initial_write();
     const auto t_src = t.get_src();
-    if (should_use_no_conflict_publish(t_src, i->get_type())) {
+
+    const bool do_handoff =
+      should_use_no_conflict_publish(t_src, i->get_type()) &&
+      i->get_prior_instance();   // only rewrite-style fresh rewrite extents
+
+    if (do_handoff) {
+      DEBUGT("unblocking commit {}", t, *i);
+      ceph_assert(is_lba_backref_node(i->get_type()));
       ceph_assert(i->committer);
       auto &committer = *i->committer;
       auto &prior = *i->get_prior_instance();

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -983,6 +983,8 @@ void Cache::commit_replace_extent(
     CachedExtentRef next,
     CachedExtentRef prev)
 {
+  LOG_PREFIX(Cache::commit_replace_extent);
+  SUBDEBUGT(seastore_t, "", t);
   assert(next->get_paddr() == prev->get_paddr());
   assert(next->get_paddr().is_absolute() || next->get_paddr().is_root());
   assert(next->version == prev->version + 1);
@@ -1372,6 +1374,7 @@ record_t Cache::prepare_record(
       continue;
     }
     if (should_use_no_conflict_publish(t.get_src(), i->get_type())) {
+      DEBUGT("prepaing handoff, blocking transaction -- {}", t, *i);
       i->new_committer(t);
       i->committer->block_trans(t);
     }
@@ -1487,12 +1490,16 @@ record_t Cache::prepare_record(
    * - prepare_commit()
    */
   for (auto &i: t.mutated_block_list) {
+    DEBUGT("inspecting mutated_block_list {}~0x{:x} -- {}", t, i->get_paddr(), i->get_length(), *i);
     if (!i->is_valid()) {
+      DEBUGT("marked invalid {}", t, *i);
       continue;
     }
 
     if (i->is_mutation_pending()) {
       const bool use_no_conflict = should_use_no_conflict_publish(t.get_src(), i->get_type());
+      DEBUGT("mutation pending {} use_no_conflict {}", t, *i, use_no_conflict);
+
       // Block the new extent readers until the journal commit completes.
       i->set_io_wait(CachedExtent::extent_state_t::DIRTY, use_no_conflict);
 
@@ -1995,6 +2002,7 @@ void Cache::complete_commit(
   }
 
   backref_entry_refs_t backref_entries;
+  DEBUGT("commit fresh blocks", t);
   t.for_each_finalized_fresh_block([&](const CachedExtentRef &i) {
     if (!i->is_valid()) {
       return;
@@ -2035,9 +2043,7 @@ void Cache::complete_commit(
       committer.commit_state();
       committer.sync_checksum();
       committer.commit_and_share_paddr();
-      if (is_lba_backref_node(i->get_type())) {
-        committer.commit_data();
-      }
+      committer.commit_data();
       touch_extent_fully(prior, &t_src, t.get_cache_hint());
       committer.sync_version();
       committer.unblock_trans(t);
@@ -2090,6 +2096,7 @@ void Cache::complete_commit(
     }
   });
 
+    DEBUGT("commit mutated blocks", t);
   // Add new copy of mutated blocks, set_io_wait to block until written
   for (auto &i: t.mutated_block_list) {
     if (!i->is_valid()) {
@@ -2115,7 +2122,7 @@ void Cache::complete_commit(
     }
     i->on_delta_write(final_block_start);
     if (should_use_no_conflict_publish(t.get_src(), i->get_type())) {
-      TRACET("committing paddr to prior for {}, prior={}",
+      DEBUGT("committing paddr to prior for {}, prior={}",
         t, *i, *i->prior_instance);
       assert(i->committer);
       auto &committer = *i->committer;

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -2159,15 +2159,16 @@ void Cache::complete_commit(
     commit_backref_entries(std::move(backref_entries), start_seq);
   }
 
-  t.for_each_finalized_fresh_block([&t](const CachedExtentRef &i) {
-    if (should_use_no_conflict_publish(t.get_src(), i->get_type())) {
+  // Rewrite publishes committed state into the shared prior instance.
+  // "next" extents are staging objects and must be discarded.
+  // TODO: Apply for user-txn once safe.
+  if (is_rewrite_transaction(t.get_src())) {
+    t.for_each_finalized_fresh_block([&t](const CachedExtentRef &i) {
       i->set_invalid(t);
-    }
-  });
-
-  for (auto &i: t.mutated_block_list) {
-    if (should_use_no_conflict_publish(t.get_src(), i->get_type())) {
+    });
+    for (auto &i: t.mutated_block_list) {
         i->set_invalid(t);
+      }
     }
   }
 }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
@@ -690,8 +690,7 @@ eagain_ifuture<Ref<Node>> Node::load(
   return c.nm.read_extent(c.t, addr
   ).handle_error_interruptible(
     eagain_iertr::pass_further{},
-    crimson::ct_error::assert_all(fmt::format(
-      "{} -- addr={}, is_level_tail={}", FNAME, addr, expect_is_level_tail).c_str())
+    crimson::ct_error::assert_all("fatal error in Node::load")
   ).si_then([FNAME, c, addr, expect_is_level_tail](auto extent)
 	      -> eagain_ifuture<Ref<Node>> {
     assert(extent);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
@@ -550,9 +550,7 @@ class NodeExtentAccessorT {
       return c.nm.retire_extent(c.t, to_discard
       ).handle_error_interruptible(
         eagain_iertr::pass_further{},
-        crimson::ct_error::assert_all(fmt::format(
-          "{} during retire -- to_disgard={}, fresh={}",
-          FNAME, to_discard->get_laddr(), fresh_extent->get_laddr()).c_str())
+        crimson::ct_error::assert_all("fatal error in OTree::Extent::rebuild")
       );
     }).si_then([this, c] {
       boost::ignore_unused(c);  // avoid clang warning;
@@ -568,8 +566,7 @@ class NodeExtentAccessorT {
     return c.nm.retire_extent(c.t, std::move(extent)
     ).handle_error_interruptible(
       eagain_iertr::pass_further{},
-      crimson::ct_error::assert_all(fmt::format(
-        "{} addr={}", FNAME, addr).c_str())
+      crimson::ct_error::assert_all("fatal error in OTree::Extent::retire")
 #ifndef NDEBUG
     ).si_then([c] {
       assert(!c.t.is_conflicted());

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -2286,9 +2286,9 @@ constexpr bool is_modify_transaction(transaction_type_t type) {
  *
  * Currently true for:
  *  - rewrite (background) transactions, for any non-root extent
+ *  - user (txn_manager) transactions that mutate LBA nodes
  *
  *  To be expanded to:
- *  - user (txn_manager) transactions that mutate LBA nodes
  *  - Onode/Omap nodes
  */
 constexpr bool should_use_no_conflict_publish(transaction_type_t txn_type,
@@ -2298,10 +2298,8 @@ constexpr bool should_use_no_conflict_publish(transaction_type_t txn_type,
     return false;
   }
 
-  // TODO: Extend this as support grows (e.g. Onode/OMAP nodes).
-  //       is_user_transaction(txn_type) && is_lba_node(ext_type)
-
-  return is_rewrite_transaction(txn_type);
+  return is_rewrite_transaction(txn_type) ||
+         (is_user_transaction(txn_type) && is_lba_node(ext_type) && is_modify_transaction(txn_type));
 }
 
 

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -545,6 +545,8 @@ TransactionManager::do_submit_transaction(
   );
 
   while (tref.need_wait_visibility) {
+    SUBDEBUGT(seastore_t, "awaiting visibilty", tref);
+    // TODO: Add perf count
     co_await trans_intr::make_interruptible(seastar::yield());
   }
   if (trim_alloc_to && *trim_alloc_to != JOURNAL_SEQ_NULL) {


### PR DESCRIPTION
Use the generalized `stage_visibility_handoff` from:
- https://github.com/ceph/ceph/pull/68127

Originated for Backref tree txns in:
- https://github.com/ceph/ceph/pull/67589  


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
