### PR TITLE
crimson/os/seastore: SegmentManager::get_segment_manager() cleanups

### DIFF
--- a/src/crimson/os/seastore/segment_manager.cc
+++ b/src/crimson/os/seastore/segment_manager.cc
@@ -39,7 +39,8 @@ SegmentManager::get_segment_manager(
 	seastar::open_flags::rw);
   ceph_assert(file);
   uint32_t nr_zones = 0;
-  [[maybe_unused]] auto ret = co_await file.ioctl(BLKGETNRZONES, &nr_zones);
+  auto ret = co_await file.ioctl(BLKGETNRZONES, &nr_zones);
+  ceph_assert(ret == 0);
   INFO("Found {} zones.", nr_zones);
   if (nr_zones != 0) {
     co_return std::make_unique<segment_manager::zbd::ZBDSegmentManager>(device + "/block");

--- a/src/crimson/os/seastore/segment_manager.cc
+++ b/src/crimson/os/seastore/segment_manager.cc
@@ -33,48 +33,22 @@ SegmentManager::get_segment_manager(
   const std::string &device, device_type_t dtype)
 {
 #ifdef HAVE_ZNS
-LOG_PREFIX(SegmentManager::get_segment_manager);
-  return seastar::do_with(
-    static_cast<size_t>(0),
-    [FNAME,
-     dtype,
-     device](auto &nr_zones) {
-      return seastar::open_file_dma(
+  LOG_PREFIX(SegmentManager::get_segment_manager);
+  auto file = co_await seastar::open_file_dma(
 	device + "/block",
-	seastar::open_flags::rw
-      ).then([FNAME,
-	      dtype,
-	      device,
-	      &nr_zones](auto file) {
-	return seastar::do_with(
-	  file,
-	  [&nr_zones](auto &f) -> seastar::future<int> {
-	    ceph_assert(f);
-	    return f.ioctl(BLKGETNRZONES, (void *)&nr_zones);
-	  });
-      }).then([FNAME,
-	       dtype,
-	       device,
-	       &nr_zones](auto ret) -> crimson::os::seastore::SegmentManagerRef {
-	crimson::os::seastore::SegmentManagerRef sm;
-	INFO("Found {} zones.", nr_zones);
-	if (nr_zones != 0) {
-	  return std::make_unique<
-	    segment_manager::zbd::ZBDSegmentManager
-	    >(device + "/block");
-	} else {
-	  return std::make_unique<
-	    segment_manager::block::BlockSegmentManager
-	    >(device + "/block", dtype);
-	}
-      });
-    });
+	seastar::open_flags::rw);
+  ceph_assert(file);
+  size_t nr_zones = 0;
+  [[maybe_unused]] auto ret = co_await file.ioctl(BLKGETNRZONES, (void *)&nr_zones);
+  INFO("Found {} zones.", nr_zones);
+  if (nr_zones != 0) {
+    co_return std::make_unique<segment_manager::zbd::ZBDSegmentManager>(device + "/block");
+  } else {
+    co_return std::make_unique<segment_manager::block::BlockSegmentManager>(device + "/block", dtype);
+  }
 #else
-  return seastar::make_ready_future<crimson::os::seastore::SegmentManagerRef>(
-    std::make_unique<
-      segment_manager::block::BlockSegmentManager
-    >(device + "/block", dtype));
+  co_return std::make_unique<segment_manager::block::BlockSegmentManager>(device + "/block", dtype);
 #endif
 }
 
-}
+} // namespace crimson::os::seastore

--- a/src/crimson/os/seastore/segment_manager.cc
+++ b/src/crimson/os/seastore/segment_manager.cc
@@ -38,8 +38,8 @@ SegmentManager::get_segment_manager(
 	device + "/block",
 	seastar::open_flags::rw);
   ceph_assert(file);
-  size_t nr_zones = 0;
-  [[maybe_unused]] auto ret = co_await file.ioctl(BLKGETNRZONES, (void *)&nr_zones);
+  uint32_t nr_zones = 0;
+  [[maybe_unused]] auto ret = co_await file.ioctl(BLKGETNRZONES, &nr_zones);
   INFO("Found {} zones.", nr_zones);
   if (nr_zones != 0) {
     co_return std::make_unique<segment_manager::zbd::ZBDSegmentManager>(device + "/block");

--- a/src/crimson/os/seastore/segment_manager.cc
+++ b/src/crimson/os/seastore/segment_manager.cc
@@ -44,12 +44,9 @@ SegmentManager::get_segment_manager(
   INFO("Found {} zones.", nr_zones);
   if (nr_zones != 0) {
     co_return std::make_unique<segment_manager::zbd::ZBDSegmentManager>(device + "/block");
-  } else {
-    co_return std::make_unique<segment_manager::block::BlockSegmentManager>(device + "/block", dtype);
   }
-#else
-  co_return std::make_unique<segment_manager::block::BlockSegmentManager>(device + "/block", dtype);
 #endif
+  co_return std::make_unique<segment_manager::block::BlockSegmentManager>(device + "/block", dtype);
 }
 
 } // namespace crimson::os::seastore


### PR DESCRIPTION
in this changeset, we have multiple cleanups in `SegmentManager::get_segment_manager()`. non behavior changes are included.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
