### PR TITLE
cmake: Fix ISA-L build on arm

### DIFF
--- a/cmake/modules/BuildISAL.cmake
+++ b/cmake/modules/BuildISAL.cmake
@@ -21,15 +21,15 @@ function(build_isal)
   if(CMAKE_C_COMPILER_ID MATCHES "Clang" AND HAVE_ARMV8_SIMD)
     list(APPEND arm_cflags "-no-integrated-as")
   endif()
-  # isa-l 2.32.0 requires SVE assembly support
+  # isa-l 2.32.0 includes SVE and SVE2-optimized assembly for better performance on
+  # compatible ARM CPUs
   if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64")
     list(APPEND arm_cflags "-Wa,-march=armv8-a+sve")
   endif()
   if(arm_cflags)
     string(REPLACE ";" " " arm_cflags_str "${arm_cflags}")
-    list(APPEND configure_cmd "CFLAGS=${arm_cflags_string}")
+    list(APPEND configure_cmd "CFLAGS=$ENV{CFLAGS} -fPIC ${arm_cflags_str}")
   endif()
-  
 
   include(ExternalProject)
   ExternalProject_Add(isal_ext


### PR DESCRIPTION
A typo in CFLAGS means we're passing an empty string to configure_cmd.
We are then overwriting the build environment CFLAGS with our empty string CFLAGS,
which can result in build failures in certain environments, as seen in the tracker.
This fix gets any build environment CFLAGS and appends the other flags
we want to use when building ISA-L 2.32.0

Introduced in https://github.com/ceph/ceph/pull/67749/changes/6930c4260023fa98d0ad3d777a4c84ac15dec8fe

Fixes: https://tracker.ceph.com/issues/76389

Testing completed:

1. Test existing buggy code
Create Fedora container on macbook M1 pro with ARM-based CPU
./do_cmake.sh
ninja -j3 isal_ext
cat ceph/src/isa-l/config.log | grep -E "^CFLAGS"
CFLAGS=''

2. Build fix and test with no CFLAGS var set
./do_cmake.sh
ninja -j3 isal_ext
cat ceph/src/isa-l/config.log | grep -E "^CFLAGS"
CFLAGS='-g -O2 -Wa,-march=armv8-a+sve'

3. Set an environment similar to the build server environment
export CFLAGS="$(rpm --eval '%{optflags}')"
./do_cmake.sh
ninja -j3 isal_ext
cat ceph/src/isa-l/config.log | grep -E "^CFLAGS"
CFLAGS='-O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wno-complain-wrong-lang -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -mbranch-protection=standard -fasynchronous-unwind-tables -fstack-clash-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -Wa,-march=armv8-a+sve'

4. Build unittest_erasure_code_isa
Run tests and watch them pass
Run nm lib/libec_isa.so | grep -i "sve" to check that we built with sve/2 support (the mac CPU only supports neon, but sve still gets built into the library and we use the multibinary to select the appropriate function for the CPU)
[root@c8b80ca7dddf build]# nm lib/libec_isa.so | grep -i "sve"
0000000000053930 T ec_encode_data_sve
0000000000053c00 T ec_encode_data_sve2
00000000000539a0 t ec_encode_data_sve2_impl
00000000000536d0 t ec_encode_data_sve_impl
0000000000053e50 T ec_encode_data_update_sve
0000000000053c70 t ec_encode_data_update_sve_impl
0000000000039f48 T gf_2vect_dot_prod_sve
0000000000047380 T gf_2vect_dot_prod_sve2
0000000000055f40 T gf_2vect_mad_sve
000000000003bd98 T gf_3vect_dot_prod_sve
00000000000491d0 T gf_3vect_dot_prod_sve2
0000000000056000 T gf_3vect_mad_sve
000000000003dbe8 T gf_4vect_dot_prod_sve
000000000004b020 T gf_4vect_dot_prod_sve2
00000000000560c0 T gf_4vect_mad_sve
000000000003fa38 T gf_5vect_dot_prod_sve
000000000004ce70 T gf_5vect_dot_prod_sve2
00000000000561c0 T gf_5vect_mad_sve
0000000000041888 T gf_6vect_dot_prod_sve
000000000004ecc0 T gf_6vect_dot_prod_sve2
0000000000056300 T gf_6vect_mad_sve
00000000000436d8 T gf_7vect_dot_prod_sve
0000000000050b10 T gf_7vect_dot_prod_sve2
00000000000380d4 T gf_vect_dot_prod_sve
0000000000045528 T gf_vect_dot_prod_sve2
0000000000038000 T gf_vect_mad_sve
0000000000038080 T gf_vect_mul_sve

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
