### PR TITLE
osd: Correct missing list on divergent merge of partial writes

### DIFF
--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -1165,18 +1165,26 @@ protected:
         last = i->version;
       }
     }
-    if (entries.empty()) {
+    if (!prior_version_opt) {
       ldpp_dout(dpp, 10) << __func__ << ": no non-ERROR entries" << dendl;
       return;
     }
 
+    bool object_not_in_store = false;
+
     ceph_assert(prior_version_opt);
-    const eversion_t prior_version = *prior_version_opt;
-    const eversion_t first_divergent_update = entries.begin()->version;
-    const eversion_t last_divergent_update = entries.rbegin()->version;
-    const bool object_not_in_store =
-      !missing.is_missing(hoid) &&
-      entries.rbegin()->is_delete();
+    eversion_t prior_version = *prior_version_opt;
+    eversion_t first_divergent_update;
+    eversion_t last_divergent_update;
+
+    if (!entries.empty()) {
+      first_divergent_update = entries.begin()->version;
+      last_divergent_update = entries.rbegin()->version;
+      object_not_in_store =
+        !missing.is_missing(hoid) &&
+        entries.rbegin()->is_delete();
+    }
+
     ldpp_dout(dpp, 10) << __func__ << ": hoid " << " object_not_in_store: "
                        << object_not_in_store << dendl;
     ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid
@@ -1186,7 +1194,7 @@ protected:
 		       << dendl;
 
     auto objiter = log.objects.find(hoid);
-    if (objiter != log.objects.end() &&
+    if (objiter != log.objects.end() && !entries.empty() &&
 	objiter->second->version >= first_divergent_update) {
       /// Case 1)
       ldpp_dout(dpp, 10) << __func__ << ": more recent entry found: "
@@ -1226,7 +1234,7 @@ protected:
 
     ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid
 		       <<" has no more recent entries in log" << dendl;
-    if (prior_version == eversion_t() || entries.front().is_clone()) {
+    if (prior_version == eversion_t() || (!entries.empty() && entries.front().is_clone())) {
       /// Case 2)
       ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid
 			 << " prior_version or op type indicates creation,"

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -1102,11 +1102,11 @@ protected:
     const DoutPrefixProvider *dpp        ///< [in] logging provider
     ) {
     ldpp_dout(dpp, 20) << __func__ << ": merging hoid " << hoid
-		       << " entries: " << orig_entries << dendl;
+                       << " entries: " << orig_entries << dendl;
 
     if (hoid > info.last_backfill) {
       ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid << " after last_backfill"
-			 << dendl;
+                         << dendl;
       return;
     }
 
@@ -1118,8 +1118,8 @@ protected:
     bool seen_non_error = false;
     std::optional<eversion_t> prior_version_opt;
     for (auto i = orig_entries.begin();
-	 i != orig_entries.end();
-	 ++i) {
+         i != orig_entries.end();
+         ++i) {
       // all entries are on hoid
       ceph_assert(i->soid == hoid);
       // did not see error entries before this entry and this entry is not error
@@ -1129,7 +1129,7 @@ protected:
         // see a non error entry now
         seen_non_error = true;
       }
-      
+
       // No need to check the first entry since it prior_version is unavailable
       // in the std::list
       // No need to check if the prior_version is the minimal version
@@ -1137,16 +1137,16 @@ protected:
       // entries are not its prior version
       if (i != orig_entries.begin() && i->prior_version != eversion_t() &&
           ! first_non_error) {
-	// in increasing order of version
-	ceph_assert(i->version > last);
-	// prior_version correct (unless it is an ERROR entry)
-	if (ec_optimizations_enabled) {
-	  // With partial writes prior_verson may be > last because of
-	  // skipped log entries
-	  ceph_assert(i->prior_version >= last || i->is_error());
-	} else {
-	  ceph_assert(i->prior_version == last || i->is_error());
-	}
+        // in increasing order of version
+        ceph_assert(i->version > last);
+        // prior_version correct (unless it is an ERROR entry)
+        if (ec_optimizations_enabled) {
+          // With partial writes prior_verson may be > last because of
+          // skipped log entries
+          ceph_assert(i->prior_version >= last || i->is_error());
+        } else {
+          ceph_assert(i->prior_version == last || i->is_error());
+        }
       }
       if (i->is_error()) {
         ldpp_dout(dpp, 20) << __func__ << ": ignoring " << *i << dendl;
@@ -1188,67 +1188,67 @@ protected:
     ldpp_dout(dpp, 10) << __func__ << ": hoid " << " object_not_in_store: "
                        << object_not_in_store << dendl;
     ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid
-		       << " prior_version: " << prior_version
-		       << " first_divergent_update: " << first_divergent_update
-		       << " last_divergent_update: " << last_divergent_update
-		       << dendl;
+                       << " prior_version: " << prior_version
+                       << " first_divergent_update: " << first_divergent_update
+                       << " last_divergent_update: " << last_divergent_update
+                       << dendl;
 
     auto objiter = log.objects.find(hoid);
     if (objiter != log.objects.end() && !entries.empty() &&
-	objiter->second->version >= first_divergent_update) {
+        objiter->second->version >= first_divergent_update) {
       /// Case 1)
       ldpp_dout(dpp, 10) << __func__ << ": more recent entry found: "
-			 << *objiter->second << ", already merged" << dendl;
+                         << *objiter->second << ", already merged" << dendl;
 
       ceph_assert(objiter->second->version > last_divergent_update);
 
       // ensure missing has been updated appropriately
       if (objiter->second->is_update() ||
-	  (missing.may_include_deletes && objiter->second->is_delete())) {
-	if (ec_optimizations_enabled) {
-	  // relax the assert for partial writes. The log may not contain any
-	  // updates for this object, in which case the object will not be in
-	  // the missing list. If it is in the missing list, then the need version
-	  // had better be higher or equal to the log version
-	  ceph_assert(!missing.is_missing(hoid) ||
-		      missing.get_items().at(hoid).need >= objiter->second->version);
-	} else {
-	  ceph_assert(missing.is_missing(hoid) &&
-		      missing.get_items().at(hoid).need == objiter->second->version);
-	}
+          (missing.may_include_deletes && objiter->second->is_delete())) {
+        if (ec_optimizations_enabled) {
+          // relax the assert for partial writes. The log may not contain any
+          // updates for this object, in which case the object will not be in
+          // the missing list. If it is in the missing list, then the need version
+          // had better be higher or equal to the log version
+          ceph_assert(!missing.is_missing(hoid) ||
+                      missing.get_items().at(hoid).need >= objiter->second->version);
+        } else {
+          ceph_assert(missing.is_missing(hoid) &&
+                      missing.get_items().at(hoid).need == objiter->second->version);
+        }
       } else {
-	ceph_assert(!missing.is_missing(hoid));
+        ceph_assert(!missing.is_missing(hoid));
       }
       missing.revise_have(hoid, eversion_t());
       missing.mark_fully_dirty(hoid);
       if (rollbacker) {
-	if (!object_not_in_store) {
-	  rollbacker->remove(hoid);
-	}
-	for (auto &&i: entries) {
-	  rollbacker->trim(i);
-	}
+        if (!object_not_in_store) {
+          rollbacker->remove(hoid);
+        }
+        for (auto &&i: entries) {
+          rollbacker->trim(i);
+        }
       }
       return;
     }
 
     ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid
-		       <<" has no more recent entries in log" << dendl;
+                       << " has no more recent entries in log" << dendl;
     if (prior_version == eversion_t() || (!entries.empty() && entries.front().is_clone())) {
       /// Case 2)
       ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid
-			 << " prior_version or op type indicates creation,"
-			 << " deleting"
-			 << dendl;
+                         << " prior_version or op type indicates creation,"
+                         << " deleting"
+                         << dendl;
       if (missing.is_missing(hoid))
-	missing.rm(missing.get_items().find(hoid));
+        missing.rm(missing.get_items().find(hoid));
       if (rollbacker) {
-	if (!object_not_in_store) {
-	  rollbacker->remove(hoid);
-	}
-	for (auto &&i: entries) {
-	  rollbacker->trim(i);
-	}
+        if (!object_not_in_store) {
+          rollbacker->remove(hoid);
+        }
+        for (auto &&i: entries) {
+          rollbacker->trim(i);
+        }
       }
       return;
     }
@@ -1256,38 +1256,38 @@ protected:
     if (missing.is_missing(hoid)) {
       /// Case 3)
       ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid
-			 << " missing, " << missing.get_items().at(hoid)
-			 << " adjusting" << dendl;
+                         << " missing, " << missing.get_items().at(hoid)
+                         << " adjusting" << dendl;
 
       if (missing.get_items().at(hoid).have == prior_version) {
-	ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid
-			   << " missing.have is prior_version " << prior_version
-			   << " removing from missing" << dendl;
-	missing.rm(missing.get_items().find(hoid));
+        ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid
+                           << " missing.have is prior_version " << prior_version
+                           << " removing from missing" << dendl;
+        missing.rm(missing.get_items().find(hoid));
       } else {
-	ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid
-			   << " missing.have is " << missing.get_items().at(hoid).have
-			   << ", adjusting" << dendl;
-	missing.revise_need(hoid, prior_version, false);
-	if (prior_version <= info.log_tail) {
-	  ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid
-			     << " prior_version " << prior_version
-			     << " <= info.log_tail "
-			     << info.log_tail << dendl;
-	}
+        ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid
+                           << " missing.have is " << missing.get_items().at(hoid).have
+                           << ", adjusting" << dendl;
+        missing.revise_need(hoid, prior_version, false);
+        if (prior_version <= info.log_tail) {
+          ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid
+                             << " prior_version " << prior_version
+                             << " <= info.log_tail "
+                             << info.log_tail << dendl;
+        }
       }
       if (rollbacker) {
-	for (auto &&i: entries) {
-	  rollbacker->trim(i);
-	}
+        for (auto &&i: entries) {
+          rollbacker->trim(i);
+        }
       }
       return;
     }
 
     ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid
-		       << " must be rolled back or recovered,"
-		       << " attempting to rollback"
-		       << dendl;
+                       << " must be rolled back or recovered,"
+                       << " attempting to rollback"
+                       << dendl;
     bool can_rollback = true;
     // We are going to make an important decision based on the
     // olog_can_rollback_to value we have received, better known it.
@@ -1297,42 +1297,42 @@ protected:
     /// Distinguish between 4) and 5)
     for (auto i = entries.rbegin(); i != entries.rend(); ++i) {
       if (!i->can_rollback() || i->version <= olog_can_rollback_to) {
-	ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid << " cannot rollback "
-			   << *i << dendl;
-	can_rollback = false;
-	break;
+        ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid << " cannot rollback "
+                           << *i << dendl;
+        can_rollback = false;
+        break;
       }
     }
 
     if (can_rollback) {
       /// Case 4)
       for (auto i = entries.rbegin(); i != entries.rend(); ++i) {
-	ceph_assert(i->can_rollback() && i->version > olog_can_rollback_to);
-	ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid
-			   << " rolling back " << *i << dendl;
-	if (rollbacker)
-	  rollbacker->rollback(*i);
+        ceph_assert(i->can_rollback() && i->version > olog_can_rollback_to);
+        ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid
+                           << " rolling back " << *i << dendl;
+        if (rollbacker)
+          rollbacker->rollback(*i);
       }
       ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid
-			 << " rolled back" << dendl;
+                         << " rolled back" << dendl;
       return;
     } else {
       /// Case 5)
       ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid << " cannot roll back, "
-			 << "removing and adding to missing" << dendl;
+                         << "removing and adding to missing" << dendl;
       if (rollbacker) {
-	if (!object_not_in_store)
-	  rollbacker->remove(hoid);
-	for (auto &&i: entries) {
-	  rollbacker->trim(i);
-	}
+        if (!object_not_in_store)
+          rollbacker->remove(hoid);
+        for (auto &&i: entries) {
+          rollbacker->trim(i);
+        }
       }
       missing.add(hoid, prior_version, eversion_t(), false);
       if (prior_version <= info.log_tail) {
-	ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid
-			   << " prior_version " << prior_version
-			   << " <= info.log_tail "
-			   << info.log_tail << dendl;
+        ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid
+                           << " prior_version " << prior_version
+                           << " <= info.log_tail "
+                           << info.log_tail << dendl;
       }
     }
   }

--- a/src/test/osd/ECPeeringTestFixture.cc
+++ b/src/test/osd/ECPeeringTestFixture.cc
@@ -674,8 +674,28 @@ void ECPeeringTestFixture::run_parallel_recovery_and_verify_callbacks(
 
       ASSERT_EQ(target_missing_item, missing_item) << "Missing on shard and primary should match";
 
-
-      std::cout << "  OSD " << target_osd << " is a peer and has object " << obj_names[i] << " in peer_missing" << std::endl;
+      // Read the OI directly from the primary's store to get the authoritative version
+      // This avoids relying on potentially stale cached data in the OBC
+      ObjectStore::CollectionHandle primary_ch = chs[primary_shard];
+      ASSERT_TRUE(primary_ch) << "Primary shard " << primary_shard << " must have a valid collection handle";
+      
+      ghobject_t primary_ghoid(hoid, ghobject_t::NO_GEN, shard_id_t(primary_shard));
+      ceph::buffer::ptr oi_ptr;
+      int r = store->getattr(primary_ch, primary_ghoid, OI_ATTR, oi_ptr);
+      ASSERT_GE(r, 0) << "Failed to read OI_ATTR from primary store for " << obj_names[i];
+      
+      bufferlist oi_bl;
+      oi_bl.append(oi_ptr);
+      object_info_t oi;
+      auto p = oi_bl.cbegin();
+      oi.decode(p);
+      
+      std::cout << "  OSD " << target_osd << " is a peer and has object " << obj_names[i]
+                << " in peer_missing (OI version from primary store: " << oi.version << ")" << std::endl;
+      
+      // Verify the missing item's need version matches what we read from the store
+      ASSERT_EQ(missing_item.need, oi.version)
+        << "Missing item need version should match OI version from primary store for " << obj_names[i];
     }
 
     missing_items.push_back(missing_item);

--- a/src/test/osd/TestECFailoverWithPeering.cc
+++ b/src/test/osd/TestECFailoverWithPeering.cc
@@ -807,6 +807,42 @@ TEST_P(
   run_recovery_and_verify_callbacks(obj_name, recovery_target_shard, pattern_p1);
 }
 
+/**
+ * Test rollback after a sequence of blocked full-stripe and chunk writes.
+ * This is a similar scenario to the previous test, but we force the shard
+ * to do a sync, rather than async recovery at the end.
+ * Recreate for tracker https://tracker.ceph.com/issues/75962
+ */
+TEST_P(
+  TestECFailoverWithPeering,
+  RollbackAfterMixedBlockedWritesWithOSDFailure3
+) {
+  if (m < 2) {
+    GTEST_SKIP() << "RollbackAfterMixedBlockedWritesWithOSDFailure requires m >= 2";
+  }
+  set_config("osd_async_recovery_min_cost", "0");
+
+  const int blocked_shard = k + 1;
+  const int recovery_target_shard = 1;
+  const std::string obj_name = "test_mixed_blocked_writes";
+  const size_t full_stripe_size = stripe_unit * k;
+  const std::string pattern_p1(full_stripe_size, 'A');
+  mark_osd_down(recovery_target_shard);
+  create_and_write_verify(obj_name, pattern_p1);
+  mark_osd_up(recovery_target_shard);
+  create_and_write_verify("dummy", pattern_p1);
+  suspend_primary_to_osd(blocked_shard);
+  int result = write_attribute(obj_name, "test_attr", "value2", false);
+  ASSERT_EQ(-EINPROGRESS, result);
+  mark_osd_down(2);
+  unsuspend_primary_to_osd(blocked_shard);
+  event_loop->run_until_idle();
+
+  run_recovery_and_verify_callbacks(obj_name, recovery_target_shard, pattern_p1);
+
+  set_config("osd_async_recovery_min_cost", "100");
+}
+
 // ---------------------------------------------------------------------------
 // Instantiate TestECFailoverWithPeering with EC configurations
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
With recent fixes to divergent log merging, a regression was introduced whereby a partial write would be rolled forward, updating the missing list, then not rolled back during divergent log merge. 

Fixes: https://tracker.ceph.com/issues/75962


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
