### PR TITLE
docs/security: added workinggroup.rst and securitylead.rst

### DIFF
--- a/doc/security/securitylead.rst
+++ b/doc/security/securitylead.rst
@@ -1,0 +1,14 @@
+The CSC designates a member as Security Lead, with responsibility for
+co-ordinating security posture. The Security Lead also keeps the CSC updated
+about vulnerabilities within Ceph and progress toward addressing them. The lead
+notably drives resolution of critical vulnerabilities.
+
+A responsibility of this role will be to give a monthly status report to the CSC
+on vulnerabilities and novel security concerns, such as AI exploit scanners and
+quantum-resistant encryption. They will also update the CSC with new and
+improved security processes. The Security Lead is the point of contact for and
+has responsibility for ensuring the proper intake, triage, and assignment of
+security vulnerabilities, and coordinate open source unembargos of security
+vulnerabilities when fixes are ready. This person will maintain the
+security@ceph.io email list, checking it regularly, and ensuring stakeholder
+emails are kept up to date on an occasional basis.

--- a/doc/security/workinggroup.rst
+++ b/doc/security/workinggroup.rst
@@ -1,0 +1,33 @@
+In order to fully support Ceph, the security working group
+co-ordinates security improvements. This is essential as industry
+focuses more on security, and Ceph has become a mature software
+project. Vulnerabilities have increased in number and in complexity,
+and are expected to continue to do so. A reactive process is no longer
+adequate, and preemptive policies ought to be discussed within a group
+of knowledgeable and motivated people to ensure their viability.
+
+We welcome involvement in the Security Working Group. Any reasonable
+stakeholder in Ceph Security is encouraged to join with the approval
+of the CSC and Security group. Any CSC member may nominate someone to
+join the working group and attend meetings. Should someone not attend
+meetings for 1+ years, or breach an embargo intentionally, they will
+be removed and notified.
+
+By joining this working group, one may contribute to Ceph Security
+processes, see all embargoed bugs, and help coordinate fixes across
+upstream Ceph. There is no expectation to create security fixes,
+however, such efforts are welcome. The expectation is to triage,
+assign, and coordinate fixes as appropriate.
+
+The responsibilities are to attend a twice-monthly meeting for the
+working group, report back to the CSC on a monthly basis and to uphold
+any embargos on reported vulnerabilities. Additionally, tasks will be
+shared among volunteers from the group, based on interest and
+availability.
+
+Initial target projects are: Writing a Security Incident Response
+Process for Ceph, Writing an Embargo Process for Ceph, coordinating
+the fixes in our backlog of security bugs, coordinating penetration
+tests and scans of Ceph, reviewing dependencies and containers within
+Ceph for upgrades, and eventual collaboration on Ceph Quantum-Resistant
+encryption implementation.


### PR DESCRIPTION
docs/security: added workinggroup.rst and securitylead.rst

Created a description of the working group, and the security lead role on the CSC. 
Signed-off-by: Sage McTaggart <SageMcT@ibm.com>


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [X] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
