### PR TITLE
tentacle: doc/radosgw: document account-root for PUT and POST /admin/user

### DIFF
--- a/doc/radosgw/adminops.rst
+++ b/doc/radosgw/adminops.rst
@@ -1189,7 +1189,7 @@ A tenant name may also specified as a part of ``uid``, by following the syntax
 
 ``account-id``
 
-:Description: the account under which a user should exist.
+:Description: The account under which a user should exist.
 :Type: string
 :Example: RGW00000000000000001
 :Required: No
@@ -1402,6 +1402,15 @@ Request Parameters
 :Description: default storage class for the user, default-placement must be defined when setting this option.
 :Type: string
 :Example: STANDARD-1A
+:Required: No
+
+.. versionadded:: Squid
+
+``account-id``
+
+:Description: The account under which a user should exist. Cannot be changed or removed once set.
+:Type: string
+:Example: RGW00000000000000001
 :Required: No
 
 Response Entities

--- a/doc/radosgw/adminops.rst
+++ b/doc/radosgw/adminops.rst
@@ -1194,6 +1194,13 @@ A tenant name may also specified as a part of ``uid``, by following the syntax
 :Example: RGW00000000000000001
 :Required: No
 
+``account-root``
+
+:Description: Whether the user should be root for its account.
+:Type: Boolean
+:Example: False [False]
+:Required: No
+
 Response Entities
 ~~~~~~~~~~~~~~~~~
 
@@ -1411,6 +1418,13 @@ Request Parameters
 :Description: The account under which a user should exist. Cannot be changed or removed once set.
 :Type: string
 :Example: RGW00000000000000001
+:Required: No
+
+``account-root``
+
+:Description: Whether the user should be root for its account.
+:Type: Boolean
+:Example: False [False]
 :Required: No
 
 Response Entities


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75051

---

backport of https://github.com/ceph/ceph/pull/67397
parent tracker: https://tracker.ceph.com/issues/74047

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh