### PR TITLE
radosgw-admin: fix `radosgw-admin user list` in posix backend

### DIFF
--- a/src/rgw/driver/dbstore/common/dbstore.h
+++ b/src/rgw/driver/dbstore/common/dbstore.h
@@ -1580,6 +1580,11 @@ class DB {
     virtual int ListAllUsers(const DoutPrefixProvider *dpp, DBOpParams *params) = 0;
     virtual int ListAllObjects(const DoutPrefixProvider *dpp, DBOpParams *params) = 0;
 
+    virtual int list_user_ids(const DoutPrefixProvider* dpp,
+                  const std::string& marker, int max,
+                  std::list<std::string>& ids,
+                  bool* truncated) = 0;
+
     int get_user(const DoutPrefixProvider *dpp,
         const std::string& query_str, const std::string& query_str_val,
         RGWUserInfo& uinfo, std::map<std::string, bufferlist> *pattrs,

--- a/src/rgw/driver/dbstore/sqlite/sqliteDB.cc
+++ b/src/rgw/driver/dbstore/sqlite/sqliteDB.cc
@@ -1008,6 +1008,59 @@ int SQLiteDB::ListAllUsers(const DoutPrefixProvider *dpp, DBOpParams *params)
   return ret;
 }
 
+int SQLiteDB::list_user_ids(const DoutPrefixProvider* dpp,
+                            const std::string& marker, int max,
+                            std::list<std::string>& ids,
+                            bool* truncated)
+{
+  sqlite3* sdb = static_cast<sqlite3*>(DB::db);
+  if (!sdb) {
+    return -ENOTCONN;
+  }
+
+  if (max < 0) {
+    return -EINVAL;
+  }
+
+  const std::string query = fmt::format(
+      "SELECT UserID FROM '{}' WHERE UserID > ? ORDER BY UserID LIMIT ?",
+      getUserTable());
+
+  sqlite3_stmt* stmt = nullptr;
+  int rc = sqlite3_prepare_v2(sdb, query.c_str(), -1, &stmt, nullptr);
+  if (rc != SQLITE_OK) {
+    ldpp_dout(dpp, 0) << "list_user_ids: prepare failed: "
+                      << sqlite3_errmsg(sdb) << dendl;
+    return -EIO;
+  }
+
+  sqlite3_bind_text(stmt, 1, marker.c_str(), -1, SQLITE_TRANSIENT);
+  sqlite3_bind_int(stmt, 2, max + 1);
+
+  int count = 0;
+  while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
+    const char* uid = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
+    if (!uid) {
+      continue;
+    }
+    if (count < max) {
+      ids.push_back(uid);
+    }
+    ++count;
+  }
+
+  if (rc != SQLITE_DONE) {
+    ldpp_dout(dpp, 0) << "list_user_ids: step error: "
+                      << sqlite3_errmsg(sdb) << dendl;
+    sqlite3_finalize(stmt);
+    return -EIO;
+  }
+
+  sqlite3_finalize(stmt);
+  *truncated = (count > max);
+  return 0;
+}
+
 int SQLiteDB::ListAllBuckets(const DoutPrefixProvider *dpp, DBOpParams *params)
 {
   int ret = -1;

--- a/src/rgw/driver/dbstore/sqlite/sqliteDB.h
+++ b/src/rgw/driver/dbstore/sqlite/sqliteDB.h
@@ -69,6 +69,10 @@ class SQLiteDB : public DB, virtual public DBOp {
     int ListAllBuckets(const DoutPrefixProvider *dpp, DBOpParams *params) override;
     int ListAllUsers(const DoutPrefixProvider *dpp, DBOpParams *params) override;
     int ListAllObjects(const DoutPrefixProvider *dpp, DBOpParams *params) override;
+    int list_user_ids(const DoutPrefixProvider* dpp,
+              const std::string& marker, int max,
+              std::list<std::string>& ids,
+              bool* truncated) override;
 };
 
 class SQLObjectOp : public ObjectOp {

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -4354,6 +4354,32 @@ int POSIXAtomicWriter::complete(size_t accounted_size, const std::string& etag,
   return 0;
 }
 
+int POSIXDriver::meta_list_keys_init(const DoutPrefixProvider* dpp,
+                                     const std::string& section,
+                                     const std::string& marker,
+                                     void** phandle)
+{
+  return DBListUserIdsHelper::list_keys_init(dpp, section, marker, phandle, get_user_db());
+}
+
+int POSIXDriver::meta_list_keys_next(const DoutPrefixProvider* dpp,
+                                     void* handle, int max,
+                                     std::list<std::string>& keys,
+                                     bool* truncated)
+{
+  return DBListUserIdsHelper::list_keys_next(dpp, handle, max, keys, truncated);
+}
+
+void POSIXDriver::meta_list_keys_complete(void* handle)
+{
+  DBListUserIdsHelper::list_keys_complete(handle);
+}
+
+std::string POSIXDriver::meta_get_marker(void* handle)
+{
+  return DBListUserIdsHelper::get_marker(handle);
+}
+
 } } // namespace rgw::sal
 
 extern "C" {

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -21,6 +21,7 @@
 #include "common/dout.h"
 #include "bucket_cache.h"
 #include "posixDB.h"
+#include "rgw_sal_dbstore.h"
 
 namespace rgw { namespace sal {
 
@@ -703,10 +704,10 @@ public:
 			     std::map<rgw_user_bucket, rgw_usage_log_entry>& usage) override { return 0; }
   virtual int trim_all_usage(const DoutPrefixProvider *dpp, uint64_t start_epoch, uint64_t end_epoch, optional_yield y) override { return 0; }
   virtual int get_config_key_val(std::string name, bufferlist* bl) override { return -ENOTSUP; }
-  virtual int meta_list_keys_init(const DoutPrefixProvider *dpp, const std::string& section, const std::string& marker, void** phandle) override { return 0; }
-  virtual int meta_list_keys_next(const DoutPrefixProvider *dpp, void* handle, int max, std::list<std::string>& keys, bool* truncated) override { return 0; }
-  virtual void meta_list_keys_complete(void* handle) override { return; }
-  virtual std::string meta_get_marker(void* handle) override { return ""; }
+  virtual int meta_list_keys_init(const DoutPrefixProvider *dpp, const std::string& section, const std::string& marker, void** phandle) override;
+  virtual int meta_list_keys_next(const DoutPrefixProvider *dpp, void* handle, int max, std::list<std::string>& keys, bool* truncated) override;
+  virtual void meta_list_keys_complete(void* handle) override;
+  virtual std::string meta_get_marker(void* handle) override;
   virtual int meta_remove(const DoutPrefixProvider* dpp, std::string& metadata_key, optional_yield y) override { return 0; }
   virtual const RGWSyncModuleInstanceRef& get_sync_module() override { return sync_module; }
   virtual std::string get_host_id() override { return ""; }

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -2100,22 +2100,22 @@ namespace rgw::sal {
 
   int DBStore::meta_list_keys_init(const DoutPrefixProvider *dpp, const string& section, const string& marker, void** phandle)
   {
-    return 0;
+    return DBListUserIdsHelper::list_keys_init(dpp, section, marker, phandle, db);
   }
 
   int DBStore::meta_list_keys_next(const DoutPrefixProvider *dpp, void* handle, int max, list<string>& keys, bool* truncated)
   {
-    return 0;
+    return DBListUserIdsHelper::list_keys_next(dpp, handle, max, keys, truncated);
   }
 
   void DBStore::meta_list_keys_complete(void* handle)
   {
-    return;
+    DBListUserIdsHelper::list_keys_complete(handle);
   }
 
   std::string DBStore::meta_get_marker(void* handle)
   {
-    return "";
+    return DBListUserIdsHelper::get_marker(handle);
   }
 
   int DBStore::meta_remove(const DoutPrefixProvider *dpp, string& metadata_key, optional_yield y)

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -18,6 +18,67 @@
 #include "rgw_sal_store.h"
 #include "rgw_role.h"
 #include "rgw_lc.h"
+#include "driver/dbstore/common/dbstore.h"
+
+namespace rgw { namespace sal {
+
+class DBListUserIdsHelper {
+  // Reusable implementation of meta_list_keys_* for drivers that store users
+  // in a DB. Used by DBStore and POSIXDriver to avoid duplicating the
+  // listing logic.
+public:
+  struct ListUserIdsHandle {
+    rgw::store::DB* db;
+    std::string marker;
+  };
+
+  static int list_keys_init(const DoutPrefixProvider* dpp,
+                            const std::string& section,
+                            const std::string& marker,
+                            void** phandle,
+                            rgw::store::DB* db)
+  {
+    if (section != "user") {
+      *phandle = nullptr;
+      return 0;
+    }
+    *phandle = new ListUserIdsHandle{db, marker};
+    return 0;
+  }
+
+  static int list_keys_next(const DoutPrefixProvider* dpp,
+                            void* handle, int max,
+                            std::list<std::string>& keys,
+                            bool* truncated)
+  {
+    if (!handle) {
+      *truncated = false;
+      return 0;
+    }
+
+    auto* h = static_cast<ListUserIdsHandle*>(handle);
+    int ret = h->db->list_user_ids(dpp, h->marker, max, keys, truncated);
+    if (ret < 0) {
+      return ret;
+    }
+    if (!keys.empty()) {
+      h->marker = keys.back();
+    }
+    return 0;
+  }
+
+  static void list_keys_complete(void* handle)
+  {
+    delete static_cast<ListUserIdsHandle*>(handle);
+  }
+
+  static std::string get_marker(void* handle)
+  {
+    return static_cast<ListUserIdsHandle*>(handle)->marker;
+  }
+};
+
+} }
 #include "rgw_multi.h"
 
 #include "driver/dbstore/common/dbstore.h"


### PR DESCRIPTION
Implement meta_list_keys_* methods to make `radosgw-admin user list` work with posix and dbstore RGW backends instead of running an infinite loop

<!--
      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>

# Notes
Draft because I'm waiting to have my tracker account activated to create an issue 