### PR TITLE
crypto/isa-l: update isa-l_crypto submodule to v2.26.1

### DIFF
--- a/src/crypto/isa-l/isal_crypto_accel.cc
+++ b/src/crypto/isa-l/isal_crypto_accel.cc
@@ -14,8 +14,9 @@
 
 #include "crypto/isa-l/isal_crypto_accel.h"
 
-#include "crypto/isa-l/isa-l_crypto/include/aes_cbc.h"
-#include "crypto/isa-l/isa-l_crypto/include/aes_gcm.h"
+#include "isa-l_crypto/aes_cbc.h"
+#include "isa-l_crypto/aes_gcm.h"
+#include "isa-l_crypto/aes_keyexp.h"
 #include "include/compat.h"  // for ceph_memzero_s
 #include <cstdint>
 #include <cstring>
@@ -28,11 +29,11 @@ bool ISALCryptoAccel::cbc_encrypt(unsigned char* out, const unsigned char* in, s
   if (unlikely((size % AES_256_IVSIZE) != 0)) {
     return false;
   }
-  alignas(16) struct cbc_key_data keys_blk;
-  aes_cbc_precomp(const_cast<unsigned char*>(&key[0]), AES_256_KEYSIZE, &keys_blk);
-  aes_cbc_enc_256(const_cast<unsigned char*>(in),
-                  const_cast<unsigned char*>(&iv[0]), keys_blk.enc_keys, out, size);
-  return true;
+  alignas(16) struct isal_cbc_key_data keys_blk;
+  if (isal_aes_keyexp_256(&key[0], keys_blk.enc_keys, keys_blk.dec_keys) != 0) {
+    return false;
+  }
+  return isal_aes_cbc_enc_256(in, &iv[0], keys_blk.enc_keys, out, size) == 0;
 }
 bool ISALCryptoAccel::cbc_decrypt(unsigned char* out, const unsigned char* in, size_t size,
                              const unsigned char (&iv)[AES_256_IVSIZE],
@@ -42,10 +43,11 @@ bool ISALCryptoAccel::cbc_decrypt(unsigned char* out, const unsigned char* in, s
   if (unlikely((size % AES_256_IVSIZE) != 0)) {
     return false;
   }
-  alignas(16) struct cbc_key_data keys_blk;
-  aes_cbc_precomp(const_cast<unsigned char*>(&key[0]), AES_256_KEYSIZE, &keys_blk);
-  aes_cbc_dec_256(const_cast<unsigned char*>(in), const_cast<unsigned char*>(&iv[0]), keys_blk.dec_keys, out, size);
-  return true;
+  alignas(16) struct isal_cbc_key_data keys_blk;
+  if (isal_aes_keyexp_256(&key[0], keys_blk.enc_keys, keys_blk.dec_keys) != 0) {
+    return false;
+  }
+  return isal_aes_cbc_dec_256(in, &iv[0], keys_blk.dec_keys, out, size) == 0;
 }
 
 /*
@@ -62,12 +64,12 @@ static inline bool ct_memeq(const unsigned char* a, const unsigned char* b, size
 }
 
 /*
- * Thread-local GCM key cache to avoid re-running aes_gcm_pre_256() for
+ * Thread-local GCM key cache to avoid re-running isal_aes_gcm_pre_256() for
  * repeated keys. Key material is securely wiped on thread exit.
  */
 struct gcm_key_cache_t {
   unsigned char last_key[CryptoAccel::AES_256_KEYSIZE];
-  alignas(16) gcm_key_data cached_gkey;
+  alignas(16) isal_gcm_key_data cached_gkey;
 
   ~gcm_key_cache_t() {
     ceph_memzero_s(last_key, sizeof(last_key), sizeof(last_key));
@@ -75,7 +77,7 @@ struct gcm_key_cache_t {
   }
 };
 
-static inline const gcm_key_data* get_cached_gcm_key(const unsigned char* key)
+static inline const isal_gcm_key_data* get_cached_gcm_key(const unsigned char* key)
 {
   static thread_local std::unique_ptr<gcm_key_cache_t> cache;
 
@@ -83,7 +85,7 @@ static inline const gcm_key_data* get_cached_gcm_key(const unsigned char* key)
     cache = std::make_unique<gcm_key_cache_t>();
 
   if (!ct_memeq(cache->last_key, key, CryptoAccel::AES_256_KEYSIZE)) {
-    aes_gcm_pre_256(key, &cache->cached_gkey);
+    isal_aes_gcm_pre_256(key, &cache->cached_gkey);
     memcpy(cache->last_key, key, CryptoAccel::AES_256_KEYSIZE);
   }
 
@@ -101,10 +103,10 @@ bool ISALCryptoAccel::gcm_encrypt(unsigned char* out, const unsigned char* in, s
     return false;
   }
 
-  const gcm_key_data* gkey = get_cached_gcm_key(&key[0]);
-  alignas(16) struct gcm_context_data gctx;
+  const isal_gcm_key_data* gkey = get_cached_gcm_key(&key[0]);
+  alignas(16) struct isal_gcm_context_data gctx;
 
-  aes_gcm_enc_256(gkey, &gctx,
+  isal_aes_gcm_enc_256(gkey, &gctx,
                   reinterpret_cast<uint8_t*>(out),
                   reinterpret_cast<const uint8_t*>(in),
                   static_cast<uint64_t>(size),
@@ -127,11 +129,11 @@ bool ISALCryptoAccel::gcm_decrypt(unsigned char* out, const unsigned char* in, s
     return false;
   }
 
-  const gcm_key_data* gkey = get_cached_gcm_key(&key[0]);
-  alignas(16) struct gcm_context_data gctx;
+  const isal_gcm_key_data* gkey = get_cached_gcm_key(&key[0]);
+  alignas(16) struct isal_gcm_context_data gctx;
 
   unsigned char computed_tag[AES_GCM_TAGSIZE];
-  aes_gcm_dec_256(gkey, &gctx,
+  isal_aes_gcm_dec_256(gkey, &gctx,
                   reinterpret_cast<uint8_t*>(out),
                   reinterpret_cast<const uint8_t*>(in),
                   static_cast<uint64_t>(size),


### PR DESCRIPTION
Updated ISA-L crypto submodule to version 2.26.1
Since the headers have been moved to different path internally, BuildISALCrypto.cmake was updated accordingly.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
