### PR TITLE
mgr/cephadm: Support cephadm certmgr with SMB/TLS configuration

### DIFF
--- a/doc/cephadm/services/smb.rst
+++ b/doc/cephadm/services/smb.rst
@@ -53,12 +53,99 @@ An SMB service can be applied using a specification. An example in YAML follows:
       include_ceph_users:
         - client.smb.fs.cluster.tango
 
+TLS/SSL Example
+---------------
+
+Here's an example SMB service specification with TLS/SSL configuration:
+
+.. code-block:: yaml
+
+   service_id: smbcluster
+   service_type: smb
+   cluster_id: tango
+   config_uri: rados://smb/foxtrot/config.json
+   placement:
+     hosts:
+       - host0
+   spec:
+     ssl_certificates:
+       remote_control:
+         enabled: true
+         certificate_source: inline
+         ssl_cert: |
+           -----BEGIN CERTIFICATE-----
+           ...
+           -----END CERTIFICATE-----
+
+         ssl_key: |
+           -----BEGIN PRIVATE KEY-----
+           ...
+           -----END PRIVATE KEY-----
+
+         ssl_ca_cert: |
+           -----BEGIN CERTIFICATE-----
+           ...
+           -----END CERTIFICATE-----
+       keybridge:
+         enabled: true
+         certificate_source: inline
+         ssl_cert: |
+           -----BEGIN CERTIFICATE-----
+           ...
+           -----END CERTIFICATE-----
+
+         ssl_key: |
+           -----BEGIN PRIVATE KEY-----
+           ...
+           -----END PRIVATE KEY-----
+
+         ssl_ca_cert: |
+           -----BEGIN CERTIFICATE-----
+           ...
+           -----END CERTIFICATE-----
+
+This example configures an SMB service with TLS encryption enabled using
+inline certificates.
+
+TLS/SSL Parameters
+~~~~~~~~~~~~~~~~~~
+
+The following parameters can be used to configure TLS/SSL encryption per sidecar
+for the SMB service:
+
+* ``enabled`` (boolean): Enable or disable SSL/TLS encryption. Default is ``false``.
+
+* ``certificate_source`` (string): Specifies the source of the TLS certificates.
+  Options include:
+
+  - ``cephadm-signed``: Use certificates signed by cephadm's internal CA
+  - ``inline``: Provide certificates directly in the specification using ``ssl_cert``,
+    ``ssl_key`` and ``ssl_ca_cert`` fields
+  - ``reference``: Users can register their own certificate and key with certmgr and
+    set the ``certificate_source`` to ``reference`` in the spec.
+
+* ``ssl_cert`` (string): The SSL certificate in PEM format. Required when using
+  ``inline`` certificate source.
+
+* ``ssl_key`` (string): The SSL private key in PEM format. Required when using
+  ``inline`` certificate source.
+
+* ``ssl_ca_cert`` (string): The SSL CA certificate in PEM format. Required when
+  using ``inline`` certificate source.
+
+.. note::
+   ``ssl_key``, ``ssl_cert`` and ``ssl_ca_cert`` can be set from the smb manager
+   module. If ``cert`` and ``key`` are specified in the resource_type
+   ``ceph.smb.tls.credential`` and applied from the smb manager will be automatically
+   configured as ssl_certificate is enabled and update ``ssl_key``, ``ssl_cert`` to
+   the certificate manager. ``ssl_ca_cert`` will be set if it is specified in the
+   resource_type ``ceph.smb.tls.credential``
+
 The specification can then be applied by running the following command:
 
 .. prompt:: bash #
 
    ceph orch apply -i smb.yaml
-
 
 Service Spec Options
 --------------------

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -776,6 +776,15 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         self.cert_mgr.register_cert('nvmeof', 'nvmeof_root_ca_cert', TLSObjectScope.SERVICE)
         # register haproxy monitor ssl cert and key
         self.cert_mgr.register_cert_key_pair('ingress', 'haproxy_monitor_ssl_cert', 'haproxy_monitor_ssl_key', TLSObjectScope.SERVICE)
+        # register per-feature SMB TLS cert names
+        for _smb_feature in ['remote_control', 'keybridge']:
+            self.cert_mgr.register_cert_key_pair(
+                'smb',
+                f'smb_{_smb_feature}_ssl_cert',
+                f'smb_{_smb_feature}_ssl_key',
+                TLSObjectScope.SERVICE,
+                f'smb_{_smb_feature}_ca_cert',
+            )
 
         self.cert_mgr.init_tlsobject_store()
 

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -373,12 +373,21 @@ class CephadmService(metaclass=ABCMeta):
             self.mgr.cert_mgr.save_self_signed_cert_key_pair(svc_name, tls_creds, host=daemon_spec.host, label=label)
         return tls_creds
 
+    def _get_certificates_from_spec_ssl_certificates(
+        self,
+        svc_spec: ServiceSpec,
+        daemon_spec: CephadmDaemonDeploySpec,
+        feature: Optional[str] = None
+    ) -> TLSCredentials:
+        return EMPTY_TLS_CREDENTIALS
+
     def get_certificates(self,
                          daemon_spec: CephadmDaemonDeploySpec,
                          ips: List[str] = [],
                          fqdns: List[str] = [],
                          custom_sans: List[str] = [],
-                         ca_cert_required: bool = False
+                         ca_cert_required: bool = False,
+                         feature: Optional[str] = None
                          ) -> TLSCredentials:
 
         svc_spec = cast(ServiceSpec, self.mgr.spec_store[daemon_spec.service_name].spec)
@@ -398,6 +407,7 @@ class CephadmService(metaclass=ABCMeta):
             ips=ips,
             fqdns=fqdns,
             custom_sans=custom_sans,
+            feature=feature,
         )
 
     def get_certificates_generic(
@@ -414,6 +424,7 @@ class CephadmService(metaclass=ABCMeta):
         custom_sans: Optional[List[str]] = None,
         ips: Optional[List[str]] = None,
         fqdns: Optional[List[str]] = None,
+        feature: Optional[str] = None,
     ) -> TLSCredentials:
 
         ips = ips or [self.mgr.inventory.get_addr(daemon_spec.host)]
@@ -423,7 +434,9 @@ class CephadmService(metaclass=ABCMeta):
         cert_source = getattr(svc_spec, cert_source_attr, None)
         logger.debug(f'Getting certificate for {svc_spec.service_name()} using source: {cert_source}')
 
-        if cert_source == CertificateSource.INLINE.value:
+        if feature is not None:
+            return self._get_certificates_from_spec_ssl_certificates(svc_spec, daemon_spec, feature)
+        elif cert_source == CertificateSource.INLINE.value:
             return self._get_certificates_from_spec(svc_spec, daemon_spec, cert_attr, key_attr, cert_name, key_name, ca_cert_attr, ca_cert_name)
         elif cert_source == CertificateSource.REFERENCE.value:
             return self._get_certificates_from_certmgr_store(svc_spec, fqdns, cert_name, key_name, ca_cert_name)

--- a/src/pybind/mgr/cephadm/services/smb.py
+++ b/src/pybind/mgr/cephadm/services/smb.py
@@ -16,11 +16,8 @@ from typing import (
 )
 
 from mgr_module import HandleCommandResult
-from cephadm.tlsobject_types import TLSObjectScope, TLSCredentials, EMPTY_TLS_CREDENTIALS
 from ceph.smb.constants import (
-    KEYBRIDGE, 
-    REMOTE_CONTROL,
-    FEATURES,
+    SMB_FEATURE_SUPPORTS_SSL,
 )
 
 from ceph.deployment.service_spec import (
@@ -152,21 +149,15 @@ class SMBService(CephService):
         )
         return daemon_spec
 
-    def _feature_tls_filename(self, feature: str) -> Optional[str]:
-        return {
-                KEYBRIDGE: "keybridge",
-                REMOTE_CONTROL: "remote_control"
-            }.get(feature)
-
     # Flat SSL fields on SMBSpec per feature, used as a fallback when
     # ssl_certificates is not set (backward compatibility).
     _FEATURE_FLAT_ATTRS: Dict[str, Tuple[str, str, str]] = {
-        REMOTE_CONTROL: (
+        "remote_control": (
             'remote_control_ssl_cert',
             'remote_control_ssl_key',
             'remote_control_ca_cert',
         ),
-        KEYBRIDGE: (
+        "keybridge": (
             'keybridge_kmip_ssl_cert',
             'keybridge_kmip_ssl_key',
             'keybridge_kmip_ca_cert',
@@ -177,7 +168,6 @@ class SMBService(CephService):
         self,
         daemon_spec: CephadmDaemonDeploySpec,
         smb_spec: SMBSpec,
-        support_feature: str,
         feature: str,
     ) -> TLSCredentials:
         feature_creds = self.get_certificates(
@@ -185,7 +175,7 @@ class SMBService(CephService):
         )
         if feature_creds:
             return feature_creds
-        flat_attrs = self._FEATURE_FLAT_ATTRS.get(support_feature)
+        flat_attrs = self._FEATURE_FLAT_ATTRS.get(feature)
         if flat_attrs is None:
             return EMPTY_TLS_CREDENTIALS
         cert_attr, key_attr, ca_attr = flat_attrs
@@ -225,7 +215,6 @@ class SMBService(CephService):
         smb_spec = cast(
             SMBSpec, self.mgr.spec_store[daemon_spec.service_name].spec
         )
-        ssl_certificates = smb_spec.ssl_certificates or {}
         config_blobs: Dict[str, Any] = {}
 
         config_blobs['cluster_id'] = smb_spec.cluster_id
@@ -254,11 +243,10 @@ class SMBService(CephService):
         config_blobs['service_ports'] = smb_spec.service_ports()
         if smb_spec.bind_addrs:
             config_blobs['bind_networks'] = smb_spec.bind_networks()
-        for support_feature in smb_spec.features:
-            feature = self._feature_tls_filename(support_feature)
-            if feature is not None:
+        for feature in smb_spec.ssl_certificates.keys():
+            if feature is not None and feature in SMB_FEATURE_SUPPORTS_SSL:
                 feature_creds = self._get_feature_certs(
-                    daemon_spec, smb_spec, support_feature, feature
+                    daemon_spec, smb_spec, feature
                 )
                 if feature_creds:
                     files = config_blobs.setdefault('files', {})

--- a/src/pybind/mgr/cephadm/services/smb.py
+++ b/src/pybind/mgr/cephadm/services/smb.py
@@ -16,6 +16,12 @@ from typing import (
 )
 
 from mgr_module import HandleCommandResult
+from cephadm.tlsobject_types import TLSObjectScope, TLSCredentials, EMPTY_TLS_CREDENTIALS
+from ceph.smb.constants import (
+    KEYBRIDGE, 
+    REMOTE_CONTROL,
+    FEATURES,
+)
 
 from ceph.deployment.service_spec import (
     SMBExternalCephCluster,
@@ -31,6 +37,7 @@ from .cephadmservice import (
     CephadmDaemonDeploySpec,
     simplified_keyring,
 )
+from ..tlsobject_types import TLSCredentials, EMPTY_TLS_CREDENTIALS
 from ..schedule import DaemonPlacement
 
 if TYPE_CHECKING:
@@ -145,14 +152,80 @@ class SMBService(CephService):
         )
         return daemon_spec
 
+    def _feature_tls_filename(self, feature: str) -> Optional[str]:
+        return {
+                KEYBRIDGE: "keybridge",
+                REMOTE_CONTROL: "remote_control"
+            }.get(feature)
+
+    # Flat SSL fields on SMBSpec per feature, used as a fallback when
+    # ssl_certificates is not set (backward compatibility).
+    _FEATURE_FLAT_ATTRS: Dict[str, Tuple[str, str, str]] = {
+        REMOTE_CONTROL: (
+            'remote_control_ssl_cert',
+            'remote_control_ssl_key',
+            'remote_control_ca_cert',
+        ),
+        KEYBRIDGE: (
+            'keybridge_kmip_ssl_cert',
+            'keybridge_kmip_ssl_key',
+            'keybridge_kmip_ca_cert',
+        ),
+    }
+
+    def _get_feature_certs(
+        self,
+        daemon_spec: CephadmDaemonDeploySpec,
+        smb_spec: SMBSpec,
+        support_feature: str,
+        feature: str,
+    ) -> TLSCredentials:
+        feature_creds = self.get_certificates(
+            daemon_spec, ca_cert_required=True, feature=feature
+        )
+        if feature_creds:
+            return feature_creds
+        flat_attrs = self._FEATURE_FLAT_ATTRS.get(support_feature)
+        if flat_attrs is None:
+            return EMPTY_TLS_CREDENTIALS
+        cert_attr, key_attr, ca_attr = flat_attrs
+        tc = TLSCredentials(
+            cert=getattr(smb_spec, cert_attr, None) or '',
+            key=getattr(smb_spec, key_attr, None) or '',
+            ca_cert=getattr(smb_spec, ca_attr, None) or '',
+        )
+        return tc if tc else EMPTY_TLS_CREDENTIALS
+
+    def _get_certificates_from_spec_ssl_certificates(
+        self,
+        svc_spec: ServiceSpec,
+        _daemon_spec: CephadmDaemonDeploySpec,
+        feature: Optional[str] = None,
+    ) -> TLSCredentials:
+        smb_spec = cast(SMBSpec, svc_spec)
+        ssl_certs = getattr(smb_spec, 'ssl_certificates', None)
+        if not ssl_certs:
+            return EMPTY_TLS_CREDENTIALS
+        feature_key = feature if feature is not None else ''
+        ssl_params = smb_spec.ssl_certificates.get(feature_key)
+        if not ssl_params:
+            return EMPTY_TLS_CREDENTIALS
+        return TLSCredentials(
+            cert=ssl_params.ssl_cert or '',
+            key=ssl_params.ssl_key or '',
+            ca_cert=ssl_params.ssl_ca_cert or '',
+        )
+
     def generate_config(
         self, daemon_spec: CephadmDaemonDeploySpec
     ) -> Tuple[Dict[str, Any], List[str]]:
         logger.debug('smb generate_config')
         assert self.TYPE == daemon_spec.daemon_type
+        super().register_for_certificates(daemon_spec)
         smb_spec = cast(
             SMBSpec, self.mgr.spec_store[daemon_spec.service_name].spec
         )
+        ssl_certificates = smb_spec.ssl_certificates or {}
         config_blobs: Dict[str, Any] = {}
 
         config_blobs['cluster_id'] = smb_spec.cluster_id
@@ -181,40 +254,34 @@ class SMBService(CephService):
         config_blobs['service_ports'] = smb_spec.service_ports()
         if smb_spec.bind_addrs:
             config_blobs['bind_networks'] = smb_spec.bind_networks()
-        if 'remote-control' in smb_spec.features:
-            files = config_blobs.setdefault('files', {})
-            _add_cfg(
-                files,
-                'remote_control.ssl.crt',
-                self._cert_or_uri(smb_spec.remote_control_ssl_cert),
-            )
-            _add_cfg(
-                files,
-                'remote_control.ssl.key',
-                self._cert_or_uri(smb_spec.remote_control_ssl_key),
-            )
-            _add_cfg(
-                files,
-                'remote_control.ca.crt',
-                self._cert_or_uri(smb_spec.remote_control_ca_cert),
-            )
-        if 'keybridge' in smb_spec.features:
-            files = config_blobs.setdefault('files', {})
-            _add_cfg(
-                files,
-                'keybridge.ssl.crt',
-                self._cert_or_uri(smb_spec.keybridge_kmip_ssl_cert),
-            )
-            _add_cfg(
-                files,
-                'keybridge.ssl.key',
-                self._cert_or_uri(smb_spec.keybridge_kmip_ssl_key),
-            )
-            _add_cfg(
-                files,
-                'keybridge.ca.crt',
-                self._cert_or_uri(smb_spec.keybridge_kmip_ca_cert),
-            )
+        for support_feature in smb_spec.features:
+            feature = self._feature_tls_filename(support_feature)
+            if feature is not None:
+                feature_creds = self._get_feature_certs(
+                    daemon_spec, smb_spec, support_feature, feature
+                )
+                if feature_creds:
+                    files = config_blobs.setdefault('files', {})
+                    cert_pem = self._cert_or_uri(feature_creds.cert)
+                    key_pem = self._cert_or_uri(feature_creds.key)
+                    ca_pem = self._cert_or_uri(feature_creds.ca_cert)
+                    _add_cfg(files, f'{feature}.ssl.crt', cert_pem)
+                    _add_cfg(files, f'{feature}.ssl.key', key_pem)
+                    _add_cfg(files, f'{feature}.ca.crt', ca_pem)
+                    svc_name = smb_spec.service_name()
+                    host = daemon_spec.host
+                    cert_name = f'smb_{feature}_ssl_cert'
+                    key_name = f'smb_{feature}_ssl_key'
+                    ca_cert_name = f'smb_{feature}_ca_cert'
+                    self.mgr.cert_mgr.register_cert_key_pair(
+                        'smb', cert_name, key_name, self.SCOPE, ca_cert_name
+                    )
+                    if cert_pem:
+                        self.mgr.cert_mgr.save_cert(cert_name, cert_pem, svc_name, host, user_made=True)
+                    if key_pem:
+                        self.mgr.cert_mgr.save_key(key_name, key_pem, svc_name, host, user_made=True)
+                    if ca_pem:
+                        self.mgr.cert_mgr.save_cert(ca_cert_name, ca_pem, svc_name, host, user_made=True)
         for ext_cluster in smb_spec.ceph_cluster_configs or []:
             files = config_blobs.setdefault('files', {})
             c_name = f'{ext_cluster.alias}.ceph.conf'

--- a/src/pybind/mgr/cephadm/tests/services/test_monitoring.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_monitoring.py
@@ -793,7 +793,7 @@ class TestMonitoring:
     @patch("cephadm.services.monitoring.password_hash", lambda password: 'prometheus_password_hash')
     @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: 'cephadm_root_cert')
     @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
-           lambda instance, dspec, ips=None, fqdns=None: TLSCredentials('mycert', 'mykey'))
+           lambda instance, dspec, ips=None, fqdns=None, ca_cert_required=False: TLSCredentials('mycert', 'mykey'))
     def test_prometheus_config_security_enabled(self, _run_cephadm, _get_uname, cephadm_module: CephadmOrchestrator):
         _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
         _get_uname.return_value = 'test'

--- a/src/pybind/mgr/cephadm/tests/services/test_smb.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_smb.py
@@ -1,12 +1,22 @@
 import json
 from unittest.mock import patch
 
+from ceph.smb.constants import REMOTE_CONTROL
 from cephadm.services.smb import SMBSpec, SMBExternalCephCluster
 from cephadm.module import CephadmOrchestrator
 from cephadm.tests.fixtures import with_host, with_service, async_side_effect
 
+from cephadm.services.service_registry import service_registry
+from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
+from ceph.deployment.service_spec import PlacementSpec
 
 _SAMBA_METRICS_IMAGE = 'quay.io/samba.org/samba-metrics:devbuilds-centos-any'
+
+cephadm_root_ca = """-----BEGIN CERTIFICATE-----\nMIIE7DCCAtSgAwIBAgIUE8b2zZ64geu2ns3Zfn3/4L+Cf6MwDQYJKoZIhvcNAQEL\nBQAwFzEVMBMGA1UEAwwMY2VwaGFkbS1yb290MB4XDTI0MDYyNjE0NDA1M1oXDTM0\nMDYyNzE0NDA1M1owFzEVMBMGA1UEAwwMY2VwaGFkbS1yb290MIICIjANBgkqhkiG\n9w0BAQEFAAOCAg8AMIICCgKCAgEAsZRJsdtTr9GLG1lWFql5SGc46ldFanNJd1Gl\nqXq5vgZVKRDTmNgAb/XFuNEEmbDAXYIRZolZeYKMHfn0pouPRSel0OsC6/02ZUOW\nIuN89Wgo3IYleCFpkVIumD8URP3hwdu85plRxYZTtlruBaTRH38lssyCqxaOdEt7\nAUhvYhcMPJThB17eOSQ73mb8JEC83vB47fosI7IhZuvXvRSuZwUW30rJanWNhyZq\neS2B8qw2RSO0+77H6gA4ftBnitfsE1Y8/F9Z/f92JOZuSMQXUB07msznPbRJia3f\nueO8gOc32vxd1A1/Qzp14uX34yEGY9ko2lW226cZO29IVUtXOX+LueQttwtdlpz8\ne6Npm09pXhXAHxV/OW3M28MdXmobIqT/m9MfkeAErt5guUeC5y8doz6/3VQRjFEn\nRpN0WkblgnNAQ3DONPc+Qd9Fi/wZV2X7bXoYpNdoWDsEOiE/eLmhG1A2GqU/mneP\nzQ6u79nbdwTYpwqHpa+PvusXeLfKauzI8lLUJotdXy9EK8iHUofibB61OljYye6B\nG3b8C4QfGsw8cDb4APZd/6AZYyMx/V3cGZ+GcOV7WvsC8k7yx5Uqasm/kiGQ3EZo\nuNenNEYoGYrjb8D/8QzqNUTwlEh27/ps80tO7l2GGTvWVZL0PRZbmLDvO77amtOf\nOiRXMoUCAwEAAaMwMC4wGwYDVR0RBBQwEocQAAAAAAAAAAAAAAAAAAAAATAPBgNV\nHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4ICAQAxwzX5AhYEWhTV4VUwUj5+\nqPdl4Q2tIxRokqyE+cDxoSd+6JfGUefUbNyBxDt0HaBq8obDqqrbcytxnn7mpnDu\nhtiauY+I4Amt7hqFOiFA4cCLi2mfok6g2vL53tvhd9IrsfflAU2wy7hL76Ejm5El\nA+nXlkJwps01Whl9pBkUvIbOn3pXX50LT4hb5zN0PSu957rjd2xb4HdfuySm6nW4\n4GxtVWfmGA6zbC4XMEwvkuhZ7kD2qjkAguGDF01uMglkrkCJT3OROlNBuSTSBGqt\ntntp5VytHvb7KTF7GttM3ha8/EU2KYaHM6WImQQTrOfiImAktOk4B3lzUZX3HYIx\n+sByO4P4dCvAoGz1nlWYB2AvCOGbKf0Tgrh4t4jkiF8FHTXGdfvWmjgi1pddCNAy\nn65WOCmVmLZPERAHOk1oBwqyReSvgoCFo8FxbZcNxJdlhM0Z6hzKggm3O3Dl88Xl\n5euqJjh2STkBW8Xuowkg1TOs5XyWvKoDFAUzyzeLOL8YSG+gXV22gPTUaPSVAqdb\nwd0Fx2kjConuC5bgTzQHs8XWA930U3XWZraj21Vaa8UxlBLH4fUro8H5lMSYlZNE\nJHRNW8BkznAClaFSDG3dybLsrzrBFAu/Qb5zVkT1xyq0YkepGB7leXwq6vjWA5Pw\nmZbKSphWfh0qipoqxqhfkw==\n-----END CERTIFICATE-----\n"""
+
+ceph_generated_cert = """-----BEGIN CERTIFICATE-----\nMIICxjCCAa4CEQDIZSujNBlKaLJzmvntjukjMA0GCSqGSIb3DQEBDQUAMCExDTAL\nBgNVBAoMBENlcGgxEDAOBgNVBAMMB2NlcGhhZG0wHhcNMjIwNzEzMTE0NzA3WhcN\nMzIwNzEwMTE0NzA3WjAhMQ0wCwYDVQQKDARDZXBoMRAwDgYDVQQDDAdjZXBoYWRt\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyyMe4DMA+MeYK7BHZMHB\nq7zjliEOcNgxomjU8qbf5USF7Mqrf6+/87XWqj4pCyAW8x0WXEr6A56a+cmBVmt+\nqtWDzl020aoId6lL5EgLLn6/kMDCCJLq++Lg9cEofMSvcZh+lY2f+1p+C+00xent\nrLXvXGOilAZWaQfojT2BpRnNWWIFbpFwlcKrlg2G0cFjV5c1m6a0wpsQ9JHOieq0\nSvwCixajwq3CwAYuuiU1wjI4oJO4Io1+g8yB3nH2Mo/25SApCxMXuXh4kHLQr/T4\n4hqisvG4uJYgKMcSIrWj5o25mclByGi1UI/kZkCUES94i7Z/3ihx4Bad0AMs/9tw\nFwIDAQABMA0GCSqGSIb3DQEBDQUAA4IBAQAf+pwz7Gd7mDwU2LY0TQXsK6/8KGzh\nHuX+ErOb8h5cOAbvCnHjyJFWf6gCITG98k9nxU9NToG0WYuNm/max1y/54f0dtxZ\npUo6KSNl3w6iYCfGOeUIj8isi06xMmeTgMNzv8DYhDt+P2igN6LenqWTVztogkiV\nxQ5ZJFFLEw4sN0CXnrZX3t5ruakxLXLTLKeE0I91YJvjClSBGkVJq26wOKQNHMhx\npWxeydQ5EgPZY+Aviz5Dnxe8aB7oSSovpXByzxURSabOuCK21awW5WJCGNpmqhWK\nZzACBDEstccj57c4OGV0eayHJRsluVr2e9NHRINZA3qdB37e6gsI1xHo\n-----END CERTIFICATE-----\n"""
+
+ceph_generated_key = """-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDLIx7gMwD4x5gr\nsEdkwcGrvOOWIQ5w2DGiaNTypt/lRIXsyqt/r7/ztdaqPikLIBbzHRZcSvoDnpr5\nyYFWa36q1YPOXTbRqgh3qUvkSAsufr+QwMIIkur74uD1wSh8xK9xmH6VjZ/7Wn4L\n7TTF6e2ste9cY6KUBlZpB+iNPYGlGc1ZYgVukXCVwquWDYbRwWNXlzWbprTCmxD0\nkc6J6rRK/AKLFqPCrcLABi66JTXCMjigk7gijX6DzIHecfYyj/blICkLExe5eHiQ\nctCv9PjiGqKy8bi4liAoxxIitaPmjbmZyUHIaLVQj+RmQJQRL3iLtn/eKHHgFp3Q\nAyz/23AXAgMBAAECggEAVoTB3Mm8azlPlaQB9GcV3tiXslSn+uYJ1duCf0sV52dV\nBzKW8s5fGiTjpiTNhGCJhchowqxoaew+o47wmGc2TvqbpeRLuecKrjScD0GkCYyQ\neM2wlshEbz4FhIZdgS6gbuh9WaM1dW/oaZoBNR5aTYo7xYTmNNeyLA/jO2zr7+4W\n5yES1lMSBXpKk7bDGKYY4bsX2b5RLr2Grh2u2bp7hoLABCEvuu8tSQdWXLEXWpXo\njwmV3hc6tabypIa0mj2Dmn2Dmt1ppSO0AZWG/WAizN3f4Z0r/u9HnbVrVmh0IEDw\n3uf2LP5o3msG9qKCbzv3lMgt9mMr70HOKnJ8ohMSKQKBgQDLkNb+0nr152HU9AeJ\nvdz8BeMxcwxCG77iwZphZ1HprmYKvvXgedqWtS6FRU+nV6UuQoPUbQxJBQzrN1Qv\nwKSlOAPCrTJgNgF/RbfxZTrIgCPuK2KM8I89VZv92TSGi362oQA4MazXC8RAWjoJ\nSu1/PHzK3aXOfVNSLrOWvIYeZQKBgQD/dgT6RUXKg0UhmXj7ExevV+c7oOJTDlMl\nvLngrmbjRgPO9VxLnZQGdyaBJeRngU/UXfNgajT/MU8B5fSKInnTMawv/tW7634B\nw3v6n5kNIMIjJmENRsXBVMllDTkT9S7ApV+VoGnXRccbTiDapBThSGd0wri/CuwK\nNWK1YFOeywKBgEDyI/XG114PBUJ43NLQVWm+wx5qszWAPqV/2S5MVXD1qC6zgCSv\nG9NLWN1CIMimCNg6dm7Wn73IM7fzvhNCJgVkWqbItTLG6DFf3/DPODLx1wTMqLOI\nqFqMLqmNm9l1Nec0dKp5BsjRQzq4zp1aX21hsfrTPmwjxeqJZdioqy2VAoGAXR5X\nCCdSHlSlUW8RE2xNOOQw7KJjfWT+WAYoN0c7R+MQplL31rRU7dpm1bLLRBN11vJ8\nMYvlT5RYuVdqQSP6BkrX+hLJNBvOLbRlL+EXOBrVyVxHCkDe+u7+DnC4epbn+N8P\nLYpwqkDMKB7diPVAizIKTBxinXjMu5fkKDs5n+sCgYBbZheYKk5M0sIxiDfZuXGB\nkf4mJdEkTI1KUGRdCwO/O7hXbroGoUVJTwqBLi1tKqLLarwCITje2T200BYOzj82\nqwRkCXGtXPKnxYEEUOiFx9OeDrzsZV00cxsEnX0Zdj+PucQ/J3Cvd0dWUspJfLHJ\n39gnaegswnz9KMQAvzKFdg==\n-----END PRIVATE KEY-----\n"""
 
 
 class TestSMB:
@@ -148,6 +158,49 @@ class TestSMB:
                     error_ok=True,
                     use_current_daemon_image=False,
                 )
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_smb_tls_feature_cert_in_config_blobs(
+        self, _run_cephadm, cephadm_module: CephadmOrchestrator
+    ):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        with with_host(cephadm_module, 'test', addr='1.2.3.7'):
+            cephadm_module.cache.update_host_networks(
+                'test',
+                {'1.2.3.0/24': {'if0': ['1.2.3.7']}}
+            )
+
+            smb_spec = SMBSpec(
+                cluster_id='foxtrot',
+                service_id='foo',
+                config_uri='rados://.smb/foxtrot/config2.json',
+                placement=PlacementSpec(hosts=['test']),
+                features=[REMOTE_CONTROL],
+                ssl_certificates={
+                    'remote_control': {
+                        'enabled': True,
+                        'ssl_cert': ceph_generated_cert,
+                        'ssl_key': ceph_generated_key,
+                        'ssl_ca_cert': cephadm_root_ca,
+                        'certificate_source': 'inline',
+                    },
+                },
+            )
+            service_name = smb_spec.service_name()
+
+            with with_service(cephadm_module, smb_spec):
+                smb_conf, _ = service_registry.get_service('smb').generate_config(
+                    CephadmDaemonDeploySpec(
+                        host='test',
+                        daemon_id='foo.test.0',
+                        service_name=service_name,
+                    )
+                )
+                files = smb_conf.get('files', {})
+                assert files.get('remote_control.ssl.crt') == ceph_generated_cert
+                assert files.get('remote_control.ssl.key') == ceph_generated_key
+                assert files.get('remote_control.ca.crt') == cephadm_root_ca
 
 
 def test_smb_get_dependencies(cephadm_module):

--- a/src/pybind/mgr/cephadm/tests/test_certmgr.py
+++ b/src/pybind/mgr/cephadm/tests/test_certmgr.py
@@ -307,6 +307,8 @@ class TestCertMgr(object):
         grafana_cert_host_2 = 'grafana-cert-host-2'
         nfs_ssl_cert = 'nfs-ssl-cert'
         nfs_ssl_ca_cert = 'nfs-ssl-ca-cert'
+        smb_ssl_cert = 'smb-ssl-cert'
+        smb_ssl_ca_cert = 'smb-ssl-ca-cert'
         cephadm_module.cert_mgr.save_cert('rgw_ssl_cert', rgw_frontend_rgw_foo_host2_cert, service_name='rgw.foo', user_made=True)
         cephadm_module.cert_mgr.save_cert('nvmeof_ssl_cert', nvmeof_ssl_cert, service_name='nvmeof.self-signed.foo', user_made=False)
         cephadm_module.cert_mgr.save_cert('nvmeof_client_cert', nvmeof_client_cert, service_name='nvmeof.foo', user_made=True)
@@ -315,6 +317,8 @@ class TestCertMgr(object):
         cephadm_module.cert_mgr.save_cert('grafana_ssl_cert', grafana_cert_host_2, host='host-2', user_made=True)
         cephadm_module.cert_mgr.save_cert('nfs_ssl_cert', nfs_ssl_cert, service_name='nfs.foo', user_made=True)
         cephadm_module.cert_mgr.save_cert('nfs_ssl_ca_cert', nfs_ssl_ca_cert, service_name='nfs.foo', user_made=True)
+        cephadm_module.cert_mgr.save_cert('smb_ssl_cert', smb_ssl_cert, service_name='smb.foo', user_made=True)
+        cephadm_module.cert_mgr.save_cert('smb_ssl_ca_cert', smb_ssl_ca_cert, service_name='smb.foo', user_made=True)
 
         expected_calls = [
             mock.call(f'{TLSOBJECT_STORE_CERT_PREFIX}rgw_ssl_cert', json.dumps({'rgw.foo': Cert(rgw_frontend_rgw_foo_host2_cert, True).to_json()})),
@@ -326,6 +330,8 @@ class TestCertMgr(object):
                                                                                     'host-2': Cert(grafana_cert_host_2, True).to_json()})),
             mock.call(f'{TLSOBJECT_STORE_CERT_PREFIX}nfs_ssl_cert', json.dumps({'nfs.foo': Cert(nfs_ssl_cert, True).to_json()})),
             mock.call(f'{TLSOBJECT_STORE_CERT_PREFIX}nfs_ssl_ca_cert', json.dumps({'nfs.foo': Cert(nfs_ssl_ca_cert, True).to_json()})),
+            mock.call(f'{TLSOBJECT_STORE_CERT_PREFIX}smb_ssl_cert', json.dumps({'smb.foo': Cert(smb_ssl_cert, True).to_json()})),
+            mock.call(f'{TLSOBJECT_STORE_CERT_PREFIX}smb_ssl_ca_cert', json.dumps({'smb.foo': Cert(smb_ssl_ca_cert, True).to_json()})),
         ]
         _set_store.assert_has_calls(expected_calls)
 
@@ -444,6 +450,24 @@ class TestCertMgr(object):
             "scope": "service",
             "certificates": {
                 "nfs.foo": get_generated_cephadm_cert_info_2(),
+            },
+        }
+        compare_certls_dicts(expected_ls)
+
+        cephadm_module.cert_mgr.save_cert('smb_ssl_cert', CEPHADM_SELF_GENERATED_CERT_1, service_name='smb.foo', user_made=True)
+        expected_ls["smb_ssl_cert"] = {
+            "scope": "service",
+            "certificates": {
+                "smb.foo": get_generated_cephadm_cert_info_1(),
+            },
+        }
+        compare_certls_dicts(expected_ls)
+
+        cephadm_module.cert_mgr.save_cert('smb_ssl_ca_cert', CEPHADM_SELF_GENERATED_CERT_2, service_name='smb.foo', user_made=True)
+        expected_ls["smb_ssl_ca_cert"] = {
+            "scope": "service",
+            "certificates": {
+                "smb.foo": get_generated_cephadm_cert_info_2(),
             },
         }
         compare_certls_dicts(expected_ls)
@@ -612,6 +636,8 @@ class TestCertMgr(object):
             'mgmt_gateway_ssl_cert': ('mgmt-gateway', 'mgmt-gw-cert', TLSObjectScope.GLOBAL),
             'nfs_ssl_cert': ('nfs.foo', 'nfs-ssl-cert', TLSObjectScope.SERVICE),
             'nfs_ssl_ca_cert': ('nfs.foo', 'nfs-ssl-ca-cert', TLSObjectScope.SERVICE),
+            'smb_ssl_cert': ('smb.foo', 'smb-ssl-cert', TLSObjectScope.SERVICE),
+            'smb_ssl_ca_cert': ('smb.foo', 'smb-ssl-ca-cert', TLSObjectScope.SERVICE),
         }
         unknown_certs = {
             'unknown_per_service_cert': ('unknown-svc.foo', 'unknown-cert', TLSObjectScope.SERVICE),
@@ -629,6 +655,7 @@ class TestCertMgr(object):
             'ingress_ssl_key': ('ingress', 'ingress-ssl-key', TLSObjectScope.SERVICE),
             'iscsi_ssl_key': ('iscsi', 'iscsi-ssl-key', TLSObjectScope.SERVICE),
             'nfs_ssl_key': ('nfs.foo', 'nfs-ssl-key', TLSObjectScope.SERVICE),
+            'smb_ssl_key': ('smb.foo', 'smb-ssl-key', TLSObjectScope.SERVICE),
         }
         unknown_keys = {
             'unknown_per_service_key': ('unknown-svc.foo', 'unknown-key', TLSObjectScope.SERVICE),
@@ -703,10 +730,13 @@ class TestCertMgr(object):
             'mgmt_gateway_ssl_cert': ('mgmt-gateway', 'good-global-cert', TLSObjectScope.GLOBAL),
             'nfs_ssl_cert': ('nfs.foo', 'nfs-ssl-cert', TLSObjectScope.SERVICE),
             'nfs_ssl_ca_cert': ('nfs.foo', 'nfs-ssl-ca-cert', TLSObjectScope.SERVICE),
+            'smb_ssl_cert': ('smb.foo', 'smb-ssl-cert', TLSObjectScope.SERVICE),
+            'smb_ssl_ca_cert': ('smb.foo', 'smb-ssl-ca-cert', TLSObjectScope.SERVICE),
         }
         good_keys = {
             'rgw_ssl_key': ('rgw.foo', 'good-key', TLSObjectScope.SERVICE),
             'nfs_ssl_key': ('nfs.foo', 'nfs-ssl-key', TLSObjectScope.SERVICE),
+            'smb_ssl_key': ('smb.foo', 'smb-ssl-key', TLSObjectScope.SERVICE),
         }
 
         # Helpers to dump valid JSON structures
@@ -757,12 +787,18 @@ class TestCertMgr(object):
         assert cert_store['nfs_ssl_cert']['nfs.foo'] == Cert('nfs-ssl-cert', True)
         assert 'nfs_ssl_ca_cert' in cert_store
         assert cert_store['nfs_ssl_ca_cert']['nfs.foo'] == Cert('nfs-ssl-ca-cert', True)
+        assert 'smb_ssl_cert' in cert_store
+        assert cert_store['smb_ssl_cert']['smb.foo'] == Cert('smb-ssl-cert', True)
+        assert 'smb_ssl_ca_cert' in cert_store
+        assert cert_store['smb_ssl_ca_cert']['smb.foo'] == Cert('smb-ssl-ca-cert', True)
         assert 'mgmt_gateway_ssl_cert' in cert_store
         assert cert_store['mgmt_gateway_ssl_cert'] == Cert('good-global-cert', True)
         assert 'rgw_ssl_key' in key_store
         assert key_store['rgw_ssl_key']['rgw.foo'] == PrivKey('good-key')
         assert 'nfs_ssl_key' in key_store
         assert key_store['nfs_ssl_key']['nfs.foo'] == PrivKey('nfs-ssl-key')
+        assert 'smb_ssl_key' in key_store
+        assert key_store['smb_ssl_key']['smb.foo'] == PrivKey('smb-ssl-key')
 
         # Bad ones: object names exist (pre-registered), but **no targets** were added
         # Service / Host scoped => dict should be empty

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -20,7 +20,11 @@ import logging
 import time
 
 import ceph.smb.constants
-from ceph.deployment.service_spec import SMBExternalCephCluster, SMBSpec
+from ceph.deployment.service_spec import (
+    SMBExternalCephCluster,
+    SMBSpec,
+    SSLParameters,
+)
 from ceph.fs.earmarking import EarmarkTopScope
 
 from . import config_store, external, resources
@@ -631,6 +635,7 @@ class ClusterConfigHandler:
             change_group.cluster.cluster_id,
         )
         cluster = change_group.cluster
+        ssl_certificates: Dict[str, SSLParameters] = {}
         assert isinstance(cluster, resources.Cluster)
         # vols: hold the cephfs volumes our shares touch. some operations are
         # disabled/skipped unless we touch volumes.
@@ -688,6 +693,7 @@ class ClusterConfigHandler:
         if change_group.ext_ceph_clusters:
             assert len(change_group.ext_ceph_clusters) == 1
             ext_ceph_cluster = change_group.ext_ceph_clusters[0]
+
         smb_spec = _generate_smb_service_spec(
             cluster,
             config_entries=config_entries,
@@ -697,6 +703,7 @@ class ClusterConfigHandler:
             data_entity=cluster_conf.data_entity,
             needs_proxy=_has_proxied_vfs(change_group),
             ext_ceph_cluster=ext_ceph_cluster,
+            ssl_certificates=ssl_certificates,
         )
         _save_pending_spec_backup(self.public_store, change_group, smb_spec)
         # if orch was ever needed in the past we must "re-orch", but if we have
@@ -1058,6 +1065,7 @@ def _generate_smb_service_spec(
     data_entity: str = '',
     needs_proxy: bool = False,
     ext_ceph_cluster: Optional[resources.ExternalCephCluster],
+    ssl_certificates: Dict[str, SSLParameters],
 ) -> SMBSpec:
     features = []
     if cluster.auth_mode == AuthMode.ACTIVE_DIRECTORY:
@@ -1092,8 +1100,9 @@ def _generate_smb_service_spec(
     user_entities: Optional[List[str]] = None
     if data_entity:
         user_entities = [data_entity]
+
     rc_cert = rc_key = rc_ca_cert = None
-    if cluster.remote_control_is_enabled:
+    if cluster.is_feature_enabled(_REMOTE_CONTROL):
         assert cluster.remote_control
         rc_cert = _tls_uri(
             cluster.remote_control.cert, tls_credential_entries
@@ -1102,8 +1111,18 @@ def _generate_smb_service_spec(
         rc_ca_cert = _tls_uri(
             cluster.remote_control.ca_cert, tls_credential_entries
         )
+        feature = ceph.smb.constants.FEATURE_FILE_NAMES.get(_REMOTE_CONTROL)
+        if feature is not None:
+            ssl_certificates[feature] = SSLParameters(
+                enabled=bool(rc_cert and rc_key),
+                ssl_cert=rc_cert,
+                ssl_key=rc_key,
+                ssl_ca_cert=rc_ca_cert,
+                certificate_source='uri',
+            )
+
     kb_cert = kb_key = kb_ca_cert = None
-    if cluster.keybridge_is_enabled:
+    if cluster.is_feature_enabled(_KEYBRIDGE):
         assert cluster.keybridge  # type narrow
         # TODO: current all KMIP scopes must share the same tls creds
         # and that sucks. need to update keybridge to fetch cert URIs directly
@@ -1122,6 +1141,16 @@ def _generate_smb_service_spec(
             kb_ca_cert = _tls_uri(
                 kmip_scope.kmip_ca_cert, tls_credential_entries
             )
+            feature = ceph.smb.constants.FEATURE_FILE_NAMES.get(_KEYBRIDGE)
+            if feature is not None:
+                ssl_certificates[feature] = SSLParameters(
+                    enabled=bool(kb_cert and kb_key),
+                    ssl_cert=kb_cert,
+                    ssl_key=kb_key,
+                    ssl_ca_cert=kb_ca_cert,
+                    certificate_source='uri',
+                )
+
     ceph_cluster_configs = None
     if ext_ceph_cluster:
         exo = checked(ext_ceph_cluster.cluster)
@@ -1134,7 +1163,6 @@ def _generate_smb_service_spec(
                 key=exo.cephfs_user.key,
             )
         ]
-
     return SMBSpec(
         service_id=cluster.cluster_id,
         placement=cluster.placement,
@@ -1148,12 +1176,7 @@ def _generate_smb_service_spec(
         cluster_public_addrs=cluster.service_spec_public_addrs(),
         custom_ports=cluster.custom_ports,
         bind_addrs=cluster.service_spec_bind_addrs(),
-        remote_control_ssl_cert=rc_cert,
-        remote_control_ssl_key=rc_key,
-        remote_control_ca_cert=rc_ca_cert,
-        keybridge_kmip_ssl_cert=kb_cert,
-        keybridge_kmip_ssl_key=kb_key,
-        keybridge_kmip_ca_cert=kb_ca_cert,
+        ssl_certificates=ssl_certificates or None,
         ceph_cluster_configs=ceph_cluster_configs,
         tunables=_service_spec_tunables(cluster),
     )

--- a/src/pybind/mgr/smb/resources.py
+++ b/src/pybind/mgr/smb/resources.py
@@ -19,6 +19,7 @@ from ceph.smb.constants import (
     BURST_MULT_MIN,
     BYTES_LIMIT_MAX,
     IOPS_LIMIT_MAX,
+    KEYBRIDGE,
     REMOTE_CONTROL,
     REMOTE_CONTROL_LOCAL,
 )
@@ -988,6 +989,15 @@ class Cluster(_RBase):
         if not self.keybridge:
             return False
         return self.keybridge.is_enabled
+
+    def is_feature_enabled(self, feature: str) -> bool:
+        """Return true if the specified SMB feature is enabled for this
+        cluster.
+        """
+        return {
+            REMOTE_CONTROL: self.remote_control_is_enabled,
+            KEYBRIDGE: self.keybridge_is_enabled,
+        }[feature]
 
     def is_clustered(self) -> bool:
         """Return true if smbd instance should use (CTDB) clustering."""

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -907,6 +907,7 @@ class ServiceSpec(object):
         'mgmt-gateway': {'user_cert_allowed': True, 'scope': 'global', 'requires_ca_cert': False},
         'nvmeof': {'user_cert_allowed': True, 'scope': 'service', 'requires_ca_cert': False},
         'nfs': {'user_cert_allowed': True, 'scope': 'service', 'requires_ca_cert': True},
+        'smb': {'user_cert_allowed': True, 'scope': 'service', 'requires_ca_cert': True},
 
         # Services that only support cephadm-signed certificates
         'agent': {'user_cert_allowed': False, 'scope': 'host', 'requires_ca_cert': False},

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -3959,6 +3959,68 @@ class SMBClusterBindIPSpec:
         return out
 
 
+class SSLParameters:
+    def __init__(
+        self,
+        enabled: bool = False,
+        ssl_cert: Optional[str] = None,
+        ssl_key: Optional[str] = None,
+        ssl_ca_cert: Optional[str] = None,
+        certificate_source: Optional[str] = None,
+    ):
+        self.enabled = enabled
+        self.ssl_cert = ssl_cert
+        self.ssl_key = ssl_key
+        self.ssl_ca_cert = ssl_ca_cert
+        self.certificate_source = certificate_source
+        self.validate()
+
+    def validate(
+        self,
+        component: str = "ssl",
+        ca_cert_required: bool = False,
+    ) -> None:
+        if not self.enabled:
+            return
+        missing: list[Any] = []
+        if not self.certificate_source:
+            missing.append("certificate_source")
+        if self.certificate_source == 'inline':
+            if not self.ssl_cert:
+                missing.append("ssl_cert")
+            if not self.ssl_key:
+                missing.append("ssl_key")
+            if ca_cert_required and not self.ssl_ca_cert:
+                missing.append("ssl_ca_cert")
+        if missing:
+            raise ValueError(
+                f"[{component}] SSL is enabled "
+                f"but the following fields are missing: {', '.join(missing)}"
+            )
+
+    @classmethod
+    def from_dict(cls, data: Any) -> 'SSLParameters':
+        if not isinstance(data, dict):
+            return cls(enabled=False)
+
+        return cls(
+            enabled=data.get('enabled', False),
+            ssl_cert=data.get('ssl_cert'),
+            ssl_key=data.get('ssl_key'),
+            ssl_ca_cert=data.get('ssl_ca_cert'),
+            certificate_source=data.get('certificate_source'),
+        )
+
+    def to_json(self) -> Dict[str, Any]:
+        return {
+            'enabled': self.enabled,
+            'ssl_cert': self.ssl_cert,
+            'ssl_key': self.ssl_key,
+            'ssl_ca_cert': self.ssl_ca_cert,
+            'certificate_source': self.certificate_source,
+        }
+
+
 class SMBExternalCephCluster:
     """Configure access to a non-local Ceph cluster for SMB services."""
     def __init__(
@@ -4101,6 +4163,8 @@ class SMBSpec(ServiceSpec):
         # not listed the default port will be used.
         custom_ports: Optional[Dict[str, int]] = None,
         bind_addrs: Optional[List[SMBClusterBindIPSpec]] = None,
+        ssl: Optional[bool] = None,
+        ssl_certificates: Optional[Dict[str, SSLParameters]] = None,
         # === remote control server ===
         remote_control_ssl_cert: Optional[str] = None,
         remote_control_ssl_key: Optional[str] = None,
@@ -4124,12 +4188,23 @@ class SMBSpec(ServiceSpec):
     ) -> None:
         if service_type != self.service_type:
             raise ValueError(f'invalid service_type: {service_type!r}')
+
+        self.ssl_certificates = {
+            name: (
+                value
+                if isinstance(value, SSLParameters)
+                else SSLParameters.from_dict(value)
+            )
+            for name, value in (ssl_certificates or {}).items()
+        }
+        any_ssl = any(p.enabled for p in self.ssl_certificates.values())
         super().__init__(
             self.service_type,
             service_id=service_id,
             placement=placement,
             count=count,
             config=config,
+            ssl=any_ssl,
             unmanaged=unmanaged,
             preview_only=preview_only,
             networks=networks,
@@ -4200,6 +4275,12 @@ class SMBSpec(ServiceSpec):
         for key in self.custom_ports or {}:
             if key not in self._valid_service_names:
                 raise ValueError(f'{key} is not a valid service name')
+        # TLS certificate validation
+        for feature_name, ssl_params in self.ssl_certificates.items():
+            ssl_params.validate(
+                component=feature_name,
+                ca_cert_required=feature_name in smbconst.CA_CERT_REQUIRED_FEATURES
+            )
 
     def _derive_cluster_uri(self, uri: str, objname: str) -> str:
         if not uri.startswith(('rados://', 'mem:')):
@@ -4253,6 +4334,10 @@ class SMBSpec(ServiceSpec):
             spec['ceph_cluster_configs'] = [
                 c.to_json() for c in spec['ceph_cluster_configs']
             ]
+        if spec and spec.get('ssl_certificates'):
+            spec['ssl_certificates'] = {
+                k: v.to_json() for k, v in self.ssl_certificates.items()
+            }
         return obj
 
 

--- a/src/python-common/ceph/smb/constants.py
+++ b/src/python-common/ceph/smb/constants.py
@@ -17,7 +17,6 @@ REMOTE_CONTROL = 'remote-control'
 REMOTE_CONTROL_LOCAL = 'remote-control-local'
 SMBMETRICS = 'smbmetrics'
 
-
 # Features are optional components that can be deployed in a suite of smb
 # related containers. It may run as a separate sidecar or side-effect the
 # configuration of another component.
@@ -39,6 +38,15 @@ SERVICES = {
     SMBMETRICS,
 }
 
+FEATURE_FILE_NAMES = {
+    KEYBRIDGE: KEYBRIDGE,
+    REMOTE_CONTROL: "remote_control",
+}
+SMB_FEATURE_SUPPORTS_SSL = {
+    "remote_control",
+    KEYBRIDGE,
+}
+CA_CERT_REQUIRED_FEATURES = {'keybridge'}
 
 # Default port values
 SMB_PORT = 445


### PR DESCRIPTION
This PR has create to support tls/ssl certificate for smb in certificate manager. certificates can be set from cephadm as well as from smb manager module. These certificates will be set for service for host.

Unit Test
-----------------------
```
[root@mycephfs21 ~]# ceph orch certmgr bindings ls
service:
  smb:
    certs:
    - smb_ssl_cert
    - smb_ssl_ca_cert
    keys:
    - smb_ssl_key
```

Certificate applied from smb manager module

```
ceph smb apply -i smb_remote_control.yaml 
{
  "results": [
    {
```

Output
```
[root@mycephfs21 ~]# ceph orch certmgr cert  ls
smb_ssl_cert
  scope: service
  certificates
    smb.mycephfs21
      subject
        countryName: AB
        stateOrProvinceName: samba
        localityName: samba
        organizationName: samba
        organizationalUnitName: samba
        commonName: samba
      validity
        remaining_days: 181
smb_ssl_ca_cert
  scope: service
  certificates
    smb.mycephfs21
      subject
        commonName: mycephfs21
      validity
        remaining_days: 306
cephadm_root_ca_cert
  scope: global
  certificates
    subject
      commonName: cephadm-root-f44864f0-5967-11f1-b176-52540016ec6f
    validity
      remaining_days: 3647
[root@mycephfs21 ~]# ceph orch certmgr key  ls
smb_ssl_key
  scope: service
  keys
    smb.mycephfs21
      key_type: RSA
      key_size: 4096

```
certificate applied form cephadm
==============================

```
[root@mycephfs21 ~]# ceph orch apply -i smb.yaml 
Scheduled smb.tango update...

```
Output
-----------

```
[root@mycephfs21 ~]# ceph orch certmgr cert  ls
smb_ssl_cert
  scope: service
  certificates
    smb.tango
      subject
        countryName: AB
        stateOrProvinceName: Samba
        localityName: Samba
        organizationName: Samba
        organizationalUnitName: Samba
        commonName: samba-server
        1.2.840.113549.1.9.1: samba@samba.com
      validity
        remaining_days: 3472
smb_ssl_ca_cert
  scope: service
  certificates
    smb.tango
      subject
        countryName: AB
        stateOrProvinceName: Samba
        localityName: Samba
        organizationName: Samba
        organizationalUnitName: Samba
        commonName: samba-server
        1.2.840.113549.1.9.1: samba@samba.com
      validity
        remaining_days: 3472
cephadm_root_ca_cert
  scope: global
  certificates
    subject
      commonName: cephadm-root-f44864f0-5967-11f1-b176-52540016ec6f
    validity
      remaining_days: 3647
[root@mycephfs21 ~]# ceph orch certmgr key  ls
smb_ssl_key
  scope: service
  keys
    smb.tango
      key_type: RSA
      key_size: 4096
```



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
