### PR TITLE
tentacle: osd: FastEC: always update pwlc epoch when activating

### DIFF
--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -2892,6 +2892,10 @@ void PeeringState::activate(
   send_notify = false;
 
   if (is_primary()) {
+    // Update the epoch so that pwlc used by the primary during
+    // peering becomes the definitive copy of pwlc
+    info.partial_writes_last_complete_epoch = get_osdmap_epoch();
+
     // only update primary last_epoch_started if we will go active
     if (acting_set_writeable()) {
       ceph_assert(cct->_conf->osd_find_best_info_ignore_history_les ||
@@ -3347,9 +3351,6 @@ void PeeringState::consider_rollback_pwlc(eversion_t last_complete)
 		 << info.partial_writes_last_complete[shard] << dendl;
     }
   }
-  // Update the epoch so that pwlc adjustments made by the whole
-  // proc_master_log process are recognized as the newest updates
-  info.partial_writes_last_complete_epoch = get_osdmap_epoch();
 }
 
 void PeeringState::proc_master_log(


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76383

---

backport of https://github.com/ceph/ceph/pull/66685
parent tracker: https://tracker.ceph.com/issues/74218

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh