### PR TITLE
rgw: sync Keystone ACL strategies between S3 and Swift APIs

### DIFF
--- a/doc/radosgw/keystone.rst
+++ b/doc/radosgw/keystone.rst
@@ -199,3 +199,21 @@ Enabling this will cause an expired token given in the ``X-Auth-Token`` header t
 if coupled with a ``X-Service-Token`` header that contains a valid token with the accepted
 roles. This can allow long running processes using a user token in ``X-Auth-Token`` to function
 beyond the expiration of the token.
+
+Swift and S3 ACL Interoperability
+---------------------------------
+
+When Keystone is the identity provider, ACLs set via the Swift API are
+automatically honored by S3 API requests (and vice versa). This enables
+mixed deployments where some clients use Swift and others use S3 to access
+the same buckets/containers.
+
+The following ACL grant formats are supported for cross-API access:
+
+- **Project:User grants** (e.g., ``project_id:user_id``): ACLs using the
+  ``project:user`` format set via Swift container ACLs are matched against
+  S3 Keystone-authenticated requests by comparing all combinations of
+  project/user UUIDs and names.
+
+- **Wildcard grants**: Standard Swift wildcards (``project_id:*``,
+  ``*:user_id``) are supported for both Swift and S3 access.

--- a/doc/radosgw/keystone.rst
+++ b/doc/radosgw/keystone.rst
@@ -209,3 +209,21 @@ Enabling this will cause an expired token given in the ``X-Auth-Token`` header t
 if coupled with a ``X-Service-Token`` header that contains a valid token with the accepted
 roles. This can allow long-running processes using a user token in ``X-Auth-Token`` to function
 beyond the expiration of the token.
+
+Swift and S3 ACL Interoperability
+---------------------------------
+
+When Keystone is the identity provider, ACLs set via the Swift API are
+automatically honored by S3 API requests (and vice versa). This enables
+mixed deployments where some clients use Swift and others use S3 to access
+the same buckets/containers.
+
+The following ACL grant formats are supported for cross-API access:
+
+- **Project:User grants** (e.g., ``project_id:user_id``): ACLs using the
+  ``project:user`` format set via Swift container ACLs are matched against
+  S3 Keystone-authenticated requests by comparing all combinations of
+  project/user UUIDs and names.
+
+- **Wildcard grants**: Standard Swift wildcards (``project_id:*``,
+  ``*:user_id``) are supported for both Swift and S3 access.

--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -180,52 +180,63 @@ make_spec_item(const std::string& tenant, const std::string& id)
   return tenant + ":" + id;
 }
 
-TokenEngine::acl_strategy_t
-TokenEngine::get_acl_strategy(const TokenEngine::token_envelope_t& token) const
+/* Mirrors Swift keystoneauth's _authorize_cross_tenant() Cartesian product
+ * over {tenant_id, tenant_name, '*'} x {user_id, user_name, '*'}, plus a
+ * system-reader role grant. Shared by TokenEngine and EC2Engine so S3 and
+ * Swift requests authenticated via Keystone evaluate ACLs identically. */
+rgw::auth::RemoteApplier::acl_strategy_t
+make_keystone_acl_strategy(const std::string& tenant_id,
+                           const std::string& tenant_name,
+                           const std::string& user_id,
+                           const std::string& user_name,
+                           std::list<rgw::keystone::TokenEnvelope::Role> roles)
 {
-  /* The primary identity is constructed upon UUIDs. */
-  const auto& tenant_uuid = token.get_project_id();
-  const auto& user_uuid = token.get_user_id();
-
-  /* For Keystone v2 an alias may be also used. */
-  const auto& tenant_name = token.get_project_name();
-  const auto& user_name = token.get_user_name();
-
-  /* Construct all possible combinations including Swift's wildcards. */
-  const std::array<std::string, 6> allowed_items = {
-    make_spec_item(tenant_uuid, user_uuid),
+  const std::array<std::string, 7> allowed_items = {
+    make_spec_item(tenant_id, user_id),
     make_spec_item(tenant_name, user_name),
-
-    /* Wildcards. */
-    make_spec_item(tenant_uuid, "*"),
+    make_spec_item(tenant_id, "*"),
     make_spec_item(tenant_name, "*"),
-    make_spec_item("*", user_uuid),
+    make_spec_item("*", user_id),
     make_spec_item("*", user_name),
+    make_spec_item("*", "*"),
   };
 
-  /* Lambda will obtain a copy of (not a reference to!) allowed_items. */
-  return [allowed_items, token_roles=token.roles](const rgw::auth::Identity::aclspec_t& aclspec) {
+  /* Capture allowed_items and roles by value so the strategy outlives token. */
+  return [allowed_items, token_roles=std::move(roles)](const rgw::auth::Identity::aclspec_t& aclspec) {
     uint32_t perm = 0;
 
     for (const auto& allowed_item : allowed_items) {
       const auto iter = aclspec.find(allowed_item);
-
       if (std::end(aclspec) != iter) {
         perm |= iter->second;
       }
     }
 
     for (const auto& r : token_roles) {
-      if (r.is_reader) {
-        if (r.is_admin) {
-          /* System scope reader defeats project-level permissions. */
-          perm |= RGW_OP_TYPE_READ;
-        }
+      if (r.is_reader && r.is_admin) {
+        /* System scope reader defeats project-level permissions. */
+        perm |= RGW_OP_TYPE_READ;
       }
     }
 
     return perm;
   };
+}
+
+static rgw::auth::RemoteApplier::acl_strategy_t
+keystone_acl_strategy_from_token(const rgw::keystone::TokenEnvelope& token)
+{
+  return make_keystone_acl_strategy(token.get_project_id(),
+                                    token.get_project_name(),
+                                    token.get_user_id(),
+                                    token.get_user_name(),
+                                    token.roles);
+}
+
+TokenEngine::acl_strategy_t
+TokenEngine::get_acl_strategy(const TokenEngine::token_envelope_t& token) const
+{
+  return keystone_acl_strategy_from_token(token);
 }
 
 TokenEngine::result_t
@@ -639,51 +650,7 @@ auto EC2Engine::get_access_token(const DoutPrefixProvider* dpp,
 EC2Engine::acl_strategy_t
 EC2Engine::get_acl_strategy(const EC2Engine::token_envelope_t& token) const
 {
-  /* The primary identity is constructed upon UUIDs. */
-  const auto& tenant_uuid = token.get_project_id();
-  const auto& user_uuid = token.get_user_id();
-
-  /* For Keystone v2 an alias may be also used. */
-  const auto& tenant_name = token.get_project_name();
-  const auto& user_name = token.get_user_name();
-
-  /* Construct all possible combinations including Swift's wildcards.
-   * This mirrors TokenEngine::get_acl_strategy() to allow S3 requests
-   * authenticated via Keystone to honor Swift-format ACL entries. */
-  const std::array<std::string, 6> allowed_items = {
-    make_spec_item(tenant_uuid, user_uuid),
-    make_spec_item(tenant_name, user_name),
-
-    /* Wildcards. */
-    make_spec_item(tenant_uuid, "*"),
-    make_spec_item(tenant_name, "*"),
-    make_spec_item("*", user_uuid),
-    make_spec_item("*", user_name),
-  };
-
-  /* Lambda will obtain a copy of (not a reference to!) allowed_items. */
-  return [allowed_items, token_roles=token.roles](const rgw::auth::Identity::aclspec_t& aclspec) {
-    uint32_t perm = 0;
-
-    for (const auto& allowed_item : allowed_items) {
-      const auto iter = aclspec.find(allowed_item);
-
-      if (std::end(aclspec) != iter) {
-        perm |= iter->second;
-      }
-    }
-
-    for (const auto& r : token_roles) {
-      if (r.is_reader) {
-        if (r.is_admin) {
-          /* System scope reader defeats project-level permissions. */
-          perm |= RGW_OP_TYPE_READ;
-        }
-      }
-    }
-
-    return perm;
-  };
+  return keystone_acl_strategy_from_token(token);
 }
 
 EC2Engine::auth_info_t

--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -217,11 +217,8 @@ TokenEngine::get_acl_strategy(const TokenEngine::token_envelope_t& token) const
 
     for (const auto& r : token_roles) {
       if (r.is_reader) {
-        if (r.is_admin) {    /* system scope reader persona */
-          /*
-           * Because system reader defeats permissions,
-           * we don't even look at the aclspec.
-           */
+        if (r.is_admin) {
+          /* System scope reader defeats project-level permissions. */
           perm |= RGW_OP_TYPE_READ;
         }
       }
@@ -640,11 +637,53 @@ auto EC2Engine::get_access_token(const DoutPrefixProvider* dpp,
 }
 
 EC2Engine::acl_strategy_t
-EC2Engine::get_acl_strategy(const EC2Engine::token_envelope_t&) const
+EC2Engine::get_acl_strategy(const EC2Engine::token_envelope_t& token) const
 {
-  /* This is based on the assumption that the default acl strategy in
-   * get_perms_from_aclspec, will take care. Extra acl spec is not required. */
-  return nullptr;
+  /* The primary identity is constructed upon UUIDs. */
+  const auto& tenant_uuid = token.get_project_id();
+  const auto& user_uuid = token.get_user_id();
+
+  /* For Keystone v2 an alias may be also used. */
+  const auto& tenant_name = token.get_project_name();
+  const auto& user_name = token.get_user_name();
+
+  /* Construct all possible combinations including Swift's wildcards.
+   * This mirrors TokenEngine::get_acl_strategy() to allow S3 requests
+   * authenticated via Keystone to honor Swift-format ACL entries. */
+  const std::array<std::string, 6> allowed_items = {
+    make_spec_item(tenant_uuid, user_uuid),
+    make_spec_item(tenant_name, user_name),
+
+    /* Wildcards. */
+    make_spec_item(tenant_uuid, "*"),
+    make_spec_item(tenant_name, "*"),
+    make_spec_item("*", user_uuid),
+    make_spec_item("*", user_name),
+  };
+
+  /* Lambda will obtain a copy of (not a reference to!) allowed_items. */
+  return [allowed_items, token_roles=token.roles](const rgw::auth::Identity::aclspec_t& aclspec) {
+    uint32_t perm = 0;
+
+    for (const auto& allowed_item : allowed_items) {
+      const auto iter = aclspec.find(allowed_item);
+
+      if (std::end(aclspec) != iter) {
+        perm |= iter->second;
+      }
+    }
+
+    for (const auto& r : token_roles) {
+      if (r.is_reader) {
+        if (r.is_admin) {
+          /* System scope reader defeats project-level permissions. */
+          perm |= RGW_OP_TYPE_READ;
+        }
+      }
+    }
+
+    return perm;
+  };
 }
 
 EC2Engine::auth_info_t

--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -183,52 +183,63 @@ make_spec_item(const std::string& tenant, const std::string& id)
   return tenant + ":" + id;
 }
 
-TokenEngine::acl_strategy_t
-TokenEngine::get_acl_strategy(const TokenEngine::token_envelope_t& token) const
+/* Mirrors Swift keystoneauth's _authorize_cross_tenant() Cartesian product
+ * over {tenant_id, tenant_name, '*'} x {user_id, user_name, '*'}, plus a
+ * system-reader role grant. Shared by TokenEngine and EC2Engine so S3 and
+ * Swift requests authenticated via Keystone evaluate ACLs identically. */
+rgw::auth::RemoteApplier::acl_strategy_t
+make_keystone_acl_strategy(const std::string& tenant_id,
+                           const std::string& tenant_name,
+                           const std::string& user_id,
+                           const std::string& user_name,
+                           std::list<rgw::keystone::TokenEnvelope::Role> roles)
 {
-  /* The primary identity is constructed upon UUIDs. */
-  const auto& tenant_uuid = token.get_project_id();
-  const auto& user_uuid = token.get_user_id();
-
-  /* For Keystone v2 an alias may be also used. */
-  const auto& tenant_name = token.get_project_name();
-  const auto& user_name = token.get_user_name();
-
-  /* Construct all possible combinations including Swift's wildcards. */
-  const std::array<std::string, 6> allowed_items = {
-    make_spec_item(tenant_uuid, user_uuid),
+  const std::array<std::string, 7> allowed_items = {
+    make_spec_item(tenant_id, user_id),
     make_spec_item(tenant_name, user_name),
-
-    /* Wildcards. */
-    make_spec_item(tenant_uuid, "*"),
+    make_spec_item(tenant_id, "*"),
     make_spec_item(tenant_name, "*"),
-    make_spec_item("*", user_uuid),
+    make_spec_item("*", user_id),
     make_spec_item("*", user_name),
+    make_spec_item("*", "*"),
   };
 
-  /* Lambda will obtain a copy of (not a reference to!) allowed_items. */
-  return [allowed_items, token_roles=token.roles](const rgw::auth::Identity::aclspec_t& aclspec) {
+  /* Capture allowed_items and roles by value so the strategy outlives token. */
+  return [allowed_items, token_roles=std::move(roles)](const rgw::auth::Identity::aclspec_t& aclspec) {
     uint32_t perm = 0;
 
     for (const auto& allowed_item : allowed_items) {
       const auto iter = aclspec.find(allowed_item);
-
       if (std::end(aclspec) != iter) {
         perm |= iter->second;
       }
     }
 
     for (const auto& r : token_roles) {
-      if (r.is_reader) {
-        if (r.is_admin) {
-          /* System scope reader defeats project-level permissions. */
-          perm |= RGW_OP_TYPE_READ;
-        }
+      if (r.is_reader && r.is_admin) {
+        /* System scope reader defeats project-level permissions. */
+        perm |= RGW_OP_TYPE_READ;
       }
     }
 
     return perm;
   };
+}
+
+static rgw::auth::RemoteApplier::acl_strategy_t
+keystone_acl_strategy_from_token(const rgw::keystone::TokenEnvelope& token)
+{
+  return make_keystone_acl_strategy(token.get_project_id(),
+                                    token.get_project_name(),
+                                    token.get_user_id(),
+                                    token.get_user_name(),
+                                    token.roles);
+}
+
+TokenEngine::acl_strategy_t
+TokenEngine::get_acl_strategy(const TokenEngine::token_envelope_t& token) const
+{
+  return keystone_acl_strategy_from_token(token);
 }
 
 TokenEngine::result_t
@@ -642,51 +653,7 @@ auto EC2Engine::get_access_token(const DoutPrefixProvider* dpp,
 EC2Engine::acl_strategy_t
 EC2Engine::get_acl_strategy(const EC2Engine::token_envelope_t& token) const
 {
-  /* The primary identity is constructed upon UUIDs. */
-  const auto& tenant_uuid = token.get_project_id();
-  const auto& user_uuid = token.get_user_id();
-
-  /* For Keystone v2 an alias may be also used. */
-  const auto& tenant_name = token.get_project_name();
-  const auto& user_name = token.get_user_name();
-
-  /* Construct all possible combinations including Swift's wildcards.
-   * This mirrors TokenEngine::get_acl_strategy() to allow S3 requests
-   * authenticated via Keystone to honor Swift-format ACL entries. */
-  const std::array<std::string, 6> allowed_items = {
-    make_spec_item(tenant_uuid, user_uuid),
-    make_spec_item(tenant_name, user_name),
-
-    /* Wildcards. */
-    make_spec_item(tenant_uuid, "*"),
-    make_spec_item(tenant_name, "*"),
-    make_spec_item("*", user_uuid),
-    make_spec_item("*", user_name),
-  };
-
-  /* Lambda will obtain a copy of (not a reference to!) allowed_items. */
-  return [allowed_items, token_roles=token.roles](const rgw::auth::Identity::aclspec_t& aclspec) {
-    uint32_t perm = 0;
-
-    for (const auto& allowed_item : allowed_items) {
-      const auto iter = aclspec.find(allowed_item);
-
-      if (std::end(aclspec) != iter) {
-        perm |= iter->second;
-      }
-    }
-
-    for (const auto& r : token_roles) {
-      if (r.is_reader) {
-        if (r.is_admin) {
-          /* System scope reader defeats project-level permissions. */
-          perm |= RGW_OP_TYPE_READ;
-        }
-      }
-    }
-
-    return perm;
-  };
+  return keystone_acl_strategy_from_token(token);
 }
 
 EC2Engine::auth_info_t

--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -220,11 +220,8 @@ TokenEngine::get_acl_strategy(const TokenEngine::token_envelope_t& token) const
 
     for (const auto& r : token_roles) {
       if (r.is_reader) {
-        if (r.is_admin) {    /* system scope reader persona */
-          /*
-           * Because system reader defeats permissions,
-           * we don't even look at the aclspec.
-           */
+        if (r.is_admin) {
+          /* System scope reader defeats project-level permissions. */
           perm |= RGW_OP_TYPE_READ;
         }
       }
@@ -643,11 +640,53 @@ auto EC2Engine::get_access_token(const DoutPrefixProvider* dpp,
 }
 
 EC2Engine::acl_strategy_t
-EC2Engine::get_acl_strategy(const EC2Engine::token_envelope_t&) const
+EC2Engine::get_acl_strategy(const EC2Engine::token_envelope_t& token) const
 {
-  /* This is based on the assumption that the default acl strategy in
-   * get_perms_from_aclspec, will take care. Extra acl spec is not required. */
-  return nullptr;
+  /* The primary identity is constructed upon UUIDs. */
+  const auto& tenant_uuid = token.get_project_id();
+  const auto& user_uuid = token.get_user_id();
+
+  /* For Keystone v2 an alias may be also used. */
+  const auto& tenant_name = token.get_project_name();
+  const auto& user_name = token.get_user_name();
+
+  /* Construct all possible combinations including Swift's wildcards.
+   * This mirrors TokenEngine::get_acl_strategy() to allow S3 requests
+   * authenticated via Keystone to honor Swift-format ACL entries. */
+  const std::array<std::string, 6> allowed_items = {
+    make_spec_item(tenant_uuid, user_uuid),
+    make_spec_item(tenant_name, user_name),
+
+    /* Wildcards. */
+    make_spec_item(tenant_uuid, "*"),
+    make_spec_item(tenant_name, "*"),
+    make_spec_item("*", user_uuid),
+    make_spec_item("*", user_name),
+  };
+
+  /* Lambda will obtain a copy of (not a reference to!) allowed_items. */
+  return [allowed_items, token_roles=token.roles](const rgw::auth::Identity::aclspec_t& aclspec) {
+    uint32_t perm = 0;
+
+    for (const auto& allowed_item : allowed_items) {
+      const auto iter = aclspec.find(allowed_item);
+
+      if (std::end(aclspec) != iter) {
+        perm |= iter->second;
+      }
+    }
+
+    for (const auto& r : token_roles) {
+      if (r.is_reader) {
+        if (r.is_admin) {
+          /* System scope reader defeats project-level permissions. */
+          perm |= RGW_OP_TYPE_READ;
+        }
+      }
+    }
+
+    return perm;
+  };
 }
 
 EC2Engine::auth_info_t

--- a/src/rgw/rgw_auth_keystone.h
+++ b/src/rgw/rgw_auth_keystone.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <list>
 #include <string_view>
 #include <utility>
 #include <boost/optional.hpp>
@@ -19,6 +20,16 @@ namespace keystone {
 /* Dedicated namespace for Keystone-related auth engines. We need it because
  * Keystone offers three different authentication mechanisms (token, EC2 and
  * regular user/pass). RadosGW actually does support the first two. */
+
+/* Build the ACL-matching strategy shared by TokenEngine (Swift) and
+ * EC2Engine (S3). Exposed here for unit testing; see rgw_auth_keystone.cc
+ * for the identity/wildcard matching semantics. */
+rgw::auth::RemoteApplier::acl_strategy_t
+make_keystone_acl_strategy(const std::string& tenant_id,
+                           const std::string& tenant_name,
+                           const std::string& user_id,
+                           const std::string& user_name,
+                           std::list<rgw::keystone::TokenEnvelope::Role> roles);
 
 class TokenEngine : public rgw::auth::Engine {
   CephContext* const cct;

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -124,6 +124,11 @@ add_executable(unittest_http_manager test_http_manager.cc)
 add_ceph_unittest(unittest_http_manager)
 target_link_libraries(unittest_http_manager ${rgw_libs})
 
+# unittest_rgw_auth_keystone
+add_executable(unittest_rgw_auth_keystone test_rgw_auth_keystone.cc)
+add_ceph_unittest(unittest_rgw_auth_keystone)
+target_link_libraries(unittest_rgw_auth_keystone ${rgw_libs})
+
 if(WITH_RADOSGW_RADOS)
 # unittest_rgw_reshard_wait
 add_executable(unittest_rgw_reshard_wait test_rgw_reshard_wait.cc)

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -158,6 +158,11 @@ add_executable(unittest_http_manager test_http_manager.cc)
 add_ceph_unittest(unittest_http_manager)
 target_link_libraries(unittest_http_manager ${rgw_libs})
 
+# unittest_rgw_auth_keystone
+add_executable(unittest_rgw_auth_keystone test_rgw_auth_keystone.cc)
+add_ceph_unittest(unittest_rgw_auth_keystone)
+target_link_libraries(unittest_rgw_auth_keystone ${rgw_libs})
+
 if(WITH_RADOSGW_RADOS)
 # unittest_rgw_reshard_wait
 add_executable(unittest_rgw_reshard_wait test_rgw_reshard_wait.cc)

--- a/src/test/rgw/test_rgw_auth_keystone.cc
+++ b/src/test/rgw/test_rgw_auth_keystone.cc
@@ -1,0 +1,182 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+#include <list>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "rgw_auth.h"
+#include "rgw_common.h"
+#include "rgw_keystone.h"
+
+namespace rgw::auth::keystone {
+
+rgw::auth::RemoteApplier::acl_strategy_t
+make_keystone_acl_strategy(const std::string& tenant_id,
+                           const std::string& tenant_name,
+                           const std::string& user_id,
+                           const std::string& user_name,
+                           std::list<rgw::keystone::TokenEnvelope::Role> roles);
+
+} // namespace rgw::auth::keystone
+
+namespace {
+
+constexpr const char* kTenantId   = "11111111111111111111111111111111";
+constexpr const char* kTenantName = "shared";
+constexpr const char* kUserId     = "22222222222222222222222222222222";
+constexpr const char* kUserName   = "consumer1";
+
+rgw::auth::RemoteApplier::acl_strategy_t make_strategy_no_roles()
+{
+  return rgw::auth::keystone::make_keystone_acl_strategy(
+      kTenantId, kTenantName, kUserId, kUserName, {});
+}
+
+rgw::auth::Identity::aclspec_t single_grant(const std::string& key, uint32_t perm)
+{
+  rgw::auth::Identity::aclspec_t spec;
+  spec[key] = perm;
+  return spec;
+}
+
+} // namespace
+
+TEST(KeystoneAclStrategy, MatchesProjectIdUserId)
+{
+  auto strategy = make_strategy_no_roles();
+  const auto spec = single_grant(std::string{kTenantId} + ":" + kUserId,
+                                 RGW_OP_TYPE_READ);
+  EXPECT_EQ(RGW_OP_TYPE_READ, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, MatchesProjectNameUserName)
+{
+  auto strategy = make_strategy_no_roles();
+  const auto spec = single_grant(std::string{kTenantName} + ":" + kUserName,
+                                 RGW_OP_TYPE_WRITE);
+  EXPECT_EQ(RGW_OP_TYPE_WRITE, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, MatchesProjectIdWildcardUser)
+{
+  auto strategy = make_strategy_no_roles();
+  const auto spec = single_grant(std::string{kTenantId} + ":*",
+                                 RGW_OP_TYPE_READ);
+  EXPECT_EQ(RGW_OP_TYPE_READ, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, MatchesProjectNameWildcardUser)
+{
+  auto strategy = make_strategy_no_roles();
+  const auto spec = single_grant(std::string{kTenantName} + ":*",
+                                 RGW_OP_TYPE_READ);
+  EXPECT_EQ(RGW_OP_TYPE_READ, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, MatchesWildcardTenantUserId)
+{
+  auto strategy = make_strategy_no_roles();
+  const auto spec = single_grant(std::string{"*:"} + kUserId,
+                                 RGW_OP_TYPE_READ);
+  EXPECT_EQ(RGW_OP_TYPE_READ, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, MatchesWildcardTenantUserName)
+{
+  auto strategy = make_strategy_no_roles();
+  const auto spec = single_grant(std::string{"*:"} + kUserName,
+                                 RGW_OP_TYPE_READ);
+  EXPECT_EQ(RGW_OP_TYPE_READ, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, MatchesAuthenticatedWildcard)
+{
+  auto strategy = make_strategy_no_roles();
+  const auto spec = single_grant("*:*", RGW_OP_TYPE_READ);
+  EXPECT_EQ(RGW_OP_TYPE_READ, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, OrsMultipleMatchingGrants)
+{
+  auto strategy = make_strategy_no_roles();
+  rgw::auth::Identity::aclspec_t spec;
+  spec[std::string{kTenantId} + ":" + kUserId] = RGW_OP_TYPE_READ;
+  spec[std::string{kTenantId} + ":*"] = RGW_OP_TYPE_WRITE;
+  EXPECT_EQ(RGW_OP_TYPE_READ | RGW_OP_TYPE_WRITE, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, NoMatchReturnsZero)
+{
+  auto strategy = make_strategy_no_roles();
+  const auto spec = single_grant("other_tenant:other_user", RGW_OP_TYPE_READ);
+  EXPECT_EQ(0u, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, EmptyAclspecReturnsZero)
+{
+  auto strategy = make_strategy_no_roles();
+  rgw::auth::Identity::aclspec_t spec;
+  EXPECT_EQ(0u, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, BareRoleNameIsNotHonored)
+{
+  /* Bare role-name ACL elements are intentionally unsupported until the
+   * acl_strategy_t callback can see the bucket owner; otherwise a role
+   * shared across projects would leak access. See PR #68795 commit message. */
+  rgw::keystone::TokenEnvelope::Role member;
+  member.name = "Member";
+  std::list<rgw::keystone::TokenEnvelope::Role> roles{member};
+
+  auto strategy = rgw::auth::keystone::make_keystone_acl_strategy(
+      kTenantId, kTenantName, kUserId, kUserName, std::move(roles));
+  const auto spec = single_grant("Member", RGW_OP_TYPE_READ);
+  EXPECT_EQ(0u, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, SystemReaderAdminGrantsRead)
+{
+  rgw::keystone::TokenEnvelope::Role role;
+  role.name = "system-reader";
+  role.is_reader = true;
+  role.is_admin = true;
+  std::list<rgw::keystone::TokenEnvelope::Role> roles{role};
+
+  auto strategy = rgw::auth::keystone::make_keystone_acl_strategy(
+      kTenantId, kTenantName, kUserId, kUserName, std::move(roles));
+
+  rgw::auth::Identity::aclspec_t empty;
+  EXPECT_EQ(static_cast<uint32_t>(RGW_OP_TYPE_READ), strategy(empty));
+}
+
+TEST(KeystoneAclStrategy, ReaderWithoutAdminDoesNotGrant)
+{
+  rgw::keystone::TokenEnvelope::Role role;
+  role.name = "reader";
+  role.is_reader = true;
+  role.is_admin = false;
+  std::list<rgw::keystone::TokenEnvelope::Role> roles{role};
+
+  auto strategy = rgw::auth::keystone::make_keystone_acl_strategy(
+      kTenantId, kTenantName, kUserId, kUserName, std::move(roles));
+
+  rgw::auth::Identity::aclspec_t empty;
+  EXPECT_EQ(0u, strategy(empty));
+}
+
+TEST(KeystoneAclStrategy, SystemReaderAddsToAclMatchedPerm)
+{
+  rgw::keystone::TokenEnvelope::Role role;
+  role.name = "system-reader";
+  role.is_reader = true;
+  role.is_admin = true;
+  std::list<rgw::keystone::TokenEnvelope::Role> roles{role};
+
+  auto strategy = rgw::auth::keystone::make_keystone_acl_strategy(
+      kTenantId, kTenantName, kUserId, kUserName, std::move(roles));
+  const auto spec = single_grant(std::string{kTenantId} + ":" + kUserId,
+                                 RGW_OP_TYPE_WRITE);
+  EXPECT_EQ(RGW_OP_TYPE_READ | RGW_OP_TYPE_WRITE, strategy(spec));
+}

--- a/src/test/rgw/test_rgw_auth_keystone.cc
+++ b/src/test/rgw/test_rgw_auth_keystone.cc
@@ -1,0 +1,172 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+#include <list>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "rgw_auth.h"
+#include "rgw_auth_keystone.h"
+#include "rgw_common.h"
+#include "rgw_keystone.h"
+
+namespace {
+
+constexpr const char* TENANT_ID   = "11111111111111111111111111111111";
+constexpr const char* TENANT_NAME = "shared";
+constexpr const char* USER_ID     = "22222222222222222222222222222222";
+constexpr const char* USER_NAME   = "consumer1";
+
+rgw::auth::RemoteApplier::acl_strategy_t make_strategy_no_roles()
+{
+  return rgw::auth::keystone::make_keystone_acl_strategy(
+      TENANT_ID, TENANT_NAME, USER_ID, USER_NAME, {});
+}
+
+rgw::auth::Identity::aclspec_t single_grant(const std::string& key, uint32_t perm)
+{
+  rgw::auth::Identity::aclspec_t spec;
+  spec[key] = perm;
+  return spec;
+}
+
+} // namespace
+
+TEST(KeystoneAclStrategy, MatchesProjectIdUserId)
+{
+  auto strategy = make_strategy_no_roles();
+  const auto spec = single_grant(std::string{TENANT_ID} + ":" + USER_ID,
+                                 RGW_OP_TYPE_READ);
+  EXPECT_EQ(RGW_OP_TYPE_READ, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, MatchesProjectNameUserName)
+{
+  auto strategy = make_strategy_no_roles();
+  const auto spec = single_grant(std::string{TENANT_NAME} + ":" + USER_NAME,
+                                 RGW_OP_TYPE_WRITE);
+  EXPECT_EQ(RGW_OP_TYPE_WRITE, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, MatchesProjectIdWildcardUser)
+{
+  auto strategy = make_strategy_no_roles();
+  const auto spec = single_grant(std::string{TENANT_ID} + ":*",
+                                 RGW_OP_TYPE_READ);
+  EXPECT_EQ(RGW_OP_TYPE_READ, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, MatchesProjectNameWildcardUser)
+{
+  auto strategy = make_strategy_no_roles();
+  const auto spec = single_grant(std::string{TENANT_NAME} + ":*",
+                                 RGW_OP_TYPE_READ);
+  EXPECT_EQ(RGW_OP_TYPE_READ, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, MatchesWildcardTenantUserId)
+{
+  auto strategy = make_strategy_no_roles();
+  const auto spec = single_grant(std::string{"*:"} + USER_ID,
+                                 RGW_OP_TYPE_READ);
+  EXPECT_EQ(RGW_OP_TYPE_READ, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, MatchesWildcardTenantUserName)
+{
+  auto strategy = make_strategy_no_roles();
+  const auto spec = single_grant(std::string{"*:"} + USER_NAME,
+                                 RGW_OP_TYPE_READ);
+  EXPECT_EQ(RGW_OP_TYPE_READ, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, MatchesAuthenticatedWildcard)
+{
+  auto strategy = make_strategy_no_roles();
+  const auto spec = single_grant("*:*", RGW_OP_TYPE_READ);
+  EXPECT_EQ(RGW_OP_TYPE_READ, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, OrsMultipleMatchingGrants)
+{
+  auto strategy = make_strategy_no_roles();
+  rgw::auth::Identity::aclspec_t spec;
+  spec[std::string{TENANT_ID} + ":" + USER_ID] = RGW_OP_TYPE_READ;
+  spec[std::string{TENANT_ID} + ":*"] = RGW_OP_TYPE_WRITE;
+  EXPECT_EQ(RGW_OP_TYPE_READ | RGW_OP_TYPE_WRITE, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, NoMatchReturnsZero)
+{
+  auto strategy = make_strategy_no_roles();
+  const auto spec = single_grant("other_tenant:other_user", RGW_OP_TYPE_READ);
+  EXPECT_EQ(0u, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, EmptyAclspecReturnsZero)
+{
+  auto strategy = make_strategy_no_roles();
+  rgw::auth::Identity::aclspec_t spec;
+  EXPECT_EQ(0u, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, BareRoleNameIsNotHonored)
+{
+  /* Bare role-name ACL elements are intentionally unsupported until the
+   * acl_strategy_t callback can see the bucket owner; otherwise a role
+   * shared across projects would leak access. See PR #68795 commit message. */
+  rgw::keystone::TokenEnvelope::Role member;
+  member.name = "Member";
+  std::list<rgw::keystone::TokenEnvelope::Role> roles{member};
+
+  auto strategy = rgw::auth::keystone::make_keystone_acl_strategy(
+      TENANT_ID, TENANT_NAME, USER_ID, USER_NAME, std::move(roles));
+  const auto spec = single_grant("Member", RGW_OP_TYPE_READ);
+  EXPECT_EQ(0u, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, SystemReaderAdminGrantsRead)
+{
+  rgw::keystone::TokenEnvelope::Role role;
+  role.name = "system-reader";
+  role.is_reader = true;
+  role.is_admin = true;
+  std::list<rgw::keystone::TokenEnvelope::Role> roles{role};
+
+  auto strategy = rgw::auth::keystone::make_keystone_acl_strategy(
+      TENANT_ID, TENANT_NAME, USER_ID, USER_NAME, std::move(roles));
+
+  rgw::auth::Identity::aclspec_t empty;
+  EXPECT_EQ(static_cast<uint32_t>(RGW_OP_TYPE_READ), strategy(empty));
+}
+
+TEST(KeystoneAclStrategy, ReaderWithoutAdminDoesNotGrant)
+{
+  rgw::keystone::TokenEnvelope::Role role;
+  role.name = "reader";
+  role.is_reader = true;
+  role.is_admin = false;
+  std::list<rgw::keystone::TokenEnvelope::Role> roles{role};
+
+  auto strategy = rgw::auth::keystone::make_keystone_acl_strategy(
+      TENANT_ID, TENANT_NAME, USER_ID, USER_NAME, std::move(roles));
+
+  rgw::auth::Identity::aclspec_t empty;
+  EXPECT_EQ(0u, strategy(empty));
+}
+
+TEST(KeystoneAclStrategy, SystemReaderAddsToAclMatchedPerm)
+{
+  rgw::keystone::TokenEnvelope::Role role;
+  role.name = "system-reader";
+  role.is_reader = true;
+  role.is_admin = true;
+  std::list<rgw::keystone::TokenEnvelope::Role> roles{role};
+
+  auto strategy = rgw::auth::keystone::make_keystone_acl_strategy(
+      TENANT_ID, TENANT_NAME, USER_ID, USER_NAME, std::move(roles));
+  const auto spec = single_grant(std::string{TENANT_ID} + ":" + USER_ID,
+                                 RGW_OP_TYPE_WRITE);
+  EXPECT_EQ(RGW_OP_TYPE_READ | RGW_OP_TYPE_WRITE, strategy(spec));
+}


### PR DESCRIPTION
## Summary

When Keystone is the identity provider, ACLs set via the Swift API were not
honored by S3 API requests. The root cause: `EC2Engine::get_acl_strategy()`
returned `nullptr`, so S3 requests only matched ACLs by the bare `project_id`
string (via the default strategy in `RemoteApplier::get_perms_from_aclspec()`).
Swift ACLs store grantees in `project:user` colon-separated format, which the
default strategy cannot match.

This patch implements a complete ACL strategy in `EC2Engine::get_acl_strategy()`
mirroring the existing `TokenEngine::get_acl_strategy()` logic, factors the
shared body into one helper, and adds the authenticated wildcard `*:*`.

### Changes (`src/rgw/rgw_auth_keystone.cc`)

1. Replace the `EC2Engine::get_acl_strategy()` stub with a real strategy.
2. Hoist the duplicated body into a free function
   `rgw::auth::keystone::make_keystone_acl_strategy()` taking plain strings
   and a roles list. Both engines now go through a thin envelope adapter,
   `keystone_acl_strategy_from_token()`. Behaviour is identical between
   Swift and S3 by construction.
3. Add `make_spec_item("*", "*")` to `allowed_items`. Swift's
   `keystoneauth._authorize_cross_tenant()` iterates the full
   `{tenant_id, tenant_name, '*'} x {user_id, user_name, '*'}` Cartesian
   product, so containers with `X-Container-Read: *:*` must grant read to
   any authenticated Keystone user. The previous six-element array silently
   denied this case in both engines.

### Tests (`src/test/rgw/test_rgw_auth_keystone.cc`)

New `unittest_rgw_auth_keystone` covering:

- All six identity combinations (`project_id:user_id`, `name:name`,
  `project_id:*`, `name:*`, `*:user_id`, `*:user_name`)
- The new `*:*` authenticated wildcard
- OR-ing of multiple matching grants
- No-match and empty aclspec return zero permissions
- System-reader admin role grants `RGW_OP_TYPE_READ`
- Reader-without-admin does not grant
- Bare role-name ACL elements are *not* honored (pinned deliberately —
  see "Out of scope" below)

### Out of scope: bare-role-name ACLs (#68476)

Bare Keystone role names (e.g. `X-Container-Read: Member`) are not matched
against the aclspec. Swift's `keystoneauth` middleware scopes role-name ACL
elements to the project that owns the container (the tenant-mismatch gate
runs before the user_role-in-roles loop in
`swift/common/middleware/keystoneauth.py`). The `acl_strategy_t` callback in
RGW does not see the bucket owner, so a bare-role-name lookup here would
grant the permission to any token carrying that role regardless of project
scope, leaking access across Keystone projects in multi-tenant clouds.
Project-scoped role-name ACLs require a separate change that threads the
container/bucket owner through ACL evaluation.

### How it works

`RemoteApplier::get_perms_from_aclspec()` calls `extra_acl_strategy(aclspec)`
if non-null and ORs the result into the permission mask. Returning a real
strategy from `EC2Engine::get_acl_strategy()` lets S3 Keystone requests
match Swift-format identity strings in the ACL spec map.

### Documentation (`doc/radosgw/keystone.rst`)

Documents the cross-API ACL interoperability behavior and the supported
grant formats.

### Test plan

- Build: `cd build && ninja bin/radosgw bin/unittest_rgw_auth_keystone`
- Unit: `ctest -R unittest_rgw_auth_keystone`
- Existing: `ctest -R rgw` (no regressions)
- Manual integration test with vstart + Keystone:
  1. Set container read ACL via Swift to `project_id:user_id`
  2. Access that container via S3 as that user → access granted
  3. Set container read ACL via Swift to `*:*`
  4. Access via S3 with any authenticated Keystone user → access granted
  5. Verify a user with neither matching identity nor any wildcard grant
     is denied

Fixes: https://tracker.ceph.com/issues/68492
Refs:  https://tracker.ceph.com/issues/68476

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
