### PR TITLE
doc/rados/bluestore: RockDB cache shards, perf counters

### DIFF
--- a/doc/rados/bluestore/rocksdb-config.rst
+++ b/doc/rados/bluestore/rocksdb-config.rst
@@ -1,0 +1,140 @@
+============================
+ RocksDB Config Reference
+============================
+
+.. note:: As of the Tentacle release, two Ceph services use RocksDB: Monitors and OSDs.
+   This document focuses on OSD's RocksDB.
+
+.. index:: bluestore; rocksdb caching
+
+RocksDB caching
+===============
+
+RocksDB caching is based on preserving parts of ``.sst`` files in block cache.
+For more details, see the `Block-Cache wiki <https://github.com/facebook/rocksdb/wiki/Block-Cache>`_.
+Ceph implements its own flavor of block cache.
+See the `source code <https://github.com/ceph/ceph/tree/main/src/kv/rocksdb_cache>`_ for more details.
+This custom implementation brings together RocksDB block cache, BlueStore metadata cache,
+and BlueStore data cache to compete for available memory.
+
+Cache sharding
+--------------
+
+As the default RocksDB block cache, Ceph block cache is sharded.
+Sharding is controlled by configuration. The purpose of sharding is to
+streamline multi-threaded access.
+
+.. confval:: rocksdb_cache_shard_bits
+
+
+Perf counters
+-------------
+
+Ceph RocksDB cache operations are tracked by performance counters.
+In the default configuration BlueStore creates two block caches:
+``O`` for onodes, and ``default`` for everything else.
+The sections created in performance counters are named ``rocksdb-cache-O`` and
+``rocksdb-cache-default``.
+
+.. prompt:: bash #
+
+  ceph tell osd.0 perf dump rocksdb-cache-O
+
+.. code-block:: 
+
+  "rocksdb-cache-O": {
+    "capacity": 134217728,
+    "usage": 134182832,
+    "pinned": 0,
+    "elems": 24502,
+    "inserts": 25806978,
+    "lookups": 150436987,
+    "hits": 124629911,
+    "misses": 25807076
+  }
+
+Values ``capacity``, ``usage``, ``pinned`` and ``elems`` reflect the current state of the cache.
+Values ``inserts``, ``lookups``, ``hits`` and ``misses`` are increased on relevant event.
+
+.. index:: rocksdb; perf counters
+
+Admin commands
+--------------
+
+Performance counters show a brief summation, but each cache shard has its own stats.
+To list RocksDB onode block cache details for each shard, run an admin socket command:
+
+.. prompt:: bash #
+
+  ceph tell osd.0 rocksdb show cache O
+
+.. code-block::
+
+    shard  capacity     usage   pinned   elems  inserts  lookups     hits   misses
+        0  13631488  11076400        0    2099   136987   822679   685923   136756
+        1  13631488  11549712        0    2043   133359   571500   438383   133117
+        2  13631488  11060608        0    2232   135076   908468   773313   135155
+        3  13631488  11166896        0    2269   134006   427070   293147   133923
+        4  13631488  11117984        0    2297   133367   700242   567318   132924
+        5  13631488  11306672        0    2155   137501  1130135   991810   138325
+        6  13631488  11506512        0    2353   134515   662792   528514   134278
+        7  13631488  11093856        0    2316   135348   718971   583421   135550
+        8  13631488  11660624        0    2424   137363  1092043   954248   137795
+        9  13631488  10962000        0    2561   131982   431702   300467   131235
+       10  13631488  11379392        0    1916   134543   477118   342854   134264
+       11  13631488  11294272        0    2555   134508   512393   378337   134056
+       12  13631488  11277136        0    2079   137312  1131571   993692   137879
+       13  13631488  10887776        0    2543   134001   567073   432903   134170
+       14  13631488  10986528        0    2394   133288   584452   451018   133434
+       15  13631488  11954464        0    2456   134615   708285   573374   134911
+
+Counters that support clearing can be reset to zero by running a command:
+
+.. prompt:: bash #
+
+   ceph tell osd.0 rocksdb reset cache O
+
+.. index:: bluestore; rocksdb; admin commands
+
+Optimum shard count
+-------------------
+
+In most cases 16 shards as defined by ``rocksdb_cache_shard_bits=4`` is a good choice.
+Large OSDs can easily accommodate millions of objects and thus having millions of keys
+to encode onode metadata. While the number of keys is not directly a problem,
+it causes RocksDB to create very large index blocks.
+During leveled compaction RocksDB merges two levels. Two index blocks are
+needed at the same time.
+A problem appears if both index blocks belong to the same shard
+and their total size is more than capacity of the shard.
+Both index blocks cannot fit in the shard simultaneously and access to index block
+causes the other block to be evicted from the cache.
+The constant thrashing persists until the current RocksDB compaction step finishes.
+
+Thrashing detection
+*******************
+
+.. prompt:: bash #
+
+  ceph tell osd.0 rocksdb show cache O
+
+.. code-block::
+
+    shard  capacity     usage   pinned   elems  inserts  lookups     hits   misses
+      ...
+        2  13631488  11060608        0    2232   135076   908468   773313   135155
+        3  13631488   8166896        0       1   134006   427070   293147   133923
+        4  13631488  11117984        0    2297   133367   700242   567318   132924
+      ...
+
+It is likely that shard 3 is doing constant eviction. To verify, reset counters to zero
+and observe the relation between ``misses`` and ``hits``.
+Also, the perf counter for ``bluefs.read_bytes`` will be increasing very fast as RocksDB is
+reading the same index blocks over and over again.
+
+Mitigation
+**********
+
+More like a workaround. Reduce ``rocksdb_cache_shard_bits``.
+This will have a slight negative effect on the baseline RocksDB performance,
+as fewer shards means more opportunity for lock contention.

--- a/doc/rados/configuration/index.rst
+++ b/doc/rados/configuration/index.rst
@@ -20,6 +20,7 @@ For general object store configuration, refer to the following:
    :maxdepth: 1
 
    Storage devices <storage-devices>
+   BlueStore RocksDB cache <../bluestore/rocksdb-config>
    ceph-conf
 
 

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -3508,10 +3508,14 @@ options:
   with_legacy: true
 # rocksdb block cache shard bits, 4 bit -> 16 shards
 - name: rocksdb_cache_shard_bits
+  desc: Specifies the number of shards by designating the number of significant bits in hash keys.
+    4 bits -> 16 shards.
   type: int
   level: advanced
   default: 4
   with_legacy: true
+  flags:
+  - startup
 # 'lru' or 'clock'
 - name: rocksdb_cache_type
   type: str


### PR DESCRIPTION
Document role of RocksDB cache shards.
Explain how to monitor cache status and performance.
Give explanation how to detect cache flickering.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
