### PR TITLE
crimson+classic/osd/scrub: limit scrubbing under snap-trimming overload

### DIFF
--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -329,6 +329,13 @@ options:
     under most load conditions.
   default: 10.0
   with_legacy: true
+- name: osd_scrub_queued_snaptrims_limit
+  type: uint
+  level: advanced
+  desc: Do not initiate periodic scrubs when the total snap-trim queues across all
+    PGs exceeds this value. A value of '0' disables this limit.
+  default: 500
+  with_legacy: false
 - name: osd_scrub_min_interval
   type: float
   level: advanced

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -69,6 +69,7 @@ SET_SUBSYS(osd);
 
 namespace {
   static constexpr int TICK_INTERVAL = 1;
+  static constexpr int TRIM_QLENGTHS_UPDATE_PERIOD = 5;
 }
 
 using std::make_unique;
@@ -122,6 +123,15 @@ OSD::OSD(int id, uint32_t nonce,
       ).then([this] {
 	update_stats();
         mgrc->update_daemon_health(get_health_metrics());
+	if (++trim_queue_length_countdown >= TRIM_QLENGTHS_UPDATE_PERIOD) {
+	  trim_queue_length_countdown = 0;
+	  std::ignore = pg_shard_manager.calc_snap_trim_queue_total(
+	  ).then([this](uint64_t total) {
+	    LOG_PREFIX(OSD::tick);
+	    snap_trim_queue_total = total;
+	    DEBUG("snap_trim_queue_total: {}", total);
+	  });
+	}
 	tick_timer.arm(
 	  std::chrono::seconds(TICK_INTERVAL));
       });

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -127,6 +127,10 @@ class OSD final : public crimson::net::Dispatcher,
 
   std::unique_ptr<Heartbeat> heartbeat;
   seastar::timer<seastar::lowres_clock> tick_timer;
+  uint_fast16_t trim_queue_length_countdown = 0;
+  /// caching the total snap trim queue length across all PGs,
+  /// updated periodically by the tick_timer
+  uint64_t snap_trim_queue_total = 0;
 
   seastar::timer<seastar::lowres_clock> stats_timer;
   std::vector<ShardServices::shard_stats_t> shard_stats;

--- a/src/crimson/osd/pg_shard_manager.cc
+++ b/src/crimson/osd/pg_shard_manager.cc
@@ -117,4 +117,16 @@ seastar::future<> PGShardManager::set_superblock(OSDSuperblock superblock) {
   });
 }
 
+seastar::future<uint64_t>
+PGShardManager::calc_snap_trim_queue_total() const
+{
+  uint64_t total = 0;
+  co_await for_each_pg([&total](const auto&, const auto &pg) {
+    if (pg->is_primary()) {
+      total += pg->get_snap_trimq_size();
+    }
+  });
+  co_return total;
+}
+
 }

--- a/src/crimson/osd/pg_shard_manager.h
+++ b/src/crimson/osd/pg_shard_manager.h
@@ -337,6 +337,8 @@ public:
       });
   }
 
+  seastar::future<uint64_t> calc_snap_trim_queue_total() const;
+
   /**
    * for_each_pgid
    *

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6469,6 +6469,12 @@ void OSD::tick_without_osd_lock()
   }
 
   if (is_active()) {
+    constexpr uint_fast16_t snap_trim_scan_interval = 5;
+    if (++trim_queue_length_countdown >= snap_trim_scan_interval) {
+      trim_queue_length_countdown = 0;
+      service.snap_trim_queue_total =
+	service.calc_snap_trim_queue_total();
+    }
     service.get_scrub_services().initiate_scrub(service.is_recovery_active());
     service.promote_throttle_recalibrate();
     resume_creating_pg();
@@ -7889,6 +7895,22 @@ std::optional<PGLockWrapper> OSDService::get_locked_pg(spg_t pgid)
   }
 }
 
+
+uint64_t OSDService::calc_snap_trim_queue_total()
+{
+  std::vector<spg_t> pgids;
+  osd->_get_pgids(&pgids);
+  uint64_t total = 0;
+  for (auto& pgid : pgids) {
+    if (auto locked_pg = get_locked_pg(pgid)) {
+      const auto& pg = locked_pg->pg();
+      if (pg->is_primary()) {
+	total += pg->get_snap_trimq_size();
+      }
+    }
+  }
+  return total;
+}
 
 MPGStats* OSD::collect_pg_stats()
 {

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -152,6 +152,18 @@ public:
   }
 
   int get_nodeid() const final { return whoami; }
+
+  /// iterate over all PGs, summing their snap trim queue lengths
+  uint64_t calc_snap_trim_queue_total();
+  uint64_t get_snap_trim_queue_total() const {
+    // the cached value, calculated by calc_snap_trim_queue_total()
+    return snap_trim_queue_total;
+  }
+
+  // not atomic: both write (tick_without_osd_lock) and read (initiate_scrub,
+  // called from the same timer callback) are on the same thread
+  uint64_t snap_trim_queue_total{0};
+
 private:
   OSDMapRef osdmap;
 
@@ -1240,6 +1252,7 @@ class OSD : public Dispatcher,
   // Tick timer for those stuff that do not need osd_lock
   ceph::mutex tick_timer_lock = ceph::make_mutex("OSD::tick_timer_lock");
   SafeTimer tick_timer_without_osd_lock;
+  uint_fast16_t trim_queue_length_countdown = 0;
   std::string gss_ktfile_client{};
 
 public:

--- a/src/osd/scrubber/osd_scrub.cc
+++ b/src/osd/scrubber/osd_scrub.cc
@@ -107,6 +107,11 @@ void OsdScrub::initiate_scrub(bool is_recovery_active)
 	<< dendl;
   }
 
+  {
+    auto stqt = m_osd_svc.get_snap_trim_queue_total();
+    dout(20) << fmt::format("snap_trim_queue_total: {}", stqt) << dendl;
+  }
+
   const utime_t scrub_time = ceph_clock_now();
 
   // check the OSD-wide environment conditions (scrub resources, time, etc.).

--- a/src/osd/scrubber/osd_scrub.cc
+++ b/src/osd/scrubber/osd_scrub.cc
@@ -181,6 +181,10 @@ bool OsdScrub::is_sched_target_eligible(
   if (r.cpu_overloaded && ScrubJob::observes_load_limit(e.urgency)) {
     return false;
   }
+  if (r.overload_of_snap_trimming &&
+      ScrubJob::observes_trims_load(e.urgency)) {
+    return false;
+  }
   if (r.recovery_in_progress && ScrubJob::observes_recovery(e.urgency)) {
     return false;
   }
@@ -217,6 +221,11 @@ Scrub::OSDRestrictions OsdScrub::restrictions_on_scrubbing(
 
   env_conditions.restricted_time = !scrub_time_permit(scrub_clock_now);
   env_conditions.cpu_overloaded = !scrub_load_below_threshold();
+  const auto snaptrims_limit =
+      cct->_conf.get_val<uint64_t>("osd_scrub_queued_snaptrims_limit");
+  env_conditions.overload_of_snap_trimming =
+      (snaptrims_limit > 0) &&
+      (m_osd_svc.get_snap_trim_queue_total() > snaptrims_limit);
 
   return env_conditions;
 }

--- a/src/osd/scrubber/osd_scrub_sched.h
+++ b/src/osd/scrubber/osd_scrub_sched.h
@@ -140,6 +140,8 @@ class ScrubSchedListener {
    */
   virtual AsyncReserver<spg_t, Finisher>& get_scrub_reserver() = 0;
 
+  virtual uint64_t get_snap_trim_queue_total() const = 0;
+
   virtual ~ScrubSchedListener() {}
 };
 

--- a/src/osd/scrubber/scrub_job.cc
+++ b/src/osd/scrubber/scrub_job.cc
@@ -389,6 +389,11 @@ bool ScrubJob::observes_load_limit(urgency_t urgency)
   return urgency < urgency_t::after_repair;
 }
 
+bool ScrubJob::observes_trims_load(urgency_t urgency)
+{
+  return urgency < urgency_t::repairing;
+}
+
 bool ScrubJob::requires_reservation(urgency_t urgency)
 {
   return urgency < urgency_t::after_repair;

--- a/src/osd/scrubber/scrub_job.h
+++ b/src/osd/scrubber/scrub_job.h
@@ -316,6 +316,8 @@ class ScrubJob {
  *   if continued into the forbidden times, by having a longer sleep time;
  *   (note that this is only applicable to the wq scheduler).
  * - load: the scrub must not be initiated if the OSD is under heavy CPU load;
+ * - trims: the scrub must not be initiated if the OSD has too many snap-trim
+ *   jobs pending;
  * - noscrub: the scrub is aborted if the 'noscrub' flag (or the
  *  'nodeep-scrub' flag for deep scrubs) is set;
  * - randomization: the scrub's target time is extended by a random
@@ -335,10 +337,11 @@ class ScrubJob {
  *  | limitation |  must-  | after-repair |repairing| operator | must-repair |
  *  |            |  scrub  |(aft recovery)|(errors) | request  |             |
  *  +------------+---------+--------------+---------+----------+-------------+
- *  | reservation|    yes! |      no      |    no?  |     no   |      no     |
- *  | dow/time   |    yes  |     yes      |    no   |     no   |      no     |
+ *  | reservation|    yes! |      no      |    no   |     no   |      no     |
+ *  | dow/time   |    yes  |      yes     |    no X |     no   |      no     |
  *  | ext-sleep  |    no   |      no      |    no   |     no   |      no     |
  *  | load       |    yes  |      no      |    no   |     no   |      no     |
+ *  | trims      |    yes  |      yes     |    no   |     no   |      no     |
  *  | noscrub    |    yes  |      no      |    Yes  |     no   |      no     |
  *  | max-scrubs |    yes  |      yes     |    Yes  |     no   |      no     |
  *  | backoff    |    yes  |      no      |    no   |     no   |      no     |
@@ -356,6 +359,8 @@ class ScrubJob {
   static bool observes_extended_sleep(urgency_t urgency);
 
   static bool observes_load_limit(urgency_t urgency);
+
+  static bool observes_trims_load(urgency_t urgency);
 
   static bool requires_reservation(urgency_t urgency);
 

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -102,6 +102,9 @@ struct OSDRestrictions {
   /// the CPU load is high. No regular scrubs are allowed.
   bool cpu_overloaded:1{false};
 
+  /// long snap-trimming queues.
+  bool overload_of_snap_trimming:1{false};
+
   /// outside of allowed scrubbing hours/days
   bool restricted_time:1{false};
 
@@ -181,10 +184,11 @@ struct formatter<Scrub::OSDRestrictions> {
   template <typename FormatContext>
   auto format(const Scrub::OSDRestrictions& conds, FormatContext& ctx) const {
     return fmt::format_to(
-	ctx.out(), "<{}.{}.{}.{}.{}>",
+	ctx.out(), "<{}.{}.{}.{}.{}.{}>",
 	conds.max_concurrency_reached ? "max-scrubs" : "",
 	conds.random_backoff_active ? "backoff" : "",
 	conds.cpu_overloaded ? "high-load" : "",
+	conds.overload_of_snap_trimming ? "trim-overload" : "",
 	conds.restricted_time ? "time-restrict" : "",
 	conds.recovery_in_progress ? "recovery" : "");
   }


### PR DESCRIPTION
When the snap-trim queues are long, scrubbing is likely to
make things worse. This change adds a new scrubbing restriction
for that case, and prevents periodic scrubs from starting when
the total snap-trim queue length across all PGs exceeds a
configurable threshold.

Note - for Crimson, this is only a partial implementation
(pending the completion of the scrub scheduler).

