### PR TITLE
test/rgw/notifications: setting conf options in teuthology

### DIFF
--- a/src/test/rgw/bucket_notification/README.rst
+++ b/src/test/rgw/bucket_notification/README.rst
@@ -8,7 +8,6 @@ running the tests and modify it if needed. This file can be used to run the buck
 with the `vstart.sh` script.
 For the tests covering Kafka and RabbitMQ security, the RGW will need to accept use/password without TLS connection between the client and the RGW.
 So, the cluster will have to be started with the following ``rgw_allow_notification_secrets_in_cleartext`` parameter set to ``true``.
-
 The test suite can be run against a multisite setup, in the configuration file we will have to decide which RGW and which cluster will be used for the test,
 and using which version (v1 or v2) of topics/notifications we should use. By default, a new cluster would use v2, which means that if a realm was never defined, v1 cannot be used.
 For example, if the ``test-rgw-multisite.sh`` script is used to setup multisite, and we want to test v1 against the first RGW in the first cluster, 

--- a/src/test/rgw/bucket_notification/api.py
+++ b/src/test/rgw/bucket_notification/api.py
@@ -7,7 +7,7 @@ import base64
 import xmltodict
 from http import client as http_client
 from urllib import parse as urlparse
-from time import gmtime, strftime
+from time import gmtime, strftime, sleep
 import boto3
 from botocore.client import Config
 from botocore.exceptions import ClientError
@@ -512,7 +512,9 @@ def delete_all_topics(conn, tenant, cluster):
             for topic in topics_json:
                 admin(['topic', 'rm', '--tenant', tenant, '--topic', topic['name']], cluster)
 
-def set_rgw_config_option(client, option, value, cluster='noname'):
+def set_rgw_config_option(option, value, cluster='noname'):
     """ change a config option """
-    print(f'Setting {option} to {value} for {client} in cluster {cluster}')
-    return ceph_admin(['config', 'set', client, option, str(value)], cluster)
+    log.info(f'Setting {option} to {value} in cluster {cluster}')
+    ceph_admin(['config', 'set', 'client.rgw', option, str(value)], cluster)
+    sleep(1)
+

--- a/src/test/rgw/bucket_notification/api.py
+++ b/src/test/rgw/bucket_notification/api.py
@@ -491,6 +491,11 @@ def ceph_admin(args, cluster='noname', **kwargs):
     cmd = [test_path + 'test-rgw-call.sh', 'call_ceph', cluster] + args
     return bash(cmd, **kwargs)
 
+def rados_admin(args, cluster='noname', **kwargs):
+    """ rados command """
+    cmd = [test_path + 'test-rgw-call.sh', 'call_rgw_rados', cluster] + args
+    return bash(cmd, **kwargs)
+
 def delete_all_topics(conn, tenant, cluster):
     """ delete all topics """
     if tenant == '':
@@ -516,5 +521,5 @@ def set_rgw_config_option(option, value, cluster='noname'):
     """ change a config option """
     log.info(f'Setting {option} to {value} in cluster {cluster}')
     ceph_admin(['config', 'set', 'client.rgw', option, str(value)], cluster)
-    sleep(1)
+    sleep(5)
 

--- a/src/test/rgw/bucket_notification/test_bn.py
+++ b/src/test/rgw/bucket_notification/test_bn.py
@@ -39,6 +39,7 @@ from .api import PSTopicS3, \
     delete_all_topics, \
     put_object_tagging, \
     admin, \
+    rados_admin, \
     set_rgw_config_option, \
     bash, \
     S3Connection, \
@@ -5773,14 +5774,35 @@ def test_topic_migration_to_an_account():
         if account_id is not None:
             admin(["account", "rm", "--account-id", account_id], get_config_cluster())
 
-def persistent_notification_shard_config_change(endpoint_type, conn, new_num_shards, old_num_shards=11): 
+
+def get_notif_pool(cluster):
+    """ get the notif pool name and namespace from zone config """
+    result, status = admin(['zone', 'get'], cluster)
+    assert status == 0
+    zone_info = json.loads(result)
+    notif_pool = zone_info['notif_pool']
+    # pool format is "pool_name:namespace"
+    pool, namespace = notif_pool.rsplit(':', 1)
+    return pool, namespace
+
+
+def get_topic_shard_count(topic_name, cluster):
+    """ count the number of shard objects for a persistent topic in the notif pool """
+    pool, namespace = get_notif_pool(cluster)
+    queue_prefix = ':' + topic_name
+    result, status = rados_admin(['ls', '-p', pool, '-N', namespace], cluster)
+    assert status == 0
+    return sum(1 for obj in result.splitlines()
+               if obj == queue_prefix or obj.startswith(queue_prefix + '.'))
+
+
+def persistent_notification_shard_config_change(endpoint_type, conn, new_num_shards, old_num_shards):
     """ test persistent notification shard config change """
     """ test to check if notifications work when config value for determining num_shards is changed..."""
-    
+
     default_num_shards = 11
     cluster = get_config_cluster()
-    if (old_num_shards != default_num_shards):
-        set_rgw_config_option('rgw_bucket_persistent_notif_num_shards', old_num_shards, cluster)
+    set_rgw_config_option('rgw_bucket_persistent_notif_num_shards', old_num_shards, cluster)
 
     bucket_name = gen_bucket_name()
     bucket = conn.create_bucket(bucket_name)
@@ -5811,6 +5833,10 @@ def persistent_notification_shard_config_change(endpoint_type, conn, new_num_sha
     topic_conf = PSTopicS3(conn, topic_name, zonegroup, endpoint_args=endpoint_args)
     topic_arn = topic_conf.set_config()
 
+    shard_count = get_topic_shard_count(topic_name, cluster)
+    assert shard_count == old_num_shards, \
+        f'expected {old_num_shards} shards after topic creation, got {shard_count}'
+
     # create notification
     notif_1 = bucket_name +  '_notif_1'
     topic_conf_list = [{'Id': notif_1, 'TopicArn': topic_arn,
@@ -5831,6 +5857,9 @@ def persistent_notification_shard_config_change(endpoint_type, conn, new_num_sha
     ## create objects in the bucket (async)
     expected_keys = []
     create_object_and_verify_events(bucket, 'bar', topic_name, receiver, expected_keys, deletions=True)
+    shard_count = get_topic_shard_count(topic_name, cluster)
+    assert shard_count == old_num_shards, \
+        f'expected {old_num_shards} shards after config change (no resharding), got {shard_count}'
 
     # cleanup
     receiver.close(task)
@@ -5840,8 +5869,7 @@ def persistent_notification_shard_config_change(endpoint_type, conn, new_num_sha
     conn.delete_bucket(bucket_name)
 
     ##revert config value for num_shards to default
-    if (new_num_shards != default_num_shards):
-        set_rgw_config_option('rgw_bucket_persistent_notif_num_shards', default_num_shards, cluster)
+    set_rgw_config_option('rgw_bucket_persistent_notif_num_shards', default_num_shards, cluster)
 
 
 def create_object_and_verify_events(bucket, key_name, topic_name, receiver, expected_keys, deletions=False):

--- a/src/test/rgw/bucket_notification/test_bn.py
+++ b/src/test/rgw/bucket_notification/test_bn.py
@@ -39,7 +39,6 @@ from .api import PSTopicS3, \
     delete_all_topics, \
     put_object_tagging, \
     admin, \
-    ceph_admin, \
     set_rgw_config_option, \
     bash, \
     S3Connection, \
@@ -905,7 +904,7 @@ def test_topic():
     list_topics(0, tenant)
 
 
-@pytest.mark.manual_test
+@pytest.mark.basic_test
 def test_topic_name():
     """ test topic name validation """
     conn = connection()
@@ -915,7 +914,6 @@ def test_topic_name():
     zonegroup = get_config_zonegroup()
     bucket_name = gen_bucket_name()
     invalid_topic_name = bucket_name + '+' + TOPIC_SUFFIX
-    rgw_client = f'client.rgw.{get_config_port()}'
 
     # fail to create topic
     endpoint_address = 'http://127.0.0.1:7001/'
@@ -924,13 +922,13 @@ def test_topic_name():
     pytest.raises(Exception, topic_conf.set_config)
 
     # relax topic name validation
-    set_rgw_config_option(rgw_client, 'rgw_relaxed_topic_names', 'true', get_config_cluster())
+    set_rgw_config_option('rgw_relaxed_topic_names', 'true', get_config_cluster())
     # create topic
     expected_arn = 'arn:aws:sns:' + zonegroup + '::' + invalid_topic_name
     topic_arn = topic_conf.set_config()
     assert topic_arn == expected_arn
 
-    set_rgw_config_option(rgw_client, 'rgw_relaxed_topic_names', 'false', get_config_cluster())
+    set_rgw_config_option('rgw_relaxed_topic_names', 'false', get_config_cluster())
 
     # get topic (should be possible regardless of the relaxed topic name setting)
     parsed_result = get_topic(invalid_topic_name)
@@ -3705,7 +3703,7 @@ def test_persistent_notification_pushback():
 
 
 def verify_idleness(port, sleep_time, max_time):
-    set_rgw_config_option('client.rgw', 'rgw_kafka_connection_idle', max_time, get_config_cluster())
+    set_rgw_config_option('rgw_kafka_connection_idle', max_time, get_config_cluster())
     is_idle = False
     start_time = time.time()
     while not is_idle:
@@ -3722,7 +3720,7 @@ def verify_idleness(port, sleep_time, max_time):
                 assert False, "radosgw<->kafka connection is still not idle after {}s".format(time_diff)
 
     # set the original idle time
-    set_rgw_config_option('client.rgw', 'rgw_kafka_connection_idle', 300, get_config_cluster())
+    set_rgw_config_option('rgw_kafka_connection_idle', 300, get_config_cluster())
 
 
 @pytest.mark.kafka_test
@@ -5780,9 +5778,9 @@ def persistent_notification_shard_config_change(endpoint_type, conn, new_num_sha
     """ test to check if notifications work when config value for determining num_shards is changed..."""
     
     default_num_shards = 11
-    rgw_client = f'client.rgw.{get_config_port()}'
+    cluster = get_config_cluster()
     if (old_num_shards != default_num_shards):
-        set_rgw_config_option(rgw_client, 'rgw_bucket_persistent_notif_num_shards', old_num_shards, get_config_cluster())
+        set_rgw_config_option('rgw_bucket_persistent_notif_num_shards', old_num_shards, cluster)
 
     bucket_name = gen_bucket_name()
     bucket = conn.create_bucket(bucket_name)
@@ -5828,8 +5826,8 @@ def persistent_notification_shard_config_change(endpoint_type, conn, new_num_sha
     create_object_and_verify_events(bucket, 'foo', topic_name, receiver, expected_keys, deletions=True)
 
     ## change config value for num_shards to new_num_shards
-    set_rgw_config_option(rgw_client, 'rgw_bucket_persistent_notif_num_shards', new_num_shards, get_config_cluster())
-    
+    set_rgw_config_option('rgw_bucket_persistent_notif_num_shards', new_num_shards, cluster)
+
     ## create objects in the bucket (async)
     expected_keys = []
     create_object_and_verify_events(bucket, 'bar', topic_name, receiver, expected_keys, deletions=True)
@@ -5843,7 +5841,7 @@ def persistent_notification_shard_config_change(endpoint_type, conn, new_num_sha
 
     ##revert config value for num_shards to default
     if (new_num_shards != default_num_shards):
-        set_rgw_config_option(rgw_client, 'rgw_bucket_persistent_notif_num_shards', default_num_shards, get_config_cluster())
+        set_rgw_config_option('rgw_bucket_persistent_notif_num_shards', default_num_shards, cluster)
 
 
 def create_object_and_verify_events(bucket, key_name, topic_name, receiver, expected_keys, deletions=False):
@@ -6053,16 +6051,7 @@ def kafka_batch_size(match_batch_size):
 
     if match_batch_size:
         # set rgw_kafka_max_batch_size using the daemon-specific entity name
-        rgw_client = 'client.rgw.{}'.format(get_config_port())
-        set_rgw_config_option(rgw_client, 'rgw_kafka_max_batch_size', max_batch_size, get_config_cluster())
-        # verify config is set in mon store
-        result = ceph_admin(['config', 'get', rgw_client, 'rgw_kafka_max_batch_size'], get_config_cluster())
-        assert result[1] == 0, 'failed to get config from mon store'
-        actual_value = result[0].strip().split('\n')[-1]
-        assert actual_value == str(max_batch_size), \
-            'rgw_kafka_max_batch_size not set in mon store: got {} expected {}'.format(actual_value, max_batch_size)
-        # wait for config to propagate from monitor to RGW daemon
-        time.sleep(10)
+        set_rgw_config_option('rgw_kafka_max_batch_size', max_batch_size, get_config_cluster())
 
     # fix the topic to point to correct broker
     endpoint_address = 'kafka://' + host + ':' + str(right_port)
@@ -6088,8 +6077,7 @@ def kafka_batch_size(match_batch_size):
 
     # cleanup
     if match_batch_size:
-        rgw_client = 'client.rgw.{}'.format(get_config_port())
-        set_rgw_config_option(rgw_client, 'rgw_kafka_max_batch_size', 0, get_config_cluster())
+        set_rgw_config_option('rgw_kafka_max_batch_size', 0, get_config_cluster())
     kafka_topics = os.path.join(kafka_dir, 'bin/kafka-topics.sh')
     subprocess.run(
         [kafka_topics,
@@ -6106,13 +6094,13 @@ def kafka_batch_size(match_batch_size):
         receiver.close(task)
 
 
-@pytest.mark.manual_test
+@pytest.mark.kafka_test
 def test_kafka_batch_size():
     """ test that setting rgw_kafka_max_batch_size limits the batch size sent to kafka """
     kafka_batch_size(match_batch_size=True)
 
 
-@pytest.mark.manual_test
+@pytest.mark.kafka_test
 def test_kafka_batch_size_mismatch():
     """ test that without rgw_kafka_max_batch_size, batched messages exceed the broker limit """
     kafka_batch_size(match_batch_size=False)


### PR DESCRIPTION
some bucket notifications tests need to set config options during the execution of the test (not setup of the rgw).
using the mon (via the ceph admin comamnd)to propogate the values does work in teuthology, hence settign the value directly to the rgw via the admin socket.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
