### PR TITLE
Implement Otel traces for scrub

### DIFF
--- a/src/common/tracer.h
+++ b/src/common/tracer.h
@@ -127,7 +127,7 @@ public:
   template <typename T> void AddEvent(std::string_view name, const T& fields = {}) {}
   jspan_context GetContext() const { return _ctx; }
   void UpdateName(std::string_view) {}
-  bool IsRecording() { return false; }
+  bool IsRecording() const { return false; }
 };
 
 class jspan_ptr {

--- a/src/messages/MOSDRepScrub.h
+++ b/src/messages/MOSDRepScrub.h
@@ -25,7 +25,7 @@
 
 class MOSDRepScrub final : public MOSDFastDispatchOp {
 public:
-  static constexpr int HEAD_VERSION = 9;
+  static constexpr int HEAD_VERSION = 10;
   static constexpr int COMPAT_VERSION = 6;
 
   spg_t pgid;             // PG to scrub
@@ -108,6 +108,7 @@ public:
     encode(allow_preemption, payload);
     encode(priority, payload);
     encode(high_priority, payload);
+    encode_otel_trace(payload, features);
   }
   void decode_payload() override {
     using ceph::decode;
@@ -136,6 +137,9 @@ public:
     if (header.version >= 9) {
       decode(priority, p);
       decode(high_priority, p);
+    }
+    if (header.version >= 10) {
+      decode_otel_trace(p);
     }
   }
 };

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -1,7 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
 // vim: ts=2 sw=2 sts=2 expandtab
 
-#include "./pg_scrubber.h"  // '.' notation used to affect clang-format order
+#include "./pg_scrubber.h" // '.' notation used to affect clang-format order
 
 #include <fmt/ranges.h>
 
@@ -11,24 +11,23 @@
 #include <sstream>
 #include <vector>
 
+#include "common/debug.h"
 #include "debug.h"
 
 #include "common/ceph_time.h"
-#include "common/debug.h"
 #include "common/errno.h"
+#include "include/utime_fmt.h"
 #include "messages/MOSDOp.h"
 #include "messages/MOSDRepScrub.h"
 #include "messages/MOSDRepScrubMap.h"
 #include "messages/MOSDScrubReserve.h"
 #include "osd/OSD.h"
 #include "osd/PG.h"
-#include "include/utime_fmt.h"
 #include "osd/osd_types_fmt.h"
 
 #include "ScrubStore.h"
 #include "scrub_backend.h"
 #include "scrub_machine.h"
-
 #include "scrubber_tracer.h"
 
 using std::list;
@@ -1173,7 +1172,10 @@ eversion_t PgScrubber::search_log_for_updates() const
     return p->version;
 }
 
-void PgScrubber::get_replicas_maps(bool replica_can_preempt)
+void
+PgScrubber::get_replicas_maps(
+    bool replica_can_preempt,
+    const jspan_context& parent_ctx)
 {
   dout(10) << __func__ << " started in epoch/interval: " << m_epoch_start << "/"
 	   << m_interval_start << " pg same_interval_since: "
@@ -1188,12 +1190,9 @@ void PgScrubber::get_replicas_maps(bool replica_can_preempt)
       continue;
 
     m_maps_status.mark_replica_map_request(i);
-    _request_scrub_map(i,
-		       m_subset_last_update,
-		       m_start,
-		       m_end,
-		       m_is_deep,
-		       replica_can_preempt);
+    _request_scrub_map(
+        i, m_subset_last_update, m_start, m_end, m_is_deep, replica_can_preempt,
+        parent_ctx);
   }
 
   dout(10) << __func__ << " awaiting" << m_maps_status << dendl;
@@ -1240,12 +1239,15 @@ std::string_view PgScrubber::get_op_mode_text() const
   return m_mode_desc;
 }
 
-void PgScrubber::_request_scrub_map(pg_shard_t replica,
-				    eversion_t version,
-				    hobject_t start,
-				    hobject_t end,
-				    bool deep,
-				    bool allow_preemption)
+void
+PgScrubber::_request_scrub_map(
+    pg_shard_t replica,
+    eversion_t version,
+    hobject_t start,
+    hobject_t end,
+    bool deep,
+    bool allow_preemption,
+    const jspan_context& parent_ctx)
 {
   ceph_assert(replica != m_pg_whoami);
   dout(10) << __func__ << " scrubmap from osd." << replica
@@ -1261,6 +1263,7 @@ void PgScrubber::_request_scrub_map(pg_shard_t replica,
 				     allow_preemption,
 				     m_flags.priority,
 				     m_pg->ops_blocked_by_scrub());
+  repscrubop->otel_trace = parent_ctx;
 
   // default priority. We want the replica-scrub processed prior to any recovery
   // or client io messages (we are holding a lock!)
@@ -1656,6 +1659,7 @@ void PgScrubber::replica_scrub_op(OpRequestRef op)
   replica_scrubmap = ScrubMap{};
   replica_scrubmap_pos = ScrubMapBuilder{};
 
+  m_fsm->set_replica_parent_ctx(msg->otel_trace);
   m_replica_min_epoch = msg->min_epoch;
   m_start = msg->start;
   m_end = msg->end;
@@ -2678,12 +2682,8 @@ PgScrubber::PgScrubber(PG* pg)
     , preemption_data{pg}
 {
   tracing::scrubber::tracer.init(m_osds->cct, "pg_scrubber");
-  bool tracer_enabled = tracing::scrubber::tracer.is_enabled();
-  auto scrubber_parent_span = tracing::scrubber::tracer.start_trace("pg-scrubber-initialized");
-  bool root_recording = scrubber_parent_span && scrubber_parent_span->IsRecording();
-  dout(10) << "PgScrubber::ctor pg=" << m_pg->pg_id
-	   << " tracer_enabled=" << tracer_enabled
-	   << " root_span_recording=" << root_recording << dendl;
+  auto scrubber_parent_span =
+      tracing::scrubber::tracer.start_trace("pg-scrubber-initialized");
   m_fsm = std::make_unique<ScrubMachine>(m_pg, this, scrubber_parent_span);
   m_fsm->initiate();
   m_scrub_job.emplace(m_osds->cct, m_pg->pg_id, m_osds->get_nodeid());

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -29,6 +29,8 @@
 #include "scrub_backend.h"
 #include "scrub_machine.h"
 
+#include "scrubber_tracer.h"
+
 using std::list;
 using std::pair;
 using std::stringstream;
@@ -2675,7 +2677,14 @@ PgScrubber::PgScrubber(PG* pg)
 	m_osds->cct->_conf, "osd_stats_update_period_not_scrubbing"}
     , preemption_data{pg}
 {
-  m_fsm = std::make_unique<ScrubMachine>(m_pg, this);
+  tracing::scrubber::tracer.init(m_osds->cct, "pg_scrubber");
+  bool tracer_enabled = tracing::scrubber::tracer.is_enabled();
+  auto scrubber_parent_span = tracing::scrubber::tracer.start_trace("pg-scrubber-initialized");
+  bool root_recording = scrubber_parent_span && scrubber_parent_span->IsRecording();
+  dout(10) << "PgScrubber::ctor pg=" << m_pg->pg_id
+	   << " tracer_enabled=" << tracer_enabled
+	   << " root_span_recording=" << root_recording << dendl;
+  m_fsm = std::make_unique<ScrubMachine>(m_pg, this, scrubber_parent_span);
   m_fsm->initiate();
   m_scrub_job.emplace(m_osds->cct, m_pg->pg_id, m_osds->get_nodeid());
 }

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -511,7 +511,9 @@ class PgScrubber : public ScrubPgIF,
   std::chrono::milliseconds get_scrub_sleep_time() const final;
   void queue_for_scrub_resched(Scrub::scrub_prio_t prio) final;
 
-  void get_replicas_maps(bool replica_can_preempt) final;
+  void get_replicas_maps(
+      bool replica_can_preempt,
+      const jspan_context& parent_ctx) final;
 
   void on_digest_updates() final;
 
@@ -952,12 +954,14 @@ class PgScrubber : public ScrubPgIF,
   hobject_t m_max_end;	///< Largest end that may have been sent to replicas
   ScrubMapBuilder m_primary_scrubmap_pos;
 
-  void _request_scrub_map(pg_shard_t replica,
-			  eversion_t version,
-			  hobject_t start,
-			  hobject_t end,
-			  bool deep,
-			  bool allow_preemption);
+  void _request_scrub_map(
+      pg_shard_t replica,
+      eversion_t version,
+      hobject_t start,
+      hobject_t end,
+      bool deep,
+      bool allow_preemption,
+      const jspan_context& parent_ctx);
 
 
   Scrub::MapsCollectionStatus m_maps_status;

--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -13,6 +13,7 @@
 
 #include "ScrubStore.h"
 #include "common/debug.h"
+#include "scrubber_tracer.h"
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_osd
@@ -132,6 +133,7 @@ NotActive::NotActive(my_context ctx)
 {
   dout(10) << "-- state -->> NotActive" << dendl;
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
+  machine.clear_spans();
   scrbr->clear_queued_or_active();
 }
 
@@ -146,6 +148,9 @@ PrimaryActive::PrimaryActive(my_context ctx)
   dout(10) << "-- state -->> PrimaryActive" << dendl;
   // insert this PG into the OSD scrub queue. Calculate initial schedule
   scrbr->schedule_scrub_with_osd();
+  // No span pushed here — PrimaryActive outlives the scrub session,
+  // so its span would not be exported until much later (interval change
+  // or PG destruction). Session spans parent directly to m_root_ctx.
 }
 
 PrimaryActive::~PrimaryActive()
@@ -197,11 +202,21 @@ Session::Session(my_context ctx)
   m_osd_counters = scrbr->get_osd_perf_counters();
   m_counters_idx = &scrbr->get_unlabeled_counters();
   m_osd_counters->inc(m_counters_idx->started_cnt);
+
+  // Push PrimaryActive's span here (not in PrimaryActive's ctor) so that
+  // it gets exported when Session ends. PrimaryActive itself outlives the
+  // scrub session, so a span pushed there would stay unexported for too long.
+  context<ScrubMachine>().push_span(
+      fmt::format("{}_primary_PrimaryActive", pg_id.pgid));
+  context<ScrubMachine>().push_span(
+      fmt::format("{}_primary_PrimaryActive/Session", pg_id.pgid));
 }
 
 Session::~Session()
 {
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
+  machine.pop_span();  // Session
+  machine.pop_span();  // PrimaryActive
   m_reservations.reset();
   machine.m_session_started_at.reset();
 
@@ -270,6 +285,14 @@ ReservingReplicas::ReservingReplicas(my_context ctx)
     // can't transit directly from here
     post_event(RemotesReserved{});
   }
+
+  context<ScrubMachine>().push_span(
+      fmt::format("{}_primary_PrimaryActive/Session/ReservingReplicas", pg_id.pgid));
+}
+
+ReservingReplicas::~ReservingReplicas()
+{
+  context<ScrubMachine>().pop_span();
 }
 
 sc::result ReservingReplicas::react(const ReplicaGrant& ev)
@@ -331,6 +354,9 @@ ActiveScrubbing::ActiveScrubbing(my_context ctx)
       << fmt::format("{} {} starts", pg_id.pgid, scrbr->get_op_mode_text());
 
   scrbr->on_init();
+
+  context<ScrubMachine>().push_span(
+      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing", pg_id.pgid));
 }
 
 /**
@@ -339,6 +365,7 @@ ActiveScrubbing::ActiveScrubbing(my_context ctx)
 ActiveScrubbing::~ActiveScrubbing()
 {
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
+  machine.pop_span();
   auto& session = context<Session>();
   dout(15) << __func__ << dendl;
 
@@ -374,6 +401,8 @@ RangeBlocked::RangeBlocked(my_context ctx)
 {
   dout(10) << "-- state -->> Session/Act/RangeBlocked" << dendl;
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
+  machine.push_span(
+      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/RangeBlocked", pg_id.pgid));
 
   auto grace = scrbr->get_range_blocked_grace();
   if (grace == ceph::timespan{}) {
@@ -414,6 +443,11 @@ sc::result RangeBlocked::react(const RangeBlockedAlarm&)
   return discard_event();
 }
 
+RangeBlocked::~RangeBlocked()
+{
+  context<ScrubMachine>().pop_span();
+}
+
 // ----------------------- PendingTimer -----------------------------------
 
 /**
@@ -425,6 +459,9 @@ PendingTimer::PendingTimer(my_context ctx)
 {
   dout(10) << "-- state -->> Session/Act/PendingTimer" << dendl;
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
+
+  machine.push_span(
+      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/PendingTimer", pg_id.pgid));
 
   auto sleep_time = scrbr->get_scrub_sleep_time();
   if (sleep_time.count()) {
@@ -453,6 +490,11 @@ sc::result PendingTimer::react(const SleepComplete&)
   return discard_event();
 }
 
+PendingTimer::~PendingTimer()
+{
+  context<ScrubMachine>().pop_span();
+}
+
 // ----------------------- NewChunk -----------------------------------
 
 /**
@@ -474,6 +516,8 @@ NewChunk::NewChunk(my_context ctx)
   //  ChunkIsBusy. If 'busy', we transition to Blocked, and wait for the
   //  range to become available.
   scrbr->select_range_n_notify();
+  machine.push_span(
+      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/NewChunk", pg_id.pgid));
 }
 
 sc::result NewChunk::react(const SelectedChunkFree&)
@@ -485,14 +529,27 @@ sc::result NewChunk::react(const SelectedChunkFree&)
   return transit<WaitPushes>();
 }
 
+NewChunk::~NewChunk()
+{
+  context<ScrubMachine>().pop_span();
+}
+
 // ----------------------- WaitPushes -----------------------------------
 
 WaitPushes::WaitPushes(my_context ctx)
     : my_base(ctx)
     , NamedSimply(context<ScrubMachine>().m_scrbr, "Session/Act/WaitPushes")
 {
+  DECLARE_LOCALS;
   dout(10) << " -- state -->> Session/Act/WaitPushes" << dendl;
+  machine.push_span(
+      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/WaitPushes", pg_id.pgid));
   post_event(ActivePushesUpd{});
+}
+
+WaitPushes::~WaitPushes()
+{
+  context<ScrubMachine>().pop_span();
 }
 
 /*
@@ -519,8 +576,16 @@ WaitLastUpdate::WaitLastUpdate(my_context ctx)
     : my_base(ctx)
     , NamedSimply(context<ScrubMachine>().m_scrbr, "Session/Act/WaitLastUpdate")
 {
+  DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
   dout(10) << " -- state -->> Session/Act/WaitLastUpdate" << dendl;
+  machine.push_span(
+      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/WaitLastUpdate", pg_id.pgid));
   post_event(UpdatesApplied{});
+}
+
+WaitLastUpdate::~WaitLastUpdate()
+{
+  context<ScrubMachine>().pop_span();
 }
 
 /**
@@ -553,7 +618,16 @@ sc::result WaitLastUpdate::react(const InternalAllUpdates&)
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
   dout(10) << "WaitLastUpdate::react(const InternalAllUpdates&)" << dendl;
 
-  scrbr->get_replicas_maps(scrbr->get_preemptor().is_preemptable());
+  auto& span = context<ScrubMachine>().current_span();
+  bool span_valid = span && span->IsRecording();
+  auto ctx = span ? span->GetContext() : jspan_context{false, false};
+  dout(10) << "WaitLastUpdate::react: propagating trace to replicas"
+	   << " current_span_recording=" << span_valid
+	   << " ctx_valid=" << ctx.IsValid()
+	   << " stack_depth=" << context<ScrubMachine>().m_span_stack.size()
+	   << dendl;
+
+  scrbr->get_replicas_maps(scrbr->get_preemptor().is_preemptable(), ctx);
   return transit<BuildMap>();
 }
 
@@ -569,6 +643,8 @@ BuildMap::BuildMap(my_context ctx)
 
   // no need to check for an epoch change, as all possible flows that brought
   // us here have a check_interval() verification of their final event.
+  machine.push_span(
+      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/BuildMap", pg_id.pgid));
 
   if (scrbr->get_preemptor().was_preempted()) {
 
@@ -595,6 +671,12 @@ BuildMap::BuildMap(my_context ctx)
   }
 }
 
+BuildMap::~BuildMap()
+{
+  context<ScrubMachine>().pop_span();
+}
+
+
 sc::result BuildMap::react(const IntLocalMapDone&)
 {
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
@@ -611,8 +693,16 @@ DrainReplMaps::DrainReplMaps(my_context ctx)
     , NamedSimply(context<ScrubMachine>().m_scrbr, "Session/Act/DrainReplMaps")
 {
   dout(10) << "-- state -->> Session/Act/DrainReplMaps" << dendl;
+  DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
+  machine.push_span(
+      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/DrainReplMaps", pg_id.pgid));
   // we may have got all maps already. Send the event that will make us check.
   post_event(GotReplicas{});
+}
+
+DrainReplMaps::~DrainReplMaps()
+{
+  context<ScrubMachine>().pop_span();
 }
 
 sc::result DrainReplMaps::react(const GotReplicas&)
@@ -637,8 +727,16 @@ WaitReplicas::WaitReplicas(my_context ctx)
     : my_base(ctx)
     , NamedSimply(context<ScrubMachine>().m_scrbr, "Session/Act/WaitReplicas")
 {
+  DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
   dout(10) << "-- state -->> Session/Act/WaitReplicas" << dendl;
+  machine.push_span(
+      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/WaitReplicas", pg_id.pgid));
   post_event(GotReplicas{});
+}
+
+WaitReplicas::~WaitReplicas()
+{
+  context<ScrubMachine>().pop_span();
 }
 
 /**
@@ -700,10 +798,18 @@ WaitDigestUpdate::WaitDigestUpdate(my_context ctx)
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
   dout(10) << "-- state -->> Session/Act/WaitDigestUpdate" << dendl;
 
+  machine.push_span(
+      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/WaitDigestUpdate", pg_id.pgid));
+
   // perform an initial check: maybe we already
   // have all the updates we need:
   // (note that DigestUpdate is usually an external event)
   post_event(DigestUpdate{});
+}
+
+WaitDigestUpdate::~WaitDigestUpdate()
+{
+  context<ScrubMachine>().pop_span();
 }
 
 sc::result WaitDigestUpdate::react(const DigestUpdate&)
@@ -742,9 +848,60 @@ sc::result WaitDigestUpdate::react(const ScrubFinished&)
 ScrubMachine::ScrubMachine(PG* pg, ScrubMachineListener* pg_scrub, jspan_ptr root_span)
     : m_pg_id{pg->pg_id}
     , m_scrbr{pg_scrub}
-{}
+{
+  // Save the root span's context so we can parent future spans to it.
+  // The root span itself is not stored — it ends when the caller's
+  // shared_ptr goes out of scope, ensuring it gets exported promptly.
+  if (root_span && root_span->IsRecording()) {
+    m_root_ctx = root_span->GetContext();
+    dout(10) << "ScrubMachine::ctor pg=" << m_pg_id
+	     << " root_ctx valid=" << m_root_ctx.IsValid() << dendl;
+  } else {
+    dout(10) << "ScrubMachine::ctor pg=" << m_pg_id
+	     << " root_span is null or not recording" << dendl;
+  }
+}
 
 ScrubMachine::~ScrubMachine() = default;
+
+static const jspan_ptr empty_jspan_ptr;
+
+const jspan_ptr& ScrubMachine::current_span() const
+{
+  return m_span_stack.empty() ? empty_jspan_ptr : m_span_stack.back();
+}
+
+void ScrubMachine::push_span(const std::string& label)
+{
+  jspan_ptr span;
+  if (!m_span_stack.empty()) {
+    auto& parent = m_span_stack.back();
+    span = tracing::scrubber::tracer.add_span(label, parent);
+  } else {
+    span = tracing::scrubber::tracer.add_span(label, m_root_ctx);
+  }
+  bool span_recording = span && span->IsRecording();
+  dout(10) << "push_span: " << label
+	   << " stack_depth=" << m_span_stack.size()
+	   << " new_span_recording=" << span_recording << dendl;
+  m_span_stack.push_back(std::move(span));
+}
+
+void ScrubMachine::pop_span()
+{
+  if (!m_span_stack.empty()) {
+    dout(10) << "pop_span: stack_depth=" << m_span_stack.size() << dendl;
+    m_span_stack.pop_back();
+  } else {
+    dout(5) << "pop_span: WARNING stack already empty!" << dendl;
+  }
+}
+
+void ScrubMachine::clear_spans()
+{
+  dout(10) << "clear_spans: clearing " << m_span_stack.size() << " spans" << dendl;
+  m_span_stack.clear();
+}
 
 
 // -------- for replicas -----------------------------------------------------
@@ -960,7 +1117,10 @@ ReplicaIdle::ReplicaIdle(my_context ctx)
     , NamedSimply(context<ScrubMachine>().m_scrbr, "ReplicaActive/ReplicaIdle")
 {
   dout(10) << "-- state -->> ReplicaActive/ReplicaIdle" << dendl;
+  context<ScrubMachine>().clear_spans();
 }
+
+ReplicaIdle::~ReplicaIdle() = default;
 
 
 sc::result ReplicaIdle::react(const StartReplica& ev)
@@ -998,6 +1158,7 @@ ReplicaActiveOp::~ReplicaActiveOp()
 {
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
   dout(10) << __func__ << dendl;
+  machine.pop_span();
   scrbr->replica_handling_done();
 }
 
@@ -1033,10 +1194,17 @@ ReplicaWaitUpdates::ReplicaWaitUpdates(my_context ctx)
 	  context<ScrubMachine>().m_scrbr,
 	  "ReplicaActive/ReplicaActiveOp/ReplicaWaitUpdates")
 {
+  DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
   dout(10) << "-- state -->> ReplicaActive/ReplicaActiveOp/ReplicaWaitUpdates"
 	   << dendl;
+  machine.push_span(
+      fmt::format("{}_replica_ReplicaActive/ReplicaActiveOp/ReplicaWaitUpdates", pg_id.pgid));   
 }
 
+ReplicaWaitUpdates::~ReplicaWaitUpdates()
+{
+  context<ScrubMachine>().pop_span();
+}
 
 /*
  * Triggered externally, by the entity that had an update re pushes
@@ -1064,9 +1232,17 @@ ReplicaBuildingMap::ReplicaBuildingMap(my_context ctx)
 	  context<ScrubMachine>().m_scrbr,
 	  "ReplicaActive/ReplicaActiveOp/ReplicaBuildingMap")
 {
+  DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
   dout(10) << "-- state -->> ReplicaActive/ReplicaActiveOp/ReplicaBuildingMap"
 	   << dendl;
+  machine.push_span(
+      fmt::format("{}_replica_ReplicaActive/ReplicaActiveOp/ReplicaBuildingMap", pg_id.pgid));
   post_event(SchedReplica{});
+}
+
+ReplicaBuildingMap::~ReplicaBuildingMap()
+{
+  context<ScrubMachine>().pop_span();
 }
 
 

--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -739,7 +739,7 @@ sc::result WaitDigestUpdate::react(const ScrubFinished&)
   return transit<PrimaryIdle>();
 }
 
-ScrubMachine::ScrubMachine(PG* pg, ScrubMachineListener* pg_scrub)
+ScrubMachine::ScrubMachine(PG* pg, ScrubMachineListener* pg_scrub, jspan_ptr root_span)
     : m_pg_id{pg->pg_id}
     , m_scrbr{pg_scrub}
 {}

--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -207,9 +207,11 @@ Session::Session(my_context ctx)
   // it gets exported when Session ends. PrimaryActive itself outlives the
   // scrub session, so a span pushed there would stay unexported for too long.
   context<ScrubMachine>().push_span(
-      fmt::format("{}_primary_PrimaryActive", pg_id.pgid));
+      fmt::format("{}_primary_PrimaryActive", pg_id.pgid),
+      tracing::scrubber::ROLE_PRIMARY);
   context<ScrubMachine>().push_span(
-      fmt::format("{}_primary_PrimaryActive/Session", pg_id.pgid));
+      fmt::format("{}_primary_PrimaryActive/Session", pg_id.pgid),
+      tracing::scrubber::ROLE_PRIMARY);
 }
 
 Session::~Session()
@@ -285,9 +287,10 @@ ReservingReplicas::ReservingReplicas(my_context ctx)
     // can't transit directly from here
     post_event(RemotesReserved{});
   }
-
   context<ScrubMachine>().push_span(
-      fmt::format("{}_primary_PrimaryActive/Session/ReservingReplicas", pg_id.pgid));
+      fmt::format(
+          "{}_primary_PrimaryActive/Session/ReservingReplicas", pg_id.pgid),
+      tracing::scrubber::ROLE_PRIMARY);
 }
 
 ReservingReplicas::~ReservingReplicas()
@@ -354,9 +357,10 @@ ActiveScrubbing::ActiveScrubbing(my_context ctx)
       << fmt::format("{} {} starts", pg_id.pgid, scrbr->get_op_mode_text());
 
   scrbr->on_init();
-
   context<ScrubMachine>().push_span(
-      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing", pg_id.pgid));
+      fmt::format(
+          "{}_primary_PrimaryActive/Session/ActiveScrubbing", pg_id.pgid),
+      tracing::scrubber::ROLE_PRIMARY);
 }
 
 /**
@@ -402,7 +406,10 @@ RangeBlocked::RangeBlocked(my_context ctx)
   dout(10) << "-- state -->> Session/Act/RangeBlocked" << dendl;
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
   machine.push_span(
-      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/RangeBlocked", pg_id.pgid));
+      fmt::format(
+          "{}_primary_PrimaryActive/Session/ActiveScrubbing/RangeBlocked",
+          pg_id.pgid),
+      tracing::scrubber::ROLE_PRIMARY);
 
   auto grace = scrbr->get_range_blocked_grace();
   if (grace == ceph::timespan{}) {
@@ -459,9 +466,11 @@ PendingTimer::PendingTimer(my_context ctx)
 {
   dout(10) << "-- state -->> Session/Act/PendingTimer" << dendl;
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
-
   machine.push_span(
-      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/PendingTimer", pg_id.pgid));
+      fmt::format(
+          "{}_primary_PrimaryActive/Session/ActiveScrubbing/PendingTimer",
+          pg_id.pgid),
+      tracing::scrubber::ROLE_PRIMARY);
 
   auto sleep_time = scrbr->get_scrub_sleep_time();
   if (sleep_time.count()) {
@@ -517,7 +526,10 @@ NewChunk::NewChunk(my_context ctx)
   //  range to become available.
   scrbr->select_range_n_notify();
   machine.push_span(
-      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/NewChunk", pg_id.pgid));
+      fmt::format(
+          "{}_primary_PrimaryActive/Session/ActiveScrubbing/NewChunk",
+          pg_id.pgid),
+      tracing::scrubber::ROLE_PRIMARY);
 }
 
 sc::result NewChunk::react(const SelectedChunkFree&)
@@ -543,7 +555,10 @@ WaitPushes::WaitPushes(my_context ctx)
   DECLARE_LOCALS;
   dout(10) << " -- state -->> Session/Act/WaitPushes" << dendl;
   machine.push_span(
-      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/WaitPushes", pg_id.pgid));
+      fmt::format(
+          "{}_primary_PrimaryActive/Session/ActiveScrubbing/WaitPushes",
+          pg_id.pgid),
+      tracing::scrubber::ROLE_PRIMARY);
   post_event(ActivePushesUpd{});
 }
 
@@ -579,7 +594,10 @@ WaitLastUpdate::WaitLastUpdate(my_context ctx)
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
   dout(10) << " -- state -->> Session/Act/WaitLastUpdate" << dendl;
   machine.push_span(
-      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/WaitLastUpdate", pg_id.pgid));
+      fmt::format(
+          "{}_primary_PrimaryActive/Session/ActiveScrubbing/WaitLastUpdate",
+          pg_id.pgid),
+      tracing::scrubber::ROLE_PRIMARY);
   post_event(UpdatesApplied{});
 }
 
@@ -619,13 +637,13 @@ sc::result WaitLastUpdate::react(const InternalAllUpdates&)
   dout(10) << "WaitLastUpdate::react(const InternalAllUpdates&)" << dendl;
 
   auto& span = context<ScrubMachine>().current_span();
-  bool span_valid = span && span->IsRecording();
   auto ctx = span ? span->GetContext() : jspan_context{false, false};
-  dout(10) << "WaitLastUpdate::react: propagating trace to replicas"
-	   << " current_span_recording=" << span_valid
-	   << " ctx_valid=" << ctx.IsValid()
-	   << " stack_depth=" << context<ScrubMachine>().m_span_stack.size()
-	   << dendl;
+  dout(10) << fmt::format(
+                  "WaitLastUpdate::react: propagating trace to replicas"
+                  " current_span_recording={}, ctx_valid={}, stack_depth={}",
+                  span && span->IsRecording(), ctx.IsValid(),
+                  context<ScrubMachine>().m_span_stack.size())
+           << dendl;
 
   scrbr->get_replicas_maps(scrbr->get_preemptor().is_preemptable(), ctx);
   return transit<BuildMap>();
@@ -644,7 +662,10 @@ BuildMap::BuildMap(my_context ctx)
   // no need to check for an epoch change, as all possible flows that brought
   // us here have a check_interval() verification of their final event.
   machine.push_span(
-      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/BuildMap", pg_id.pgid));
+      fmt::format(
+          "{}_primary_PrimaryActive/Session/ActiveScrubbing/BuildMap",
+          pg_id.pgid),
+      tracing::scrubber::ROLE_PRIMARY);
 
   if (scrbr->get_preemptor().was_preempted()) {
 
@@ -695,7 +716,10 @@ DrainReplMaps::DrainReplMaps(my_context ctx)
   dout(10) << "-- state -->> Session/Act/DrainReplMaps" << dendl;
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
   machine.push_span(
-      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/DrainReplMaps", pg_id.pgid));
+      fmt::format(
+          "{}_primary_PrimaryActive/Session/ActiveScrubbing/DrainReplMaps",
+          pg_id.pgid),
+      tracing::scrubber::ROLE_PRIMARY);
   // we may have got all maps already. Send the event that will make us check.
   post_event(GotReplicas{});
 }
@@ -730,7 +754,10 @@ WaitReplicas::WaitReplicas(my_context ctx)
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
   dout(10) << "-- state -->> Session/Act/WaitReplicas" << dendl;
   machine.push_span(
-      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/WaitReplicas", pg_id.pgid));
+      fmt::format(
+          "{}_primary_PrimaryActive/Session/ActiveScrubbing/WaitReplicas",
+          pg_id.pgid),
+      tracing::scrubber::ROLE_PRIMARY);
   post_event(GotReplicas{});
 }
 
@@ -797,9 +824,11 @@ WaitDigestUpdate::WaitDigestUpdate(my_context ctx)
 {
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
   dout(10) << "-- state -->> Session/Act/WaitDigestUpdate" << dendl;
-
   machine.push_span(
-      fmt::format("{}_primary_PrimaryActive/Session/ActiveScrubbing/WaitDigestUpdate", pg_id.pgid));
+      fmt::format(
+          "{}_primary_PrimaryActive/Session/ActiveScrubbing/WaitDigestUpdate",
+          pg_id.pgid),
+      tracing::scrubber::ROLE_PRIMARY);
 
   // perform an initial check: maybe we already
   // have all the updates we need:
@@ -847,6 +876,7 @@ sc::result WaitDigestUpdate::react(const ScrubFinished&)
 
 ScrubMachine::ScrubMachine(PG* pg, ScrubMachineListener* pg_scrub, jspan_ptr root_span)
     : m_pg_id{pg->pg_id}
+    , m_pg_id_str{stringify(pg->pg_id.pgid)}
     , m_scrbr{pg_scrub}
 {
   // Save the root span's context so we can parent future spans to it.
@@ -854,11 +884,16 @@ ScrubMachine::ScrubMachine(PG* pg, ScrubMachineListener* pg_scrub, jspan_ptr roo
   // shared_ptr goes out of scope, ensuring it gets exported promptly.
   if (root_span && root_span->IsRecording()) {
     m_root_ctx = root_span->GetContext();
-    dout(10) << "ScrubMachine::ctor pg=" << m_pg_id
-	     << " root_ctx valid=" << m_root_ctx.IsValid() << dendl;
+    dout(10) << fmt::format(
+                    "ScrubMachine::ctor pg={} root_ctx valid={}", m_pg_id,
+                    m_root_ctx.IsValid())
+             << dendl;
   } else {
-    dout(10) << "ScrubMachine::ctor pg=" << m_pg_id
-	     << " root_span is null or not recording" << dendl;
+    dout(10)
+        << fmt::format(
+               "ScrubMachine::ctor pg={} root_span is null or not recording",
+               m_pg_id)
+        << dendl;
   }
 }
 
@@ -871,7 +906,8 @@ const jspan_ptr& ScrubMachine::current_span() const
   return m_span_stack.empty() ? empty_jspan_ptr : m_span_stack.back();
 }
 
-void ScrubMachine::push_span(const std::string& label)
+const jspan_ptr&
+ScrubMachine::push_span(const std::string& label, const char* role)
 {
   jspan_ptr span;
   if (!m_span_stack.empty()) {
@@ -880,17 +916,40 @@ void ScrubMachine::push_span(const std::string& label)
   } else {
     span = tracing::scrubber::tracer.add_span(label, m_root_ctx);
   }
-  bool span_recording = span && span->IsRecording();
-  dout(10) << "push_span: " << label
-	   << " stack_depth=" << m_span_stack.size()
-	   << " new_span_recording=" << span_recording << dendl;
+  dout(20) << fmt::format(
+                  "push_span: {}, stack_depth={}, new_span_recording={}", label,
+                  m_span_stack.size(), span && span->IsRecording())
+           << dendl;
+  span->SetAttribute(tracing::scrubber::PG_ID, m_pg_id_str);
+  span->SetAttribute(tracing::scrubber::PG_ROLE, role);
   m_span_stack.push_back(std::move(span));
+  return m_span_stack.back();
+}
+
+const jspan_ptr&
+ScrubMachine::push_span(
+    const std::string& label,
+    const jspan_context& parent_ctx,
+    const char* role)
+{
+  auto span = tracing::scrubber::tracer.add_span(label, parent_ctx);
+  dout(20) << fmt::format(
+                  "push_span(ctx): {}, parent_ctx_valid={}, stack_depth={}, "
+                  "new_span_recording={}",
+                  label, parent_ctx.IsValid(), m_span_stack.size(),
+                  span && span->IsRecording())
+           << dendl;
+  span->SetAttribute(tracing::scrubber::PG_ID, m_pg_id_str);
+  span->SetAttribute(tracing::scrubber::PG_ROLE, role);
+  m_span_stack.push_back(std::move(span));
+  return m_span_stack.back();
 }
 
 void ScrubMachine::pop_span()
 {
   if (!m_span_stack.empty()) {
-    dout(10) << "pop_span: stack_depth=" << m_span_stack.size() << dendl;
+    dout(20) << fmt::format("pop_span: stack_depth={}", m_span_stack.size())
+             << dendl;
     m_span_stack.pop_back();
   } else {
     dout(5) << "pop_span: WARNING stack already empty!" << dendl;
@@ -899,7 +958,8 @@ void ScrubMachine::pop_span()
 
 void ScrubMachine::clear_spans()
 {
-  dout(10) << "clear_spans: clearing " << m_span_stack.size() << " spans" << dendl;
+  dout(20) << fmt::format("clear_spans: clearing {} spans", m_span_stack.size())
+           << dendl;
   m_span_stack.clear();
 }
 
@@ -1150,6 +1210,11 @@ ReplicaActiveOp::ReplicaActiveOp(my_context ctx)
 {
   dout(10) << "-- state -->> ReplicaActive/ReplicaActiveOp" << dendl;
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
+  // Use the trace context propagated from the primary via MOSDRepScrub so that
+  // replica spans are linked under the same trace as the primary.
+  machine.push_span(
+      fmt::format("{}_replica_ReplicaActive/ReplicaActiveOp", pg_id.pgid),
+      machine.m_replica_parent_ctx, tracing::scrubber::ROLE_REPLICA);
   scrbr->on_replica_init();
 }
 
@@ -1198,7 +1263,10 @@ ReplicaWaitUpdates::ReplicaWaitUpdates(my_context ctx)
   dout(10) << "-- state -->> ReplicaActive/ReplicaActiveOp/ReplicaWaitUpdates"
 	   << dendl;
   machine.push_span(
-      fmt::format("{}_replica_ReplicaActive/ReplicaActiveOp/ReplicaWaitUpdates", pg_id.pgid));   
+      fmt::format(
+          "{}_replica_ReplicaActive/ReplicaActiveOp/ReplicaWaitUpdates",
+          pg_id.pgid),
+      tracing::scrubber::ROLE_REPLICA);
 }
 
 ReplicaWaitUpdates::~ReplicaWaitUpdates()
@@ -1236,7 +1304,10 @@ ReplicaBuildingMap::ReplicaBuildingMap(my_context ctx)
   dout(10) << "-- state -->> ReplicaActive/ReplicaActiveOp/ReplicaBuildingMap"
 	   << dendl;
   machine.push_span(
-      fmt::format("{}_replica_ReplicaActive/ReplicaActiveOp/ReplicaBuildingMap", pg_id.pgid));
+      fmt::format(
+          "{}_replica_ReplicaActive/ReplicaActiveOp/ReplicaBuildingMap",
+          pg_id.pgid),
+      tracing::scrubber::ROLE_REPLICA);
   post_event(SchedReplica{});
 }
 

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -29,6 +29,9 @@
 #include "scrub_machine_lstnr.h"
 #include "scrub_reservations.h"
 
+#include "common/tracer.h"
+
+
 /// a wrapper that sets the FSM state description used by the
 /// PgScrubber
 /// \todo consider using the full NamedState as in Peering
@@ -291,7 +294,7 @@ class ScrubMachine : public ScrubFsmIf, public sc::state_machine<ScrubMachine, N
  public:
   friend class PgScrubber;
 
-  explicit ScrubMachine(PG* pg, ScrubMachineListener* pg_scrub);
+  explicit ScrubMachine(PG* pg, ScrubMachineListener* pg_scrub, jspan_ptr root_span);
   virtual ~ScrubMachine();
 
   spg_t m_pg_id;

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -299,6 +299,30 @@ class ScrubMachine : public ScrubFsmIf, public sc::state_machine<ScrubMachine, N
 
   spg_t m_pg_id;
   ScrubMachineListener* m_scrbr;
+
+  /// span stack for tracing - mirrors the state machine nesting.
+  /// Each state constructor pushes a span, each destructor pops it.
+  std::vector<jspan_ptr> m_span_stack;
+
+  /// saved context from the root span created in PgScrubber ctor.
+  /// The root span itself ends promptly (so it gets exported), but its
+  /// context stays valid and serves as the parent when the stack is empty.
+  jspan_context m_root_ctx{false, false};
+
+  /// return the current (topmost) span, or an empty jspan_ptr if the stack is empty
+  const jspan_ptr& current_span() const;
+
+  /// push a new span as a child of the current top-of-stack span,
+  /// or as a child of the root context if the stack is empty.
+  void push_span(const std::string& label);
+
+  /// pop and end the topmost span
+  void pop_span();
+
+  /// end all active spans (used by RESET states)
+  void clear_spans();
+
+
   std::ostream& gen_prefix(std::ostream& out) const;
 
   void assert_not_in_session() const final;
@@ -599,7 +623,7 @@ struct Session : sc::state<Session, PrimaryActive, ReservingReplicas>,
 
 struct ReservingReplicas : sc::state<ReservingReplicas, Session>, NamedSimply {
   explicit ReservingReplicas(my_context ctx);
-  ~ReservingReplicas() = default;
+  ~ReservingReplicas();
   using reactions = mpl::list<
       sc::custom_reaction<ReplicaGrant>,
       sc::custom_reaction<ReplicaReject>,
@@ -648,6 +672,7 @@ struct ActiveScrubbing
 
 struct RangeBlocked : sc::state<RangeBlocked, ActiveScrubbing>, NamedSimply {
   explicit RangeBlocked(my_context ctx);
+  ~RangeBlocked();
   using reactions = mpl::list<
     sc::custom_reaction<RangeBlockedAlarm>,
     sc::transition<Unblocked, PendingTimer>>;
@@ -667,6 +692,7 @@ struct RangeBlocked : sc::state<RangeBlocked, ActiveScrubbing>, NamedSimply {
 struct PendingTimer : sc::state<PendingTimer, ActiveScrubbing>, NamedSimply {
 
   explicit PendingTimer(my_context ctx);
+  ~PendingTimer();
 
   using reactions = mpl::list<
     sc::transition<InternalSchedScrub, NewChunk>,
@@ -680,6 +706,7 @@ struct PendingTimer : sc::state<PendingTimer, ActiveScrubbing>, NamedSimply {
 struct NewChunk : sc::state<NewChunk, ActiveScrubbing>, NamedSimply {
 
   explicit NewChunk(my_context ctx);
+  ~NewChunk();
 
   using reactions = mpl::list<sc::transition<ChunkIsBusy, RangeBlocked>,
 			      sc::custom_reaction<SelectedChunkFree>>;
@@ -699,6 +726,7 @@ struct NewChunk : sc::state<NewChunk, ActiveScrubbing>, NamedSimply {
 struct WaitPushes : sc::state<WaitPushes, ActiveScrubbing>, NamedSimply {
 
   explicit WaitPushes(my_context ctx);
+  ~WaitPushes();
 
   using reactions = mpl::list<sc::custom_reaction<ActivePushesUpd>>;
 
@@ -709,6 +737,7 @@ struct WaitLastUpdate : sc::state<WaitLastUpdate, ActiveScrubbing>,
 			NamedSimply {
 
   explicit WaitLastUpdate(my_context ctx);
+  ~WaitLastUpdate();
 
   void on_new_updates(const UpdatesApplied&);
 
@@ -723,6 +752,7 @@ struct WaitLastUpdate : sc::state<WaitLastUpdate, ActiveScrubbing>,
 
 struct BuildMap : sc::state<BuildMap, ActiveScrubbing>, NamedSimply {
   explicit BuildMap(my_context ctx);
+  ~BuildMap();
 
   // possible error scenarios:
   // - an error reported by the backend will cause the scrubber to
@@ -745,6 +775,7 @@ struct BuildMap : sc::state<BuildMap, ActiveScrubbing>, NamedSimply {
  */
 struct DrainReplMaps : sc::state<DrainReplMaps, ActiveScrubbing>, NamedSimply {
   explicit DrainReplMaps(my_context ctx);
+  ~DrainReplMaps();
 
   using reactions =
     // all replicas are accounted for:
@@ -755,6 +786,7 @@ struct DrainReplMaps : sc::state<DrainReplMaps, ActiveScrubbing>, NamedSimply {
 
 struct WaitReplicas : sc::state<WaitReplicas, ActiveScrubbing>, NamedSimply {
   explicit WaitReplicas(my_context ctx);
+  ~WaitReplicas();
 
   using reactions = mpl::list<
     // all replicas are accounted for:
@@ -769,6 +801,7 @@ struct WaitReplicas : sc::state<WaitReplicas, ActiveScrubbing>, NamedSimply {
 struct WaitDigestUpdate : sc::state<WaitDigestUpdate, ActiveScrubbing>,
 			  NamedSimply {
   explicit WaitDigestUpdate(my_context ctx);
+  ~WaitDigestUpdate();
 
   using reactions = mpl::list<sc::custom_reaction<DigestUpdate>,
 			      sc::custom_reaction<ScrubFinished>,
@@ -948,7 +981,7 @@ struct ReplicaActive : sc::state<ReplicaActive, ScrubMachine, ReplicaIdle>,
 
 struct ReplicaIdle : sc::state<ReplicaIdle, ReplicaActive>, NamedSimply {
   explicit ReplicaIdle(my_context ctx);
-  ~ReplicaIdle() = default;
+  ~ReplicaIdle();
   using reactions = mpl::list<sc::custom_reaction<StartReplica>>;
 
   sc::result react(const StartReplica& ev);
@@ -1000,6 +1033,7 @@ struct ReplicaActiveOp
 struct ReplicaWaitUpdates : sc::state<ReplicaWaitUpdates, ReplicaActiveOp>,
 			    NamedSimply {
   explicit ReplicaWaitUpdates(my_context ctx);
+  ~ReplicaWaitUpdates();
   using reactions = mpl::list<sc::custom_reaction<ReplicaPushesUpd>>;
 
   sc::result react(const ReplicaPushesUpd&);
@@ -1008,6 +1042,7 @@ struct ReplicaWaitUpdates : sc::state<ReplicaWaitUpdates, ReplicaActiveOp>,
 struct ReplicaBuildingMap : sc::state<ReplicaBuildingMap, ReplicaActiveOp>,
 			    NamedSimply {
   explicit ReplicaBuildingMap(my_context ctx);
+  ~ReplicaBuildingMap();
   using reactions = mpl::list<sc::custom_reaction<SchedReplica>>;
 
   sc::result react(const SchedReplica&);

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -298,6 +298,9 @@ class ScrubMachine : public ScrubFsmIf, public sc::state_machine<ScrubMachine, N
   virtual ~ScrubMachine();
 
   spg_t m_pg_id;
+  /// cached stringified pg id, set once in the ctor and reused as the
+  /// 'pg.id' attribute of every span (avoids re-stringifying per push).
+  std::string m_pg_id_str;
   ScrubMachineListener* m_scrbr;
 
   /// span stack for tracing - mirrors the state machine nesting.
@@ -309,12 +312,23 @@ class ScrubMachine : public ScrubFsmIf, public sc::state_machine<ScrubMachine, N
   /// context stays valid and serves as the parent when the stack is empty.
   jspan_context m_root_ctx{false, false};
 
+  /// trace context received from primary via MOSDRepScrub
+  jspan_context m_replica_parent_ctx{false, false};
+
   /// return the current (topmost) span, or an empty jspan_ptr if the stack is empty
   const jspan_ptr& current_span() const;
 
   /// push a new span as a child of the current top-of-stack span,
   /// or as a child of the root context if the stack is empty.
-  void push_span(const std::string& label);
+  /// Sets the common 'pg.id'/'pg.role' attributes and returns the
+  /// newly-pushed span so the caller may add further attributes.
+  const jspan_ptr& push_span(const std::string& label, const char* role);
+
+  /// push a new span parented to a specific trace context (for replica spans)
+  const jspan_ptr& push_span(
+      const std::string& label,
+      const jspan_context& parent_ctx,
+      const char* role);
 
   /// pop and end the topmost span
   void pop_span();
@@ -340,6 +354,12 @@ class ScrubMachine : public ScrubFsmIf, public sc::state_machine<ScrubMachine, N
 
   void process_event(const boost::statechart::event_base& evt) final {
     sc::state_machine<ScrubMachine, NotActive>::process_event(evt);
+  }
+
+  void
+  set_replica_parent_ctx(const jspan_context& ctx)
+  {
+    m_replica_parent_ctx = ctx;
   }
 
   /// the time when the session was initiated

--- a/src/osd/scrubber/scrub_machine_if.h
+++ b/src/osd/scrubber/scrub_machine_if.h
@@ -53,6 +53,8 @@ class ScrubFsmIf {
 
   /// "initiate" the state machine (an internal state_chart function)
   virtual void initiate() = 0;
+
+  virtual void set_replica_parent_ctx(const jspan_context& ctx) = 0;
 };
 
 }  // namespace Scrub

--- a/src/osd/scrubber/scrub_machine_lstnr.h
+++ b/src/osd/scrubber/scrub_machine_lstnr.h
@@ -6,6 +6,7 @@
  * \file the PgScrubber interface used by the scrub FSM
  */
 #include "common/LogClient.h"
+#include "common/tracer.h"
 #include "common/version.h"
 #include "include/Context.h"
 #include "osd/osd_types.h"
@@ -162,7 +163,9 @@ struct ScrubMachineListener {
   /**
    * Ask all replicas for their scrub maps for the current chunk.
    */
-  virtual void get_replicas_maps(bool replica_can_preempt) = 0;
+  virtual void get_replicas_maps(
+      bool replica_can_preempt,
+      const jspan_context& parent_ctx) = 0;
 
   virtual void on_digest_updates() = 0;
 

--- a/src/osd/scrubber/scrubber_tracer.h
+++ b/src/osd/scrubber/scrubber_tracer.h
@@ -10,5 +10,13 @@ namespace scrubber {
 
 inline tracing::Tracer tracer;
 
+// span attribute keys
+inline constexpr const char* PG_ID = "pg.id";
+inline constexpr const char* PG_ROLE = "pg.role";
+
+// values for the PG_ROLE attribute
+inline constexpr const char* ROLE_PRIMARY = "primary";
+inline constexpr const char* ROLE_REPLICA = "replica";
+
 } // namespace scrubber
 } // namespace tracing

--- a/src/osd/scrubber/scrubber_tracer.h
+++ b/src/osd/scrubber/scrubber_tracer.h
@@ -1,0 +1,14 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#pragma once
+
+#include "common/tracer.h"
+
+namespace tracing {
+namespace scrubber {
+
+inline tracing::Tracer tracer;
+
+} // namespace scrubber
+} // namespace tracing


### PR DESCRIPTION

<img width="2493" height="1829" alt="image" src="https://github.com/user-attachments/assets/6f57aee5-2c11-4a7a-94d8-66633e17a3bd" />

Closes: https://tracker.ceph.com/issues/78961


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
