### PR TITLE
osd/SnapMapper::update_snaps() to handle a missing OBJ_ record

### DIFF
--- a/src/osd/SnapMapper.cc
+++ b/src/osd/SnapMapper.cc
@@ -522,7 +522,7 @@ void SnapMapper::clear_snaps(
   const hobject_t &oid,
   MapCacher::Transaction<std::string, ceph::buffer::list> *t)
 {
-  dout(20) << __func__ << " " << oid << dendl;
+  dout(10) << __func__ << " " << oid << dendl;
   ceph_assert(check(oid));
   set<string> to_remove;
   to_remove.insert(to_object_key(oid));
@@ -589,6 +589,15 @@ int SnapMapper::update_snaps(
   // Tolerate missing keys but not disk errors
   if (r < 0 && r != -ENOENT)
     return r;
+  if (r == -ENOENT) {
+    // Recently recovered replicas may observe missing snap-mapper state.
+    // Avoid creating an inconsistent state (OBJ_ without matching SNA_ entries) that
+    // would be detected by scrub later on - instead rebuild the mapping from scratch.
+    dout(10) << fmt::format("{}: {} no existing snap mapping, creating for {}",
+	       __func__, oid, new_snaps) << dendl;
+    add_oid(oid, new_snaps, t);
+    return 0;
+  }
   if (old_snaps_check)
     ceph_assert(out.snaps == *old_snaps_check);
 
@@ -770,7 +779,7 @@ int SnapMapper::remove_oid(
   const hobject_t &oid,
   MapCacher::Transaction<std::string, ceph::buffer::list> *t)
 {
-  dout(20) << *this << __func__ << " " << oid << dendl;
+  dout(10) << *this << __func__ << " " << oid << dendl;
   ceph_assert(check(oid));
   return _remove_oid(oid, t);
 }


### PR DESCRIPTION

Update_snaps() to handle a missing OBJ_ record
by falling back to add_oid() instead of silently creating an
inconsistent state (OBJ_ without matching SNA_ entries). This
was observed on replicas that had recently recovered objects:
the snap mapper entries created during recovery were not visible
to a subsequent snap-trim repop's update_snaps() call, leaving
the clone with no snap mapper entries. Scrub would then detect
and report the inconsistency as an error.

Promote snap mapper remove_oid/clear_snaps logging to dout(10)
and add apply_op_stats tracing to aid diagnosis of any remaining
stat or snap mapper drift.

Details:

add_oid() always creates both OBJ_ and SNA_ entries.
update_snaps() only diffs against existing SNA_ entries.
When there are no existing entries, update_snaps() must
delegate to add_oid() to avoid the OBJ_/SNA_ inconsistency.

Take https://pulpito.ceph.com/rfriedma-2026-04-30_04:51:15-rados:thrash-wip-rf-stqlength-distro-default-trial/187081/
as an example. Bug scenario:

```
Snap Mapper Bug: Missing SNA_ entries after recovery + snap-trim
================================================================

Object: clone :138 of trial17148508-43
Snaps at recovery time: {134, 130}
Snap-trim arrives for snap 134, leaving {130}

Snap mapper stores two types of keys:
  OBJ_<oid>       → set of snapids for this clone
  SNA_<snap>_<oid> → reverse index (snap → clone)


BEFORE THE FIX
==============

1. Recovery pushes clone :138 to new replica
   on_local_recover() → add_oid(:138, {134, 130})

   OBJ_:138       = {134, 130}    ← written to transaction A
   SNA_134_:138   = (exists)      ← written to transaction A
   SNA_130_:138   = (exists)      ← written to transaction A

   Transaction A is submitted to BlueStore (commits asynchronously).

2. Transaction A commits. MapCacher cache entries released.

3. Snap-trim repop arrives (trim snap 134 → new snaps {130})
   update_snap_map() → update_snaps(:138, {130})

   get_snaps(:138) → ENOENT       ← OBJ_ key not found (*)

   update_snaps proceeds with out.snaps = {}:

   OBJ_:138       = {130}         ← set_snaps() overwrites with new value
   SNA_ removals  = (none)        ← loop over out.snaps is empty, nothing to remove
   SNA_ additions = (none)        ← update_snaps NEVER creates SNA_ entries

   Result after transaction B commits:

   OBJ_:138       = {130}         ✓ correct
   SNA_134_:138   = ???           ? may or may not survive from txn A
   SNA_130_:138   = ???           ? may or may not survive from txn A

   (*) Root cause of ENOENT is under investigation.
       The OBJ_ key written by transaction A is not visible
       to transaction B's get_snaps() read.

4. Scrub runs, checks consistency:

   OBJ_:138 says snaps = {130}
   Looks up SNA_130_:138 → NOT FOUND

   ══════════════════════════════════════════
   INCONSISTENCY: OBJ_ and SNA_ disagree
   → logs [ERR], triggers PG_DAMAGED
   ══════════════════════════════════════════
```

With this fix:

```
1–2. Same as above.

3. Snap-trim repop arrives (trim snap 134 → new snaps {130})
   update_snap_map() → update_snaps(:138, {130})

   get_snaps(:138) → ENOENT       ← same situation

   NEW CODE PATH: ENOENT detected, fall back to add_oid(:138, {130})

   add_oid creates BOTH key types:

   OBJ_:138       = {130}         ← set_snaps()
   SNA_130_:138   = (exists)      ← backend.set_keys()

   Result after transaction B commits:

   OBJ_:138       = {130}         ✓ correct
   SNA_130_:138   = (exists)      ✓ correct

4. Scrub runs, checks consistency:

   OBJ_:138 says snaps = {130}
   Looks up SNA_130_:138 → FOUND

   ══════════════════════
   CONSISTENT — no error
   ══════════════════════

```







