### PR TITLE
mgr/cephadm: redirect browser to correct port by identity provider

### DIFF
--- a/src/pybind/mgr/cephadm/templates/services/mgmt-gateway/external_server.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/mgmt-gateway/external_server.conf.j2
@@ -55,17 +55,17 @@ server {
 {% if enable_oauth2_proxy %}
     location /oauth2/ {
         proxy_pass https://oauth2_proxy_servers;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Scheme $scheme;
         # Check for original-uri header
-        proxy_set_header X-Auth-Request-Redirect $scheme://$host$request_uri;
+        proxy_set_header X-Auth-Request-Redirect $scheme://$http_host$request_uri;
     }
 
     location = /oauth2/auth {
         internal;
         proxy_pass https://oauth2_proxy_servers;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Scheme $scheme;
         # nginx auth_request includes headers but not body
@@ -97,12 +97,12 @@ server {
         auth_request_set $auth_cookie $upstream_http_set_cookie;
         add_header Set-Cookie $auth_cookie;
 
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Host $host:80;
-        proxy_set_header X-Forwarded-Port 80;
-        proxy_set_header X-Forwarded-Server $host;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header X-Forwarded-Server $http_host;
         proxy_set_header X-Forwarded-Groups $groups;
 
         proxy_http_version 1.1;
@@ -134,7 +134,7 @@ server {
         # Pass role header to Grafana
         proxy_set_header X-WEBAUTH-ROLE $http_x_auth_request_role;
 
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;

--- a/src/pybind/mgr/cephadm/tests/services/test_mgmt_gateway.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_mgmt_gateway.py
@@ -437,17 +437,17 @@ class TestMgmtGateway:
 
                                                  location /oauth2/ {
                                                      proxy_pass https://oauth2_proxy_servers;
-                                                     proxy_set_header Host $host;
+                                                     proxy_set_header Host $http_host;
                                                      proxy_set_header X-Real-IP $remote_addr;
                                                      proxy_set_header X-Scheme $scheme;
                                                      # Check for original-uri header
-                                                     proxy_set_header X-Auth-Request-Redirect $scheme://$host$request_uri;
+                                                     proxy_set_header X-Auth-Request-Redirect $scheme://$http_host$request_uri;
                                                  }
 
                                                  location = /oauth2/auth {
                                                      internal;
                                                      proxy_pass https://oauth2_proxy_servers;
-                                                     proxy_set_header Host $host;
+                                                     proxy_set_header Host $http_host;
                                                      proxy_set_header X-Real-IP $remote_addr;
                                                      proxy_set_header X-Scheme $scheme;
                                                      # nginx auth_request includes headers but not body
@@ -476,12 +476,12 @@ class TestMgmtGateway:
                                                      auth_request_set $auth_cookie $upstream_http_set_cookie;
                                                      add_header Set-Cookie $auth_cookie;
 
-                                                     proxy_set_header Host $host;
+                                                     proxy_set_header Host $http_host;
                                                      proxy_set_header X-Real-IP $remote_addr;
                                                      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                                                     proxy_set_header X-Forwarded-Host $host:80;
-                                                     proxy_set_header X-Forwarded-Port 80;
-                                                     proxy_set_header X-Forwarded-Server $host;
+                                                     proxy_set_header X-Forwarded-Host $http_host;
+                                                     proxy_set_header X-Forwarded-Port $server_port;
+                                                     proxy_set_header X-Forwarded-Server $http_host;
                                                      proxy_set_header X-Forwarded-Groups $groups;
 
                                                      proxy_http_version 1.1;
@@ -509,7 +509,7 @@ class TestMgmtGateway:
                                                      # Pass role header to Grafana
                                                      proxy_set_header X-WEBAUTH-ROLE $http_x_auth_request_role;
 
-                                                     proxy_set_header Host $host;
+                                                     proxy_set_header Host $http_host;
                                                      proxy_set_header X-Real-IP $remote_addr;
                                                      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
                                                      proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
After authentication, the external identity provider was redirecting to the correct dashboard address but omitting the external port causing the browser to redirect to the default https port (443) which isn't used since an external port was configured in mgmt-gateway spec file.

The nginx external_server_conf.j2 file was changed to use $http_host instead of $host in order for the oauth2-proxy service to correctly construct the dashboard URL including the non-standard port.

Fixes: https://tracker.ceph.com/issues/74024


Steps to reproduce:

1) Deploy ceph cluster with monitoring stack.
2) Create VIP for the mgmt-gateway dashboard:
`ip addr add 192.168.100.150/24 dev ens3`
3) Deploy mgmt-gateway with ingress (keepalived):
```
ceph orch host label add ceph-node-0 mgmt

ceph orch apply -i - <<EOF
service_type: mgmt-gateway
placement:
  label: mgmt
spec:
  enable_auth: true
  virtual_ip: '192.168.100.150'
  port: 28080
EOF

ceph orch apply -i - <<EOF
service_type: ingress
service_id: ingress-mgmt-gw
placement:
  label: mgmt
virtual_ip: '192.168.100.150'
backend_service: mgmt-gateway
keepalive_only: true
EOF

```

4) Run Keycloak service as external identity provider:
```
  podman run -d --name keycloak-test \
  -p 8888:8080 \
  -e KEYCLOAK_ADMIN=admin \
  -e KEYCLOAK_ADMIN_PASSWORD=adminpass \
  quay.io/keycloak/keycloak:latest start-dev

```

5) Create client on external identity provider (Keycloak).
    Set valid redirect URLs to: https://<mgmt-gateway dahsboard vip>:28080/oauth2/callback
    Save the generated client secret for usage in oauth2-proxy service.
    
6) Deploy oauth2-proxy service and enable oauth2 sso:
```
ceph orch apply -i - <<EOF
service_type: oauth2-proxy
service_name: oauth2-proxy
placement:
  label: mgmt
spec:
  certificate_source: cephadm-signed
  client_id: ceph-proxy
  client_secret: <copied from the credentials tab in keycloak>
  oidc_issuer_url: http://127.0.0.1:8888/realms/ceph-test
  provider_display_name: Keycloak
  redirect_url: https://<mgmt-gateway dahsboard vip>:28080/oauth2/callback
  ssl: true
EOF

ceph dashboard sso enable oauth2
```

7) Connect to dahsboard from browser: https://<mgmt-gateway dhsboard vip>:28080 -->
Redirected to external identity provider:
<img width="1242" height="762" alt="image" src="https://github.com/user-attachments/assets/7e840e4d-f611-49c3-8813-5c760256869c" />

--> Login with credentials, and redirected back to dashboard missing the non-standard port resulting in **ERR_CONNECTION_REFUSED**:

<img width="933" height="591" alt="image" src="https://github.com/user-attachments/assets/a9895e96-c7d1-453e-b840-de662a94d207" />


8) In /var/lib/ceph/9ac1fb32-453d-11f1-8a2d-525400a791ba/mgmt-gateway.ceph-node-0/etc/nginx_external_server.conf Change occurrences of $host to $http_host, and occurrences of port 80 with $server_port.

9) After redeploying the cluster with the suggested PR, and going over steps (1) - (7), the identity provider redirection was performed properly to the https://<mgmt-gateway dhsboard vip>:28080 address:
<img width="508" height="261" alt="image" src="https://github.com/user-attachments/assets/d23f6193-5908-4c2f-bffd-8bc7beed69c0" />


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
