### PR TITLE
mgr/dashboard: fix listener add errors

### DIFF
--- a/src/pybind/mgr/dashboard/services/nvmeof_client.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_client.py
@@ -118,6 +118,13 @@ else:
             status = getattr(response, "status", None)
             error_message = getattr(response, "error_message", None)
 
+            # Normalize the response so callers do not see a non-zero status in
+            # a successful HTTP response.
+            if status == errno.EREMOTE:
+                response.status = 0
+                if hasattr(response, "error_message"):
+                    response.error_message = ""
+                return response
             if status not in (None, 0):
                 raise DashboardException(
                     msg=error_message or "NVMeoF operation failed",

--- a/src/pybind/mgr/dashboard/tests/test_nvmeof_client.py
+++ b/src/pybind/mgr/dashboard/tests/test_nvmeof_client.py
@@ -1,11 +1,13 @@
+import errno
 from typing import Dict, List, NamedTuple, Optional
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from ..exceptions import DashboardException
 from ..services import nvmeof_client
 from ..services.nvmeof_client import MaxRecursionDepthError, convert_to_model, \
-    obj_to_namedtuple, pick
+    handle_nvmeof_error, obj_to_namedtuple, pick
 
 
 class TestObjToNamedTuple:
@@ -491,3 +493,156 @@ class TestPick:
             return None
         with pytest.raises(TypeError):
             get_person()
+
+
+class TestHandleNvmeofError:
+
+    def test_success_with_status_zero(self):
+
+        @handle_nvmeof_error
+        def mock_function():
+            response = MagicMock()
+            response.status = 0
+            response.error_message = "Success"
+            return response
+
+        result = mock_function()
+        assert result.status == 0
+        assert result.error_message == "Success"
+
+    def test_success_with_status_none(self):
+        @handle_nvmeof_error
+        def mock_function():
+            response = MagicMock()
+            response.status = None
+            response.error_message = None
+            return response
+
+        result = mock_function()
+        assert result.status is None
+
+    def test_success_with_eremote_status(self):
+        @handle_nvmeof_error
+        def mock_function():
+            response = MagicMock()
+            response.status = errno.EREMOTE
+            response.error_message = "Host name mismatch, listener will only be " \
+                                     "active when the appropriate gateway is up"
+            return response
+
+        # Should not raise an exception
+        result = mock_function()
+        assert result.status == 0
+        assert result.error_message == ""
+
+    def test_error_with_einval(self):
+        @handle_nvmeof_error
+        def mock_function():
+            response = MagicMock()
+            response.status = errno.EINVAL
+            response.error_message = "Invalid argument"
+            return response
+
+        with pytest.raises(DashboardException) as exc_info:
+            mock_function()
+
+        assert exc_info.value.code == str(errno.EINVAL)
+        assert "Invalid argument" in str(exc_info.value)
+        assert exc_info.value.component == "nvmeof"
+
+    def test_error_with_enoent(self):
+        @handle_nvmeof_error
+        def mock_function():
+            response = MagicMock()
+            response.status = errno.ENOENT
+            response.error_message = "Not found"
+            return response
+
+        with pytest.raises(DashboardException) as exc_info:
+            mock_function()
+
+        assert exc_info.value.code == str(errno.ENOENT)
+        assert exc_info.value.status == 404
+        assert "Not found" in str(exc_info.value)
+
+    def test_error_with_eexist(self):
+        @handle_nvmeof_error
+        def mock_function():
+            response = MagicMock()
+            response.status = errno.EEXIST
+            response.error_message = "Already exists"
+            return response
+
+        with pytest.raises(DashboardException) as exc_info:
+            mock_function()
+
+        assert exc_info.value.code == str(errno.EEXIST)
+        assert exc_info.value.status == 409
+        assert "Already exists" in str(exc_info.value)
+
+    def test_error_with_unknown_status(self):
+        @handle_nvmeof_error
+        def mock_function():
+            response = MagicMock()
+            response.status = 999  # Unknown error code
+            response.error_message = "Unknown error"
+            return response
+
+        with pytest.raises(DashboardException) as exc_info:
+            mock_function()
+
+        assert exc_info.value.code == str(999)
+        assert exc_info.value.status == 400  # Default HTTP status
+        assert "Unknown error" in str(exc_info.value)
+
+    def test_error_without_message(self):
+        @handle_nvmeof_error
+        def mock_function():
+            response = MagicMock()
+            response.status = errno.EINVAL
+            response.error_message = None
+            return response
+
+        with pytest.raises(DashboardException) as exc_info:
+            mock_function()
+
+        assert "NVMeoF operation failed" in str(exc_info.value)
+
+    def test_grpc_inactive_rpc_error(self):
+        class MockInactiveRpcError(Exception):
+            def __init__(self, details_msg, code_val):
+                super().__init__(details_msg)
+                self._details = details_msg
+                self._code = code_val
+
+            def details(self):
+                return self._details
+
+            def code(self):
+                return self._code
+
+        # Mock grpc module
+        with patch('dashboard.services.nvmeof_client.grpc') as mock_grpc:
+            # pylint: disable=protected-access
+            mock_grpc._channel._InactiveRpcError = MockInactiveRpcError
+
+            @handle_nvmeof_error
+            def mock_function():
+                raise MockInactiveRpcError("Connection failed", "UNAVAILABLE")
+
+            with pytest.raises(DashboardException) as exc_info:
+                mock_function()
+
+            assert exc_info.value.status == 504
+            assert exc_info.value.component == "nvmeof"
+            assert "Connection failed" in str(exc_info.value)
+
+    def test_response_without_status_attribute(self):
+        @handle_nvmeof_error
+        def mock_function():
+            response = MagicMock(spec=[])  # No attributes
+            return response
+
+        # Should not raise an exception when status is None (default)
+        result = mock_function()
+        assert result is not None


### PR DESCRIPTION
Some internal warnings were treated like errors


Before:
```
[root@test-node1 ~]# ceph nvmeof listener add --nqn=nqn.2016-06.io.spdk:cnode5.mygroup1 --host-name=test-node2 --traddr=********
Error EINVAL: Host name mismatch, listener will only be active when the appropriate gateway is up
```

After:
```
[root@test-node1 ~]# ceph nvmeof listener add --nqn=nqn.2016-06.io.spdk:cnode5.mygroup1 --host-name=test-node2 --traddr=********
Adding nqn.2016-06.io.spdk:cnode5.mygroup1 listener at ********:4420: Successful
```

Before

fixes: https://tracker.ceph.com/issues/76418





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
