### PR TITLE
crimson/osd: make PGAdvanceMap idempotent

### DIFF
--- a/src/crimson/osd/osd_operations/pg_advance_map.cc
+++ b/src/crimson/osd/osd_operations/pg_advance_map.cc
@@ -59,7 +59,6 @@ PGPeeringPipeline &PGAdvanceMap::peering_pp(PG &pg)
 seastar::future<> PGAdvanceMap::start()
 {
   LOG_PREFIX(PGAdvanceMap::start);
-  using cached_map_t = OSDMapService::cached_map_t;
 
   DEBUG("{}: start", *this);
   auto exit_handle = seastar::defer([FNAME, thiz = IRef{this}] {
@@ -112,7 +111,6 @@ seastar::future<> PGAdvanceMap::check_for_splits(
     cached_map_t next_map)
 {
   LOG_PREFIX(PGAdvanceMap::check_for_splits);
-  using cached_map_t = OSDMapService::cached_map_t;
   cached_map_t old_map = co_await shard_services.get_map(old_epoch);
   if (!old_map->have_pg_pool(pg->get_pgid().pool())) {
     DEBUG("{} pool doesn't exist in epoch {}", pg->get_pgid(),

--- a/src/crimson/osd/osd_operations/pg_advance_map.cc
+++ b/src/crimson/osd/osd_operations/pg_advance_map.cc
@@ -35,7 +35,6 @@ void PGAdvanceMap::print(std::ostream &lhs) const
 {
   lhs << "PGAdvanceMap("
       << "pg=" << pg->get_pgid()
-      << " from=" << (from ? *from : -1)
       << " to=" << to;
   if (do_init) {
     lhs << " do_init";
@@ -47,9 +46,6 @@ void PGAdvanceMap::dump_detail(Formatter *f) const
 {
   f->open_object_section("PGAdvanceMap");
   f->dump_stream("pgid") << pg->get_pgid();
-  if (from) {
-    f->dump_int("from", *from);
-  }
   f->dump_int("to", to);
   f->dump_bool("do_init", do_init);
   f->close_section();
@@ -77,23 +73,13 @@ seastar::future<> PGAdvanceMap::start()
       return seastar::now();
     }
 
-    /*
-     * PGAdvanceMap is scheduled at pg creation and when
-     * broadcasting new osdmaps to pgs. We are not able to serialize
-     * between the two different PGAdvanceMap callers since a new pg
-     * will get advanced to the latest osdmap at it's creation.
-     * As a result, we may need to adjust the PGAdvance operation
-     * 'from' epoch.
-     * See: https://tracker.ceph.com/issues/61744
-     */
-    from = pg->get_osdmap_epoch();
+    epoch_t from = pg->get_osdmap_epoch();
     if (do_init) {
       pg->handle_initialize(rctx);
       pg->handle_activate_map(rctx);
     }
-    ceph_assert(std::cmp_less_equal(*from, to));
     return seastar::do_for_each(
-      boost::make_counting_iterator(*from + 1),
+      boost::make_counting_iterator(from + 1),
       boost::make_counting_iterator(to + 1),
       [this, FNAME](epoch_t next_epoch) {
 	DEBUG("{}: start: getting map {}",

--- a/src/crimson/osd/osd_operations/pg_advance_map.cc
+++ b/src/crimson/osd/osd_operations/pg_advance_map.cc
@@ -71,6 +71,9 @@ seastar::future<> PGAdvanceMap::start()
   // pg may have been deleted while this op was queued; see PG::do_delete_work.
   if (pg->is_deleted()) {
     DEBUG("{}: pg is deleted, skipping advance", *this);
+    co_await pg->complete_rctx(std::move(rctx));
+    co_await handle.complete();
+    exit_handle.cancel();
     co_return;
   }
 

--- a/src/crimson/osd/osd_operations/pg_advance_map.cc
+++ b/src/crimson/osd/osd_operations/pg_advance_map.cc
@@ -62,55 +62,49 @@ seastar::future<> PGAdvanceMap::start()
   using cached_map_t = OSDMapService::cached_map_t;
 
   DEBUG("{}: start", *this);
-
-  IRef ref = this;
-  return enter_stage<>(
-    peering_pp(*pg).process
-  ).then([this, FNAME] {
-    // pg may have been deleted while this op was queued; see PG::do_delete_work.
-    if (pg->is_deleted()) {
-      DEBUG("{}: pg is deleted, skipping advance", *this);
-      return seastar::now();
-    }
-
-    epoch_t from = pg->get_osdmap_epoch();
-    if (do_init) {
-      pg->handle_initialize(rctx);
-      pg->handle_activate_map(rctx);
-    }
-    return seastar::do_for_each(
-      boost::make_counting_iterator(from + 1),
-      boost::make_counting_iterator(to + 1),
-      [this, FNAME](epoch_t next_epoch) {
-	DEBUG("{}: start: getting map {}",
-		       *this, next_epoch);
-	return shard_services.get_map(next_epoch).then(
-	  [this, FNAME] (cached_map_t&& next_map) {
-	    DEBUG("{}: advancing map to {}",
-		  *this, next_map->get_epoch());
-        // Use the current OSDMap epoch to check for splits consecutively.
-        epoch_t current_epoch = pg->get_osdmap_epoch();
-        pg->handle_advance_map(next_map, rctx);
-        DEBUG("{}: checking for splits between {} and {}",
-              *this, current_epoch, next_map->get_epoch());
-        return check_for_splits(current_epoch, next_map);
-	  });
-      }).then([this, FNAME] {
-	pg->handle_activate_map(rctx);
-	DEBUG("{}: map activated", *this);
-	if (do_init) {
-	  shard_services.pg_created(pg->get_pgid(), pg);
-	  INFO("PGAdvanceMap::start new pg {}", *pg);
-	}
-	return pg->complete_rctx(std::move(rctx));
-      });
-  }).then([this, FNAME] {
-    DEBUG("{}: complete", *this);
-    return handle.complete();
-  }).finally([this, FNAME, ref=std::move(ref)] {
-    DEBUG("{}: exit", *this);
-    handle.exit();
+  auto exit_handle = seastar::defer([FNAME, thiz = IRef{this}] {
+    DEBUG("{}: exit", *thiz);
+    thiz->handle.exit();
   });
+
+  co_await enter_stage<>(peering_pp(*pg).process);
+
+  // pg may have been deleted while this op was queued; see PG::do_delete_work.
+  if (pg->is_deleted()) {
+    DEBUG("{}: pg is deleted, skipping advance", *this);
+    co_return;
+  }
+
+  epoch_t from = pg->get_osdmap_epoch();
+  if (do_init) {
+    pg->handle_initialize(rctx);
+    pg->handle_activate_map(rctx);
+  }
+  for (epoch_t next_epoch = from + 1; next_epoch <= to; next_epoch++) {
+    DEBUG("{}: start: getting map {}",
+          *this, next_epoch);
+    cached_map_t next_map = co_await shard_services.get_map(next_epoch);
+    DEBUG("{}: advancing map to {}",
+          *this, next_map->get_epoch());
+    // Use the current OSDMap epoch to check for splits consecutively.
+    epoch_t current_epoch = pg->get_osdmap_epoch();
+    pg->handle_advance_map(next_map, rctx);
+    DEBUG("{}: checking for splits between {} and {}",
+          *this, current_epoch, next_map->get_epoch());
+    co_await check_for_splits(current_epoch, std::move(next_map));
+  }
+
+  pg->handle_activate_map(rctx);
+  DEBUG("{}: map activated", *this);
+  if (do_init) {
+    shard_services.pg_created(pg->get_pgid(), pg);
+    INFO("PGAdvanceMap::start new pg {}", *pg);
+  }
+  co_await pg->complete_rctx(std::move(rctx));
+  DEBUG("{}: complete", *this);
+
+  co_await handle.complete();
+  exit_handle.cancel();
 }
 
 seastar::future<> PGAdvanceMap::check_for_splits(

--- a/src/crimson/osd/osd_operations/pg_advance_map.h
+++ b/src/crimson/osd/osd_operations/pg_advance_map.h
@@ -31,7 +31,6 @@ protected:
   ShardServices &shard_services;
   PipelineHandle handle;
 
-  std::optional<epoch_t> from;
   epoch_t to;
 
   PeeringCtx rctx;


### PR DESCRIPTION
PGAdvanceMap is scheduled by two independent callers: pg creation (do_init=true, to=current_epoch) and `broadcast_map_to_pgs`. They do not coordinate, so a broadcast advance can race with an init advance that has already pushed the pg past the broadcast's target. The op carried a `std::optional<from>` that was overwritten at start-time, guarded by `ceph_assert(from <= to)` which fires in this race.

The "from" parameter was never really an input. It was always re-read inside the pipeline from `pg->get_osdmap_epoch()`; the value passed in (when there was one) was discarded. Drop the member and let the op contract be: "ensure pg has processed osdmaps up to at least 'to'". If the pg is already past 'to', skip. This matches OSD::advance_pg() in the classic OSD and removes the need to serialize the two callers.

Fixes: https://tracker.ceph.com/issues/61744





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
