### PR TITLE
squid: test/libcephfs: Fixed path buffer overflow

### DIFF
--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -4321,11 +4321,9 @@ TEST(LibCephFS, UnmountHangAfterOpenatFilePath) {
   struct ceph_statx stx;
   ASSERT_EQ(ceph_statxat(cmount, root_fd, c_rel_dir, &stx, 0, 0), 0);
 
-  char c_rel_path[PATH_MAX];
-  char c_path[PATH_MAX];
-  sprintf(c_rel_path, "created_file_%d", mypid);
-  sprintf(c_path, "%s/%s", c_dir, c_rel_path);
-  int file_fd = ceph_openat(cmount, dir_fd, c_rel_path, O_RDONLY | O_CREAT, 0777);
+  std::string c_rel_path = fmt::format("created_file_{}", mypid);
+  std::string c_path = fmt::format("{}/{}", c_dir, c_rel_path);
+  int file_fd = ceph_openat(cmount, dir_fd, c_rel_path.c_str(), O_RDONLY | O_CREAT, 0777);
   ASSERT_GT(file_fd, 0);
   int fd = ceph_openat(cmount, file_fd, ".", O_RDONLY, 0777);
   ASSERT_EQ(fd, -ENOTDIR);
@@ -4334,7 +4332,7 @@ TEST(LibCephFS, UnmountHangAfterOpenatFilePath) {
   ASSERT_EQ(ceph_close(cmount, dir_fd), 0);
   ASSERT_EQ(ceph_close(cmount, root_fd), 0);
 
-  ASSERT_EQ(0, ceph_unlink(cmount, c_path));
+  ASSERT_EQ(0, ceph_unlink(cmount, c_path.c_str()));
   ASSERT_EQ(0, ceph_rmdir(cmount, c_dir));
 
   std::cout << "Before ceph_unmount()" << std::endl;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/74118

---

backport of https://github.com/ceph/ceph/pull/66030
parent tracker: https://tracker.ceph.com/issues/73617

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh