### PR TITLE
tentacle: osd: Avoid assertion on empty object read when reading multiple objects

### DIFF
--- a/src/osd/ECCommon.cc
+++ b/src/osd/ECCommon.cc
@@ -493,8 +493,8 @@ void ECCommon::ReadPipeline::do_read_op(ReadOp &rop) {
       }
     }
     ceph_assert(!need_attrs);
-    ceph_assert(reads_sent);
   }
+  ceph_assert(reads_sent);
 
   std::optional<ECSubRead> local_read_op;
   std::vector<std::pair<int, Message*>> m;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76386

---

backport of https://github.com/ceph/ceph/pull/68637
parent tracker: https://tracker.ceph.com/issues/75432

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh