### PR TITLE
mgr/cephadm: add upgrade_preflight_checks to validate cluster before …

### DIFF
--- a/doc/cephadm/upgrade.rst
+++ b/doc/cephadm/upgrade.rst
@@ -78,6 +78,36 @@ online and that your cluster is healthy by running the following command:
 
    ceph -s
 
+
+Preflight Checks
+----------------
+
+An optional ``upgrade_preflight_checks`` flag can be enabled to automatically
+validate cluster health before starting an upgrade. When enabled, ``ceph orch
+upgrade start`` will fail immediately if:
+
+* Cluster health is not ``HEALTH_OK`` (ignoring muted checks)
+* Any OSD is not ``up+in``
+* Any PG is in a state other than exactly ``active+clean``
+
+To enable preflight checks:
+
+.. prompt:: bash #
+
+   ceph config set mgr mgr/cephadm/upgrade_preflight_checks true
+
+When preflight checks block an upgrade, the error message includes details
+about which checks failed and instructions to override:
+
+.. prompt:: bash #
+
+   ceph config set mgr mgr/cephadm/upgrade_preflight_checks false
+
+.. note::
+
+   This option is disabled by default. Muted health warnings (via
+   ``ceph health mute``) are ignored by the preflight checks.
+
 To upgrade to a specific release, run a command of the following form:
 
 .. prompt:: bash #

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -505,6 +505,14 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             default='169.254.1.1',
             desc="Default IP address for RedFish API (OOB management)."
         ),
+        Option(
+            'upgrade_preflight_checks',
+            type='bool',
+            default=False,
+            desc='When enabled, ceph orch upgrade start runs preflight validation '
+                 'and blocks the upgrade if the cluster is not in a healthy state '
+                 '(health not OK, OSDs not up+in, PGs not active+clean).',
+        ),
     ]
     for image in DefaultImages:
         MODULE_OPTIONS.append(Option(image.key, default=image.image_ref, desc=image.desc))
@@ -611,6 +619,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             self.certificate_automated_rotation_enabled = False
             self.certificate_check_debug_mode = False
             self.certificate_check_period = 0
+            self.upgrade_preflight_checks = False
 
         self.notify(NotifyType.mon_map, None)
         self.config_notify()

--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -479,3 +479,173 @@ def test_staggered_upgrade_validation(
     else:
         cephadm_module.upgrade._validate_upgrade_filters(
             'new_image_name', daemon_types, hosts, services)
+
+
+class TestPreflightChecks:
+    """Tests for the upgrade_preflight_checks feature."""
+
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_upgrade_starts_normally_when_preflight_disabled(self, cephadm_module: CephadmOrchestrator):
+        """When upgrade_preflight_checks=false, upgrades start normally (no blocking)."""
+        cephadm_module.upgrade_preflight_checks = False
+        with with_host(cephadm_module, 'test'):
+            with with_host(cephadm_module, 'test2'):
+                with with_service(cephadm_module, ServiceSpec('mgr', placement=PlacementSpec(count=2)), status_running=True):
+                    assert wait(cephadm_module, cephadm_module.upgrade_start(
+                        'image_id', None)) == 'Initiating upgrade to image_id'
+
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    @mock.patch("cephadm.CephadmOrchestrator.get")
+    def test_upgrade_blocked_unhealthy_cluster(self, mock_get, cephadm_module: CephadmOrchestrator):
+        """When upgrade_preflight_checks=true, blocks if health is not HEALTH_OK."""
+        cephadm_module.upgrade_preflight_checks = True
+
+        def _get(key):
+            if key == 'health':
+                return {'json': json.dumps({
+                    'status': 'HEALTH_WARN',
+                    'checks': {
+                        'OSDMAP_FLAGS': {
+                            'severity': 'HEALTH_WARN',
+                            'summary': {'message': 'noout flag(s) set'},
+                        }
+                    },
+                    'mutes': [],
+                })}
+            elif key == 'osd_map':
+                return {'osds': [{'osd': 0, 'up': 1, 'in': 1}]}
+            elif key == 'pg_summary':
+                return {'by_pool': {'1': {'active+clean': 64}}}
+            return {}
+        mock_get.side_effect = _get
+
+        with with_host(cephadm_module, 'test'):
+            with with_host(cephadm_module, 'test2'):
+                with with_service(cephadm_module, ServiceSpec('mgr', placement=PlacementSpec(count=2)), status_running=True):
+                    with pytest.raises(OrchestratorError, match='preflight checks'):
+                        wait(cephadm_module, cephadm_module.upgrade_start('image_id', None))
+
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    @mock.patch("cephadm.CephadmOrchestrator.get")
+    def test_upgrade_blocked_osd_not_up_in(self, mock_get, cephadm_module: CephadmOrchestrator):
+        """When upgrade_preflight_checks=true, blocks if any OSD is not up+in."""
+        cephadm_module.upgrade_preflight_checks = True
+
+        def _get(key):
+            if key == 'health':
+                return {'json': json.dumps({
+                    'status': 'HEALTH_OK',
+                    'checks': {},
+                    'mutes': [],
+                })}
+            elif key == 'osd_map':
+                return {'osds': [
+                    {'osd': 0, 'up': 1, 'in': 1},
+                    {'osd': 1, 'up': 0, 'in': 1},
+                    {'osd': 2, 'up': 1, 'in': 0},
+                ]}
+            elif key == 'pg_summary':
+                return {'by_pool': {'1': {'active+clean': 64}}}
+            return {}
+        mock_get.side_effect = _get
+
+        with with_host(cephadm_module, 'test'):
+            with with_host(cephadm_module, 'test2'):
+                with with_service(cephadm_module, ServiceSpec('mgr', placement=PlacementSpec(count=2)), status_running=True):
+                    with pytest.raises(OrchestratorError, match='OSD.*not up\\+in'):
+                        wait(cephadm_module, cephadm_module.upgrade_start('image_id', None))
+
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    @mock.patch("cephadm.CephadmOrchestrator.get")
+    def test_upgrade_blocked_pgs_not_clean(self, mock_get, cephadm_module: CephadmOrchestrator):
+        """When upgrade_preflight_checks=true, blocks if PGs are not active+clean."""
+        cephadm_module.upgrade_preflight_checks = True
+
+        def _get(key):
+            if key == 'health':
+                return {'json': json.dumps({
+                    'status': 'HEALTH_OK',
+                    'checks': {},
+                    'mutes': [],
+                })}
+            elif key == 'osd_map':
+                return {'osds': [{'osd': 0, 'up': 1, 'in': 1}]}
+            elif key == 'pg_summary':
+                return {'by_pool': {
+                    '1': {
+                        'active+clean': 100,
+                        'active+degraded': 5,
+                        'active+recovering': 2,
+                    }
+                }}
+            return {}
+        mock_get.side_effect = _get
+
+        with with_host(cephadm_module, 'test'):
+            with with_host(cephadm_module, 'test2'):
+                with with_service(cephadm_module, ServiceSpec('mgr', placement=PlacementSpec(count=2)), status_running=True):
+                    with pytest.raises(OrchestratorError, match='PGs not in upgrade-safe state'):
+                        wait(cephadm_module, cephadm_module.upgrade_start('image_id', None))
+
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    @mock.patch("cephadm.CephadmOrchestrator.get")
+    def test_upgrade_passes_preflight_healthy_cluster(self, mock_get, cephadm_module: CephadmOrchestrator):
+        """When upgrade_preflight_checks=true and cluster is healthy, upgrade starts."""
+        cephadm_module.upgrade_preflight_checks = True
+
+        def _get(key):
+            if key == 'health':
+                return {'json': json.dumps({
+                    'status': 'HEALTH_OK',
+                    'checks': {},
+                    'mutes': [],
+                })}
+            elif key == 'osd_map':
+                return {'osds': [
+                    {'osd': 0, 'up': 1, 'in': 1},
+                    {'osd': 1, 'up': 1, 'in': 1},
+                ]}
+            elif key == 'pg_summary':
+                return {'by_pool': {
+                    '1': {'active+clean': 128},
+                    '2': {'active+clean': 64},
+                }}
+            return {}
+        mock_get.side_effect = _get
+
+        with with_host(cephadm_module, 'test'):
+            with with_host(cephadm_module, 'test2'):
+                with with_service(cephadm_module, ServiceSpec('mgr', placement=PlacementSpec(count=2)), status_running=True):
+                    assert wait(cephadm_module, cephadm_module.upgrade_start(
+                        'image_id', None)) == 'Initiating upgrade to image_id'
+
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    @mock.patch("cephadm.CephadmOrchestrator.get")
+    def test_upgrade_ignores_muted_health_checks(self, mock_get, cephadm_module: CephadmOrchestrator):
+        """Muted health checks should not block the upgrade."""
+        cephadm_module.upgrade_preflight_checks = True
+
+        def _get(key):
+            if key == 'health':
+                return {'json': json.dumps({
+                    'status': 'HEALTH_WARN',
+                    'checks': {
+                        'TOO_FEW_PGS': {
+                            'severity': 'HEALTH_WARN',
+                            'summary': {'message': 'too few PGs per OSD'},
+                        }
+                    },
+                    'mutes': [{'code': 'TOO_FEW_PGS'}],
+                })}
+            elif key == 'osd_map':
+                return {'osds': [{'osd': 0, 'up': 1, 'in': 1}]}
+            elif key == 'pg_summary':
+                return {'by_pool': {'1': {'active+clean': 32}}}
+            return {}
+        mock_get.side_effect = _get
+
+        with with_host(cephadm_module, 'test'):
+            with with_host(cephadm_module, 'test2'):
+                with with_service(cephadm_module, ServiceSpec('mgr', placement=PlacementSpec(count=2)), status_running=True):
+                    assert wait(cephadm_module, cephadm_module.upgrade_start(
+                        'image_id', None)) == 'Initiating upgrade to image_id'

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -130,6 +130,10 @@ class CephadmUpgrade:
         'UPGRADE_OFFLINE_HOST'
     ]
 
+    # When upgrade_preflight_checks is enabled, only PGs that are active+clean
+    # are considered safe to proceed with an upgrade. Any other state will block.
+    UPGRADE_SAFE_PG_STATES = {'active', 'clean'}
+
     def __init__(self, mgr: "CephadmOrchestrator"):
         self.mgr = mgr
 
@@ -310,6 +314,64 @@ class CephadmUpgrade:
             r["tags"] = sorted(ls)
         return r
 
+    def _run_preflight_checks(self) -> Optional[str]:
+        """Validate cluster health before starting an upgrade.
+
+        Returns an error message if checks fail, or None if all pass.
+        """
+        errors: List[str] = []
+
+        # Check cluster health, ignoring muted checks
+        try:
+            health_data = json.loads(self.mgr.get('health')['json'])
+            if health_data.get('status') != 'HEALTH_OK':
+                muted = {m['code'] for m in health_data.get('mutes', [])}
+                active = sorted(c for c in health_data.get('checks', {}) if c not in muted)
+                if active:
+                    errors.append(
+                        f'Cluster health is {health_data["status"]}. '
+                        f'Active (non-muted) checks: {", ".join(active)}'
+                    )
+        except Exception as e:
+            errors.append(f'Failed to retrieve cluster health: {e}')
+
+        # Check that all OSDs are up+in
+        try:
+            osdmap = self.mgr.get('osd_map')
+            not_up_in = [
+                f'osd.{osd["osd"]} ({"up" if osd.get("up") else "down"}+'
+                f'{"in" if osd.get("in") else "out"})'
+                for osd in osdmap.get('osds', [])
+                if not (osd.get('up') and osd.get('in'))
+            ]
+            if not_up_in:
+                display = ', '.join(not_up_in[:10])
+                suffix = f' (and {len(not_up_in) - 10} more)' if len(not_up_in) > 10 else ''
+                errors.append(f'{len(not_up_in)} OSD(s) not up+in: {display}{suffix}')
+        except Exception as e:
+            errors.append(f'Failed to retrieve OSD map: {e}')
+
+        # Check PG states — only UPGRADE_SAFE_PG_STATES are allowed
+        try:
+            pg_summary = self.mgr.get('pg_summary')
+            unsafe_pgs: Dict[str, int] = {}
+            for states in pg_summary.get('by_pool', {}).values():
+                for state_name, count in states.items():
+                    for bad in set(state_name.split('+')) - self.UPGRADE_SAFE_PG_STATES:
+                        unsafe_pgs[bad] = unsafe_pgs.get(bad, 0) + count
+            if unsafe_pgs:
+                pg_details = ', '.join(f'{n} {s}' for s, n in sorted(unsafe_pgs.items()))
+                errors.append(f'PGs not in upgrade-safe state (active+clean): {pg_details}')
+        except Exception as e:
+            errors.append(f'Failed to retrieve PG summary: {e}')
+
+        if not errors:
+            return None
+        return ('Upgrade blocked by preflight checks:\n  - '
+                + '\n  - '.join(errors)
+                + '\n\nTo proceed with the upgrade despite these warnings, run:\n'
+                  '  ceph config set mgr mgr/cephadm/upgrade_preflight_checks false')
+
     def upgrade_start(self, image: str, version: str, daemon_types: Optional[List[str]] = None,
                       hosts: Optional[List[str]] = None, services: Optional[List[str]] = None, limit: Optional[int] = None) -> str:
         fail_fs_value = cast(bool, self.mgr.get_module_option_ex(
@@ -346,6 +408,11 @@ class CephadmUpgrade:
 
         if running_mgr_count < 2:
             raise OrchestratorError('Need at least 2 running mgr daemons for upgrade')
+
+        if self.mgr.upgrade_preflight_checks:
+            preflight_error = self._run_preflight_checks()
+            if preflight_error:
+                raise OrchestratorError(preflight_error)
 
         self.mgr.log.info('Upgrade: Started with target %s' % target_name)
         self.upgrade_state = UpgradeState(


### PR DESCRIPTION
mgr/cephadm: add upgrade_preflight_checks to validate cluster before upgrade

Introduce a new module option 'upgrade_preflight_checks' (default: false) that, when enabled, validates cluster state before allowing an upgrade to start. The check runs synchronously and fails immediately if:
- health is not HEALTH_OK (ignoring muted checks)
- any OSD is not up+in
- any PG is in a state other than exactly active+clean

To enable:
  ceph config set mgr mgr/cephadm/upgrade_preflight_checks true

File changes:
module.py:
  Add 'upgrade_preflight_checks' boolean option to MODULE_OPTIONS and Initialize the attribute in __init__

upgrade.py:
  - Add UPGRADE_SAFE_PG_STATES constant representing the active+clean allowlist
  - Add _run_preflight_checks() method that queries health, osd_map and pg_summary to validate cluster readiness
  - Call preflight checks from upgrade_start() when option is enabled

tests/test_upgrade.py:
  - Add TestPreflightChecks class with 6 tests:
    1. test_upgrade_starts_normally_when_preflight_disabled
    2. test_upgrade_blocked_unhealthy_cluster
    3. test_upgrade_blocked_osd_not_up_in
    4. test_upgrade_blocked_pgs_not_clean
    5. test_upgrade_passes_preflight_healthy_cluster
    6. test_upgrade_ignores_muted_health_checks

doc/cephadm/upgrade.rst:
  - Add "Preflight Checks" subsection documenting the option,
    the three validation conditions, and how to enable/disable

Manual Tests:
All tests performed with upgrade_preflight_checks enabled unless noted:

ceph config set mgr mgr/cephadm/upgrade_preflight_checks true ceph orch upgrade start --image quay.io/ceph/ceph:v20.2.0

Test 1: Upgrade blocked — cluster in HEALTH_WARN with multiple issues
Setup: ceph osd set noout, 1 OSD out, PGs remapped
Result: Upgrade fails immediately:
Error EINVAL: Upgrade blocked by preflight checks:
  - Cluster health is HEALTH_WARN. Active (non-muted) checks: OSDMAP_FLAGS
  - 1 OSD(s) not up+in: osd.0 (up+out)
  - PGs not in upgrade-safe state (active+clean): 1 remapped

Test 2: Upgrade blocked — PGs not exactly active+clean
Setup: ceph osd out 0 with replica size 3 (3 OSDs). PGs in active+clean+remapped.
Result: Upgrade fails — PGs contain remapped which is not in the safe allowlist.

Test 3: Upgrade blocked — OSD out even though HEALTH_OK
Setup: Pool replica size set to 2, ceph osd out 0. Health reports OK but ceph osd tree shows osd.0 out.
Result: Upgrade fails:
Error EINVAL: Upgrade blocked by preflight checks:
  - 1 OSD(s) not up+in: osd.0 (up+out)

Test 4: Upgrade blocked — muted warning but OSD still out
Setup: ceph osd set noout, ceph health mute OSDMAP_FLAGS 4h, ceph osd out 0
Result: Upgrade fails — muting the health warning doesn't bypass the OSD check:
Error EINVAL: Upgrade blocked by preflight checks:
  - 1 OSD(s) not up+in: osd.0 (up+out)

Test 5: Upgrade starts — warning is muted, cluster otherwise healthy Setup: All OSDs up+in, all PGs active+clean, one health warning muted. Result: Upgrade starts successfully:
Initiating upgrade to quay.io/ceph/ceph:v20.2.0

Test 6: Upgrade starts — fully healthy cluster
Setup: All OSDs up+in, all PGs active+clean, no warnings. Result: Upgrade starts successfully:
Initiating upgrade to quay.io/ceph/ceph:v20.2.0

Test 7: Upgrade starts — option disabled, cluster unhealthy Setup: ceph config set mgr mgr/cephadm/upgrade_preflight_checks false, 1 OSD out, PGs not clean, HEALTH_WARN. Result: Upgrade starts successfully (no blocking): Initiating upgrade to quay.io/ceph/ceph:v20.2.0

Fixes: https://tracker.ceph.com/issues/76112
Signed-off-by: Yael Azulay <yazulay@redhat.com>


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
