### PR TITLE
mgr/cephadm: allow nvmeof group assignment for NVMe-oF services

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3875,6 +3875,30 @@ Then run the following:
                 )
         return cert_warning
 
+    def _is_adding_nvmeof_group_to_existing_service(self, nvmeof_spec: NvmeofServiceSpec) -> bool:
+        """
+        Check whether this spec is assigning a group to an existing NVMe-oF
+        service that does not have a group yet.
+
+        This allows an existing service to keep its current service_id while adding
+        a group for the first time. New services and services that already have a
+        group must still follow the normal service_id/group validation.
+        """
+        existing_spec = self.spec_store.active_specs.get(nvmeof_spec.service_name())
+        if existing_spec is None:
+            return False
+
+        if existing_spec.service_type != 'nvmeof':
+            return False
+
+        existing_nvmeof_spec = cast(NvmeofServiceSpec, existing_spec)
+
+        return (
+            existing_nvmeof_spec.service_id == nvmeof_spec.service_id
+            and not existing_nvmeof_spec.group
+            and bool(nvmeof_spec.group)
+        )
+
     def _apply_service_spec(self, spec: ServiceSpec) -> str:
         if spec.placement.is_empty():
             # fill in default placement
@@ -3932,11 +3956,13 @@ Then run the following:
             except OrchestratorError as e:
                 self.log.debug(f"{e}")
                 raise
-            nvmeof_spec = cast(NvmeofServiceSpec, spec)
             assert nvmeof_spec.service_id is not None  # for mypy
             if nvmeof_spec.group and not nvmeof_spec.service_id.endswith(nvmeof_spec.group):
-                raise OrchestratorError("The 'nvmeof' service id/name must end with '.<nvmeof-group-name>'. Found "
-                                        f"group name '{nvmeof_spec.group}' and service id '{nvmeof_spec.service_id}'")
+                if not self._is_adding_nvmeof_group_to_existing_service(nvmeof_spec):
+                    raise OrchestratorError(
+                        "The 'nvmeof' service id/name must end with '.<nvmeof-group-name>'. Found "
+                        f"group name '{nvmeof_spec.group}' and service id '{nvmeof_spec.service_id}'"
+                    )
             for sspec in [s.spec for s in self.spec_store.get_by_service_type('nvmeof')]:
                 nspec = cast(NvmeofServiceSpec, sspec)
                 if nvmeof_spec.group == nspec.group and nvmeof_spec.service_id != nspec.service_id:


### PR DESCRIPTION
mgr/cephadm: allow nvmeof group assignment for NVMe-oF services

NVMe-oF services created in older releases may have a service_id that does not include the gateway group name, because those services could be created without a group.
The current validation requires an NVMe-oF service_id to end with the configured group name when spec.group is set. This is correct for new services, but it blocks the documented upgrade flow for existing legacy services where the user exports the existing spec, adds spec.group, and applies it back.

Allow this narrow update path when the service already exists, the stored spec has no group, and the incoming spec keeps the same service_id while adding a non-empty group. Keep the existing validation for new services and for services that already have a group, so duplicate or misleading group configurations are still rejected.

Testing logs:

Created the service without group:
```
[ceph: root@ceph-node-0 ~]# cat legacy-nvmeof-1.yaml 
service_type: nvmeof
service_id: nvmeof_pool01
service_name: nvmeof.nvmeof_pool01
placement:
  label: nvmeof
spec:
  abort_discovery_on_errors: true
  abort_on_errors: true
  abort_on_update_error: true
  allowed_consecutive_spdk_ping_failures: 1
  break_update_interval_sec: 25
  cluster_connections: 32
  conn_retries: 10
  discovery_bind_retries_limit: 10
  discovery_bind_sleep_interval: 0.5
  discovery_port: 8009
  enable_monitor_client: true
  enable_prometheus_exporter: true
  io_stats_enabled: true
  kmip_cert_dir: ./certs/kmip/{server_name}
  log_directory: /var/log/ceph/
  log_files_enabled: true
  log_files_rotation_enabled: true
  log_level: INFO
  max_gws_in_grp: 16
  max_hosts: 2048
  max_hosts_per_namespace: 16
  max_hosts_per_subsystem: 128
  max_log_directory_backups: 10
  max_log_file_size_in_mb: 10
  max_log_files_count: 20
  max_message_length_in_mb: 4
  max_namespaces: 4096
  max_namespaces_per_subsystem: 512
  max_namespaces_with_netmask: 1000
  max_ns_to_change_lb_grp: 8
  max_subsystems: 128
  monitor_timeout: 1.0
  notifications_interval: 60
  omap_file_lock_duration: 40
  omap_file_lock_on_read: true
  omap_file_lock_retries: 30
  omap_file_lock_retry_sleep_interval: 1.0
  omap_file_update_attempts: 500
  omap_file_update_reloads: 10
  pool: nvmeof_pool01
  port: 5500

```
Added a group:
```

[ceph: root@ceph-node-0 ~]# grep -A3 -B2 "pool: nvmeof_pool01" legacy-nvmeof-1.yaml
  omap_file_update_attempts: 500
  omap_file_update_reloads: 10
  pool: nvmeof_pool01
  group: nvmeof_group01
  port: 5500
  prometheus_connection_list_cache_expiration: 60
```

```
[ceph: root@ceph-node-0 ~]# ceph orch ls
NAME                       PORTS                   RUNNING  REFRESHED  AGE  PLACEMENT     
crash                                                  3/3  7m ago     22m  *             
mgr                                                    2/2  7m ago     22m  count:2       
mon                                                    3/5  7m ago     22m  count:5       
nvmeof.nvmeof_pool01       ?:4420,5500,8009,10008      2/2  7m ago     83s  label:nvmeof  
osd.all-available-devices                                3  7m ago     21m  *  
```

Export o/p:
```
[ceph: root@ceph-node-0 ~]# ceph orch ls --export nvmeof
service_type: nvmeof
service_id: nvmeof_pool01
service_name: nvmeof.nvmeof_pool01
placement:
  label: nvmeof
spec:
  abort_discovery_on_errors: true
  abort_on_errors: true
  abort_on_update_error: true
  allowed_consecutive_spdk_ping_failures: 1
  break_update_interval_sec: 25
  cluster_connections: 32
  conn_retries: 10
  discovery_bind_retries_limit: 10
  discovery_bind_sleep_interval: 0.5
  discovery_port: 8009
  enable_monitor_client: true
  enable_prometheus_exporter: true
  **group: nvmeof_group01**
  io_stats_enabled: true
  kmip_cert_dir: ./certs/kmip/{server_name}
  log_directory: /var/log/ceph/
  log_files_enabled: true
  log_files_rotation_enabled: true
  log_level: INFO
  max_gws_in_grp: 16
  max_hosts: 2048
  max_hosts_per_namespace: 16
  max_hosts_per_subsystem: 128
  max_log_directory_backups: 10
  max_log_file_size_in_mb: 10
  max_log_files_count: 20
  max_message_length_in_mb: 4
  max_namespaces: 4096
  max_namespaces_per_subsystem: 512
  max_namespaces_with_netmask: 1000
  max_ns_to_change_lb_grp: 8
  max_subsystems: 128
  monitor_timeout: 1.0
  notifications_interval: 60
  omap_file_lock_duration: 40
  omap_file_lock_on_read: true
  omap_file_lock_retries: 30
  omap_file_lock_retry_sleep_interval: 1.0
  omap_file_update_attempts: 500
  omap_file_update_reloads: 10
  pool: nvmeof_pool01
  port: 5500
  prometheus_connection_list_cache_expiration: 60
  prometheus_cycles_to_adjust_speed: 3
  prometheus_frequency_slow_down_factor: 3.0
  prometheus_port: 10008
  prometheus_startup_delay: 240
  prometheus_stats_interval: 10
  rbd_with_crc32c: true
  rebalance_period_sec: 7
  rpc_socket_dir: /var/tmp/
  rpc_socket_name: spdk.sock
  spdk_path: /usr/local/bin/nvmf_tgt
  spdk_ping_interval_in_seconds: 2.0
  spdk_protocol_log_level: WARNING
  spdk_timeout: 60.0
  state_update_interval_sec: 5
  state_update_notify: true
  subsystem_cache_expiration: 30
  tgt_path: /usr/local/bin/nvmf_tgt
  transport_tcp_options:
    in_capsule_data_size: 8192
    max_io_qpairs_per_ctrlr: 7
  transports: tcp
  verbose_log_messages: true
  verify_keys: true
  verify_listener_ip: true
  verify_nqns: true
```

Preserving the existing behaviour:
```
nvmeof.nvmeof_pool01       ?:4420,5500,8009,10008      2/2  7m ago     83s  label:nvmeof  
osd.all-available-devices                                3  7m ago     21m  *             
[ceph: root@ceph-node-0 ~]# cat > bad-new-nvmeof.yaml <<'EOF'
service_type: nvmeof
service_id: other_pool
service_name: nvmeof.other_pool
placement:
  label: nvmeof
spec:
  pool: nvmeof_pool01
  group: bad_group
EOF

ceph orch apply -i bad-new-nvmeof.yaml
Error EINVAL: The 'nvmeof' service id/name must end with '.<nvmeof-group-name>'. Found group name 'bad_group' and service id 'other_pool'

```

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
