### PR TITLE
rgw: return proper error code and message when creating an existing bucket

### DIFF
--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -190,7 +190,7 @@ int RadosBucket::create(const DoutPrefixProvider* dpp,
      * client about a name conflict.
      */
     if (info.owner != params.owner) {
-      return -ERR_BUCKET_EXISTS;
+      return -EEXIST;
     }
     // prevent re-creation with different index type or shard count
     if ((params.index_type && *params.index_type !=

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -110,7 +110,7 @@ rgw_http_errors rgw_http_s3_errors({
     { ERR_METHOD_NOT_ALLOWED, {405, "MethodNotAllowed" }},
     { ETIMEDOUT, {408, "RequestTimeout" }},
     { EEXIST, {409, "BucketAlreadyExists" }},
-    { ERR_BUCKET_EXISTS, {409, "BucketAlreadyExists" }},
+    { ERR_BUCKET_EXISTS, {409, "BucketAlreadyOwnedByYou" }},
     { ERR_USER_EXIST, {409, "UserAlreadyExists" }},
     { ERR_EMAIL_EXIST, {409, "EmailExists" }},
     { ERR_KEY_EXIST, {409, "KeyExists"}},

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4011,12 +4011,28 @@ void RGWCreateBucket::execute(optional_yield y)
   s->bucket_exists = (op_ret != -ENOENT);
   ceph_assert(s->bucket); // creates handle even on ENOENT
 
+  // need_metadata_upload() is always false for S3, so use the check to decide
+  // if it's a s3 request and not a swift request.
+  bool is_s3 = !need_metadata_upload();
+  const auto eexist_override = s->cct->_conf.get_val<bool>("rgw_bucket_eexist_override");
+
   if (s->bucket_exists) {
     const RGWBucketInfo& info = s->bucket->get_info();
 
-    if (!s->system_request && createparams.zonegroup_id != info.zonegroup) {
-      s->err.message = "Cannot modify existing bucket's zonegroup";
+    // check bucket ownership first: if the requester doesn't own the
+    // bucket, return BucketAlreadyExists immediately without leaking
+    // details about the existing bucket's configuration
+    if (info.owner != s->owner.id) {
       op_ret = -EEXIST;
+      return;
+    }
+
+    // for s3 request, if rgw_bucket_eexist_override is true, just return back if bucekt
+    // exists, as we do not allow any changes in bucket's configuration;
+    // if rgw_bucket_eexist_override is false, allow checking bucket's configuration
+    // before returning 200.
+    if (is_s3 && eexist_override) {
+      op_ret = -ERR_BUCKET_EXISTS;
       return;
     }
 
@@ -4027,44 +4043,48 @@ void RGWCreateBucket::execute(optional_yield y)
     // don't allow changes to placement
     if (createparams.placement_rule != info.placement_rule) {
       s->err.message = "Cannot modify existing bucket's placement rule";
-      op_ret = -EEXIST;
+      // for swift, -ERR_BUCKET_EXISTS is translated as STATUS_ACCEPTED which doesn't indicate an error.
+      // however swift does need an error here since X-Storage-Policy can not be changed
+      op_ret = (is_s3 ? -ERR_BUCKET_EXISTS : -EEXIST);
       return;
     }
 
-    // prevent re-creation with different index type or shard count
-    if ((createparams.index_type && *createparams.index_type !=
-         info.layout.current_index.layout.type) ||
-        (createparams.index_shards && *createparams.index_shards !=
-         info.layout.current_index.layout.normal.num_shards)) {
-      s->err.message =
-          "Cannot modify existing bucket's index type or shard count";
-      op_ret = -EEXIST;
-      return;
-    }
-
-    // don't allow changes to object lock
-    if (createparams.obj_lock_enabled != info.obj_lock_enabled()) {
-      s->err.message = "Cannot modify existing bucket's object lock";
-      op_ret = -EEXIST;
-      return;
-    }
-
-    // don't allow changes to the acl policy
-    RGWAccessControlPolicy old_policy;
-    int r = rgw_op_get_bucket_policy_from_attr(this, s->cct, driver, info.owner,
-                                               s->bucket->get_attrs(),
-                                               old_policy, y);
-    if (r >= 0 && old_policy != policy) {
-      s->err.message = "Cannot modify existing access control policy";
-      op_ret = -EEXIST;
-      return;
-    }
-
-    // For s3::CreateBucket just return back if bucket exists, as we do not allow
-    // any changes in bucket config param. need_metadata_upload() is always false
-    // for S3, so use the check to decide if its s3 request and not swift request.
-    if (!need_metadata_upload()) {
+    if (is_s3) {
       op_ret = -ERR_BUCKET_EXISTS;
+
+      if (!s->system_request && createparams.zonegroup_id != info.zonegroup) {
+        s->err.message = "Cannot modify existing bucket's zonegroup";
+        return;
+      }
+
+      // prevent re-creation with different index type or shard count
+      if ((createparams.index_type && *createparams.index_type !=
+           info.layout.current_index.layout.type) ||
+          (createparams.index_shards && *createparams.index_shards !=
+           info.layout.current_index.layout.normal.num_shards)) {
+        s->err.message =
+            "Cannot modify existing bucket's index type or shard count";
+        return;
+      }
+
+      // don't allow changes to object lock
+      if (createparams.obj_lock_enabled != info.obj_lock_enabled()) {
+        s->err.message = "Cannot modify existing bucket's object lock";
+        return;
+      }
+
+      // don't allow changes to the acl policy for s3
+      // swift acl updates will be handled in put_swift_bucket_metadata
+      RGWAccessControlPolicy old_policy;
+      int r = rgw_op_get_bucket_policy_from_attr(this, s->cct, driver, info.owner,
+                                                 s->bucket->get_attrs(),
+                                                 old_policy, y);
+      if (r >= 0 && old_policy != policy) {
+        s->err.message = "Cannot modify existing access control policy";
+        return;
+      }
+
+      op_ret = 0;
       return;
     } else {
       // For swift, update the bucket metadata and do not call createbucket.
@@ -4141,6 +4161,11 @@ void RGWCreateBucket::execute(optional_yield y)
 
   ldpp_dout(this, 10) << "user=" << s->user << " bucket=" << s->bucket << dendl;
   op_ret = s->bucket->create(this, createparams, y);
+  // swift: keep ERR_BUCKET_EXISTS to be transalted as STATUS_ACCEPTED
+  // s3 with rgw_bucket_eexist_override as true: keep ERR_BUCKET_EXISTS to return BucketAlreadyOwnedByYou
+  if (op_ret == -ERR_BUCKET_EXISTS && is_s3 && !eexist_override) {
+    op_ret = 0;
+  }
 
   /* continue if EEXIST and create_bucket will fail below.  this way we can
    * recover from a partial create by retrying it. */

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2751,13 +2751,12 @@ int RGWCreateBucket_ObjStore_S3::get_params(optional_yield y)
 
 void RGWCreateBucket_ObjStore_S3::send_response()
 {
-  if (op_ret == -ERR_BUCKET_EXISTS) {
-    const auto eexist_override = s->cct->_conf.get_val<bool>("rgw_bucket_eexist_override");
-    if (! eexist_override) [[likely]] {
-      op_ret = 0;
-    } else {
+  if (op_ret == -ERR_BUCKET_EXISTS && s->err.message.empty()) {
+    s->err.message = "The bucket you tried to create already exists, and you own it.";
+  }
+
+  if (op_ret == -EEXIST && s->err.message.empty()) {
       s->err.message = "The requested bucket name is not available. The bucket namespace is shared by all users of the system. Specify a different name and try again.";
-    }
   }
 
   if (op_ret) {


### PR DESCRIPTION
Make the behavior consistent with the following docs (except the reseting acl part for s3)

AWS s3: https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html#API_CreateBucket_Errors
```
BucketAlreadyExists
The requested bucket name is not available. The bucket namespace is shared by all users of the system.
Select a different name and try again.

HTTP Status Code: 409

BucketAlreadyOwnedByYou
The bucket you tried to create already exists, and you own it. Amazon S3 returns this error in all AWS
Regions except in the North Virginia Region. For legacy compatibility, if you re-create an existing bucket
that you already own in the North Virginia Region, Amazon S3 returns 200 OK and resets the bucket access
control lists (ACLs).

HTTP Status Code: 409
```

Swift create container (PUT): https://docs.openstack.org/api-ref/object-store/#create-container
```
You do not need to check whether a container already exists before issuing a PUT operation because the
operation is idempotent: It creates a container or updates an existing container, as appropriate.
```


Fixes: https://tracker.ceph.com/issues/76398
Signed-off-by: Jane Zhu [jzhu116@bloomberg.net](mailto:jzhu116@bloomberg.net)

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
