### PR TITLE
tentacle: osd: Avoid pwlc spanning intervals

### DIFF
--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -896,8 +896,9 @@ struct ECClassicalOp : ECCommon::RMWPipeline::Op {
     map<hobject_t, ECUtil::shard_extent_map_t> *written,
     shard_id_map<ObjectStore::Transaction> *transactions,
     DoutPrefixProvider *dpp,
-    const OSDMapRef &osdmap) final {
-    assert(t);
+    const OSDMapRef &osdmap,
+    bool& first_write_in_interval) final {
+    ceph_assert(t);
     ECTransaction::generate_transactions(
       t.get(),
       plan,
@@ -911,7 +912,8 @@ struct ECClassicalOp : ECCommon::RMWPipeline::Op {
       &temp_added,
       &temp_cleared,
       dpp,
-      osdmap);
+      osdmap,
+      first_write_in_interval);
   }
 
   bool skip_transaction(

--- a/src/osd/ECCommon.cc
+++ b/src/osd/ECCommon.cc
@@ -787,7 +787,8 @@ void ECCommon::RMWPipeline::cache_ready(Op &op) {
     &written,
     &trans,
     get_parent()->get_dpp(),
-    get_osdmap());
+    get_osdmap(),
+    first_write_in_interval);
 
   dout(20) << __func__ << ": written: " << written << ", op: " << op << dendl;
 
@@ -918,7 +919,8 @@ struct ECDummyOp final : ECCommon::RMWPipeline::Op {
       map<hobject_t, ECUtil::shard_extent_map_t> *written,
       shard_id_map<ObjectStore::Transaction> *transactions,
       DoutPrefixProvider *dpp,
-      const OSDMapRef &osdmap
+      const OSDMapRef &osdmap,
+      bool &first_write_in_interval
     ) override {
     // NOP, as -- in contrast to ECClassicalOp -- there is no
     // transaction involved
@@ -1000,6 +1002,7 @@ void ECCommon::RMWPipeline::on_change() {
   oid_to_version.clear();
   waiting_commit.clear();
   next_write_all_shards = false;
+  first_write_in_interval = true;
 }
 
 void ECCommon::RMWPipeline::on_change2() {

--- a/src/osd/ECCommon.h
+++ b/src/osd/ECCommon.h
@@ -535,7 +535,8 @@ struct ECCommon {
           std::map<hobject_t, ECUtil::shard_extent_map_t> *written,
           shard_id_map<ceph::os::Transaction> *transactions,
           DoutPrefixProvider *dpp,
-          const OSDMapRef &osdmap) = 0;
+          const OSDMapRef &osdmap,
+          bool &first_write_in_interval) = 0;
 
       virtual bool skip_transaction(
           std::set<shard_id_t> &pending_roll_forward,
@@ -648,6 +649,11 @@ struct ECCommon {
     ECExtentCache extent_cache;
     uint64_t ec_pdw_write_mode;
     bool next_write_all_shards = false;
+
+    // Set by on_change, forces first write in each interval to be
+    // a full write to avoid PWLC spanning intervals. Fixes
+    // https://tracker.ceph.com/issues/73891
+    bool first_write_in_interval;
 
     RMWPipeline(CephContext *cct,
                 ceph::ErasureCodeInterfaceRef ec_impl,

--- a/src/osd/ECTransaction.cc
+++ b/src/osd/ECTransaction.cc
@@ -468,7 +468,8 @@ ECTransaction::Generate::Generate(PGTransaction &t,
     PGTransaction::ObjectOperation &op,
     WritePlanObj &plan,
     DoutPrefixProvider *dpp,
-    pg_log_entry_t *entry)
+    pg_log_entry_t *entry,
+    bool &first_write_in_interval)
   : t(t),
     ec_impl(ec_impl),
     pgid(pgid),
@@ -584,8 +585,9 @@ ECTransaction::Generate::Generate(PGTransaction &t,
     }
   }
 
-  if (size_change || clear_whiteout) {
+  if (size_change || clear_whiteout || first_write_in_interval) {
     all_shards_written();
+    first_write_in_interval = false;
   } else {
     // All primary shards must always be written, regardless of the write plan.
     shards_written(sinfo.get_parity_shards());
@@ -1007,7 +1009,8 @@ void ECTransaction::generate_transactions(
     set<hobject_t> *temp_added,
     set<hobject_t> *temp_removed,
     DoutPrefixProvider *dpp,
-    const OSDMapRef &osdmap) {
+    const OSDMapRef &osdmap,
+    bool &first_write_in_interval) {
   ceph_assert(written_map);
   ceph_assert(transactions);
   ceph_assert(temp_added);
@@ -1040,7 +1043,7 @@ void ECTransaction::generate_transactions(
       ceph_assert(plan.hoid == oid);
 
       Generate generate(t, ec_impl, pgid, sinfo, partial_extents, written_map,
-        *transactions, osdmap, oid, op, plan, dpp, entry);
+        *transactions, osdmap, oid, op, plan, dpp, entry, first_write_in_interval);
 
       plans.plans.pop_front();
   });

--- a/src/osd/ECTransaction.h
+++ b/src/osd/ECTransaction.h
@@ -120,7 +120,8 @@ class Generate {
     const hobject_t &oid, PGTransaction::ObjectOperation &op,
     WritePlanObj &plan,
     DoutPrefixProvider *dpp,
-    pg_log_entry_t *entry);
+    pg_log_entry_t *entry,
+    bool &first_write_in_interval);
 };
 
 void generate_transactions(
@@ -136,6 +137,7 @@ void generate_transactions(
     std::set<hobject_t> *temp_added,
     std::set<hobject_t> *temp_removed,
     DoutPrefixProvider *dpp,
-    const OSDMapRef &osdmap
+    const OSDMapRef &osdmap,
+    bool &first_write_in_interval
   );
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75538

---

backport of https://github.com/ceph/ceph/pull/67244
parent tracker: https://tracker.ceph.com/issues/73891

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

Note trivial merge conflict for src/osd/ECBackend.cc where assert had been changed to ceph_assert in main. Kept this change in the backport.