### PR TITLE
doc/rados: add kernel client notes to require_min_compat_client

### DIFF
--- a/doc/rados/operations/require-min-compat-client.rst
+++ b/doc/rados/operations/require-min-compat-client.rst
@@ -106,18 +106,30 @@ Features gated by the flag
 Raising the flag does not enable any feature on its own. It authorizes the
 operator to run commands that would otherwise be rejected with an error
 like ``min_compat_client luminous < reef, which is required for
-pg-upmap-primary``:
+pg-upmap-primary``.
+
+The Linux kernel Ceph client (``krbd`` for RBD block devices, ``kcephfs``
+for CephFS) ships with the kernel, not with Ceph packages, so its version
+is independent of the cluster release. New OSD map features reach the
+kernel client only after they are implemented and merged upstream, which
+can lag the Ceph daemon release by months or years.
+
+The *Min kernel* column shows the minimum Linux kernel version required on
+kernel client hosts before the corresponding commands are used. If no
+kernel clients are present in the cluster, that column can be ignored.
 
 .. list-table::
    :header-rows: 1
-   :widths: 60 25
+   :widths: 40 20 25
 
    * - Command
      - Minimum release
+     - Min kernel
    * - | ``ceph osd primary-affinity``
        | ``ceph osd primary-temp``
        | ``ceph osd rm-primary-temp``
      - ``firefly``
+     - any
    * - | ``ceph osd pg-upmap``
        | ``ceph osd rm-pg-upmap``
        | ``ceph osd pg-upmap-items``
@@ -125,18 +137,35 @@ pg-upmap-primary``:
        | ``ceph osd crush weight-set``
        | balancer ``upmap`` mode
      - ``luminous``
+     - 4.13
    * - | ``ceph osd pg-upmap-primary``
        | ``ceph osd rm-pg-upmap-primary``
        | ``ceph osd rm-pg-upmap-primary-all``
        | balancer ``read`` mode
        | balancer ``upmap-read`` mode
      - ``reef``
+     - not yet implemented
 
-Note that adding CRUSH MSR rules is *not* gated at command time; however,
-once an MSR rule is in the map, the features-in-use floor rises to
-``squid`` (see the table above).
+.. warning::
+
+   ``pg-upmap-primary`` (``reef``) and CRUSH MSR rules (``squid``) are
+   not yet implemented in the kernel client.  Kernel clients that
+   encounter ``pg-upmap-primary`` entries will silently route I/O to
+   the wrong OSD, causing **I/O hangs** on the affected PGs.  Kernel
+   clients that encounter CRUSH MSR rules will fail to compute a PG
+   mapping, causing **I/O errors**.  Do not enable either feature while
+   kernel clients are present (use ``ceph features`` to check).  Note
+   that CRUSH MSR rules are added via ``osd setcrushmap`` and are
+   **not** gated by ``require_min_compat_client``, but they immediately
+   raise the features-in-use floor to ``squid``
+   (see `Lowering the flag`_).  To check whether either is active::
+
+      ceph osd dump | grep -E "pg_upmap_primary|msr"
+
+   See :ref:`read_balancer` for removal commands.
 
 See :ref:`upmap` and :ref:`read_balancer` for the operational procedures
 that depend on raising the flag. CephFS clients must satisfy both this
 flag and any per-filesystem :ref:`cephfs_required_client_features` on
-the file systems they mount.
+the file systems they mount. For CephFS-specific kernel version guidance,
+see :ref:`cephfs_which_kernel_version` and :doc:`/cephfs/kernel-features`.


### PR DESCRIPTION
Add a "Min kernel" column to the "Features gated by the flag" table: pg-upmap requires kernel 4.13, pg-upmap-primary and CRUSH MSR are not yet implemented in the kernel client.

Add a warning noting the distinct failure modes (pg-upmap-primary causes I/O hangs from silently dropped misdirected ops; CRUSH MSR rules cause I/O errors because crush_find_rule fails) and that CRUSH MSR rules are added via osd setcrushmap without require_min_compat_client gating but immediately raise the features-in-use floor to squid.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
