### PR TITLE
ceph-volume: fallback to default for empty get_file_contents values

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_system.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_system.py
@@ -208,6 +208,16 @@ class TestGetFileContents(object):
         result = system.get_file_contents(interesting_file.path)
         assert result == "0\n1"
 
+    def test_path_empty_returns_default(self, fake_filesystem):
+        interesting_file = fake_filesystem.create_file('/tmp/fake-file', contents="")
+        result = system.get_file_contents(interesting_file.path, 'default')
+        assert result == 'default'
+
+    def test_path_whitespace_returns_default(self, fake_filesystem):
+        interesting_file = fake_filesystem.create_file('/tmp/fake-file', contents="   \n\t")
+        result = system.get_file_contents(interesting_file.path, 'default')
+        assert result == 'default'
+
     def test_exception_returns_default(self):
         with patch('builtins.open') as mocked_open:
             mocked_open.side_effect = Exception()

--- a/src/ceph-volume/ceph_volume/util/system.py
+++ b/src/ceph-volume/ceph_volume/util/system.py
@@ -122,7 +122,7 @@ def get_file_contents(path, default=''):
         return contents
     try:
         with open(path, 'r') as open_file:
-            contents = open_file.read().strip()
+            contents = open_file.read().strip() or default
     except Exception:
         logger.exception('Failed to read contents from: %s' % path)
 


### PR DESCRIPTION
With this change, get_file_contents() returns the default when a file exists but reads as empty.
This avoids repeating fallback checks in callers.

Fixes: https://tracker.ceph.com/issues/76431

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
