### PR TITLE
tools/cephfs_mirror: Mirror metrics via  new mgr interface

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -188,6 +188,13 @@
   ``fs mirror peer status`` fields (directory state, current sync, last sync, and
   snap summary) and are labeled by peer UUID and mirrored directory path. See
   https://tracker.ceph.com/issues/73457
+* CephFS Mirroring: The mirroring module provides ``ceph fs snapshot mirror status``,
+  a Ceph CLI command similar to the ``fs mirror peer status`` admin socket interface
+  for viewing per-directory snapshot sync metrics. The output layout matches
+  ``fs mirror peer status`` for core sync fields and additionally includes
+  ``metrics_updated_at`` (time of the last omap write). Optional filters by
+  mirrored directory path and peer UUID are supported. For more information,
+  see https://tracker.ceph.com/issues/76686
 * RBD: Mirror snapshot creation and trash purge schedules are now automatically
   staggered when no explicit "start-time" is specified. This reduces scheduling
   spikes and distributes work more evenly over time.

--- a/doc/cephfs/cephfs-mirroring.rst
+++ b/doc/cephfs/cephfs-mirroring.rst
@@ -229,8 +229,8 @@ subdirectories or ancestor directories is disallowed::
   Error EINVAL: /d0/d1/d2/d3 is a subtree of tracked path /d0/d1/d2
 
 The :ref:`Mirroring Status<cephfs_mirroring_mirroring_status>` section contains
-information about the commands for checking the directory mapping (to mirror
-daemons) and for checking the directory distribution. 
+information about checking directory synchronization metrics, directory mapping
+(to mirror daemons), and directory distribution.
 
 .. _cephfs_mirroring_bootstrap_peers:
 
@@ -307,8 +307,300 @@ CephFS mirroring module provides ``mirror daemon status`` interface to check mir
 
 An entry per mirror daemon instance is displayed along with information such as configured
 peers and basic stats. The peer information includes the remote file system name (``fs_name``),
-cluster's Monitor addresses (``mon_host``) and cluster FSID (``fsid``). For more detailed
-stats, use the admin socket interface as detailed below.
+cluster's Monitor addresses (``mon_host``) and cluster FSID (``fsid``).
+
+.. _cephfs_mirroring_sync_metric_fields:
+
+Snapshot sync metric fields
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Both ``ceph fs snapshot mirror status`` and ``fs mirror peer status`` report the
+same core per-directory sync fields. The ``cephfs-mirror`` daemon writes these
+fields (and omap metadata described below) to the metadata pool omap (on the
+``cephfs_mirror`` RADOS object) so that the mirroring Manager module can read
+them and serve ``ceph fs snapshot mirror status`` without requiring access to a
+mirror daemon host or admin socket. On daemon restart, only a subset of fields
+is loaded back into daemon memory; the rest are rebuilt or reset for the new
+session.
+
+``ceph fs snapshot mirror status`` additionally exposes ``metrics_updated_at``,
+the wall-clock time of the last omap write for that directory and peer. This
+field is not present in ``fs mirror peer status``, which reads live in-memory
+state from the daemon and does not need a separate persist timestamp. In the
+mgr command it helps operators judge how fresh omap-backed metrics are, given
+the omap persist interval (``cephfs_mirror_tick_interval``) and Manager response
+caching (``snapshot_mirror_metrics_cache_enabled`` and
+``snapshot_mirror_metrics_cache_ttl``).
+
+**Per-session counters**
+
+``snaps_synced``, ``snaps_deleted``, and ``snaps_renamed`` are written to omap
+but count activity in the **current daemon session** only. They are not loaded
+from omap when a ``cephfs-mirror`` daemon starts or when a directory is reassigned
+to another mirror daemon instance. Counters therefore reset to zero in daemon
+memory on restart and on directory reshuffle (in multi-daemon deployments). The
+admin socket reflects this immediately; omap may still hold the previous session's
+values until the new owning daemon writes an updated entry.
+
+**Omap persistence and restore on restart**
+
+.. list-table::
+   :widths: 30 20 25 25
+   :header-rows: 1
+
+   * - Field
+     - Written to omap
+     - Loaded on daemon restart
+     - Notes
+   * - ``last_synced_snap`` (and its subfields)
+     - Yes
+     - Yes
+     - Survives daemon restart; reconciled against the remote snap map on load
+   * - ``current_syncing_snap``
+     - Yes (while syncing)
+     - No
+     - Rebuilt when synchronization resumes
+   * - ``snaps_synced``, ``snaps_deleted``, ``snaps_renamed``
+     - Yes
+     - No
+     - Written to omap but per-session; not loaded on restart (see above)
+   * - ``state``, ``failure_reason``
+     - Yes
+     - No
+     - Reflect the last writer's view until omap is updated again
+   * - ``_instance_id``
+     - Yes
+     - No
+     - Internal; used by the Manager for stale detection and omitted from CLI output
+   * - ``metrics_updated_at``
+     - Yes
+     - No
+     - Wall-clock time of the last omap write; exposed only by
+       ``ceph fs snapshot mirror status`` (not ``fs mirror peer status``)
+
+**Omap cleanup**
+
+When a directory is removed from mirroring, the ``cephfs-mirror`` daemon deletes
+the corresponding omap entry from the ``cephfs_mirror`` object.
+
+.. _cephfs_mirroring_mgr_snapshot_status:
+
+Directory snapshot sync metrics
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The mirroring module provides the ``fs snapshot mirror status`` command to query
+per-directory snapshot synchronization metrics for a mirrored file system. This is
+the recommended way to inspect mirroring progress from the Ceph CLI without using
+the ``cephfs-mirror`` admin socket.
+
+Unlike ``fs mirror peer status``, which reads in-memory state from a running mirror
+daemon on the local host, this command is implemented in the mirroring Manager
+module and reads metrics that ``cephfs-mirror`` has written to the metadata pool
+omap. That persistence is what makes cluster-wide status available from any node
+that can run ``ceph`` commands. While a sync is in progress, the daemon updates
+these omap entries periodically (see ``cephfs_mirror_tick_interval``).
+The Manager formats the omap data and returns JSON in the same nested structure
+as the admin socket ``fs mirror peer status`` command, including
+``metrics_updated_at`` when metrics are read from omap.
+
+**Syntax**
+
+.. prompt:: bash $
+
+   ceph fs snapshot mirror status <fs_name> [<mirrored_dir_path>] [--peer_uuid=<peer_uuid>]
+
+``<fs_name>``
+  File system on the primary cluster for which mirroring is enabled.
+
+``<mirrored_dir_path>`` (optional)
+  Absolute path of a directory configured for mirroring (for example ``/d0``).
+  When omitted, metrics for all mirrored directories (subject to
+  ``--peer_uuid``) are returned.
+
+``--peer_uuid=<peer_uuid>`` (optional)
+  UUID of a mirror peer (from ``ceph fs snapshot mirror peer_list``). When
+  omitted, metrics for all configured peers are returned. When both
+  ``<mirrored_dir_path>`` and ``--peer_uuid`` are specified, only that
+  directory/peer pair is reported.
+
+Examples::
+
+  # All directories and peers
+  $ ceph fs snapshot mirror status cephfs
+
+  # One mirrored directory, all peers
+  $ ceph fs snapshot mirror status cephfs /d0
+
+  # All directories for one peer
+  $ ceph fs snapshot mirror status cephfs --peer_uuid=a2dc7784-e7a1-4723-b103-03ee8d8768f8
+
+  # One directory and one peer
+  $ ceph fs snapshot mirror status cephfs /d0 --peer_uuid=a2dc7784-e7a1-4723-b103-03ee8d8768f8
+
+**Output format**
+
+The command returns a JSON object with a top-level ``metrics`` key. Per-directory
+statistics are nested under ``metrics/<mirrored-dir-path>/peer/<peer-uuid>`` so the
+same directory path can be reported for multiple peers without key collisions.
+
+When mirroring is enabled but no peers are configured, the command succeeds and
+returns an empty metrics object::
+
+  $ ceph fs snapshot mirror status cephfs
+  {
+      "metrics": {}
+  }
+
+When a directory has been added for mirroring but no snapshot has been synchronized
+yet, the Manager reports the same default idle statistics as the admin socket
+interface (``state`` is ``idle`` with zero snap counters and no ``last_synced_snap``).
+Full-file-system queries include every directory in the mirror policy, using these
+defaults for any directory or peer that does not yet have an omap entry.
+
+A minimal idle example (one directory, one peer)::
+
+  $ ceph fs snapshot mirror status cephfs /d0
+  {
+      "metrics": {
+          "/d0": {
+              "peer": {
+                  "a2dc7784-e7a1-4723-b103-03ee8d8768f8": {
+                      "state": "idle",
+                      "snaps_synced": 0,
+                      "snaps_deleted": 0,
+                      "snaps_renamed": 0
+                  }
+              }
+          }
+      }
+  }
+
+After snapshots are synchronized, fields such as ``last_synced_snap``,
+``current_syncing_snap``, ``snaps_synced``, ``snaps_deleted``, and ``snaps_renamed``
+match the admin socket output while the owning daemon is actively persisting omap
+updates. The mgr command also includes ``metrics_updated_at`` (see above).
+Durations and byte counts are formatted for display (for example ``33s``,
+``149.94 MiB``). See :ref:`Snapshot sync metric fields<cephfs_mirroring_sync_metric_fields>`
+for persistence and per-session counter behavior.
+
+**Directory states**
+
+A directory can be in one of the following states (under each peer):
+
+- ``idle``: The directory is not currently being synchronized.
+- ``syncing``: The directory is currently being synchronized. The
+  ``current_syncing_snap`` object describes in-progress snapshot sync (see field
+  tables below).
+- ``stale``: Reported by the Manager when persisted omap data is no longer owned
+  by a live mirror daemon instance (see :ref:`Stale progress detection<cephfs_mirroring_stale_metrics>`).
+  ``current_syncing_snap`` is omitted.
+- ``failed``: The directory has hit the upper limit of consecutive synchronization
+  failures. A ``failure_reason`` string may be present.
+
+.. _cephfs_mirroring_stale_metrics:
+
+**Stale progress detection**
+
+Each omap entry records an internal ``_instance_id`` (the RADOS client instance
+of the ``cephfs-mirror`` daemon that last wrote the entry). The Manager compares
+this value against the set of live mirror daemon instances and against the instance
+currently assigned to the directory in the mirroring module's directory map:
+
+- If the persisted ``_instance_id`` is **not** among the live mirror instances,
+  the entry is reported as ``stale`` (regardless of the persisted ``state``).
+- If the directory's tracked instance differs from the persisted ``_instance_id``
+  and the persisted ``state`` is not ``idle``, the entry is reported as ``stale``
+  (for example after a directory is reshuffled to another daemon mid-sync).
+
+In both cases ``current_syncing_snap`` is omitted from the output. The ``stale``
+state is reported only by ``ceph fs snapshot mirror status``, which can read omap
+even when no mirror daemon is running. The admin socket requires an active
+``cephfs-mirror`` daemon; ``ceph --admin-daemon`` commands fail when the mirror
+daemon is not running.
+
+**After a daemon restart**
+
+Immediately after a ``cephfs-mirror`` restart, omap may still contain metrics
+written by the previous session (including a stale ``_instance_id``). The Manager
+may report ``stale`` until the new daemon instance writes an updated omap entry.
+Per-session counters in omap can likewise reflect the previous session until the
+new daemon persists; the admin socket on the restarted daemon already shows zero
+for those counters. See :ref:`Snapshot sync metric fields<cephfs_mirroring_sync_metric_fields>`.
+
+**Caching**
+
+To reduce load on the metadata pool, the Manager keeps two short-lived in-memory
+caches of formatted metrics returned by ``fs snapshot mirror status``:
+
+- **Complete cache** — one entry per file system with all mirrored directories
+  and peers (a full omap snapshot). Used for ``ceph fs snapshot mirror status
+  <fs_name>`` and for optional ``--peer_uuid`` filtering.
+- **Partial cache** — per-directory omap reads keyed by file system, directory
+  path, and peer set. Single-directory queries (``<fs_name> <mirrored_dir_path>``)
+  peek the complete cache first; on miss they use the partial cache so a cold
+  complete cache does not trigger a full omap scan.
+
+Caching is enabled by default (``snapshot_mirror_metrics_cache_enabled``). When
+disabled, each query reads omap directly. When enabled, the default time-to-live
+is 15 seconds (``snapshot_mirror_metrics_cache_ttl``) for both caches. Repeated
+queries within the TTL may be served without reading omap again. After the cache
+expires, the next query reloads metrics from omap.
+
+**Comparison with the admin socket**
+
+.. list-table::
+   :widths: 50 50
+   :header-rows: 1
+
+   * - ``ceph fs snapshot mirror status``
+     - ``fs mirror peer status`` (admin socket)
+   * - Invoked via the Ceph CLI through the Manager
+     - Invoked with ``ceph --admin-daemon`` on a mirror daemon host
+   * - Reads metrics persisted in the metadata pool omap
+     - Reads in-memory state from the mirror daemon
+   * - ``last_synced_snap`` survives daemon restart (from omap)
+     - ``last_synced_snap`` restored from omap on daemon start
+   * - Per-session counters may lag omap until the owning daemon re-persists
+     - Per-session counters reset to zero on daemon restart
+   * - Can report ``stale`` when the omap writer is no longer live
+     - Requires a running mirror daemon (unavailable when none is active)
+   * - Includes ``metrics_updated_at`` (time of last omap write)
+     - Not present; reads live in-memory state only
+   * - Optional filters by mirrored directory path and peer UUID
+     - Reports all mirrored directories for the given peer
+
+For interactive debugging on a specific mirror daemon host, the admin socket
+remains useful. For operators and monitoring integrations that prefer a standard
+``ceph`` subcommand, use ``fs snapshot mirror status``.
+
+**Configuration**
+
+- ``cephfs_mirror_tick_interval`` (``cephfs-mirror`` daemon,
+  default: ``5`` seconds) — tick interval for periodic mirroring work,
+  including how often live sync progress is written to omap while a snapshot
+  is synchronizing.
+
+- ``snapshot_mirror_metrics_cache_enabled`` (``mgr/mirroring`` module, default:
+  ``true``) — whether the Manager caches ``fs snapshot mirror status`` responses.
+  When ``false``, each query reads omap directly::
+
+     ceph config set mgr mgr/mirroring/snapshot_mirror_metrics_cache_enabled false
+
+- ``snapshot_mirror_metrics_cache_ttl`` (``mgr/mirroring`` module, default:
+  ``15`` seconds) — when caching is enabled, how long the Manager caches
+  formatted ``fs snapshot mirror status`` responses before reading omap again::
+
+     ceph config set mgr mgr/mirroring/snapshot_mirror_metrics_cache_ttl 15
+
+**Errors**
+
+The command fails with a non-zero exit code and an error message when:
+
+- ``<fs_name>`` does not exist
+- Mirroring is not enabled for the file system
+- ``<mirrored_dir_path>`` is not an absolute path, is not configured for mirroring,
+  or is not found in the mirror policy
+- ``<peer_uuid>`` is not configured for the file system
 
 CephFS mirror daemons provide admin socket commands for querying mirror status. To check
 available commands for mirror status use::
@@ -463,14 +755,21 @@ Monotonic clock time in seconds (since daemon startup) when the snapshot sync fi
 printed with sub-second precision and an ``s`` suffix (for example, ``274900.558797s``). This
 is not a wall-clock or epoch timestamp.
 
-Synchronization stats including ``snaps_synced``, ``snaps_deleted`` and ``snaps_renamed`` are reset
-on daemon restart and/or when a directory is reassigned to another mirror daemon (when
-multiple mirror daemons are deployed).
+``snaps_synced``, ``snaps_deleted``, and ``snaps_renamed`` are
+:ref:`per-session counters<cephfs_mirroring_sync_metric_fields>`: they count
+activity in the current ``cephfs-mirror`` daemon session only and are not restored
+from omap on restart. They reset to zero on daemon restart and when a directory is
+reassigned to another mirror daemon (in multi-daemon deployments).
 
 A directory can be in one of the following states:
 
 - ``idle``: The directory is currently not being synchronized.
 - ``syncing``: The directory is currently being synchronized.
+- ``stale``: Reported only by ``ceph fs snapshot mirror status`` when persisted
+  omap data is no longer owned by a live mirror daemon instance (see
+  :ref:`Stale progress detection<cephfs_mirroring_stale_metrics>`). The admin
+  socket does not use this state; ``fs mirror peer status`` requires a running
+  ``cephfs-mirror`` daemon and fails when none is active.
 - ``failed``: The directory has hit upper limit of consecutive failures.
 
 When a directory is currently being synchronized, the mirror daemon marks it as ``syncing`` and

--- a/doc/dev/cephfs-mirroring.rst
+++ b/doc/dev/cephfs-mirroring.rst
@@ -326,8 +326,48 @@ For example:
   ]
 
 One entry per mirror-daemon instance is displayed, along with information
-including configured peers and basic statistics. For more detailed statistics,
-use the admin socket interface as detailed below.
+including configured peers and basic statistics.
+
+**Directory snapshot sync metrics (mgr)**
+
+The mirroring module implements ``ceph fs snapshot mirror status``. The
+``cephfs-mirror`` daemon persists per-directory sync statistics to the
+``cephfs_mirror`` object omap in the metadata pool so the Manager can expose
+them through the Ceph CLI without an admin socket on a mirror daemon host. The
+``metrics_status`` handler reads that omap, applies stale detection and default
+idle metrics for newly mirrored directories, and returns JSON in the same nested
+``metrics/<dir>/peer/<uuid>`` format as ``fs mirror peer status``. When
+``snapshot_mirror_metrics_cache_enabled`` is true (default TTL 15 seconds via
+``snapshot_mirror_metrics_cache_ttl``), responses are served from a complete
+cache (full file system snapshot) and, for single-directory queries, a partial
+per-directory cache that avoids full omap scans on complete-cache miss. When
+caching is disabled, each query reads omap directly. Omap entries are marked
+``stale`` when the persisted ``_instance_id`` is not among live mirror instances
+or does not match the directory's tracked instance while persisted state is not
+``idle``.
+
+Each omap value includes metadata fields written by ``cephfs-mirror``:
+
+- ``_instance_id`` — RADOS client instance of the writer; used for stale
+  detection and stripped from CLI output.
+- ``metrics_updated_at`` — wall-clock time of the last omap write. Exposed in
+  ``ceph fs snapshot mirror status`` output only; omitted from admin socket
+  ``fs mirror peer status``, which reads live in-memory state and does not
+  need a separate persist timestamp. Operators use this field to judge how
+  fresh omap-backed metrics are, given ``cephfs_mirror_tick_interval`` omap
+  persist cadence and Manager caching (``snapshot_mirror_metrics_cache_enabled``
+  and ``snapshot_mirror_metrics_cache_ttl``).
+
+Omap entries are removed when a directory is removed from mirroring. All metric
+fields are written to omap; on daemon restart only ``last_synced_snap`` metadata
+is loaded back. Per-session counters (``snaps_synced``, ``snaps_deleted``,
+``snaps_renamed``) are persisted but not loaded and therefore start at zero each
+session.
+
+See :ref:`Directory snapshot sync metrics<cephfs_mirroring_mgr_snapshot_status>`
+and :ref:`Snapshot sync metric fields<cephfs_mirroring_sync_metric_fields>` in
+:doc:`/cephfs/cephfs-mirroring` for command syntax, examples, and operator
+guidance.
 
 CephFS mirror daemons provide admin socket commands for querying mirror status.
 To list the available commands for ``mirror status``, run the following

--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -5,6 +5,7 @@ import base64
 import errno
 import logging
 import random
+import signal
 import time
 import functools
 
@@ -14,6 +15,7 @@ from collections import deque
 from tasks.cephfs.cephfs_test_case import CephFSTestCase
 from teuthology.exceptions import CommandFailedError
 from teuthology.contextutil import safe_while
+from teuthology.orchestra import run
 
 log = logging.getLogger(__name__)
 
@@ -70,6 +72,8 @@ class TestMirroring(CephFSTestCase):
     PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR_FS = "cephfs_mirror_mirrored_filesystems"
     PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR_PEER = "cephfs_mirror_peers"
     PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR_DIRECTORY = "cephfs_mirror_directory"
+    MGR_METRICS_CACHE_TTL = 3
+    MIRROR_TICK_INTERVAL = 1
 
     def setUp(self):
         super(TestMirroring, self).setUp()
@@ -79,6 +83,60 @@ class TestMirroring(CephFSTestCase):
         self.secondary_fs_id = self.backup_fs.id
         self.enable_mirroring_module()
         self.config_set('client.mirror', 'cephfs_mirror_directory_scan_interval', 1)
+        self.config_set('client.mirror', 'cephfs_mirror_tick_interval',
+                          self.MIRROR_TICK_INTERVAL)
+        self.config_set('mgr', 'mgr/mirroring/snapshot_mirror_metrics_cache_ttl',
+                          self.MGR_METRICS_CACHE_TTL)
+        self.enable_mgr_metrics_cache()
+
+    def disable_mgr_metrics_cache(self):
+        self.config_set('mgr', 'mgr/mirroring/snapshot_mirror_metrics_cache_enabled',
+                        False)
+
+    def enable_mgr_metrics_cache(self):
+        self.config_set('mgr', 'mgr/mirroring/snapshot_mirror_metrics_cache_enabled',
+                        True)
+
+    def assert_mgr_mirror_status_scopes(self, fs_name, dir_path, peer_uuid,
+                                        expected_dirs, asok_res):
+        full_res = self.mgr_mirror_status(fs_name)
+        self.assertEqual(set(full_res['metrics'].keys()), set(expected_dirs))
+
+        peer_res = self.mgr_mirror_status(fs_name, peer_uuid=peer_uuid)
+        self.assertEqual(set(peer_res['metrics'].keys()), set(expected_dirs))
+        for path in expected_dirs:
+            self.assertEqual(
+                set(peer_res['metrics'][path]['peer'].keys()), {peer_uuid})
+
+        dir_res = self.mgr_mirror_status(fs_name, dir_path)
+        self.assertEqual(set(dir_res['metrics'].keys()), {dir_path})
+
+        dir_peer_res = self.mgr_mirror_status(fs_name, dir_path, peer_uuid)
+        self.assertEqual(set(dir_peer_res['metrics'].keys()), {dir_path})
+        self.assertEqual(
+            set(dir_peer_res['metrics'][dir_path]['peer'].keys()), {peer_uuid})
+
+        for path in expected_dirs:
+            for res in (full_res, peer_res):
+                mgr_stat = self.peer_dir_status(res, path, peer_uuid)
+                asok_stat = self.peer_dir_status(asok_res, path, peer_uuid)
+                self.assert_mgr_dir_stat_matches_asok(mgr_stat, asok_stat)
+
+        for res in (dir_res, dir_peer_res):
+            mgr_stat = self.peer_dir_status(res, dir_path, peer_uuid)
+            asok_stat = self.peer_dir_status(asok_res, dir_path, peer_uuid)
+            self.assert_mgr_dir_stat_matches_asok(mgr_stat, asok_stat)
+
+    @retry_assert(timeout=120, interval=1)
+    def check_mgr_snapshot_mirror_status_scopes_match_asok(
+            self, fs_name, fs_id, dir_path, peer_uuid, expected_dirs,
+            expected_state=None):
+        asok_res = self.peer_status(fs_name, fs_id, peer_uuid)
+        asok_stat = self.peer_dir_status(asok_res, dir_path, peer_uuid)
+        if expected_state is not None:
+            self.assertEqual(asok_stat['state'], expected_state)
+        self.assert_mgr_mirror_status_scopes(
+            fs_name, dir_path, peer_uuid, expected_dirs, asok_res)
 
     def tearDown(self):
         self.disable_mirroring_module()
@@ -361,6 +419,172 @@ class TestMirroring(CephFSTestCase):
             self.assertIn('sync_percent', files_obj)
         self.assertTrue(
             snap['eta'] == 'calculating...' or bool(re.search(r'\d', snap['eta'])))
+
+    def mgr_mirror_status(self, fs_name, mirrored_dir_path=None, peer_uuid=None):
+        args = ["fs", "snapshot", "mirror", "status", fs_name]
+        if mirrored_dir_path is not None:
+            args.append(mirrored_dir_path)
+        if peer_uuid is not None:
+            args.append(f'--peer_uuid={peer_uuid}')
+        return json.loads(self.get_ceph_cmd_stdout(*args))
+
+    def peer_status(self, fs_name, fs_id, peer_uuid):
+        return self.mirror_daemon_command(
+            f'peer status for fs: {fs_name}',
+            'fs', 'mirror', 'peer', 'status',
+            f'{fs_name}@{fs_id}', peer_uuid)
+
+    def dir_status_from_mgr(self, fs_name, dir_name, peer_uuid,
+                            mirrored_dir_path=None):
+        res = self.mgr_mirror_status(
+            fs_name, mirrored_dir_path or dir_name, peer_uuid)
+        return self.peer_dir_status(res, dir_name, peer_uuid)
+
+    def dir_status_from_asok(self, fs_name, fs_id, dir_name, peer_uuid):
+        res = self.peer_status(fs_name, fs_id, peer_uuid)
+        return self.peer_dir_status(res, dir_name, peer_uuid)
+
+    def assert_default_idle_dir_stat(self, dir_stat):
+        self.assertEqual(dir_stat['state'], 'idle')
+        self.assertEqual(dir_stat['snaps_synced'], 0)
+        self.assertEqual(dir_stat['snaps_deleted'], 0)
+        self.assertEqual(dir_stat['snaps_renamed'], 0)
+        self.assertNotIn('last_synced_snap', dir_stat)
+
+    def assert_mgr_dir_stat_matches_asok(self, mgr_stat, asok_stat):
+        self.assertEqual(mgr_stat['state'], asok_stat['state'])
+        for key in ('snaps_synced', 'snaps_deleted', 'snaps_renamed'):
+            self.assertEqual(mgr_stat.get(key), asok_stat.get(key))
+        if 'failure_reason' in asok_stat:
+            self.assertEqual(mgr_stat.get('failure_reason'), asok_stat['failure_reason'])
+        if 'last_synced_snap' in asok_stat:
+            self.assertIn('last_synced_snap', mgr_stat)
+            self.assertEqual(mgr_stat['last_synced_snap']['name'],
+                             asok_stat['last_synced_snap']['name'])
+            self.assert_last_synced_snap_metrics(mgr_stat['last_synced_snap'])
+        if 'current_syncing_snap' in asok_stat:
+            self.assertIn('current_syncing_snap', mgr_stat)
+            mgr_snap = mgr_stat['current_syncing_snap']
+            asok_snap = asok_stat['current_syncing_snap']
+            self.assertEqual(mgr_snap['name'], asok_snap['name'])
+            self.assert_syncing_snap_metrics(
+                mgr_snap, sync_mode=asok_snap.get('sync-mode'))
+
+    @retry_assert(timeout=120, interval=1)
+    def check_mgr_dir_stat_matches_asok(self, fs_name, fs_id, dir_name, peer_uuid,
+                                      mirrored_dir_path=None):
+        mgr_stat = self.dir_status_from_mgr(
+            fs_name, dir_name, peer_uuid, mirrored_dir_path)
+        asok_stat = self.dir_status_from_asok(fs_name, fs_id, dir_name, peer_uuid)
+        try:
+            self.assert_mgr_dir_stat_matches_asok(mgr_stat, asok_stat)
+        except RETRY_EXCEPTIONS as e:
+            e.mgr_stat = mgr_stat
+            e.asok_stat = asok_stat
+            raise
+
+    def wait_for_mirror_daemon_stop(self, pid):
+        with safe_while(sleep=1, tries=60,
+                        action='wait for mirror daemon stop') as proceed:
+            while proceed():
+                try:
+                    cur_pid = self.get_mirror_daemon_pid()
+                except CommandFailedError:
+                    return
+                if cur_pid != pid:
+                    return
+                p = self.mount_a.run_shell(['kill', '-0', cur_pid],
+                                           check_status=False)
+                if p.returncode != 0:
+                    return
+
+    def restart_mirror_daemon(self):
+        # daemon.start() always calls restart(), which skips stop() once proc
+        # is cleared.  Stop the real cephfs-mirror via its pid file first so
+        # the new instance can take the pidfile lock.
+        daemons = list(self.ctx.daemons.iter_daemons_of_role('cephfs-mirror'))
+        self.assertEqual(len(daemons), 1,
+                         'expected a single cephfs-mirror daemon')
+        daemon = daemons[0]
+        rados_inst_before = self.get_mirror_rados_addr(
+            self.primary_fs_name, self.primary_fs_id)
+        pid = self.get_mirror_daemon_pid()
+
+        log.debug(f'SIGTERM to cephfs-mirror pid {pid}')
+        if daemon.running():
+            try:
+                daemon.signal(signal.SIGTERM, silent=True)
+            except Exception as e:
+                log.debug(f'failed to signal cephfs-mirror via teuthology: {e}')
+        self.mount_a.run_shell(['kill', '-TERM', pid])
+        self.wait_for_mirror_daemon_stop(pid)
+
+        if daemon.running():
+            try:
+                run.wait([daemon.proc], timeout=10)
+            except CommandFailedError:
+                pass
+        daemon.reset()
+
+        log.debug('starting cephfs-mirror')
+        daemon.start()
+
+        time.sleep(60)
+        with safe_while(sleep=2, tries=30,
+                        action='wait for mirror daemon restart') as proceed:
+            while proceed():
+                try:
+                    rados_inst = self.get_mirror_rados_addr(
+                        self.primary_fs_name, self.primary_fs_id)
+                    if rados_inst and rados_inst != rados_inst_before:
+                        break
+                except CommandFailedError:
+                    pass
+
+    def wait_for_mirror_daemon_recovery(self, fs_name, fs_id, dir_name, peer_uuid):
+        # A new rados_inst alone does not mean mirroring is ready: wait until the
+        # peer is configured, the snap dir is registered, and asok reports it.
+        with safe_while(sleep=2, tries=60,
+                        action='wait for mirror daemon recovery') as proceed:
+            while proceed():
+                if not self.get_mirror_rados_addr(fs_name, fs_id):
+                    continue
+                try:
+                    mirror_res = self.mirror_daemon_command(
+                        f'mirror status for fs: {fs_name}',
+                        'fs', 'mirror', 'status', f'{fs_name}@{fs_id}')
+                except CommandFailedError:
+                    continue
+                if peer_uuid not in mirror_res.get('peers', {}):
+                    continue
+                if mirror_res.get('snap_dirs', {}).get('dir_count', 0) < 1:
+                    continue
+                try:
+                    peer_res = self.peer_status(fs_name, fs_id, peer_uuid)
+                    self.peer_dir_status(peer_res, dir_name, peer_uuid)
+                except RETRY_EXCEPTIONS:
+                    continue
+                return
+
+    @retry_assert(timeout=120, interval=1)
+    def check_mgr_and_asok_session_counters_zero(self, fs_name, fs_id, dir_name,
+                                                 peer_uuid):
+        mgr_stat = self.dir_status_from_mgr(fs_name, dir_name, peer_uuid)
+        asok_stat = self.dir_status_from_asok(fs_name, fs_id, dir_name, peer_uuid)
+        self.assertEqual(mgr_stat['state'], 'idle')
+        self.assertEqual(asok_stat['state'], 'idle')
+        for key in ('snaps_synced', 'snaps_deleted', 'snaps_renamed'):
+            self.assertEqual(mgr_stat.get(key), 0, msg=f'mgr {key}')
+            self.assertEqual(asok_stat.get(key), 0, msg=f'asok {key}')
+        self.assertEqual(mgr_stat['last_synced_snap']['name'],
+                         asok_stat['last_synced_snap']['name'])
+
+    @retry_assert(timeout=90, interval=5)
+    def check_mgr_dir_stat_stale(self, fs_name, dir_name, peer_uuid):
+        mgr_stat = self.dir_status_from_mgr(fs_name, dir_name, peer_uuid)
+        self.assertEqual(mgr_stat['state'], 'stale',
+                         msg=f'unexpected mgr stat: {mgr_stat}')
+        self.assertNotIn('current_syncing_snap', mgr_stat)
 
     @retry_assert(timeout=120, interval=1)
     def check_peer_syncing_progress_metrics(self, fs_name, fs_id, peer_spec, dir_name,
@@ -2174,6 +2398,459 @@ class TestMirroring(CephFSTestCase):
 
         self.config_set('client.mirror', 'cephfs_mirror_distribute_datasync_threads', 'true')
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+    def test_mgr_snapshot_mirror_status_matches_asok_idle(self):
+        """Mgr snapshot mirror status matches asok peer status after sync."""
+        self.setup_mount_b(mds_perm='rw')
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        peer_spec = "client.mirror_remote@ceph"
+        self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec,
+                      self.secondary_fs_name)
+
+        dir_name = 'mgr_status_dir'
+        self.mount_a.run_shell(['mkdir', dir_name])
+        self.mount_a.create_n_files(f'{dir_name}/file', 50, sync=True)
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, f'/{dir_name}')
+
+        snap_name = 'snap0'
+        self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/{snap_name}'])
+        self.check_peer_status_idle(self.primary_fs_name, self.primary_fs_id,
+                                    peer_spec, f'/{dir_name}', snap_name, 1)
+
+        peer_uuid = self.get_peer_uuid(peer_spec)
+        self.check_mgr_dir_stat_matches_asok(
+            self.primary_fs_name, self.primary_fs_id, f'/{dir_name}', peer_uuid)
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+    def test_mgr_snapshot_mirror_status_matches_asok_syncing(self):
+        """Mgr snapshot mirror status matches asok peer status during sync."""
+        self.setup_mount_b(mds_perm='rw')
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        peer_spec = "client.mirror_remote@ceph"
+        self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec,
+                      self.secondary_fs_name)
+
+        dir_name = 'mgr_sync_dir'
+        self.mount_a.run_shell(['mkdir', dir_name])
+        self.mount_a.create_n_files(f'{dir_name}/file', 8000, sync=True)
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, f'/{dir_name}')
+
+        snap_name = 'snap0'
+        self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/{snap_name}'])
+        self.check_peer_syncing_progress_metrics(
+            self.primary_fs_name, self.primary_fs_id, peer_spec, f'/{dir_name}',
+            snap_name, sync_mode='full')
+
+        peer_uuid = self.get_peer_uuid(peer_spec)
+        self.check_mgr_dir_stat_matches_asok(
+            self.primary_fs_name, self.primary_fs_id, f'/{dir_name}', peer_uuid)
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+    def test_mgr_snapshot_mirror_status_default_idle_new_dir(self):
+        """Mgr status reports default idle metrics for a newly added directory."""
+        self.setup_mount_b(mds_perm='rw')
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        peer_spec = "client.mirror_remote@ceph"
+        self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec,
+                      self.secondary_fs_name)
+
+        dir_name = 'mgr_default_dir'
+        self.mount_a.run_shell(['mkdir', dir_name])
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, f'/{dir_name}')
+
+        peer_uuid = self.get_peer_uuid(peer_spec)
+        mgr_stat = self.dir_status_from_mgr(
+            self.primary_fs_name, f'/{dir_name}', peer_uuid)
+        self.assert_default_idle_dir_stat(mgr_stat)
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+    def test_mgr_snapshot_mirror_status_stale_after_daemon_stop(self):
+        """Mgr status marks frozen omap syncing progress as stale."""
+        self.setup_mount_b(mds_perm='rw')
+        self.mount_a.run_shell(["mkdir", "d0"])
+        for i in range(8):
+            self.mount_a.write_n_mb(os.path.join('d0', f'file.{i}'), 1024)
+
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, '/d0')
+        peer_spec = "client.mirror_remote@ceph"
+        self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec,
+                      self.secondary_fs_name)
+
+        self.mount_a.run_shell(["mkdir", "d0/.snap/snap0"])
+        self.check_peer_snap_in_progress(self.primary_fs_name, self.primary_fs_id,
+                                         peer_spec, '/d0', 'snap0')
+
+        peer_uuid = self.get_peer_uuid(peer_spec)
+        # Wait for live metrics to reach omap before freezing the daemon.
+        # Stale detection requires a persisted _instance_id; without an omap
+        # write the mgr reports default idle metrics instead of stale.
+        mgr_syncing = False
+        with safe_while(sleep=2, tries=30,
+                        action='wait for omap syncing metrics') as proceed:
+            while proceed():
+                mgr_stat = self.dir_status_from_mgr(
+                    self.primary_fs_name, '/d0', peer_uuid)
+                if mgr_stat.get('state') == 'syncing':
+                    mgr_syncing = True
+                    break
+        self.assertTrue(
+            mgr_syncing,
+            'mgr never reported syncing before SIGSTOP; '
+            f'last mgr stat: {mgr_stat}')
+
+        pid = self.get_mirror_daemon_pid()
+        log.debug(f'SIGSTOP to cephfs-mirror pid {pid}')
+        self.mount_a.run_shell(['kill', '-SIGSTOP', pid])
+        try:
+            # InstanceWatcher INSTANCE_TIMEOUT is 30s; allow extra time for
+            # the mgr notify loop to age out the frozen instance.
+            time.sleep(40)
+            self.check_mgr_dir_stat_stale(
+                self.primary_fs_name, '/d0', peer_uuid)
+        finally:
+            log.debug('SIGCONT to cephfs-mirror')
+            self.mount_a.run_shell(['kill', '-SIGCONT', pid])
+
+        # wait for restart mirror on blocklist
+        time.sleep(60)
+        with safe_while(sleep=2, tries=20,
+                        action='wait for mirror daemon recovery after SIGSTOP') as proceed:
+            while proceed():
+                if not self.get_mirror_rados_addr(self.primary_fs_name,
+                                                   self.primary_fs_id):
+                    continue
+                res = self.mirror_daemon_command(
+                    f'mirror status for fs: {self.primary_fs_name}',
+                    'fs', 'mirror', 'status',
+                    f'{self.primary_fs_name}@{self.primary_fs_id}')
+                if 'snap_dirs' in res:
+                    break
+
+        self.remove_directory(self.primary_fs_name, self.primary_fs_id, '/d0')
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+    def test_mgr_snapshot_mirror_status_no_peers(self):
+        """Mgr status returns empty metrics when no peers are configured."""
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        res = self.mgr_mirror_status(self.primary_fs_name)
+        self.assertEqual(res, {'metrics': {}})
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+    def test_mgr_snapshot_mirror_status_errors(self):
+        """Mgr status returns expected errors for invalid inputs."""
+        self.setup_mount_b(mds_perm='rw')
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        peer_spec = "client.mirror_remote@ceph"
+        self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec,
+                      self.secondary_fs_name)
+
+        dir_name = 'mgr_err_dir'
+        self.mount_a.run_shell(['mkdir', dir_name])
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, f'/{dir_name}')
+
+        try:
+            self.get_ceph_cmd_stdout("fs", "snapshot", "mirror", "status",
+                                     "nonexistent_fs_name")
+        except CommandFailedError as ce:
+            if ce.exitstatus != errno.ENOENT:
+                raise RuntimeError(-errno.ENOENT,
+                                   'incorrect error for unknown filesystem')
+        else:
+            raise RuntimeError(-errno.ENOENT, 'expected unknown filesystem to fail')
+
+        self.remove_directory(self.primary_fs_name, self.primary_fs_id, f'/{dir_name}')
+        self.peer_remove(self.primary_fs_name, self.primary_fs_id, peer_spec)
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        try:
+            self.get_ceph_cmd_stdout("fs", "snapshot", "mirror", "status",
+                                     self.primary_fs_name)
+        except CommandFailedError as ce:
+            if ce.exitstatus != errno.EINVAL:
+                raise RuntimeError(-errno.EINVAL,
+                                   'incorrect error for non-mirrored filesystem')
+        else:
+            raise RuntimeError(-errno.EINVAL, 'expected non-mirrored fs to fail')
+
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        try:
+            self.get_ceph_cmd_stdout("fs", "snapshot", "mirror", "status",
+                                     self.primary_fs_name, '/not_mirrored')
+        except CommandFailedError as ce:
+            if ce.exitstatus != errno.ENOENT:
+                raise RuntimeError(-errno.ENOENT,
+                                   'incorrect error for unknown directory')
+        else:
+            raise RuntimeError(-errno.ENOENT, 'expected unknown directory to fail')
+
+        try:
+            self.get_ceph_cmd_stdout(
+                "fs", "snapshot", "mirror", "status",
+                self.primary_fs_name, f'/{dir_name}',
+                '--peer_uuid=00000000-0000-0000-0000-000000000000')
+        except CommandFailedError as ce:
+            if ce.exitstatus != errno.ENOENT:
+                raise RuntimeError(-errno.ENOENT,
+                                   'incorrect error for unknown peer')
+        else:
+            raise RuntimeError(-errno.ENOENT, 'expected unknown peer to fail')
+
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+    def test_mgr_snapshot_mirror_status_filter_scopes(self):
+        """Mgr status filters by filesystem, directory, and peer scope."""
+        self.setup_mount_b(mds_perm='rw')
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        peer_spec = "client.mirror_remote@ceph"
+        self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec,
+                      self.secondary_fs_name)
+
+        for dir_name in ('mgr_f0', 'mgr_f1'):
+            self.mount_a.run_shell(['mkdir', dir_name])
+            self.mount_a.create_n_files(f'{dir_name}/file', 50, sync=True)
+            self.add_directory(self.primary_fs_name, self.primary_fs_id,
+                              f'/{dir_name}')
+            self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/snap0'])
+
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               peer_spec, '/mgr_f0', 'snap0', 1)
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               peer_spec, '/mgr_f1', 'snap0', 1)
+
+        peer_uuid = self.get_peer_uuid(peer_spec)
+        full_res = self.mgr_mirror_status(self.primary_fs_name)
+        self.assertIn('/mgr_f0', full_res['metrics'])
+        self.assertIn('/mgr_f1', full_res['metrics'])
+
+        dir_res = self.mgr_mirror_status(self.primary_fs_name, '/mgr_f0')
+        self.assertEqual(set(dir_res['metrics'].keys()), {'/mgr_f0'})
+
+        peer_res = self.mgr_mirror_status(
+            self.primary_fs_name, '/mgr_f0', peer_uuid)
+        self.assertEqual(set(peer_res['metrics'].keys()), {'/mgr_f0'})
+        self.assertIn(peer_uuid, peer_res['metrics']['/mgr_f0']['peer'])
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+    def test_mgr_snapshot_mirror_status_survives_daemon_restart(self):
+        """Mgr status keeps persisted last_synced_snap and resets session counters after restart."""
+        self.setup_mount_b(mds_perm='rw')
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        peer_spec = "client.mirror_remote@ceph"
+        self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec,
+                      self.secondary_fs_name)
+
+        dir_name = 'mgr_restart_dir'
+        self.mount_a.run_shell(['mkdir', dir_name])
+        self.mount_a.create_n_files(f'{dir_name}/file', 3000, sync=True)
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, f'/{dir_name}')
+
+        snap0 = 'snap0'
+        self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/{snap0}'])
+        self.check_peer_status_idle(self.primary_fs_name, self.primary_fs_id,
+                                    peer_spec, f'/{dir_name}', snap0, 1)
+
+        for i in range(5):
+            self.mount_a.write_n_mb(os.path.join(dir_name, f'more_file.{i}'), 1)
+
+        snap1 = 'snap1'
+        self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/{snap1}'])
+        self.check_peer_status_idle(self.primary_fs_name, self.primary_fs_id,
+                                    peer_spec, f'/{dir_name}', snap1, 2)
+
+        self.mount_a.run_shell(['rmdir', f'{dir_name}/.snap/{snap0}'])
+        self.check_peer_status_deleted_snap(self.primary_fs_name, self.primary_fs_id,
+                                            peer_spec, f'/{dir_name}', 1)
+        snap_list = self.mount_b.ls(path=f'{dir_name}/.snap')
+        self.assertNotIn(snap0, snap_list)
+
+        snap2 = 'snap2'
+        self.mount_a.run_shell(['mv', f'{dir_name}/.snap/{snap1}',
+                                f'{dir_name}/.snap/{snap2}'])
+        self.check_peer_status_renamed_snap(self.primary_fs_name, self.primary_fs_id,
+                                            peer_spec, f'/{dir_name}', 1)
+        snap_list = self.mount_b.ls(path=f'{dir_name}/.snap')
+        self.assertNotIn(snap1, snap_list)
+        self.assertIn(snap2, snap_list)
+        self.check_peer_status_idle(self.primary_fs_name, self.primary_fs_id,
+                                    peer_spec, f'/{dir_name}', snap2, 2)
+
+        peer_uuid = self.get_peer_uuid(peer_spec)
+        before = self.dir_status_from_mgr(
+            self.primary_fs_name, f'/{dir_name}', peer_uuid)
+        self.assertEqual(before['snaps_synced'], 2)
+        self.assertEqual(before['snaps_deleted'], 1)
+        self.assertEqual(before['snaps_renamed'], 1)
+        self.assertEqual(before['last_synced_snap']['name'], snap2)
+
+        self.restart_mirror_daemon()
+        self.wait_for_mirror_daemon_recovery(
+            self.primary_fs_name, self.primary_fs_id, f'/{dir_name}', peer_uuid)
+        self.check_mgr_and_asok_session_counters_zero(
+            self.primary_fs_name, self.primary_fs_id, f'/{dir_name}', peer_uuid)
+
+        after = self.dir_status_from_mgr(
+            self.primary_fs_name, f'/{dir_name}', peer_uuid)
+        self.assertEqual(after['last_synced_snap']['name'],
+                         before['last_synced_snap']['name'])
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+    def test_mgr_snapshot_mirror_status_after_directory_remove(self):
+        """Mgr status for a removed directory returns ENOENT."""
+        self.setup_mount_b(mds_perm='rw')
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        peer_spec = "client.mirror_remote@ceph"
+        self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec,
+                      self.secondary_fs_name)
+
+        dir_name = 'mgr_rm_dir'
+        self.mount_a.run_shell(['mkdir', dir_name])
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, f'/{dir_name}')
+        self.remove_directory(self.primary_fs_name, self.primary_fs_id, f'/{dir_name}')
+
+        try:
+            self.mgr_mirror_status(self.primary_fs_name, f'/{dir_name}')
+        except CommandFailedError as ce:
+            if ce.exitstatus != errno.ENOENT:
+                raise RuntimeError(-errno.ENOENT,
+                                   'incorrect error for removed directory')
+        else:
+            raise RuntimeError(-errno.ENOENT, 'expected removed directory to fail')
+
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+    def test_mgr_snapshot_mirror_status_failed_state(self):
+        """Mgr status reports failed state like asok peer status."""
+        self.setup_mount_b(mds_perm='rwps')
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        peer_spec = "client.mirror_remote@ceph"
+        self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec,
+                      self.secondary_fs_name)
+
+        dir_name = 'd0'
+        self.mount_a.run_shell(['mkdir', dir_name])
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, f'/{dir_name}')
+
+        snap_name = "snap_a"
+        self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/{snap_name}'])
+        self.check_peer_status_idle(self.primary_fs_name, self.primary_fs_id,
+                                    peer_spec, f'/{dir_name}', snap_name, 1)
+
+        remote_snap_path = f'{dir_name}/.snap/snap_b'
+        self.mount_b.run_shell(['sudo', 'mkdir', remote_snap_path], omit_sudo=False)
+
+        self.verify_failed_directory(self.primary_fs_name, self.primary_fs_id,
+                                     peer_spec, f'/{dir_name}')
+        peer_uuid = self.get_peer_uuid(peer_spec)
+        self.check_mgr_dir_stat_matches_asok(
+            self.primary_fs_name, self.primary_fs_id, f'/{dir_name}', peer_uuid)
+
+        self.mount_b.run_shell(['sudo', 'rmdir', remote_snap_path], omit_sudo=False)
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+    def test_mgr_snapshot_mirror_status_cache(self):
+        """Repeated mgr status calls hit the metrics cache within TTL."""
+        self.setup_mount_b(mds_perm='rw')
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        peer_spec = "client.mirror_remote@ceph"
+        self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec,
+                      self.secondary_fs_name)
+
+        dir_name = 'mgr_cache_dir'
+        self.mount_a.run_shell(['mkdir', dir_name])
+        self.mount_a.create_n_files(f'{dir_name}/file', 50, sync=True)
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, f'/{dir_name}')
+
+        snap0 = 'snap0'
+        self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/{snap0}'])
+        self.check_peer_status_idle(self.primary_fs_name, self.primary_fs_id,
+                                    peer_spec, f'/{dir_name}', snap0, 1)
+
+        res1 = self.mgr_mirror_status(self.primary_fs_name)
+        res2 = self.mgr_mirror_status(self.primary_fs_name)
+        self.assertEqual(res1, res2)
+
+        snap1 = 'snap1'
+        self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/{snap1}'])
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               peer_spec, f'/{dir_name}', snap1, 2)
+
+        time.sleep(self.MGR_METRICS_CACHE_TTL + 1)
+        res3 = self.mgr_mirror_status(self.primary_fs_name)
+        peer_uuid = self.get_peer_uuid(peer_spec)
+        self.assertEqual(
+            res3['metrics'][f'/{dir_name}']['peer'][peer_uuid]['snaps_synced'], 2)
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+    def test_mgr_snapshot_mirror_status_cache_disabled(self):
+        """Mgr snapshot mirror status reads omap for all scopes when cache is disabled."""
+        self.disable_mgr_metrics_cache()
+        try:
+            self.setup_mount_b(mds_perm='rw')
+            self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+            peer_spec = "client.mirror_remote@ceph"
+            self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec,
+                          self.secondary_fs_name)
+
+            dirs = []
+            for dir_name in ('mgr_nc0', 'mgr_nc1'):
+                self.mount_a.run_shell(['mkdir', dir_name])
+                self.mount_a.create_n_files(f'{dir_name}/file', 50, sync=True)
+                self.add_directory(self.primary_fs_name, self.primary_fs_id,
+                                   f'/{dir_name}')
+                self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/snap0'])
+                dirs.append(f'/{dir_name}')
+
+            peer_uuid = self.get_peer_uuid(peer_spec)
+            for dir_path in dirs:
+                self.check_peer_status_idle(self.primary_fs_name, self.primary_fs_id,
+                                            peer_spec, dir_path, 'snap0', 1)
+
+            self.check_mgr_snapshot_mirror_status_scopes_match_asok(
+                self.primary_fs_name, self.primary_fs_id, dirs[0], peer_uuid,
+                dirs)
+
+            self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        finally:
+            self.enable_mgr_metrics_cache()
+
+    def test_mgr_snapshot_mirror_status_cache_disabled_syncing(self):
+        """Mgr snapshot mirror status reads omap during sync when cache is disabled."""
+        self.disable_mgr_metrics_cache()
+        try:
+            self.setup_mount_b(mds_perm='rw')
+            self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+            peer_spec = "client.mirror_remote@ceph"
+            self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec,
+                          self.secondary_fs_name)
+
+            idle_dir = 'mgr_nc_idle'
+            self.mount_a.run_shell(['mkdir', idle_dir])
+            self.mount_a.create_n_files(f'{idle_dir}/file', 50, sync=True)
+            self.add_directory(self.primary_fs_name, self.primary_fs_id,
+                               f'/{idle_dir}')
+            self.mount_a.run_shell(['mkdir', f'{idle_dir}/.snap/snap0'])
+            self.check_peer_status_idle(self.primary_fs_name, self.primary_fs_id,
+                                        peer_spec, f'/{idle_dir}', 'snap0', 1)
+
+            sync_dir = 'mgr_nc_sync'
+            self.mount_a.run_shell(['mkdir', sync_dir])
+            self.mount_a.create_n_files(f'{sync_dir}/file', 10000, sync=True)
+            self.add_directory(self.primary_fs_name, self.primary_fs_id,
+                               f'/{sync_dir}')
+            snap_name = 'snap0'
+            self.mount_a.run_shell(['mkdir', f'{sync_dir}/.snap/{snap_name}'])
+            self.check_peer_syncing_progress_metrics(
+                self.primary_fs_name, self.primary_fs_id, peer_spec,
+                f'/{sync_dir}', snap_name, sync_mode='full')
+
+            peer_uuid = self.get_peer_uuid(peer_spec)
+            dirs = [f'/{idle_dir}', f'/{sync_dir}']
+            self.check_mgr_snapshot_mirror_status_scopes_match_asok(
+                self.primary_fs_name, self.primary_fs_id, f'/{sync_dir}',
+                peer_uuid, dirs, expected_state='syncing')
+            self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        finally:
+            self.enable_mgr_metrics_cache()
 
     def test_cephfs_mirror_duplicate_acquire_notify(self):
         """Duplicate acquire notifies must not leave a ghost replayer directory.

--- a/src/pybind/mgr/mirroring/fs/dir_map/policy.py
+++ b/src/pybind/mgr/mirroring/fs/dir_map/policy.py
@@ -105,6 +105,12 @@ class Policy:
                         'purging': dir_state.purging}
             return None
 
+    def get_tracked_instance_id(self, dir_path):
+        lookup = self.lookup(dir_path)
+        if not lookup:
+            return None
+        return lookup.get('instance_id')
+
     def map(self, dir_path, dir_state):
         log.debug(f'mapping {dir_path}')
         min_instance_id = None

--- a/src/pybind/mgr/mirroring/fs/metrics/cache.py
+++ b/src/pybind/mgr/mirroring/fs/metrics/cache.py
@@ -1,0 +1,202 @@
+from collections import OrderedDict, namedtuple
+from functools import wraps
+from typing import Any, Callable, Dict
+
+import time
+
+from ..utils import norm_path
+from .format import format_and_order_sync_stat_for_display, format_peer_status_metrics
+
+# Two caches are used instead of one unified cache:
+#
+# - Complete cache holds a full omap snapshot (all dirs, all peers) per
+#   filesystem. A hit guarantees the entry is complete, so full-scan queries
+#   ('status <fs>', 'status <fs> <peer>') can be served without doubt.
+#
+# - Partial cache holds per-directory omap loads. Single-dir queries
+#   ('status <fs> <dir>') peek the complete cache first; on miss they use
+#   partial cache to avoid a full omap scan.
+#
+# A single cache keyed at directory granularity cannot cleanly answer "do I
+# have every directory?" — partial entries may be present while others are
+# missing, so serving a full scan from cache would require extra bookkeeping
+# to prove completeness. Splitting complete vs partial makes that contract
+# explicit: complete = all dirs; partial = one dir.
+
+# LRU max entries for complete-cache lookups (one entry per filesystem per TTL
+# window; each entry holds all dirs and all peers for that filesystem).
+# Cache key: (time_token, filesystem).
+COMPLETE_CACHE_MAX = 8
+# LRU max entries for partial-cache lookups (per-directory omap batch load).
+# Cache key: (time_token, filesystem, dir_path, peer_ids).
+PARTIAL_CACHE_MAX = 32
+
+CacheInfo = namedtuple('CacheInfo', ['hits', 'misses', 'maxsize', 'currsize'])
+
+
+# functools.lru_cache is not sufficient here for two reasons:
+#
+# 1. TTL: entries must expire after snapshot_mirror_metrics_cache_ttl. lru_cache
+#    has no TTL, so we bucket keys with a time_token derived from monotonic time.
+#
+# 2. cache_peek: single-directory status queries must read the complete cache
+#    without loading on miss (otherwise a cold complete cache would trigger a
+#    full omap scan). lru_cache has no peek API; calling the wrapper always
+#    invokes the loader on miss. Inspecting lru_cache.cache for a hit-only
+#    lookup is also not viable: that attribute is not part of the public API and
+#    is unavailable on Python 3.14+ (_lru_cache_wrapper has no .cache).
+#
+# _TimedLRUCache therefore implements TTL-bucketed LRU storage plus peek().
+class _TimedLRUCache:
+    def __init__(self, func, maxsize):
+        self.func = func
+        self.maxsize = maxsize
+        self.store = OrderedDict()
+        self.hits = 0
+        self.misses = 0
+
+    def _key(self, time_token, args):
+        # time_token buckets entries by snapshot_mirror_metrics_cache_ttl; args are
+        # the decorated method's positional arguments (e.g. filesystem, or
+        # filesystem+dir+peers).
+        return (time_token,) + args
+
+    def get(self, time_token, args, load=True):
+        key = self._key(time_token, args)
+        if key in self.store:
+            self.hits += 1
+            self.store.move_to_end(key)
+            return self.store[key]
+        if not load:
+            return None
+        self.misses += 1
+        val = self.func(*args)
+        self.store[key] = val
+        while len(self.store) > self.maxsize:
+            self.store.popitem(last=False)
+        return val
+
+    def peek(self, time_token, args):
+        return self.get(time_token, args, load=False)
+
+    def clear(self):
+        self.store.clear()
+        self.hits = 0
+        self.misses = 0
+
+    def info(self):
+        return CacheInfo(self.hits, self.misses, self.maxsize, len(self.store))
+
+
+def _resolve_ttl(ttl_getter, args, kwargs):
+    try:
+        return ttl_getter(*args, **kwargs)
+    except TypeError:
+        return ttl_getter()
+
+
+def lru_cache_timeout(ttl_getter: Callable[..., int], maxsize: int = 128):
+    def decorator(func):
+        cache = _TimedLRUCache(func, maxsize)
+
+        # BoundCached is returned from CachedMethod.__get__ so cache_peek,
+        # cache_info, and cache_clear are bound to the instance. Attaching
+        # those helpers to a plain wrapper function would drop self (e.g.
+        # self.sync_stat_complete_cache.cache_peek(fs) would pass only fs),
+        # breaking ttl_getter lambdas that use self.mgr.
+        class BoundCached:
+            def __init__(self, instance):
+                self._instance = instance
+
+            def _full_args(self, *args):
+                return (self._instance,) + args
+
+            def __call__(self, *args, **kwargs):
+                full = self._full_args(*args)
+                ttl = _resolve_ttl(ttl_getter, full, kwargs)
+                if not ttl:
+                    return func(*full, **kwargs)
+                time_token = int(time.monotonic() / ttl)
+                return cache.get(time_token, full)
+
+            def cache_peek(self, *args, **kwargs):
+                full = self._full_args(*args)
+                ttl = _resolve_ttl(ttl_getter, full, kwargs)
+                if not ttl:
+                    return None
+                time_token = int(time.monotonic() / ttl)
+                return cache.peek(time_token, full)
+
+            def cache_clear(self):
+                cache.clear()
+
+            def cache_info(self):
+                return cache.info()
+
+        # Descriptor: self.method(...) and self.method.cache_peek(...) share
+        # the same BoundCached instance and cache keys.
+        class CachedMethod:
+            def __get__(self, obj, owner=None):
+                if obj is None:
+                    return self
+                return BoundCached(obj)
+
+            def __call__(self, *args, **kwargs):
+                ttl = _resolve_ttl(ttl_getter, args, kwargs)
+                if not ttl:
+                    return func(*args, **kwargs)
+                time_token = int(time.monotonic() / ttl)
+                return cache.get(time_token, args)
+
+        cached = CachedMethod()
+        wraps(func)(cached)
+        return cached
+    return decorator
+
+
+def _peer_stats_for_dir(metrics, dir_path):
+    return metrics.get(dir_path, {}).get('peer', {})
+
+
+def _requested_peers_have_stats(metrics, peers, dir_path):
+    peer_stats = _peer_stats_for_dir(metrics, dir_path)
+    return all(peer in peer_stats for peer in peers)
+
+
+def metrics_for_dir_and_peers(metrics, dir_path, peers):
+    result: Dict[str, Any] = {}
+    peer_stats = _peer_stats_for_dir(metrics, dir_path)
+    for peer in peers:
+        if peer in peer_stats:
+            format_peer_status_metrics(
+                result, dir_path, peer,
+                format_and_order_sync_stat_for_display(peer_stats[peer]))
+    return result
+
+
+def metrics_for_peer(metrics, peer_uuid):
+    result: Dict[str, Any] = {}
+    for dir_path, dir_entry in metrics.items():
+        peer_stats = dir_entry.get('peer', {})
+        if peer_uuid in peer_stats:
+            format_peer_status_metrics(
+                result, dir_path, peer_uuid,
+                format_and_order_sync_stat_for_display(peer_stats[peer_uuid]))
+    return result
+
+
+def try_get_from_complete(metrics, mirrored_dir_path, peer_uuid, peers):
+    """Filter complete cache (all dirs, all peers) for the CLI request.
+
+    The complete cache always holds every peer and directory. peer_uuid and
+    peers select the subset to return; they do not affect what is loaded.
+    """
+    if mirrored_dir_path:
+        dir_path = norm_path(mirrored_dir_path)
+        if _requested_peers_have_stats(metrics, peers, dir_path):
+            return metrics_for_dir_and_peers(metrics, dir_path, peers)
+        return None
+
+    if peer_uuid is None:
+        return dict(metrics)
+    return metrics_for_peer(metrics, peer_uuid)

--- a/src/pybind/mgr/mirroring/fs/metrics/format.py
+++ b/src/pybind/mgr/mirroring/fs/metrics/format.py
@@ -1,0 +1,113 @@
+# Matches the format_time function used in peer_status
+def _format_time(total_seconds_d):
+    total_seconds = int(round(total_seconds_d))
+    days = total_seconds // 86400
+    total_seconds %= 86400
+    hours = total_seconds // 3600
+    total_seconds %= 3600
+    minutes = total_seconds // 60
+    seconds = total_seconds % 60
+    if days > 0:
+        return (f'{days}d {hours:02d}h {minutes:02d}m {seconds:02d}s')
+    if hours > 0:
+        return f'{hours}h {minutes:02d}m {seconds:02d}s'
+    if minutes > 0:
+        return f'{minutes}m {seconds:02d}s'
+    return f'{seconds}s'
+
+
+# Matches the format_bytes function used in peer_status
+def _format_bytes(bytes_val):
+    kib = 1024.0
+    mib = kib * 1024.0
+    gib = mib * 1024.0
+    tib = gib * 1024.0
+    pib = tib * 1024.0
+    if bytes_val >= pib:
+        return f'{bytes_val / pib:.2f} PiB'
+    if bytes_val >= tib:
+        return f'{bytes_val / tib:.2f} TiB'
+    if bytes_val >= gib:
+        return f'{bytes_val / gib:.2f} GiB'
+    if bytes_val >= mib:
+        return f'{bytes_val / mib:.2f} MiB'
+    if bytes_val >= kib:
+        return f'{bytes_val / kib:.2f} KiB'
+    return f'{bytes_val:.2f} B'
+
+
+def _order_dict(d, keys):
+    ordered = {}
+    for key in keys:
+        if key in d:
+            ordered[key] = d[key]
+    for key, val in d.items():
+        if key not in ordered:
+            ordered[key] = val
+    return ordered
+
+
+def _order_current_syncing_snap(snap):
+    if not isinstance(snap, dict):
+        return snap
+    snap = dict(snap)
+    crawl = snap.get('crawl')
+    if isinstance(crawl, dict):
+        snap['crawl'] = _order_dict(crawl, ('state', 'duration'))
+    dq_wait = snap.get('datasync_queue_wait')
+    if isinstance(dq_wait, dict):
+        snap['datasync_queue_wait'] = _order_dict(dq_wait, ('state', 'duration'))
+    bytes_obj = snap.get('bytes')
+    if isinstance(bytes_obj, dict):
+        snap['bytes'] = _order_dict(
+            bytes_obj, ('sync_bytes', 'total_bytes', 'sync_percent'))
+    files_obj = snap.get('files')
+    if isinstance(files_obj, dict):
+        snap['files'] = _order_dict(
+            files_obj, ('sync_files', 'total_files', 'sync_percent'))
+    return _order_dict(
+        snap, ('id', 'name', 'sync-mode', 'avg_read_throughput_bytes',
+               'avg_write_throughput_bytes', 'crawl', 'datasync_queue_wait',
+               'bytes', 'files', 'eta'))
+
+
+def format_peer_status_metrics(metrics, dir_path, peer_uuid, stat):
+    metrics.setdefault(dir_path, {}).setdefault('peer', {})[peer_uuid] = stat
+
+
+# to match the output of peer_status
+def format_and_order_sync_stat_for_display(stat):
+    if not isinstance(stat, dict):
+        return stat
+
+    out = dict(stat)
+    last_synced_snap = out.get('last_synced_snap')
+    if isinstance(last_synced_snap, dict):
+        snap = dict(last_synced_snap)
+        for key in ('crawl_duration', 'datasync_queue_wait_duration',
+                    'sync_duration'):
+            val = snap.get(key)
+            if isinstance(val, (int, float)):
+                snap[key] = _format_time(val)
+        sync_bytes = snap.get('sync_bytes')
+        if isinstance(sync_bytes, (int, float)):
+            snap['sync_bytes'] = _format_bytes(sync_bytes)
+        sync_time_stamp = snap.get('sync_time_stamp')
+        if isinstance(sync_time_stamp, (int, float)):
+            snap['sync_time_stamp'] = f'{sync_time_stamp:.6f}s'
+        out['last_synced_snap'] = _order_dict(
+            snap, ('id', 'name', 'crawl_duration',
+                   'datasync_queue_wait_duration', 'sync_duration',
+                   'sync_time_stamp', 'sync_bytes', 'sync_files'))
+
+    current_syncing_snap = out.get('current_syncing_snap')
+    if isinstance(current_syncing_snap, dict):
+        out['current_syncing_snap'] = _order_current_syncing_snap(
+            current_syncing_snap)
+
+    out.pop('_instance_id', None)
+
+    return _order_dict(
+        out, ('state', 'failure_reason', 'current_syncing_snap',
+              'last_synced_snap', 'snaps_synced', 'snaps_deleted',
+              'snaps_renamed', 'metrics_updated_at'))

--- a/src/pybind/mgr/mirroring/fs/metrics/format.py
+++ b/src/pybind/mgr/mirroring/fs/metrics/format.py
@@ -1,3 +1,12 @@
+def default_sync_stat_metrics():
+    return {
+        'state': 'idle',
+        'snaps_synced': 0,
+        'snaps_deleted': 0,
+        'snaps_renamed': 0,
+    }
+
+
 # Matches the format_time function used in peer_status
 def _format_time(total_seconds_d):
     total_seconds = int(round(total_seconds_d))

--- a/src/pybind/mgr/mirroring/fs/metrics/format.py
+++ b/src/pybind/mgr/mirroring/fs/metrics/format.py
@@ -75,12 +75,44 @@ def format_peer_status_metrics(metrics, dir_path, peer_uuid, stat):
     metrics.setdefault(dir_path, {}).setdefault('peer', {})[peer_uuid] = stat
 
 
+def _mark_sync_stat_stale(stat):
+    out = dict(stat)
+    out.pop('current_syncing_snap', None)
+    out['state'] = 'stale'
+    return out
+
+
+def _apply_stale_sync_metrics(stat, policy=None, dir_path=None,
+                              live_instance_ids=None):
+    if not isinstance(stat, dict) or policy is None or dir_path is None:
+        return stat
+
+    persisted_instance_id = stat.get('_instance_id')
+    if persisted_instance_id is None:
+        return stat
+
+    persisted_id = str(persisted_instance_id)
+    if (live_instance_ids is not None and
+            persisted_id not in live_instance_ids):
+        return _mark_sync_stat_stale(stat)
+
+    tracked_id = policy.get_tracked_instance_id(dir_path)
+    if tracked_id is not None:
+        tracked_id = str(tracked_id)
+    if (tracked_id != persisted_id and
+            stat.get('state') != 'idle'):
+        return _mark_sync_stat_stale(stat)
+    return stat
+
+
 # to match the output of peer_status
-def format_and_order_sync_stat_for_display(stat):
+def format_and_order_sync_stat_for_display(stat, policy=None, dir_path=None,
+                                           live_instance_ids=None):
     if not isinstance(stat, dict):
         return stat
 
-    out = dict(stat)
+    out = dict(_apply_stale_sync_metrics(
+        stat, policy, dir_path, live_instance_ids))
     last_synced_snap = out.get('last_synced_snap')
     if isinstance(last_synced_snap, dict):
         snap = dict(last_synced_snap)

--- a/src/pybind/mgr/mirroring/fs/metrics/load.py
+++ b/src/pybind/mgr/mirroring/fs/metrics/load.py
@@ -14,12 +14,9 @@ from ..utils import (
     get_metadata_pool,
     parse_sync_stat_omap_key,
 )
+from .format import format_and_order_sync_stat_for_display, format_peer_status_metrics
 
 log = logging.getLogger(__name__)
-
-
-def nest_sync_stat_in_metrics(metrics, dir_path, peer_uuid, stat):
-    metrics.setdefault(dir_path, {}).setdefault('peer', {})[peer_uuid] = stat
 
 
 def load_sync_stat_by_keys(ioctx, keys):
@@ -88,7 +85,9 @@ def load_sync_stat_metrics(ioctx, filesystem, peer_uuid=None):
                     except (json.JSONDecodeError, UnicodeDecodeError) as e:
                         log.warning(f'failed to decode sync stat for key {key}: {e}')
                         continue
-                    nest_sync_stat_in_metrics(metrics, dir_path, peer, stat)
+                    format_peer_status_metrics(
+                        metrics, dir_path, peer,
+                        format_and_order_sync_stat_for_display(stat))
                 start = omap_vals.popitem()[0]
     except rados.Error as e:
         log.error(f'failed to read sync stat omap: {e}')

--- a/src/pybind/mgr/mirroring/fs/metrics/load.py
+++ b/src/pybind/mgr/mirroring/fs/metrics/load.py
@@ -12,7 +12,9 @@ from ..utils import (
     SYNC_STAT_KEY_PREFIX,
     decode_sync_stat_val,
     get_metadata_pool,
+    norm_path,
     parse_sync_stat_omap_key,
+    sync_stat_omap_key,
 )
 from .format import format_and_order_sync_stat_for_display, format_peer_status_metrics
 
@@ -93,3 +95,22 @@ def load_sync_stat_metrics(ioctx, filesystem, peer_uuid=None):
         log.error(f'failed to read sync stat omap: {e}')
         raise MirrorException(-e.errno, 'failed to read sync stat omap')
     return metrics
+
+
+def fetch_sync_stat_metrics(ioctx, filesystem, peers, mirrored_dir_path, peer_uuid):
+    if mirrored_dir_path:
+        dir_path = norm_path(mirrored_dir_path)
+        keys = [sync_stat_omap_key(filesystem, peer, dir_path) for peer in peers]
+        omap_stats = load_sync_stat_by_keys(ioctx, keys)
+        metrics: Dict[str, Any] = {}
+        for peer in peers:
+            omap_key = sync_stat_omap_key(filesystem, peer, dir_path)
+            stat = omap_stats.get(omap_key)
+            if stat is not None:
+                format_peer_status_metrics(
+                    metrics, dir_path, peer,
+                    format_and_order_sync_stat_for_display(stat))
+        return metrics, False, dir_path
+
+    metrics = load_sync_stat_metrics(ioctx, filesystem, peer_uuid)
+    return metrics, True, None

--- a/src/pybind/mgr/mirroring/fs/metrics/load.py
+++ b/src/pybind/mgr/mirroring/fs/metrics/load.py
@@ -16,7 +16,11 @@ from ..utils import (
     parse_sync_stat_omap_key,
     sync_stat_omap_key,
 )
-from .format import format_and_order_sync_stat_for_display, format_peer_status_metrics
+from .format import (
+    default_sync_stat_metrics,
+    format_and_order_sync_stat_for_display,
+    format_peer_status_metrics,
+)
 
 log = logging.getLogger(__name__)
 
@@ -57,8 +61,23 @@ def open_metadata_ioctx(rados_inst, fs_map, filesystem):
                               f'failed to open metadata pool for {filesystem}')
 
 
+def _fill_missing_sync_stat_defaults(metrics, dir_paths, peers, policy,
+                                     live_instance_ids, peer_uuid=None):
+    default_stat = default_sync_stat_metrics()
+    for dir_path in dir_paths:
+        for peer in peers:
+            if peer_uuid is not None and peer != peer_uuid:
+                continue
+            if metrics.get(dir_path, {}).get('peer', {}).get(peer) is not None:
+                continue
+            format_peer_status_metrics(
+                metrics, dir_path, peer,
+                format_and_order_sync_stat_for_display(
+                    default_stat, policy, dir_path, live_instance_ids))
+
+
 def load_sync_stat_metrics(ioctx, filesystem, peer_uuid=None, policy=None,
-                           live_instance_ids=None):
+                           live_instance_ids=None, peers=None):
     metrics: Dict[str, Any] = {}
     prefix = f'{SYNC_STAT_KEY_PREFIX}/{filesystem}/'
     if peer_uuid:
@@ -96,6 +115,11 @@ def load_sync_stat_metrics(ioctx, filesystem, peer_uuid=None, policy=None,
     except rados.Error as e:
         log.error(f'failed to read sync stat omap: {e}')
         raise MirrorException(-e.errno, 'failed to read sync stat omap')
+    if policy is not None and peers:
+        with policy.lock:
+            dir_paths = list(policy.dir_states.keys())
+        _fill_missing_sync_stat_defaults(
+            metrics, dir_paths, peers, policy, live_instance_ids, peer_uuid)
     return metrics
 
 
@@ -106,14 +130,14 @@ def fetch_sync_stat_metrics(ioctx, filesystem, peers, mirrored_dir_path,
         keys = [sync_stat_omap_key(filesystem, peer, dir_path) for peer in peers]
         omap_stats = load_sync_stat_by_keys(ioctx, keys)
         metrics: Dict[str, Any] = {}
+        default_stat = default_sync_stat_metrics()
         for peer in peers:
             omap_key = sync_stat_omap_key(filesystem, peer, dir_path)
-            stat = omap_stats.get(omap_key)
-            if stat is not None:
-                format_peer_status_metrics(
-                    metrics, dir_path, peer,
-                    format_and_order_sync_stat_for_display(
-                        stat, policy, dir_path, live_instance_ids))
+            stat = omap_stats.get(omap_key, default_stat)
+            format_peer_status_metrics(
+                metrics, dir_path, peer,
+                format_and_order_sync_stat_for_display(
+                    stat, policy, dir_path, live_instance_ids))
         return metrics, False, dir_path
 
     metrics = load_sync_stat_metrics(

--- a/src/pybind/mgr/mirroring/fs/metrics/load.py
+++ b/src/pybind/mgr/mirroring/fs/metrics/load.py
@@ -24,6 +24,20 @@ from .format import (
 
 log = logging.getLogger(__name__)
 
+MIRROR_OBJECT_NOT_FOUND_MSG = (
+    'cephfs_mirror object not found; enable snapshot mirroring with '
+    '"ceph fs snapshot mirror enable <fs_name>"')
+
+
+def _raise_on_sync_stat_read_error(err):
+    if isinstance(err, rados.Error) and err.errno == errno.ENOENT:
+        raise MirrorException(-errno.ENOENT, MIRROR_OBJECT_NOT_FOUND_MSG)
+    if isinstance(err, rados.Error):
+        log.error(f'failed to read sync stat omap: {err}')
+        err_no = err.errno if err.errno is not None else errno.EINVAL
+        raise MirrorException(-err_no, 'failed to read sync stat omap')
+    raise err
+
 
 def load_sync_stat_by_keys(ioctx, keys):
     stats: Dict[str, Any] = {}
@@ -43,8 +57,7 @@ def load_sync_stat_by_keys(ioctx, keys):
                 except (json.JSONDecodeError, UnicodeDecodeError) as e:
                     log.warning(f'failed to decode sync stat for key {key}: {e}')
     except rados.Error as e:
-        log.error(f'failed to read sync stat omap keys: {e}')
-        raise MirrorException(-e.errno, 'failed to read sync stat omap keys')
+        _raise_on_sync_stat_read_error(e)
     return stats
 
 
@@ -113,8 +126,7 @@ def load_sync_stat_metrics(ioctx, filesystem, peer_uuid=None, policy=None,
                             stat, policy, dir_path, live_instance_ids))
                 start = omap_vals.popitem()[0]
     except rados.Error as e:
-        log.error(f'failed to read sync stat omap: {e}')
-        raise MirrorException(-e.errno, 'failed to read sync stat omap')
+        _raise_on_sync_stat_read_error(e)
     if policy is not None and peers:
         with policy.lock:
             dir_paths = list(policy.dir_states.keys())

--- a/src/pybind/mgr/mirroring/fs/metrics/load.py
+++ b/src/pybind/mgr/mirroring/fs/metrics/load.py
@@ -57,7 +57,8 @@ def open_metadata_ioctx(rados_inst, fs_map, filesystem):
                               f'failed to open metadata pool for {filesystem}')
 
 
-def load_sync_stat_metrics(ioctx, filesystem, peer_uuid=None):
+def load_sync_stat_metrics(ioctx, filesystem, peer_uuid=None, policy=None,
+                           live_instance_ids=None):
     metrics: Dict[str, Any] = {}
     prefix = f'{SYNC_STAT_KEY_PREFIX}/{filesystem}/'
     if peer_uuid:
@@ -89,7 +90,8 @@ def load_sync_stat_metrics(ioctx, filesystem, peer_uuid=None):
                         continue
                     format_peer_status_metrics(
                         metrics, dir_path, peer,
-                        format_and_order_sync_stat_for_display(stat))
+                        format_and_order_sync_stat_for_display(
+                            stat, policy, dir_path, live_instance_ids))
                 start = omap_vals.popitem()[0]
     except rados.Error as e:
         log.error(f'failed to read sync stat omap: {e}')
@@ -97,7 +99,8 @@ def load_sync_stat_metrics(ioctx, filesystem, peer_uuid=None):
     return metrics
 
 
-def fetch_sync_stat_metrics(ioctx, filesystem, peers, mirrored_dir_path, peer_uuid):
+def fetch_sync_stat_metrics(ioctx, filesystem, peers, mirrored_dir_path,
+                            peer_uuid, policy=None, live_instance_ids=None):
     if mirrored_dir_path:
         dir_path = norm_path(mirrored_dir_path)
         keys = [sync_stat_omap_key(filesystem, peer, dir_path) for peer in peers]
@@ -109,8 +112,10 @@ def fetch_sync_stat_metrics(ioctx, filesystem, peers, mirrored_dir_path, peer_uu
             if stat is not None:
                 format_peer_status_metrics(
                     metrics, dir_path, peer,
-                    format_and_order_sync_stat_for_display(stat))
+                    format_and_order_sync_stat_for_display(
+                        stat, policy, dir_path, live_instance_ids))
         return metrics, False, dir_path
 
-    metrics = load_sync_stat_metrics(ioctx, filesystem, peer_uuid)
+    metrics = load_sync_stat_metrics(
+        ioctx, filesystem, peer_uuid, policy, live_instance_ids)
     return metrics, True, None

--- a/src/pybind/mgr/mirroring/fs/metrics/load.py
+++ b/src/pybind/mgr/mirroring/fs/metrics/load.py
@@ -1,0 +1,96 @@
+import errno
+import json
+import logging
+from typing import Any, Dict
+
+import rados
+
+from ..dir_map.load import MAX_RETURN
+from ..exception import MirrorException
+from ..utils import (
+    MIRROR_OBJECT_NAME,
+    SYNC_STAT_KEY_PREFIX,
+    decode_sync_stat_val,
+    get_metadata_pool,
+    parse_sync_stat_omap_key,
+)
+
+log = logging.getLogger(__name__)
+
+
+def nest_sync_stat_in_metrics(metrics, dir_path, peer_uuid, stat):
+    metrics.setdefault(dir_path, {}).setdefault('peer', {})[peer_uuid] = stat
+
+
+def load_sync_stat_by_keys(ioctx, keys):
+    stats: Dict[str, Any] = {}
+    if not keys:
+        return stats
+    try:
+        with rados.ReadOpCtx() as read_op:
+            it, ret = ioctx.get_omap_vals_by_keys(read_op, keys)
+            if ret != 0:
+                log.error('failed to read sync stat omap keys')
+                raise MirrorException(-errno.EINVAL,
+                                      'failed to read sync stat omap keys')
+            ioctx.operate_read_op(read_op, MIRROR_OBJECT_NAME)
+            for key, val in it:
+                try:
+                    stats[key] = decode_sync_stat_val(val)
+                except (json.JSONDecodeError, UnicodeDecodeError) as e:
+                    log.warning(f'failed to decode sync stat for key {key}: {e}')
+    except rados.Error as e:
+        log.error(f'failed to read sync stat omap keys: {e}')
+        raise MirrorException(-e.errno, 'failed to read sync stat omap keys')
+    return stats
+
+
+def open_metadata_ioctx(rados_inst, fs_map, filesystem):
+    metadata_pool_id = get_metadata_pool(filesystem, fs_map)
+    if not metadata_pool_id:
+        raise MirrorException(-errno.EINVAL,
+                              f'cannot find metadata pool for filesystem {filesystem}')
+    try:
+        return rados_inst.open_ioctx2(metadata_pool_id)
+    except rados.Error as e:
+        log.error(f'failed to open metadata pool for {filesystem}: {e}')
+        raise MirrorException(-e.errno,
+                              f'failed to open metadata pool for {filesystem}')
+
+
+def load_sync_stat_metrics(ioctx, filesystem, peer_uuid=None):
+    metrics: Dict[str, Any] = {}
+    prefix = f'{SYNC_STAT_KEY_PREFIX}/{filesystem}/'
+    if peer_uuid:
+        prefix += f'{peer_uuid}/'
+    try:
+        with rados.ReadOpCtx() as read_op:
+            start = ""
+            while True:
+                it, ret = ioctx.get_omap_vals(read_op, start, prefix, MAX_RETURN)
+                if ret != 0:
+                    log.error('failed to read sync stat omap')
+                    raise MirrorException(-errno.EINVAL,
+                                          'failed to read sync stat omap')
+                ioctx.operate_read_op(read_op, MIRROR_OBJECT_NAME)
+                omap_vals = dict(it)
+                if not omap_vals:
+                    break
+                for key, val in omap_vals.items():
+                    parsed = parse_sync_stat_omap_key(key, filesystem)
+                    if not parsed:
+                        continue
+                    peer, dir_path = parsed
+                    if peer_uuid and peer != peer_uuid:
+                        continue
+                    try:
+                        stat = decode_sync_stat_val(val)
+                    except (json.JSONDecodeError, UnicodeDecodeError) as e:
+                        log.warning(f'failed to decode sync stat for key {key}: {e}')
+                        continue
+                    nest_sync_stat_in_metrics(metrics, dir_path, peer, stat)
+                start = omap_vals.popitem()[0]
+    except rados.Error as e:
+        log.error(f'failed to read sync stat omap: {e}')
+        raise MirrorException(-e.errno, 'failed to read sync stat omap')
+    return metrics

--- a/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
+++ b/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
@@ -181,10 +181,12 @@ class FSPolicy:
             return json.dumps({'dir_path': dir_path,
                                'mode': 'acquire'
                                })
-        def release_message(dir_path):
-            return json.dumps({'dir_path': dir_path,
-                               'mode': 'release'
-                               })
+        def release_message(dir_path, purging=False):
+            msg = {'dir_path': dir_path,
+                   'mode': 'release'}
+            if purging:
+                msg['purging'] = True
+            return json.dumps(msg)
         with self.lock:
             if not self.dir_paths or self.stopping.is_set():
                 return
@@ -211,7 +213,9 @@ class FSPolicy:
                 elif action_type == ActionType.ACQUIRE:
                     notifies[dir_path] = (lookup_info['instance_id'], acquire_message(dir_path))
                 elif action_type == ActionType.RELEASE:
-                    notifies[dir_path] = (lookup_info['instance_id'], release_message(dir_path))
+                    notifies[dir_path] = (lookup_info['instance_id'],
+                                          release_message(dir_path,
+                                                          lookup_info['purging']))
             if update_map or removals:
                 self.update_mapping(update_map, removals, callback=self.continue_action)
             for dir_path, message in notifies.items():

--- a/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
+++ b/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
@@ -900,6 +900,9 @@ class FSSnapshotMirror:
                 return 0, json.dumps({'metrics': metrics}, indent=4), ''
         except MirrorException as me:
             return me.args[0], '', me.args[1]
+        except Exception as e:
+            log.error(f'failed to get snapshot mirror metrics: {e}')
+            return -errno.EINVAL, '', 'failed to get snapshot mirror metrics'
 
     def daemon_status(self, format='json'):
         try:

--- a/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
+++ b/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
@@ -19,7 +19,10 @@ from mgr_module import NotifyType
 from .blocklist import blocklist
 from .notify import Notifier, InstanceWatcher
 from .utils import INSTANCE_ID_PREFIX, MIRROR_OBJECT_NAME, Finisher, \
-    AsyncOpTracker, connect_to_filesystem, disconnect_from_filesystem
+    AsyncOpTracker, get_metadata_pool, norm_path, connect_to_filesystem, \
+    disconnect_from_filesystem, sync_stat_omap_key
+from .metrics import load as metrics_load
+from .metrics.load import nest_sync_stat_in_metrics
 from .exception import MirrorException
 from .dir_map.create import create_mirror_object
 from .dir_map.load import load_dir_map, load_instances
@@ -314,13 +317,6 @@ class FSSnapshotMirror:
             raise MirrorException(-errno.EINVAL, f'invalid cluster spec {spec}')
 
     @staticmethod
-    def get_metadata_pool(filesystem, fs_map):
-        for fs in fs_map['filesystems']:
-            if fs['mdsmap']['fs_name'] == filesystem:
-                return fs['mdsmap']['metadata_pool']
-        return None
-
-    @staticmethod
     def get_filesystem_id(filesystem, fs_map):
         for fs in fs_map['filesystems']:
             if fs['mdsmap']['fs_name'] == filesystem:
@@ -483,7 +479,7 @@ class FSSnapshotMirror:
             disconnect_from_filesystem(cluster_name, remote_fs_name, remote_cluster, remote_fs)
 
     def init_pool_policy(self, filesystem):
-        metadata_pool_id = FSSnapshotMirror.get_metadata_pool(filesystem, self.fs_map)
+        metadata_pool_id = get_metadata_pool(filesystem, self.fs_map)
         if not metadata_pool_id:
             log.error(f'cannot find metadata pool-id for filesystem {filesystem}')
             raise Exception(-errno.EINVAL)
@@ -522,7 +518,7 @@ class FSSnapshotMirror:
         log.info(f'enabling mirror for filesystem {filesystem}')
         with self.lock:
             try:
-                metadata_pool_id = FSSnapshotMirror.get_metadata_pool(filesystem, self.fs_map)
+                metadata_pool_id = get_metadata_pool(filesystem, self.fs_map)
                 if not metadata_pool_id:
                     log.error(f'cannot find metadata pool-id for filesystem {filesystem}')
                     raise Exception(-errno.EINVAL)
@@ -690,12 +686,6 @@ class FSSnapshotMirror:
         remote_cluster_spec = f'{client_name}@{cluster_name}'
         return self.peer_add(filesystem, remote_cluster_spec, remote_fs_name, token_dct)
 
-    @staticmethod
-    def norm_path(dir_path):
-        if not os.path.isabs(dir_path):
-            raise MirrorException(-errno.EINVAL, f'{dir_path} should be an absolute path')
-        return os.path.normpath(dir_path)
-
     def add_dir(self, filesystem, dir_path):
         try:
             with self.lock:
@@ -704,7 +694,7 @@ class FSSnapshotMirror:
                 fspolicy = self.pool_policy.get(filesystem, None)
                 if not fspolicy:
                     raise MirrorException(-errno.EINVAL, f'filesystem {filesystem} is not mirrored')
-                dir_path = FSSnapshotMirror.norm_path(dir_path)
+                dir_path = norm_path(dir_path)
                 log.debug(f'path normalized to {dir_path}')
                 fspolicy.add_dir(dir_path)
                 return 0, json.dumps({}), ''
@@ -721,7 +711,7 @@ class FSSnapshotMirror:
                 fspolicy = self.pool_policy.get(filesystem, None)
                 if not fspolicy:
                     raise MirrorException(-errno.EINVAL, f'filesystem {filesystem} is not mirrored')
-                dir_path = FSSnapshotMirror.norm_path(dir_path)
+                dir_path = norm_path(dir_path)
                 fspolicy.remove_dir(dir_path)
                 return 0, json.dumps({}), ''
         except MirrorException as me:
@@ -751,7 +741,7 @@ class FSSnapshotMirror:
                 fspolicy = self.pool_policy.get(filesystem, None)
                 if not fspolicy:
                     raise MirrorException(-errno.EINVAL, f'filesystem {filesystem} is not mirrored')
-                dir_path = FSSnapshotMirror.norm_path(dir_path)
+                dir_path = norm_path(dir_path)
                 return fspolicy.status(dir_path)
         except MirrorException as me:
             return me.args[0], '', me.args[1]
@@ -765,6 +755,53 @@ class FSSnapshotMirror:
                 if not fspolicy:
                     raise MirrorException(-errno.EINVAL, f'filesystem {filesystem} is not mirrored')
                 return fspolicy.summary()
+        except MirrorException as me:
+            return me.args[0], '', me.args[1]
+
+    def metrics_status(self, filesystem, mirrored_dir_path, peer_uuid):
+        """Return persisted mirror directory snapshot metrics as JSON"""
+        try:
+            with self.lock:
+                if not self.filesystem_exist(filesystem):
+                    raise MirrorException(-errno.ENOENT,
+                                          f'filesystem {filesystem} does not exist')
+                fspolicy = self.pool_policy.get(filesystem, None)
+                if not fspolicy:
+                    raise MirrorException(-errno.EINVAL,
+                                          f'filesystem {filesystem} is not mirrored')
+                if mirrored_dir_path:
+                    dir_path = norm_path(mirrored_dir_path)
+                    if not fspolicy.policy.lookup(dir_path):
+                        raise MirrorException(-errno.ENOENT,
+                                              f'directory {dir_path} is not mirrored')
+                peers = self.get_filesystem_peers(filesystem)
+                if not peers:
+                    return 0, json.dumps({}), ''
+
+                if peer_uuid:
+                    if peer_uuid not in peers:
+                        raise MirrorException(-errno.ENOENT,
+                                              f'peer {peer_uuid} not found for '
+                                              f'filesystem {filesystem}')
+                    peers = {peer_uuid: peers[peer_uuid]}
+
+                ioctx = metrics_load.open_metadata_ioctx(
+                    self.rados, self.fs_map, filesystem)
+                if mirrored_dir_path:
+                    dir_path = norm_path(mirrored_dir_path)
+                    keys = [sync_stat_omap_key(filesystem, peer, dir_path)
+                            for peer in peers]
+                    omap_stats = metrics_load.load_sync_stat_by_keys(ioctx, keys)
+                    metrics = {}
+                    for peer in peers:
+                        omap_key = sync_stat_omap_key(filesystem, peer, dir_path)
+                        if omap_key in omap_stats:
+                            nest_sync_stat_in_metrics(metrics, dir_path, peer,
+                                                      omap_stats[omap_key])
+                else:
+                    metrics = metrics_load.load_sync_stat_metrics(
+                        ioctx, filesystem, peer_uuid)
+                return 0, json.dumps(metrics, indent=4), ''
         except MirrorException as me:
             return me.args[0], '', me.args[1]
 

--- a/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
+++ b/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
@@ -22,7 +22,7 @@ from .utils import INSTANCE_ID_PREFIX, MIRROR_OBJECT_NAME, Finisher, \
     AsyncOpTracker, get_metadata_pool, norm_path, connect_to_filesystem, \
     disconnect_from_filesystem
 from .metrics.cache import (
-    CACHE_TTL_SECS, COMPLETE_CACHE_MAX, lru_cache_timeout, PARTIAL_CACHE_MAX,
+    COMPLETE_CACHE_MAX, lru_cache_timeout, PARTIAL_CACHE_MAX,
     metrics_for_dir_and_peers, try_get_from_complete)
 from .metrics import load as metrics_load
 from .exception import MirrorException
@@ -768,7 +768,8 @@ class FSSnapshotMirror:
             return me.args[0], '', me.args[1]
 
     @lru_cache_timeout(
-        lambda self, *_args, **_kwargs: CACHE_TTL_SECS,
+        lambda self, *_args, **_kwargs: self.mgr.get_module_option(
+            'snapshot_mirror_metrics_cache_ttl'),
         COMPLETE_CACHE_MAX)
     def sync_stat_complete_cache(self, filesystem):
         """Load all directories and all peers for a filesystem from omap.
@@ -790,7 +791,8 @@ class FSSnapshotMirror:
             self.get_filesystem_peers(filesystem))
 
     @lru_cache_timeout(
-        lambda self, *_args, **_kwargs: CACHE_TTL_SECS,
+        lambda self, *_args, **_kwargs: self.mgr.get_module_option(
+            'snapshot_mirror_metrics_cache_ttl'),
         PARTIAL_CACHE_MAX)
     def sync_stat_partial_cache(self, filesystem, dir_path, peer_ids):
         """Load sync-stat omap keys for one directory and a peer set.

--- a/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
+++ b/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
@@ -20,10 +20,11 @@ from .blocklist import blocklist
 from .notify import Notifier, InstanceWatcher
 from .utils import INSTANCE_ID_PREFIX, MIRROR_OBJECT_NAME, Finisher, \
     AsyncOpTracker, get_metadata_pool, norm_path, connect_to_filesystem, \
-    disconnect_from_filesystem, sync_stat_omap_key
+    disconnect_from_filesystem
+from .metrics.cache import (
+    CACHE_TTL_SECS, COMPLETE_CACHE_MAX, lru_cache_timeout, PARTIAL_CACHE_MAX,
+    metrics_for_dir_and_peers, try_get_from_complete)
 from .metrics import load as metrics_load
-from .metrics.format import format_and_order_sync_stat_for_display, \
-    format_peer_status_metrics
 from .exception import MirrorException
 from .dir_map.create import create_mirror_object
 from .dir_map.load import load_dir_map, load_instances
@@ -759,8 +760,52 @@ class FSSnapshotMirror:
         except MirrorException as me:
             return me.args[0], '', me.args[1]
 
+    @lru_cache_timeout(
+        lambda self, *_args, **_kwargs: CACHE_TTL_SECS,
+        COMPLETE_CACHE_MAX)
+    def sync_stat_complete_cache(self, filesystem):
+        """Load all directories and all peers for a filesystem from omap.
+
+        Cache key: (time_token, filesystem). Each entry stores the full omap
+        snapshot for that filesystem (all dirs, all peers). A hit means every
+        directory is present, so full-scan queries can be served safely.
+        Used for 'status <fs>' and 'status <fs> --peer_uuid=<uuid>'; peer
+        filtering is applied when serving.
+        """
+        log.debug('sync stat metrics for filesystem %s loaded from omap (complete)',
+                  filesystem)
+        ioctx = metrics_load.open_metadata_ioctx(
+            self.rados, self.fs_map, filesystem)
+        return metrics_load.load_sync_stat_metrics(ioctx, filesystem)
+
+    @lru_cache_timeout(
+        lambda self, *_args, **_kwargs: CACHE_TTL_SECS,
+        PARTIAL_CACHE_MAX)
+    def sync_stat_partial_cache(self, filesystem, dir_path, peer_ids):
+        """Load sync-stat omap keys for one directory and a peer set.
+
+        Cache key: (time_token, filesystem, dir_path, peer_ids). Used as a
+        fallback for 'status <fs> <dir>' when the complete cache is cold or
+        does not contain the requested directory.
+        """
+        peer_scope = (next(iter(peer_ids)) if len(peer_ids) == 1 else '*')
+        log.debug('sync stat metrics for filesystem %s (dir=%s, peer=%s) '
+                  'loaded from omap',
+                  filesystem, dir_path, peer_scope)
+        peers = {peer_id: None for peer_id in peer_ids}
+        ioctx = metrics_load.open_metadata_ioctx(
+            self.rados, self.fs_map, filesystem)
+        metrics, _, _ = metrics_load.fetch_sync_stat_metrics(
+            ioctx, filesystem, peers, dir_path, None)
+        return metrics
+
     def metrics_status(self, filesystem, mirrored_dir_path, peer_uuid):
-        """Return persisted mirror directory snapshot metrics as JSON"""
+        """Return persisted mirror directory snapshot metrics as JSON.
+
+        Uses two caches (see metrics/cache.py): complete for full-scan queries
+        where a hit proves all dirs are present; partial for single-dir
+        queries when the complete cache is cold or lacks that directory.
+        """
         try:
             with self.lock:
                 if not self.filesystem_exist(filesystem):
@@ -775,35 +820,70 @@ class FSSnapshotMirror:
                     if not fspolicy.policy.lookup(dir_path):
                         raise MirrorException(-errno.ENOENT,
                                               f'directory {dir_path} is not mirrored')
-                peers = self.get_filesystem_peers(filesystem)
-                if not peers:
+                all_peers = self.get_filesystem_peers(filesystem)
+                if not all_peers:
                     return 0, json.dumps({'metrics': {}}, indent=4), ''
 
                 if peer_uuid:
-                    if peer_uuid not in peers:
+                    if peer_uuid not in all_peers:
                         raise MirrorException(-errno.ENOENT,
                                               f'peer {peer_uuid} not found for '
                                               f'filesystem {filesystem}')
-                    peers = {peer_uuid: peers[peer_uuid]}
+                    requested_peers = {peer_uuid: all_peers[peer_uuid]}
+                else:
+                    requested_peers = all_peers
 
-                ioctx = metrics_load.open_metadata_ioctx(
-                    self.rados, self.fs_map, filesystem)
                 if mirrored_dir_path:
                     dir_path = norm_path(mirrored_dir_path)
-                    keys = [sync_stat_omap_key(filesystem, peer, dir_path)
-                            for peer in peers]
-                    omap_stats = metrics_load.load_sync_stat_by_keys(ioctx, keys)
-                    metrics = {}
-                    for peer in peers:
-                        omap_key = sync_stat_omap_key(filesystem, peer, dir_path)
-                        if omap_key in omap_stats:
-                            format_peer_status_metrics(
-                                metrics, dir_path, peer,
-                                format_and_order_sync_stat_for_display(
-                                    omap_stats[omap_key]))
+                    # Single-dir query: peek complete cache (key: filesystem
+                    # only); on miss fall back to partial cache (key:
+                    # filesystem, dir_path, peer_ids).
+                    complete_metrics = self.sync_stat_complete_cache.cache_peek(
+                        filesystem)
+                    if complete_metrics is not None:
+                        metrics = try_get_from_complete(
+                            complete_metrics, mirrored_dir_path, peer_uuid,
+                            requested_peers)
+                        if metrics is not None:
+                            log.debug('sync stat metrics for filesystem %s (dir=%s, peer=%s) '
+                                      'served from complete cache',
+                                      filesystem, dir_path, peer_uuid or '*')
+                            return 0, json.dumps({'metrics': metrics}, indent=4), ''
+
+                    partial_info_before = self.sync_stat_partial_cache.cache_info()
+                    raw_metrics = self.sync_stat_partial_cache(
+                        filesystem, dir_path, frozenset(requested_peers))
+                    if (self.sync_stat_partial_cache.cache_info().hits >
+                            partial_info_before.hits):
+                        log.debug('sync stat metrics for filesystem %s (dir=%s, peer=%s) '
+                                  'served from partial cache',
+                                  filesystem, dir_path, peer_uuid or '*')
+                    else:
+                        log.debug('sync stat metrics for filesystem %s (dir=%s, peer=%s) '
+                                  'loaded from omap',
+                                  filesystem, dir_path, peer_uuid or '*')
+                    metrics = metrics_for_dir_and_peers(
+                        raw_metrics, dir_path, requested_peers)
+                    return 0, json.dumps({'metrics': metrics}, indent=4), ''
+
+                # Full-scan query: load complete cache on miss (key: filesystem
+                # only); peer filtering is applied when serving.
+                complete_info_before = self.sync_stat_complete_cache.cache_info()
+                complete_metrics = self.sync_stat_complete_cache(filesystem)
+                complete_hit = (self.sync_stat_complete_cache.cache_info().hits >
+                                complete_info_before.hits)
+                metrics = try_get_from_complete(
+                    complete_metrics, mirrored_dir_path, peer_uuid, requested_peers)
+                if complete_hit:
+                    log.debug('sync stat metrics for filesystem %s (dir=%s, peer=%s) '
+                              'served from complete cache',
+                              filesystem, mirrored_dir_path or '*',
+                              peer_uuid or '*')
                 else:
-                    metrics = metrics_load.load_sync_stat_metrics(
-                        ioctx, filesystem, peer_uuid)
+                    log.debug('sync stat metrics for filesystem %s (dir=%s, peer=%s) '
+                              'loaded from omap',
+                              filesystem, mirrored_dir_path or '*',
+                              peer_uuid or '*')
                 return 0, json.dumps({'metrics': metrics}, indent=4), ''
         except MirrorException as me:
             return me.args[0], '', me.args[1]

--- a/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
+++ b/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
@@ -767,6 +767,9 @@ class FSSnapshotMirror:
         except MirrorException as me:
             return me.args[0], '', me.args[1]
 
+    def _metrics_cache_enabled(self):
+        return self.mgr.get_module_option('snapshot_mirror_metrics_cache_enabled')
+
     @lru_cache_timeout(
         lambda self, *_args, **_kwargs: self.mgr.get_module_option(
             'snapshot_mirror_metrics_cache_ttl'),
@@ -814,6 +817,22 @@ class FSSnapshotMirror:
             fspolicy.policy, fspolicy.get_live_instance_ids())
         return metrics
 
+    def _load_sync_stat_metrics_from_omap(self, filesystem, mirrored_dir_path,
+                                          peer_uuid, peers, fspolicy):
+        ioctx = metrics_load.open_metadata_ioctx(
+            self.rados, self.fs_map, filesystem)
+        if mirrored_dir_path:
+            dir_path = norm_path(mirrored_dir_path)
+            metrics, _, _ = metrics_load.fetch_sync_stat_metrics(
+                ioctx, filesystem, peers, mirrored_dir_path, peer_uuid,
+                fspolicy.policy, fspolicy.get_live_instance_ids())
+            return metrics_for_dir_and_peers(metrics, dir_path, peers)
+        complete_metrics = metrics_load.load_sync_stat_metrics(
+            ioctx, filesystem, None, fspolicy.policy,
+            fspolicy.get_live_instance_ids(), peers)
+        return try_get_from_complete(
+            complete_metrics, mirrored_dir_path, peer_uuid, peers)
+
     def metrics_status(self, filesystem, mirrored_dir_path, peer_uuid):
         """Return persisted mirror directory snapshot metrics as JSON.
 
@@ -847,6 +866,16 @@ class FSSnapshotMirror:
                     requested_peers = {peer_uuid: all_peers[peer_uuid]}
                 else:
                     requested_peers = all_peers
+
+                if not self._metrics_cache_enabled():
+                    log.debug('sync stat metrics for filesystem %s (dir=%s, peer=%s) '
+                              'cache disabled; loading from omap',
+                              filesystem, mirrored_dir_path or '*',
+                              peer_uuid or '*')
+                    metrics = self._load_sync_stat_metrics_from_omap(
+                        filesystem, mirrored_dir_path, peer_uuid,
+                        requested_peers, fspolicy)
+                    return 0, json.dumps({'metrics': metrics}, indent=4), ''
 
                 if mirrored_dir_path:
                     dir_path = norm_path(mirrored_dir_path)

--- a/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
+++ b/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
@@ -22,7 +22,8 @@ from .utils import INSTANCE_ID_PREFIX, MIRROR_OBJECT_NAME, Finisher, \
     AsyncOpTracker, get_metadata_pool, norm_path, connect_to_filesystem, \
     disconnect_from_filesystem, sync_stat_omap_key
 from .metrics import load as metrics_load
-from .metrics.load import nest_sync_stat_in_metrics
+from .metrics.format import format_and_order_sync_stat_for_display, \
+    format_peer_status_metrics
 from .exception import MirrorException
 from .dir_map.create import create_mirror_object
 from .dir_map.load import load_dir_map, load_instances
@@ -776,7 +777,7 @@ class FSSnapshotMirror:
                                               f'directory {dir_path} is not mirrored')
                 peers = self.get_filesystem_peers(filesystem)
                 if not peers:
-                    return 0, json.dumps({}), ''
+                    return 0, json.dumps({'metrics': {}}, indent=4), ''
 
                 if peer_uuid:
                     if peer_uuid not in peers:
@@ -796,12 +797,14 @@ class FSSnapshotMirror:
                     for peer in peers:
                         omap_key = sync_stat_omap_key(filesystem, peer, dir_path)
                         if omap_key in omap_stats:
-                            nest_sync_stat_in_metrics(metrics, dir_path, peer,
-                                                      omap_stats[omap_key])
+                            format_peer_status_metrics(
+                                metrics, dir_path, peer,
+                                format_and_order_sync_stat_for_display(
+                                    omap_stats[omap_key]))
                 else:
                     metrics = metrics_load.load_sync_stat_metrics(
                         ioctx, filesystem, peer_uuid)
-                return 0, json.dumps(metrics, indent=4), ''
+                return 0, json.dumps({'metrics': metrics}, indent=4), ''
         except MirrorException as me:
             return me.args[0], '', me.args[1]
 

--- a/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
+++ b/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
@@ -66,6 +66,13 @@ class FSPolicy:
     def schedule_action(self, dir_paths):
         self.dir_paths.extend(dir_paths)
 
+    def get_live_instance_ids(self):
+        watcher = self.instance_watcher
+        if watcher is None:
+            return None
+        with watcher.lock:
+            return frozenset(str(instance_id) for instance_id in watcher.instances)
+
     def init(self, dir_mapping, instances):
         with self.lock:
             self.policy.init(dir_mapping)
@@ -774,9 +781,12 @@ class FSSnapshotMirror:
         """
         log.debug('sync stat metrics for filesystem %s loaded from omap (complete)',
                   filesystem)
+        fspolicy = self.pool_policy[filesystem]
         ioctx = metrics_load.open_metadata_ioctx(
             self.rados, self.fs_map, filesystem)
-        return metrics_load.load_sync_stat_metrics(ioctx, filesystem)
+        return metrics_load.load_sync_stat_metrics(
+            ioctx, filesystem, None, fspolicy.policy,
+            fspolicy.get_live_instance_ids())
 
     @lru_cache_timeout(
         lambda self, *_args, **_kwargs: CACHE_TTL_SECS,
@@ -793,10 +803,12 @@ class FSSnapshotMirror:
                   'loaded from omap',
                   filesystem, dir_path, peer_scope)
         peers = {peer_id: None for peer_id in peer_ids}
+        fspolicy = self.pool_policy[filesystem]
         ioctx = metrics_load.open_metadata_ioctx(
             self.rados, self.fs_map, filesystem)
         metrics, _, _ = metrics_load.fetch_sync_stat_metrics(
-            ioctx, filesystem, peers, dir_path, None)
+            ioctx, filesystem, peers, dir_path, None,
+            fspolicy.policy, fspolicy.get_live_instance_ids())
         return metrics
 
     def metrics_status(self, filesystem, mirrored_dir_path, peer_uuid):

--- a/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
+++ b/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
@@ -786,7 +786,8 @@ class FSSnapshotMirror:
             self.rados, self.fs_map, filesystem)
         return metrics_load.load_sync_stat_metrics(
             ioctx, filesystem, None, fspolicy.policy,
-            fspolicy.get_live_instance_ids())
+            fspolicy.get_live_instance_ids(),
+            self.get_filesystem_peers(filesystem))
 
     @lru_cache_timeout(
         lambda self, *_args, **_kwargs: CACHE_TTL_SECS,

--- a/src/pybind/mgr/mirroring/fs/utils.py
+++ b/src/pybind/mgr/mirroring/fs/utils.py
@@ -1,5 +1,7 @@
 import errno
+import json
 import logging
+import os
 import threading
 
 import rados
@@ -12,8 +14,42 @@ MIRROR_OBJECT_NAME = MIRROR_OBJECT_PREFIX
 
 INSTANCE_ID_PREFIX = "instance_"
 DIRECTORY_MAP_PREFIX = "dir_map_"
+SYNC_STAT_KEY_PREFIX = "sync_stat"
 
 log = logging.getLogger(__name__)
+
+
+def get_metadata_pool(filesystem, fs_map):
+    for fs in fs_map['filesystems']:
+        if fs['mdsmap']['fs_name'] == filesystem:
+            return fs['mdsmap']['metadata_pool']
+    return None
+
+
+def norm_path(dir_path):
+    if not os.path.isabs(dir_path):
+        raise MirrorException(-errno.EINVAL, f'{dir_path} should be an absolute path')
+    return os.path.normpath(dir_path)
+
+
+def sync_stat_omap_key(filesystem, peer_uuid, dir_path):
+    return (f'{SYNC_STAT_KEY_PREFIX}/{filesystem}/{peer_uuid}/'
+            f'{dir_path.lstrip("/")}')
+
+
+def parse_sync_stat_omap_key(key, filesystem):
+    prefix = f'{SYNC_STAT_KEY_PREFIX}/{filesystem}/'
+    if not key.startswith(prefix):
+        return None
+    suffix = key[len(prefix):]
+    peer_uuid, sep, dir_rel = suffix.partition('/')
+    if not peer_uuid or not sep:
+        return None
+    return peer_uuid, os.path.normpath('/' + dir_rel)
+
+
+def decode_sync_stat_val(val):
+    return json.loads(val.decode('utf-8'))
 
 def connect_to_cluster(client_name, cluster_name, conf_dct, desc=''):
     try:

--- a/src/pybind/mgr/mirroring/module.py
+++ b/src/pybind/mgr/mirroring/module.py
@@ -8,7 +8,15 @@ from .fs.snapshot_mirror import FSSnapshotMirror
 
 class Module(MgrModule):
     CLICommand = MirroringCLICommand
-    MODULE_OPTIONS: List[Option] = []
+    MODULE_OPTIONS: List[Option] = [
+        Option(
+            'snapshot_mirror_metrics_cache_ttl',
+            type='secs',
+            default=15,
+            desc='TTL for cached fs snapshot mirror status omap metrics',
+            runtime=True,
+        ),
+    ]
     NOTIFY_TYPES = [NotifyType.fs_map]
 
     def __init__(self, *args, **kwargs):

--- a/src/pybind/mgr/mirroring/module.py
+++ b/src/pybind/mgr/mirroring/module.py
@@ -10,6 +10,13 @@ class Module(MgrModule):
     CLICommand = MirroringCLICommand
     MODULE_OPTIONS: List[Option] = [
         Option(
+            'snapshot_mirror_metrics_cache_enabled',
+            type='bool',
+            default=True,
+            desc='Cache fs snapshot mirror status omap metrics',
+            runtime=True,
+        ),
+        Option(
             'snapshot_mirror_metrics_cache_ttl',
             type='secs',
             default=15,

--- a/src/pybind/mgr/mirroring/module.py
+++ b/src/pybind/mgr/mirroring/module.py
@@ -116,3 +116,13 @@ class Module(MgrModule):
                                       format: str = 'json'):
         """Get mirror daemon status"""
         return self.fs_snapshot_mirror.daemon_status(format)
+
+    @MirroringCLICommand.Read('fs snapshot mirror status')
+    def snapshot_mirror_status(self,
+                               fs_name: str,
+                               mirrored_dir_path: Optional[str] = None,
+                               _end_positional_: int = 0,
+                               peer_uuid: Optional[str] = None):
+        """Get snapshot mirror metrics for a filesystem (optional mirrored directory and peer)"""
+        return self.fs_snapshot_mirror.metrics_status(fs_name, mirrored_dir_path,
+                                                      peer_uuid)

--- a/src/tools/cephfs_mirror/FSMirror.cc
+++ b/src/tools/cephfs_mirror/FSMirror.cc
@@ -421,7 +421,8 @@ void FSMirror::add_peer(const Peer &peer) {
   }
 
   auto replayer = std::make_unique<PeerReplayer>(
-    m_cct, this, m_cluster, m_filesystem, peer, m_directories, m_mount, m_service_daemon);
+    m_cct, this, m_cluster, m_filesystem, peer, m_directories,
+    std::make_shared<librados::IoCtx>(m_ioctx), m_mount, m_service_daemon);
   int r = init_replayer(replayer.get());
   if (r < 0) {
     m_service_daemon->add_or_update_peer_attribute(m_filesystem.fscid, peer,

--- a/src/tools/cephfs_mirror/FSMirror.cc
+++ b/src/tools/cephfs_mirror/FSMirror.cc
@@ -390,8 +390,8 @@ void FSMirror::handle_acquire_directory(string_view dir_path) {
   }
 }
 
-void FSMirror::handle_release_directory(string_view dir_path) {
-  dout(5) << ": dir_path=" << dir_path << dendl;
+void FSMirror::handle_release_directory(string_view dir_path, bool purging) {
+  dout(5) << ": dir_path=" << dir_path << ", purging=" << purging << dendl;
 
   {
     std::scoped_lock locker(m_lock);
@@ -402,7 +402,7 @@ void FSMirror::handle_release_directory(string_view dir_path) {
                                                    m_directories.size());
       for (auto &[peer, peer_replayer] : m_peer_replayers) {
         dout(10) << ": peer=" << peer << dendl;
-        peer_replayer->remove_directory(dir_path);
+        peer_replayer->remove_directory(dir_path, purging);
       }
     }
     if (m_perf_counters) {

--- a/src/tools/cephfs_mirror/FSMirror.h
+++ b/src/tools/cephfs_mirror/FSMirror.h
@@ -117,8 +117,8 @@ private:
       fs_mirror->handle_acquire_directory(dir_path);
     }
 
-    void release_directory(std::string_view dir_path) override {
-      fs_mirror->handle_release_directory(dir_path);
+    void release_directory(std::string_view dir_path, bool purging) override {
+      fs_mirror->handle_release_directory(dir_path, purging);
     }
 
   };
@@ -189,7 +189,7 @@ private:
   void handle_shutdown_instance_watcher(int r);
 
   void handle_acquire_directory(std::string_view dir_path);
-  void handle_release_directory(std::string_view dir_path);
+  void handle_release_directory(std::string_view dir_path, bool purging);
 };
 
 } // namespace mirror

--- a/src/tools/cephfs_mirror/InstanceWatcher.cc
+++ b/src/tools/cephfs_mirror/InstanceWatcher.cc
@@ -87,21 +87,23 @@ void InstanceWatcher::handle_notify(uint64_t notify_id, uint64_t handle,
 
   std::string dir_path;
   std::string mode;
+  bool purging = false;
   try {
     JSONDecoder jd(bl);
     JSONDecoder::decode_json("dir_path", dir_path, &jd.parser, true);
     JSONDecoder::decode_json("mode", mode, &jd.parser, true);
+    JSONDecoder::decode_json("purging", purging, &jd.parser, false);
   } catch (const JSONDecoder::err &e) {
     derr << ": failed to decode notify json: " << e.what() << dendl;
   }
 
   dout(20) << ": notifier_id=" << notifier_id << ", dir_path=" << dir_path
-           << ", mode=" << mode << dendl;
+           << ", mode=" << mode << ", purging=" << purging << dendl;
 
   if (mode == "acquire") {
     m_listener.acquire_directory(dir_path);
   } else if (mode == "release") {
-    m_listener.release_directory(dir_path);
+    m_listener.release_directory(dir_path, purging);
   } else {
     derr << ": unknown mode" << dendl;
   }

--- a/src/tools/cephfs_mirror/InstanceWatcher.h
+++ b/src/tools/cephfs_mirror/InstanceWatcher.h
@@ -27,7 +27,7 @@ public:
     }
 
     virtual void acquire_directory(std::string_view dir_path) = 0;
-    virtual void release_directory(std::string_view dir_path) = 0;
+    virtual void release_directory(std::string_view dir_path, bool purging) = 0;
   };
 
   static InstanceWatcher *create(librados::IoCtx &ioctx,

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -1166,6 +1166,7 @@ int PeerReplayer::propagate_snap_deletes(const std::string &dir_root,
       return r;
     }
     inc_deleted_snap(dir_root);
+    persist_dir_sync_stat(dir_root);
     if (m_perf_counters) {
       m_perf_counters->inc(l_cephfs_mirror_peer_replayer_snaps_deleted);
     }
@@ -1192,6 +1193,7 @@ int PeerReplayer::propagate_snap_renames(
       return r;
     }
     inc_renamed_snap(dir_root);
+    persist_dir_sync_stat(dir_root);
     if (m_perf_counters) {
       m_perf_counters->inc(l_cephfs_mirror_peer_replayer_snaps_renamed);
     }
@@ -2849,6 +2851,7 @@ int PeerReplayer::do_sync_snaps(const std::string &dir_root) {
     }
 
     set_last_synced_stat(dir_root, it->first, it->second, duration);
+    persist_dir_sync_stat(dir_root);
     if (--snaps_per_cycle == 0) {
       break;
     }
@@ -2878,6 +2881,11 @@ int PeerReplayer::sync_snaps(const std::string &dir_root,
     update_directory_current_sync_perf_counters(dir_perf,
                                                 m_snap_sync_stats.at(dir_root));
   }
+  if (r < 0) {
+    locker.unlock();
+    persist_dir_sync_stat(dir_root);
+    locker.lock();
+  }
   return r;
 }
 
@@ -2898,6 +2906,18 @@ void PeerReplayer::run_tick() {
     for (const auto &kv : m_registered) {
       refresh_directory_current_sync_perf_counters(kv.first);
     }
+
+    // persist sync stats to omap for registered directories
+    std::vector<std::string> dirs;
+    dirs.reserve(m_registered.size());
+    for (const auto &kv : m_registered) {
+      dirs.push_back(kv.first);
+    }
+    locker.unlock();
+    for (const auto &dir_root : dirs) {
+      persist_dir_sync_stat(dir_root);
+    }
+    locker.lock();
   }
 }
 
@@ -2947,6 +2967,9 @@ void PeerReplayer::run(SnapshotReplayerThread *replayer) {
               update_directory_current_sync_perf_counters(
                 dir_perf, m_snap_sync_stats.at(*dir_root));
             }
+            locker.unlock();
+            persist_dir_sync_stat(*dir_root);
+            locker.lock();
             if (m_perf_counters) {
               m_perf_counters->inc(l_cephfs_mirror_peer_replayer_snap_sync_failures);
             }

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -10,6 +10,7 @@
 #include <boost/scope_exit.hpp>
 
 #include "common/admin_socket.h"
+#include "common/Clock.h"
 #include "common/ceph_context.h"
 #include "common/debug.h"
 #include "common/errno.h"
@@ -20,6 +21,7 @@
 #include "FSMirror.h"
 #include "PeerReplayer.h"
 #include "Utils.h"
+#include "aio_utils.h"
 
 #include "json_spirit/json_spirit.h"
 
@@ -117,6 +119,23 @@ std::string peer_config_key(const std::string &fs_name, const std::string &uuid)
   return PEER_CONFIG_KEY_PREFIX + "/" + fs_name + "/" + uuid;
 }
 
+double monotime_to_double(monotime t) {
+  return sec_duration(t.time_since_epoch()).count();
+}
+
+struct C_PersistSyncStatAio : Context {
+  std::string dir_root;
+
+  explicit C_PersistSyncStatAio(std::string dir_root_)
+    : dir_root(std::move(dir_root_)) {}
+
+  void finish(int r) override {
+    if (r < 0) {
+      generic_derr << "cephfs::mirror: aio persist sync stats failed for dir_root="
+                     << dir_root << ": " << cpp_strerror(r) << dendl;
+    }
+  }
+};
 class PeerAdminSocketCommand {
 public:
   virtual ~PeerAdminSocketCommand() {
@@ -201,10 +220,11 @@ private:
 PeerReplayer::PeerReplayer(CephContext *cct, FSMirror *fs_mirror,
                            RadosRef local_cluster, const Filesystem &filesystem,
                            const Peer &peer, const std::set<std::string, std::less<>> &directories,
-                           MountRef mount, ServiceDaemon *service_daemon)
+                           IoCtxRef local_ioctx, MountRef mount, ServiceDaemon *service_daemon)
   : m_cct(cct),
     m_fs_mirror(fs_mirror),
     m_local_cluster(local_cluster),
+    m_local_ioctx(local_ioctx),
     m_filesystem(filesystem),
     m_peer(peer),
     m_directories(directories.begin(), directories.end()),
@@ -271,10 +291,6 @@ uint64_t percent_basis_points(uint64_t num, uint64_t den) {
     return 0;
   }
   return static_cast<uint64_t>((static_cast<double>(num) * 10000.0) / den);
-}
-
-double monotime_to_double(monotime t) {
-  return sec_duration(t.time_since_epoch()).count();
 }
 
 void PeerReplayer::create_directory_perf_counters(const std::string &dir_root) {
@@ -725,6 +741,192 @@ void PeerReplayer::remove_directory(string_view dir_root) {
     it1->second.canceled = true;
   }
   m_cond.notify_all();
+}
+
+std::string PeerReplayer::peer_sync_stat_omap_key(std::string_view dir_root) const {
+  // dir_root is usually absolute (e.g. "/d0"); avoid ".../uuid//d0" from an extra slash.
+  std::string d(dir_root);
+  while (!d.empty() && d.front() == '/') {
+    d.erase(0, 1);
+  }
+  return PEER_SYNC_STAT_KEY_PREFIX + "/" + m_filesystem.fs_name + "/" + m_peer.uuid
+         + "/" + d;
+}
+
+void PeerReplayer::add_live_sync_metrics_to_persist(json_spirit::mObject &obj,
+                                                    SnapSyncStat &sync_stat) {
+  if (sync_stat.current_syncing_snap) {
+    json_spirit::mObject snap;
+    snap["id"] =
+      json_spirit::mValue(static_cast<boost::uint64_t>(sync_stat.current_syncing_snap->first));
+    snap["name"] = json_spirit::mValue(sync_stat.current_syncing_snap->second);
+    snap["sync-mode"] = json_spirit::mValue(sync_stat.snapdiff ? "delta" : "full");
+
+    double read_bps = sync_stat.read_time_sec > 0 ?
+        sync_stat.bytes_read / sync_stat.read_time_sec : 0;
+    double write_bps = sync_stat.write_time_sec > 0 ?
+        sync_stat.bytes_written / sync_stat.write_time_sec : 0;
+    snap["avg_read_throughput_bytes"] =
+      json_spirit::mValue(format_bytes(read_bps) + "/s");
+    snap["avg_write_throughput_bytes"] =
+      json_spirit::mValue(format_bytes(write_bps) + "/s");
+
+    json_spirit::mObject crawl;
+    if (sync_stat.crawl_finished) {
+      crawl["state"] = json_spirit::mValue("completed");
+      crawl["duration"] = json_spirit::mValue(format_time(sync_stat.crawl_duration));
+    } else {
+      crawl["state"] = json_spirit::mValue("in-progress");
+      auto cur_time = clock::now();
+      sec_duration crawl_duration_till_now =
+        sec_duration(cur_time - sync_stat.crawl_start_time);
+      crawl["duration"] =
+        json_spirit::mValue(format_time(crawl_duration_till_now.count()));
+    }
+    snap["crawl"] = json_spirit::mValue(crawl);
+
+    if (sync_stat.datasync_queue_wait_duration ||
+        sync_stat.datasync_queue_wait_start_time) {
+      json_spirit::mObject datasync_queue_wait;
+      if (sync_stat.datasync_queue_wait_duration) {
+        datasync_queue_wait["state"] = json_spirit::mValue("completed");
+        datasync_queue_wait["duration"] =
+          json_spirit::mValue(format_time(*sync_stat.datasync_queue_wait_duration));
+      } else {
+        datasync_queue_wait["state"] = json_spirit::mValue("waiting");
+        auto cur_time = clock::now();
+        sec_duration dq_wait =
+          sec_duration(cur_time - *sync_stat.datasync_queue_wait_start_time);
+        datasync_queue_wait["duration"] =
+          json_spirit::mValue(format_time(dq_wait.count()));
+      }
+      snap["datasync_queue_wait"] = json_spirit::mValue(datasync_queue_wait);
+    }
+
+    json_spirit::mObject bytes;
+    bytes["sync_bytes"] = json_spirit::mValue(format_bytes(sync_stat.sync_bytes));
+    bytes["total_bytes"] = json_spirit::mValue(format_bytes(sync_stat.total_bytes));
+    if (sync_stat.total_bytes > 0) {
+      double sync_pct =
+        (static_cast<double>(sync_stat.sync_bytes) * 100.0) / sync_stat.total_bytes;
+      std::ostringstream os;
+      os << std::fixed << std::setprecision(2) << sync_pct << "%";
+      bytes["sync_percent"] = json_spirit::mValue(os.str());
+    }
+    snap["bytes"] = json_spirit::mValue(bytes);
+
+    json_spirit::mObject files;
+    files["sync_files"] =
+      json_spirit::mValue(static_cast<boost::uint64_t>(sync_stat.sync_files));
+    files["total_files"] =
+      json_spirit::mValue(static_cast<boost::uint64_t>(sync_stat.total_files));
+    if (sync_stat.total_files > 0) {
+      double sync_file_pct =
+        (static_cast<double>(sync_stat.sync_files) * 100.0) / sync_stat.total_files;
+      std::ostringstream os;
+      os << std::fixed << std::setprecision(2) << sync_file_pct << "%";
+      files["sync_percent"] = json_spirit::mValue(os.str());
+    }
+    snap["files"] = json_spirit::mValue(files);
+
+    double eta = compute_eta(sync_stat);
+    if (eta == -1.0) {
+      snap["eta"] = json_spirit::mValue("calculating...");
+    } else {
+      snap["eta"] = json_spirit::mValue(format_time(eta));
+    }
+
+    obj["state"] = json_spirit::mValue("syncing");
+    obj["current_syncing_snap"] = json_spirit::mValue(snap);
+  } else if (sync_stat.failed) {
+    obj["state"] = json_spirit::mValue("failed");
+    if (sync_stat.last_failed_reason) {
+      obj["failure_reason"] = json_spirit::mValue(*sync_stat.last_failed_reason);
+    }
+  } else {
+    obj["state"] = json_spirit::mValue("idle");
+  }
+}
+
+void PeerReplayer::add_last_sync_metrics_to_persist(json_spirit::mObject &obj,
+                                                    SnapSyncStat &sync_stat) {
+  if (sync_stat.last_synced_snap) {
+    json_spirit::mObject snap;
+    snap["id"] =
+      json_spirit::mValue(static_cast<boost::uint64_t>(sync_stat.last_synced_snap->first));
+    snap["name"] = json_spirit::mValue(sync_stat.last_synced_snap->second);
+    if (sync_stat.last_sync_crawl_duration) {
+      snap["crawl_duration"] = json_spirit::mValue(*sync_stat.last_sync_crawl_duration);
+    }
+    if (sync_stat.last_sync_datasync_queue_wait_duration) {
+      snap["datasync_queue_wait_duration"] =
+        json_spirit::mValue(*sync_stat.last_sync_datasync_queue_wait_duration);
+    }
+    if (sync_stat.last_sync_duration) {
+      snap["sync_duration"] = json_spirit::mValue(*sync_stat.last_sync_duration);
+    }
+    if (!clock::is_zero(sync_stat.last_synced)) {
+      snap["sync_time_stamp"] =
+        json_spirit::mValue(monotime_to_double(sync_stat.last_synced));
+    }
+    if (sync_stat.last_sync_bytes) {
+      snap["sync_bytes"] =
+        json_spirit::mValue(static_cast<boost::uint64_t>(*sync_stat.last_sync_bytes));
+    }
+    if (sync_stat.last_sync_files) {
+      snap["sync_files"] =
+        json_spirit::mValue(static_cast<boost::uint64_t>(*sync_stat.last_sync_files));
+    }
+    obj["last_synced_snap"] = json_spirit::mValue(snap);
+  }
+
+  obj["snaps_synced"] =
+    json_spirit::mValue(static_cast<boost::uint64_t>(sync_stat.synced_snap_count));
+  obj["snaps_deleted"] =
+    json_spirit::mValue(static_cast<boost::uint64_t>(sync_stat.deleted_snap_count));
+  obj["snaps_renamed"] =
+    json_spirit::mValue(static_cast<boost::uint64_t>(sync_stat.renamed_snap_count));
+}
+
+void PeerReplayer::persist_dir_sync_stat(const std::string &dir_root) {
+  ceph_assert(m_local_ioctx);
+
+  SnapSyncStat sync_stat;
+  {
+    std::scoped_lock locker(m_lock);
+    auto it = m_snap_sync_stats.find(dir_root);
+    if (it == m_snap_sync_stats.end()) {
+      return;
+    }
+    sync_stat = it->second;
+  }
+
+  json_spirit::mObject obj;
+  add_live_sync_metrics_to_persist(obj, sync_stat);
+  add_last_sync_metrics_to_persist(obj, sync_stat);
+  obj["metrics_updated_at"] =
+    json_spirit::mValue(static_cast<double>(ceph_clock_now()));
+  obj["_instance_id"] =
+    json_spirit::mValue(stringify(m_local_ioctx->get_instance_id()));
+
+  bufferlist bl;
+  bl.append(json_spirit::write(json_spirit::mValue(obj)));
+  std::map<std::string, bufferlist> kv{{peer_sync_stat_omap_key(dir_root), bl}};
+
+  librados::ObjectWriteOperation write_op;
+  write_op.omap_set(kv);
+
+  Context *ctx = new C_PersistSyncStatAio(dir_root);
+  librados::AioCompletion *aio_comp = create_rados_callback(ctx);
+  int r = m_local_ioctx->aio_operate(CEPHFS_MIRROR_OBJECT, aio_comp, &write_op);
+  if (r < 0) {
+    delete ctx;
+    derr << ": failed to submit aio persist sync stats for dir_root=" << dir_root
+         << ": " << cpp_strerror(r) << dendl;
+    aio_comp->release();
+    return;
+  }
+  aio_comp->release();
 }
 
 void PeerReplayer::enqueue_syncm(const std::shared_ptr<SyncMechanism>& item) {

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -89,6 +89,9 @@ namespace {
 
 const std::string PEER_CONFIG_KEY_PREFIX = "cephfs/mirror/peer";
 
+// Matches the mgr mirroring omap read batch size (dir_map/load.py MAX_RETURN).
+constexpr size_t SYNC_STAT_OMAP_LOAD_BATCH_SIZE = 256;
+
 std::string snapshot_dir_path(CephContext *cct, const std::string &path) {
   return path + "/" + cct->_conf->client_snapdir;
 }
@@ -119,8 +122,24 @@ std::string peer_config_key(const std::string &fs_name, const std::string &uuid)
   return PEER_CONFIG_KEY_PREFIX + "/" + fs_name + "/" + uuid;
 }
 
+bool get_json_value(const json_spirit::mObject& obj,
+                    const std::string& key,
+                    json_spirit::mValue *val) {
+  auto it = obj.find(key);
+  if (it != obj.end()) {
+    *val = it->second;
+    return true;
+  }
+  return false;
+}
+
 double monotime_to_double(monotime t) {
   return sec_duration(t.time_since_epoch()).count();
+}
+
+monotime monotime_from_double(double seconds) {
+  auto d = std::chrono::duration_cast<clock::duration>(sec_duration(seconds));
+  return monotime(d);
 }
 
 struct C_PersistSyncStatAio : Context {
@@ -136,6 +155,21 @@ struct C_PersistSyncStatAio : Context {
     }
   }
 };
+
+struct C_RemovePersistedSyncStatAio : Context {
+  std::string dir_root;
+
+  explicit C_RemovePersistedSyncStatAio(std::string dir_root_)
+    : dir_root(std::move(dir_root_)) {}
+
+  void finish(int r) override {
+    if (r < 0 && r != -ENOENT) {
+      generic_derr << "cephfs::mirror: aio remove persisted sync stats failed for dir_root="
+                     << dir_root << ": " << cpp_strerror(r) << dendl;
+    }
+  }
+};
+
 class PeerAdminSocketCommand {
 public:
   virtual ~PeerAdminSocketCommand() {
@@ -559,6 +593,7 @@ int PeerReplayer::init() {
   for (auto &dir_root : m_directories) {
     m_snap_sync_stats.emplace(dir_root, SnapSyncStat());
   }
+  load_persisted_dir_sync_stats();
   for (auto &dir_root : m_directories) {
     create_directory_perf_counters(dir_root);
     auto *dir_perf = find_directory_perf_counters(dir_root);
@@ -703,14 +738,18 @@ void PeerReplayer::add_directory(string_view dir_root) {
   dout(20) << ": dir_root=" << dir_root << dendl;
   auto _dir_root = std::string(dir_root);
 
-  std::scoped_lock locker(m_lock);
-  if (std::find(m_directories.begin(), m_directories.end(), _dir_root) !=
-      m_directories.end()) {
-    dout(10) << ": dir_root=" << _dir_root << " already in replay list" << dendl;
-    return;
+  {
+    std::scoped_lock locker(m_lock);
+    if (std::find(m_directories.begin(), m_directories.end(), _dir_root) !=
+        m_directories.end()) {
+      dout(10) << ": dir_root=" << _dir_root << " already in replay list" << dendl;
+      return;
+    }
+    m_directories.emplace_back(_dir_root);
+    m_snap_sync_stats.emplace(_dir_root, SnapSyncStat());
   }
-  m_directories.emplace_back(_dir_root);
-  m_snap_sync_stats.emplace(_dir_root, SnapSyncStat());
+  load_persisted_dir_sync_stat(_dir_root);
+  std::scoped_lock locker(m_lock);
   if (m_directory_perf_counters.find(_dir_root) ==
       m_directory_perf_counters.end()) {
     create_directory_perf_counters(_dir_root);
@@ -723,24 +762,44 @@ void PeerReplayer::add_directory(string_view dir_root) {
   m_cond.notify_all();
 }
 
-void PeerReplayer::remove_directory(string_view dir_root) {
-  dout(20) << ": dir_root=" << dir_root << dendl;
+void PeerReplayer::remove_directory(string_view dir_root, bool purging) {
+  dout(20) << ": dir_root=" << dir_root << ", purging=" << purging << dendl;
   auto _dir_root = std::string(dir_root);
+  bool persist_idle = false;
 
-  std::scoped_lock locker(m_lock);
-  auto it = std::find(m_directories.begin(), m_directories.end(), _dir_root);
-  if (it != m_directories.end()) {
-    m_directories.erase(it);
+  {
+    std::scoped_lock locker(m_lock);
+    auto it = std::find(m_directories.begin(), m_directories.end(), _dir_root);
+    if (it != m_directories.end()) {
+      m_directories.erase(it);
+    }
+
+    auto it1 = m_registered.find(_dir_root);
+    if (it1 == m_registered.end()) {
+      if (purging) {
+        remove_persisted_dir_sync_stat(_dir_root);
+      }
+      remove_directory_perf_counters(_dir_root);
+      m_snap_sync_stats.erase(_dir_root);
+    } else {
+      it1->second.canceled = true;
+      if (purging) {
+        m_purging_directories.insert(_dir_root);
+      } else {
+        auto &sync_stat = m_snap_sync_stats.at(_dir_root);
+        sync_stat.current_syncing_snap = boost::none;
+        if (auto *dir_perf = find_directory_perf_counters(_dir_root)) {
+          update_directory_current_sync_perf_counters(dir_perf, sync_stat);
+        }
+        persist_idle = true;
+      }
+    }
+    m_cond.notify_all();
   }
 
-  auto it1 = m_registered.find(_dir_root);
-  if (it1 == m_registered.end()) {
-    remove_directory_perf_counters(_dir_root);
-    m_snap_sync_stats.erase(_dir_root);
-  } else {
-    it1->second.canceled = true;
+  if (persist_idle) {
+    persist_dir_sync_stat(_dir_root);
   }
-  m_cond.notify_all();
 }
 
 std::string PeerReplayer::peer_sync_stat_omap_key(std::string_view dir_root) const {
@@ -751,6 +810,167 @@ std::string PeerReplayer::peer_sync_stat_omap_key(std::string_view dir_root) con
   }
   return PEER_SYNC_STAT_KEY_PREFIX + "/" + m_filesystem.fs_name + "/" + m_peer.uuid
          + "/" + d;
+}
+
+void PeerReplayer::apply_persisted_dir_sync_stat(SnapSyncStat &sync_stat,
+                                                 const bufferlist &bl) {
+  json_spirit::mValue root;
+  if (!json_spirit::read(bl.to_str(), root) || root.type() != json_spirit::obj_type) {
+    return;
+  }
+
+  auto &obj = root.get_obj();
+  json_spirit::mValue v;
+
+  if (get_json_value(obj, "last_synced_snap", &v) && v.type() == json_spirit::obj_type) {
+    auto &last_synced_snap = v.get_obj();
+    if (get_json_value(last_synced_snap, "id", &v)) {
+      uint64_t snap_id = v.get_uint64();
+      if (get_json_value(last_synced_snap, "name", &v)) {
+        sync_stat.last_synced_snap = std::make_pair(snap_id, v.get_str());
+      }
+    }
+    if (get_json_value(last_synced_snap, "crawl_duration", &v)) {
+      sync_stat.last_sync_crawl_duration = v.get_real();
+    }
+    if (get_json_value(last_synced_snap, "datasync_queue_wait_duration", &v)) {
+      sync_stat.last_sync_datasync_queue_wait_duration = v.get_real();
+    }
+    if (get_json_value(last_synced_snap, "sync_duration", &v)) {
+      sync_stat.last_sync_duration = v.get_real();
+    }
+    if (get_json_value(last_synced_snap, "sync_time_stamp", &v)) {
+      sync_stat.last_synced = monotime_from_double(v.get_real());
+    }
+    if (get_json_value(last_synced_snap, "sync_bytes", &v)) {
+      sync_stat.last_sync_bytes = v.get_uint64();
+    }
+    if (get_json_value(last_synced_snap, "sync_files", &v)) {
+      sync_stat.last_sync_files = v.get_uint64();
+    }
+  }
+}
+
+void PeerReplayer::load_persisted_dir_sync_stat(const std::string &dir_root) {
+  ceph_assert(m_local_ioctx);
+
+  const std::string key = peer_sync_stat_omap_key(dir_root);
+  std::set<std::string> keys{key};
+  std::map<std::string, bufferlist> vals;
+  // Sync call is fine since it's called once during add_directory
+  int r = m_local_ioctx->omap_get_vals_by_keys(CEPHFS_MIRROR_OBJECT, keys, &vals);
+  if (r == -ENOENT) {
+    return;
+  }
+  if (r < 0) {
+    derr << ": failed to read persisted sync stat for dir_root=" << dir_root
+         << ": " << cpp_strerror(r) << dendl;
+    return;
+  }
+
+  auto vit = vals.find(key);
+  if (vit == vals.end()) {
+    return;
+  }
+
+  std::scoped_lock locker(m_lock);
+  auto st_it = m_snap_sync_stats.find(dir_root);
+  if (st_it == m_snap_sync_stats.end()) {
+    return;
+  }
+  apply_persisted_dir_sync_stat(st_it->second, vit->second);
+}
+
+void PeerReplayer::load_persisted_dir_sync_stats() {
+  ceph_assert(m_local_ioctx);
+  if (m_directories.empty()) {
+    return;
+  }
+
+  std::vector<std::string> omap_keys;
+  omap_keys.reserve(m_directories.size());
+  std::map<std::string, std::string> key_to_dir;
+  for (const auto &dir_root : m_directories) {
+    const std::string key = peer_sync_stat_omap_key(dir_root);
+    omap_keys.push_back(key);
+    key_to_dir[key] = dir_root;
+  }
+
+  std::map<std::string, bufferlist> all_vals;
+
+  auto fetch_keys = [&](const std::set<std::string> &keys) -> int {
+    if (keys.empty()) {
+      return 0;
+    }
+    std::map<std::string, bufferlist> vals;
+    // Sync call is fine since the stats are loaded once during startup
+    int r = m_local_ioctx->omap_get_vals_by_keys(CEPHFS_MIRROR_OBJECT, keys, &vals);
+    if (r == -ENOENT) {
+      return 0;
+    }
+    if (r < 0) {
+      return r;
+    }
+    all_vals.merge(std::move(vals));
+    return 0;
+  };
+
+  if (m_directories.size() <= SYNC_STAT_OMAP_LOAD_BATCH_SIZE) {
+    std::set<std::string> keys(omap_keys.begin(), omap_keys.end());
+    int r = fetch_keys(keys);
+    if (r < 0) {
+      derr << ": failed to read persisted sync stats: " << cpp_strerror(r) << dendl;
+      return;
+    }
+  } else {
+    for (size_t i = 0; i < omap_keys.size(); i += SYNC_STAT_OMAP_LOAD_BATCH_SIZE) {
+      std::set<std::string> keys;
+      const size_t end = std::min(i + SYNC_STAT_OMAP_LOAD_BATCH_SIZE, omap_keys.size());
+      for (size_t j = i; j < end; ++j) {
+        keys.insert(omap_keys[j]);
+      }
+      int r = fetch_keys(keys);
+      if (r < 0) {
+        derr << ": failed to read persisted sync stats: " << cpp_strerror(r) << dendl;
+        return;
+      }
+    }
+  }
+
+  std::scoped_lock locker(m_lock);
+  for (auto &[key, bl] : all_vals) {
+    auto kit = key_to_dir.find(key);
+    if (kit == key_to_dir.end()) {
+      continue;
+    }
+    auto st_it = m_snap_sync_stats.find(kit->second);
+    if (st_it == m_snap_sync_stats.end()) {
+      continue;
+    }
+    apply_persisted_dir_sync_stat(st_it->second, bl);
+  }
+}
+
+void PeerReplayer::remove_persisted_dir_sync_stat(const std::string &dir_root) {
+  ceph_assert(m_local_ioctx);
+
+  const std::string key = peer_sync_stat_omap_key(dir_root);
+  dout(5) << ": removing persisted sync stat omap key=" << key
+          << " for dir_root=" << dir_root << dendl;
+  librados::ObjectWriteOperation write_op;
+  write_op.omap_rm_keys({key});
+
+  Context *ctx = new C_RemovePersistedSyncStatAio(dir_root);
+  librados::AioCompletion *aio_comp = create_rados_callback(ctx);
+  int r = m_local_ioctx->aio_operate(CEPHFS_MIRROR_OBJECT, aio_comp, &write_op);
+  if (r < 0) {
+    delete ctx;
+    derr << ": failed to submit aio remove persisted sync stats for dir_root="
+         << dir_root << ": " << cpp_strerror(r) << dendl;
+    aio_comp->release();
+    return;
+  }
+  aio_comp->release();
 }
 
 void PeerReplayer::add_live_sync_metrics_to_persist(json_spirit::mObject &obj,
@@ -980,7 +1200,8 @@ int PeerReplayer::register_directory(const std::string &dir_root,
   return 0;
 }
 
-void PeerReplayer::unregister_directory(const std::string &dir_root) {
+void PeerReplayer::unregister_directory(const std::string &dir_root,
+                                        std::unique_lock<ceph::mutex> &locker) {
   dout(20) << ": dir_root=" << dir_root << dendl;
 
   auto it = m_registered.find(dir_root);
@@ -989,6 +1210,18 @@ void PeerReplayer::unregister_directory(const std::string &dir_root) {
   unlock_directory(it->first, it->second);
   m_registered.erase(it);
   if (std::find(m_directories.begin(), m_directories.end(), dir_root) == m_directories.end()) {
+    if (m_purging_directories.erase(dir_root)) {
+      remove_persisted_dir_sync_stat(dir_root);
+    } else {
+      auto &sync_stat = m_snap_sync_stats.at(dir_root);
+      sync_stat.current_syncing_snap = boost::none;
+      if (auto *dir_perf = find_directory_perf_counters(dir_root)) {
+        update_directory_current_sync_perf_counters(dir_perf, sync_stat);
+      }
+      locker.unlock();
+      persist_dir_sync_stat(dir_root);
+      locker.lock();
+    }
     remove_directory_perf_counters(dir_root);
     m_snap_sync_stats.erase(dir_root);
   }
@@ -2799,8 +3032,11 @@ int PeerReplayer::do_sync_snaps(const std::string &dir_root) {
     auto last = remote_snap_map.rbegin();
     last_snap_id = last->first;
     last_snap_name = last->second;
-    set_last_synced_snap(dir_root, last_snap_id, last_snap_name);
+
+    reconcile_last_synced_snap(dir_root, last_snap_id, last_snap_name);
   }
+  // Session counters reset on restart; persist unconditionally to clear stale state.
+  persist_dir_sync_stat(dir_root);
 
   dout(5) << ": last snap-id transferred=" << last_snap_id << dendl;
   auto it = local_snap_map.upper_bound(last_snap_id);
@@ -2974,7 +3210,7 @@ void PeerReplayer::run(SnapshotReplayerThread *replayer) {
               m_perf_counters->inc(l_cephfs_mirror_peer_replayer_snap_sync_failures);
             }
           }
-          unregister_directory(*dir_root);
+          unregister_directory(*dir_root, locker);
         }
       }
 

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -9,6 +9,7 @@
 #include "mds/FSMap.h"
 #include "ServiceDaemon.h"
 #include "Types.h"
+#include "json_spirit/json_spirit.h"
 
 #include <stack>
 #include <boost/optional.hpp>
@@ -24,7 +25,7 @@ public:
   PeerReplayer(CephContext *cct, FSMirror *fs_mirror,
                RadosRef local_cluster, const Filesystem &filesystem,
                const Peer &peer, const std::set<std::string, std::less<>> &directories,
-               MountRef mount, ServiceDaemon *service_daemon);
+               IoCtxRef local_ioctx, MountRef mount, ServiceDaemon *service_daemon);
   ~PeerReplayer();
 
   // initialize replayer for a peer
@@ -50,6 +51,7 @@ private:
 
   inline static const std::string SERVICE_DAEMON_FAILED_DIR_COUNT_KEY = "failure_count";
   inline static const std::string SERVICE_DAEMON_RECOVERED_DIR_COUNT_KEY = "recovery_count";
+  inline static const std::string PEER_SYNC_STAT_KEY_PREFIX = "sync_stat";
 
   using Snapshot = std::pair<std::string, uint64_t>;
 
@@ -647,6 +649,7 @@ private:
   CephContext *m_cct;
   FSMirror *m_fs_mirror;
   RadosRef m_local_cluster;
+  IoCtxRef m_local_ioctx;
   Filesystem m_filesystem;
   Peer m_peer;
   // probably need to be encapsulated when supporting cancelations
@@ -712,6 +715,12 @@ private:
                          DirRegistry *registry);
   void unlock_directory(const std::string &dir_root, const DirRegistry &registry);
   int sync_snaps(const std::string &dir_root, std::unique_lock<ceph::mutex> &locker);
+  void persist_dir_sync_stat(const std::string &dir_root);
+  void add_live_sync_metrics_to_persist(json_spirit::mObject &obj,
+                                        SnapSyncStat &sync_stat);
+  void add_last_sync_metrics_to_persist(json_spirit::mObject &obj,
+                                        SnapSyncStat &sync_stat);
+  std::string peer_sync_stat_omap_key(std::string_view dir_root) const;
 
 
   int build_snap_map(const std::string &dir_root, std::map<uint64_t, std::string> *snap_map,

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -11,6 +11,7 @@
 #include "Types.h"
 #include "json_spirit/json_spirit.h"
 
+#include <set>
 #include <stack>
 #include <boost/optional.hpp>
 
@@ -38,7 +39,7 @@ public:
   void add_directory(std::string_view dir_root);
 
   // remove a directory from queue
-  void remove_directory(std::string_view dir_root);
+  void remove_directory(std::string_view dir_root, bool purging = false);
 
   // admin socket helpers
   void peer_status(Formatter *f);
@@ -458,6 +459,32 @@ private:
     sync_stat.last_failed_reason = boost::none;
   }
 
+  void _reset_last_synced_snap_stat(const std::string &dir_root) {
+    auto &sync_stat = m_snap_sync_stats.at(dir_root);
+    sync_stat.last_synced = clock::zero();
+    sync_stat.last_sync_duration.reset();
+    sync_stat.last_sync_crawl_duration.reset();
+    sync_stat.last_sync_datasync_queue_wait_duration.reset();
+    sync_stat.last_sync_bytes.reset();
+    sync_stat.last_sync_files.reset();
+  }
+
+  void reconcile_last_synced_snap(const std::string &dir_root, uint64_t snap_id,
+                                  const std::string &snap_name) {
+    std::scoped_lock locker(m_lock);
+    auto &sync_stat = m_snap_sync_stats.at(dir_root);
+    if (sync_stat.last_synced_snap &&
+        sync_stat.last_synced_snap->first == snap_id &&
+        sync_stat.last_synced_snap->second == snap_name) {
+      return;
+    }
+    _reset_last_synced_snap_stat(dir_root);
+    _set_last_synced_snap(dir_root, snap_id, snap_name);
+    if (auto *dir_perf = find_directory_perf_counters(dir_root)) {
+      update_directory_last_sync_perf_counters(dir_perf, sync_stat);
+    }
+  }
+
   void _reset_sync_stat(const std::string &dir_root) {
     auto &sync_stat = m_snap_sync_stats.at(dir_root);
     sync_stat.sync_bytes = 0;
@@ -656,6 +683,7 @@ private:
   std::map<std::string, DirRegistry> m_registered;
   std::vector<std::string> m_directories;
   std::map<std::string, SnapSyncStat> m_snap_sync_stats;
+  std::set<std::string> m_purging_directories;
   MountRef m_local_mount;
   ServiceDaemon *m_service_daemon;
   PeerReplayerAdminSocketHook *m_asok_hook = nullptr;
@@ -710,11 +738,16 @@ private:
 
   boost::optional<std::string> pick_directory();
   int register_directory(const std::string &dir_root, SnapshotReplayerThread *replayer);
-  void unregister_directory(const std::string &dir_root);
+  void unregister_directory(const std::string &dir_root,
+                            std::unique_lock<ceph::mutex> &locker);
   int try_lock_directory(const std::string &dir_root, SnapshotReplayerThread *replayer,
                          DirRegistry *registry);
   void unlock_directory(const std::string &dir_root, const DirRegistry &registry);
   int sync_snaps(const std::string &dir_root, std::unique_lock<ceph::mutex> &locker);
+  void load_persisted_dir_sync_stats();
+  void load_persisted_dir_sync_stat(const std::string &dir_root);
+  void apply_persisted_dir_sync_stat(SnapSyncStat &sync_stat, const bufferlist &bl);
+  void remove_persisted_dir_sync_stat(const std::string &dir_root);
   void persist_dir_sync_stat(const std::string &dir_root);
   void add_live_sync_metrics_to_persist(json_spirit::mObject &obj,
                                         SnapSyncStat &sync_stat);

--- a/src/tools/cephfs_mirror/aio_utils.h
+++ b/src/tools/cephfs_mirror/aio_utils.h
@@ -4,10 +4,20 @@
 #ifndef CEPHFS_MIRROR_AIO_UTILS_H
 #define CEPHFS_MIRROR_AIO_UTILS_H
 
+#include "include/Context.h"
 #include "include/rados/librados.hpp"
 
 namespace cephfs {
 namespace mirror {
+
+inline void rados_ctx_callback(rados_completion_t c, void *arg) {
+  Context *on_finish = reinterpret_cast<Context *>(arg);
+  on_finish->complete(rados_aio_get_return_value(c));
+}
+
+inline librados::AioCompletion *create_rados_callback(Context *on_finish) {
+  return librados::Rados::aio_create_completion(on_finish, rados_ctx_callback);
+}
 
 template <typename T, void(T::*MF)(int)>
 void rados_callback(rados_completion_t c, void *arg) {


### PR DESCRIPTION
Add new interface to expose mirroring metrics.
The mirror daemon persists mirroring metrics at configured
interval (default 5 seconds) as omap on cephfs_mirror object.

The mgr/mirroring module builds 'fs snapshot mirror status'
from persisted sync_stat omap data.

Fixes: https://tracker.ceph.com/issues/76686
Signed-off-by: Kotresh HR <khiremat@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
