### PR TITLE
rgw: add project-scoped reader role support for Keystone

### DIFF
--- a/doc/radosgw/keystone.rst
+++ b/doc/radosgw/keystone.rst
@@ -199,3 +199,26 @@ Enabling this will cause an expired token given in the ``X-Auth-Token`` header t
 if coupled with a ``X-Service-Token`` header that contains a valid token with the accepted
 roles. This can allow long running processes using a user token in ``X-Auth-Token`` to function
 beyond the expiration of the token.
+
+Swift and S3 ACL Interoperability
+---------------------------------
+
+When Keystone is the identity provider, ACLs set via the Swift API are
+automatically honored by S3 API requests (and vice versa). This enables
+mixed deployments where some clients use Swift and others use S3 to access
+the same buckets/containers.
+
+The following ACL grant formats are supported for cross-API access:
+
+- **Project:User grants** (e.g., ``project_id:user_id``): ACLs using the
+  ``project:user`` format set via Swift container ACLs are matched against
+  S3 Keystone-authenticated requests by comparing all combinations of
+  project/user UUIDs and names.
+
+- **Role-based grants**: Swift container ACLs can grant access to a bare
+  Keystone role name (e.g., ``X-Container-Read: Member``). Any user whose
+  Keystone token carries that role will be granted the corresponding
+  permission, regardless of whether the request arrives via Swift or S3.
+
+- **Wildcard grants**: Standard Swift wildcards (``project_id:*``,
+  ``*:user_id``) are supported for both Swift and S3 access.

--- a/doc/radosgw/keystone.rst
+++ b/doc/radosgw/keystone.rst
@@ -222,3 +222,28 @@ The following ACL grant formats are supported for cross-API access:
 
 - **Wildcard grants**: Standard Swift wildcards (``project_id:*``,
   ``*:user_id``) are supported for both Swift and S3 access.
+
+Reader Roles
+------------
+
+The ``rgw keystone accepted reader roles`` option lists Keystone roles that
+grant implicit read access. The behavior depends on whether the user also
+holds an admin role:
+
+- **System-scope reader** (role is in both ``rgw keystone accepted reader roles``
+  and ``rgw keystone accepted admin roles``): The user gets unconditional read
+  access across all projects, bypassing ACLs entirely.
+
+- **Project-scope reader** (role is in ``rgw keystone accepted reader roles``
+  only): The user gets implicit read access to resources within their own
+  Keystone project. Write operations are denied unless separately granted
+  via ACLs.
+
+This option defaults to empty. No reader behavior is enabled unless the
+operator explicitly configures it::
+
+   rgw keystone accepted reader roles = reader
+
+Users whose only Keystone role is a reader role do not need to be
+separately listed in ``rgw keystone accepted roles``; the reader role
+configuration is sufficient for authentication.

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -917,7 +917,11 @@ options:
 - name: rgw_keystone_accepted_reader_roles
   type: str
   level: advanced
-  desc: List of roles that can only be used for reads (Keystone).
+  desc: >
+    List of roles granting implicit read access (Keystone). Users with
+    a role listed here AND an admin role get system-scope read (bypassing
+    ACLs). Users with only a reader role get project-scope read (read
+    access within their Keystone project).
   services:
   - rgw
   with_legacy: true

--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -230,6 +230,9 @@ TokenEngine::get_acl_strategy(const TokenEngine::token_envelope_t& token) const
         if (r.is_admin) {
           /* System scope reader defeats project-level permissions. */
           perm |= RGW_OP_TYPE_READ;
+        } else {
+          /* Project scope reader grants read within the project. */
+          perm |= RGW_PERM_READ;
         }
       }
     }
@@ -258,6 +261,8 @@ TokenEngine::authenticate(const DoutPrefixProvider* dpp,
 
       /* Let's suppose that having an admin role implies also a regular one. */
       plain.insert(std::end(plain), std::begin(admin), std::end(admin));
+      /* A reader role also implies a regular one. */
+      plain.insert(std::end(plain), std::begin(reader), std::end(reader));
     }
 
     std::vector<std::string> plain;
@@ -698,6 +703,9 @@ EC2Engine::get_acl_strategy(const EC2Engine::token_envelope_t& token) const
         if (r.is_admin) {
           /* System scope reader defeats project-level permissions. */
           perm |= RGW_OP_TYPE_READ;
+        } else {
+          /* Project scope reader grants read within the project. */
+          perm |= RGW_PERM_READ;
         }
       }
     }
@@ -761,13 +769,17 @@ rgw::auth::Engine::result_t EC2Engine::authenticate(
     explicit RolesCacher(CephContext* const cct) {
       get_str_vec(cct->_conf->rgw_keystone_accepted_roles, plain);
       get_str_vec(cct->_conf->rgw_keystone_accepted_admin_roles, admin);
+      get_str_vec(cct->_conf->rgw_keystone_accepted_reader_roles, reader);
 
       /* Let's suppose that having an admin role implies also a regular one. */
       plain.insert(std::end(plain), std::begin(admin), std::end(admin));
+      /* A reader role also implies a regular one. */
+      plain.insert(std::end(plain), std::begin(reader), std::end(reader));
     }
 
     std::vector<std::string> plain;
     std::vector<std::string> admin;
+    std::vector<std::string> reader;
   } accepted_roles(cct);
 
   /* When we handle a HTTP OPTIONS call we must ignore the signature */
@@ -793,6 +805,8 @@ rgw::auth::Engine::result_t EC2Engine::authenticate(
                   << " expired: " << t->get_expires() << dendl;
     return result_t::deny();
   }
+
+  t->update_roles(accepted_roles.admin, accepted_roles.reader);
 
   /* check if we have a valid role */
   bool found = false;

--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -215,13 +215,20 @@ TokenEngine::get_acl_strategy(const TokenEngine::token_envelope_t& token) const
       }
     }
 
+    /* Match Keystone role names against the ACL spec map. Swift container
+     * ACLs can grant access to bare role names (stored without a tenant
+     * prefix), so we look up each role the token carries. */
+    for (const auto& r : token_roles) {
+      const auto iter = aclspec.find(r.name);
+      if (std::end(aclspec) != iter) {
+        perm |= iter->second;
+      }
+    }
+
     for (const auto& r : token_roles) {
       if (r.is_reader) {
-        if (r.is_admin) {    /* system scope reader persona */
-          /*
-           * Because system reader defeats permissions,
-           * we don't even look at the aclspec.
-           */
+        if (r.is_admin) {
+          /* System scope reader defeats project-level permissions. */
           perm |= RGW_OP_TYPE_READ;
         }
       }
@@ -640,11 +647,63 @@ auto EC2Engine::get_access_token(const DoutPrefixProvider* dpp,
 }
 
 EC2Engine::acl_strategy_t
-EC2Engine::get_acl_strategy(const EC2Engine::token_envelope_t&) const
+EC2Engine::get_acl_strategy(const EC2Engine::token_envelope_t& token) const
 {
-  /* This is based on the assumption that the default acl strategy in
-   * get_perms_from_aclspec, will take care. Extra acl spec is not required. */
-  return nullptr;
+  /* The primary identity is constructed upon UUIDs. */
+  const auto& tenant_uuid = token.get_project_id();
+  const auto& user_uuid = token.get_user_id();
+
+  /* For Keystone v2 an alias may be also used. */
+  const auto& tenant_name = token.get_project_name();
+  const auto& user_name = token.get_user_name();
+
+  /* Construct all possible combinations including Swift's wildcards.
+   * This mirrors TokenEngine::get_acl_strategy() to allow S3 requests
+   * authenticated via Keystone to honor Swift-format ACL entries. */
+  const std::array<std::string, 6> allowed_items = {
+    make_spec_item(tenant_uuid, user_uuid),
+    make_spec_item(tenant_name, user_name),
+
+    /* Wildcards. */
+    make_spec_item(tenant_uuid, "*"),
+    make_spec_item(tenant_name, "*"),
+    make_spec_item("*", user_uuid),
+    make_spec_item("*", user_name),
+  };
+
+  /* Lambda will obtain a copy of (not a reference to!) allowed_items. */
+  return [allowed_items, token_roles=token.roles](const rgw::auth::Identity::aclspec_t& aclspec) {
+    uint32_t perm = 0;
+
+    for (const auto& allowed_item : allowed_items) {
+      const auto iter = aclspec.find(allowed_item);
+
+      if (std::end(aclspec) != iter) {
+        perm |= iter->second;
+      }
+    }
+
+    /* Match Keystone role names against the ACL spec map. Swift container
+     * ACLs can grant access to bare role names (stored without a tenant
+     * prefix), so we look up each role the token carries. */
+    for (const auto& r : token_roles) {
+      const auto iter = aclspec.find(r.name);
+      if (std::end(aclspec) != iter) {
+        perm |= iter->second;
+      }
+    }
+
+    for (const auto& r : token_roles) {
+      if (r.is_reader) {
+        if (r.is_admin) {
+          /* System scope reader defeats project-level permissions. */
+          perm |= RGW_OP_TYPE_READ;
+        }
+      }
+    }
+
+    return perm;
+  };
 }
 
 EC2Engine::auth_info_t


### PR DESCRIPTION
## Summary

Extends the Keystone reader role feature to support project-scoped readers, complementing the existing system-scope reader persona introduced in 07f947684cc.

- **EC2Engine (S3)**: Load reader roles from `rgw_keystone_accepted_reader_roles` and call `update_roles()` — previously the reader check in EC2Engine was dead code.
- **Both engines**: Add reader roles to the acceptance gate so reader-only users authenticate without needing a separate entry in `rgw_keystone_accepted_roles`.
- **Both ACL strategies**: Project-scoped readers (`is_reader && !is_admin`) get implicit read within their Keystone project.

The feature is fully opt-in: `rgw_keystone_accepted_reader_roles` defaults to empty, so no behavior changes unless explicitly configured.

## Depends on

- #68795 (S3/Swift ACL interop) — this PR is stacked on that commit.

## Test plan

- [ ] Build: `ninja bin/radosgw` (no compile errors)
- [ ] Existing tests: `ctest -R rgw` (no regressions)
- [ ] Manual test with vstart + fake Keystone:
  - Configure `rgw_keystone_accepted_reader_roles = reader`
  - User with `reader` role scoped to project → GET/HEAD/LIST succeed (Swift + S3)
  - Same user → PUT/DELETE denied
  - User in a different project → denied

Fixes: https://tracker.ceph.com/issues/68473