### PR TITLE
common/admin_socket: use POSIX timer for delayed signal delivery

### DIFF
--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -20,7 +20,9 @@
 #include <sys/un.h>
 
 #ifndef WIN32
-#include <sys/wait.h>
+#include <time.h>
+#else
+typedef void* timer_t;
 #endif
 
 #include <iomanip>
@@ -825,9 +827,44 @@ class RaiseHook: public AdminSocketHook {
   using clock = ceph::coarse_mono_clock;
   struct Killer {
     CephContext* m_cct;
-    pid_t pid;
+    std::optional<timer_t> timer_id;
     int signal;
     clock::time_point due;
+
+    Killer(CephContext* cct, timer_t id, int sig, clock::time_point d)
+        : m_cct(cct), timer_id(id), signal(sig), due(d) {}
+
+    Killer(Killer&& o) noexcept {
+      *this = std::move(o);
+    }
+
+    void release() noexcept {
+#ifndef WIN32
+      if (timer_id) {
+        timer_delete(*timer_id);
+        timer_id = std::nullopt;
+      }
+#endif
+    }
+
+    Killer& operator=(Killer&& o) noexcept {
+      if (this == &o) {
+        return *this;
+      }
+      release();
+      m_cct = o.m_cct;
+      timer_id = o.timer_id;
+      signal = o.signal;
+      due = o.due;
+      o.timer_id = std::nullopt;
+      return *this;
+    }
+    Killer(const Killer&) = delete;
+    Killer& operator=(const Killer&) = delete;
+
+    ~Killer() {
+      release();
+    }
 
     std::string describe()
     {
@@ -835,84 +872,52 @@ class RaiseHook: public AdminSocketHook {
       using std::chrono::seconds;
       auto remaining = (due - clock::now());
       return fmt::format(
-        "pending signal ({}) due in {}", 
+        "pending signal ({}) due in {}",
         strsignal_compat(signal),
         duration_cast<seconds>(remaining).count());
     }
 
     bool cancel()
     {
-#   ifndef WIN32
-      int wstatus;
-      int status;
-      if (0 == (status = waitpid(pid, &wstatus, WNOHANG))) {
-        status = kill(pid, SIGKILL);
-        if (status) {
-          ldout(m_cct, 5) << __func__ << "couldn't kill the killer. Error: " << strerror(errno) << dendl;
-          return false;
-        }
-        while (pid == waitpid(pid, &wstatus, 0)) {
-          if (WIFEXITED(wstatus)) {
-            return false;
-          }
-          if (WIFSIGNALED(wstatus)) {
-            return true;
-          }
-        }
+#ifndef WIN32
+      struct itimerspec zero = {};
+      struct itimerspec prev = {};
+      if (timer_settime(*timer_id, 0, &zero, &prev) < 0) {
+        ldout(m_cct, 5) << __func__ << " timer_settime failed: " << strerror(errno) << dendl;
+        return false;
       }
-      if (status < 0) {
-        ldout(m_cct, 5) << __func__ << "waitpid(killer, NOHANG) returned " << status << "; " << strerror(errno) << dendl;
-      } else {
-        ldout(m_cct, 20) << __func__ << "killer process " << pid << "\"" << describe() << "\" reaped. "
-                         << "WIFEXITED: " << WIFEXITED(wstatus)
-                         << "WIFSIGNALED: " << WIFSIGNALED(wstatus)
-                         << dendl;
-      }
-#   endif
+      return prev.it_value.tv_sec > 0 || prev.it_value.tv_nsec > 0;
+#endif
       return false;
     }
 
-    static std::optional<Killer> fork(CephContext *m_cct, int signal_to_send, double delay) {
-#   ifndef WIN32
-      pid_t victim = getpid();
-      clock::time_point until = clock::now() + ceph::make_timespan(delay);
+    static std::optional<Killer> arm(CephContext* m_cct, int signal_to_send, double delay)
+    {
+#ifndef WIN32
+      struct sigevent sev = {};
+      sev.sigev_notify = SIGEV_SIGNAL;
+      sev.sigev_signo = signal_to_send;
 
-      int fresult = ::fork();
-      if (fresult < 0) {
-        ldout(m_cct, 5) << __func__ << "couldn't fork the killer. Error: " << strerror(errno) << dendl;
+      timer_t timer_id;
+      if (timer_create(CLOCK_MONOTONIC, &sev, &timer_id) < 0) {
+        ldout(m_cct, 5) << __func__ << " timer_create failed: " << strerror(errno) << dendl;
         return std::nullopt;
       }
 
-      if (fresult) {
-        // this is parent
-        return {{m_cct, fresult, signal_to_send, until}};
+      auto span = ceph::make_timespan(delay);
+      auto sec = std::chrono::floor<std::chrono::seconds>(span);
+      struct itimerspec spec = {};
+      spec.it_value.tv_sec  = sec.count();
+      spec.it_value.tv_nsec = std::chrono::duration_cast<std::chrono::nanoseconds>(span - sec).count();
+
+      if (timer_settime(timer_id, 0, &spec, nullptr) < 0) {
+        ldout(m_cct, 5) << __func__ << " timer_settime failed: " << strerror(errno) << dendl;
+        timer_delete(timer_id);
+        return std::nullopt;
       }
 
-      const ceph::signedspan poll_interval = ceph::make_timespan(0.1);
-      while (getppid() == victim) {
-        ceph::signedspan remaining = (until - clock::now());
-        if (remaining.count() > 0) {
-          using std::chrono::duration_cast;
-          using std::chrono::nanoseconds;
-          std::this_thread::sleep_for(duration_cast<nanoseconds>(std::min(remaining, poll_interval)));
-        } else {
-          break;
-        }
-      }
-
-      if (getppid() != victim) {
-        // suicide if my parent has changed
-        // this means that the original parent process has terminated
-        ldout(m_cct, 5) << __func__ << "my parent isn't what it used to be, i'm out" << strerror(errno) << dendl;
-        _exit(1);
-      }
-
-      int status = kill(victim, signal_to_send);
-      if (0 != status) {
-        ldout(m_cct, 5) << __func__ << "couldn't kill the victim: " << strerror(errno) << dendl;
-      }
-      _exit(status);
-#   endif
+      return Killer{m_cct, timer_id, signal_to_send, clock::now() + span};
+#endif
       return std::nullopt;
     }
   };
@@ -970,8 +975,8 @@ public:
   static const char* get_help()
   {
     return "deliver the <signal> to the daemon process, optionally delaying <after> seconds; "
-           "when --after is used, the program will fork before sleeping, which allows to "
-           "schedule signal delivery to a stopped daemon; it's possible to --cancel a pending signal delivery. "
+           "when --after is used, a POSIX timer is armed to deliver the signal, "
+           "allowing scheduling to a stopped daemon; it's possible to --cancel a pending signal delivery. "
            "<signal> can be in the forms '9', '-9', 'kill', '-KILL'. Use `raise -l` to list known signal names.";
   }
 
@@ -1030,13 +1035,13 @@ public:
         }
       }
 
-      killer = Killer::fork(m_cct, signal_to_send, delay);
+      killer = Killer::arm(m_cct, signal_to_send, delay);
 
       if (killer) {
         errss << "scheduled " << killer->describe() << endl;
         ldout(m_cct, 20) << __func__ << "scheduled " << killer->describe() << dendl;
       } else {
-        errss << "couldn't fork the killer" << std::endl;
+        errss << "couldn't arm the signal timer" << std::endl;
         return -EAGAIN;
       }
     } else {


### PR DESCRIPTION
AdminSocketRaise.AsyncReschedule was flaking on arm64:
```
  [ RUN      ] AdminSocketRaise.AsyncReschedule
  /ceph/src/test/admin_socket.cc:497: Failure
  Expected equality of these values:
    0
    sig2.count.load()
      Which is: 1
  [  FAILED  ] AdminSocketRaise.AsyncReschedule (1045 ms)
```
The old approach forked a child that polled the clock and called kill() at the deadline.  The problem is: the deadline was computed before fork(), so any fork latency ate directly into the timing budget.  On a busy arm64 host that 50 ms margin just wasn't enough.

The fix is to let the kernel own the timer via timer_create(). No child process, no polling, no fork overhead, and `SIGCONT` still works.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
