### PR TITLE
Wip naveen trace span stack

### DIFF
--- a/src/messages/MOSDRepScrub.h
+++ b/src/messages/MOSDRepScrub.h
@@ -25,7 +25,7 @@
 
 class MOSDRepScrub final : public MOSDFastDispatchOp {
 public:
-  static constexpr int HEAD_VERSION = 9;
+  static constexpr int HEAD_VERSION = 10;
   static constexpr int COMPAT_VERSION = 6;
 
   spg_t pgid;             // PG to scrub
@@ -108,6 +108,7 @@ public:
     encode(allow_preemption, payload);
     encode(priority, payload);
     encode(high_priority, payload);
+    encode_otel_trace(payload, features);
   }
   void decode_payload() override {
     using ceph::decode;
@@ -136,6 +137,9 @@ public:
     if (header.version >= 9) {
       decode(priority, p);
       decode(high_priority, p);
+    }
+    if (header.version >= 10) {
+      decode_otel_trace(p);
     }
   }
 };

--- a/src/osd/CMakeLists.txt
+++ b/src/osd/CMakeLists.txt
@@ -29,6 +29,7 @@ set(osd_srcs
   scrubber/scrub_resources.cc
   scrubber/ScrubStore.cc
   scrubber/scrub_backend.cc
+  scrubber/scrubber_tracer.cc
   Watch.cc
   Session.cc
   SnapMapper.cc

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -1661,7 +1661,8 @@ void PgScrubber::replica_scrub_op(OpRequestRef op)
   replica_scrubmap = ScrubMap{};
   replica_scrubmap_pos = ScrubMapBuilder{};
 
-  m_fsm->m_replica_parent_ctx = msg->otel_trace;
+  // m_fsm->m_replica_parent_ctx = msg->otel_trace;
+  m_fsm->set_replica_parent_ctx(msg->otel_trace);
   m_replica_min_epoch = msg->min_epoch;
   m_start = msg->start;
   m_end = msg->end;

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -29,6 +29,8 @@
 #include "scrub_backend.h"
 #include "scrub_machine.h"
 
+#include "scrubber_tracer.h"
+
 using std::list;
 using std::pair;
 using std::stringstream;
@@ -2676,7 +2678,9 @@ PgScrubber::PgScrubber(PG* pg)
 	m_osds->cct->_conf, "osd_stats_update_period_not_scrubbing"}
     , preemption_data{pg}
 {
-  m_fsm = std::make_unique<ScrubMachine>(m_pg, this);
+  tracing::scrubber::tracer.init(m_osds->cct, "pg_scrubber");
+  auto scrubber_parent_span = tracing::scrubber::tracer.add_span("pg-scrubber-initialized");
+  m_fsm = std::make_unique<ScrubMachine>(m_pg, this, scrubber_parent_span);
   m_fsm->initiate();
   m_scrub_job.emplace(m_osds->cct, m_pg->pg_id, m_osds->get_nodeid());
 }

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -2679,7 +2679,7 @@ PgScrubber::PgScrubber(PG* pg)
     , preemption_data{pg}
 {
   tracing::scrubber::tracer.init(m_osds->cct, "pg_scrubber");
-  auto scrubber_parent_span = tracing::scrubber::tracer.add_span("pg-scrubber-initialized");
+  auto scrubber_parent_span = tracing::scrubber::tracer.start_trace("pg-scrubber-initialized");
   m_fsm = std::make_unique<ScrubMachine>(m_pg, this, scrubber_parent_span);
   m_fsm->initiate();
   m_scrub_job.emplace(m_osds->cct, m_pg->pg_id, m_osds->get_nodeid());

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -1174,7 +1174,8 @@ eversion_t PgScrubber::search_log_for_updates() const
     return p->version;
 }
 
-void PgScrubber::get_replicas_maps(bool replica_can_preempt)
+void PgScrubber::get_replicas_maps(bool replica_can_preempt,
+				   const jspan_context& parent_ctx)
 {
   dout(10) << __func__ << " started in epoch/interval: " << m_epoch_start << "/"
 	   << m_interval_start << " pg same_interval_since: "
@@ -1194,7 +1195,8 @@ void PgScrubber::get_replicas_maps(bool replica_can_preempt)
 		       m_start,
 		       m_end,
 		       m_is_deep,
-		       replica_can_preempt);
+		       replica_can_preempt,
+		       parent_ctx);
   }
 
   dout(10) << __func__ << " awaiting" << m_maps_status << dendl;
@@ -1246,7 +1248,8 @@ void PgScrubber::_request_scrub_map(pg_shard_t replica,
 				    hobject_t start,
 				    hobject_t end,
 				    bool deep,
-				    bool allow_preemption)
+				    bool allow_preemption,
+				    const jspan_context& parent_ctx)
 {
   ceph_assert(replica != m_pg_whoami);
   dout(10) << __func__ << " scrubmap from osd." << replica
@@ -1262,6 +1265,7 @@ void PgScrubber::_request_scrub_map(pg_shard_t replica,
 				     allow_preemption,
 				     m_flags.priority,
 				     m_pg->ops_blocked_by_scrub());
+  repscrubop->otel_trace = parent_ctx;
 
   // default priority. We want the replica-scrub processed prior to any recovery
   // or client io messages (we are holding a lock!)
@@ -1657,6 +1661,7 @@ void PgScrubber::replica_scrub_op(OpRequestRef op)
   replica_scrubmap = ScrubMap{};
   replica_scrubmap_pos = ScrubMapBuilder{};
 
+  m_fsm->m_replica_parent_ctx = msg->otel_trace;
   m_replica_min_epoch = msg->min_epoch;
   m_start = msg->start;
   m_end = msg->end;

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -1266,6 +1266,8 @@ void PgScrubber::_request_scrub_map(pg_shard_t replica,
 				     m_flags.priority,
 				     m_pg->ops_blocked_by_scrub());
   repscrubop->otel_trace = parent_ctx;
+  dout(10) << __func__ << " osd." << replica
+	   << " otel_trace_valid=" << parent_ctx.IsValid() << dendl;
 
   // default priority. We want the replica-scrub processed prior to any recovery
   // or client io messages (we are holding a lock!)
@@ -1661,7 +1663,9 @@ void PgScrubber::replica_scrub_op(OpRequestRef op)
   replica_scrubmap = ScrubMap{};
   replica_scrubmap_pos = ScrubMapBuilder{};
 
-  // m_fsm->m_replica_parent_ctx = msg->otel_trace;
+  bool otel_valid = msg->otel_trace.IsValid();
+  dout(10) << __func__ << " pg:" << m_pg->pg_id
+	   << " otel_trace_valid=" << otel_valid << dendl;
   m_fsm->set_replica_parent_ctx(msg->otel_trace);
   m_replica_min_epoch = msg->min_epoch;
   m_start = msg->start;
@@ -2685,7 +2689,12 @@ PgScrubber::PgScrubber(PG* pg)
     , preemption_data{pg}
 {
   tracing::scrubber::tracer.init(m_osds->cct, "pg_scrubber");
+  bool tracer_enabled = tracing::scrubber::tracer.is_enabled();
   auto scrubber_parent_span = tracing::scrubber::tracer.start_trace("pg-scrubber-initialized");
+  bool root_recording = scrubber_parent_span && scrubber_parent_span->IsRecording();
+  dout(10) << "PgScrubber::ctor pg=" << m_pg->pg_id
+	   << " tracer_enabled=" << tracer_enabled
+	   << " root_span_recording=" << root_recording << dendl;
   m_fsm = std::make_unique<ScrubMachine>(m_pg, this, scrubber_parent_span);
   m_fsm->initiate();
   m_scrub_job.emplace(m_osds->cct, m_pg->pg_id, m_osds->get_nodeid());

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -511,7 +511,8 @@ class PgScrubber : public ScrubPgIF,
   std::chrono::milliseconds get_scrub_sleep_time() const final;
   void queue_for_scrub_resched(Scrub::scrub_prio_t prio) final;
 
-  void get_replicas_maps(bool replica_can_preempt) final;
+  void get_replicas_maps(bool replica_can_preempt,
+			 const jspan_context& parent_ctx) final;
 
   void on_digest_updates() final;
 
@@ -957,7 +958,8 @@ class PgScrubber : public ScrubPgIF,
 			  hobject_t start,
 			  hobject_t end,
 			  bool deep,
-			  bool allow_preemption);
+			  bool allow_preemption,
+			  const jspan_context& parent_ctx);
 
 
   Scrub::MapsCollectionStatus m_maps_status;

--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -751,7 +751,7 @@ sc::result WaitDigestUpdate::react(const ScrubFinished&)
 ScrubMachine::ScrubMachine(PG* pg, ScrubMachineListener* pg_scrub, jspan_ptr parent_span)
     : m_pg_id{pg->pg_id}
     , m_scrbr{pg_scrub}
-    , m_tracer{tracer}
+    , m_tracer{parent_span}
 {}
 
 ScrubMachine::~ScrubMachine() = default;

--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -172,7 +172,6 @@ PrimaryIdle::PrimaryIdle(my_context ctx)
     , NamedSimply(context<ScrubMachine>().m_scrbr, "PrimaryActive/PrimaryIdle")
 {
   dout(10) << "-- state -->> PrimaryActive/PrimaryIdle" << dendl;
-  context<ScrubMachine>().clear_spans();
 }
 
 sc::result PrimaryIdle::react(const StartScrub&)
@@ -847,15 +846,16 @@ ScrubMachine::ScrubMachine(PG* pg, ScrubMachineListener* pg_scrub, jspan_ptr roo
     : m_pg_id{pg->pg_id}
     , m_scrbr{pg_scrub}
 {
-  // seed the stack with the root span so the first state has a parent
-  if (root_span) {
-    bool recording = root_span->IsRecording();
+  // Save the root span's context so we can parent future spans to it.
+  // The root span itself is not stored — it ends when the caller's
+  // shared_ptr goes out of scope, ensuring it gets exported promptly.
+  if (root_span && root_span->IsRecording()) {
+    m_root_ctx = root_span->GetContext();
     dout(10) << "ScrubMachine::ctor pg=" << m_pg_id
-	     << " root_span recording=" << recording << dendl;
-    m_span_stack.push_back(std::move(root_span));
+	     << " root_ctx valid=" << m_root_ctx.IsValid() << dendl;
   } else {
     dout(10) << "ScrubMachine::ctor pg=" << m_pg_id
-	     << " root_span is null" << dendl;
+	     << " root_span is null or not recording" << dendl;
   }
 }
 
@@ -870,14 +870,15 @@ const jspan_ptr& ScrubMachine::current_span() const
 
 void ScrubMachine::push_span(const std::string& label)
 {
-  auto& parent = current_span();
-  bool parent_valid = parent && parent->IsRecording();
-  bool tracer_enabled = tracing::scrubber::tracer.is_enabled();
-  auto span = tracing::scrubber::tracer.add_span(label, parent);
+  jspan_ptr span;
+  if (!m_span_stack.empty()) {
+    auto& parent = m_span_stack.back();
+    span = tracing::scrubber::tracer.add_span(label, parent);
+  } else if (m_root_ctx.IsValid()) {
+    span = tracing::scrubber::tracer.add_span(label, m_root_ctx);
+  }
   bool span_recording = span && span->IsRecording();
   dout(10) << "push_span: " << label
-	   << " tracer_enabled=" << tracer_enabled
-	   << " parent_valid=" << parent_valid
 	   << " stack_depth=" << m_span_stack.size()
 	   << " new_span_recording=" << span_recording << dendl;
   m_span_stack.push_back(std::move(span));
@@ -907,8 +908,8 @@ void ScrubMachine::pop_span()
 
 void ScrubMachine::clear_spans()
 {
-  // dout(10) << "clear_spans: clearing " << m_span_stack.size() << " spans" << dendl;
-  // m_span_stack.clear();
+  dout(10) << "clear_spans: clearing " << m_span_stack.size() << " spans" << dendl;
+  m_span_stack.clear();
 }
 
 

--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -907,8 +907,8 @@ void ScrubMachine::pop_span()
 
 void ScrubMachine::clear_spans()
 {
-  dout(10) << "clear_spans: clearing " << m_span_stack.size() << " spans" << dendl;
-  m_span_stack.clear();
+  // dout(10) << "clear_spans: clearing " << m_span_stack.size() << " spans" << dendl;
+  // m_span_stack.clear();
 }
 
 

--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -619,7 +619,13 @@ sc::result WaitLastUpdate::react(const InternalAllUpdates&)
   dout(10) << "WaitLastUpdate::react(const InternalAllUpdates&)" << dendl;
 
   auto& span = context<ScrubMachine>().current_span();
+  bool span_valid = span && span->IsRecording();
   auto ctx = span ? span->GetContext() : jspan_context{false, false};
+  dout(10) << "WaitLastUpdate::react: propagating trace to replicas"
+	   << " current_span_recording=" << span_valid
+	   << " ctx_valid=" << ctx.IsValid()
+	   << " stack_depth=" << context<ScrubMachine>().m_span_stack.size()
+	   << dendl;
   scrbr->get_replicas_maps(scrbr->get_preemptor().is_preemptable(), ctx);
   return transit<BuildMap>();
 }
@@ -843,7 +849,13 @@ ScrubMachine::ScrubMachine(PG* pg, ScrubMachineListener* pg_scrub, jspan_ptr roo
 {
   // seed the stack with the root span so the first state has a parent
   if (root_span) {
+    bool recording = root_span->IsRecording();
+    dout(10) << "ScrubMachine::ctor pg=" << m_pg_id
+	     << " root_span recording=" << recording << dendl;
     m_span_stack.push_back(std::move(root_span));
+  } else {
+    dout(10) << "ScrubMachine::ctor pg=" << m_pg_id
+	     << " root_span is null" << dendl;
   }
 }
 
@@ -858,25 +870,44 @@ const jspan_ptr& ScrubMachine::current_span() const
 
 void ScrubMachine::push_span(const std::string& label)
 {
-  auto span = tracing::scrubber::tracer.add_span(label, current_span());
+  auto& parent = current_span();
+  bool parent_valid = parent && parent->IsRecording();
+  bool tracer_enabled = tracing::scrubber::tracer.is_enabled();
+  auto span = tracing::scrubber::tracer.add_span(label, parent);
+  bool span_recording = span && span->IsRecording();
+  dout(10) << "push_span: " << label
+	   << " tracer_enabled=" << tracer_enabled
+	   << " parent_valid=" << parent_valid
+	   << " stack_depth=" << m_span_stack.size()
+	   << " new_span_recording=" << span_recording << dendl;
   m_span_stack.push_back(std::move(span));
 }
 
 void ScrubMachine::push_span(const std::string& label, const jspan_context& parent_ctx)
 {
+  bool ctx_valid = parent_ctx.IsValid();
   auto span = tracing::scrubber::tracer.add_span(label, parent_ctx);
+  bool span_recording = span && span->IsRecording();
+  dout(10) << "push_span(ctx): " << label
+	   << " parent_ctx_valid=" << ctx_valid
+	   << " stack_depth=" << m_span_stack.size()
+	   << " new_span_recording=" << span_recording << dendl;
   m_span_stack.push_back(std::move(span));
 }
 
 void ScrubMachine::pop_span()
 {
   if (!m_span_stack.empty()) {
+    dout(10) << "pop_span: stack_depth=" << m_span_stack.size() << dendl;
     m_span_stack.pop_back();
+  } else {
+    dout(5) << "pop_span: WARNING stack already empty!" << dendl;
   }
 }
 
 void ScrubMachine::clear_spans()
 {
+  dout(10) << "clear_spans: clearing " << m_span_stack.size() << " spans" << dendl;
   m_span_stack.clear();
 }
 

--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -150,14 +150,14 @@ PrimaryActive::PrimaryActive(my_context ctx)
   dout(10) << "-- state -->> PrimaryActive" << dendl;
   // insert this PG into the OSD scrub queue. Calculate initial schedule
   scrbr->schedule_scrub_with_osd();
-  context<ScrubMachine>().push_span(
-      fmt::format("{}_primary_PrimaryActive", pg_id.pgid));
+  // No span pushed here — PrimaryActive outlives the scrub session,
+  // so its span would not be exported until much later (interval change
+  // or PG destruction). Session spans parent directly to m_root_ctx.
 }
 
 PrimaryActive::~PrimaryActive()
 {
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
-  machine.pop_span();
   // we may have set some PG state flags without reaching Session.
   // And we may be holding a 'local resource'.
   scrbr->clear_pgscrub_state();

--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -31,11 +31,7 @@ using namespace std::chrono_literals;
   ScrubMachineListener* scrbr = machine.m_scrbr;		 \
   std::ignore = scrbr;                                           \
   auto pg_id = machine.m_pg_id;					 \
-  std::ignore = pg_id; \
-  auto trace = machine.m_tracer; \
-  std::ignore = trace;  \
-  auto parent_trace = machine.m_parent_trace;  \
-  std::ignore = parent_trace; \
+  std::ignore = pg_id;
 
 NamedSimply::NamedSimply(ScrubMachineListener* scrubber, const char* name)
 {
@@ -139,6 +135,7 @@ NotActive::NotActive(my_context ctx)
 {
   dout(10) << "-- state -->> NotActive" << dendl;
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
+  machine.clear_spans();
   scrbr->clear_queued_or_active();
 }
 
@@ -153,22 +150,14 @@ PrimaryActive::PrimaryActive(my_context ctx)
   dout(10) << "-- state -->> PrimaryActive" << dendl;
   // insert this PG into the OSD scrub queue. Calculate initial schedule
   scrbr->schedule_scrub_with_osd();
-  // TODO: Naveen: The "trace" should be part of pg_scrubber. That way we can maintain
-  // the information better. Maybe a function like "scrbr->get_current_span() ?"
-  auto span_label = fmt::format("{}_primary_PrimaryActive", pg_id.pgid);
-  auto span = tracing::scrubber::tracer.add_span(span_label, context<ScrubMachine>().m_tracer);
-  if (span && span->IsRecording()){
-    auto text = "TRACE SPAN " + span_label + " active";
-    dout(10) << text<< dendl;
-  }
-
-  context<ScrubMachine>().m_parent_trace = context<ScrubMachine>().m_tracer;
-  std::swap(span, context<ScrubMachine>().m_tracer);
+  context<ScrubMachine>().push_span(
+      fmt::format("{}_primary_PrimaryActive", pg_id.pgid));
 }
 
 PrimaryActive::~PrimaryActive()
 {
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
+  machine.pop_span();
   // we may have set some PG state flags without reaching Session.
   // And we may be holding a 'local resource'.
   scrbr->clear_pgscrub_state();
@@ -183,6 +172,7 @@ PrimaryIdle::PrimaryIdle(my_context ctx)
     , NamedSimply(context<ScrubMachine>().m_scrbr, "PrimaryActive/PrimaryIdle")
 {
   dout(10) << "-- state -->> PrimaryActive/PrimaryIdle" << dendl;
+  context<ScrubMachine>().clear_spans();
 }
 
 sc::result PrimaryIdle::react(const StartScrub&)
@@ -216,19 +206,14 @@ Session::Session(my_context ctx)
   m_counters_idx = &scrbr->get_unlabeled_counters();
   m_osd_counters->inc(m_counters_idx->started_cnt);
 
-  auto span_label = fmt::format("{}_primary_PrimaryActive/Session", pg_id.pgid);
-  auto span = tracing::scrubber::tracer.add_span(span_label, context<ScrubMachine>().m_tracer);
-  context<ScrubMachine>().m_parent_trace = context<ScrubMachine>().m_tracer;
-  if (span && span->IsRecording()){
-    auto text = "TRACE SPAN " + span_label + " active";
-    dout(10) << text<< dendl;
-  }
-  std::swap(span, context<ScrubMachine>().m_tracer);
+  context<ScrubMachine>().push_span(
+      fmt::format("{}_primary_PrimaryActive/Session", pg_id.pgid));
 }
 
 Session::~Session()
 {
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
+  machine.pop_span();
   m_reservations.reset();
   machine.m_session_started_at.reset();
 
@@ -298,14 +283,13 @@ ReservingReplicas::ReservingReplicas(my_context ctx)
     post_event(RemotesReserved{});
   }
 
-  auto span_label = fmt::format("{}_primary_PrimaryActive/Session/ReservingReplicas", pg_id.pgid);
-  auto span = tracing::scrubber::tracer.add_span(span_label, context<ScrubMachine>().m_tracer);
-  if (span && span->IsRecording()){
-    auto text = "TRACE SPAN " + span_label + " active";
-    dout(10) << text<< dendl;
-  }
-  context<ScrubMachine>().m_parent_trace = context<ScrubMachine>().m_tracer; // parent trace, _primary_PrimaryActive/Session/
-  // std::swap(span, context<ScrubMachine>().m_tracer); no need to swap because we aren't extending down the chain
+  context<ScrubMachine>().push_span(
+      fmt::format("{}_primary_PrimaryActive/Session/ReservingReplicas", pg_id.pgid));
+}
+
+ReservingReplicas::~ReservingReplicas()
+{
+  context<ScrubMachine>().pop_span();
 }
 
 sc::result ReservingReplicas::react(const ReplicaGrant& ev)
@@ -370,13 +354,8 @@ ActiveScrubbing::ActiveScrubbing(my_context ctx)
 
   scrbr->on_init();
 
-  auto span_label = fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing", pg_id.pgid);
-  auto span = tracing::scrubber::tracer.add_span(span_label, context<ScrubMachine>().m_parent_trace);
-  if (span && span->IsRecording()){
-    auto text = "TRACE SPAN " + span_label + " active";
-    dout(10) << text<< dendl;
-  }
-  std::swap(span, context<ScrubMachine>().m_tracer);
+  context<ScrubMachine>().push_span(
+      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing", pg_id.pgid));
 }
 
 /**
@@ -385,6 +364,7 @@ ActiveScrubbing::ActiveScrubbing(my_context ctx)
 ActiveScrubbing::~ActiveScrubbing()
 {
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
+  machine.pop_span();
   auto& session = context<Session>();
   dout(15) << __func__ << dendl;
 
@@ -420,6 +400,8 @@ RangeBlocked::RangeBlocked(my_context ctx)
 {
   dout(10) << "-- state -->> Session/Act/RangeBlocked" << dendl;
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
+  machine.push_span(
+      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/RangeBlocked", pg_id.pgid));
 
   auto grace = scrbr->get_range_blocked_grace();
   if (grace == ceph::timespan{}) {
@@ -460,6 +442,11 @@ sc::result RangeBlocked::react(const RangeBlockedAlarm&)
   return discard_event();
 }
 
+RangeBlocked::~RangeBlocked()
+{
+  context<ScrubMachine>().pop_span();
+}
+
 // ----------------------- PendingTimer -----------------------------------
 
 /**
@@ -472,8 +459,11 @@ PendingTimer::PendingTimer(my_context ctx)
   dout(10) << "-- state -->> Session/Act/PendingTimer" << dendl;
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
 
+  machine.push_span(
+      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/PendingTimer", pg_id.pgid));
+
   auto sleep_time = scrbr->get_scrub_sleep_time();
-  
+
   if (sleep_time.count()) {
     // the following log line is used by osd-scrub-test.sh
     dout(20) << __func__ << " scrub state is PendingTimer, sleeping" << dendl;
@@ -482,15 +472,6 @@ PendingTimer::PendingTimer(my_context ctx)
 	     << " sleeping for " << sleep_time << dendl;
     m_sleep_timer = machine.schedule_timer_event_after<SleepComplete>(
       sleep_time);
-
-  auto span_label = fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/PendingTimer", pg_id.pgid);
-  auto span = tracing::scrubber::tracer.add_span(span_label, context<ScrubMachine>().m_tracer);
-  if (span && span->IsRecording()){
-    auto text = "TRACE SPAN " + span_label + " active";
-    dout(10) << text<< dendl;
-  }
-  context<ScrubMachine>().m_parent_trace = context<ScrubMachine>().m_tracer; // parent trace, _primary_PrimaryActive/Session/ActiveScrubbing/
-  // std::swap(span, context<ScrubMachine>().m_tracer); no need to swap because we aren't extending down the chain
   } else {
     scrbr->queue_for_scrub_resched(Scrub::scrub_prio_t::high_priority);
   }
@@ -507,6 +488,11 @@ sc::result PendingTimer::react(const SleepComplete&)
 
   scrbr->queue_for_scrub_resched(Scrub::scrub_prio_t::low_priority);
   return discard_event();
+}
+
+PendingTimer::~PendingTimer()
+{
+  context<ScrubMachine>().pop_span();
 }
 
 // ----------------------- NewChunk -----------------------------------
@@ -530,15 +516,8 @@ NewChunk::NewChunk(my_context ctx)
   //  ChunkIsBusy. If 'busy', we transition to Blocked, and wait for the
   //  range to become available.
   scrbr->select_range_n_notify();
-  // auto span_label = fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/NewChunk", pg_id.pgid);
-  // auto span = tracing::scrubber::tracer.add_span(span_label, trace);
-  // std::swap(span, trace);
-  auto span_label = fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/NewChunk", pg_id.pgid);
-  auto span = tracing::scrubber::tracer.add_span(span_label, context<ScrubMachine>().m_tracer);
-  if (span && span->IsRecording()){
-    auto text = "TRACE SPAN " + span_label + " active";
-    dout(10) << text<< dendl;
-  }
+  machine.push_span(
+      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/NewChunk", pg_id.pgid));
 }
 
 sc::result NewChunk::react(const SelectedChunkFree&)
@@ -550,18 +529,27 @@ sc::result NewChunk::react(const SelectedChunkFree&)
   return transit<WaitPushes>();
 }
 
+NewChunk::~NewChunk()
+{
+  context<ScrubMachine>().pop_span();
+}
+
 // ----------------------- WaitPushes -----------------------------------
 
 WaitPushes::WaitPushes(my_context ctx)
     : my_base(ctx)
     , NamedSimply(context<ScrubMachine>().m_scrbr, "Session/Act/WaitPushes")
 {
-  DECLARE_LOCALS;  
+  DECLARE_LOCALS;
   dout(10) << " -- state -->> Session/Act/WaitPushes" << dendl;
-  auto span_label = fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/WaitPushes", pg_id.pgid);
-  auto span = tracing::scrubber::tracer.add_span(span_label, context<ScrubMachine>().m_tracer);
+  machine.push_span(
+      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/WaitPushes", pg_id.pgid));
   post_event(ActivePushesUpd{});
-  
+}
+
+WaitPushes::~WaitPushes()
+{
+  context<ScrubMachine>().pop_span();
 }
 
 /*
@@ -590,9 +578,14 @@ WaitLastUpdate::WaitLastUpdate(my_context ctx)
 {
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
   dout(10) << " -- state -->> Session/Act/WaitLastUpdate" << dendl;
-  auto span_label = fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/WaitLastUpdate", pg_id.pgid);
-  auto span = tracing::scrubber::tracer.add_span(span_label, context<ScrubMachine>().m_tracer);
+  machine.push_span(
+      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/WaitLastUpdate", pg_id.pgid));
   post_event(UpdatesApplied{});
+}
+
+WaitLastUpdate::~WaitLastUpdate()
+{
+  context<ScrubMachine>().pop_span();
 }
 
 /**
@@ -625,8 +618,8 @@ sc::result WaitLastUpdate::react(const InternalAllUpdates&)
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
   dout(10) << "WaitLastUpdate::react(const InternalAllUpdates&)" << dendl;
 
-  auto& tracer = context<ScrubMachine>().m_tracer;
-  auto ctx = tracer ? tracer->GetContext() : jspan_context{false, false};
+  auto& span = context<ScrubMachine>().current_span();
+  auto ctx = span ? span->GetContext() : jspan_context{false, false};
   scrbr->get_replicas_maps(scrbr->get_preemptor().is_preemptable(), ctx);
   return transit<BuildMap>();
 }
@@ -643,9 +636,8 @@ BuildMap::BuildMap(my_context ctx)
 
   // no need to check for an epoch change, as all possible flows that brought
   // us here have a check_interval() verification of their final event.
-  auto span_label = fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/BuildMap", pg_id.pgid);
-  auto span = tracing::scrubber::tracer.add_span(span_label, context<ScrubMachine>().m_tracer);
-
+  machine.push_span(
+      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/BuildMap", pg_id.pgid));
 
   if (scrbr->get_preemptor().was_preempted()) {
 
@@ -672,6 +664,11 @@ BuildMap::BuildMap(my_context ctx)
   }
 }
 
+BuildMap::~BuildMap()
+{
+  context<ScrubMachine>().pop_span();
+}
+
 sc::result BuildMap::react(const IntLocalMapDone&)
 {
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
@@ -688,8 +685,16 @@ DrainReplMaps::DrainReplMaps(my_context ctx)
     , NamedSimply(context<ScrubMachine>().m_scrbr, "Session/Act/DrainReplMaps")
 {
   dout(10) << "-- state -->> Session/Act/DrainReplMaps" << dendl;
+  DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
+  machine.push_span(
+      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/DrainReplMaps", pg_id.pgid));
   // we may have got all maps already. Send the event that will make us check.
   post_event(GotReplicas{});
+}
+
+DrainReplMaps::~DrainReplMaps()
+{
+  context<ScrubMachine>().pop_span();
 }
 
 sc::result DrainReplMaps::react(const GotReplicas&)
@@ -716,9 +721,14 @@ WaitReplicas::WaitReplicas(my_context ctx)
 {
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
   dout(10) << "-- state -->> Session/Act/WaitReplicas" << dendl;
-  auto span_label = fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/WaitReplicas", pg_id.pgid);
-  auto span = tracing::scrubber::tracer.add_span(span_label, context<ScrubMachine>().m_tracer);
+  machine.push_span(
+      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/WaitReplicas", pg_id.pgid));
   post_event(GotReplicas{});
+}
+
+WaitReplicas::~WaitReplicas()
+{
+  context<ScrubMachine>().pop_span();
 }
 
 /**
@@ -780,14 +790,18 @@ WaitDigestUpdate::WaitDigestUpdate(my_context ctx)
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
   dout(10) << "-- state -->> Session/Act/WaitDigestUpdate" << dendl;
 
-  auto span_label = fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/WaitDigestUpdate", pg_id.pgid);
-  auto span = tracing::scrubber::tracer.add_span(span_label, context<ScrubMachine>().m_tracer);
-  std::swap(span, context<ScrubMachine>().m_tracer);
+  machine.push_span(
+      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/WaitDigestUpdate", pg_id.pgid));
 
   // perform an initial check: maybe we already
   // have all the updates we need:
   // (note that DigestUpdate is usually an external event)
   post_event(DigestUpdate{});
+}
+
+WaitDigestUpdate::~WaitDigestUpdate()
+{
+  context<ScrubMachine>().pop_span();
 }
 
 sc::result WaitDigestUpdate::react(const DigestUpdate&)
@@ -823,13 +837,48 @@ sc::result WaitDigestUpdate::react(const ScrubFinished&)
   return transit<PrimaryIdle>();
 }
 
-ScrubMachine::ScrubMachine(PG* pg, ScrubMachineListener* pg_scrub, jspan_ptr parent_span)
+ScrubMachine::ScrubMachine(PG* pg, ScrubMachineListener* pg_scrub, jspan_ptr root_span)
     : m_pg_id{pg->pg_id}
     , m_scrbr{pg_scrub}
-    , m_tracer{parent_span}
-{}
+{
+  // seed the stack with the root span so the first state has a parent
+  if (root_span) {
+    m_span_stack.push_back(std::move(root_span));
+  }
+}
 
 ScrubMachine::~ScrubMachine() = default;
+
+static const jspan_ptr empty_jspan_ptr;
+
+const jspan_ptr& ScrubMachine::current_span() const
+{
+  return m_span_stack.empty() ? empty_jspan_ptr : m_span_stack.back();
+}
+
+void ScrubMachine::push_span(const std::string& label)
+{
+  auto span = tracing::scrubber::tracer.add_span(label, current_span());
+  m_span_stack.push_back(std::move(span));
+}
+
+void ScrubMachine::push_span(const std::string& label, const jspan_context& parent_ctx)
+{
+  auto span = tracing::scrubber::tracer.add_span(label, parent_ctx);
+  m_span_stack.push_back(std::move(span));
+}
+
+void ScrubMachine::pop_span()
+{
+  if (!m_span_stack.empty()) {
+    m_span_stack.pop_back();
+  }
+}
+
+void ScrubMachine::clear_spans()
+{
+  m_span_stack.clear();
+}
 
 
 // -------- for replicas -----------------------------------------------------
@@ -1045,7 +1094,10 @@ ReplicaIdle::ReplicaIdle(my_context ctx)
     , NamedSimply(context<ScrubMachine>().m_scrbr, "ReplicaActive/ReplicaIdle")
 {
   dout(10) << "-- state -->> ReplicaActive/ReplicaIdle" << dendl;
+  context<ScrubMachine>().clear_spans();
 }
+
+ReplicaIdle::~ReplicaIdle() = default;
 
 
 sc::result ReplicaIdle::react(const StartReplica& ev)
@@ -1075,18 +1127,11 @@ ReplicaActiveOp::ReplicaActiveOp(my_context ctx)
 {
   dout(10) << "-- state -->> ReplicaActive/ReplicaActiveOp" << dendl;
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
-  auto span_label = fmt::format("{}_replica_ReplicaActive/ReplicaActiveOp", pg_id.pgid);
   // Use the trace context propagated from the primary via MOSDRepScrub so that
   // replica spans are linked under the same trace as the primary.
-  auto& primary_ctx = context<ScrubMachine>().m_replica_parent_ctx;
-  auto span = tracing::scrubber::tracer.add_span(span_label, primary_ctx);
-  if (span && span->IsRecording()) {
-    dout(10) << "REPLICA TRACE SPAN " << span_label << " active" << dendl;
-  } else {
-    dout(10) << "REPLICA TRACE SPAN " << span_label << " inactive (no primary context)" << dendl;
-  }
-  context<ScrubMachine>().m_parent_trace = context<ScrubMachine>().m_tracer;
-  std::swap(span, context<ScrubMachine>().m_tracer);
+  machine.push_span(
+      fmt::format("{}_replica_ReplicaActive/ReplicaActiveOp", pg_id.pgid),
+      machine.m_replica_parent_ctx);
   scrbr->on_replica_init();
 }
 
@@ -1095,6 +1140,7 @@ ReplicaActiveOp::~ReplicaActiveOp()
 {
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
   dout(10) << __func__ << dendl;
+  machine.pop_span();
   scrbr->replica_handling_done();
 }
 
@@ -1133,15 +1179,13 @@ ReplicaWaitUpdates::ReplicaWaitUpdates(my_context ctx)
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
   dout(10) << "-- state -->> ReplicaActive/ReplicaActiveOp/ReplicaWaitUpdates"
 	   << dendl;
-  auto span_label = fmt::format("{}_replica_ReplicaActive/ReplicaActiveOp/ReplicaWaitUpdates", pg_id.pgid);
-  if (context<ScrubMachine>().m_tracer && context<ScrubMachine>().m_tracer->IsRecording()){
-    auto text = "REPLICA TRACE SPAN " + span_label + " active";
-    dout(10) << text<< dendl;
-  } else {
-    auto text = "REPLICA TRACE SPAN " + span_label + " inactive";
-    dout(10) << text<< dendl;
-  }
-  auto span = tracing::scrubber::tracer.add_span(span_label, context<ScrubMachine>().m_tracer);
+  machine.push_span(
+      fmt::format("{}_replica_ReplicaActive/ReplicaActiveOp/ReplicaWaitUpdates", pg_id.pgid));
+}
+
+ReplicaWaitUpdates::~ReplicaWaitUpdates()
+{
+  context<ScrubMachine>().pop_span();
 }
 
 
@@ -1174,9 +1218,14 @@ ReplicaBuildingMap::ReplicaBuildingMap(my_context ctx)
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
   dout(10) << "-- state -->> ReplicaActive/ReplicaActiveOp/ReplicaBuildingMap"
 	   << dendl;
-  auto span_label = fmt::format("{}_replica_ReplicaActive/ReplicaActiveOp/ReplicaBuildingMap", pg_id.pgid);
-  auto span = tracing::scrubber::tracer.add_span(span_label, context<ScrubMachine>().m_tracer);
+  machine.push_span(
+      fmt::format("{}_replica_ReplicaActive/ReplicaActiveOp/ReplicaBuildingMap", pg_id.pgid));
   post_event(SchedReplica{});
+}
+
+ReplicaBuildingMap::~ReplicaBuildingMap()
+{
+  context<ScrubMachine>().pop_span();
 }
 
 

--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -205,6 +205,11 @@ Session::Session(my_context ctx)
   m_counters_idx = &scrbr->get_unlabeled_counters();
   m_osd_counters->inc(m_counters_idx->started_cnt);
 
+  // Push PrimaryActive's span here (not in PrimaryActive's ctor) so that
+  // it gets exported when Session ends. PrimaryActive itself outlives the
+  // scrub session, so a span pushed there would stay unexported for too long.
+  context<ScrubMachine>().push_span(
+      fmt::format("{}_primary_PrimaryActive", pg_id.pgid));
   context<ScrubMachine>().push_span(
       fmt::format("{}_primary_PrimaryActive/Session", pg_id.pgid));
 }
@@ -212,7 +217,8 @@ Session::Session(my_context ctx)
 Session::~Session()
 {
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
-  machine.pop_span();
+  machine.pop_span();  // Session
+  machine.pop_span();  // PrimaryActive
   m_reservations.reset();
   machine.m_session_started_at.reset();
 

--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -625,7 +625,9 @@ sc::result WaitLastUpdate::react(const InternalAllUpdates&)
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
   dout(10) << "WaitLastUpdate::react(const InternalAllUpdates&)" << dendl;
 
-  scrbr->get_replicas_maps(scrbr->get_preemptor().is_preemptable());
+  auto& tracer = context<ScrubMachine>().m_tracer;
+  auto ctx = tracer ? tracer->GetContext() : jspan_context{false, false};
+  scrbr->get_replicas_maps(scrbr->get_preemptor().is_preemptable(), ctx);
   return transit<BuildMap>();
 }
 
@@ -1074,15 +1076,15 @@ ReplicaActiveOp::ReplicaActiveOp(my_context ctx)
   dout(10) << "-- state -->> ReplicaActive/ReplicaActiveOp" << dendl;
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
   auto span_label = fmt::format("{}_replica_ReplicaActive/ReplicaActiveOp", pg_id.pgid);
-  if (context<ScrubMachine>().m_tracer && context<ScrubMachine>().m_tracer->IsRecording()){
-    auto text = "REPLICA TRACE SPAN " + span_label + " active";
-    dout(10) << text<< dendl;
+  // Use the trace context propagated from the primary via MOSDRepScrub so that
+  // replica spans are linked under the same trace as the primary.
+  auto& primary_ctx = context<ScrubMachine>().m_replica_parent_ctx;
+  auto span = tracing::scrubber::tracer.add_span(span_label, primary_ctx);
+  if (span && span->IsRecording()) {
+    dout(10) << "REPLICA TRACE SPAN " << span_label << " active" << dendl;
   } else {
-    auto text = "REPLICA TRACE SPAN " + span_label + " inactive";
-    dout(10) << text<< dendl;
+    dout(10) << "REPLICA TRACE SPAN " << span_label << " inactive (no primary context)" << dendl;
   }
-  
-  auto span = tracing::scrubber::tracer.add_span(span_label, context<ScrubMachine>().m_tracer);
   context<ScrubMachine>().m_parent_trace = context<ScrubMachine>().m_tracer;
   std::swap(span, context<ScrubMachine>().m_tracer);
   scrbr->on_replica_init();

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -300,6 +300,7 @@ class ScrubMachine : public ScrubFsmIf, public sc::state_machine<ScrubMachine, N
   spg_t m_pg_id;
   ScrubMachineListener* m_scrbr;
   jspan_ptr m_tracer;
+  jspan_ptr m_parent_trace;
   std::ostream& gen_prefix(std::ostream& out) const;
 
   void assert_not_in_session() const final;

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -29,6 +29,9 @@
 #include "scrub_machine_lstnr.h"
 #include "scrub_reservations.h"
 
+#include "common/tracer.h"
+
+
 /// a wrapper that sets the FSM state description used by the
 /// PgScrubber
 /// \todo consider using the full NamedState as in Peering
@@ -291,11 +294,12 @@ class ScrubMachine : public ScrubFsmIf, public sc::state_machine<ScrubMachine, N
  public:
   friend class PgScrubber;
 
-  explicit ScrubMachine(PG* pg, ScrubMachineListener* pg_scrub);
+  explicit ScrubMachine(PG* pg, ScrubMachineListener* pg_scrub, jspn_ptr tracer);
   virtual ~ScrubMachine();
 
   spg_t m_pg_id;
   ScrubMachineListener* m_scrbr;
+  jspan_ptr m_tracer;
   std::ostream& gen_prefix(std::ostream& out) const;
 
   void assert_not_in_session() const final;

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -294,7 +294,7 @@ class ScrubMachine : public ScrubFsmIf, public sc::state_machine<ScrubMachine, N
  public:
   friend class PgScrubber;
 
-  explicit ScrubMachine(PG* pg, ScrubMachineListener* pg_scrub, jspn_ptr tracer);
+  explicit ScrubMachine(PG* pg, ScrubMachineListener* pg_scrub, jspan_ptr tracer);
   virtual ~ScrubMachine();
 
   spg_t m_pg_id;

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -304,13 +304,19 @@ class ScrubMachine : public ScrubFsmIf, public sc::state_machine<ScrubMachine, N
   /// Each state constructor pushes a span, each destructor pops it.
   std::vector<jspan_ptr> m_span_stack;
 
+  /// saved context from the root span created in PgScrubber ctor.
+  /// The root span itself ends promptly (so it gets exported), but its
+  /// context stays valid and serves as the parent when the stack is empty.
+  jspan_context m_root_ctx{false, false};
+
   /// trace context received from primary via MOSDRepScrub
   jspan_context m_replica_parent_ctx{false, false};
 
   /// return the current (topmost) span, or an empty jspan_ptr if the stack is empty
   const jspan_ptr& current_span() const;
 
-  /// push a new span as a child of the current top-of-stack span
+  /// push a new span as a child of the current top-of-stack span,
+  /// or as a child of the root context if the stack is empty.
   void push_span(const std::string& label);
 
   /// push a new span parented to a specific trace context (for replica spans)

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -294,14 +294,34 @@ class ScrubMachine : public ScrubFsmIf, public sc::state_machine<ScrubMachine, N
  public:
   friend class PgScrubber;
 
-  explicit ScrubMachine(PG* pg, ScrubMachineListener* pg_scrub, jspan_ptr tracer);
+  explicit ScrubMachine(PG* pg, ScrubMachineListener* pg_scrub, jspan_ptr root_span);
   virtual ~ScrubMachine();
 
   spg_t m_pg_id;
   ScrubMachineListener* m_scrbr;
-  jspan_ptr m_tracer;
-  jspan_ptr m_parent_trace;
-  jspan_context m_replica_parent_ctx{false, false};  ///< trace context received from primary via MOSDRepScrub
+
+  /// span stack for tracing - mirrors the state machine nesting.
+  /// Each state constructor pushes a span, each destructor pops it.
+  std::vector<jspan_ptr> m_span_stack;
+
+  /// trace context received from primary via MOSDRepScrub
+  jspan_context m_replica_parent_ctx{false, false};
+
+  /// return the current (topmost) span, or an empty jspan_ptr if the stack is empty
+  const jspan_ptr& current_span() const;
+
+  /// push a new span as a child of the current top-of-stack span
+  void push_span(const std::string& label);
+
+  /// push a new span parented to a specific trace context (for replica spans)
+  void push_span(const std::string& label, const jspan_context& parent_ctx);
+
+  /// pop and end the topmost span
+  void pop_span();
+
+  /// end all active spans (used by RESET states)
+  void clear_spans();
+
   std::ostream& gen_prefix(std::ostream& out) const;
 
   void assert_not_in_session() const final;
@@ -321,7 +341,7 @@ class ScrubMachine : public ScrubFsmIf, public sc::state_machine<ScrubMachine, N
     sc::state_machine<ScrubMachine, NotActive>::process_event(evt);
   }
 
-  void set_replica_parent_ctx(const jspan_context& ctx){
+  void set_replica_parent_ctx(const jspan_context& ctx) {
     m_replica_parent_ctx = ctx;
   }
 
@@ -606,7 +626,7 @@ struct Session : sc::state<Session, PrimaryActive, ReservingReplicas>,
 
 struct ReservingReplicas : sc::state<ReservingReplicas, Session>, NamedSimply {
   explicit ReservingReplicas(my_context ctx);
-  ~ReservingReplicas() = default;
+  ~ReservingReplicas();
   using reactions = mpl::list<
       sc::custom_reaction<ReplicaGrant>,
       sc::custom_reaction<ReplicaReject>,
@@ -655,6 +675,7 @@ struct ActiveScrubbing
 
 struct RangeBlocked : sc::state<RangeBlocked, ActiveScrubbing>, NamedSimply {
   explicit RangeBlocked(my_context ctx);
+  ~RangeBlocked();
   using reactions = mpl::list<
     sc::custom_reaction<RangeBlockedAlarm>,
     sc::transition<Unblocked, PendingTimer>>;
@@ -674,6 +695,7 @@ struct RangeBlocked : sc::state<RangeBlocked, ActiveScrubbing>, NamedSimply {
 struct PendingTimer : sc::state<PendingTimer, ActiveScrubbing>, NamedSimply {
 
   explicit PendingTimer(my_context ctx);
+  ~PendingTimer();
 
   using reactions = mpl::list<
     sc::transition<InternalSchedScrub, NewChunk>,
@@ -687,6 +709,7 @@ struct PendingTimer : sc::state<PendingTimer, ActiveScrubbing>, NamedSimply {
 struct NewChunk : sc::state<NewChunk, ActiveScrubbing>, NamedSimply {
 
   explicit NewChunk(my_context ctx);
+  ~NewChunk();
 
   using reactions = mpl::list<sc::transition<ChunkIsBusy, RangeBlocked>,
 			      sc::custom_reaction<SelectedChunkFree>>;
@@ -706,6 +729,7 @@ struct NewChunk : sc::state<NewChunk, ActiveScrubbing>, NamedSimply {
 struct WaitPushes : sc::state<WaitPushes, ActiveScrubbing>, NamedSimply {
 
   explicit WaitPushes(my_context ctx);
+  ~WaitPushes();
 
   using reactions = mpl::list<sc::custom_reaction<ActivePushesUpd>>;
 
@@ -716,6 +740,7 @@ struct WaitLastUpdate : sc::state<WaitLastUpdate, ActiveScrubbing>,
 			NamedSimply {
 
   explicit WaitLastUpdate(my_context ctx);
+  ~WaitLastUpdate();
 
   void on_new_updates(const UpdatesApplied&);
 
@@ -730,6 +755,7 @@ struct WaitLastUpdate : sc::state<WaitLastUpdate, ActiveScrubbing>,
 
 struct BuildMap : sc::state<BuildMap, ActiveScrubbing>, NamedSimply {
   explicit BuildMap(my_context ctx);
+  ~BuildMap();
 
   // possible error scenarios:
   // - an error reported by the backend will cause the scrubber to
@@ -752,6 +778,7 @@ struct BuildMap : sc::state<BuildMap, ActiveScrubbing>, NamedSimply {
  */
 struct DrainReplMaps : sc::state<DrainReplMaps, ActiveScrubbing>, NamedSimply {
   explicit DrainReplMaps(my_context ctx);
+  ~DrainReplMaps();
 
   using reactions =
     // all replicas are accounted for:
@@ -762,6 +789,7 @@ struct DrainReplMaps : sc::state<DrainReplMaps, ActiveScrubbing>, NamedSimply {
 
 struct WaitReplicas : sc::state<WaitReplicas, ActiveScrubbing>, NamedSimply {
   explicit WaitReplicas(my_context ctx);
+  ~WaitReplicas();
 
   using reactions = mpl::list<
     // all replicas are accounted for:
@@ -776,6 +804,7 @@ struct WaitReplicas : sc::state<WaitReplicas, ActiveScrubbing>, NamedSimply {
 struct WaitDigestUpdate : sc::state<WaitDigestUpdate, ActiveScrubbing>,
 			  NamedSimply {
   explicit WaitDigestUpdate(my_context ctx);
+  ~WaitDigestUpdate();
 
   using reactions = mpl::list<sc::custom_reaction<DigestUpdate>,
 			      sc::custom_reaction<ScrubFinished>,
@@ -955,7 +984,7 @@ struct ReplicaActive : sc::state<ReplicaActive, ScrubMachine, ReplicaIdle>,
 
 struct ReplicaIdle : sc::state<ReplicaIdle, ReplicaActive>, NamedSimply {
   explicit ReplicaIdle(my_context ctx);
-  ~ReplicaIdle() = default;
+  ~ReplicaIdle();
   using reactions = mpl::list<sc::custom_reaction<StartReplica>>;
 
   sc::result react(const StartReplica& ev);
@@ -1007,6 +1036,7 @@ struct ReplicaActiveOp
 struct ReplicaWaitUpdates : sc::state<ReplicaWaitUpdates, ReplicaActiveOp>,
 			    NamedSimply {
   explicit ReplicaWaitUpdates(my_context ctx);
+  ~ReplicaWaitUpdates();
   using reactions = mpl::list<sc::custom_reaction<ReplicaPushesUpd>>;
 
   sc::result react(const ReplicaPushesUpd&);
@@ -1015,6 +1045,7 @@ struct ReplicaWaitUpdates : sc::state<ReplicaWaitUpdates, ReplicaActiveOp>,
 struct ReplicaBuildingMap : sc::state<ReplicaBuildingMap, ReplicaActiveOp>,
 			    NamedSimply {
   explicit ReplicaBuildingMap(my_context ctx);
+  ~ReplicaBuildingMap();
   using reactions = mpl::list<sc::custom_reaction<SchedReplica>>;
 
   sc::result react(const SchedReplica&);

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -321,6 +321,10 @@ class ScrubMachine : public ScrubFsmIf, public sc::state_machine<ScrubMachine, N
     sc::state_machine<ScrubMachine, NotActive>::process_event(evt);
   }
 
+  void set_replica_parent_ctx(const jspan_context& ctx){
+    m_replica_parent_ctx = ctx;
+  }
+
   /// the time when the session was initiated
   std::optional<ScrubTimePoint> m_session_started_at;
 

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -301,6 +301,7 @@ class ScrubMachine : public ScrubFsmIf, public sc::state_machine<ScrubMachine, N
   ScrubMachineListener* m_scrbr;
   jspan_ptr m_tracer;
   jspan_ptr m_parent_trace;
+  jspan_context m_replica_parent_ctx{false, false};  ///< trace context received from primary via MOSDRepScrub
   std::ostream& gen_prefix(std::ostream& out) const;
 
   void assert_not_in_session() const final;

--- a/src/osd/scrubber/scrub_machine_if.h
+++ b/src/osd/scrubber/scrub_machine_if.h
@@ -11,6 +11,7 @@
 #include <boost/statechart/state.hpp>
 #include <boost/statechart/state_machine.hpp>
 
+#include "common/tracer.h"
 #include "osd/scrubber_common.h"
 
 namespace Scrub {
@@ -53,6 +54,8 @@ class ScrubFsmIf {
 
   /// "initiate" the state machine (an internal state_chart function)
   virtual void initiate() = 0;
+
+  virtual void set_replica_parent_ctx(const jspan_context& ctx) = 0;
 };
 
 }  // namespace Scrub

--- a/src/osd/scrubber/scrub_machine_lstnr.h
+++ b/src/osd/scrubber/scrub_machine_lstnr.h
@@ -6,6 +6,7 @@
  * \file the PgScrubber interface used by the scrub FSM
  */
 #include "common/LogClient.h"
+#include "common/tracer.h"
 #include "common/version.h"
 #include "include/Context.h"
 #include "osd/osd_types.h"
@@ -162,7 +163,8 @@ struct ScrubMachineListener {
   /**
    * Ask all replicas for their scrub maps for the current chunk.
    */
-  virtual void get_replicas_maps(bool replica_can_preempt) = 0;
+  virtual void get_replicas_maps(bool replica_can_preempt,
+				 const jspan_context& parent_ctx) = 0;
 
   virtual void on_digest_updates() = 0;
 

--- a/src/osd/scrubber/scrubber_tracer.cc
+++ b/src/osd/scrubber/scrubber_tracer.cc
@@ -1,0 +1,12 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#include "common/tracer.h"
+
+namespace tracing {
+namespace scrubber {
+
+tracing::Tracer tracer;
+
+} // namespace scrubber
+} // namespace tracing

--- a/src/osd/scrubber/scrubber_tracer.h
+++ b/src/osd/scrubber/scrubber_tracer.h
@@ -1,0 +1,14 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#pragma once
+
+#include "common/tracer.h"
+
+namespace tracing {
+namespace scrubber {
+
+extern tracing::Tracer tracer;
+
+} // namespace scrubber
+} // namespace tracing


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
