### PR TITLE
tentacle: qa/cephfs: treat "implicit declaration of function" for blogbench workunit for newer gcc version

### DIFF
--- a/qa/workunits/suites/blogbench.sh
+++ b/qa/workunits/suites/blogbench.sh
@@ -7,6 +7,7 @@ wget http://download.ceph.com/qa/blogbench-1.0.tar.bz2
 tar -xvf blogbench-1.0.tar.bz2
 cd blogbench-1.0/
 echo "making blogbench"
+export CFLAGS="-Wno-error=implicit-function-declaration"
 ./configure
 make
 cd src


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76177

---

backport of https://github.com/ceph/ceph/pull/67867
parent tracker: https://tracker.ceph.com/issues/75380

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh