### PR TITLE
smb: add a smb remote control client tool frontend

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -144,7 +144,11 @@
 %global _find_debuginfo_dwz_opts %{nil}
 %endif
 %bcond_with sccache
+%if 0%{?rhel} && 0%{?rhel} >= 10
+%bcond_without pypkg
+%else
 %bcond_with pypkg
+%endif
 
 %{!?_udevrulesdir: %global _udevrulesdir /lib/udev/rules.d}
 %{!?tmpfiles_create: %global tmpfiles_create systemd-tmpfiles --create}

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1251,6 +1251,9 @@ descriptions, and submitting the command to the appropriate daemon.
 Summary:	Python 3 utility libraries for Ceph
 %if 0%{?fedora} || 0%{?rhel} >= 8 || 0%{?openEuler}
 Requires:       python%{python3_pkgversion}-pyyaml
+%if %{with pypkg}
+Recommends:     python%{python3_pkgversion}-ceph-smb-ctl
+%endif
 %endif
 %if 0%{?suse_version}
 Requires:       python%{python3_pkgversion}-PyYAML
@@ -1396,6 +1399,22 @@ Group:          System/Monitoring
 %endif
 %description node-proxy
 This package provides a Ceph hardware monitoring agent.
+
+%if %{with pypkg}
+%package -n python%{python3_pkgversion}-ceph-smb-ctl
+Summary:        Ceph SMB Service Remote-Control Client
+BuildArch:      noarch
+%if 0%{?suse_version}
+Group:          System/Filesystems
+%endif
+Requires:       python%{python3_pkgversion}-ceph-common = %{_epoch_prefix}%{version}-%{release}
+Requires:       python%{python3_pkgversion}-grpcio
+Requires:       python%{python3_pkgversion}-grpcio-reflection
+%description -n python%{python3_pkgversion}-ceph-smb-ctl
+This package provides a tool to interact with Ceph's SMB Service Remote-Control
+gRPC API as a client.
+%endif
+%dnl end package python%{python3_pkgversion}-ceph-smb-ctl
 
 #################################################################################
 # common
@@ -2787,5 +2806,10 @@ exit 0
 %dir %{python3_sitelib}/ceph_node_proxy
 %{python3_sitelib}/ceph_node_proxy/*
 %{python3_sitelib}/ceph_node_proxy-*
+
+%if %{with pypkg}
+%files -n python%{python3_pkgversion}-ceph-smb-ctl
+%{_bindir}/ceph-smb-ctl
+%endif
 
 %changelog

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -180,6 +180,9 @@ RUN set -euo pipefail; \
     source /etc/ceph-distro.env; \
     if [ "$MAJOR" -le 9 ]; then \
         echo "python3-saml" >> packages.txt; \
+    fi ; \
+    if [ "$MAJOR" -ge 10 ]; then \
+        echo "python3-ceph-smb-ctl" >> packages.txt; \
     fi
 
 # NFS-Ganesha

--- a/doc/mgr/smb.rst
+++ b/doc/mgr/smb.rst
@@ -773,8 +773,9 @@ remote_control
     uses port 54445. The port can be configured using the ``custom_ports``
     parameter in the cluster resource. If the service is enabled and any of the
     ``cert``, ``key``, or ``ca_cert`` fields are not populated mTLS will be
-    disabled and the service will operate in a read-only mode. Running the
-    service with mTLS disabled is not recommended.
+    disabled. Running the service with mTLS disabled is not recommended.
+    Consult the :ref:`SMB Remote Control <smb-remote-control>` section for
+    more details about the remote-control server and how to access it.
     Fields:
 
     enabled
@@ -1526,3 +1527,148 @@ at the prompt. Refer to the `smbclient documentation`_ for more details.
 
 .. _smbclient documentation:
    https://www.samba.org/samba/docs/current/man-html/smbclient.1.html
+
+.. _smb-remote-control:
+
+SMB Remote Control
+==================
+
+Ceph's SMB Service offers an optional sidecar service called remote-control
+(sometimes abbreviated as ``remotectl``). This service offers the ability to
+directly interact with the containerized Samba daemons through a gRPC based
+interface. You can view status, settings, or make limited changes without going
+through additional layers of orchestration.
+
+The remote-control service is provided as part of the Samba containers
+deployed by cephadm and the code is available as part of the `sambacc project`_.
+
+.. _sambacc project: https://github.com/samba-in-kubernetes/sambacc
+
+There are two main methods of connecting to the remote-control service:
+
+1. Over the network using an mTLS enabled TCP connection
+2. On the Ceph cluster node running one or more smb services
+
+To configure the system for TCP & mTLS connections the parameters ``cert``,
+``key``, and ``ca_cert`` should be provided under the ``remote_control``
+settings block. Providing these credential references automatically enables the
+service.
+
+To configure the system for local unix socket access, specify
+``locally_enabled: true`` under the ``remote_control`` settings block.  When
+deployed as part of a Ceph cluster this mode requires the client to pass ceph
+user and key information as part of the gRPC headers.
+
+You can enable both TCP & mTLS connection and unix socket connections at the
+same time.
+
+In addition to these main methods one can also enable remote-control but
+disable mTLS support. Note that doing so is highly risky as any gRPC client can
+view and make changes using remote-control. This option exists for development
+and debugging purposes and should only be used in controlled environments.
+To enable this mode supply no tls credential options but set ``enabled: true``
+when configuring the ``remote_control`` settings in the cluster.
+
+
+Accessing Remote Control as an API
+----------------------------------
+
+One of the use cases for the remote-control sidecar service is to provide an
+interface for a control-plane outside of the Ceph cluster to directly operate
+on processes running inside the Samba containers. In many cases we expect this
+to be implemented by the client control-plane using a binding to the gRPC API.
+
+One can generate gRPC bindings for a number of languages, including C/C++, Go,
+Python, and Java. Providing detailed documentation for creating a binding for
+your application is out of scope for this document. The main `grpc.io`_ website
+provides detailed documentation and tutorials for getting started with gRPC. To
+generate bindings for the remote-control sidecar service the `sambacc project`_
+provides a `.proto file`_ that describes the available API and can be used to
+generate bindings.
+
+The remote-control gRPC server also supports "gRPC reflection" that allows
+dynamic bindings instead of generating them ahead of time. Refer to the `gRPC
+reflection`_ documentation and the related documentation for your language on
+how to make use of reflection.
+
+.. _grpc.io: https://grpc.io
+
+.. _gRPC reflection: https://grpc.io/docs/guides/reflection/
+
+.. _.proto file: https://github.com/samba-in-kubernetes/sambacc/blob/master/sambacc/grpc/protobufs/control.proto
+
+Accessing Remote Control using grpcurl
+--------------------------------------
+
+The remote-control API can be accessed on the command line using the `grpcurl`_
+tool. This tool is described as "like cURL, but for gRPC" on the project's
+GitHub page. This tool is meant for general gRPC use and can either be
+configured to use the .proto file or gRPC reflection to "learn" the APIs
+available on the server. Similarly, the tool supports command line options
+for TLS credentials, optional arguments (as JSON) and the server and API to
+call. Please refer to the grpcurl site for documentation.
+
+An example using grpcurl:
+
+.. prompt:: bash #
+
+   grpcurl -cacert ~/certs/ca.crt -cert ~/certs/client1.crt  -key ~/certs/client1.key -d '{"ip_address": "192.168.76.145"}' 192.168.76.200:54445  SambaControl/KillClientConnection
+
+This example demonstrates making a TCP & mTLS based connection to the server
+running at ``192.168.76.200:54445`` and calling the ``KillClientConnection``
+API with the arguments specifying a client with IP Address ``192.168.76.145``.
+This instructs the ``smbd`` server to terminate any established connection it
+has to a client with that IP Address.
+
+.. _grpcurl: https://github.com/fullstorydev/grpcurl
+
+Accessing Remote Control using ceph-smb-ctl
+-------------------------------------------
+
+In addition to general gRPC clients, the Ceph project now provides a more
+specific client for the remote-control service called ``ceph-smb-ctl``.  This
+client is available as part of the container images provided by the Ceph
+project. It can be invoked using the ``cephadm shell`` command on a Ceph
+cluster node that is running smb services. It will automatically use the unix
+sockets by default.  If more than one smb service is running on the same node
+the ``--cluster`` option may be used to distinguish which smb cluster to
+connect to.
+
+This tool is primarily meant as a tool for Ceph administrators to perform
+diagnostics and debugging activities for the SMB on Ceph service. The
+various APIs are represented by commands that can be listed using the ``--help``
+option. These commands include but are not limited to:
+
+* ``info`` - Get basic server info
+* ``status`` - Report on Samba smbd server status
+* ``close-share`` - Block I/O to certain clients by share name
+* ``kill-client-connection`` - Terminate a client connection by IP Address
+* ``config-dump`` - Dump configuration data
+* ``get-debug-level`` - Get the current debug level of an smb subsystem
+* ``set-debug-level`` - Set the debug level of an smb subsystem
+
+For example:
+
+.. prompt:: bash #
+
+   cephadm shell ceph-smb-ctl status
+
+Reports on the status of the smb services in a JSON representation.
+
+.. prompt:: bash #
+
+   cephadm shell ceph-smb-ctl kill-client-connection 192.168.76.145
+
+Demonstrates the use of ``ceph-smb-ctl`` to request smbd terminate any
+established connection it has to the client with IP Address 192.168.76.145.
+
+In addition to operating on the local smb server instance it can also
+use TCP & mTLS to connect to a remote sidecar server. Note that making
+the appropriate TLS credentials available on the node is up to you.
+
+.. prompt:: bash #
+
+   cephadm shell -v /path/to/my/certs:/c ceph-smb-ctl --address 192.168.76.202:54445  --tls-cert=/c/edfu.crt --tls-key=/c/edfu.key --tls-ca-cert=/c/ca/ca.crt  config-dump samba
+
+This example will remotely fetch and print the samba-level configuration from
+a sidecar service listening on the specified address and port.

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_dom.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_dom.yaml
@@ -50,6 +50,8 @@ tasks:
               - "{{ctx.samba_ad_dc_ip}}"
             placement:
               count: 1
+            remote_control:
+              locally_enabled: true
           - resource_type: ceph.smb.join.auth
             auth_id: join1-admin
             auth:
@@ -91,7 +93,7 @@ tasks:
     timeout: 1h
     clients:
       client.0:
-        - [default, hosts_access, rate_limiting]
+        - [default, hosts_access, rate_limiting, ceph_smb_ctl_local]
 
 - cephadm.shell:
     host.a:

--- a/qa/workunits/smb/tests/pytest.ini
+++ b/qa/workunits/smb/tests/pytest.ini
@@ -5,3 +5,4 @@ markers =
     default: Default tests
     hosts_access: Host access tests
     rate_limiting: Rate limit tests
+    ceph_smb_ctl_local: Local/container test of ceph-smb-ctl tool

--- a/qa/workunits/smb/tests/test_ceph_smb_ctl.py
+++ b/qa/workunits/smb/tests/test_ceph_smb_ctl.py
@@ -1,0 +1,160 @@
+import time
+
+import pytest
+
+import cephutil
+import smbutil
+
+CEPH_SMB_CTL = 'ceph-smb-ctl'
+
+
+@pytest.mark.ceph_smb_ctl_local
+class TestCephSMBCtlLocal:
+    def test_get_info(self, smb_cfg):
+        jres = cephutil.cephadm_shell_cmd(
+            smb_cfg,
+            [CEPH_SMB_CTL, 'info'],
+            load_json=True,
+        )
+        assert jres.returncode == 0
+        assert jres.obj
+        assert 'samba_info' in jres.obj
+        assert 'version' in jres.obj['samba_info']
+        assert 'clustered' in jres.obj['samba_info']
+
+    def test_status_empty(self, smb_cfg):
+        jres = cephutil.cephadm_shell_cmd(
+            smb_cfg,
+            [CEPH_SMB_CTL, 'status'],
+            load_json=True,
+        )
+        assert jres.returncode == 0
+        assert jres.obj
+        assert 'server_timestamp' in jres.obj
+        assert 'sessions' in jres.obj
+        assert 'tree_connections' in jres.obj
+        assert not jres.obj['sessions']
+        assert not jres.obj['tree_connections']
+
+    def test_status_connected(self, smb_cfg):
+        share_name = smbutil.get_shares(smb_cfg)[0]['name']
+        with smbutil.connection(smb_cfg, share_name) as sharep:
+            sharep.listdir()  # trigger a tree connect in client lib
+            time.sleep(0.2)
+            jres = cephutil.cephadm_shell_cmd(
+                smb_cfg,
+                [CEPH_SMB_CTL, 'status'],
+                load_json=True,
+            )
+        assert jres.returncode == 0
+        assert jres.obj
+        assert 'server_timestamp' in jres.obj
+        assert 'sessions' in jres.obj
+        assert 'tree_connections' in jres.obj
+        assert len(jres.obj['sessions']) == 1
+        assert len(jres.obj['tree_connections']) == 1
+        assert (
+            jres.obj['sessions'][0]['session_id']
+            == jres.obj['tree_connections'][0]['session_id']
+        )
+
+    def test_config_dump_samba(self, smb_cfg):
+        share_name = smbutil.get_shares(smb_cfg)[0]['name']
+        res = cephutil.cephadm_shell_cmd(
+            smb_cfg,
+            [CEPH_SMB_CTL, 'config-dump', 'samba'],
+            capture_output=True,
+            text=True,
+        )
+        assert res.returncode == 0
+        assert f'[{share_name}]' in res.stdout
+
+    def test_config_dump_sambacc(self, smb_cfg):
+        jres = cephutil.cephadm_shell_cmd(
+            smb_cfg,
+            [CEPH_SMB_CTL, 'config-dump', 'sambacc'],
+            load_json=True,
+        )
+        assert jres.returncode == 0
+        assert jres.obj
+
+    def test_config_dump_cmp_hash(self, smb_cfg):
+        res = cephutil.cephadm_shell_cmd(
+            smb_cfg,
+            [CEPH_SMB_CTL, 'config-dump', '--sha256', 'samba'],
+            capture_output=True,
+            text=True,
+        )
+        assert res.returncode == 0
+        lines = res.stdout.splitlines()
+        digest_lines = [line for line in lines if 'digest =' in line]
+        assert len(digest_lines) == 1
+        parts = [s.strip() for s in digest_lines[0].split('=')]
+        alg, digest = parts[-1].split(':', 1)
+        assert alg == 'sha256'
+
+        jres = cephutil.cephadm_shell_cmd(
+            smb_cfg,
+            [CEPH_SMB_CTL, 'config-summary', '--sha256', 'samba'],
+            load_json=True,
+        )
+        assert jres.returncode == 0
+        assert 'digest' in jres.obj
+        assert 'config_digest' in jres.obj['digest']
+        assert jres.obj['digest']['config_digest'] == digest
+
+    def test_config_shares_list(self, smb_cfg):
+        jres = cephutil.cephadm_shell_cmd(
+            smb_cfg,
+            [CEPH_SMB_CTL, 'config-shares-list', 'samba'],
+            load_json=True,
+        )
+        assert jres.returncode == 0
+        share_names = [v['name'] for v in smbutil.get_shares(smb_cfg)]
+        assert jres.obj
+        for share_name in share_names:
+            assert share_name in jres.obj, f"missing {share_name}"
+
+        # the shares list in sambacc should always map exactly to the
+        # shares list in samba itself
+        prev_names = jres.obj
+        jres = cephutil.cephadm_shell_cmd(
+            smb_cfg,
+            [CEPH_SMB_CTL, 'config-shares-list', 'sambacc'],
+            load_json=True,
+        )
+        assert jres.returncode == 0
+        assert sorted(jres.obj) == sorted(prev_names)
+
+    def test_debug_get_set(self, smb_cfg):
+        jres = cephutil.cephadm_shell_cmd(
+            smb_cfg,
+            [CEPH_SMB_CTL, 'get-debug-level', 'smb'],
+            load_json=True,
+        )
+        assert jres.returncode == 0, "get-debug-level smb failed"
+        assert "debug_level" in jres.obj
+        orig_debug_level = jres.obj["debug_level"]
+
+        jres = cephutil.cephadm_shell_cmd(
+            smb_cfg,
+            [CEPH_SMB_CTL, 'set-debug-level', 'smb', "10"],
+            load_json=True,
+        )
+        assert jres.returncode == 0, "set-debug-level smb 10 failed"
+
+        jres = cephutil.cephadm_shell_cmd(
+            smb_cfg,
+            [CEPH_SMB_CTL, 'get-debug-level', 'smb'],
+            load_json=True,
+        )
+        assert jres.returncode == 0, "get-debug-level smb failed"
+        assert "debug_level" in jres.obj
+        assert jres.obj["debug_level"] == "10"
+
+        jres = cephutil.cephadm_shell_cmd(
+            smb_cfg,
+            [CEPH_SMB_CTL, 'set-debug-level', 'smb', orig_debug_level],
+            load_json=True,
+        )
+        assert jres.returncode == 0, "set-debug-level smb orig level failed"

--- a/src/python-common/ceph/smb/ctl/__main__.py
+++ b/src/python-common/ceph/smb/ctl/__main__.py
@@ -511,7 +511,7 @@ def parse_cli() -> argparse.Namespace:
     mg.add_argument(
         '--address',
         type=str,
-        help='Address of gRPC server',
+        help='Location of gRPC server - <host_or_addr>:<port> for TCP servers',
     )
     mg.add_argument(
         '--cluster',

--- a/src/python-common/pyproject.toml
+++ b/src/python-common/pyproject.toml
@@ -19,6 +19,9 @@ email = "dev@ceph.io"
 Homepage = "https://ceph.io"
 Repository = "https://github.com/ceph/ceph"
 
+[project.scripts]
+ceph-smb-ctl = "ceph.smb.ctl.__main__:main"
+
 [build-system]
 requires = ["setuptools >= 61.0"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
~~Depends on: #68756~~
~~Depends on: #68401~~

Add a frontend script `ceph-smb-ctl` and rpm packaging for this script to the ceph build.




## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
