### PR TITLE
cmake,debian: enable ceph-mon-client-nvmeof on Debian derivatives

### DIFF
--- a/debian/ceph-mon-client-nvmeof.install
+++ b/debian/ceph-mon-client-nvmeof.install
@@ -1,0 +1,1 @@
+usr/bin/ceph-nvmeof-monitor-client

--- a/debian/control
+++ b/debian/control
@@ -72,6 +72,8 @@ Build-Depends: automake,
                libxml2-dev,
                librabbitmq-dev,
                libre2-dev,
+               libgrpc++-dev,
+               protobuf-compiler-grpc,
                libutf8proc-dev (>= 2.2.0),
                librdkafka-dev (>= 1.1.0),
                libthrift-dev (>= 0.13.0),
@@ -85,7 +87,7 @@ Build-Depends: automake,
                libndctl-dev (>= 63) <pkg.ceph.pmdk>,
                libpmem-dev <pkg.ceph.pmdk>,
                libpmemobj-dev (>= 1.8) <pkg.ceph.pmdk>,
-               libprotobuf-dev <pkg.ceph.crimson>,
+               libprotobuf-dev,
                libxsimd-dev <!pkg.ceph.arrow>,
                ninja-build,
                nlohmann-json3-dev,
@@ -416,6 +418,33 @@ Description: debugging symbols for ceph-mon
  block and file system storage.
  .
  This package contains the debugging symbols for ceph-mon.
+
+Package: ceph-mon-client-nvmeof
+Architecture: linux-any
+Depends: librados2 (= ${binary:Version}),
+         ${misc:Depends},
+         ${shlibs:Depends},
+Description: NVMe-oF Gateway Monitor Client for Ceph
+ Ceph is a massively scalable, open-source, distributed
+ storage system that runs on commodity hardware and delivers object,
+ block and file system storage.
+ .
+ This package contains the NVMe-oF Gateway Monitor Client. It distributes
+ Paxos ANA info to the NVMe-oF Gateway and provides beacons to the
+ ceph-mon daemon.
+
+Package: ceph-mon-client-nvmeof-dbg
+Architecture: linux-any
+Section: debug
+Priority: extra
+Depends: ceph-mon-client-nvmeof (= ${binary:Version}),
+         ${misc:Depends},
+Description: debugging symbols for ceph-mon-client-nvmeof
+ Ceph is a massively scalable, open-source, distributed
+ storage system that runs on commodity hardware and delivers object,
+ block and file system storage.
+ .
+ This package contains the debugging symbols for ceph-mon-client-nvmeof.
 
 Package: ceph-osd
 Architecture: linux-any

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1015,12 +1015,7 @@ if(WITH_FUSE)
 endif(WITH_FUSE)
 
 # NVMEOF GATEWAY MONITOR CLIENT
-# Supported on RPM-based platforms only, depends on grpc devel libraries/tools
-if(EXISTS "/etc/redhat-release" OR EXISTS "/etc/fedora-release")
-  option(WITH_NVMEOF_GATEWAY_MONITOR_CLIENT "build nvmeof gateway monitor client" ON)
-else()
-  option(WITH_NVMEOF_GATEWAY_MONITOR_CLIENT "build nvmeof gateway monitor client" OFF)
-endif()
+option(WITH_NVMEOF_GATEWAY_MONITOR_CLIENT "build nvmeof gateway monitor client" ON)
 
 if(WITH_NVMEOF_GATEWAY_MONITOR_CLIENT)
 
@@ -1037,16 +1032,31 @@ if(WITH_NVMEOF_GATEWAY_MONITOR_CLIENT)
     set(_PROTOBUF_PROTOC $<TARGET_FILE:protobuf::protoc>)
   endif()
 
-  # Find gRPC installation
-  # Looks for gRPCConfig.cmake file installed by gRPC's cmake installation.
-  find_package(gRPC CONFIG REQUIRED)
-  message(STATUS "Using gRPC ${gRPC_VERSION}")
-  set(_GRPC_GRPCPP gRPC::grpc++)
-  if(CMAKE_CROSSCOMPILING)
-    find_program(_GRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin
-      REQUIRED)
+  # Find gRPC - try cmake config first (gRPC >= 1.50 and RHEL/Rocky packages),
+  # fall back to pkg-config for distros without cmake config files (e.g. Ubuntu 22.04).
+  find_package(gRPC CONFIG QUIET)
+  if(gRPC_FOUND)
+    message(STATUS "Using gRPC ${gRPC_VERSION}")
+    set(_GRPC_GRPCPP gRPC::grpc++)
+    if(CMAKE_CROSSCOMPILING)
+      find_program(_GRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin REQUIRED)
+    else()
+      set(_GRPC_CPP_PLUGIN_EXECUTABLE $<TARGET_FILE:gRPC::grpc_cpp_plugin>)
+    endif()
+    # Modern gRPC links system absl; HAVE_ABSEIL makes opentelemetry-cpp do the
+    # same so their two absl inline namespaces don't collide in shared TUs.
+    set(_HAVE_ABSEIL ON)
   else()
-    set(_GRPC_CPP_PLUGIN_EXECUTABLE $<TARGET_FILE:gRPC::grpc_cpp_plugin>)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(GRPCPP REQUIRED IMPORTED_TARGET grpc++)
+    message(STATUS "Using gRPC ${GRPCPP_VERSION} (via pkg-config)")
+    set(_GRPC_GRPCPP PkgConfig::GRPCPP)
+    find_program(_GRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin REQUIRED)
+    # Older gRPC (e.g. Jammy's 1.30.2) uses bundled absl; libabsl-dev not required.
+    set(_HAVE_ABSEIL OFF)
+    # grpc++.pc omits protobuf from Requires; add it so PkgConfig::GRPCPP
+    # carries the same transitive dependency as the cmake-config gRPC::grpc++.
+    target_link_libraries(PkgConfig::GRPCPP INTERFACE protobuf::libprotobuf)
   endif()
 
   # Gateway Proto file
@@ -1111,9 +1121,7 @@ if(WITH_NVMEOF_GATEWAY_MONITOR_CLIENT)
     nvmeof/NVMeofGwMonitorClient.cc)
   add_executable(ceph-nvmeof-monitor-client ${ceph_nvmeof_monitor_client_srcs})
   add_dependencies(ceph-nvmeof-monitor-client ceph-common)
-  # absl is installed as grpc build dependency on RPM based systems
-  # Also isolate this flag to specific targets which needs this package
-  if(EXISTS "/etc/redhat-release" OR EXISTS "/etc/fedora-release")
+  if(_HAVE_ABSEIL)
     target_compile_definitions(ceph-nvmeof-monitor-client PRIVATE HAVE_ABSEIL)
     target_compile_definitions(ceph-mon PRIVATE HAVE_ABSEIL)
   endif()

--- a/win32_build.sh
+++ b/win32_build.sh
@@ -196,6 +196,7 @@ cmake -D CMAKE_PREFIX_PATH=$depsDirs \
       -D ENABLE_SHARED=$ENABLE_SHARED -D WITH_RBD=ON -D BUILD_GMOCK=ON \
       -D WITH_CEPHFS=OFF -D WITH_MANPAGE=OFF \
       -D WITH_MGR_DASHBOARD_FRONTEND=OFF -D WITH_SYSTEMD=OFF -D WITH_TESTS=ON \
+      -D WITH_NVMEOF_GATEWAY_MONITOR_CLIENT=OFF \
       -D LZ4_INCLUDE_DIR=$lz4Include -D LZ4_LIBRARY=$lz4Lib \
       -D Backtrace_INCLUDE_DIR="$backtraceDir/include" \
       -D Backtrace_LIBRARY="$backtraceDir/lib/libbacktrace.a" \


### PR DESCRIPTION
5843c6b04ba gated the build on /etc/redhat-release because gRPC devel libs weren't packaged on Debian yet. They are now (libgrpc++-dev, protobuf-compiler-grpc), so we can finally bring Debian derivatives on par with Fedora/RHEL and ship the NVMe-oF gateway monitor client there too.

This change:

- drops the /etc/redhat-release sniff and unconditionally enables WITH_NVMEOF_GATEWAY_MONITOR_CLIENT.
- adds libgrpc++-dev and protobuf-compiler-grpc to debian/control's Build-Depends, plus a ceph-mon-client-nvmeof / -dbg pair so the binary actually gets packaged.
- adds a pkg-config fallback for gRPC discovery. Jammy's libgrpc++-dev (1.30.2) ships no cmake config files [1], so find_package(gRPC CONFIG REQUIRED) fails at configure time. Noble's libgrpc++-dev (1.51.1) does ship them [2], as do RHEL/Rocky packages. We now try cmake config first (QUIET) and fall back to pkg_check_modules(IMPORTED_TARGET grpc++) when it isn't found.
- patches PkgConfig::GRPCPP to carry protobuf::libprotobuf as an interface dependency. grpc++.pc omits protobuf from its Requires, so gateway.pb.cc (which calls GOOGLE_PROTOBUF_VERIFY_VERSION) would fail to link on the pkg-config path. The cmake-config gRPC::grpc++ declares this dependency properly; we match that behaviour with target_link_libraries(PkgConfig::GRPCPP INTERFACE protobuf::libprotobuf).
- applies HAVE_ABSEIL only on the cmake-config path (Noble, RHEL/Rocky), where gRPC links system absl. Without it, opentelemetry-cpp's private absl (inline namespace otel_v1) collides with system absl (inline namespace debian7) in any TU that includes both tracer.h and grpcpp/grpcpp.h, giving "reference to base_internal is ambiguous". On the pkg-config path (Jammy's gRPC 1.30.2) libabsl-dev is not installed, so HAVE_ABSEIL must be skipped there.

[1] https://packages.ubuntu.com/jammy/amd64/libgrpc-dev/filelist
[2] https://packages.ubuntu.com/noble/amd64/libgrpc-dev/filelist





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
