### PR TITLE
test/osd: Improve test logging with OSD identification

### DIFF
--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -40,12 +40,22 @@ namespace logging {
 
 static OnExitManager exit_callbacks;
 
+// Static hook for getting log prefix (set by tests).
+// NOTE: Not thread-safe. Intended for single-threaded unit test harnesses
+// and should be set once during startup.
+static Log::prefix_hook_t prefix_hook = nullptr;
+
 static void log_on_exit(void *p)
 {
   Log *l = *(Log **)p;
   if (l)
     l->flush();
   delete (Log **)p;// Delete allocated pointer (not Log object, the pointer only!)
+}
+
+void Log::set_prefix_hook(prefix_hook_t hook)
+{
+  prefix_hook = hook;
 }
 
 Log::Log(const SubsystemMap *s)
@@ -409,7 +419,15 @@ void Log::_flush(EntryVector& t, bool crash)
         used += (std::size_t)snprintf(pos + used, allocated - used, "%6ld> ", -(--len));
       }
       used += (std::size_t)append_time(stamp, pos + used, allocated - used);
-      used += (std::size_t)snprintf(pos + used, allocated - used, " %lx %2d ", (unsigned long)thread, prio);
+      
+      // In tests, replace thread ID with custom prefix (e.g., "osd.X" or "harness")
+      const char* prefix = prefix_hook ? prefix_hook() : nullptr;
+      if (prefix) {
+        used += (std::size_t)snprintf(pos + used, allocated - used, " %s %2d ", prefix, prio);
+      } else {
+        used += (std::size_t)snprintf(pos + used, allocated - used, " %lx %2d ", (unsigned long)thread, prio);
+      }
+      
       memcpy(pos + used, str.data(), str.size());
       used += str.size();
       pos[used] = '\0';

--- a/src/log/Log.h
+++ b/src/log/Log.h
@@ -35,6 +35,7 @@ class Log : private Thread
 {
 public:
   using Thread::is_started;
+  using prefix_hook_t = const char* (*)();
 
   Log(const SubsystemMap *s);
   ~Log() override;
@@ -80,6 +81,14 @@ public:
   /// induce a segv on the next log event
   void inject_segv();
   void reset_segv();
+
+  /**
+   * Set a hook to get the log prefix (replaces thread ID in log output).
+   *
+   * @note Not thread-safe. Must be called once during startup before any
+   *       logging occurs. Designed for single-threaded unit test harnesses only.
+   */
+  static void set_prefix_hook(prefix_hook_t hook);
 
 protected:
   using EntryVector = std::vector<ConcreteEntry>;

--- a/src/test/osd/ECPeeringTestFixture.cc
+++ b/src/test/osd/ECPeeringTestFixture.cc
@@ -19,7 +19,6 @@
 
 // ShardDpp implementation
 std::ostream& ECPeeringTestFixture::ShardDpp::gen_prefix(std::ostream& out) const {
-  out << "shard " << shard << ": ";
   if (fixture->shard_peering_states.contains(shard)) {
     PeeringState *ps = fixture->shard_peering_states[shard].get();
     out << *ps;

--- a/src/test/osd/EventLoop.h
+++ b/src/test/osd/EventLoop.h
@@ -15,7 +15,6 @@
 
 #pragma once
 
-#include <iostream>
 #include <functional>
 #include <deque>
 #include <map>
@@ -27,6 +26,7 @@
 #include "osd/OpRequest.h"
 #include "osd/PeeringState.h"
 #include "os/ObjectStore.h"
+#include "common/dout.h"
 
 /**
  * EventLoop - Unified single-threaded event loop for OSD tests.
@@ -48,7 +48,37 @@ public:
     PEERING_EVENT
   };
   
+  /**
+   * Get the log prefix for the currently executing context.
+   * Returns "osd.X" if an OSD is currently executing, "harness" if not.
+   * This is used by Log::_flush() to replace thread IDs with meaningful names.
+   */
+  static const char* get_log_prefix() {
+    static thread_local char prefix_buf[32];
+    
+    // Read the value once to ensure consistency within this call
+    int osd_id = current_executing_osd;
+    
+    if (osd_id >= 0) {
+      snprintf(prefix_buf, sizeof(prefix_buf), "osd.%d", osd_id);
+      return prefix_buf;
+    }
+    // osd_id is -1 (harness/test code, not in OSD event)
+    return "harness";
+  }
+  
+  /**
+   * Get the OSD number currently executing in the EventLoop.
+   * Returns -1 if no OSD is currently executing or if called outside an EventLoop context.
+   * This is a simple static variable that can be easily accessed from lldb at any time.
+   */
+  static int get_current_executing_osd() {
+    return current_executing_osd;
+  }
+  
 private:
+  // Static storage for the currently executing OSD
+  static int current_executing_osd;
   struct Event {
     EventType type;
     int from_osd;  // -1 for generic events or when not applicable
@@ -60,13 +90,13 @@ private:
   };
   
   std::deque<Event> events;
-  bool verbose = false;
   int events_executed = 0;
   std::map<EventType, int> events_by_type;
   std::set<int> suspended_from_osds;
   std::set<int> suspended_to_osds;
   std::set<std::pair<int, int>> suspended_from_to_osds;
   int current_osd = -1;
+  DoutPrefixProvider *dpp;
   
   // Map from OSD number to its queue of suspended events
   std::map<int, std::deque<Event>> suspended_events;
@@ -87,7 +117,7 @@ private:
   }
   
 public:
-  EventLoop(bool verbose = false) : verbose(verbose) {}
+  EventLoop(DoutPrefixProvider *dpp) : dpp(dpp) {}
   
   void schedule_generic(GenericEvent event) {
     events.emplace_back(EventType::GENERIC, -1, -1, std::move(event));
@@ -96,6 +126,8 @@ public:
   void schedule_osd_message(int from_osd, int to_osd, GenericEvent callback) {
     ceph_assert(from_osd >= 0);
     ceph_assert(to_osd >= 0);
+    ldpp_dout(dpp, 20) << "EventLoop: scheduling OSD_MESSAGE from OSD." << from_osd
+                       << " to OSD." << to_osd << dendl;
     events.emplace_back(EventType::OSD_MESSAGE, from_osd, to_osd, std::move(callback));
   }
   
@@ -107,12 +139,16 @@ public:
   void schedule_peering_message(int from_osd, int to_osd, GenericEvent callback) {
     ceph_assert(from_osd >= 0);
     ceph_assert(to_osd >= 0);
+    ldpp_dout(dpp, 20) << "EventLoop: scheduling PEERING_MESSAGE from OSD." << from_osd
+                       << " to OSD." << to_osd << dendl;
     events.emplace_back(EventType::PEERING_MESSAGE, from_osd, to_osd, std::move(callback));
   }
   
   void schedule_cluster_message(int from_osd, int to_osd, GenericEvent callback) {
     ceph_assert(from_osd >= 0);
     ceph_assert(to_osd >= 0);
+    ldpp_dout(dpp, 20) << "EventLoop: scheduling CLUSTER_MESSAGE from OSD." << from_osd
+                       << " to OSD." << to_osd << dendl;
     events.emplace_back(EventType::CLUSTER_MESSAGE, from_osd, to_osd, std::move(callback));
   }
   
@@ -172,68 +208,32 @@ public:
     
     if (should_suspend) {
       // Move to suspended queue
-      if (verbose) {
-        std::cout << "  [Event " << (events_executed + 1) << "] "
-                  << event_type_name(event.type);
-        if (event.from_osd >= 0 && event.to_osd >= 0) {
-          std::cout << " (OSD." << event.from_osd << " -> OSD." << event.to_osd << ")";
-        } else if (event.to_osd >= 0) {
-          std::cout << " (to OSD." << event.to_osd << ")";
-        } else if (event.from_osd >= 0) {
-          std::cout << " (from OSD." << event.from_osd << ")";
-        }
-        std::cout << " *** SUSPENDED - moving to suspended queue ***" << std::endl;
-      }
       suspended_events[suspend_osd].push_back(std::move(event));
       return true;  // We processed an event (by suspending it)
     }
     
-    // Print banner if switching to a different OSD
+    // Track which OSD we're currently processing
     int active_osd = (event.to_osd >= 0) ? event.to_osd : event.from_osd;
     if (active_osd >= 0 && active_osd != current_osd) {
       current_osd = active_osd;
-      if (verbose) {
-        std::cout << "\n==== Processing events for OSD." << current_osd
-                  << " ====" << std::endl;
-      }
     }
     
-    if (verbose) {
-      std::cout << "  [Event " << (events_executed + 1) << "] "
-                << event_type_name(event.type);
-      if (event.from_osd >= 0 && event.to_osd >= 0) {
-        std::cout << " (OSD." << event.from_osd << " -> OSD." << event.to_osd << ")";
-      } else if (event.to_osd >= 0) {
-        std::cout << " (to OSD." << event.to_osd << ")";
-      } else if (event.from_osd >= 0) {
-        std::cout << " (from OSD." << event.from_osd << ")";
-      }
-      std::cout << " Executing..." << std::endl;
-    }
+    current_executing_osd = active_osd;
     
     // Execute the event
     event.callback();
     events_executed++;
     events_by_type[event.type]++;
+    current_executing_osd = -1;
     
     return true;
   }
   
   int run_many(int count) {
-    if (verbose) {
-      std::cout << "\n=== Running " << count << " events ===" << std::endl;
-    }
-    
     int executed = 0;
     for (int i = 0; i < count && run_one(); i++) {
       executed++;
     }
-    
-    if (verbose) {
-      std::cout << "=== Executed " << executed << " events, "
-                << events.size() << " remaining ===" << std::endl;
-    }
-    
     return executed;
   }
 
@@ -253,14 +253,6 @@ public:
    * Returns -1 if max_events was reached before the queue emptied.
    */
   void run_until_idle(int max_events = 10000) {
-    if (verbose) {
-      std::cout << "\n=== Running until idle";
-      if (max_events > 0) {
-        std::cout << " (max " << max_events << " events)";
-      }
-      std::cout << " ===" << std::endl;
-    }
-
     do {
       ceph_assert(--max_events);
       while (has_events()) {
@@ -274,10 +266,6 @@ public:
     suspended_events.clear();
   }
   
-  void set_verbose(bool v) {
-    verbose = v;
-  }
-  
   // OSD management methods
   /**
    * Suspend events FROM an OSD - events originating from this OSD will be queued
@@ -285,9 +273,6 @@ public:
    */
   void suspend_from_osd(int osd) {
     suspended_from_osds.insert(osd);
-    if (verbose) {
-      std::cout << "*** Events FROM OSD." << osd << " marked as SUSPENDED ***" << std::endl;
-    }
   }
   
   /**
@@ -300,21 +285,11 @@ public:
     // Move all suspended events for this OSD back to the main queue
     auto it = suspended_events.find(osd);
     if (it != suspended_events.end()) {
-      if (verbose) {
-        std::cout << "*** Events FROM OSD." << osd << " marked as UNSUSPENDED - restoring "
-                  << it->second.size() << " suspended events ***" << std::endl;
-      }
-      
       // Append suspended events to the main queue
       for (auto& event : it->second) {
         events.push_back(std::move(event));
       }
-      
       suspended_events.erase(it);
-    } else {
-      if (verbose) {
-        std::cout << "*** Events FROM OSD." << osd << " marked as UNSUSPENDED ***" << std::endl;
-      }
     }
   }
   
@@ -324,9 +299,6 @@ public:
    */
   void suspend_to_osd(int osd) {
     suspended_to_osds.insert(osd);
-    if (verbose) {
-      std::cout << "*** Events TO OSD." << osd << " marked as SUSPENDED ***" << std::endl;
-    }
   }
   
   /**
@@ -339,21 +311,11 @@ public:
     // Move all suspended events for this OSD back to the main queue
     auto it = suspended_events.find(osd);
     if (it != suspended_events.end()) {
-      if (verbose) {
-        std::cout << "*** Events TO OSD." << osd << " marked as UNSUSPENDED - restoring "
-                  << it->second.size() << " suspended events ***" << std::endl;
-      }
-      
       // Append suspended events to the main queue
       for (auto& event : it->second) {
         events.push_back(std::move(event));
       }
-      
       suspended_events.erase(it);
-    } else {
-      if (verbose) {
-        std::cout << "*** Events TO OSD." << osd << " marked as UNSUSPENDED ***" << std::endl;
-      }
     }
   }
   
@@ -363,10 +325,6 @@ public:
    */
   void suspend_from_to_osd(int from_osd, int to_osd) {
     suspended_from_to_osds.insert({from_osd, to_osd});
-    if (verbose) {
-      std::cout << "*** Events FROM OSD." << from_osd << " TO OSD." << to_osd
-                << " marked as SUSPENDED ***" << std::endl;
-    }
   }
   
   /**
@@ -379,23 +337,11 @@ public:
     // Move all suspended events for this OSD pair back to the main queue
     auto it = suspended_events.find(to_osd);
     if (it != suspended_events.end()) {
-      if (verbose) {
-        std::cout << "*** Events FROM OSD." << from_osd << " TO OSD." << to_osd
-                  << " marked as UNSUSPENDED - restoring "
-                  << it->second.size() << " suspended events ***" << std::endl;
-      }
-      
       // Append suspended events to the main queue
       for (auto& event : it->second) {
         events.push_back(std::move(event));
       }
-      
       suspended_events.erase(it);
-    } else {
-      if (verbose) {
-        std::cout << "*** Events FROM OSD." << from_osd << " TO OSD." << to_osd
-                  << " marked as UNSUSPENDED ***" << std::endl;
-      }
     }
   }
   
@@ -436,4 +382,8 @@ public:
     std::cout << "  TOTAL: " << events_executed << std::endl;
   }
 };
+
+// Define the static variable
+// Initialized to -1 (no OSD currently executing)
+inline int EventLoop::current_executing_osd = -1;
 

--- a/src/test/osd/PGBackendTestFixture.h
+++ b/src/test/osd/PGBackendTestFixture.h
@@ -109,16 +109,7 @@ protected:
   // The epoch comes from osdmap, this tracks the second version number
   uint64_t next_version = 1;
   
-  class TestDpp : public NoDoutPrefix {
-  public:
-    TestDpp(CephContext *cct) : NoDoutPrefix(cct, ceph_subsys_osd) {}
-    
-    std::ostream& gen_prefix(std::ostream& out) const override {
-      out << "PGBackendTest: ";
-      return out;
-    }
-  };
-  std::unique_ptr<TestDpp> dpp;
+  std::unique_ptr<NoDoutPrefix> dpp;
 
 public:
   explicit PGBackendTestFixture(PoolType type = EC) : pool_type(type)
@@ -142,6 +133,7 @@ public:
   }
   
   void SetUp() override {
+    ceph::logging::Log::set_prefix_hook(&EventLoop::get_log_prefix);
     int r = ::mkdir(data_dir.c_str(), 0777);
     if (r < 0) {
       r = -errno;
@@ -158,8 +150,14 @@ public:
     g_conf().set_safe_to_start_threads();
     
     CephContext *cct = g_ceph_context;
-    dpp = std::make_unique<TestDpp>(cct);
-    event_loop = std::make_unique<EventLoop>(false);
+    
+    // Make dout statements flush immediately - we don't care about performance in tests
+    if (cct->_log) {
+      cct->_log->set_max_new(1);
+    }
+    
+    dpp = std::make_unique<NoDoutPrefix>(cct, ceph_subsys_osd);
+    event_loop = std::make_unique<EventLoop>(dpp.get());
     
     if (pool_type == EC) {
       setup_ec_pool();
@@ -208,6 +206,7 @@ public:
     }
 
     cleanup_data_dir();
+    ceph::logging::Log::set_prefix_hook(nullptr);
   }
   
 private:


### PR DESCRIPTION
Modified the logging system to show which OSD is executing in test logs,
making it easier to debug multi-OSD test scenarios.

Changes:
- Added Log::set_prefix_hook() to allow tests to customize log prefixes
- Modified Log::_flush() to use prefix_hook when set, replacing thread IDs
- Added EventLoop::get_log_prefix() to return 'osd.X' or 'harness' based on context
- Updated EventLoop to track current_executing_osd during event execution
- Simplified PGBackendTestFixture to use NoDoutPrefix directly
- Removed redundant 'shard X:' prefix from ShardDpp (info already in PG identifier)

Benefits:
- Test logs now show 'osd.X' instead of thread IDs during event execution
- Shows 'harness' for test setup/teardown code outside events
- Makes multi-OSD test scenarios much easier to follow and debug
- No changes to production logging code

Code was AI assisted, but carefully reviewed. 

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
