### PR TITLE
crimson/osd: defer snap trimming while scrubbing

### DIFF
--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -623,6 +623,13 @@ void PG::on_active_actmap()
       logger().debug("{}: {} already trimming.", *this, __func__);
       return;
     }
+    // Temporary: defer snap trimming while scrubbing, until the full scrub
+    // scheduling code (including is_scrub_queued_or_active()) is merged.
+    // (mark https://tracker.ceph.com/issues/76428 as solved once fixed).
+    if (peering_state.state_test(PG_STATE_SCRUBBING)) {
+      logger().info("{}: {} scrubbing, deferring snap trim", *this, __func__);
+      return;
+    }
     // loops until snap_trimq is empty or SNAPTRIM_ERROR.
     Ref<PG> pg_ref = this;
     std::ignore = interruptor::with_interruption([this] {
@@ -654,6 +661,16 @@ void PG::on_active_actmap()
   } else {
     logger().debug("pg not clean, skipping snap trim");
     ceph_assert(!peering_state.state_test(PG_STATE_SNAPTRIM));
+  }
+}
+
+void PG::kick_snap_trim()
+{
+  if (peering_state.is_active() && peering_state.is_clean()
+      && !snap_trimq.empty()
+      && !peering_state.state_test(PG_STATE_SNAPTRIM)) {
+    logger().info("{}: scrub complete, retriggering snap trim", *this);
+    on_active_actmap();
   }
 }
 

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -907,6 +907,10 @@ private:
   interruptible_future<seastar::stop_iteration> trim_snap(
     snapid_t to_trim,
     bool needs_pause);
+  /// Re-trigger snap trimming after scrub completion. Snap trimming is
+  /// deferred while the PG is scrubbing; call this from notify_scrub_end()
+  /// to resume.
+  void kick_snap_trim();
 
 private:
   PG_OSDMapGate osdmap_gate;

--- a/src/crimson/osd/scrub/pg_scrubber.cc
+++ b/src/crimson/osd/scrub/pg_scrubber.cc
@@ -134,6 +134,7 @@ void PGScrubber::notify_scrub_end(bool deep)
     pg.peering_state.state_clear(PG_STATE_DEEP_SCRUB);
   }
   pg.publish_stats_to_osd();
+  pg.kick_snap_trim();
 }
 
 const std::set<pg_shard_t> &PGScrubber::get_ids_to_scrub() const


### PR DESCRIPTION
Classic OSD enforces mutual exclusion between scrubbing and snap trimming via the WaitScrub state in the snap trim state machine. Crimson was missing this, allowing both to run concurrently on the same PG (visible as active+clean+scrubbing+deep+snaptrim), which could prevent snap trimming from completing within the expected timeout.

Defer snap trim initiation while PG_STATE_SCRUBBING is set, and re-trigger it from notify_scrub_end() via kick_snap_trim().

**This is a temporary fix until the full scrub scheduling code, including is_scrub_queued_or_active(), is merged.**

