### PR TITLE
squid: aio_cxx: Fix mutual deadlock and resolve test unreliability

### DIFF
--- a/src/test/librados/aio_cxx.cc
+++ b/src/test/librados/aio_cxx.cc
@@ -2331,6 +2331,7 @@ ceph::mutex my_lock = ceph::make_mutex("my_lock");
 set<unsigned> inflight;
 unsigned max_success = 0;
 unsigned min_failed = 0;
+std::condition_variable_any cv_inflight;
 
 struct io_info {
   unsigned i;
@@ -2358,6 +2359,9 @@ void pool_io_callback(completion_t cb, void *arg /* Actually AioCompletion* */)
     if (!min_failed || i < min_failed) {
       min_failed = i;
     }
+    if (inflight.empty()) {
+      cv_inflight.notify_all();
+    }
   }
 }
 
@@ -2370,15 +2374,32 @@ TEST(LibRadosAio, PoolEIOFlag) {
   std::unique_ptr<std::thread> t;
   std::atomic<bool> missed_eio{false};
   
-  unsigned max = 100;
-  unsigned timeout = max * 10;
+  auto start_time = std::chrono::steady_clock::now();
+  const int max_run_seconds = 30;
   unsigned long i = 1;
-  for (; min_failed == 0 && i <= timeout; ++i) {
+
+  while (true) {
+    {
+      std::unique_lock l(my_lock);
+      if (min_failed != 0) {
+            break;
+      }
+      inflight.insert(i);
+    }
     io_info *info = new io_info;
     info->i = i;
     info->c = Rados::aio_create_completion();
     info->c->set_complete_callback((void*)info, pool_io_callback);
     int r = test_data.m_ioctx.aio_write(test_data.m_oid, info->c, bl, bl.length(), 0);
+    if (r < 0) {
+      std::cout << "Race caught: aio_write returned " << r << " at index " << i << std::endl;
+      std::scoped_lock l(my_lock);
+      inflight.erase(i);
+      if (inflight.empty()) {
+        cv_inflight.notify_all();
+      }
+      break;
+    }
 
     // Trigger EIO after 100 ops have been submitted
     if (i == 100) {
@@ -2392,33 +2413,41 @@ TEST(LibRadosAio, PoolEIOFlag) {
             "val": "true"
             }})", test_data.m_pool_name),
           {}, nullptr, nullptr));
-
-        {
-          std::scoped_lock lk(my_lock);
-          missed_eio = (!min_failed && max_success == max);
-        }
       });
     }
 
-    std::this_thread::sleep_for(10ms);
-    my_lock.lock();
-    if (r < 0) {
-      inflight.erase(i);
-      break;
+    // Timeout to avoid infinite loop in case EIO never takes effect
+    // Check every 100 ops if we've exceeded max run time
+    if (i % 100 == 0) {
+      auto now = std::chrono::steady_clock::now();
+      if (std::chrono::duration_cast<std::chrono::seconds>(now - start_time).count() > max_run_seconds) {
+        // Stop loop if EIO never happened (Cluster issue?)
+        std::cout << "Timed out waiting for EIO to take effect after " << i << " ops" << std::endl;
+        missed_eio = true;
+        break;
+      }
+    }
+    i++;
+  }
+
+  {
+    std::unique_lock l(my_lock);
+    std::cout << "waiting for inflight ios to complete, count=" << inflight.size() << std::endl;
+    bool finished = cv_inflight.wait_for(l, std::chrono::seconds(60), []{ 
+      return inflight.empty(); 
+    });
+    if (!finished) {
+      GTEST_FAIL() << "timeout waiting for inflight ios to complete";
     }
   }
   if (t && t->joinable()) {
     t->join();
   }
 
-  // wait for ios to finish
-  for (; !inflight.empty(); ++i) {
-    cout << "waiting for " << inflight.size() << std::endl;
-    my_lock.unlock();
-    sleep(1);
-    my_lock.lock();
+  std::scoped_lock l(my_lock);
+  if (missed_eio) {
+    GTEST_SKIP() << "eio flag missed all ios that already completed";
   }
-
   cout << "max_success " << max_success << ", min_failed " << min_failed << std::endl;
   ASSERT_TRUE(min_failed > 0) << "Did not catch any EIO errors";
   ASSERT_TRUE(max_success + 1 == min_failed);

--- a/src/test/librados/aio_cxx.cc
+++ b/src/test/librados/aio_cxx.cc
@@ -27,7 +27,7 @@ class AioTestDataPP
 {
 public:
   AioTestDataPP()
-    : m_init(false),    
+    : m_init(false),
       m_oid("foo")
   {
   }
@@ -2367,36 +2367,37 @@ TEST(LibRadosAio, PoolEIOFlag) {
 
   bufferlist bl;
   bl.append("some data");
-  std::thread *t = nullptr;
+  std::unique_ptr<std::thread> t;
+  std::atomic<bool> missed_eio{false};
   
   unsigned max = 100;
   unsigned timeout = max * 10;
   unsigned long i = 1;
-  my_lock.lock();
   for (; min_failed == 0 && i <= timeout; ++i) {
     io_info *info = new io_info;
     info->i = i;
     info->c = Rados::aio_create_completion();
     info->c->set_complete_callback((void*)info, pool_io_callback);
-    inflight.insert(i);
-    my_lock.unlock();
     int r = test_data.m_ioctx.aio_write(test_data.m_oid, info->c, bl, bl.length(), 0);
-    //cout << "start " << i << " r = " << r << std::endl;
 
-    if (i == max / 2) {
-      cout << "setting pool EIO" << std::endl;
-      t = new std::thread(
-	[&] {
-	  bufferlist empty;
-	  ASSERT_EQ(0, test_data.m_cluster.mon_command(
-	    fmt::format(R"({{
-	                "prefix": "osd pool set",
-	                "pool": "{}",
-	                "var": "eio",
-	                "val": "true"
-	                }})", test_data.m_pool_name),
-	    empty, nullptr, nullptr));
-	});
+    // Trigger EIO after 100 ops have been submitted
+    if (i == 100) {
+      t = std::make_unique<std::thread>([&] {
+        cout << "sending pool EIO time: " << ceph_clock_now() << std::endl;
+        ASSERT_EQ(0, test_data.m_cluster.mon_command(
+          fmt::format(R"({{
+            "prefix": "osd pool set",
+            "pool": "{}",
+            "var": "eio",
+            "val": "true"
+            }})", test_data.m_pool_name),
+          {}, nullptr, nullptr));
+
+        {
+          std::scoped_lock lk(my_lock);
+          missed_eio = (!min_failed && max_success == max);
+        }
+      });
     }
 
     std::this_thread::sleep_for(10ms);
@@ -2406,8 +2407,9 @@ TEST(LibRadosAio, PoolEIOFlag) {
       break;
     }
   }
-  t->join();
-  delete t;
+  if (t && t->joinable()) {
+    t->join();
+  }
 
   // wait for ios to finish
   for (; !inflight.empty(); ++i) {
@@ -2418,8 +2420,8 @@ TEST(LibRadosAio, PoolEIOFlag) {
   }
 
   cout << "max_success " << max_success << ", min_failed " << min_failed << std::endl;
+  ASSERT_TRUE(min_failed > 0) << "Did not catch any EIO errors";
   ASSERT_TRUE(max_success + 1 == min_failed);
-  my_lock.unlock();
 }
 
 // This test case reproduces https://tracker.ceph.com/issues/57152


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76453

---

backport of https://github.com/ceph/ceph/pull/66430
parent tracker: https://tracker.ceph.com/issues/73946

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh