### PR TITLE
mon: add OSD-only failure detection for stretch mode degraded mode

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -15,6 +15,7 @@
 
 #include "Monitor.h"
 
+#include <algorithm>
 #include <iomanip> // for std::setw()
 #include <iterator>
 #include <sstream>
@@ -2518,7 +2519,8 @@ void Monitor::finish_election()
 		     leader);
     return;
   }
-  do_stretch_mode_election_work();
+  // Check for stretch mode failures after election
+  maybe_go_degraded_stretch_mode();
 }
 
 void Monitor::_apply_compatset_features(CompatSet &new_features)
@@ -6917,46 +6919,14 @@ void Monitor::try_disable_stretch_mode()
     stretch_bucket_divider.clear();
     degraded_stretch_mode = false;
     recovering_stretch_mode = false;
-  }
-
-}
-
-void Monitor::do_stretch_mode_election_work()
-{
-  dout(20) << __func__ << dendl;
-  if (!is_stretch_mode() ||
-      !is_leader()) return;
-  dout(20) << "checking for degraded stretch mode" << dendl;
-  map<string, set<string>> old_dead_buckets;
-  old_dead_buckets.swap(dead_mon_buckets);
-  up_mon_buckets.clear();
-  // identify if we've lost a CRUSH bucket, request OSDMonitor check for death
-  map<string,set<string>> down_mon_buckets;
-  for (unsigned i = 0; i < monmap->size(); ++i) {
-    const auto &mi = monmap->mon_info[monmap->get_name(i)];
-    auto ci = mi.crush_loc.find(stretch_bucket_divider);
-    ceph_assert(ci != mi.crush_loc.end());
-    if (quorum.count(i)) {
-      up_mon_buckets.insert(ci->second);
-    } else {
-      down_mon_buckets[ci->second].insert(mi.name);
-    }
-  }
-  dout(20) << "prior dead_mon_buckets: " << old_dead_buckets
-	   << "; down_mon_buckets: " << down_mon_buckets
-	   << "; up_mon_buckets: " << up_mon_buckets << dendl;
-  for (const auto& di : down_mon_buckets) {
-    if (!up_mon_buckets.count(di.first)) {
-      dead_mon_buckets[di.first] = di.second;
-    }
-  }
-  dout(20) << "new dead_mon_buckets " << dead_mon_buckets << dendl;
-
-  if (dead_mon_buckets != old_dead_buckets &&
-      dead_mon_buckets.size() >= old_dead_buckets.size()) {
-    maybe_go_degraded_stretch_mode();
+    dead_osd_buckets.clear();
+    up_osd_buckets.clear();
+    dead_mon_buckets.clear();
+    up_mon_buckets.clear();
   }
 }
+
+
 
 struct CMonGoDegraded : public Context {
   Monitor *m;
@@ -6985,9 +6955,16 @@ void Monitor::go_recovery_stretch_mode()
   if (is_recovering_stretch_mode()) return;
   dout(20) << "dead_mon_buckets.size(): " << dead_mon_buckets.size() << dendl;
   dout(20) << "dead_mon_buckets: " << dead_mon_buckets << dendl;
+  dout(20) << "dead_osd_buckets.size(): " << dead_osd_buckets.size() << dendl;
+  dout(20) << "dead_osd_buckets: " << dead_osd_buckets << dendl;
   if (dead_mon_buckets.size()) {
     ceph_assert( 0 == "how did we try and do stretch recovery while we have dead monitor buckets?");
     // we can't recover if we are missing monitors in a zone!
+    return;
+  }
+  if (dead_osd_buckets.size()) {
+    dout(20) << "cannot recover yet, still have dead OSD buckets" << dendl;
+    // we can't recover if we still have zones with all OSDs down!
     return;
   }
   
@@ -7013,62 +6990,148 @@ void Monitor::set_recovery_stretch_mode()
   osdmon()->set_recovery_stretch_mode();
 }
 
+void Monitor::populate_dead_mon_buckets(
+  const MonMap& monmap,
+  const set<int>& quorum,
+  const string& stretch_bucket_divider,
+  map<string, set<string>>& dead_mon_buckets,
+  set<string>& up_mon_buckets)
+{
+  dead_mon_buckets.clear();
+  up_mon_buckets.clear();
+  
+  // Get tiebreaker zone to filter it out
+  ceph_assert(monmap.contains(monmap.tiebreaker_mon));
+  const auto &tiebreaker_mi = monmap.mon_info.at(monmap.tiebreaker_mon);
+  auto tiebreaker_ci = tiebreaker_mi.crush_loc.find(stretch_bucket_divider);
+  ceph_assert(tiebreaker_ci != tiebreaker_mi.crush_loc.end());
+  string tiebreaker_zone = tiebreaker_ci->second;
+
+  // if mon in quorum then it's up, otherwise it's down
+  map<string, set<string>> bucket_to_down_mons;
+  for (unsigned i = 0; i < monmap.size(); ++i) {
+    const auto &mi = monmap.mon_info.at(monmap.get_name(i));
+    auto ci = mi.crush_loc.find(stretch_bucket_divider);
+    if (quorum.count(i)) {
+      up_mon_buckets.insert(ci->second);
+    } else {
+      bucket_to_down_mons[ci->second].insert(mi.name);
+    }
+  }
+  // Only track dead buckets for non-tiebreaker zones
+  for (const auto& [bucket_name, mons] : bucket_to_down_mons) {
+    if (!up_mon_buckets.count(bucket_name) && bucket_name != tiebreaker_zone) {
+      dead_mon_buckets[bucket_name] = mons;
+    }
+  }
+}
+
+void Monitor::populate_dead_osd_buckets(
+  const OSDMap& osdmap,
+  std::set<std::string>& dead_osd_buckets,
+  std::set<std::string>& up_osd_buckets)
+{
+  dead_osd_buckets.clear();
+  up_osd_buckets.clear();
+  vector<int> subtrees;
+  int32_t stretch_divider_id = osdmap.stretch_mode_bucket;
+  osdmap.crush->get_subtree_of_type(stretch_divider_id, &subtrees);
+  set<int> down_cache;
+  for (int bucket_id : subtrees) {
+    if (osdmap.subtree_is_down(bucket_id, &down_cache)) {
+      string bucket_name = osdmap.crush->get_item_name(bucket_id);
+      dead_osd_buckets.insert(bucket_name);
+    } else {
+      string bucket_name = osdmap.crush->get_item_name(bucket_id);
+      up_osd_buckets.insert(bucket_name);
+    }
+  }
+}
+
+void Monitor::compute_dead_zones_and_mons(
+  const map<string, set<string>>& dead_mon_buckets,
+  const set<string>& dead_osd_buckets,
+  set<string>& matched_down_mons,
+  set<string>& dead_zones)
+{
+  matched_down_mons.clear();
+  dead_zones.clear();
+  
+  // Collect all down monitors
+  for (const auto& [zone, mons] : dead_mon_buckets) {
+    matched_down_mons.insert(mons.begin(), mons.end());
+  }
+  
+  // Compute union of dead zones (zones with dead monitors OR dead OSDs)
+  for (const auto& [zone, mons] : dead_mon_buckets) {
+    dead_zones.insert(zone);
+  }
+  dead_zones.insert(dead_osd_buckets.begin(), dead_osd_buckets.end());
+}
+
 void Monitor::maybe_go_degraded_stretch_mode()
 {
   dout(20) << __func__ << dendl;
   if (!is_stretch_mode()) return;
   if (is_degraded_stretch_mode()) return;
   if (!is_leader()) return;
-  if (dead_mon_buckets.empty()) return;
   if (!osdmon()->is_readable()) {
     osdmon()->wait_for_readable_ctx(new CMonGoDegraded(this));
     return;
   }
-  ceph_assert(monmap->contains(monmap->tiebreaker_mon));
-  // filter out the tiebreaker zone and check if remaining sites are down by OSDs too
-  const auto &mi = monmap->mon_info[monmap->tiebreaker_mon];
-  auto ci = mi.crush_loc.find(stretch_bucket_divider);
-  map<string, set<string>> filtered_dead_buckets = dead_mon_buckets;
-  filtered_dead_buckets.erase(ci->second);
 
-  set<int> matched_down_buckets;
-  set<string> matched_down_mons;
-  bool dead = osdmon()->check_for_dead_crush_zones(filtered_dead_buckets,
-						   &matched_down_buckets,
-						   &matched_down_mons);
-  if (dead) {
-    if (!osdmon()->is_writeable()) {
-      dout(20) << "osdmon is not writeable" << dendl;
-      osdmon()->wait_for_writeable_ctx(new CMonGoDegraded(this));
-      return;
-    }
-    if (!monmon()->is_writeable()) {
-      dout(20) << "monmon is not writeable" << dendl;
-      monmon()->wait_for_writeable_ctx(new CMonGoDegraded(this));
-      return;
-    }
-    trigger_degraded_stretch_mode(matched_down_mons, matched_down_buckets);
+  // Check for zone failures in Monitors and OSDs, disregarding tiebreaker.
+  populate_dead_mon_buckets(*monmap, quorum, stretch_bucket_divider,
+                            dead_mon_buckets, up_mon_buckets);
+  dout(20) << "dead_mon_buckets: " << dead_mon_buckets
+           << "; up_mon_buckets: " << up_mon_buckets << dendl;
+
+  populate_dead_osd_buckets(osdmon()->osdmap,
+    dead_osd_buckets, up_osd_buckets);
+  dout(20) << "dead_osd_buckets: " << dead_osd_buckets
+           << "; up_osd_buckets: " << up_osd_buckets << dendl;
+
+  // Early return if no failures detected
+  if (dead_mon_buckets.empty() && dead_osd_buckets.empty()) return;
+  
+  // Compute degraded stretch mode parameters
+  set<string> dead_mons;
+  set<string> dead_zones;
+  compute_dead_zones_and_mons(dead_mon_buckets, dead_osd_buckets,
+                              dead_mons, dead_zones);
+  
+  // Trigger degraded mode if any zone has all monitors down OR all OSDs down
+  if (!osdmon()->is_writeable()) {
+    dout(20) << "osdmon is not writeable" << dendl;
+    osdmon()->wait_for_writeable_ctx(new CMonGoDegraded(this));
+    return;
   }
+  if (!monmon()->is_writeable()) {
+    dout(20) << "monmon is not writeable" << dendl;
+    monmon()->wait_for_writeable_ctx(new CMonGoDegraded(this));
+    return;
+  }
+  // Use dead_osd_buckets directly (already zone names)
+  trigger_degraded_stretch_mode(dead_mons, dead_zones);
 }
 
 void Monitor::trigger_degraded_stretch_mode(const set<string>& dead_mons,
-					    const set<int>& dead_buckets)
+					    const set<string>& dead_zones)
 {
   dout(20) << __func__ << dendl;
   if (!is_stretch_mode()) return;
   ceph_assert(osdmon()->is_writeable());
   ceph_assert(monmon()->is_writeable());
 
-  // figure out which OSD zone(s) remains alive by removing
-  // tiebreaker mon from up_mon_buckets
-  set<string> live_zones = up_mon_buckets;
-  ceph_assert(monmap->contains(monmap->tiebreaker_mon));
-  const auto &mi = monmap->mon_info[monmap->tiebreaker_mon];
-  auto ci = mi.crush_loc.find(stretch_bucket_divider);
-  live_zones.erase(ci->second);
+  // Compute live zones as the intersection of zones with live monitors AND live OSDs
+  set<string> live_zones;
+  std::set_intersection(up_mon_buckets.begin(), up_mon_buckets.end(),
+                        up_osd_buckets.begin(), up_osd_buckets.end(),
+                        std::inserter(live_zones, live_zones.begin()));
+  
   ceph_assert(live_zones.size() == 1); // only support 2 zones right now
   
-  osdmon()->trigger_degraded_stretch_mode(dead_buckets, live_zones);
+  osdmon()->trigger_degraded_stretch_mode(dead_zones, live_zones);
   monmon()->trigger_degraded_stretch_mode(dead_mons);
   set_degraded_stretch_mode();
 }

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -263,9 +263,10 @@ private:
   bool degraded_stretch_mode{false};
   bool recovering_stretch_mode{false};
   std::string stretch_bucket_divider;
-  std::map<std::string, std::set<std::string>> dead_mon_buckets; // bucket->mon ranks, locations with no live mons
-  std::set<std::string> up_mon_buckets; // locations with a live mon
-  void do_stretch_mode_election_work();
+  std::map<std::string, std::set<std::string>> dead_mon_buckets; // Map of zones to dead monitors
+  std::set<std::string> up_mon_buckets; // Zones with a live MONs
+  std::set<std::string> dead_osd_buckets; // Zones wih dead OSDs
+  std::set<std::string> up_osd_buckets; // Zones with live OSDs
 
   bool session_stretch_allowed(MonSession *s, MonOpRequestRef& op);
   void disconnect_disallowed_stretch_sessions();
@@ -274,6 +275,7 @@ private:
   std::map<std::string,std::string> crush_loc;
   bool need_set_crush_loc{false};
 public:
+
   bool is_stretch_mode() { return stretch_mode_engaged; }
   bool is_degraded_stretch_mode() { return degraded_stretch_mode; }
   bool is_recovering_stretch_mode() { return recovering_stretch_mode; }
@@ -294,7 +296,7 @@ public:
   void try_disable_stretch_mode();
   void maybe_go_degraded_stretch_mode();
   void trigger_degraded_stretch_mode(const std::set<std::string>& dead_mons,
-				     const std::set<int>& dead_buckets);
+				     const std::set<std::string>& dead_buckets);
   void set_degraded_stretch_mode();
   void go_recovery_stretch_mode();
   void set_recovery_stretch_mode();
@@ -302,6 +304,25 @@ public:
   void set_healthy_stretch_mode();
   void enable_stretch_mode();
   void set_mon_crush_location(const std::string& loc);
+
+  // Helper functions for unit testing stretch mode failure detection
+  static void populate_dead_mon_buckets(
+    const MonMap& monmap,
+    const std::set<int>& quorum,
+    const std::string& stretch_bucket_divider,
+    std::map<std::string, std::set<std::string>>& dead_mon_buckets,
+    std::set<std::string>& up_mon_buckets);
+
+  static void populate_dead_osd_buckets(
+    const OSDMap& osdmap,
+    std::set<std::string>& dead_osd_buckets,
+    std::set<std::string>& up_osd_buckets);
+
+  static void compute_dead_zones_and_mons(
+    const std::map<std::string, std::set<std::string>>& dead_mon_buckets,
+    const std::set<std::string>& dead_osd_buckets,
+    std::set<std::string>& matched_down_mons,
+    std::set<std::string>& dead_zones);
 
   
 private:

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -15698,38 +15698,7 @@ void OSDMonitor::try_enable_stretch_mode(stringstream& ss, bool *okay,
   return;
 }
 
-bool OSDMonitor::check_for_dead_crush_zones(const map<string,set<string>>& dead_buckets,
-					    set<int> *really_down_buckets,
-					    set<string> *really_down_mons)
-{
-  dout(20) << __func__ << " with dead mon zones " << dead_buckets << dendl;
-  ceph_assert(is_readable());
-  if (dead_buckets.empty()) return false;
-  set<int> down_cache;
-  bool really_down = false;
-  for (auto dbi : dead_buckets) {
-    const string& bucket_name = dbi.first;
-    if (!osdmap.crush->name_exists(bucket_name)) {
-      dout(10) << "CRUSH bucket " << bucket_name << " does not exist" << dendl;
-      continue;
-    }
-    int bucket_id = osdmap.crush->get_item_id(bucket_name);
-    dout(20) << "Checking " << bucket_name << " id " << bucket_id
-	     << " to see if OSDs are also down" << dendl;
-    bool subtree_down = osdmap.subtree_is_down(bucket_id, &down_cache);
-    if (subtree_down) {
-      dout(20) << "subtree is down!" << dendl;
-      really_down = true;
-      really_down_buckets->insert(bucket_id);
-      really_down_mons->insert(dbi.second.begin(), dbi.second.end());
-    }
-  }
-  dout(10) << "We determined CRUSH buckets " << *really_down_buckets
-	   << " and mons " << *really_down_mons << " are really down" << dendl;
-  return really_down;
-}
-
-void OSDMonitor::trigger_degraded_stretch_mode(const set<int>& dead_buckets,
+void OSDMonitor::trigger_degraded_stretch_mode(const set<std::string>& dead_zones,
 					       const set<string>& live_zones)
 {
   dout(20) << __func__ << dendl;
@@ -15738,7 +15707,7 @@ void OSDMonitor::trigger_degraded_stretch_mode(const set<int>& dead_buckets,
   pending_inc.change_stretch_mode = true;
   pending_inc.stretch_mode_enabled = osdmap.stretch_mode_enabled;
   pending_inc.new_stretch_bucket_count = osdmap.stretch_bucket_count;
-  int new_site_count = osdmap.stretch_bucket_count - dead_buckets.size();
+  int new_site_count = osdmap.stretch_bucket_count - dead_zones.size();
   ceph_assert(new_site_count == 1); // stretch count 2!
   pending_inc.new_degraded_stretch_mode = new_site_count;
   pending_inc.new_recovering_stretch_mode = 0;

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -867,18 +867,10 @@ public:
           int *errcode,
           const std::string& crush_rule);
   /**
-   * Check the input dead_buckets mapping (buckets->dead monitors) to see
-   * if the OSDs are also down. If so, fill in really_down_buckets and
-   * really_down_mons and return true; else return false.
-   */
-  bool check_for_dead_crush_zones(const std::map<std::string,std::set<std::string>>& dead_buckets,
-				  std::set<int> *really_down_buckets,
-				  std::set<std::string> *really_down_mons);
-  /**
-   * Set degraded mode in the OSDMap, adding the given dead buckets to the dead set
+   * Set degraded mode in the OSDMap, adding the given dead zones to the dead set
    * and using the live_zones (should presently be size 1)
    */
-  void trigger_degraded_stretch_mode(const std::set<int>& dead_buckets,
+  void trigger_degraded_stretch_mode(const std::set<std::string>& dead_zones,
 				     const std::set<std::string>& live_zones);
   /**
    * This is just to maintain stretch_recovery_triggered; below

--- a/src/test/mon/CMakeLists.txt
+++ b/src/test/mon/CMakeLists.txt
@@ -88,3 +88,10 @@ add_executable(unittest_mon_election
   )
 add_ceph_unittest(unittest_mon_election)
 target_link_libraries(unittest_mon_election mon global)
+
+#unittest_maybe_go_degraded_stretch_mode
+add_executable(unittest_maybe_go_degraded_stretch_mode
+  test_maybe_go_degraded_stretch_mode.cc
+  )
+add_ceph_unittest(unittest_maybe_go_degraded_stretch_mode)
+target_link_libraries(unittest_maybe_go_degraded_stretch_mode mon global)

--- a/src/test/mon/test_maybe_go_degraded_stretch_mode.cc
+++ b/src/test/mon/test_maybe_go_degraded_stretch_mode.cc
@@ -1,0 +1,399 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+/*
+ * Test maybe_go_degraded_stretch_mode and helper functions
+ *
+ * Tests the stretch mode failure detection mechanism that monitors both
+ * monitor and OSD health to determine when to trigger degraded stretch mode.
+ */
+
+#include "gtest/gtest.h"
+#include "mon/Monitor.h"
+#include "mon/MonMap.h"
+#include "osd/OSDMap.h"
+#include "crush/CrushWrapper.h"
+#include "common/ceph_context.h"
+
+#include <memory>
+#include <sstream>
+
+using namespace std;
+
+class StretchModeTest : public ::testing::Test {
+protected:
+  unique_ptr<CephContext> cct;
+  OSDMap osdmap;
+  shared_ptr<CrushWrapper> crush;
+  MonMap monmap;
+  string stretch_bucket_divider;
+
+  void SetUp() override {
+    vector<const char*> args;
+    cct.reset(new CephContext(CEPH_ENTITY_TYPE_MON));
+    crush = make_shared<CrushWrapper>();
+    stretch_bucket_divider = "datacenter";
+  }
+
+  void setup_crush_three_zones() {
+    // Create a CRUSH map with three zones: dc1, dc2 (data)
+    crush->create();
+    crush->set_max_devices(10);
+
+    crush->set_type_name(10, "root");
+    crush->set_type_name(8, "datacenter");
+    crush->set_type_name(1, "host");
+    crush->set_type_name(0, "osd");
+
+    // DC1 - data zone
+    map<string,string> loc_dc1;
+    loc_dc1["root"] = "default";
+    loc_dc1["datacenter"] = "dc1";
+    loc_dc1["host"] = "host1";
+    crush->insert_item(cct.get(), 0, 1.0, "osd.0", loc_dc1);
+    crush->insert_item(cct.get(), 1, 1.0, "osd.1", loc_dc1);
+
+    // DC2 - data zone
+    map<string,string> loc_dc2;
+    loc_dc2["root"] = "default";
+    loc_dc2["datacenter"] = "dc2";
+    loc_dc2["host"] = "host2";
+    crush->insert_item(cct.get(), 2, 1.0, "osd.2", loc_dc2);
+    crush->insert_item(cct.get(), 3, 1.0, "osd.3", loc_dc2);
+
+     // Tiebreaker zone only has monitors, not OSDs
+  }
+
+  void setup_osdmap_all_up() {
+    osdmap.set_max_osd(4);
+    osdmap.crush = crush;
+    
+    // Set stretch mode bucket type
+    int32_t stretch_divider_id = crush->get_type_id("datacenter");
+    osdmap.stretch_mode_bucket = stretch_divider_id;
+    
+    for (int i = 0; i < 4; i++) {
+      osdmap.set_state(i, CEPH_OSD_EXISTS | CEPH_OSD_UP);
+      osdmap.set_weight(i, CEPH_OSD_IN);
+    }
+  }
+
+  void setup_osdmap_dc2_down() {
+    // OSDs 0,1 (dc1) are up, OSDs 2,3 (dc2) are down
+    osdmap.set_max_osd(4);
+    osdmap.crush = crush;
+    
+    // Set stretch mode bucket type
+    int32_t stretch_divider_id = crush->get_type_id("datacenter");
+    osdmap.stretch_mode_bucket = stretch_divider_id;
+    
+    osdmap.set_state(0, CEPH_OSD_EXISTS | CEPH_OSD_UP);
+    osdmap.set_weight(0, CEPH_OSD_IN);
+    osdmap.set_state(1, CEPH_OSD_EXISTS | CEPH_OSD_UP);
+    osdmap.set_weight(1, CEPH_OSD_IN);
+    
+    // OSDs in dc2 are down
+    osdmap.set_state(2, CEPH_OSD_EXISTS);
+    osdmap.set_weight(2, CEPH_OSD_IN);
+    osdmap.set_state(3, CEPH_OSD_EXISTS);
+    osdmap.set_weight(3, CEPH_OSD_IN);
+  }
+
+  void setup_monmap_three_zones() {
+    // Create monitors in three zones: dc1 (2 mons), dc2 (2 mons), arbiter (1 mon)
+    monmap.epoch = 1;
+    monmap.stretch_mode_enabled = true;
+    monmap.tiebreaker_mon = "mon.arbiter";
+    
+    // DC1 monitors
+    entity_addrvec_t addrs_dc1_mon0;
+    addrs_dc1_mon0.v.push_back(entity_addr_t());
+    mon_info_t& mon_dc1_0 = monmap.mon_info["mon.dc1-0"];
+    mon_dc1_0.name = "mon.dc1-0";
+    mon_dc1_0.public_addrs = addrs_dc1_mon0;
+    mon_dc1_0.crush_loc = {{"datacenter", "dc1"}};
+    monmap.ranks.push_back("mon.dc1-0");
+    
+    entity_addrvec_t addrs_dc1_mon1;
+    addrs_dc1_mon1.v.push_back(entity_addr_t());
+    mon_info_t& mon_dc1_1 = monmap.mon_info["mon.dc1-1"];
+    mon_dc1_1.name = "mon.dc1-1";
+    mon_dc1_1.public_addrs = addrs_dc1_mon1;
+    mon_dc1_1.crush_loc = {{"datacenter", "dc1"}};
+    monmap.ranks.push_back("mon.dc1-1");
+    
+    // DC2 monitors
+    entity_addrvec_t addrs_dc2_mon0;
+    addrs_dc2_mon0.v.push_back(entity_addr_t());
+    mon_info_t& mon_dc2_0 = monmap.mon_info["mon.dc2-0"];
+    mon_dc2_0.name = "mon.dc2-0";
+    mon_dc2_0.public_addrs = addrs_dc2_mon0;
+    mon_dc2_0.crush_loc = {{"datacenter", "dc2"}};
+    monmap.ranks.push_back("mon.dc2-0");
+    
+    entity_addrvec_t addrs_dc2_mon1;
+    addrs_dc2_mon1.v.push_back(entity_addr_t());
+    mon_info_t& mon_dc2_1 = monmap.mon_info["mon.dc2-1"];
+    mon_dc2_1.name = "mon.dc2-1";
+    mon_dc2_1.public_addrs = addrs_dc2_mon1;
+    mon_dc2_1.crush_loc = {{"datacenter", "dc2"}};
+    monmap.ranks.push_back("mon.dc2-1");
+    
+    // Arbiter monitor
+    entity_addrvec_t addrs_arbiter;
+    addrs_arbiter.v.push_back(entity_addr_t());
+    mon_info_t& mon_arbiter = monmap.mon_info["mon.arbiter"];
+    mon_arbiter.name = "mon.arbiter";
+    mon_arbiter.public_addrs = addrs_arbiter;
+    mon_arbiter.crush_loc = {{"datacenter", "arbiter"}};
+    monmap.ranks.push_back("mon.arbiter");
+  }
+};
+
+// Test: DC2 zone has all OSDs down
+TEST_F(StretchModeTest, DC2_OSDsDown) {
+  setup_crush_three_zones();
+  setup_osdmap_dc2_down();
+  setup_monmap_three_zones();
+
+  // All monitors in quorum
+  set<int> quorum = {0, 1, 2, 3, 4};
+  
+  // Populate monitor and OSD failure state
+  map<string, set<string>> dead_mon_buckets;
+  set<string> up_mon_buckets;
+  set<string> dead_osd_buckets;
+  set<string> up_osd_buckets;
+  
+  Monitor::populate_dead_mon_buckets(monmap, quorum, stretch_bucket_divider,
+                                     dead_mon_buckets, up_mon_buckets);
+  Monitor::populate_dead_osd_buckets(osdmap, dead_osd_buckets, up_osd_buckets);
+  
+  // Compute final degraded mode parameters
+  set<string> dead_mons;
+  set<string> dead_zones;
+  Monitor::compute_dead_zones_and_mons(dead_mon_buckets, dead_osd_buckets,
+                                       dead_mons, dead_zones);
+  
+  // Verify results
+  EXPECT_EQ(dead_mons.size(), 0u) << "No monitors should be down";
+  EXPECT_EQ(dead_zones.size(), 1u) << "Should have 1 dead zone (dc2)";
+  EXPECT_TRUE(dead_zones.count("dc2")) << "dc2 should be in dead_zones";
+  EXPECT_EQ(dead_osd_buckets.size(), 1u) << "dc2 OSDs are down";
+  EXPECT_EQ(up_osd_buckets.size(), 1u) << "dc1 OSDs are up";
+}
+
+// Test: All OSDs and monitors healthy
+TEST_F(StretchModeTest, AllHealthy) {
+  setup_crush_three_zones();
+  setup_osdmap_all_up();
+  setup_monmap_three_zones();
+
+  // All monitors in quorum
+  set<int> quorum = {0, 1, 2, 3, 4};
+  
+  // Populate monitor and OSD failure state
+  map<string, set<string>> dead_mon_buckets;
+  set<string> up_mon_buckets;
+  set<string> dead_osd_buckets;
+  set<string> up_osd_buckets;
+  
+  Monitor::populate_dead_mon_buckets(monmap, quorum, stretch_bucket_divider,
+                                     dead_mon_buckets, up_mon_buckets);
+  Monitor::populate_dead_osd_buckets(osdmap, dead_osd_buckets, up_osd_buckets);
+  
+  // Compute final degraded mode parameters
+  set<string> dead_mons;
+  set<string> dead_zones;
+  Monitor::compute_dead_zones_and_mons(dead_mon_buckets, dead_osd_buckets,
+                                       dead_mons, dead_zones);
+  
+  // Verify results
+  EXPECT_EQ(dead_mons.size(), 0u) << "No monitors should be down";
+  EXPECT_EQ(dead_zones.size(), 0u) << "No zones should be dead";
+  EXPECT_EQ(dead_mon_buckets.size(), 0u) << "All monitors up";
+  EXPECT_EQ(dead_osd_buckets.size(), 0u) << "All OSDs up";
+  EXPECT_EQ(up_mon_buckets.size(), 3u) << "dc1, dc2, arbiter all have monitors";
+  EXPECT_EQ(up_osd_buckets.size(), 2u) << "dc1, dc2 have OSDs";
+}
+
+// ============================================================================
+// Monitor Failure Detection Tests
+// ============================================================================
+
+// Test: DC2 monitors are all down
+TEST_F(StretchModeTest, DC2_MonitorsDown) {
+  setup_crush_three_zones();
+  setup_osdmap_all_up();
+  setup_monmap_three_zones();
+
+  // Only dc1 and arbiter monitors in quorum (dc2 down)
+  set<int> quorum = {0, 1, 4};
+  
+  // Populate monitor and OSD failure state
+  map<string, set<string>> dead_mon_buckets;
+  set<string> up_mon_buckets;
+  set<string> dead_osd_buckets;
+  set<string> up_osd_buckets;
+  
+  Monitor::populate_dead_mon_buckets(monmap, quorum, stretch_bucket_divider,
+                                     dead_mon_buckets, up_mon_buckets);
+  Monitor::populate_dead_osd_buckets(osdmap, dead_osd_buckets, up_osd_buckets);
+  
+  // Compute final degraded mode parameters
+  set<string> dead_mons;
+  set<string> dead_zones;
+  Monitor::compute_dead_zones_and_mons(dead_mon_buckets, dead_osd_buckets,
+                                       dead_mons, dead_zones);
+  
+  // Verify results
+  EXPECT_EQ(dead_mons.size(), 2u) << "Should have 2 down monitors";
+  EXPECT_TRUE(dead_mons.count("mon.dc2-0"));
+  EXPECT_TRUE(dead_mons.count("mon.dc2-1"));
+  
+  EXPECT_EQ(dead_zones.size(), 1u) << "Should have 1 dead zone (dc2)";
+  EXPECT_TRUE(dead_zones.count("dc2")) << "dc2 should be in dead_zones";
+  
+  EXPECT_EQ(dead_mon_buckets.size(), 1u);
+  EXPECT_EQ(dead_osd_buckets.size(), 0u) << "All OSDs still up";
+}
+
+// Test: Arbiter monitor down (should not trigger degraded mode)
+TEST_F(StretchModeTest, ArbiterDown) {
+  setup_crush_three_zones();
+  setup_osdmap_all_up();
+  setup_monmap_three_zones();
+
+  // Arbiter down, both data zones have monitors
+  set<int> quorum = {0, 1, 2, 3};
+  
+  // Populate monitor and OSD failure state
+  map<string, set<string>> dead_mon_buckets;
+  set<string> up_mon_buckets;
+  set<string> dead_osd_buckets;
+  set<string> up_osd_buckets;
+  
+  Monitor::populate_dead_mon_buckets(monmap, quorum, stretch_bucket_divider,
+                                     dead_mon_buckets, up_mon_buckets);
+  Monitor::populate_dead_osd_buckets(osdmap, dead_osd_buckets, up_osd_buckets);
+  
+  // Compute final degraded mode parameters
+  set<string> dead_mons;
+  set<string> dead_zones;
+  Monitor::compute_dead_zones_and_mons(dead_mon_buckets, dead_osd_buckets,
+                                       dead_mons, dead_zones);
+  
+  // Verify results - arbiter is filtered out so no dead zones
+  EXPECT_EQ(dead_mons.size(), 0u) << "Arbiter filtered out, no data zone monitors down";
+  EXPECT_EQ(dead_zones.size(), 0u) << "Arbiter filtered out, no dead zones";
+  EXPECT_EQ(dead_mon_buckets.size(), 0u) << "Tiebreaker zone filtered out";
+}
+
+// ============================================================================
+// Combined Monitor and OSD Failure Tests
+// ============================================================================
+
+// Test: Both monitors AND OSDs down in dc2
+TEST_F(StretchModeTest, DC2_CompleteFailure) {
+  setup_crush_three_zones();
+  setup_osdmap_dc2_down();
+  setup_monmap_three_zones();
+
+  // DC2 monitors out of quorum
+  set<int> quorum = {0, 1, 4};
+  
+  // Populate monitor and OSD failure state
+  map<string, set<string>> dead_mon_buckets;
+  set<string> up_mon_buckets;
+  set<string> dead_osd_buckets;
+  set<string> up_osd_buckets;
+  
+  Monitor::populate_dead_mon_buckets(monmap, quorum, stretch_bucket_divider,
+                                     dead_mon_buckets, up_mon_buckets);
+  Monitor::populate_dead_osd_buckets(osdmap, dead_osd_buckets, up_osd_buckets);
+  
+  // Compute final degraded mode parameters
+  set<string> dead_mons;
+  set<string> dead_zones;
+  Monitor::compute_dead_zones_and_mons(dead_mon_buckets, dead_osd_buckets,
+                                       dead_mons, dead_zones);
+  
+  // Verify results
+  EXPECT_EQ(dead_mons.size(), 2u) << "DC2 monitors are down";
+  EXPECT_TRUE(dead_mons.count("mon.dc2-0"));
+  EXPECT_TRUE(dead_mons.count("mon.dc2-1"));
+  
+  EXPECT_EQ(dead_zones.size(), 1u) << "DC2 is completely dead (mons + OSDs)";
+  EXPECT_TRUE(dead_zones.count("dc2"));
+}
+
+// Test: DC1 monitors down, DC2 OSDs down (different zones failed)
+TEST_F(StretchModeTest, DifferentZonesDown) {
+  setup_crush_three_zones();
+  setup_osdmap_dc2_down();
+  setup_monmap_three_zones();
+
+  // DC1 monitors out of quorum (only dc2 and arbiter monitors up)
+  set<int> quorum = {2, 3, 4};
+  
+  // Populate monitor and OSD failure state
+  map<string, set<string>> dead_mon_buckets;
+  set<string> up_mon_buckets;
+  set<string> dead_osd_buckets;
+  set<string> up_osd_buckets;
+  
+  Monitor::populate_dead_mon_buckets(monmap, quorum, stretch_bucket_divider,
+                                     dead_mon_buckets, up_mon_buckets);
+  Monitor::populate_dead_osd_buckets(osdmap, dead_osd_buckets, up_osd_buckets);
+  
+  // Compute final degraded mode parameters
+  set<string> dead_mons;
+  set<string> dead_zones;
+  Monitor::compute_dead_zones_and_mons(dead_mon_buckets, dead_osd_buckets,
+                                       dead_mons, dead_zones);
+  
+  // Verify results
+  EXPECT_EQ(dead_mons.size(), 2u) << "DC1 monitors are down";
+  EXPECT_TRUE(dead_mons.count("mon.dc1-0"));
+  EXPECT_TRUE(dead_mons.count("mon.dc1-1"));
+  
+  EXPECT_EQ(dead_zones.size(), 2u) << "Both dc1 (mons) and dc2 (OSDs) are dead";
+  EXPECT_TRUE(dead_zones.count("dc1"));
+  EXPECT_TRUE(dead_zones.count("dc2"));
+}
+
+// Test: One monitor down but zone still up
+TEST_F(StretchModeTest, PartialMonitorFailure) {
+  setup_crush_three_zones();
+  setup_osdmap_all_up();
+  setup_monmap_three_zones();
+
+  // One DC2 monitor down, but dc2-1 still in quorum
+  set<int> quorum = {0, 1, 3, 4};
+  
+  // Populate monitor and OSD failure state
+  map<string, set<string>> dead_mon_buckets;
+  set<string> up_mon_buckets;
+  set<string> dead_osd_buckets;
+  set<string> up_osd_buckets;
+  
+  Monitor::populate_dead_mon_buckets(monmap, quorum, stretch_bucket_divider,
+                                     dead_mon_buckets, up_mon_buckets);
+  Monitor::populate_dead_osd_buckets(osdmap, dead_osd_buckets, up_osd_buckets);
+  
+  // Compute final degraded mode parameters
+  set<string> dead_mons;
+  set<string> dead_zones;
+  Monitor::compute_dead_zones_and_mons(dead_mon_buckets, dead_osd_buckets,
+                                       dead_mons, dead_zones);
+  
+  // Verify results - partial failure doesn't count as zone down
+  EXPECT_EQ(dead_mons.size(), 0u) << "Zone still has live monitors";
+  EXPECT_EQ(dead_zones.size(), 0u) << "No complete zone failures";
+  EXPECT_EQ(dead_mon_buckets.size(), 0u) << "dc2 still has a live monitor";
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Added independent OSD failure detection to stretch mode that doesn't
require monitors to fail first. The system now checks CRUSH zone
subtrees directly using subtree_is_down() to determine if all OSDs
in a zone are down, even when monitors are still up.

Collapsed do_stretch_mode_election_work() into
maybe_go_degraded_stretch_mode() to consolidate all failure tracking
in one place. This ensures OSD failures are detected whether they
trigger elections or not.

Changes:
- Added dead_osd_buckets member to track zones with all OSDs down
- Updated maybe_go_degraded_stretch_mode() to check both monitor and
  OSD failures
- Updated go_recovery_stretch_mode() to check dead_osd_buckets
- Updated try_disable_stretch_mode() to clear dead_osd_buckets
- Updated trigger_degraded_stretch_mode() to account for zones with
  dead OSDs when calculating live_zones
- Renamed down_mon_buckets to bucket_to_down_mons for clarity
- Removed do_stretch_mode_election_work() function entirely

Signed-off-by: Kamoltat (Junior) Sirivadhna <ksirivad@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
