### PR TITLE
tentacle: mgr/cephadm: renames ceph_device to ceph_device_lvm

### DIFF
--- a/src/python-common/ceph/deployment/drive_selection/selector.py
+++ b/src/python-common/ceph/deployment/drive_selection/selector.py
@@ -78,7 +78,7 @@ class DriveSelection(object):
         # If that is the case, we don't want to count the device
         # towards the limit as it will already be counted through the
         # existing daemons
-        non_ceph_devices = [d for d in devices if not d.ceph_device]
+        non_ceph_devices = [d for d in devices if not d.ceph_device_lvm]
 
         if limit > 0 and (len(non_ceph_devices) + self.existing_daemons >= limit):
             logger.debug("Refuse to add {} due to limit policy of <{}>".format(
@@ -135,14 +135,14 @@ class DriveSelection(object):
                 logger.debug('Ignoring disk {} as it is being replaced.'.format(disk.path))
                 continue
 
-            if not disk.available and not disk.ceph_device:
+            if not disk.available and not disk.ceph_device_lvm:
                 logger.debug(
                     ("Ignoring disk {}. "
                      "Disk is unavailable due to {}".format(disk.path, disk.rejected_reasons))
                 )
                 continue
 
-            if not disk.available and disk.ceph_device and disk.lvs:
+            if not disk.available and disk.ceph_device_lvm and disk.lvs:
                 other_osdspec_affinity = ''
                 for lv in disk.lvs:
                     if 'osdspec_affinity' in lv.keys():

--- a/src/python-common/ceph/deployment/inventory.py
+++ b/src/python-common/ceph/deployment/inventory.py
@@ -44,7 +44,7 @@ class Devices(object):
 
 class Device(object):
     report_fields = [
-        'ceph_device',
+        'ceph_device_lvm',
         'rejected_reasons',
         'available',
         'path',
@@ -67,7 +67,7 @@ class Device(object):
                  device_id=None,  # type: Optional[str]
                  lsm_data=None,  # type: Optional[Dict[str, Dict[str, str]]]
                  created=None,  # type: Optional[datetime.datetime]
-                 ceph_device=None,  # type: Optional[bool]
+                 ceph_device_lvm=None,  # type: Optional[bool]
                  crush_device_class=None,  # type: Optional[str]
                  being_replaced=None,  # type: Optional[bool]
                  ):
@@ -80,7 +80,7 @@ class Device(object):
         self.device_id = device_id
         self.lsm_data = lsm_data if lsm_data is not None else {}  # type: Dict[str, Dict[str, str]]
         self.created = created if created is not None else datetime_now()
-        self.ceph_device = ceph_device
+        self.ceph_device_lvm = ceph_device_lvm
         self.crush_device_class = crush_device_class
         self.being_replaced = being_replaced
 
@@ -131,7 +131,7 @@ class Device(object):
             'path': self.path if self.path is not None else 'unknown',
             'lvs': self.lvs if self.lvs else 'None',
             'available': str(self.available),
-            'ceph_device': str(self.ceph_device),
+            'ceph_device_lvm': str(self.ceph_device_lvm),
             'crush_device_class': str(self.crush_device_class),
             'being_replaced': str(self.being_replaced)
         }

--- a/src/python-common/ceph/tests/test_disk_selector.py
+++ b/src/python-common/ceph/tests/test_disk_selector.py
@@ -568,9 +568,9 @@ class TestDeviceSelectionLimit:
         # as a ceph_device. /dev/sdb and /dev/sdc are not being used
         # for OSDs yet. The limit will be set to 2 and the DriveSelection
         # is set to have 1 pre-existing device (corresponding to /dev/sda)
-        dev_a = Device('/dev/sda', ceph_device=True, available=False)
-        dev_b = Device('/dev/sdb', ceph_device=False, available=True)
-        dev_c = Device('/dev/sdc', ceph_device=False, available=True)
+        dev_a = Device('/dev/sda', ceph_device_lvm=True, available=False)
+        dev_b = Device('/dev/sdb', ceph_device_lvm=False, available=True)
+        dev_c = Device('/dev/sdc', ceph_device_lvm=False, available=True)
         all_devices: List[Device] = [dev_a, dev_b, dev_c]
         processed_devices: List[Device] = []
         filter = DeviceSelection(all=True, limit=2)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76043

---

backport of https://github.com/ceph/ceph/pull/65986
parent tracker: https://tracker.ceph.com/issues/72696

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh