### PR TITLE
tentacle: neorados: Various Fixes to Watch/Notify

### DIFF
--- a/src/common/async/service.h
+++ b/src/common/async/service.h
@@ -64,11 +64,10 @@ class service : public boost::asio::execution_context::service {
   /// Unregister an object
   void remove(IoObject& entry) {
     auto lock = std::scoped_lock{mutex};
-    if (entries.empty()) {
-      // already shut down
-    } else {
+    if (entry.is_linked()) {
       entries.erase(entries.iterator_to(entry));
     }
+    // else: already removed by shutdown() or a previous remove()
   }
 };
 

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -1745,8 +1745,11 @@ int librados::IoCtxImpl::notify_ack(
 
 int librados::IoCtxImpl::watch_check(uint64_t cookie)
 {
-  auto linger_op = reinterpret_cast<Objecter::LingerOp*>(cookie);
-  auto r = objecter->linger_check(linger_op);
+  boost::intrusive_ptr linger_op = objecter->linger_by_cookie(cookie);
+  if (!linger_op) {
+    return -ENOTCONN;
+  }
+  auto r = objecter->linger_check(linger_op.get());
   if (r)
     return 1 + std::chrono::duration_cast<
       std::chrono::milliseconds>(*r).count();
@@ -1756,7 +1759,11 @@ int librados::IoCtxImpl::watch_check(uint64_t cookie)
 
 int librados::IoCtxImpl::unwatch(uint64_t cookie)
 {
-  Objecter::LingerOp *linger_op = reinterpret_cast<Objecter::LingerOp*>(cookie);
+  boost::intrusive_ptr linger_op = objecter->linger_by_cookie(cookie);
+  if (!linger_op) {
+    return -ENOTCONN;
+  }
+
   C_SaferCond onfinish;
   version_t ver = 0;
 
@@ -1766,7 +1773,7 @@ int librados::IoCtxImpl::unwatch(uint64_t cookie)
   objecter->mutate(linger_op->target.base_oid, oloc, wr,
 		   snapc, ceph::real_clock::now(), extra_op_flags,
 		   &onfinish, &ver);
-  objecter->linger_cancel(linger_op);
+  objecter->linger_cancel(linger_op.get());
 
   int r = onfinish.wait();
   set_sync_op_version(ver);
@@ -1776,7 +1783,10 @@ int librados::IoCtxImpl::unwatch(uint64_t cookie)
 int librados::IoCtxImpl::aio_unwatch(uint64_t cookie, AioCompletionImpl *c)
 {
   c->io = this;
-  Objecter::LingerOp *linger_op = reinterpret_cast<Objecter::LingerOp*>(cookie);
+  boost::intrusive_ptr linger_op = objecter->linger_by_cookie(cookie);
+  if (!linger_op) {
+    return -ENOTCONN;
+  }
   Context *oncomplete = new C_aio_linger_Complete(c, linger_op, true);
 
   ::ObjectOperation wr;

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -1661,8 +1661,8 @@ int librados::IoCtxImpl::watch(const object_t& oid, uint64_t *handle,
   version_t objver;
   C_SaferCond onfinish;
 
-  Objecter::LingerOp *linger_op = objecter->linger_register(oid, oloc,
-                                                            extra_op_flags);
+  boost::intrusive_ptr linger_op = objecter->linger_register(oid, oloc,
+                                                             extra_op_flags);
   *handle = linger_op->get_cookie();
   if (internal) {
     linger_op->handle = InternalWatchInfo(this, oid, ctx, ctx2);
@@ -1672,7 +1672,7 @@ int librados::IoCtxImpl::watch(const object_t& oid, uint64_t *handle,
   prepare_assert_ops(&wr);
   wr.watch(*handle, CEPH_OSD_WATCH_OP_WATCH, timeout);
   bufferlist bl;
-  objecter->linger_watch(linger_op, wr,
+  objecter->linger_watch(linger_op.get(), wr,
 			 snapc, ceph::real_clock::now(), bl,
 			 &onfinish,
 			 &objver);
@@ -1682,7 +1682,7 @@ int librados::IoCtxImpl::watch(const object_t& oid, uint64_t *handle,
   set_sync_op_version(objver);
 
   if (r < 0) {
-    objecter->linger_cancel(linger_op);
+    objecter->linger_cancel(linger_op.get());
     *handle = 0;
   }
 
@@ -1706,8 +1706,8 @@ int librados::IoCtxImpl::aio_watch(const object_t& oid,
                                    uint32_t timeout,
                                    bool internal)
 {
-  Objecter::LingerOp *linger_op = objecter->linger_register(oid, oloc,
-                                                            extra_op_flags);
+  boost::intrusive_ptr linger_op = objecter->linger_register(oid, oloc,
+                                                             extra_op_flags);
   c->io = this;
   Context *oncomplete = new C_aio_linger_Complete(c, linger_op, false);
 
@@ -1722,7 +1722,7 @@ int librados::IoCtxImpl::aio_watch(const object_t& oid,
   prepare_assert_ops(&wr);
   wr.watch(*handle, CEPH_OSD_WATCH_OP_WATCH, timeout);
   bufferlist bl;
-  objecter->linger_watch(linger_op, wr,
+  objecter->linger_watch(linger_op.get(), wr,
                          snapc, ceph::real_clock::now(), bl,
                          oncomplete, &c->objver);
 
@@ -1808,8 +1808,8 @@ int librados::IoCtxImpl::notify(const object_t& oid, bufferlist& bl,
 				bufferlist *preply_bl,
 				char **preply_buf, size_t *preply_buf_len)
 {
-  Objecter::LingerOp *linger_op = objecter->linger_register(oid, oloc,
-                                                            extra_op_flags);
+  boost::intrusive_ptr linger_op = objecter->linger_register(oid, oloc,
+                                                             extra_op_flags);
 
   C_SaferCond notify_finish_cond;
   auto e = boost::asio::prefer(
@@ -1819,7 +1819,7 @@ int librados::IoCtxImpl::notify(const object_t& oid, bufferlist& bl,
     boost::asio::bind_executor(
       std::move(e),
       CB_notify_Finish(client->cct, &notify_finish_cond,
-                       objecter, linger_op, preply_bl,
+                       objecter, linger_op.get(), preply_bl,
                        preply_buf, preply_buf_len));
   uint32_t timeout = notify_timeout;
   if (timeout_ms)
@@ -1834,7 +1834,7 @@ int librados::IoCtxImpl::notify(const object_t& oid, bufferlist& bl,
   // Issue RADOS op
   C_SaferCond onack;
   version_t objver;
-  objecter->linger_notify(linger_op,
+  objecter->linger_notify(linger_op.get(),
 			  rd, snap_seq, inbl, NULL,
 			  &onack, &objver);
 
@@ -1854,7 +1854,7 @@ int librados::IoCtxImpl::notify(const object_t& oid, bufferlist& bl,
     notify_finish_cond.wait();
   }
 
-  objecter->linger_cancel(linger_op);
+  objecter->linger_cancel(linger_op.get());
 
   set_sync_op_version(objver);
   return r;
@@ -1865,8 +1865,8 @@ int librados::IoCtxImpl::aio_notify(const object_t& oid, AioCompletionImpl *c,
                                     bufferlist *preply_bl, char **preply_buf,
                                     size_t *preply_buf_len)
 {
-  Objecter::LingerOp *linger_op = objecter->linger_register(oid, oloc,
-                                                            extra_op_flags);
+  boost::intrusive_ptr linger_op = objecter->linger_register(oid, oloc,
+                                                             extra_op_flags);
 
   c->io = this;
 
@@ -1878,7 +1878,7 @@ int librados::IoCtxImpl::aio_notify(const object_t& oid, AioCompletionImpl *c,
     boost::asio::bind_executor(
       std::move(e),
       CB_notify_Finish(client->cct, oncomplete,
-                       objecter, linger_op,
+                       objecter, linger_op.get(),
                        preply_bl, preply_buf,
                        preply_buf_len));
   Context *onack = new C_aio_notify_Ack(client->cct, oncomplete);
@@ -1894,7 +1894,7 @@ int librados::IoCtxImpl::aio_notify(const object_t& oid, AioCompletionImpl *c,
   rd.notify(linger_op->get_cookie(), 1, timeout, bl, &inbl);
 
   // Issue RADOS op
-  objecter->linger_notify(linger_op,
+  objecter->linger_notify(linger_op.get(),
 			  rd, snap_seq, inbl, NULL,
 			  onack, &c->objver);
   return 0;

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -1785,7 +1785,12 @@ int librados::IoCtxImpl::aio_unwatch(uint64_t cookie, AioCompletionImpl *c)
   c->io = this;
   boost::intrusive_ptr linger_op = objecter->linger_by_cookie(cookie);
   if (!linger_op) {
-    return -ENOTCONN;
+    // reject invalid cookies with ENOTCONN, but deliver to the
+    // AioCompletion instead of returning directly
+    boost::asio::defer(client->finish_strand,
+        boost::asio::append(CB_AioCompleteAndSafe(c), -ENOTCONN));
+
+    return 0;
   }
   Context *oncomplete = new C_aio_linger_Complete(c, linger_op, true);
 

--- a/src/neorados/RADOS.cc
+++ b/src/neorados/RADOS.cc
@@ -1758,7 +1758,7 @@ void RADOS::notify_(Object o, IOContext _ioc, bufferlist bl,
     bl, &inbl);
 
   impl->objecter->linger_notify(
-    linger_op, rd, ioc->snap_seq, inbl,
+    linger_op.get(), rd, ioc->snap_seq, inbl,
     asio::bind_executor(
       e,
       [cb](bs::error_code ec, ceph::bufferlist bl) mutable {

--- a/src/neorados/RADOS.cc
+++ b/src/neorados/RADOS.cc
@@ -1496,7 +1496,9 @@ public:
     } else if (capacity && notifications.size() >= capacity) {
       // We are allowed one over, so the client knows where in the
       // sequence of notifications we started losing data.
-      notifications.push({errc::notification_overflow, {}});
+      if (notifications.size() == capacity) {
+        notifications.push({errc::notification_overflow, {}});
+      }
     } else {
       notifications.push({{},
 			  Notification{

--- a/src/neorados/RADOS.cc
+++ b/src/neorados/RADOS.cc
@@ -1585,8 +1585,8 @@ void RADOS::watch_(Object o, IOContext _ioc, WatchComp c,
 }
 
 void RADOS::next_notification_(uint64_t cookie, NextNotificationComp c) {
-  Objecter::LingerOp* linger_op = reinterpret_cast<Objecter::LingerOp*>(cookie);
-  if (!impl->objecter->is_valid_watch(linger_op)) {
+  boost::intrusive_ptr linger_op = impl->objecter->linger_by_cookie(cookie);
+  if (!linger_op) {
     dispatch(asio::append(std::move(c),
 			  bs::error_code(ENOTCONN, bs::generic_category()),
 			  Notification{}));
@@ -1626,9 +1626,9 @@ void RADOS::notify_ack_(Object o, IOContext _ioc,
 
 tl::expected<ceph::timespan, bs::error_code> RADOS::check_watch(uint64_t cookie)
 {
-  auto linger_op = reinterpret_cast<Objecter::LingerOp*>(cookie);
-  if (impl->objecter->is_valid_watch(linger_op)) {
-    return impl->objecter->linger_check(linger_op);
+  boost::intrusive_ptr linger_op = impl->objecter->linger_by_cookie(cookie);
+  if (linger_op) {
+    return impl->objecter->linger_check(linger_op.get());
   } else {
     return tl::unexpected(bs::error_code(ENOTCONN, bs::generic_category()));
   }
@@ -1639,7 +1639,12 @@ void RADOS::unwatch_(uint64_t cookie, IOContext _ioc,
 {
   auto ioc = reinterpret_cast<const IOContextImpl*>(&_ioc.impl);
 
-  Objecter::LingerOp *linger_op = reinterpret_cast<Objecter::LingerOp*>(cookie);
+  boost::intrusive_ptr linger_op = impl->objecter->linger_by_cookie(cookie);
+  if (!linger_op) {
+    dispatch(asio::append(std::move(c),
+			  bs::error_code(ENOTCONN, bs::generic_category())));
+    return;
+  }
 
   ObjectOperation op;
   op.watch(cookie, CEPH_OSD_WATCH_OP_UNWATCH);
@@ -1652,7 +1657,7 @@ void RADOS::unwatch_(uint64_t cookie, IOContext _ioc,
 			   [objecter = impl->objecter,
 			    linger_op, c = std::move(c)]
 			   (bs::error_code ec) mutable {
-			     objecter->linger_cancel(linger_op);
+			     objecter->linger_cancel(linger_op.get());
 			     asio::dispatch(asio::append(std::move(c), ec));
 			   }));
 }

--- a/src/neorados/RADOS.cc
+++ b/src/neorados/RADOS.cc
@@ -1408,12 +1408,23 @@ class Notifier : public async::service_list_base_hook {
   std::shared_ptr<detail::Client> neoref;
 
   void service_shutdown() {
-    if (neoref) {
-      neoref = nullptr;
-    }
-    linger_op.reset();
+    // Ensure neorados object and operation live to the end of the
+    // function.
+    auto localop = std::move(linger_op);
+    [[maybe_unused]] auto localneo = std::move(neoref);
     std::unique_lock l(m);
     handlers.clear();
+    l.unlock();
+    if (localop) {
+      // We are being taken down and will execute no more
+      // handlers. Call `linger_cancel` to clean up properly in
+      // Objecter. (It doesn't call out to the OSD or anything.)
+      //
+      // Removal and decrement are guarded by `linger_op->canceled`
+      // so there's no risk of an underflow.
+      localop->objecter->linger_cancel(localop.get());
+    }
+    // The Notifier object is freed by the `linger_cancel` above.
   }
 
 public:

--- a/src/neorados/RADOS.cc
+++ b/src/neorados/RADOS.cc
@@ -1672,7 +1672,7 @@ struct NotifyHandler : std::enable_shared_from_this<NotifyHandler> {
   asio::io_context& ioc;
   asio::strand<asio::io_context::executor_type> strand;
   Objecter* objecter;
-  Objecter::LingerOp* op;
+  boost::intrusive_ptr<Objecter::LingerOp> op;
   RADOS::NotifyComp c;
 
   bool acked = false;
@@ -1682,10 +1682,10 @@ struct NotifyHandler : std::enable_shared_from_this<NotifyHandler> {
 
   NotifyHandler(asio::io_context& ioc,
 		Objecter* objecter,
-		Objecter::LingerOp* op,
+		boost::intrusive_ptr<Objecter::LingerOp> op,
 		RADOS::NotifyComp c)
     : ioc(ioc), strand(asio::make_strand(ioc)),
-      objecter(objecter), op(op), c(std::move(c)) {}
+      objecter(objecter), op(std::move(op)), c(std::move(c)) {}
 
   // Use bind or a lambda to pass this in.
   void handle_ack(bs::error_code ec,
@@ -1716,7 +1716,7 @@ struct NotifyHandler : std::enable_shared_from_this<NotifyHandler> {
     if (!res && ec)
       res = ec;
     if ((acked && finished) || res) {
-      objecter->linger_cancel(op);
+      objecter->linger_cancel(op.get());
       ceph_assert(c);
       bc::flat_map<std::pair<uint64_t, uint64_t>, buffer::list> reply_map;
       bc::flat_set<std::pair<uint64_t, uint64_t>> missed_set;

--- a/src/neorados/RADOS.cc
+++ b/src/neorados/RADOS.cc
@@ -1396,7 +1396,7 @@ class Notifier : public async::service_list_base_hook {
   };
 
   asio::io_context::executor_type ex;
-  Objecter::LingerOp* linger_op;
+  boost::intrusive_ptr<Objecter::LingerOp> linger_op;
   // Zero for unbounded. I would not recommend this.
   const uint32_t capacity;
 
@@ -1411,18 +1411,17 @@ class Notifier : public async::service_list_base_hook {
     if (neoref) {
       neoref = nullptr;
     }
-    if (linger_op) {
-      linger_op->put();
-    }
+    linger_op.reset();
     std::unique_lock l(m);
     handlers.clear();
   }
 
 public:
 
-  Notifier(asio::io_context::executor_type ex, Objecter::LingerOp* linger_op,
+  Notifier(asio::io_context::executor_type ex,
+	   boost::intrusive_ptr<Objecter::LingerOp> linger_op,
 	   uint32_t capacity, std::shared_ptr<detail::Client> neoref)
-    : ex(ex), linger_op(linger_op), capacity(capacity),
+    : ex(ex), linger_op(std::move(linger_op)), capacity(capacity),
       svc(asio::use_service<async::service<Notifier>>(
 	    asio::query(ex, boost::asio::execution::context))),
       neoref(std::move(neoref)) {
@@ -1537,12 +1536,12 @@ void RADOS::watch_(Object o, IOContext _ioc,
   auto e = asio::prefer(get_executor(),
 			asio::execution::outstanding_work.tracked);
   impl->objecter->linger_watch(
-    linger_op, op, ioc->snapc, ceph::real_clock::now(), bl,
+    linger_op.get(), op, ioc->snapc, ceph::real_clock::now(), bl,
     asio::bind_executor(
       std::move(e),
       [c = std::move(c), cookie, linger_op](bs::error_code e, cb::list) mutable {
 	if (e) {
-	  linger_op->objecter->linger_cancel(linger_op);
+	  linger_op->objecter->linger_cancel(linger_op.get());
 	  cookie = 0;
 	}
 	asio::dispatch(asio::append(std::move(c), e, cookie));
@@ -1571,13 +1570,13 @@ void RADOS::watch_(Object o, IOContext _ioc, WatchComp c,
   auto e = asio::prefer(get_executor(),
 			asio::execution::outstanding_work.tracked);
   impl->objecter->linger_watch(
-    linger_op, op, ioc->snapc, ceph::real_clock::now(), bl,
+    linger_op.get(), op, ioc->snapc, ceph::real_clock::now(), bl,
     asio::bind_executor(
       std::move(e),
       [c = std::move(c), cookie, linger_op](bs::error_code e, cb::list) mutable {
 	if (e) {
 	  linger_op->user_data.reset();
-	  linger_op->objecter->linger_cancel(linger_op);
+	  linger_op->objecter->linger_cancel(linger_op.get());
 	  cookie = 0;
 	}
 	asio::dispatch(asio::append(std::move(c), e, cookie));

--- a/src/neorados/RADOS.cc
+++ b/src/neorados/RADOS.cc
@@ -1692,6 +1692,7 @@ struct NotifyHandler : std::enable_shared_from_this<NotifyHandler> {
   bool finished = false;
   bs::error_code res;
   bufferlist rbl;
+  bool cleaned = false;
 
   NotifyHandler(asio::io_context& ioc,
 		Objecter* objecter,
@@ -1726,9 +1727,13 @@ struct NotifyHandler : std::enable_shared_from_this<NotifyHandler> {
 
   // Should be called from strand.
   void maybe_cleanup(bs::error_code ec) {
+    if (cleaned) {
+      return;
+    }
     if (!res && ec)
       res = ec;
     if ((acked && finished) || res) {
+      cleaned = true;
       objecter->linger_cancel(op.get());
       ceph_assert(c);
       bc::flat_map<std::pair<uint64_t, uint64_t>, buffer::list> reply_map;

--- a/src/neorados/RADOS.cc
+++ b/src/neorados/RADOS.cc
@@ -1731,11 +1731,16 @@ struct NotifyHandler : std::enable_shared_from_this<NotifyHandler> {
       ceph_assert(c);
       bc::flat_map<std::pair<uint64_t, uint64_t>, buffer::list> reply_map;
       bc::flat_set<std::pair<uint64_t, uint64_t>> missed_set;
-      auto p = rbl.cbegin();
-      decode(reply_map, p);
-      decode(missed_set, p);
-      asio::dispatch(asio::append(std::move(c), res, std::move(reply_map),
-				  std::move(missed_set)));
+      if (rbl.length() > 0) try {
+          auto p = rbl.cbegin();
+          decode(reply_map, p);
+          decode(missed_set, p);
+      } catch (const std::exception&) {
+        // Swallowing the decode error.
+      }
+      asio::dispatch(
+          asio::append(
+              std::move(c), res, std::move(reply_map), std::move(missed_set)));
     }
   }
 };

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -657,9 +657,10 @@ class CB_DoWatchError {
   boost::intrusive_ptr<Objecter::LingerOp> info;
   bs::error_code ec;
 public:
-  CB_DoWatchError(Objecter *o, Objecter::LingerOp *i,
+  CB_DoWatchError(Objecter *o,
+		  boost::intrusive_ptr<Objecter::LingerOp> i,
 		  bs::error_code ec)
-    : objecter(o), info(i), ec(ec) {
+    : objecter(o), info(std::move(i)), ec(ec) {
     info->_queued_async();
   }
   void operator()() {
@@ -812,7 +813,22 @@ void Objecter::_linger_cancel(LingerOp *info)
   }
 }
 
+auto Objecter::linger_by_cookie(uint64_t cookie)
+  -> boost::intrusive_ptr<LingerOp>
+{
+  auto lock = std::shared_lock{rwlock};
+  return _linger_by_cookie(cookie);
+}
 
+auto Objecter::_linger_by_cookie(uint64_t cookie)
+  -> boost::intrusive_ptr<LingerOp>
+{
+  auto info = reinterpret_cast<LingerOp*>(cookie);
+  if (!linger_ops_set.contains(info)) {
+    return nullptr; // invalid or canceled op
+  }
+  return info;
+}
 
 Objecter::LingerOp *Objecter::linger_register(const object_t& oid,
 					      const object_locator_t& oloc,
@@ -919,8 +935,10 @@ struct CB_DoWatchNotify {
   Objecter *objecter;
   boost::intrusive_ptr<Objecter::LingerOp> info;
   boost::intrusive_ptr<MWatchNotify> msg;
-  CB_DoWatchNotify(Objecter *o, Objecter::LingerOp *i, MWatchNotify *m)
-    : objecter(o), info(i), msg(m) {
+  CB_DoWatchNotify(Objecter *o,
+                   boost::intrusive_ptr<Objecter::LingerOp> i,
+                   MWatchNotify *m)
+    : objecter(o), info(std::move(i)), msg(m) {
     info->_queued_async();
   }
   void operator()() {
@@ -935,8 +953,8 @@ void Objecter::handle_watch_notify(MWatchNotify *m)
     return;
   }
 
-  LingerOp *info = reinterpret_cast<LingerOp*>(m->cookie);
-  if (linger_ops_set.count(info) == 0) {
+  boost::intrusive_ptr info = _linger_by_cookie(m->cookie);
+  if (!info) {
     ldout(cct, 7) << __func__ << " cookie " << m->cookie << " dne" << dendl;
     return;
   }
@@ -945,8 +963,8 @@ void Objecter::handle_watch_notify(MWatchNotify *m)
     if (!info->last_error) {
       info->last_error = bs::error_code(ENOTCONN, osd_category());
       if (info->handle) {
-	asio::defer(finish_strand, CB_DoWatchError(this, info,
-							  info->last_error));
+	boost::system::error_code ec = info->last_error;
+	asio::defer(finish_strand, CB_DoWatchError(this, std::move(info), ec));
       }
     }
   } else if (!info->is_watch) {
@@ -967,7 +985,7 @@ void Objecter::handle_watch_notify(MWatchNotify *m)
       info->on_notify_finish = nullptr;
     }
   } else {
-    asio::defer(finish_strand, CB_DoWatchNotify(this, info, m));
+    asio::defer(finish_strand, CB_DoWatchNotify(this, std::move(info), m));
   }
 }
 

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -789,7 +789,6 @@ void Objecter::linger_cancel(LingerOp *info)
 {
   unique_lock wl(rwlock);
   _linger_cancel(info);
-  info->put();
 }
 
 void Objecter::_linger_cancel(LingerOp *info)
@@ -852,7 +851,6 @@ auto Objecter::linger_register(const object_t& oid,
   linger_ops_set.insert(info);
   ceph_assert(linger_ops.size() == linger_ops_set.size());
 
-  info->get(); // for the caller
   return info;
 }
 

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -830,9 +830,10 @@ auto Objecter::_linger_by_cookie(uint64_t cookie)
   return info;
 }
 
-Objecter::LingerOp *Objecter::linger_register(const object_t& oid,
-					      const object_locator_t& oloc,
-					      int flags)
+auto Objecter::linger_register(const object_t& oid,
+			       const object_locator_t& oloc,
+			       int flags)
+  -> boost::intrusive_ptr<LingerOp>
 {
   unique_lock l(rwlock);
   // Acquire linger ID

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -2592,11 +2592,6 @@ public:
   friend class CB_DoWatchError;
 public:
 
-  bool is_valid_watch(LingerOp* op) {
-    std::shared_lock l(rwlock);
-    return linger_ops_set.contains(op);
-  }
-
   template<typename CT>
   auto linger_callback_flush(CT&& ct) {
     auto consigned = boost::asio::consign(
@@ -3252,6 +3247,14 @@ public:
 	       boost::system::error_code> linger_check(LingerOp *info);
   void linger_cancel(LingerOp *info);  // releases a reference
   void _linger_cancel(LingerOp *info);
+
+  // return the LingerOp associated with the given cookie.
+  // may return nullptr if the cookie is no longer valid
+  boost::intrusive_ptr<LingerOp> linger_by_cookie(uint64_t cookie);
+ private:
+  // internal version that expects the caller to hold rwlock
+  boost::intrusive_ptr<LingerOp> _linger_by_cookie(uint64_t cookie);
+ public:
 
   void _do_watch_notify(boost::intrusive_ptr<LingerOp> info,
                         boost::intrusive_ptr<MWatchNotify> m);

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -3211,8 +3211,9 @@ public:
   }
 
   // caller owns a ref
-  LingerOp *linger_register(const object_t& oid, const object_locator_t& oloc,
-			    int flags);
+  auto linger_register(const object_t& oid, const object_locator_t& oloc,
+		       int flags)
+      -> boost::intrusive_ptr<LingerOp>;
   ceph_tid_t linger_watch(LingerOp *info,
 			  ObjectOperation& op,
 			  const SnapContext& snapc, ceph::real_time mtime,

--- a/src/test/neorados/CMakeLists.txt
+++ b/src/test/neorados/CMakeLists.txt
@@ -233,3 +233,10 @@ target_link_libraries(ceph_test_neorados_watch_notify
 install(TARGETS
   ceph_test_neorados_watch_notify
   DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+add_executable(ceph_test_neorados_leak_watch_notify leak_watch_notify.cc)
+target_link_libraries(ceph_test_neorados_leak_watch_notify global libneorados
+  neoradostest-support ${unittest_libs})
+install(TARGETS
+  ceph_test_neorados_leak_watch_notify
+  DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/test/neorados/leak_watch_notify.cc
+++ b/src/test/neorados/leak_watch_notify.cc
@@ -1,0 +1,50 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2026 Contributors to the Ceph Project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include <iostream>
+#include <optional>
+
+#include <boost/asio.hpp>
+#include <boost/system/error_code.hpp>
+
+#include "include/neorados/RADOS.hpp"
+
+#include "common_tests.h"
+
+namespace asio = boost::asio;
+
+using boost::system::error_code;
+
+// Intentionally get a watch and don't unwatch it to make sure we call
+// `linger_cancel` and don't leak.
+
+int main()
+{    
+  asio::io_context c;
+  std::string_view oid = "obj";
+
+  std::optional<neorados::RADOS> rados;
+  neorados::IOContext pool;
+  neorados::RADOS::Builder{}.build(c, [&](error_code ec, neorados::RADOS r_) {
+    rados = std::move(r_);
+    create_pool(*rados, get_temp_pool_name(),
+		[&](error_code ec, int64_t poolid) {
+		  pool.set_pool(poolid);
+		  rados->watch(oid, pool, [&](error_code, std::uint64_t cookie) {
+		    std::cout << "Got watch: " << cookie << std::endl;
+		  });
+		});
+  });
+  c.run();
+}

--- a/src/test/neorados/leak_watch_notify.cc
+++ b/src/test/neorados/leak_watch_notify.cc
@@ -15,7 +15,8 @@
 #include <iostream>
 #include <optional>
 
-#include <boost/asio.hpp>
+#include <boost/asio/io_context.hpp>
+
 #include <boost/system/error_code.hpp>
 
 #include "include/neorados/RADOS.hpp"

--- a/src/test/neorados/watch_notify.cc
+++ b/src/test/neorados/watch_notify.cc
@@ -9,8 +9,8 @@
  *
  */
 
+#include <boost/asio/detached.hpp>
 #include <boost/system/detail/errc.hpp>
-#include <coroutine>
 #include <cstdint>
 #include <iostream>
 #include <utility>
@@ -35,8 +35,6 @@
 
 #include "gtest/gtest.h"
 
-using std::uint64_t;
-
 namespace asio = boost::asio;
 namespace buffer = ceph::buffer;
 namespace container = boost::container;
@@ -45,7 +43,6 @@ namespace sys = boost::system;
 using namespace std::literals;
 
 using neorados::ReadOp;
-using neorados::WriteOp;
 
 using std::uint64_t;
 
@@ -230,6 +227,31 @@ CORO_TEST_F(NeoRadosWatchNotifyPoll, WatchNotify, NeoRadosTest) {
       throw;
     }
   }
+  co_return;
+}
+
+CORO_TEST_F(NeoRadosWatchNotifyPoll, WatchNotifyOverflow, NeoRadosTest) {
+  static constexpr auto oid = "obj"sv;
+  co_await create_obj(oid);
+  auto handle = co_await rados().watch(oid, pool(), asio::use_awaitable,
+                                       std::nullopt, 1);
+  EXPECT_TRUE(rados().check_watch(handle));
+  // TODO: Write an awaitable future. This should work for testing for now.
+  rados().notify(oid, pool(), {}, 1s, asio::detached);
+  rados().notify(oid, pool(), {}, 1s, asio::detached);
+  rados().notify(oid, pool(), {}, 1s, asio::detached);
+  rados().notify(oid, pool(), {}, 1s, asio::detached);
+  co_await wait_for(1s);
+  co_await rados().next_notification(handle, asio::use_awaitable);
+  rados().notify(oid, pool(), {}, 1s, asio::detached);
+  co_await expect_error_code(rados().next_notification(handle, asio::use_awaitable),
+                             neorados::errc::notification_overflow);
+  rados().notify(oid, pool(), {}, 1s, asio::detached);
+  co_await rados().next_notification(handle, asio::use_awaitable);
+  co_await rados().unwatch(handle, pool(), asio::use_awaitable);
+  std::cout << "Flushing..." << std::endl;
+  co_await rados().flush_watch(asio::use_awaitable);
+  std::cout << "Flushed..." << std::endl;
   co_return;
 }
 

--- a/src/test/neorados/watch_notify.cc
+++ b/src/test/neorados/watch_notify.cc
@@ -311,6 +311,7 @@ CORO_TEST_F(NeoRadosWatchNotifyPoll, WrongWatchType, NeoRadosTest) {
   co_await expect_error_code(
     rados().next_notification(handle, asio::use_awaitable),
     sys::errc::invalid_argument);
+  co_await rados().unwatch(handle, pool(), asio::use_awaitable);
 }
 
 CORO_TEST_F(NeoRadosWatchNotifyPoll, WatchNotifyCancel, NeoRadosTest) {


### PR DESCRIPTION
Original bug: https://tracker.ceph.com/issues/75164
Original PR: https://github.com/ceph/ceph/pull/67729
Also including: https://github.com/ceph/ceph/pull/65698 and https://github.com/ceph/ceph/pull/66610 as the previous commits were built on the `linger_by_cookie` change and need the aio fix for RBD.

Added commit b367a3eb350294fca922231dabf3c6498b83a3c2 to fix a build failure on tentacle.

Backport tracker: https://tracker.ceph.com/issues/76434


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
