### PR TITLE
mgr/dashboard: [Dashboard] Incorrect action button label "Edit User" instead of "Save" in Edit User page

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
@@ -598,7 +598,7 @@
       <cd-form-button-panel
         (submitActionEvent)="submit()"
         [form]="formDir"
-        [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
+        [submitText]="submitAction"
         wrappingClass="text-right"
       ></cd-form-button-panel>
     </form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
@@ -119,6 +119,7 @@ export class RbdFormComponent extends CdForm implements OnInit {
 
   action: string;
   resource: string;
+  submitAction: string;
   private rbdImage = new ReplaySubject(1);
   private routerUrl: string;
 
@@ -352,17 +353,21 @@ export class RbdFormComponent extends CdForm implements OnInit {
     if (url.startsWith('/block/rbd/edit')) {
       this.mode = this.rbdFormMode.editing;
       this.action = this.actionLabels.EDIT;
+      this.submitAction = this.actionLabels.SAVE_CHANGES;
       this.disableForEdit();
     } else if (url.startsWith('/block/rbd/clone')) {
       this.mode = this.rbdFormMode.cloning;
       this.disableForClone();
       this.action = this.actionLabels.CLONE;
+      this.submitAction = `${this.action} ${this.resource}`;
     } else if (url.startsWith('/block/rbd/copy')) {
       this.mode = this.rbdFormMode.copying;
       this.action = this.actionLabels.COPY;
+      this.submitAction = `${this.action} ${this.resource}`;
       this.disableForCopy();
     } else {
       this.action = this.actionLabels.CREATE;
+      this.submitAction = `${this.action} ${this.resource}`;
     }
     _.each(this.features, (feature) => {
       this.rbdForm

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
@@ -11,6 +11,7 @@ import { CephSharedModule } from '~/app/ceph/shared/ceph-shared.module';
 import { CoreModule } from '~/app/core/core.module';
 import { HostService } from '~/app/shared/api/host.service';
 import { OrchestratorService } from '~/app/shared/api/orchestrator.service';
+import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 import { TableActionsComponent } from '~/app/shared/datatable/table-actions/table-actions.component';
 import { CdTableFetchDataContext } from '~/app/shared/models/cd-table-fetch-data-context';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
@@ -272,6 +273,21 @@ describe('HostsComponent', () => {
     const errorMsg = 'unsafe to stop osd.0 because of some unknown reason';
     showForceMaintenanceModal.showModalDialog(errorMsg);
     expect(showForceMaintenanceModal.showModal).toBeFalsy();
+  });
+
+  it('should set host edit modal submit label to Save changes', () => {
+    const hostService = TestBed.inject(HostService);
+    const modalService = TestBed.inject(ModalCdsService);
+    spyOn(hostService, 'getLabels').and.returnValue(of([]));
+    const showSpy = spyOn(modalService, 'show').and.stub();
+
+    component.selection = new CdTableSelection();
+    component.selection.selected = [{ hostname: 'host-test', labels: [] }];
+
+    component.editAction();
+
+    expect(showSpy).toHaveBeenCalled();
+    expect(showSpy.calls.mostRecent().args[1].submitButtonText).toBe('Save changes');
   });
 
   describe('table actions', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
@@ -2073,7 +2073,7 @@
   <cd-form-button-panel
     (submitActionEvent)="onSubmit()"
     [form]="serviceForm"
-    [submitText]="(action | titlecase) + ' ' + resource"
+    [submitText]="submitAction"
     [modalForm]="true"
   ></cd-form-button-panel>
 </cds-modal>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
@@ -81,6 +81,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
   serviceForm: CdFormGroup;
   action: string;
   resource: string;
+  submitAction: string;
   serviceTypes: string[] = [];
   serviceIds: string[] = [];
   selectedHosts: string[] = [];
@@ -697,6 +698,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
   ngOnInit(): void {
     this.open = true;
     this.action = this.actionLabels.CREATE;
+    this.submitAction = `${this.action} ${this.resource}`;
     this.resolveRoute();
     this.getRgwModuleStatus();
     this.mgrModuleService.updateCompleted$.subscribe(() => this.getRgwModuleStatus());
@@ -738,6 +740,8 @@ export class ServiceFormComponent extends CdForm implements OnInit {
 
     if (this.editing) {
       this.action = this.actionLabels.EDIT;
+      this.submitAction = this.actionLabels.SAVE_CHANGES;
+      this.disableForEditing(this.serviceType);
       this.cephServiceService
         .list(new HttpParams({ fromObject: { limit: -1, offset: 0 } }), this.serviceName)
         .observable.subscribe((response: CephServiceSpec[]) => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -1146,7 +1146,7 @@
       <cd-form-button-panel
         (submitActionEvent)="submit()"
         [form]="form"
-        [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
+        [submitText]="submitAction"
         wrappingClass="text-right form-button"
       >
       </cd-form-button-panel>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
@@ -174,6 +174,23 @@ describe('PoolFormComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  describe('submit label', () => {
+    it('should set submit label to Create Pool in create mode', () => {
+      expect(component.submitAction).toBe('Create Pool');
+    });
+
+    it('should set submit label to Save changes in edit mode', () => {
+      fixture.destroy();
+      Object.defineProperty(router, 'url', {
+        get: () => '/pool/edit/somePoolName',
+        configurable: true
+      });
+      setUpPoolComponent();
+
+      expect(component.submitAction).toBe('Save changes');
+    });
+  });
+
   describe('throws error for not allowed users', () => {
     const expectError = (redirected: boolean) => {
       navigationSpy.calls.reset();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
@@ -115,6 +115,7 @@ export class PoolFormComponent extends CdForm implements OnInit {
   currentConfigurationValues: { [configKey: string]: any } = {};
   action: string;
   resource: string;
+  submitAction: string;
   icons = Icons;
   pgAutoscaleModes: string[];
   crushUsage: string[] = undefined; // Will only be set if a rule is used by some pool
@@ -153,6 +154,9 @@ export class PoolFormComponent extends CdForm implements OnInit {
     this.editing = this.router.url.startsWith(`/pool/${URLVerbs.EDIT}`);
     this.action = this.editing ? this.actionLabels.EDIT : this.actionLabels.CREATE;
     this.resource = $localize`pool`;
+    this.submitAction = this.editing
+      ? this.actionLabels.SAVE_CHANGES
+      : `${this.action} ${_.upperFirst(this.resource)}`;
     this.authenticate();
     this.createForm();
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-form/role-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-form/role-form.component.html
@@ -79,7 +79,7 @@
         <cd-form-button-panel
           (submitActionEvent)="submit()"
           [form]="roleForm"
-          [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
+          [submitText]="submitAction"
           wrappingClass="text-right"
         >
         </cd-form-button-panel>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-form/role-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-form/role-form.component.spec.ts
@@ -82,6 +82,10 @@ describe('RoleFormComponent', () => {
       expect(component.mode).toBeUndefined();
     });
 
+    it('should set submit action to Create Role', () => {
+      expect(component.submitAction).toBe('Create Role');
+    });
+
     it('should submit', () => {
       const role: RoleFormModel = {
         name: 'role1',
@@ -136,6 +140,10 @@ describe('RoleFormComponent', () => {
 
     it('should set mode', () => {
       expect(component.mode).toBe('editing');
+    });
+
+    it('should set submit action to Save changes', () => {
+      expect(component.submitAction).toBe('Save changes');
     });
 
     it('should submit', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-form/role-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-form/role-form.component.ts
@@ -37,6 +37,7 @@ export class RoleFormComponent extends CdForm implements OnInit {
 
   action: string;
   resource: string;
+  submitAction: string;
 
   constructor(
     private route: ActivatedRoute,
@@ -98,8 +99,10 @@ export class RoleFormComponent extends CdForm implements OnInit {
     if (this.router.url.startsWith('/user-management/roles/edit')) {
       this.mode = this.roleFormMode.editing;
       this.action = this.actionLabels.EDIT;
+      this.submitAction = this.actionLabels.SAVE_CHANGES;
     } else {
       this.action = this.actionLabels.CREATE;
+      this.submitAction = `${this.action} ${_.upperFirst(this.resource)}`;
     }
     if (this.mode === this.roleFormMode.editing) {
       this.initEdit();

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.html
@@ -291,7 +291,7 @@
       <cd-form-button-panel
         (submitActionEvent)="submit()"
         [form]="userForm"
-        [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
+        [submitText]="submitAction"
         wrappingClass="text-right"
       >
       </cd-form-button-panel>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.spec.ts
@@ -86,6 +86,10 @@ describe('UserFormComponent', () => {
       component.ngOnInit();
     });
 
+    it('should set submit label to Create User', () => {
+      expect(component.submitAction).toBe('Create User');
+    });
+
     it('should not disable fields', () => {
       [
         'username',
@@ -266,6 +270,10 @@ describe('UserFormComponent', () => {
       formHelper.setValue('roles', []);
       component.onRolesClear();
       expect(form.getValue('roles')).toContain('administrator');
+    });
+
+    it('should set submit label to Save changes', () => {
+      expect(component.submitAction).toBe('Save changes');
     });
 
     it('should alert if user is removing needed role permission', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.ts
@@ -53,6 +53,7 @@ export class UserFormComponent extends CdForm implements OnInit {
   messages = new SelectMessages({ empty: $localize`There are no roles.` });
   action: string;
   resource: string;
+  submitAction: string;
   passwordPolicyHelpText = '';
   passwordStrengthLevelClass: string;
   passwordValuation: string;
@@ -146,9 +147,11 @@ export class UserFormComponent extends CdForm implements OnInit {
     if (this.router.url.startsWith('/user-management/users/edit')) {
       this.mode = this.userFormMode.editing;
       this.action = this.actionLabels.EDIT;
+      this.submitAction = this.actionLabels.SAVE_CHANGES;
       this.passwordexp = false;
     } else {
       this.action = this.actionLabels.CREATE;
+      this.submitAction = `${this.action} ${_.upperFirst(this.resource)}`;
       this.passwordexp = true;
     }
     this.userForm.get('password').updateValueAndValidity();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/app.constants.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/app.constants.ts
@@ -170,6 +170,7 @@ export class ActionLabelsI18n {
   NFS_EXPORT: string;
   VIEW: string;
   EDIT_GATEWAYS_GROUP: string;
+  SAVE_CHANGES: string;
   constructor() {
     /* Create a new item */
     this.CREATE = $localize`Create`;
@@ -263,6 +264,7 @@ export class ActionLabelsI18n {
     this.NFS_EXPORT = $localize`Create NFS Share`;
     this.VIEW = $localize`View`;
     this.EDIT_GATEWAYS_GROUP = $localize`Edit gateways group`;
+    this.SAVE_CHANGES = $localize`Save changes`;
   }
 }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/host-action.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/host-action.service.ts
@@ -44,7 +44,7 @@ export class HostActionService {
       this.cdsModalService.show(FormModalComponent, {
         titleText: $localize`Edit Host: ${host.hostname}`,
         fields: [labelsField],
-        submitButtonText: $localize`Edit Host`,
+        submitButtonText: $localize`Save changes`,
         onSubmit: (values: { labels: string[] }) => {
           this.submitHostLabelUpdate(host.hostname, values.labels, onSuccess);
         }


### PR DESCRIPTION



https://github.com/user-attachments/assets/a66d9df2-56ff-4984-a408-c7f25c8d5cc1



---

Fixes:  https://tracker.ceph.com/issues/76507
Signed-off-by: pujaoshahu <pshahu@redhat.com>

Summery:
Updated submit button labels in edit forms to display "Save changes" instead of "Edit User", "Edit Pool", or "Edit Host" for better UX consistency, while keeping form titles unchanged.

Modified Files
role-form.component.ts: Added submitAction property to control submit button label by mode; edit mode uses Save changes, create mode uses Create Role.

role-form.component.html: Submit button now binds to submitAction instead of action/resource text.

role-form.component.spec.ts: Added tests for submitAction behavior in create and edit modes.

user-form.component.ts: Uses submitAction property; edit mode label updated to Save changes.

user-form.component.html: Submit button uses submitAction binding.

user-form.component.spec.ts: Added/updated tests covering submitAction behavior.

pool-form.component.ts: Uses submitAction property; edit mode label updated to Save changes.

pool-form.component.html: Submit button uses submitAction binding.

pool-form.component.spec.ts: Updated submit label test expectation for edit mode.

hosts.component.ts: Edit host modal submit button text changed to Save changes.

hosts.component.spec.ts: Updated test to match Save changes button text.

app.constants.ts: In the current workspace snapshot, there is no SAVE constant added under ActionLabelsI18n.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
