### PR TITLE
cephadm: improve oauth2-proxy validation error messaging

### DIFF
--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -2106,12 +2106,39 @@ Usage:
                             no_overwrite: bool = False,
                             inbuf: Optional[str] = None) -> HandleCommandResult:
         """Add a cluster gateway service (cephadm only)"""
-
-        spec = OAuth2ProxySpec(
-            placement=PlacementSpec.from_string(placement),
-            unmanaged=unmanaged,
-            https_address=https_address
+        missing_oauth2_proxy_config = (
+            'Missing required configuration for oauth2-proxy. Please provide a spec '
+            'file with required fields: provider_display_name, oidc_issuer_url, '
+            'client_id, client_secret.'
         )
+        if not inbuf or not inbuf.strip():
+            raise OrchestratorError(missing_oauth2_proxy_config)
+
+        try:
+            spec_data = yaml.safe_load(inbuf)
+        except (OSError, yaml.YAMLError):
+            raise OrchestratorValidationError('oauth2-proxy spec file must be valid YAML')
+
+        if not spec_data:
+            raise OrchestratorError(missing_oauth2_proxy_config)
+        if not isinstance(spec_data, dict):
+            raise OrchestratorValidationError(
+                'oauth2-proxy spec file must contain a single YAML object'
+            )
+
+        spec = ServiceSpec.from_json(spec_data)
+        if not isinstance(spec, OAuth2ProxySpec):
+            raise OrchestratorValidationError(
+                'oauth2-proxy spec file must define service_type: oauth2-proxy'
+            )
+
+        if https_address is not None:
+            spec.https_address = https_address
+        if placement is not None:
+            spec.placement = PlacementSpec.from_string(placement)
+        if unmanaged:
+            spec.unmanaged = unmanaged
+        spec.preview_only = dry_run
 
         spec.validate()  # force any validation exceptions to be caught correctly
 

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -2106,38 +2106,14 @@ Usage:
                             no_overwrite: bool = False,
                             inbuf: Optional[str] = None) -> HandleCommandResult:
         """Add a cluster gateway service (cephadm only)"""
-        missing_oauth2_proxy_config = (
-            'Missing required configuration for oauth2-proxy. Please provide a spec '
-            'file with required fields: provider_display_name, oidc_issuer_url, '
-            'client_id, client_secret.'
+        if inbuf:
+            raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
+
+        spec = OAuth2ProxySpec(
+            placement=PlacementSpec.from_string(placement),
+            unmanaged=unmanaged,
+            https_address=https_address,
         )
-        if not inbuf or not inbuf.strip():
-            raise OrchestratorError(missing_oauth2_proxy_config)
-
-        try:
-            spec_data = yaml.safe_load(inbuf)
-        except (OSError, yaml.YAMLError):
-            raise OrchestratorValidationError('oauth2-proxy spec file must be valid YAML')
-
-        if not spec_data:
-            raise OrchestratorError(missing_oauth2_proxy_config)
-        if not isinstance(spec_data, dict):
-            raise OrchestratorValidationError(
-                'oauth2-proxy spec file must contain a single YAML object'
-            )
-
-        spec = ServiceSpec.from_json(spec_data)
-        if not isinstance(spec, OAuth2ProxySpec):
-            raise OrchestratorValidationError(
-                'oauth2-proxy spec file must define service_type: oauth2-proxy'
-            )
-
-        if https_address is not None:
-            spec.https_address = https_address
-        if placement is not None:
-            spec.placement = PlacementSpec.from_string(placement)
-        if unmanaged:
-            spec.unmanaged = unmanaged
         spec.preview_only = dry_run
 
         spec.validate()  # force any validation exceptions to be caught correctly

--- a/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
+++ b/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
@@ -351,3 +351,74 @@ class TestApplyNvmeof:
         mock_remote.assert_called_once_with('nvmeof', 'create_pool_if_not_exists')
         mock_apply_misc.assert_called_once()
         assert res.retval == 0
+
+
+@mock.patch("orchestrator.module.OrchestratorCli._apply_misc")
+class TestApplyOAuth2Proxy:
+
+    def setup_method(self):
+        self.m = OrchestratorCli('orchestrator', 0, 0)
+
+    def test_missing_spec_raises_clear_error(self, mock_apply_misc):
+        res = self.m._apply_oauth2_proxy()
+
+        assert res.retval != 0
+        assert (
+            'Missing required configuration for oauth2-proxy. Please provide a spec file '
+            'with required fields: provider_display_name, oidc_issuer_url, client_id, '
+            'client_secret.'
+        ) in res.stderr
+        mock_apply_misc.assert_not_called()
+
+    def test_missing_required_fields_raises_combined_error(self, mock_apply_misc):
+        res = self.m._apply_oauth2_proxy(inbuf=textwrap.dedent("""
+            service_type: oauth2-proxy
+            spec:
+              oidc_issuer_url: "https://idp.example.com"
+              client_id: "oauth-client"
+              client_secret: "oauth-secret"
+            """).strip())
+
+        assert res.retval != 0
+        assert (
+            'Missing required fields for oauth2-proxy: provider_display_name.'
+        ) in res.stderr
+        mock_apply_misc.assert_not_called()
+
+    def test_valid_spec_is_applied(self, mock_apply_misc):
+        mock_apply_misc.return_value = HandleCommandResult(retval=0, stdout="Success")
+
+        res = self.m._apply_oauth2_proxy(inbuf=textwrap.dedent("""
+            service_type: oauth2-proxy
+            spec:
+              provider_display_name: "My OIDC Provider"
+              oidc_issuer_url: "https://idp.example.com"
+              client_id: "oauth-client"
+              client_secret: "oauth-secret"
+            """).strip())
+
+        assert res.retval == 0
+        mock_apply_misc.assert_called_once()
+
+
+@mock.patch("orchestrator.module.OrchestratorCli._apply_misc")
+class TestApplyOAuth2ProxyYaml:
+
+    def setup_method(self):
+        self.m = OrchestratorCli('orchestrator', 0, 0)
+
+    def test_apply_yaml_missing_required_fields(self, mock_apply_misc):
+        res = self.m.apply_misc(
+            inbuf=textwrap.dedent("""
+                service_type: oauth2-proxy
+                spec:
+                  oidc_issuer_url: "https://idp.example.com"
+                """).strip()
+        )
+
+        assert res.retval != 0
+        assert (
+            'Missing required fields for oauth2-proxy: '
+            'provider_display_name, client_id, client_secret.'
+        ) in res.stderr
+        mock_apply_misc.assert_not_called()

--- a/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
+++ b/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
@@ -359,18 +359,17 @@ class TestApplyOAuth2Proxy:
     def setup_method(self):
         self.m = OrchestratorCli('orchestrator', 0, 0)
 
-    def test_missing_spec_raises_clear_error(self, mock_apply_misc):
+    def test_missing_required_fields_raises_error(self, mock_apply_misc):
         res = self.m._apply_oauth2_proxy()
 
         assert res.retval != 0
         assert (
-            'Missing required configuration for oauth2-proxy. Please provide a spec file '
-            'with required fields: provider_display_name, oidc_issuer_url, client_id, '
-            'client_secret.'
+            'Missing required fields for oauth2-proxy: provider_display_name, '
+            'oidc_issuer_url, client_id, client_secret.'
         ) in res.stderr
         mock_apply_misc.assert_not_called()
 
-    def test_missing_required_fields_raises_combined_error(self, mock_apply_misc):
+    def test_inbuf_with_missing_fields_is_rejected(self, mock_apply_misc):
         res = self.m._apply_oauth2_proxy(inbuf=textwrap.dedent("""
             service_type: oauth2-proxy
             spec:
@@ -381,13 +380,11 @@ class TestApplyOAuth2Proxy:
 
         assert res.retval != 0
         assert (
-            'Missing required fields for oauth2-proxy: provider_display_name.'
+            'unrecognized command -i; -h or --help for usage'
         ) in res.stderr
         mock_apply_misc.assert_not_called()
 
-    def test_valid_spec_is_applied(self, mock_apply_misc):
-        mock_apply_misc.return_value = HandleCommandResult(retval=0, stdout="Success")
-
+    def test_inbuf_with_valid_spec_is_rejected(self, mock_apply_misc):
         res = self.m._apply_oauth2_proxy(inbuf=textwrap.dedent("""
             service_type: oauth2-proxy
             spec:
@@ -397,8 +394,11 @@ class TestApplyOAuth2Proxy:
               client_secret: "oauth-secret"
             """).strip())
 
-        assert res.retval == 0
-        mock_apply_misc.assert_called_once()
+        assert res.retval != 0
+        assert (
+            'unrecognized command -i; -h or --help for usage'
+        ) in res.stderr
+        mock_apply_misc.assert_not_called()
 
 
 @mock.patch("orchestrator.module.OrchestratorCli._apply_misc")

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -2774,6 +2774,22 @@ class OAuth2ProxySpec(ServiceSpec):
 
     def validate(self) -> None:
         super(OAuth2ProxySpec, self).validate()
+        required_values = {
+            'provider_display_name': self.provider_display_name,
+            'oidc_issuer_url': self.oidc_issuer_url,
+            'client_id': self.client_id,
+            'client_secret': self.client_secret,
+        }
+        missing_required_fields = [
+            field for field, value in required_values.items()
+            if value is None or (isinstance(value, str) and not value.strip())
+        ]
+        if missing_required_fields:
+            raise SpecValidationError(
+                'Missing required fields for oauth2-proxy: '
+                + ', '.join(missing_required_fields)
+                + '.'
+            )
         self._validate_non_empty_string(self.provider_display_name, "provider_display_name")
         self._validate_non_empty_string(self.client_id, "client_id")
         self._validate_non_empty_string(self.client_secret, "client_secret")

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -15,6 +15,7 @@ from ceph.deployment.service_spec import (
     IngressSpec,
     IscsiServiceSpec,
     NFSServiceSpec,
+    OAuth2ProxySpec,
     PlacementSpec,
     PrometheusSpec,
     RGWSpec,
@@ -73,6 +74,33 @@ def test_apply_grafana(spec: GrafanaSpec, raise_exception: bool, msg: str):
         with pytest.raises(SpecValidationError, match=msg):
             spec.validate()
     else:
+        spec.validate()
+
+
+@pytest.mark.parametrize(
+    "spec_kwargs, expected_missing",
+    [
+        ({}, 'provider_display_name, oidc_issuer_url, client_id, client_secret'),
+        (
+            {
+                'provider_display_name': 'My OIDC Provider',
+                'oidc_issuer_url': 'https://idp.example.com',
+            },
+            'client_id, client_secret',
+        ),
+        (
+            {
+                'provider_display_name': 'My OIDC Provider',
+                'oidc_issuer_url': 'https://idp.example.com',
+                'client_secret': 'secret',
+            },
+            'client_id',
+        ),
+    ])
+def test_oauth2_proxy_missing_required_fields(spec_kwargs, expected_missing):
+    spec = OAuth2ProxySpec(**spec_kwargs)
+    expected = f'Missing required fields for oauth2-proxy: {expected_missing}.'
+    with pytest.raises(SpecValidationError, match=re.escape(expected)):
         spec.validate()
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Problem**

Running `ceph orch apply oauth2-proxy` without required configuration
produces a misleading error:

    Invalid provider_display_name: Must be a non-empty string.

Similarly, applying a YAML spec with missing fields results in field-level
validation errors instead of a clear message.

Fixes: https://tracker.ceph.com/issues/76372
Signed-off-by: Shubha Jain [SHUBHA.JAIN1@ibm.com]

**Solution**

- Add early validation for missing configuration in CLI path
- Aggregate missing required fields in OAuth2ProxySpec
- Ensure missing fields are reported before field-level validation

 **Result**

Before:
    Invalid provider_display_name: Must be a non-empty string.

After:
    Missing required configuration for oauth2-proxy...
    Missing required fields for oauth2-proxy: provider_display_name, oidc_issuer_url, client_id, client_secret

**Testing**

- Verified CLI path (`ceph orch apply oauth2-proxy`)
- Verified YAML path (`ceph orch apply -i oauth2.yaml`)
- Added unit tests for both paths
- Validated using a custom Ceph container image

**Impact**

Improves usability and clarity of error messages without affecting valid configurations.


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [X] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
