### PR TITLE
smb: add a ceph based smb remote control client tool

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -3376,6 +3376,8 @@ def command_shell(ctx):
                 mounts[mount] = dst
             else:
                 mounts[mount] = '/mnt/{}'.format(filename)
+    if '/var/lib/ceph' not in mounts:
+        mounts['/var/lib/ceph'] = '/srv/ceph:ro,z'
     if ctx.command:
         command = ctx.command
     else:

--- a/src/mypy.ini
+++ b/src/mypy.ini
@@ -77,6 +77,18 @@ ignore_missing_imports = True
 [mypy-scipy.*]
 ignore_missing_imports = True
 
+# Ignore errors from inability to import typing stubs for google.protobuf
+# package. The stubs exist but mypy gets awfully confused and insists it still
+# can't import it. After hours of debugging, I'm not 100% sure, but I think
+# this is because ceph (in this config file) disables namespace packages.
+#
+# If we ever really wanted to properly type-check with this module, a future
+# version of ceph could choose to enable namespace packages and fix the
+# bindings packages another way or we could split the mypy config between the
+# special ceph stuff and the more typical python stuff.
+[mypy-google.*]
+ignore_missing_imports = True
+
 # Make volumes happy:
 [mypy-StringIO]
 ignore_missing_imports = True

--- a/src/python-common/ceph/smb/ctl/__main__.py
+++ b/src/python-common/ceph/smb/ctl/__main__.py
@@ -1,0 +1,603 @@
+"""CLI module for smb ctl support lib."""
+
+import typing
+from typing import Any
+
+import argparse
+import configparser
+import functools
+import json
+import logging
+import logging.config
+import os
+import pathlib
+import sys
+
+from ._probe import protobuf_choose_impl
+
+# control the backend implementation of protobuf when using older versions
+# this avoids needing to document PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
+# for the user of this tool.
+protobuf_choose_impl()
+
+from .client import APICallError, Client  # noqa: E402
+from .config import ChannelType, Config, TLSPath  # noqa: E402
+
+logger = logging.getLogger()
+
+DEFAULT_SOCK_SEARCH = '/var/lib/ceph:/srv/ceph'
+
+
+class DestinationError(ValueError):
+    def __init__(
+        self, *args: Any, hints: typing.Optional[typing.List[str]] = None
+    ) -> None:
+        super().__init__(*args)
+        self.hints = hints
+
+
+class Commands:
+    """CLI Commands registry."""
+
+    def __init__(self) -> None:
+        self._commands: dict[str, dict] = {}
+        self._arguments: dict[str, typing.Callable] = {}
+
+    def register(self, name: str) -> typing.Callable:
+        def _arguments(func: typing.Callable) -> typing.Callable:
+            self._arguments[name] = func
+            return func
+
+        def _register(func: Any) -> Any:
+            self._commands[name] = {
+                "name": name,
+                "func": func,
+                "doc": (getattr(func, '__doc__', None) or ''),
+            }
+            func.cli_arguments = _arguments
+            return func
+
+        return _register
+
+    def _configure(self, subparsers: Any, parents: Any) -> None:
+        for name in sorted(self._commands):
+            self._add_subcommand(subparsers, name, parents)
+
+    def _add_subcommand(
+        self, subparsers: Any, name: str, parents: Any
+    ) -> None:
+        cmd = self._commands[name]
+        argsfn = self._arguments.get(name)
+        parser = subparsers.add_parser(
+            name, parents=parents, help=cmd.get("doc", "")
+        )
+        if argsfn:
+            argsfn(parser)
+        parser.set_defaults(target=cmd['func'])
+
+
+class ExpandingChoicesAction(argparse.Action):
+    """Helper argparse action that lets the user just specify something
+    like "samba" on the CLI but will return "CONFIG_FOR_SAMBA" like
+    the gRPC enums expect, while also letting you type "CONFIG_FOR_SAMBA"
+    if you are used to that.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        # must remove choices as the parser impl. treats objects with choices
+        # attr special and strictly thus breaking our transformation
+        self._choices = kwargs.pop('choices')
+        self._prefix = kwargs.pop('use_prefix')
+        self._case_fold = kwargs.pop('case_fold', None)
+        self._help = kwargs.pop('help', "Choices")
+        cc = sorted(self._choices)
+        ci = ''
+        if self._case_fold:
+            ci = ' {case insensitive}'
+        kwargs['help'] = f'{self._help} (one of: {", ".join(cc)}{ci})'
+        super().__init__(**kwargs)
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Any,
+        option_string: Any = None,
+    ) -> None:
+        if real_value := self._map_choice(values):
+            setattr(namespace, self.dest, real_value)
+            return
+        choices = ', '.join(self._choices)
+        raise argparse.ArgumentError(
+            self, f'invalid selection: {values} (choose from {choices})'
+        )
+
+    def _map_choice(self, value: str) -> typing.Optional[str]:
+        cf = self._case_fold or str
+        value = cf(value)
+        if not value.startswith(cf(self._prefix)):
+            value = cf(f'{self._prefix}{value}')
+        choices = {cf(f'{self._prefix}{c}') for c in self._choices}
+        return value if value in choices else None
+
+
+class Context:
+    """Command context."""
+
+    def __init__(self, cli: Any) -> None:
+        self.cli = cli
+
+    def config(self) -> Config:
+        address, chtype = self.destination()
+        cc = Config(
+            address=address,
+            channel_type=chtype,
+            tls_cert=self.cli.tls_cert,
+            tls_key=self.cli.tls_key,
+            tls_ca_cert=self.cli.tls_ca_cert,
+            headers=self._grpc_headers(),
+        )
+        return cc
+
+    def client(self) -> Client:
+        return Client(self.config())
+
+    @functools.cache
+    def destination(self) -> typing.Tuple[str, ChannelType]:
+        if address := getattr(self.cli, 'address', None):
+            if address.startswith('unix:'):
+                return address, ChannelType.INSECURE
+            chtype = ChannelType.SECURE
+            if getattr(self.cli, 'no_tls', False):
+                chtype = ChannelType.INSECURE
+            return address, chtype
+        path = self._find_socket()
+        return f'unix:{path}', ChannelType.INSECURE
+
+    def _find_socket(
+        self,
+        envname: str = 'SMB_RCTL_SOCK_SEARCH',
+        sockname: str = 'remote-control.s',
+    ) -> pathlib.Path:
+        search = os.environ.get(envname, DEFAULT_SOCK_SEARCH)
+        if not search:
+            raise DestinationError(
+                'unable to find remote-control socket: no search paths'
+            )
+        search_roots = [pathlib.Path(p) for p in search.split(':') if p]
+        matches = _find_remotectl_socket(
+            sockname, search_roots, self.cli.cluster
+        )
+        if not matches and self.cli.cluster:
+            raise DestinationError(
+                f'unable to find remote-control socket: no matches in {self.cli.cluster}'
+            )
+        elif not matches:
+            raise DestinationError(
+                'unable to find remote-control socket: no matches'
+            )
+        elif len(matches) > 1:
+            raise DestinationError(
+                'unable to select remote control socket:'
+                f' {len(matches)} sockets found',
+                hints=['select clusters using the --cluster option'],
+            )
+        return matches[0]
+
+    def _ceph_keyrings(self, searchdir: pathlib.Path) -> list[pathlib.Path]:
+        try:
+            keyrings = [
+                p for p in searchdir.iterdir() if p.name.endswith('.keyring')
+            ]
+        except OSError as err:
+            logger.debug("Invalid searchdir: %s", err)
+            return []
+        return sorted(
+            keyrings,
+            key=lambda p: ((0 if p.name == 'ceph.keyring' else 1), p.name),
+        )
+
+    def _grpc_headers(self) -> typing.Dict[str, str]:
+        out = {}
+        for key, value in self.cli.grpc_headers or []:
+            out[key] = value
+        address, chtype = self.destination()
+        if address.startswith('unix:') and chtype is ChannelType.INSECURE:
+            # probe for available ceph auth info
+            krconfig = configparser.ConfigParser()
+            for searchdir in [pathlib.Path('/etc/ceph')]:
+                for krfile in self._ceph_keyrings(searchdir):
+                    krconfig.read(krfile)
+                    if krconfig.sections():
+                        break
+            if krconfig.sections():
+                user = krconfig.sections()[0]
+                key = krconfig[user]['key']
+                out['ceph-auth-user'] = user
+                out['ceph-auth-key'] = key
+        logger.debug('gRPC headers: %r', out)
+        return out
+
+    def __str__(self) -> str:
+        address, chtype = self.destination()
+        hints = ''
+        if any(k.startswith('ceph-auth-') for k in self._grpc_headers()):
+            hints += ' with-ceph-auth'
+        return f'{address} ({chtype.value}{hints})'
+
+
+class ResultEncoder(json.JSONEncoder):
+    """JSON Encoder that unpacks result objects that have to_simplified
+    methods.
+    """
+
+    def default(self, o: Any) -> Any:
+        to_simplified = getattr(o, 'to_simplified', None)
+        if to_simplified:
+            return to_simplified()
+        return super().default(o)
+
+
+def write_result_json(result: Any) -> None:
+    """Write a result object as JSON to the stdout."""
+    json.dump(result, sys.stdout, indent=2, cls=ResultEncoder)
+    sys.stdout.write('\n')
+
+
+commands = Commands()  # global commands registry
+
+
+@commands.register("info")
+def info(ctx: Context) -> None:
+    """Get basic server info."""
+    result = ctx.client().info()
+    write_result_json(result)
+
+
+@commands.register("status")
+def status(ctx: Context) -> None:
+    """Report on Samba smbd server status."""
+    result = ctx.client().status()
+    write_result_json(result)
+
+
+@commands.register("close-share")
+def close_share(ctx: Context) -> None:
+    """Close a share (block IO on an existing connection)."""
+    share_name = ctx.cli.share_name
+    denied_users = bool(ctx.cli.denied_users_only)
+    result = ctx.client().close_share(share_name, denied_users)
+    write_result_json(result)
+
+
+@close_share.cli_arguments
+def _(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "share_name",
+        help="Name of share to close",
+    )
+    parser.add_argument(
+        "--denied-users-only",
+        "-d",
+        action="store_true",
+        help="Only close the share for users that are currently denied access",
+    )
+
+
+@commands.register("kill-client-connection")
+def kill_client_connection(ctx: Context) -> None:
+    """Terminate a client connection by IP Address."""
+    ip_address = ctx.cli.ip_address
+    result = ctx.client().kill_client_connection(ip_address)
+    write_result_json(result)
+
+
+@kill_client_connection.cli_arguments
+def _(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("ip_address", help="Address of client")
+
+
+@commands.register("config-dump")
+def config_dump(ctx: Context) -> None:
+    """Dump configuration data."""
+    source = ctx.cli.source
+    hash_alg = ctx.cli.hash_alg
+    result = ctx.client().config_dump(source, hash_alg=hash_alg)
+    # result.dump streams output to stdout rather than buffering it
+    result.dump(sys.stdout)
+
+
+@config_dump.cli_arguments
+def _(parser: argparse.ArgumentParser) -> None:
+    _cli_config_source(parser)
+    _cli_config_hashes(parser)
+
+
+@commands.register("config-summary")
+def config_summary(ctx: Context) -> None:
+    """Report a digest hash for the current configuration data."""
+    source = ctx.cli.source
+    hash_alg = ctx.cli.hash_alg
+    result = ctx.client().config_summary(source, hash_alg=hash_alg)
+    write_result_json(result)
+
+
+@config_summary.cli_arguments
+def _(parser: argparse.ArgumentParser) -> None:
+    _cli_config_source(parser)
+    _cli_config_hashes(parser)
+
+
+@commands.register("config-shares-list")
+def config_shares_list(ctx: Context) -> None:
+    """Report a list of shares configured on the server."""
+    source = ctx.cli.source
+    result = ctx.client().config_shares_list(source)
+    write_result_json(result)
+
+
+@config_shares_list.cli_arguments
+def _(parser: argparse.ArgumentParser) -> None:
+    _cli_config_source(parser)
+
+
+@commands.register("set-debug-level")
+def set_debug_level(ctx: Context) -> None:
+    """Set the debug level of an smb subsystem."""
+    process = ctx.cli.process
+    debug_level = ctx.cli.debug_level
+    result = ctx.client().set_debug_level(process, debug_level)
+    write_result_json(result)
+
+
+@set_debug_level.cli_arguments
+def _(parser: argparse.ArgumentParser) -> None:
+    _cli_process(parser)
+    parser.add_argument("debug_level", help="Target debugging level")
+
+
+@commands.register("get-debug-level")
+def get_debug_level(ctx: Context) -> None:
+    """Get the current debug level of an smb subsystem."""
+    process = ctx.cli.process
+    result = ctx.client().get_debug_level(process)
+    write_result_json(result)
+
+
+@get_debug_level.cli_arguments
+def _(parser: argparse.ArgumentParser) -> None:
+    _cli_process(parser)
+
+
+@commands.register("ctdb-status")
+def ctdb_status(ctx: Context) -> None:
+    """Report on CTDB Server status."""
+    result = ctx.client().ctdb_status()
+    write_result_json(result)
+
+
+@commands.register("ctdb-move-ip")
+def ctdb_move_ip(ctx: Context) -> None:
+    """Request a CTDB public IP be moved to a different node."""
+    ip_address = ctx.cli.ip_address
+    node = ctx.cli.node
+    result = ctx.client().ctdb_move_ip(ip_address, node)
+    write_result_json(result)
+
+
+@ctdb_move_ip.cli_arguments
+def _(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("ip_address", help="Public IP Address to move")
+    parser.add_argument("node", help="Node number of destination")
+
+
+def _cli_config_source(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "source",
+        choices={"samba", "ctdb", "sambacc"},
+        use_prefix="config_for_",
+        case_fold=str.upper,
+        action=ExpandingChoicesAction,
+        help="The configuration source to use",
+    )
+
+
+def _cli_config_hashes(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--sha256",
+        action="store_const",
+        dest="hash_alg",
+        const="HASH_ALG_SHA256",
+        help="Produce a digest hash for the configuration using SHA256",
+    )
+
+
+def _cli_process(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "process",
+        choices={"smb", "winbind", "ctdb"},
+        use_prefix="smb_process_",
+        case_fold=str.upper,
+        action=ExpandingChoicesAction,
+        help="SMB process to target",
+    )
+
+
+def _header(value: str) -> typing.Tuple[str, str]:
+    if '=' in value:
+        k, v = value.split('=', 1)
+        return k, v
+    if ':' in value:
+        k, v = value.split(':', 1)
+        return k, v
+    raise argparse.ArgumentTypeError(
+        'header value must take the form KEY=VALUE or KEY:VALUE'
+    )
+
+
+class ClusterInfo:
+    def __init__(
+        self, value: str, *, fsid: str = '', service: str = ''
+    ) -> None:
+        if '/' in value:
+            fsid, service = value.split('/', 1)
+        elif value:
+            service = value
+        if not service.startswith('smb.'):
+            service = f'smb.{service}'
+        self._fsid = fsid
+        self._service = service
+
+    @property
+    def fsid(self) -> str:
+        return self._fsid
+
+    @property
+    def service(self) -> str:
+        return self._service
+
+    def __str__(self) -> str:
+        txt = f'smb service starting with {self.service}'
+        if self.fsid:
+            txt += f' in cluster {self.fsid}'
+        return txt
+
+
+def _find_remotectl_socket(
+    sockname: str,
+    search_roots: list[pathlib.Path],
+    cluster_info: typing.Optional[ClusterInfo],
+) -> list[pathlib.Path]:
+    logger.debug(
+        'Searching for socket paths like %s in %r (%s)',
+        sockname,
+        search_roots,
+        cluster_info,
+    )
+    matches = []
+    for path in search_roots:
+        if path.is_socket():
+            matches.append(path)
+            continue
+        matches.extend(p for p in path.rglob(sockname) if p.is_socket())
+    logger.debug('Socket paths found: %r', matches)
+    if cluster_info:
+        # use cluster_info to narrow down matches
+        if fsid := cluster_info.fsid:
+            matches = [
+                p for p in matches if any(fsid == part for part in p.parts)
+            ]
+        if prefix := cluster_info.service:
+            matches = [
+                p
+                for p in matches
+                if any(part.startswith(prefix) for part in p.parts)
+            ]
+    logger.debug('Filtered socket paths found: %r', matches)
+    return matches
+
+
+def parse_cli() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    vg = parser.add_mutually_exclusive_group()
+    vg.add_argument(
+        '--verbose', '-v', action='store_true', help='Enable verbose logging'
+    )
+    vg.add_argument(
+        '--quiet', '-q', action='store_true', help='Enable minimal output'
+    )
+    g1 = parser.add_argument_group('Server Selection')
+    mg = g1.add_mutually_exclusive_group()
+    mg.add_argument(
+        '--address',
+        type=str,
+        help='Address of gRPC server',
+    )
+    mg.add_argument(
+        '--cluster',
+        '-c',
+        type=ClusterInfo,
+        help=(
+            'Ceph SMB cluster selector.'
+            ' Format [<FSID>/][smb.]<service-prefix>.'
+            ' Choose the SMB service (aka SMB cluster) to connect to'
+            ' using an optional Ceph FSID and SMB service.'
+            ' Example: 45d9b47e-47f0-11f1-906a-525400220000/smb.cluster1'
+        ),
+    )
+    g2 = parser.add_argument_group('TLS Credentials')
+    g2.add_argument(
+        '--tls-cert',
+        type=TLSPath.create,
+        help='Path to TLS certificate',
+    )
+    g2.add_argument(
+        '--tls-key',
+        type=TLSPath.create,
+        help='Path to TLS Key',
+    )
+    g2.add_argument(
+        '--tls-ca-cert',
+        type=TLSPath.create,
+        help='Path to TLS CA certificate',
+    )
+    parser.add_argument(
+        '--no-tls',
+        action='store_true',
+        help='Do not use TLS when connecting to remote server',
+    )
+    parser.add_argument(
+        '--header',
+        dest='grpc_headers',
+        type=_header,
+        action='append',
+        help='Add gRPC header to call. Takes the form <KEY>=<VALUE>',
+    )
+    commands._configure(parser.add_subparsers(required=True), [])
+    return parser.parse_args()
+
+
+def main() -> None:
+    ctx = Context(parse_cli())
+    log_level = logging.INFO
+    if ctx.cli.verbose:
+        log_level = logging.DEBUG
+    elif ctx.cli.quiet:
+        log_level = logging.WARNING
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            "formatters": {
+                "std": {"format": "%(levelname)s: %(message)s"},
+            },
+            "handlers": {
+                "console": {
+                    "class": "logging.StreamHandler",
+                    "formatter": "std",
+                },
+            },
+            "root": {
+                "handlers": ["console"],
+                "level": log_level,
+            },
+        }
+    )
+
+    try:
+        logger.info('Connecting to remote-control server at %s', str(ctx))
+        ctx.cli.target(ctx)
+    except DestinationError as err:
+        print(f'error: {err}', file=sys.stderr)
+        for hint in err.hints or []:
+            print(f'       ({hint})', file=sys.stderr)
+        sys.exit(2)
+    except APICallError as err:
+        print('error: failed gRPC call:', file=sys.stderr)
+        print(f'  code = {err.code}', file=sys.stderr)
+        print(f'  details = {err.details}', file=sys.stderr)
+        print(f'  result = {err.msg}', file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/python-common/ceph/smb/ctl/_probe.py
+++ b/src/python-common/ceph/smb/ctl/_probe.py
@@ -1,0 +1,26 @@
+"""Utility to probe protobuf version and control behavior."""
+
+from typing import Tuple
+
+
+def protobuf_ver_tuple() -> Tuple[int, ...]:
+    import google.protobuf
+
+    ver = tuple(int(p) for p in google.protobuf.__version__.split('.'))
+    return ver
+
+
+def protobuf_choose_impl() -> None:
+    """Work around the crummy old version of protobuf that is available on
+    rhel10. Force the python implementation unless 3.20 or newer because
+    we can monkeypatch the python version but not the c ext version.
+    """
+    import os
+
+    key = 'PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION'
+    if key in os.environ:
+        return
+    ver = protobuf_ver_tuple()
+    if ver[:2] >= (3, 20):
+        return
+    os.environ[key] = 'python'

--- a/src/python-common/ceph/smb/ctl/_typing.py
+++ b/src/python-common/ceph/smb/ctl/_typing.py
@@ -1,0 +1,12 @@
+"""Typing helpers"""
+
+import typing
+
+import sys
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+elif typing.TYPE_CHECKING:
+    from typing_extensions import Self
+else:
+    Self = typing.Any

--- a/src/python-common/ceph/smb/ctl/client.py
+++ b/src/python-common/ceph/smb/ctl/client.py
@@ -1,0 +1,579 @@
+"""Ceph SMB client gRPC library"""
+
+import typing
+
+# the grpc/protobuf object mapping is highly dynamic so we lean pretty heavily
+# on Any types in this module.
+from typing import Any
+
+import collections.abc
+import contextlib
+import functools
+import warnings
+
+import google.protobuf.descriptor_pool
+import google.protobuf.internal as pbint
+import grpc
+import grpc._channel as gch  # type: ignore
+import grpc_reflection.v1alpha.proto_reflection_descriptor_database
+from google.protobuf.descriptor import (
+    MethodDescriptor,
+)
+
+from ._typing import Self
+from .config import ChannelType, Config
+
+
+class ReflectionDescriptorDB(
+    grpc_reflection.v1alpha.proto_reflection_descriptor_database.ProtoReflectionDescriptorDatabase
+):
+    def _AddSymbol(self, name: Any, proto: Any) -> None:
+        # not very clean but it worked to fix my issue
+        # see also: https://github.com/protocolbuffers/protobuf/issues/9867
+        # & https://github.com/protocolbuffers/protobuf/commit/
+        #   @ 610702ed18d4323e44b9741102ed90377243470e
+        if name.startswith('.'):
+            name = name[1:]
+        super()._AddSymbol(name, proto)
+
+
+def _reflection_ddb(channel: Any) -> Any:
+    if pbint.api_implementation.Type() == 'python':
+        return ReflectionDescriptorDB(channel)
+    gra = grpc_reflection.v1alpha
+    return gra.proto_reflection_descriptor_database.ProtoReflectionDescriptorDatabase(
+        channel
+    )
+
+
+def _get_message_class(pool: Any, desc: Any) -> Any:
+    try:
+        from google.protobuf.message_factory import GetMessageClass
+
+        return GetMessageClass(desc)
+    except ImportError:
+        pass
+    try:
+        from google.protobuf.message_factory import MessageFactory
+
+        return MessageFactory(pool).GetPrototype(desc)
+    except ImportError:
+        pass
+    raise RuntimeError("no suitable method for getting message class")
+
+
+def _iscontainer(obj: Any) -> bool:
+    """Return true if obj is a container type even for protobuf container types
+    with private type implementations.
+    """
+    # of course protobuf gotta make this painful and use strange private types
+    # so we will use abc isinstance checks to see what methods they implement
+    # to probe if it's a worthy container type
+    if isinstance(obj, (str, bytes)):
+        return False
+    return isinstance(obj, collections.abc.Iterable) and not isinstance(
+        obj, collections.abc.Mapping
+    )
+
+
+def _extract(obj: Any) -> Any:
+    """Convert gRPC object to a nested dict."""
+    try:
+        desc = obj.DESCRIPTOR
+    except AttributeError:
+        # not a grpc/protobuf object
+        return obj
+    out = {}
+    for field in desc.fields:
+        if NamedValue._is_enum_field(field):
+            out[field.name] = NamedValue.from_field(obj, field)
+            continue
+        v = getattr(obj, field.name)
+        if isinstance(v, collections.abc.Mapping):
+            v = {_extract(k): _extract(vv) for k, vv in v.items()}
+        if _iscontainer(v):
+            v = [_extract(entry) for entry in v]
+        if hasattr(v, 'DESCRIPTOR'):
+            v = _extract(v)
+        out[field.name] = v
+    return out
+
+
+class NamedValue:
+    def __init__(self, name: str, value: int) -> None:
+        self.name = name
+        self.value = value
+
+    def __repr__(self) -> str:
+        return f'<NamedValue>({self.name}, {self.value})'
+
+    def __str__(self) -> str:
+        return self.name
+
+    to_simplified = __str__
+
+    @classmethod
+    def from_field(cls, obj: Any, field: Any, *, desc: Any = None) -> Self:
+        # this is convoluted. the grpc/protobuf docs are clear as mud. nothing
+        # is simple.  maybe there's a better way to do this, but I didn't find
+        # one.
+        if isinstance(field, str):
+            desc = desc if desc is not None else obj.DESCRIPTOR
+            field_obj = desc.fields_by_name[field]
+            value = getattr(obj, field)
+        else:
+            field_obj = field
+            value = getattr(obj, field.name)
+        ename = field_obj.enum_type.values_by_number[value].name
+        return cls(ename, value)
+
+    @classmethod
+    def _is_enum_field(cls, field: Any) -> bool:
+        return hasattr(getattr(field, 'enum_type', None), 'values_by_number')
+
+
+class ValueResult:
+    """Base result class that captures gRPC/protobuf results and
+    converts them to a python dict.
+    Can be serialized to JSON using the to_simplified method.
+    """
+
+    values: dict
+
+    def __init__(self, values: dict) -> None:
+        self.values = values
+
+    @classmethod
+    def convert(cls, obj: Any) -> Self:
+        return cls(_extract(obj))
+
+    def to_simplified(self) -> dict:
+        """Return this object in a form that can be JSON/YAML serialized."""
+        return self.values
+
+    def __repr__(self) -> str:
+        return f'<{self.__class__.__name__}>({self.values!r})'
+
+
+class InfoResult(ValueResult):
+    """Result value for Info API."""
+
+    pass
+
+
+class StatusResult(ValueResult):
+    """Result value for StatusResult API."""
+
+    pass
+
+
+class ConfigSummaryResult(ValueResult):
+    """Result value for ConfigSummary API."""
+
+
+class CTDBStatusResult(ValueResult):
+    """Result value for CTDBStatus API."""
+
+    pass
+
+
+class GetDebugLevelResult(ValueResult):
+    """Result value for GetDebugLevel API."""
+
+    pass
+
+
+class EmptyResult:
+    """Base result class for APIs that do not return any data."""
+
+    @classmethod
+    def convert(cls, obj: Any) -> Self:
+        return cls()
+
+    def to_simplified(self) -> dict:
+        return {}
+
+
+class CloseShareResult(EmptyResult):
+    """Result value for CloseShare API."""
+
+
+class SetDebugLevelResult(EmptyResult):
+    """Result value for SetDebugLevel API."""
+
+
+class CTDBMoveIPResult(EmptyResult):
+    """Result value for CTDBMoveIPResult API."""
+
+
+class KillClientConnectionResult(EmptyResult):
+    """Result value for KillClientConnection API."""
+
+
+class ConfigDumpResult:
+    """Result value for ConfigDump API.
+    ConfigDump is a streaming API. Pass a file-object to .dump to stream
+    converted output to a file/stdio.
+    """
+
+    @classmethod
+    def convert_stream(cls, obj: Any) -> Self:
+        return cls(obj)
+
+    def __init__(self, obj: Any) -> None:
+        self._stream = obj
+
+    def dump(self, fh: typing.IO) -> None:
+        for item in self._stream:
+            line = getattr(item, 'line', None)
+            if line:
+                fh.write(line.content)
+            digest = getattr(item, 'digest', None)
+            if digest and digest.hash != 0:
+                content = self._hash_info(digest)
+                fh.write(f'\n# digest = {content}\n')
+
+    def _hash_info(self, digest: Any) -> str:
+        hash_type = NamedValue.from_field(digest, 'hash')
+        hash_name = str(hash_type).lower().split("_")[-1]
+        return f'{hash_name}:{digest.config_digest}'
+
+
+class ConfigSharesListResult:
+    """Result value for ConfigSharesList API.
+    ConfigSharesList is a streaming API. This class will buffer the
+    streamed results in memory so as to allow output to JSON.
+    """
+
+    @classmethod
+    def convert_stream(cls, obj: Any) -> Self:
+        return cls([share.name for share in obj])
+
+    def __init__(self, shares: list[str]) -> None:
+        self._shares = shares
+
+    def to_simplified(self) -> list[str]:
+        return list(self._shares)
+
+
+class APICallError(RuntimeError):
+    def __init__(self, code: Any, details: str, msg: str) -> None:
+        self.code = code
+        self.details = details
+        self.msg = msg
+
+    def __repr__(self) -> str:
+        return f'Error calling gRPC API: {self.msg}'
+
+    __str__ = __repr__
+
+
+class _Endpoint:
+    """Helper class for constructing a virtual API endpoint."""
+
+    def __init__(self, method: MethodDescriptor, pool: Any) -> None:
+        self._method = method
+        self._pool = pool
+        self._input_type = _get_message_class(pool, method.input_type)
+        self._output_type = _get_message_class(pool, method.output_type)
+        self._expects_client_streaming: typing.Optional[bool] = None
+        self._expects_server_streaming: typing.Optional[bool] = None
+
+    def streaming(self, client: bool, server: bool) -> Self:
+        """Set streaming direction hints."""
+        # Streaming APIs should be hinted using .streaming(...) method because
+        # protobuf < 3.20.0 doesn't have the {client,server_streaming attrs.
+        # Unfortunately 3.19.6 is what ships with RHEL10 currently and we
+        # expect to deploy there.
+        # The {in_stream,out_stream} properties will produce a warning IFF
+        # we have set a hint and it differs from the attr when it is available
+        # on newer versions.
+        self._expects_client_streaming = client
+        self._expects_server_streaming = server
+        return self
+
+    @property
+    def input_type(self) -> Any:
+        """Returns python type for input message."""
+        return self._input_type
+
+    @property
+    def output_type(self) -> Any:
+        """Return python type for output message."""
+        return self._output_type
+
+    @property
+    def in_stream(self) -> bool:
+        """Return true if input messages should be streamed."""
+        chint = self._expects_client_streaming
+        try:
+            cstream = self._method.client_streaming
+        except AttributeError:
+            cstream = chint
+        if chint is not None and cstream != chint:
+            warnings.warn(
+                f'protobuf method {self._method.name} streaming'
+                ' hint differs from expected value'
+            )
+        return bool(cstream)
+
+    @property
+    def out_stream(self) -> bool:
+        """Return true if output messages should be streamed."""
+        shint = self._expects_server_streaming
+        try:
+            sstream = self._method.server_streaming
+        except AttributeError:
+            sstream = shint
+        if shint is not None and sstream != shint:
+            warnings.warn(
+                f'protobuf method {self._method.name} streaming'
+                ' hint differs from expected value'
+            )
+        return bool(sstream)
+
+    def _path(self) -> str:
+        return "/" + self._method.full_name.replace('.', '/')
+
+    def call(self, channel: Any, value: Any, *, metadata: Any = None) -> Any:
+        """Execute an RPC call."""
+        method_map = {
+            # req, resp
+            (False, False): channel.unary_unary,
+            (False, True): channel.unary_stream,
+            (True, False): channel.stream_unary,
+            (True, True): channel.stream_stream,
+        }
+        rpc_method = method_map[(self.in_stream, self.out_stream)]
+        if isinstance(metadata, dict):
+            metadata = list(metadata.items())
+        return rpc_method(
+            self._path(),
+            request_serializer=self.input_type.SerializeToString,
+            response_deserializer=self.output_type.FromString,
+        )(value, metadata=metadata)
+
+
+class _API:
+    """Helper class for mapping API names to endpoint objects."""
+
+    _SERVICE_NAME = "SambaControl"
+
+    def __init__(
+        self, channel: Any, dpool: Any, *, service_name: str = ''
+    ) -> None:
+        service_name = service_name or self._SERVICE_NAME
+        self._channel = channel
+        self._dpool = dpool
+        self._svc = dpool.FindServiceByName(service_name)
+
+    @property
+    def channel(self) -> Any:
+        return self._channel
+
+    def __getitem__(self, name: str) -> _Endpoint:
+        method = self._svc.methods_by_name[name]
+        return _Endpoint(method, pool=self._dpool)
+
+
+class Client:
+    """SambaControl gRPC API Client."""
+
+    def __init__(self, config: Config) -> None:
+        self._config = config
+
+    @functools.cache
+    def _credentials(self) -> Any:
+        ca_cert = cert = key = None
+        if cl := self._config.tls_ca_cert:
+            ca_cert = cl.load()
+        if cl := self._config.tls_cert:
+            cert = cl.load()
+        if cl := self._config.tls_key:
+            key = cl.load()
+        return grpc.ssl_channel_credentials(
+            root_certificates=ca_cert,
+            private_key=key,
+            certificate_chain=cert,
+        )
+
+    def _channel(self) -> Any:
+        """Return the grpc channel object."""
+        if self._config.channel_type is ChannelType.SECURE:
+            return grpc.secure_channel(
+                self._config.address, self._credentials()
+            )
+        return grpc.insecure_channel(self._config.address)
+
+    @contextlib.contextmanager
+    def _api(self) -> typing.Iterator[_API]:
+        """As a context manager, return a virtual API helper object."""
+        with self._channel() as channel:
+            try:
+                refdb = _reflection_ddb(channel)
+                dpool = google.protobuf.descriptor_pool.DescriptorPool(refdb)
+                yield _API(channel, dpool)
+            except (
+                gch._MultiThreadedRendezvous,
+                gch._InactiveRpcError,
+            ) as e:
+                raise APICallError(
+                    code=e.code(),
+                    details=e.details(),
+                    msg=e.debug_error_string(),
+                ) from e
+
+    def info(self) -> InfoResult:
+        """Call the SambaControl Info API."""
+        with self._api() as api:
+            info_api = api['Info']
+            result = info_api.call(
+                api.channel,
+                info_api.input_type(),
+                metadata=self._config.headers,
+            )
+        return InfoResult.convert(result)
+
+    def status(self) -> StatusResult:
+        """Call the SambaControl Status API."""
+        with self._api() as api:
+            status_api = api['Status']
+            result = status_api.call(
+                api.channel,
+                status_api.input_type(),
+                metadata=self._config.headers,
+            )
+        return StatusResult.convert(result)
+
+    def close_share(
+        self, share_name: str, denied_users: bool
+    ) -> CloseShareResult:
+        """Call the SambaControl CloseShare API."""
+        with self._api() as api:
+            close_share_api = api['CloseShare']
+            result = close_share_api.call(
+                api.channel,
+                close_share_api.input_type(
+                    share_name=share_name, denied_users=denied_users
+                ),
+                metadata=self._config.headers,
+            )
+        return CloseShareResult.convert(result)
+
+    def kill_client_connection(
+        self, ip_address: str
+    ) -> KillClientConnectionResult:
+        """Call the SambaControl KillClientConnection API."""
+        with self._api() as api:
+            kill_client_api = api['KillClientConnection']
+            result = kill_client_api.call(
+                api.channel,
+                kill_client_api.input_type(ip_address=ip_address),
+                metadata=self._config.headers,
+            )
+        return KillClientConnectionResult.convert(result)
+
+    def config_dump(
+        self, source: str, hash_alg: typing.Optional[str] = None
+    ) -> ConfigDumpResult:
+        """Call the SambaControl ConfigDump API."""
+
+        # closure to wrap streaming results
+        def later() -> Any:
+            with self._api() as api:
+                config_dump_api = api["ConfigDump"].streaming(False, True)
+                result = config_dump_api.call(
+                    api.channel,
+                    config_dump_api.input_type(
+                        source=source.upper(), hash=hash_alg
+                    ),
+                    metadata=self._config.headers,
+                )
+                yield from result
+
+        return ConfigDumpResult.convert_stream(later())
+
+    def config_summary(
+        self, source: str, hash_alg: typing.Optional[str] = None
+    ) -> ConfigSummaryResult:
+        """Call the SambaControl ConfigSummary API."""
+        with self._api() as api:
+            config_summary_api = api["ConfigSummary"]
+            result = config_summary_api.call(
+                api.channel,
+                config_summary_api.input_type(
+                    source=source.upper(),
+                    hash=hash_alg,
+                ),
+                metadata=self._config.headers,
+            )
+        return ConfigSummaryResult.convert(result)
+
+    def config_shares_list(self, source: str) -> ConfigSharesListResult:
+        """Call the SambaControl ConfigSharesList API."""
+
+        # closure to wrap streaming results
+        def later() -> Any:
+            with self._api() as api:
+                config_shares_list_api = api["ConfigSharesList"].streaming(
+                    False, True
+                )
+                result = config_shares_list_api.call(
+                    api.channel,
+                    config_shares_list_api.input_type(source=source.upper()),
+                    metadata=self._config.headers,
+                )
+                yield from result
+
+        return ConfigSharesListResult.convert_stream(later())
+
+    def set_debug_level(
+        self, process: str, debug_level: str
+    ) -> SetDebugLevelResult:
+        """Call the SambaControl SetDebugLevel API."""
+        with self._api() as api:
+            set_debug_level_api = api["SetDebugLevel"]
+            result = set_debug_level_api.call(
+                api.channel,
+                set_debug_level_api.input_type(
+                    process=process.upper(),
+                    debug_level=debug_level,
+                ),
+                metadata=self._config.headers,
+            )
+        return SetDebugLevelResult.convert(result)
+
+    def get_debug_level(self, process: str) -> GetDebugLevelResult:
+        """Call the SambaControl GetDebugLevel API."""
+        with self._api() as api:
+            get_debug_level_api = api["GetDebugLevel"]
+            result = get_debug_level_api.call(
+                api.channel,
+                get_debug_level_api.input_type(process=process.upper()),
+                metadata=self._config.headers,
+            )
+        return GetDebugLevelResult.convert(result)
+
+    def ctdb_status(
+        self,
+    ) -> CTDBStatusResult:
+        """Call the SambaControl CTDBStatus API."""
+        with self._api() as api:
+            ctdb_status_api = api["CTDBStatus"]
+            result = ctdb_status_api.call(
+                api.channel,
+                ctdb_status_api.input_type(),
+                metadata=self._config.headers,
+            )
+        return CTDBStatusResult.convert(result)
+
+    def ctdb_move_ip(self, ip_address: str, node: str) -> CTDBMoveIPResult:
+        """Call the SambaControl CTDBMoveIP API."""
+        with self._api() as api:
+            ctdb_move_ip_api = api["CTDBMoveIP"]
+            result = ctdb_move_ip_api.call(
+                api.channel,
+                ctdb_move_ip_api.input_type(ip=ip_address, node=node),
+                metadata=self._config.headers,
+            )
+        return CTDBMoveIPResult.convert(result)

--- a/src/python-common/ceph/smb/ctl/config.py
+++ b/src/python-common/ceph/smb/ctl/config.py
@@ -1,0 +1,58 @@
+"""Ceph SMB client config library"""
+
+import typing
+
+import abc
+import dataclasses
+import enum
+import pathlib
+
+from ._typing import Self
+
+
+class ChannelType(str, enum.Enum):
+    SECURE = 'secure'
+    INSECURE = 'insecure'
+
+
+class TLSLoader(abc.ABC):
+    def load(self) -> bytes:
+        raise NotImplementedError()
+
+
+@dataclasses.dataclass
+class TLSInline(TLSLoader):
+    """Configure TLS with inline cert data. Mainly for testing."""
+
+    data: typing.Union[str, bytes]
+
+    def load(self) -> bytes:
+        if isinstance(self.data, str):
+            return self.data.encode()
+        return self.data
+
+
+@dataclasses.dataclass
+class TLSPath(TLSLoader):
+    """Configure TLS using a path to cert data."""
+
+    path: pathlib.Path
+
+    @classmethod
+    def create(cls, path: typing.Union[str, pathlib.Path]) -> Self:
+        return cls(pathlib.Path(path))
+
+    def load(self) -> bytes:
+        with open(self.path, 'rb') as fh:
+            data = fh.read()
+        return data
+
+
+@dataclasses.dataclass
+class Config:
+    address: str
+    channel_type: ChannelType
+    tls_cert: typing.Optional[TLSLoader] = None
+    tls_key: typing.Optional[TLSLoader] = None
+    tls_ca_cert: typing.Optional[TLSLoader] = None
+    headers: typing.Optional[typing.Dict[str, str]] = None

--- a/src/python-common/ceph/smb/network.py
+++ b/src/python-common/ceph/smb/network.py
@@ -5,7 +5,6 @@ from typing import Optional, Union
 
 import ipaddress
 
-
 IPNetwork = Union[ipaddress.IPv4Network, ipaddress.IPv6Network]
 
 

--- a/src/python-common/tox.ini
+++ b/src/python-common/tox.ini
@@ -54,3 +54,27 @@ commands =
 deps = {[black]deps}
 commands =
     black {[black]options} {[black]modules}
+
+
+# OPT-IN import style formatting with 'isort'
+#  add your module to the modules list below to use automated import sorting
+[isortcfg]
+deps = isort
+modules = ceph/smb
+
+[isort]
+profile = black
+line_length = 78
+known_first_party = ceph,rados,rbd,cephfs,mgr
+known_typing = typing
+sections = FUTURE,TYPING,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+
+[testenv:check-isort]
+deps = {[isortcfg]deps}
+commands =
+    isort --check-only {[isortcfg]modules}
+
+[testenv:format-isort]
+deps = {[isortcfg]deps}
+commands =
+    isort {[isortcfg]modules}

--- a/src/python-common/tox.ini
+++ b/src/python-common/tox.ini
@@ -45,7 +45,7 @@ commands =
 [black]
 deps = black>=23,<25
 options = -l78 -t py36 --skip-string-normalization
-modules = ceph/cephadm ceph/cryptotools ceph/fs ceph/utils.py
+modules = ceph/cephadm ceph/cryptotools ceph/fs ceph/utils.py ceph/smb
 
 [testenv:check-black]
 deps = {[black]deps}

--- a/src/python-common/tox.ini
+++ b/src/python-common/tox.ini
@@ -14,6 +14,8 @@ commands=
 deps=
     -rrequirements.txt
     -c{toxinidir}/../mypy-constrains.txt
+    types-grpcio
+    types-grpcio-reflection
 commands=
     mypy --config-file=../mypy.ini -p ceph
 


### PR DESCRIPTION
The smb service provides an (optional) sidecar called remote-control that exposes a bunch of diagnostic APIs over grpc.  This sidecar can listen on a TCP + TLS socket or a local unix socket.

Previously, one needed to either use a tool like `grpcurl` or code up a client of your own to interact with this service. In particular, it was a lot of work to get grpcurl onto a ceph node just to talk to local unix socket.

I was asked to produce a tool that is part of the ceph project that can be used as a debugging "one stop shop" for accessing these diagnostic APIs. This PR adds 90% of that tool. The remaining work depends on #68401 - so I am filing this work now to review the library part before the final command line interface and packaging dependencies are done.

Note: to test this it would need the `python-grpcio-reflection` package which is not (yet) automatically installed in the container.
You can run `cephadm shell` and install the package with dnf and run `python3 -m ceph.smb.ctl ...` to do some preliminary testing.


Command help snippet:
```
usage: __main__.py [-h] [--verbose | --quiet]
                   [--address ADDRESS | --cluster CLUSTER]
                   [--tls-cert TLS_CERT] [--tls-key TLS_KEY]
                   [--tls-ca-cert TLS_CA_CERT] [--header GRPC_HEADERS]
                   {close-share,config-dump,config-shares-list,config-summary,ctdb-move-ip,ctdb-status,get-debug-level,info,kill-client-connection,set-debug-level,status}
                   ...

positional arguments:
  {close-share,config-dump,config-shares-list,config-summary,ctdb-move-ip,ctdb-status,get-debug-level,info,kill-client-connection,set-debug-level,status}
    close-share         Close a share (block IO on an existing connection).
    config-dump         Dump configuration data.
    config-shares-list  Report a list of shares configured on the server.
    config-summary      Report a digest hash for the current configuration
                        data.
    ctdb-move-ip        Request a CTDB public IP be moved to a different node.
    ctdb-status         Report on CTDB Server status.
    get-debug-level     Get the current debug level of an smb subsystem.
    info                Get basic server info.
    kill-client-connection
                        Terminate a client connection by IP Address.
    set-debug-level     Set the debug level of an smb subsystem.
    status              Report on Samba smbd server status.

options:
  -h, --help            show this help message and exit
  --verbose, -v         Enable verbose logging
  --quiet, -q           Enable minimal output
  --header GRPC_HEADERS
                        Add gRPC header to call. Takes the form <KEY>=<VALUE>

Server Selection:
  --address ADDRESS     Address of gRPC server
  --cluster CLUSTER, -c CLUSTER
                        Ceph SMB cluster selector. Format
                        [<FSID>/][smb.]<service-prefix>. Choose the SMB
                        service (aka SMB cluster) to connect to using an
                        optional Ceph FSID and SMB service. Example:
                        45d9b47e-47f0-11f1-906a-525400220000/smb.cluster1

TLS Credentials:
  --tls-cert TLS_CERT   Path to TLS certficiate
  --tls-key TLS_KEY     Path to TLS Key
  --tls-ca-cert TLS_CA_CERT
                        Path to TLS CA certficiate

```




## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
  - [x] Integration tests to be added in a future PR

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
