### PR TITLE
mgr/nfs:Fix NFS BYOK (Bring Your Own Key) KMIP Authentication Failure

### DIFF
--- a/doc/mgr/nfs.rst
+++ b/doc/mgr/nfs.rst
@@ -253,7 +253,7 @@ Example use cases include:
 
    .. prompt:: bash #
 
-      ceph auth get-or-create client.<user_id> mon 'allow r' osd 'allow rw pool=.nfs namespace=<nfs_cluster_name>, allow rw tag cephfs data=<fs_name>' mds 'allow rw path=<export_path>'
+      ceph auth get-or-create client.<user_id> mon 'allow r' osd 'allow rw pool=.nfs namespace=<nfs_cluster_name>, allow rw tag cephfs data=<fs_name>' mds 'allow all path=<export_path>'
 
 View Customized NFS Ganesha Configuration
 -----------------------------------------

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -625,7 +625,7 @@ class ExportMgr:
         nfs_caps = [
             'mon', 'allow r',
             'osd', osd_cap,
-            'mds', f'allow rw path={path}'
+            'mds', f'allow all path={path}'
         ]
 
         ret, out, err = self.mgr.mon_command({


### PR DESCRIPTION
Fix NFS BYOK (Bring Your Own Key) KMIP Authentication Failure

Signed-off-by: Pooja Dwivedi pooja.dwivedi@ibm.com
Fixes:  https://tracker.ceph.com/issues/76457

### Description

NFS exports with KMIP-based encryption (BYOK - Bring Your Own Key) were failing with error 13 (Permission Denied) when attempting to retrieve encryption keys from the KMIP server. This prevented users from creating or mounting encrypted NFS exports using external key management.
This issue is happening because the NFS client entity (`client.nfs.<service_id>`) lacked the necessary Ceph permissions to access the CephFS volumes and metadata required for KMIP key operations, and without permissions, the NFS daemon could not properly interact with the KMIP server to retrieve encryption keys, resulting in authentication failures.

To solve this, modified the NFS client entity creation to include the required capabilities.

### Testing Steps

1. Create nfs with byok requirements , with kmip server cert, cert and key certs.
2. Create a key in kmip server.
3. Create subvolume with kmip key and create export.
4. Try mounting in client node .

Testing Logs
``` 
[ceph: root@ceph-harish-test-fbup7z-node1-installer /]# ceph orch apply -i nfs.yaml
Scheduled nfs.nfs_byok update...
[ceph: root@ceph-harish-test-fbup7z-node1-installer /]# ceph orch ps --daemon-type nfs
NAME                                                   HOST                           PORTS              STATUS         REFRESHED  AGE  MEM USE  MEM LIM  VERSION  IMAGE ID      CONTAINER ID  
nfs.nfs_byok.0.0.ceph-harish-test-fbup7z-node2.uapaaz  ceph-harish-test-fbup7z-node2  *:2049,9587,31311  running (22s)    13s ago  22s     117M        -  9.7      fc0d1ec30d72  e374fe159908  
[ceph: root@ceph-harish-test-fbup7z-node1-installer /]# ceph fs subvolume ls cephfs ganeshagroup
[
    {
        "name": "export_byok_0"
    },
    {
        "name": "export6_subvol"
    },
    {
        "name": "subvol4"
    },
    {
        "name": "subvol1"
    }
]

[ceph: root@ceph-harish-test-fbup7z-node1-installer /]# ceph fs subvolume getpath cephfs subvol4 ganeshagroup
/volumes/ganeshagroup/subvol4/1e68399f-4897-430b-ae52-2ceee195e796
[ceph: root@ceph-harish-test-fbup7z-node1-installer /]# ceph nfs export create cephfs nfs_byok /test_kmip cephfs \
  --path=/volumes/ganeshagroup/subvol4/1e68399f-4897-430b-ae52-2ceee195e796 \
  --kmip_key_id=KEY-dbd7832-a190ffa0-669d-421a-9195-9444f3fb6ea0

[ceph: root@ceph-harish-test-fbup7z-node1-installer /]# ceph nfs export create cephfs nfs_byok /test_kmip cephfs   --path=/volumes/ganeshagroup/subvol4/1e68399f-4897-430b-ae52-2ceee195e796   --kmip_key_id=KEY-dbd7832-a190ffa0-669d-421a-9195-9444f3fb6ea0
{
  "bind": "/test_kmip",
  "cluster": "nfs_byok",
  "fs": "cephfs",
  "mode": "rw",
  "path": "/volumes/ganeshagroup/subvol4/1e68399f-4897-430b-ae52-2ceee195e796"
}
[root@ceph-harish-test-fbup7z-node2 ~]# ssh root@10.0.67.152
[root@ceph-harish-test-fbup7z-node4 ~]# mkdir mnt
[root@ceph-harish-test-fbup7z-node4 ~]# ls
ceph-harish-test-fbup7z-node4-coredump.tar  dir  dr  mnt  mntdir  pd1  pd3
[root@ceph-harish-test-fbup7z-node4 ~]# mount -t nfs -o vers=4.2,port=2049 ceph-harish-test-fbup7z-node2:/test_kmip mnt
[root@ceph-harish-test-fbup7z-node4 ~]# nfsstat -m
/root/mnt from ceph-harish-test-fbup7z-node2:/test_kmip
 Flags:	rw,seclabel,relatime,vers=4.2,rsize=1048576,wsize=1048576,namlen=255,hard,fatal_neterrors=none,proto=tcp,timeo=600,retrans=2,sec=sys,clientaddr=10.0.67.152,local_lock=none,addr=10.0.66.63

````


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [X] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
