### PR TITLE
squid: qa/radosgw_admin: replace boto2 with boto3

### DIFF
--- a/qa/tasks/radosgw_admin.py
+++ b/qa/tasks/radosgw_admin.py
@@ -896,41 +896,6 @@ def task(ctx, config):
     bucket.delete()
     rl.log_and_clear("delete_bucket", bucket_name, user1)
 
-    # TESTCASE 'policy', 'bucket', 'policy', 'get bucket policy', 'returns S3 policy'
-    bucket = connection.create_bucket(bucket_name)
-    rl.log_and_clear("create_bucket", bucket_name, user1)
-
-    # create an object
-    key = boto.s3.key.Key(bucket)
-    key.set_contents_from_string('seven')
-    rl.log_and_clear("put_obj", bucket_name, user1)
-
-    # should be private already but guarantee it
-    key.set_acl('private')
-    rl.log_and_clear("put_acls", bucket_name, user1)
-
-    (err, out) = rgwadmin(ctx, client,
-        ['policy', '--bucket', bucket.name, '--object', key.key.decode()],
-        check_status=True, format='xml')
-
-    acl = get_acl(key)
-    rl.log_and_clear("get_acls", bucket_name, user1)
-
-    assert acl == out.strip('\n')
-
-    # add another grantee by making the object public read
-    key.set_acl('public-read')
-    rl.log_and_clear("put_acls", bucket_name, user1)
-
-    (err, out) = rgwadmin(ctx, client,
-        ['policy', '--bucket', bucket.name, '--object', key.key.decode()],
-        check_status=True, format='xml')
-
-    acl = get_acl(key)
-    rl.log_and_clear("get_acls", bucket_name, user1)
-
-    assert acl == out.strip('\n')
-
     # TESTCASE 'rm-bucket', 'bucket', 'rm', 'bucket with objects', 'succeeds'
     bucket = connection.create_bucket(bucket_name)
     rl.log_and_clear("create_bucket", bucket_name, user1)

--- a/qa/tasks/radosgw_admin.py
+++ b/qa/tasks/radosgw_admin.py
@@ -14,12 +14,10 @@ Rgw admin testing against a running instance
 import json
 import logging
 import time
-import datetime
 import sys
 import errno
 
 from io import StringIO
-from queue import Queue
 
 import boto.exception
 import boto.s3.connection
@@ -226,38 +224,6 @@ class usage_acc:
             usage_acc_validate_s3select_fields(r, x, x2, "summary: s3select totals for user" + s['user'])
         return r
 
-def ignore_this_entry(cat, bucket, user, out, b_in, err):
-    pass
-class requestlog_queue():
-    def __init__(self, add):
-        self.q = Queue(1000)
-        self.adder = add
-    def handle_request_data(self, request, response, error=False):
-        now = datetime.datetime.now()
-        if error:
-            pass
-        elif response.status < 200 or response.status >= 400:
-            error = True
-        self.q.put({'t': now, 'o': request, 'i': response, 'e': error})
-    def clear(self):
-        with self.q.mutex:
-            self.q.queue.clear()
-    def log_and_clear(self, cat, bucket, user, add_entry = None):
-        while not self.q.empty():
-            j = self.q.get()
-            bytes_out = 0
-            if 'Content-Length' in j['o'].headers:
-                bytes_out = int(j['o'].headers['Content-Length'])
-            bytes_in = 0
-            msg = j['i'].msg
-            if 'content-length'in msg:
-                bytes_in = int(msg['content-length'])
-            log.info('RL: %s %s %s bytes_out=%d bytes_in=%d failed=%r'
-                     % (cat, bucket, user, bytes_out, bytes_in, j['e']))
-            if add_entry == None:
-                add_entry = self.adder
-            add_entry(cat, bucket, user, bytes_out, bytes_in, j['e'])
-
 def create_presigned_url(conn, method, bucket_name, key_name, expiration):
     return conn.generate_url(expires_in=expiration,
         method=method,
@@ -399,10 +365,6 @@ def task(ctx, config):
     connection3.auth_region_name='us-east-1'
 
     acc = usage_acc()
-    rl = requestlog_queue(acc.generate_make_entry())
-    connection.set_request_hook(rl)
-    connection2.set_request_hook(rl)
-    connection3.set_request_hook(rl)
 
     # legend (test cases can be easily grep-ed out)
     # TESTCASE 'testname','object','method','operation','assertion'
@@ -555,8 +517,6 @@ def task(ctx, config):
     # create a first bucket
     bucket = connection.create_bucket(bucket_name)
 
-    rl.log_and_clear("create_bucket", bucket_name, user1)
-
     # TESTCASE 'bucket-list','bucket','list','one bucket','succeeds, expected list'
     (err, out) = rgwadmin(ctx, client, ['bucket', 'list', '--uid', user1], check_status=True)
     assert len(out) == 1
@@ -566,8 +526,6 @@ def task(ctx, config):
     assert len(bucket_list) == 1
     assert bucket_list[0].name == bucket_name
 
-    rl.log_and_clear("list_buckets", '', user1)
-
     # TESTCASE 'bucket-list-all','bucket','list','all buckets','succeeds, expected list'
     (err, out) = rgwadmin(ctx, client, ['bucket', 'list'], check_status=True)
     assert len(out) >= 1
@@ -575,11 +533,8 @@ def task(ctx, config):
 
     # TESTCASE 'max-bucket-limit,'bucket','create','4 buckets','5th bucket fails due to max buckets == 4'
     bucket2 = connection.create_bucket(bucket_name + '2')
-    rl.log_and_clear("create_bucket", bucket_name + '2', user1)
     bucket3 = connection.create_bucket(bucket_name + '3')
-    rl.log_and_clear("create_bucket", bucket_name + '3', user1)
     bucket4 = connection.create_bucket(bucket_name + '4')
-    rl.log_and_clear("create_bucket", bucket_name + '4', user1)
     # the 5th should fail.
     failed = False
     try:
@@ -587,15 +542,11 @@ def task(ctx, config):
     except Exception:
         failed = True
     assert failed
-    rl.log_and_clear("create_bucket", bucket_name + '5', user1)
 
     # delete the buckets
     bucket2.delete()
-    rl.log_and_clear("delete_bucket", bucket_name + '2', user1)
     bucket3.delete()
-    rl.log_and_clear("delete_bucket", bucket_name + '3', user1)
     bucket4.delete()
-    rl.log_and_clear("delete_bucket", bucket_name + '4', user1)
 
     # TESTCASE 'bucket-stats3','bucket','stats','new empty bucket','succeeds, empty list'
     (err, out) = rgwadmin(ctx, client, [
@@ -611,7 +562,6 @@ def task(ctx, config):
     # use some space
     key = boto.s3.key.Key(bucket)
     key.set_contents_from_string('one')
-    rl.log_and_clear("put_obj", bucket_name, user1)
 
     # TESTCASE 'bucket-stats5','bucket','stats','after creating key','succeeds, lists one non-empty object'
     (err, out) = rgwadmin(ctx, client, [
@@ -628,7 +578,6 @@ def task(ctx, config):
 
     # reclaim it
     key.delete()
-    rl.log_and_clear("delete_obj", bucket_name, user1)
 
     # TESTCASE 'bucket unlink', 'bucket', 'unlink', 'unlink bucket from user', 'fails', 'access denied error'
     (err, out) = rgwadmin(ctx, client,
@@ -656,11 +605,9 @@ def task(ctx, config):
         denied = True
 
     assert not denied
-    rl.log_and_clear("put_obj", bucket_name, user1)
 
     # delete the object
     key.delete()
-    rl.log_and_clear("delete_obj", bucket_name, user1)
 
     # link the bucket to another user
     (err, out) = rgwadmin(ctx, client, ['metadata', 'get', 'bucket:{n}'.format(n=bucket_name)],
@@ -765,15 +712,12 @@ def task(ctx, config):
     object_name = 'four'
     key = boto.s3.key.Key(bucket, object_name)
     key.set_contents_from_string(object_name)
-    rl.log_and_clear("put_obj", bucket_name, user1)
 
     # fetch it too (for usage stats presently)
     s = key.get_contents_as_string(encoding='ascii')
-    rl.log_and_clear("get_obj", bucket_name, user1)
     assert s == object_name
     # list bucket too (for usage stats presently)
     keys = list(bucket.list())
-    rl.log_and_clear("list_bucket", bucket_name, user1)
     assert len(keys) == 1
     assert keys[0].name == object_name
 
@@ -839,7 +783,6 @@ def task(ctx, config):
         assert e.status == 403
 
     assert denied
-    rl.log_and_clear("put_obj", bucket_name, user1)
 
     # TESTCASE 'user-renable2','user','enable','suspended user','succeeds'
     (err, out) = rgwadmin(ctx, client, ['user', 'enable', '--uid', user1],
@@ -848,7 +791,6 @@ def task(ctx, config):
     # TESTCASE 'user-renable3','user','enable','reenabled user','can write objects'
     key = boto.s3.key.Key(bucket)
     key.set_contents_from_string('six')
-    rl.log_and_clear("put_obj", bucket_name, user1)
 
     # TESTCASE 'gc-list', 'gc', 'list', 'get list of objects ready for garbage collection'
 
@@ -857,11 +799,9 @@ def task(ctx, config):
 
     big_key = boto.s3.key.Key(bucket)
     big_key.set_contents_from_string(test_string)
-    rl.log_and_clear("put_obj", bucket_name, user1)
 
     # now delete the head
     big_key.delete()
-    rl.log_and_clear("delete_obj", bucket_name, user1)
 
     # wait a bit to give the garbage collector time to cycle
     time.sleep(15)
@@ -889,21 +829,16 @@ def task(ctx, config):
         bucket.delete()
     except boto.exception.S3ResponseError as e:
         assert e.status == 409
-    rl.log_and_clear("delete_bucket", bucket_name, user1)
 
     key.delete()
-    rl.log_and_clear("delete_obj", bucket_name, user1)
     bucket.delete()
-    rl.log_and_clear("delete_bucket", bucket_name, user1)
 
     # TESTCASE 'rm-bucket', 'bucket', 'rm', 'bucket with objects', 'succeeds'
     bucket = connection.create_bucket(bucket_name)
-    rl.log_and_clear("create_bucket", bucket_name, user1)
     key_name = ['eight', 'nine', 'ten', 'eleven']
     for i in range(4):
         key = boto.s3.key.Key(bucket)
         key.set_contents_from_string(key_name[i])
-    rl.log_and_clear("put_obj", bucket_name, user1)
 
     (err, out) = rgwadmin(ctx, client,
         ['bucket', 'rm', '--bucket', bucket_name, '--purge-objects'],
@@ -922,7 +857,6 @@ def task(ctx, config):
 
     # TESTCASE 'rm-user','user','rm','existing user','fails, still has buckets'
     bucket = connection.create_bucket(bucket_name)
-    rl.log_and_clear("create_bucket", bucket_name, user1)
     key = boto.s3.key.Key(bucket)
 
     (err, out) = rgwadmin(ctx, client, ['user', 'rm', '--uid', user1])
@@ -930,10 +864,8 @@ def task(ctx, config):
 
     # TESTCASE 'rm-user2', 'user', 'rm', 'user with data', 'succeeds'
     bucket = connection.create_bucket(bucket_name)
-    rl.log_and_clear("create_bucket", bucket_name, user1)
     key = boto.s3.key.Key(bucket)
     key.set_contents_from_string('twelve')
-    rl.log_and_clear("put_obj", bucket_name, user1)
 
     time.sleep(35)
 
@@ -1000,13 +932,10 @@ def task(ctx, config):
     # create a bucket
     bucket = connection3.create_bucket(bucket_name + '6')
 
-    rl.log_and_clear("create_bucket", bucket_name + '6', user3)
-
     # create object
     object_name1 = 'thirteen'
     key1 = boto.s3.key.Key(bucket, object_name1)
     key1.set_contents_from_string(object_name1)
-    rl.log_and_clear("put_obj", bucket_name + '6', user3)
 
     # rename user3
     (err, out) = rgwadmin(ctx, client, ['user', 'rename', '--uid', user3, '--new-uid', user4], check_status=True)
@@ -1019,7 +948,6 @@ def task(ctx, config):
     # get bucket and object to test if user keys are preserved
     bucket = connection3.get_bucket(bucket_name + '6')
     s = key1.get_contents_as_string(encoding='ascii')
-    rl.log_and_clear("get_obj", bucket_name + '6', user4)
     assert s == object_name1
 
     # TESTCASE 'user-rename', 'user', 'rename', 'existing user', 'another existing user', 'fails'
@@ -1037,13 +965,10 @@ def task(ctx, config):
     # create a bucket
     bucket = connection2.create_bucket(bucket_name + '7')
 
-    rl.log_and_clear("create_bucket", bucket_name + '7', user2)
-
     # create object
     object_name2 = 'fourteen'
     key2 = boto.s3.key.Key(bucket, object_name2)
     key2.set_contents_from_string(object_name2)
-    rl.log_and_clear("put_obj", bucket_name + '7', user2)
 
     (err, out) = rgwadmin(ctx, client, ['user', 'rename', '--uid', user4, '--new-uid', user2])
     assert err
@@ -1051,12 +976,10 @@ def task(ctx, config):
     # test if user 2 and user4 can still access their bucket and objects after rename fails
     bucket = connection3.get_bucket(bucket_name + '6')
     s = key1.get_contents_as_string(encoding='ascii')
-    rl.log_and_clear("get_obj", bucket_name + '6', user4)
     assert s == object_name1
 
     bucket = connection2.get_bucket(bucket_name + '7')
     s = key2.get_contents_as_string(encoding='ascii')
-    rl.log_and_clear("get_obj", bucket_name + '7', user2)
     assert s == object_name2
 
     (err, out) = rgwadmin(ctx, client,
@@ -1071,7 +994,6 @@ def task(ctx, config):
 
     # should be all through with connection. (anything using connection
     #  should be BEFORE the usage stuff above.)
-    rl.log_and_clear("(before-close)", '-', '-', ignore_this_entry)
     connection.close()
     connection = None
 

--- a/qa/tasks/radosgw_admin.py
+++ b/qa/tasks/radosgw_admin.py
@@ -19,9 +19,8 @@ import errno
 
 from io import StringIO
 
-import boto.exception
-import boto.s3.connection
-import boto.s3.acl
+import boto3
+from botocore.exceptions import ClientError
 
 import httplib2
 
@@ -334,35 +333,21 @@ def task(ctx, config):
     bucket_name2='mybar'
 
     # connect to rgw
-    connection = boto.s3.connection.S3Connection(
-        aws_access_key_id=access_key,
-        aws_secret_access_key=secret_key,
-        is_secure=False,
-        port=endpoint.port,
-        host=endpoint.hostname,
-        calling_format=boto.s3.connection.OrdinaryCallingFormat(),
-        )
-    connection.auth_region_name='us-east-1'
-
-    connection2 = boto.s3.connection.S3Connection(
-        aws_access_key_id=access_key2,
-        aws_secret_access_key=secret_key2,
-        is_secure=False,
-        port=endpoint.port,
-        host=endpoint.hostname,
-        calling_format=boto.s3.connection.OrdinaryCallingFormat(),
-        )
-    connection2.auth_region_name='us-east-1'
-
-    connection3 = boto.s3.connection.S3Connection(
-        aws_access_key_id=access_key3,
-        aws_secret_access_key=secret_key3,
-        is_secure=False,
-        port=endpoint.port,
-        host=endpoint.hostname,
-        calling_format=boto.s3.connection.OrdinaryCallingFormat(),
-        )
-    connection3.auth_region_name='us-east-1'
+    connection = boto3.client(service_name='s3',
+                              aws_access_key_id=access_key,
+                              aws_secret_access_key=secret_key,
+                              endpoint_url=endpoint.url(),
+                              use_ssl=False)
+    connection2 = boto3.client(service_name='s3',
+                               aws_access_key_id=access_key2,
+                               aws_secret_access_key=secret_key2,
+                               endpoint_url=endpoint.url(),
+                               use_ssl=False)
+    connection3 = boto3.client(service_name='s3',
+                               aws_access_key_id=access_key3,
+                               aws_secret_access_key=secret_key3,
+                               endpoint_url=endpoint.url(),
+                               use_ssl=False)
 
     acc = usage_acc()
 
@@ -515,16 +500,16 @@ def task(ctx, config):
     assert len(out) == 0
 
     # create a first bucket
-    bucket = connection.create_bucket(bucket_name)
+    connection.create_bucket(Bucket=bucket_name)
 
     # TESTCASE 'bucket-list','bucket','list','one bucket','succeeds, expected list'
     (err, out) = rgwadmin(ctx, client, ['bucket', 'list', '--uid', user1], check_status=True)
     assert len(out) == 1
     assert out[0] == bucket_name
 
-    bucket_list = connection.get_all_buckets()
+    bucket_list = connection.list_buckets()['Buckets']
     assert len(bucket_list) == 1
-    assert bucket_list[0].name == bucket_name
+    assert bucket_list[0]['Name'] == bucket_name
 
     # TESTCASE 'bucket-list-all','bucket','list','all buckets','succeeds, expected list'
     (err, out) = rgwadmin(ctx, client, ['bucket', 'list'], check_status=True)
@@ -532,9 +517,9 @@ def task(ctx, config):
     assert bucket_name in out;
 
     # TESTCASE 'max-bucket-limit,'bucket','create','4 buckets','5th bucket fails due to max buckets == 4'
-    bucket2 = connection.create_bucket(bucket_name + '2')
-    bucket3 = connection.create_bucket(bucket_name + '3')
-    bucket4 = connection.create_bucket(bucket_name + '4')
+    connection.create_bucket(Bucket=bucket_name + '2')
+    connection.create_bucket(Bucket=bucket_name + '3')
+    connection.create_bucket(Bucket=bucket_name + '4')
     # the 5th should fail.
     failed = False
     try:
@@ -544,9 +529,9 @@ def task(ctx, config):
     assert failed
 
     # delete the buckets
-    bucket2.delete()
-    bucket3.delete()
-    bucket4.delete()
+    connection.delete_bucket(Bucket=bucket_name + '2')
+    connection.delete_bucket(Bucket=bucket_name + '3')
+    connection.delete_bucket(Bucket=bucket_name + '4')
 
     # TESTCASE 'bucket-stats3','bucket','stats','new empty bucket','succeeds, empty list'
     (err, out) = rgwadmin(ctx, client, [
@@ -560,8 +545,7 @@ def task(ctx, config):
     assert out[0]['id'] == bucket_id    # does it return the same ID twice in a row?
 
     # use some space
-    key = boto.s3.key.Key(bucket)
-    key.set_contents_from_string('one')
+    connection.put_object(Bucket=bucket_name, Key='one', Body='one')
 
     # TESTCASE 'bucket-stats5','bucket','stats','after creating key','succeeds, lists one non-empty object'
     (err, out) = rgwadmin(ctx, client, [
@@ -577,7 +561,7 @@ def task(ctx, config):
     assert out['stats']['size'] > 0
 
     # reclaim it
-    key.delete()
+    connection.delete_object(Bucket=bucket_name, Key='one')
 
     # TESTCASE 'bucket unlink', 'bucket', 'unlink', 'unlink bucket from user', 'fails', 'access denied error'
     (err, out) = rgwadmin(ctx, client,
@@ -596,18 +580,8 @@ def task(ctx, config):
             check_status=True)
 
     # try creating an object with the first user before the bucket is relinked
-    denied = False
-    key = boto.s3.key.Key(bucket)
-
-    try:
-        key.set_contents_from_string('two')
-    except boto.exception.S3ResponseError:
-        denied = True
-
-    assert not denied
-
-    # delete the object
-    key.delete()
+    connection.put_object(Bucket=bucket_name, Key='two', Body='two')
+    connection.delete_object(Bucket=bucket_name, Key='two')
 
     # link the bucket to another user
     (err, out) = rgwadmin(ctx, client, ['metadata', 'get', 'bucket:{n}'.format(n=bucket_name)],
@@ -710,16 +684,15 @@ def task(ctx, config):
 
     # upload an object
     object_name = 'four'
-    key = boto.s3.key.Key(bucket, object_name)
-    key.set_contents_from_string(object_name)
+    connection.put_object(Bucket=bucket_name, Key=object_name, Body=object_name)
 
     # fetch it too (for usage stats presently)
-    s = key.get_contents_as_string(encoding='ascii')
+    s = connection.get_object(Bucket=bucket_name, Key=object_name)['Body'].read().decode()
     assert s == object_name
     # list bucket too (for usage stats presently)
-    keys = list(bucket.list())
+    keys = connection.list_objects(Bucket=bucket_name)['Contents']
     assert len(keys) == 1
-    assert keys[0].name == object_name
+    assert keys[0]['Key'] == object_name
 
     # now delete it
     (err, out) = rgwadmin(ctx, client,
@@ -776,12 +749,10 @@ def task(ctx, config):
     # TESTCASE 'user-suspend3','user','suspend','suspended user','cannot write objects'
     denied = False
     try:
-        key = boto.s3.key.Key(bucket)
-        key.set_contents_from_string('five')
-    except boto.exception.S3ResponseError as e:
+        connection.put_object(Bucket=bucket_name, Key='five', Body='five')
+    except ClientError as e:
         denied = True
-        assert e.status == 403
-
+        assert e.response['ResponseMetadata']['HTTPStatusCode'] == 403
     assert denied
 
     # TESTCASE 'user-renable2','user','enable','suspended user','succeeds'
@@ -789,19 +760,16 @@ def task(ctx, config):
         check_status=True)
 
     # TESTCASE 'user-renable3','user','enable','reenabled user','can write objects'
-    key = boto.s3.key.Key(bucket)
-    key.set_contents_from_string('six')
+    connection.put_object(Bucket=bucket_name, Key='six', Body='six')
 
     # TESTCASE 'gc-list', 'gc', 'list', 'get list of objects ready for garbage collection'
 
     # create an object large enough to be split into multiple parts
     test_string = 'foo'*10000000
-
-    big_key = boto.s3.key.Key(bucket)
-    big_key.set_contents_from_string(test_string)
+    connection.put_object(Bucket=bucket_name, Key='big', Body=test_string)
 
     # now delete the head
-    big_key.delete()
+    connection.delete_object(Bucket=bucket_name, Key='big')
 
     # wait a bit to give the garbage collector time to cycle
     time.sleep(15)
@@ -826,19 +794,17 @@ def task(ctx, config):
 
     # delete should fail because ``key`` still exists
     try:
-        bucket.delete()
-    except boto.exception.S3ResponseError as e:
-        assert e.status == 409
+        connection.delete_bucket(Bucket=bucket_name)
+    except ClientError as e:
+        assert e.response['ResponseMetadata']['HTTPStatusCode'] == 409
 
-    key.delete()
-    bucket.delete()
+    connection.delete_object(Bucket=bucket_name, Key='six')
+    connection.delete_bucket(Bucket=bucket_name)
 
     # TESTCASE 'rm-bucket', 'bucket', 'rm', 'bucket with objects', 'succeeds'
-    bucket = connection.create_bucket(bucket_name)
-    key_name = ['eight', 'nine', 'ten', 'eleven']
-    for i in range(4):
-        key = boto.s3.key.Key(bucket)
-        key.set_contents_from_string(key_name[i])
+    connection.create_bucket(Bucket=bucket_name)
+    for key_name in ['eight', 'nine', 'ten', 'eleven']:
+        connection.put_object(Bucket=bucket_name, Key=key_name, Body=key_name)
 
     (err, out) = rgwadmin(ctx, client,
         ['bucket', 'rm', '--bucket', bucket_name, '--purge-objects'],
@@ -856,16 +822,13 @@ def task(ctx, config):
     assert not out['caps']
 
     # TESTCASE 'rm-user','user','rm','existing user','fails, still has buckets'
-    bucket = connection.create_bucket(bucket_name)
-    key = boto.s3.key.Key(bucket)
+    connection.create_bucket(Bucket=bucket_name)
 
     (err, out) = rgwadmin(ctx, client, ['user', 'rm', '--uid', user1])
     assert err
 
     # TESTCASE 'rm-user2', 'user', 'rm', 'user with data', 'succeeds'
-    bucket = connection.create_bucket(bucket_name)
-    key = boto.s3.key.Key(bucket)
-    key.set_contents_from_string('twelve')
+    connection.put_object(Bucket=bucket_name, Key='twelve', Body='twelve')
 
     time.sleep(35)
 
@@ -930,12 +893,12 @@ def task(ctx, config):
         check_status=True)
 
     # create a bucket
-    bucket = connection3.create_bucket(bucket_name + '6')
+    bucket_name6 = bucket_name + '6'
+    connection3.create_bucket(Bucket=bucket_name6)
 
     # create object
     object_name1 = 'thirteen'
-    key1 = boto.s3.key.Key(bucket, object_name1)
-    key1.set_contents_from_string(object_name1)
+    connection3.put_object(Bucket=bucket_name6, Key=object_name1, Body=object_name1)
 
     # rename user3
     (err, out) = rgwadmin(ctx, client, ['user', 'rename', '--uid', user3, '--new-uid', user4], check_status=True)
@@ -946,8 +909,7 @@ def task(ctx, config):
     time.sleep(5)
 
     # get bucket and object to test if user keys are preserved
-    bucket = connection3.get_bucket(bucket_name + '6')
-    s = key1.get_contents_as_string(encoding='ascii')
+    s = connection3.get_object(Bucket=bucket_name6, Key=object_name1)['Body'].read().decode()
     assert s == object_name1
 
     # TESTCASE 'user-rename', 'user', 'rename', 'existing user', 'another existing user', 'fails'
@@ -963,23 +925,21 @@ def task(ctx, config):
         check_status=True)
 
     # create a bucket
-    bucket = connection2.create_bucket(bucket_name + '7')
+    bucket_name7 = bucket_name + '7'
+    connection2.create_bucket(Bucket=bucket_name7)
 
     # create object
     object_name2 = 'fourteen'
-    key2 = boto.s3.key.Key(bucket, object_name2)
-    key2.set_contents_from_string(object_name2)
+    connection2.put_object(Bucket=bucket_name7, Key=object_name2, Body=object_name2)
 
     (err, out) = rgwadmin(ctx, client, ['user', 'rename', '--uid', user4, '--new-uid', user2])
     assert err
 
     # test if user 2 and user4 can still access their bucket and objects after rename fails
-    bucket = connection3.get_bucket(bucket_name + '6')
-    s = key1.get_contents_as_string(encoding='ascii')
+    s = connection3.get_object(Bucket=bucket_name6, Key=object_name1)['Body'].read().decode()
     assert s == object_name1
 
-    bucket = connection2.get_bucket(bucket_name + '7')
-    s = key2.get_contents_as_string(encoding='ascii')
+    s = connection2.get_object(Bucket=bucket_name7, Key=object_name2)['Body'].read().decode()
     assert s == object_name2
 
     (err, out) = rgwadmin(ctx, client,
@@ -989,13 +949,6 @@ def task(ctx, config):
     (err, out) = rgwadmin(ctx, client,
     ['user', 'rm', '--uid', user2, '--purge-data' ],
     check_status=True)
-
-    time.sleep(5)
-
-    # should be all through with connection. (anything using connection
-    #  should be BEFORE the usage stuff above.)
-    connection.close()
-    connection = None
 
     # the usage flush interval is 30 seconds, wait that much an then some
     # to make sure everything has been flushed

--- a/qa/tasks/radosgw_admin_rest.py
+++ b/qa/tasks/radosgw_admin_rest.py
@@ -23,7 +23,7 @@ from tasks.util.rgw import get_user_summary, get_user_successful_ops, rgwadmin
 
 log = logging.getLogger(__name__)
 
-def rgwadmin_rest(connection, cmd, params=None, headers=None, raw=False):
+def rgwadmin_rest(endpoint, connection, cmd, params=None, headers=None, raw=False):
     """
     perform a rest command
     """
@@ -117,7 +117,7 @@ def rgwadmin_rest(connection, cmd, params=None, headers=None, raw=False):
         log.info(' json result: %s' % result.json())
         return result.status_code, result.json()
 
-def test_cap_user_info_without_keys_get_user_info_privileged_users(ctx, client, op, op_args, uid, display_name, access_key, secret_key, user_type):
+def test_cap_user_info_without_keys_get_user_info_privileged_users(ctx, client, endpoint, op, op_args, uid, display_name, access_key, secret_key, user_type):
     user_caps = 'user-info-without-keys=read'
 
     (err, out) = rgwadmin(ctx, client, [
@@ -133,8 +133,6 @@ def test_cap_user_info_without_keys_get_user_info_privileged_users(ctx, client, 
     logging.error(err)
     assert not err
 
-    endpoint = ctx.rgw.role_endpoints.get(client)
-
     privileged_user_conn = boto.s3.connection.S3Connection(
         aws_access_key_id=access_key,
         aws_secret_access_key=secret_key,
@@ -144,7 +142,7 @@ def test_cap_user_info_without_keys_get_user_info_privileged_users(ctx, client, 
         calling_format=boto.s3.connection.OrdinaryCallingFormat(),
         )
 
-    (ret, out) = rgwadmin_rest(privileged_user_conn, op, op_args)
+    (ret, out) = rgwadmin_rest(endpoint, privileged_user_conn, op, op_args)
     # show that even though the cap is set, since the user is privileged the user can still see keys
     assert len(out['keys']) == 1
     assert out['swift_keys'] == []
@@ -157,7 +155,7 @@ def test_cap_user_info_without_keys_get_user_info_privileged_users(ctx, client, 
     logging.error(err)
     assert not err
 
-def test_cap_user_info_without_keys_get_user_info(ctx, client, admin_conn, admin_user, op, op_args):
+def test_cap_user_info_without_keys_get_user_info(ctx, client, endpoint, admin_auth, admin_user, op, op_args):
     true_admin_uid = 'a_user'
     true_admin_display_name = 'True Admin User'
     true_admin_access_key = 'true_admin_akey'
@@ -168,8 +166,8 @@ def test_cap_user_info_without_keys_get_user_info(ctx, client, admin_conn, admin
     system_access_key = 'system_akey'
     system_secret_key = 'system_skey'
 
-    test_cap_user_info_without_keys_get_user_info_privileged_users(ctx, client, op, op_args, system_uid, system_display_name, system_access_key, system_secret_key, '--system')
-    test_cap_user_info_without_keys_get_user_info_privileged_users(ctx, client, op, op_args, true_admin_uid, true_admin_display_name, true_admin_access_key, true_admin_secret_key, '--admin')
+    test_cap_user_info_without_keys_get_user_info_privileged_users(ctx, client, endpoint, op, op_args, system_uid, system_display_name, system_access_key, system_secret_key, '--system')
+    test_cap_user_info_without_keys_get_user_info_privileged_users(ctx, client, endpoint, op, op_args, true_admin_uid, true_admin_display_name, true_admin_access_key, true_admin_secret_key, '--admin')
 
     # TESTCASE 'info-existing','user','info','existing user','returns no keys with user-info-without-keys cap set to read'
     (err, out) = rgwadmin(ctx, client, [
@@ -181,7 +179,7 @@ def test_cap_user_info_without_keys_get_user_info(ctx, client, admin_conn, admin
     logging.error(err)
     assert not err
 
-    (ret, out) = rgwadmin_rest(admin_conn, op, op_args)
+    (ret, out) = rgwadmin_rest(endpoint, admin_auth, op, op_args)
     assert 'keys' not in out
     assert 'swift_keys' not in out
 
@@ -195,7 +193,7 @@ def test_cap_user_info_without_keys_get_user_info(ctx, client, admin_conn, admin
     logging.error(err)
     assert not err
 
-    (ret, out) = rgwadmin_rest(admin_conn, op, op_args)
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, op, op_args)
     assert 'keys' not in out
     assert 'swift_keys' not in out
 
@@ -209,7 +207,7 @@ def test_cap_user_info_without_keys_get_user_info(ctx, client, admin_conn, admin
     logging.error(err)
     assert not err
 
-    (ret, out) = rgwadmin_rest(admin_conn, op, op_args)
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, op, op_args)
     assert 'keys' in out
     assert 'swift_keys' in out
 
@@ -232,7 +230,7 @@ def test_cap_user_info_without_keys_get_user_info(ctx, client, admin_conn, admin
     logging.error(err)
     assert not err
 
-    (ret, out) = rgwadmin_rest(admin_conn, op, op_args)
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, op, op_args)
     assert ret == 403
 
     # remove cap user-info-without-keys permenantly for future testing
@@ -255,7 +253,7 @@ def test_cap_user_info_without_keys_get_user_info(ctx, client, admin_conn, admin
     logging.error(err)
     assert not err
 
-def test_cap_user_info_without_keys(ctx, client, admin_conn, admin_user, user1):
+def test_cap_user_info_without_keys(ctx, client, endpoint, admin_conn, admin_user, user1):
     (err, out) = rgwadmin(ctx, client, [
             'caps', 'rm',
             '--uid', admin_user,
@@ -267,7 +265,7 @@ def test_cap_user_info_without_keys(ctx, client, admin_conn, admin_user, user1):
 
     op = ['user', 'info']
     op_args = {'uid' : user1}
-    test_cap_user_info_without_keys_get_user_info(ctx, client, admin_conn, admin_user, op, op_args)
+    test_cap_user_info_without_keys_get_user_info(ctx, client, endpoint, admin_conn, admin_user, op, op_args)
 
     # add caps that were removed earlier in the function back in
     (err, out) = rgwadmin(ctx, client, [
@@ -351,11 +349,11 @@ def task(ctx, config):
         )
 
     # TESTCASE 'info-nosuch','user','info','non-existent user','fails'
-    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'info'], {"uid": user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'info'], {"uid": user1})
     assert ret == 404
 
     # TESTCASE 'create-ok','user','create','w/all valid info','succeeds'
-    (ret, out) = rgwadmin_rest(admin_conn,
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn,
             ['user', 'create'],
             {'uid' : user1,
              'display-name' :  display_name1,
@@ -368,7 +366,7 @@ def task(ctx, config):
     assert ret == 200
 
     # TESTCASE 'list-no-user','user','list','list user keys','user list object'
-    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'list'], {'list' : '', 'max-entries' : 0})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'list'], {'list' : '', 'max-entries' : 0})
     assert ret == 200
     assert out['count'] == 0
     assert out['truncated'] == True
@@ -376,7 +374,7 @@ def task(ctx, config):
     assert len(out['marker']) > 0
 
     # TESTCASE 'list-user-without-marker','user','list','list user keys','user list object'
-    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'list'], {'list' : '', 'max-entries' : 1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'list'], {'list' : '', 'max-entries' : 1})
     assert ret == 200
     assert out['count'] == 1
     assert out['truncated'] == True
@@ -385,14 +383,14 @@ def task(ctx, config):
     marker = out['marker']
 
     # TESTCASE 'list-user-with-marker','user','list','list user keys','user list object'
-    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'list'], {'list' : '', 'max-entries' : 1, 'marker': marker})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'list'], {'list' : '', 'max-entries' : 1, 'marker': marker})
     assert ret == 200
     assert out['count'] == 1
     assert out['truncated'] == False
     assert len(out['keys']) == 1
 
     # TESTCASE 'info-existing','user','info','existing user','returns correct info'
-    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'info'], {'uid' : user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'info'], {'uid' : user1})
 
     assert out['user_id'] == user1
     assert out['email'] == email
@@ -422,7 +420,7 @@ def task(ctx, config):
     assert out['type'] == 'rgw'
     assert out['mfa_ids'] == []
     # TESTCASE 'info-existing','user','info','existing user query with wrong uid but correct access key','returns correct info'
-    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'info'], {'access-key' : access_key, 'uid': 'uid_not_exist'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'info'], {'access-key' : access_key, 'uid': 'uid_not_exist'})
 
     assert out['user_id'] == user1
     assert out['email'] == email
@@ -453,29 +451,29 @@ def task(ctx, config):
     assert out['mfa_ids'] == []
 
     # TESTCASES for cap user-info-without-keys
-    test_cap_user_info_without_keys(ctx, client, admin_conn, admin_user, user1)
+    test_cap_user_info_without_keys(ctx, client, endpoint, admin_conn, admin_user, user1)
 
     # TESTCASE 'suspend-ok','user','suspend','active user','succeeds'
-    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'modify'], {'uid' : user1, 'suspended' : True})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'modify'], {'uid' : user1, 'suspended' : True})
     assert ret == 200
 
     # TESTCASE 'suspend-suspended','user','suspend','suspended user','succeeds w/advisory'
-    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'info'], {'uid' : user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'info'], {'uid' : user1})
     assert ret == 200
     assert out['suspended']
     assert out['email'] == email
 
     # TESTCASE 're-enable','user','enable','suspended user','succeeds'
-    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'modify'], {'uid' : user1, 'suspended' : 'false'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'modify'], {'uid' : user1, 'suspended' : 'false'})
     assert not err
 
     # TESTCASE 'info-re-enabled','user','info','re-enabled user','no longer suspended'
-    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'info'], {'uid' : user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'info'], {'uid' : user1})
     assert ret == 200
     assert not out['suspended']
 
     # TESTCASE 'add-keys','key','create','w/valid info','succeeds'
-    (ret, out) = rgwadmin_rest(admin_conn,
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn,
             ['key', 'create'],
             {'uid' : user1,
              'access-key' : access_key2,
@@ -486,14 +484,14 @@ def task(ctx, config):
     assert ret == 200
 
     # TESTCASE 'info-new-key','user','info','after key addition','returns all keys'
-    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'info'], {'uid' : user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'info'], {'uid' : user1})
     assert ret == 200
     assert len(out['keys']) == 2
     assert out['keys'][0]['access_key'] == access_key2 or out['keys'][1]['access_key'] == access_key2
     assert out['keys'][0]['secret_key'] == secret_key2 or out['keys'][1]['secret_key'] == secret_key2
 
     # TESTCASE 'rm-key','key','rm','newly added key','succeeds, key is removed'
-    (ret, out) = rgwadmin_rest(admin_conn,
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn,
             ['key', 'rm'],
             {'uid' : user1,
              'access-key' : access_key2
@@ -501,14 +499,14 @@ def task(ctx, config):
 
     assert ret == 200
 
-    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'info'], {'uid' : user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'info'], {'uid' : user1})
 
     assert len(out['keys']) == 1
     assert out['keys'][0]['access_key'] == access_key
     assert out['keys'][0]['secret_key'] == secret_key
 
     # TESTCASE 'add-swift-key','key','create','swift key','succeeds'
-    (ret, out) = rgwadmin_rest(admin_conn,
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn,
             ['subuser', 'create'],
             {'subuser' : subuser1,
              'secret-key' : swift_secret1,
@@ -518,14 +516,14 @@ def task(ctx, config):
     assert ret == 200
 
     # TESTCASE 'info-swift-key','user','info','after key addition','returns all keys'
-    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'info'], {'uid' : user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'info'], {'uid' : user1})
     assert ret == 200
     assert len(out['swift_keys']) == 1
     assert out['swift_keys'][0]['user'] == subuser1
     assert out['swift_keys'][0]['secret_key'] == swift_secret1
 
     # TESTCASE 'add-swift-subuser','key','create','swift sub-user key','succeeds'
-    (ret, out) = rgwadmin_rest(admin_conn,
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn,
             ['subuser', 'create'],
             {'subuser' : subuser2,
              'secret-key' : swift_secret2,
@@ -535,14 +533,14 @@ def task(ctx, config):
     assert ret == 200
 
     # TESTCASE 'info-swift-subuser','user','info','after key addition','returns all sub-users/keys'
-    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'info'], {'uid' :  user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'info'], {'uid' :  user1})
     assert ret == 200
     assert len(out['swift_keys']) == 2
     assert out['swift_keys'][0]['user'] == subuser2 or out['swift_keys'][1]['user'] == subuser2
     assert out['swift_keys'][0]['secret_key'] == swift_secret2 or out['swift_keys'][1]['secret_key'] == swift_secret2
 
     # TESTCASE 'rm-swift-key1','key','rm','subuser','succeeds, one key is removed'
-    (ret, out) = rgwadmin_rest(admin_conn,
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn,
             ['key', 'rm'],
             {'subuser' : subuser1,
              'key-type' :'swift'
@@ -550,22 +548,22 @@ def task(ctx, config):
 
     assert ret == 200
 
-    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'info'], {'uid' :  user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'info'], {'uid' :  user1})
     assert len(out['swift_keys']) == 1
 
     # TESTCASE 'rm-subuser','subuser','rm','subuser','success, subuser is removed'
-    (ret, out) = rgwadmin_rest(admin_conn,
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn,
             ['subuser', 'rm'],
             {'subuser' : subuser1
             })
 
     assert ret == 200
 
-    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'info'], {'uid' :  user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'info'], {'uid' :  user1})
     assert len(out['subusers']) == 1
 
     # TESTCASE 'rm-subuser-with-keys','subuser','rm','subuser','succeeds, second subser and key is removed'
-    (ret, out) = rgwadmin_rest(admin_conn,
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn,
             ['subuser', 'rm'],
             {'subuser' : subuser2,
              'key-type' : 'swift',
@@ -574,12 +572,12 @@ def task(ctx, config):
 
     assert ret == 200
 
-    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'info'], {'uid' :  user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'info'], {'uid' :  user1})
     assert len(out['swift_keys']) == 0
     assert len(out['subusers']) == 0
 
     # TESTCASE 'bucket-stats','bucket','info','no session/buckets','succeeds, empty list'
-    (ret, out) = rgwadmin_rest(admin_conn, ['bucket', 'info'], {'uid' :  user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['bucket', 'info'], {'uid' :  user1})
     assert ret == 200
     assert len(out) == 0
 
@@ -594,7 +592,7 @@ def task(ctx, config):
         )
 
     # TESTCASE 'bucket-stats2','bucket','stats','no buckets','succeeds, empty list'
-    (ret, out) = rgwadmin_rest(admin_conn, ['bucket', 'info'], {'uid' : user1, 'stats' : True})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['bucket', 'info'], {'uid' : user1, 'stats' : True})
     assert ret == 200
     assert len(out) == 0
 
@@ -602,13 +600,13 @@ def task(ctx, config):
     bucket = connection.create_bucket(bucket_name)
 
     # TESTCASE 'bucket-list','bucket','list','one bucket','succeeds, expected list'
-    (ret, out) = rgwadmin_rest(admin_conn, ['bucket', 'info'], {'uid' : user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['bucket', 'info'], {'uid' : user1})
     assert ret == 200
     assert len(out) == 1
     assert out[0] == bucket_name
 
     # TESTCASE 'bucket-stats3','bucket','stats','new empty bucket','succeeds, empty list'
-    (ret, out) = rgwadmin_rest(admin_conn,
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn,
             ['bucket', 'info'], {'bucket' : bucket_name, 'stats' : True})
 
     assert ret == 200
@@ -617,7 +615,7 @@ def task(ctx, config):
     bucket_id = out['id']
 
     # TESTCASE 'bucket-stats4','bucket','stats','new empty bucket','succeeds, expected bucket ID'
-    (ret, out) = rgwadmin_rest(admin_conn, ['bucket', 'info'], {'uid' : user1, 'stats' : True})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['bucket', 'info'], {'uid' : user1, 'stats' : True})
     assert ret == 200
     assert len(out) == 1
     assert out[0]['id'] == bucket_id    # does it return the same ID twice in a row?
@@ -627,14 +625,14 @@ def task(ctx, config):
     key.set_contents_from_string('one')
 
     # TESTCASE 'bucket-stats5','bucket','stats','after creating key','succeeds, lists one non-empty object'
-    (ret, out) = rgwadmin_rest(admin_conn, ['bucket', 'info'], {'bucket' : bucket_name, 'stats' : True})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['bucket', 'info'], {'bucket' : bucket_name, 'stats' : True})
     assert ret == 200
     assert out['id'] == bucket_id
     assert out['usage']['rgw.main']['num_objects'] == 1
     assert out['usage']['rgw.main']['size_kb'] > 0
 
     # TESTCASE 'bucket-stats6', 'bucket', 'stats', 'non-existent bucket', 'fails, 'bucket not found error'
-    (ret, out) = rgwadmin_rest(admin_conn, ['bucket', 'info'], {'bucket' : 'doesnotexist'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['bucket', 'info'], {'bucket' : 'doesnotexist'})
     assert ret == 404
     assert out['Code'] == 'NoSuchBucket'
 
@@ -642,12 +640,12 @@ def task(ctx, config):
     key.delete()
 
     # TESTCASE 'bucket unlink', 'bucket', 'unlink', 'unlink bucket from user', 'fails', 'access denied error'
-    (ret, out) = rgwadmin_rest(admin_conn, ['bucket', 'unlink'], {'uid' : user1, 'bucket' : bucket_name})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['bucket', 'unlink'], {'uid' : user1, 'bucket' : bucket_name})
 
     assert ret == 200
 
     # create a second user to link the bucket to
-    (ret, out) = rgwadmin_rest(admin_conn,
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn,
             ['user', 'create'],
             {'uid' : user2,
             'display-name' :  display_name2,
@@ -673,7 +671,7 @@ def task(ctx, config):
     key.delete()
 
     # link the bucket to another user
-    (ret, out) = rgwadmin_rest(admin_conn,
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn,
             ['bucket', 'link'],
             {'uid' : user2,
              'bucket' : bucket_name,
@@ -693,7 +691,7 @@ def task(ctx, config):
     assert denied
 
     # relink the bucket to the first user and delete the second user
-    (ret, out) = rgwadmin_rest(admin_conn,
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn,
             ['bucket', 'link'],
             {'uid' : user1,
              'bucket' : bucket_name,
@@ -701,7 +699,7 @@ def task(ctx, config):
             })
     assert ret == 200
 
-    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'rm'], {'uid' : user2})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'rm'], {'uid' : user2})
     assert ret == 200
 
     # TESTCASE 'object-rm', 'object', 'rm', 'remove object', 'succeeds, object is removed'
@@ -712,11 +710,11 @@ def task(ctx, config):
     key.set_contents_from_string(object_name)
 
     # now delete it
-    (ret, out) = rgwadmin_rest(admin_conn, ['object', 'rm'], {'bucket' : bucket_name, 'object' : object_name})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['object', 'rm'], {'bucket' : bucket_name, 'object' : object_name})
     assert ret == 200
 
     # TESTCASE 'bucket-stats6','bucket','stats','after deleting key','succeeds, lists one no objects'
-    (ret, out) = rgwadmin_rest(admin_conn, ['bucket', 'info'], {'bucket' : bucket_name, 'stats' : True})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['bucket', 'info'], {'bucket' : bucket_name, 'stats' : True})
     assert ret == 200
     assert out['id'] == bucket_id
     assert out['usage']['rgw.main']['num_objects'] == 0
@@ -736,7 +734,7 @@ def task(ctx, config):
     # need to wait for all usage data to get flushed, should take up to 30 seconds
     timestamp = time.time()
     while time.time() - timestamp <= (20 * 60):      # wait up to 20 minutes
-        (ret, out) = rgwadmin_rest(admin_conn, ['usage', 'show'], {'categories' : 'delete_obj'})  # last operation we did is delete obj, wait for it to flush
+        (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['usage', 'show'], {'categories' : 'delete_obj'})  # last operation we did is delete obj, wait for it to flush
 
         if get_user_successful_ops(out, user1) > 0:
             break
@@ -745,7 +743,7 @@ def task(ctx, config):
     assert time.time() - timestamp <= (20 * 60)
 
     # TESTCASE 'usage-show' 'usage' 'show' 'all usage' 'succeeds'
-    (ret, out) = rgwadmin_rest(admin_conn, ['usage', 'show'])
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['usage', 'show'])
     assert ret == 200
     assert len(out['entries']) > 0
     assert len(out['summary']) > 0
@@ -754,7 +752,7 @@ def task(ctx, config):
     assert total['successful_ops'] > 0
 
     # TESTCASE 'usage-show2' 'usage' 'show' 'user usage' 'succeeds'
-    (ret, out) = rgwadmin_rest(admin_conn, ['usage', 'show'], {'uid' : user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['usage', 'show'], {'uid' : user1})
     assert ret == 200
     assert len(out['entries']) > 0
     assert len(out['summary']) > 0
@@ -766,7 +764,7 @@ def task(ctx, config):
     # TESTCASE 'usage-show3' 'usage' 'show' 'user usage categories' 'succeeds'
     test_categories = ['create_bucket', 'put_obj', 'delete_obj', 'delete_bucket']
     for cat in test_categories:
-        (ret, out) = rgwadmin_rest(admin_conn, ['usage', 'show'], {'uid' : user1, 'categories' : cat})
+        (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['usage', 'show'], {'uid' : user1, 'categories' : cat})
         assert ret == 200
         assert len(out['summary']) > 0
         user_summary = out['summary'][0]
@@ -777,15 +775,15 @@ def task(ctx, config):
         assert entry['successful_ops'] > 0
 
     # TESTCASE 'usage-trim' 'usage' 'trim' 'user usage' 'succeeds, usage removed'
-    (ret, out) = rgwadmin_rest(admin_conn, ['usage', 'trim'], {'uid' : user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['usage', 'trim'], {'uid' : user1})
     assert ret == 200
-    (ret, out) = rgwadmin_rest(admin_conn, ['usage', 'show'], {'uid' : user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['usage', 'show'], {'uid' : user1})
     assert ret == 200
     assert len(out['entries']) == 0
     assert len(out['summary']) == 0
 
     # TESTCASE 'user-suspend2','user','suspend','existing user','succeeds'
-    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'modify'], {'uid' : user1, 'suspended' : True})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'modify'], {'uid' : user1, 'suspended' : True})
     assert ret == 200
 
     # TESTCASE 'user-suspend3','user','suspend','suspended user','cannot write objects'
@@ -796,7 +794,7 @@ def task(ctx, config):
         assert e.status == 403
 
     # TESTCASE 'user-renable2','user','enable','suspended user','succeeds'
-    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'modify'], {'uid' :  user1, 'suspended' : 'false'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'modify'], {'uid' :  user1, 'suspended' : 'false'})
     assert ret == 200
 
     # TESTCASE 'user-renable3','user','enable','reenabled user','can write objects'
@@ -815,7 +813,7 @@ def task(ctx, config):
     big_key.delete()
 
     # TESTCASE 'rm-user-buckets','user','rm','existing user','fails, still has buckets'
-    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'rm'], {'uid' : user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'rm'], {'uid' : user1})
     assert ret == 409
 
     # delete should fail because ``key`` still exists
@@ -837,14 +835,14 @@ def task(ctx, config):
     # should be private already but guarantee it
     key.set_acl('private')
 
-    (ret, out) = rgwadmin_rest(admin_conn, ['policy', 'show'], {'bucket' : bucket.name, 'object' : key.key})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['policy', 'show'], {'bucket' : bucket.name, 'object' : key.key})
     assert ret == 200
     assert len(out['acl']['grant_map']) == 1
 
     # add another grantee by making the object public read
     key.set_acl('public-read')
 
-    (ret, out) = rgwadmin_rest(admin_conn, ['policy', 'show'], {'bucket' : bucket.name, 'object' : key.key})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['policy', 'show'], {'bucket' : bucket.name, 'object' : key.key})
     assert ret == 200
     assert len(out['acl']['grant_map']) == 2
 
@@ -855,22 +853,22 @@ def task(ctx, config):
         key = boto.s3.key.Key(bucket)
         key.set_contents_from_string(key_name[i])
 
-    (ret, out) = rgwadmin_rest(admin_conn, ['bucket', 'rm'], {'bucket' : bucket_name, 'purge-objects' : True})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['bucket', 'rm'], {'bucket' : bucket_name, 'purge-objects' : True})
     assert ret == 200
 
     # TESTCASE 'rm-bucket', 'bucket', 'rm', 'non-existent bucket', 'correct error'
-    (ret, out) = rgwadmin_rest(admin_conn, ['bucket', 'rm'], {'bucket' : bucket_name})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['bucket', 'rm'], {'bucket' : bucket_name})
     assert ret == 404
     assert out['Code'] == 'NoSuchBucket'
 
     # TESTCASE 'caps-add', 'caps', 'add', 'add user cap', 'succeeds'
     caps = 'usage=read'
-    (ret, out) = rgwadmin_rest(admin_conn, ['caps', 'add'], {'uid' :  user1, 'user-caps' : caps})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['caps', 'add'], {'uid' :  user1, 'user-caps' : caps})
     assert ret == 200
     assert out[0]['perm'] == 'read'
 
     # TESTCASE 'caps-rm', 'caps', 'rm', 'remove existing cap from user', 'succeeds'
-    (ret, out) = rgwadmin_rest(admin_conn, ['caps', 'rm'], {'uid' :  user1, 'user-caps' : caps})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['caps', 'rm'], {'uid' :  user1, 'user-caps' : caps})
     assert ret == 200
     assert not out
 
@@ -878,7 +876,7 @@ def task(ctx, config):
     bucket = connection.create_bucket(bucket_name)
     key = boto.s3.key.Key(bucket)
 
-    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'rm'], {'uid' : user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'rm'], {'uid' : user1})
     assert ret == 409
 
     # TESTCASE 'rm-user2', 'user', 'rm', user with data', 'succeeds'
@@ -886,15 +884,15 @@ def task(ctx, config):
     key = boto.s3.key.Key(bucket)
     key.set_contents_from_string('twelve')
 
-    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'rm'], {'uid' : user1, 'purge-data' : True})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'rm'], {'uid' : user1, 'purge-data' : True})
     assert ret == 200
 
     # TESTCASE 'rm-user3','user','info','deleted user','fails'
-    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'info'], {'uid' :  user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'info'], {'uid' :  user1})
     assert ret == 404
 
     # TESTCASE 'info' 'display info' 'succeeds'
-    (ret, out) = rgwadmin_rest(admin_conn, ['info', ''])
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['info', ''])
     assert ret == 200
     info = out['info']
     backends = info['storage_backends']
@@ -907,7 +905,7 @@ def task(ctx, config):
     assert len(fsid) > 0
     
     # TESTCASE 'ratelimit' 'user' 'info' 'succeeds'
-    (ret, out) = rgwadmin_rest(admin_conn,
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn,
         ['user', 'create'],
         {'uid' : ratelimit_user,
          'display-name' :  display_name1,
@@ -916,69 +914,69 @@ def task(ctx, config):
          'secret-key' : secret_key,
          'max-buckets' : '1000'
         })
-    (ret, out) = rgwadmin_rest(admin_conn, ['ratelimit', 'info'], {'ratelimit-scope' : 'user', 'uid' : ratelimit_user})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'info'], {'ratelimit-scope' : 'user', 'uid' : ratelimit_user})
     assert ret == 200
 
     # TESTCASE 'ratelimit' 'user' 'info'  'not existing user' 'fails'
-    (ret, out) = rgwadmin_rest(admin_conn, ['ratelimit', 'info'], {'ratelimit-scope' : 'user', 'uid' : ratelimit_user + 'string'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'info'], {'ratelimit-scope' : 'user', 'uid' : ratelimit_user + 'string'})
     assert ret == 404
 
     # TESTCASE 'ratelimit' 'user' 'info'  'uid not specified' 'fails'
-    (ret, out) = rgwadmin_rest(admin_conn, ['ratelimit', 'info'], {'ratelimit-scope' : 'user'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'info'], {'ratelimit-scope' : 'user'})
     assert ret == 400
 
     # TESTCASE 'ratelimit' 'bucket' 'info' 'succeeds'
     ratelimit_bucket = 'ratelimitbucket'
     connection.create_bucket(ratelimit_bucket)
-    (ret, out) = rgwadmin_rest(admin_conn, ['ratelimit', 'info'], {'ratelimit-scope' : 'bucket', 'bucket' : ratelimit_bucket})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'info'], {'ratelimit-scope' : 'bucket', 'bucket' : ratelimit_bucket})
     assert ret == 200
 
     # TESTCASE 'ratelimit' 'bucket' 'info'  'not existing bucket' 'fails'
-    (ret, out) = rgwadmin_rest(admin_conn, ['ratelimit', 'info'], {'ratelimit-scope' : 'bucket', 'bucket' : ratelimit_bucket + 'string'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'info'], {'ratelimit-scope' : 'bucket', 'bucket' : ratelimit_bucket + 'string'})
     assert ret == 404
 
     # TESTCASE 'ratelimit' 'bucket' 'info' 'bucket not specified' 'fails'
-    (ret, out) = rgwadmin_rest(admin_conn, ['ratelimit', 'info'], {'ratelimit-scope' : 'bucket'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'info'], {'ratelimit-scope' : 'bucket'})
     assert ret == 400
 
     # TESTCASE 'ratelimit' 'global' 'info' 'succeeds'
-    (ret, out) = rgwadmin_rest(admin_conn, ['ratelimit', 'info'], {'global' : 'true'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'info'], {'global' : 'true'})
     assert ret == 200
 
     # TESTCASE 'ratelimit' 'user' 'modify'  'not existing user' 'fails'
-    (ret, out) = rgwadmin_rest(admin_conn, ['ratelimit', 'modify'], {'ratelimit-scope' : 'user', 'uid' : ratelimit_user + 'string', 'enabled' : 'true'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'modify'], {'ratelimit-scope' : 'user', 'uid' : ratelimit_user + 'string', 'enabled' : 'true'})
     assert ret == 404
 
     # TESTCASE 'ratelimit' 'user' 'modify'  'uid not specified' 'fails'
-    (ret, out) = rgwadmin_rest(admin_conn, ['ratelimit', 'modify'], {'ratelimit-scope' : 'user'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'modify'], {'ratelimit-scope' : 'user'})
     assert ret == 400
     
     # TESTCASE 'ratelimit' 'bucket' 'modify'  'not existing bucket' 'fails'
-    (ret, out) = rgwadmin_rest(admin_conn, ['ratelimit', 'modify'], {'ratelimit-scope' : 'bucket', 'bucket' : ratelimit_bucket + 'string', 'enabled' : 'true'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'modify'], {'ratelimit-scope' : 'bucket', 'bucket' : ratelimit_bucket + 'string', 'enabled' : 'true'})
     assert ret == 404
 
     # TESTCASE 'ratelimit' 'bucket' 'modify' 'bucket not specified' 'fails'
-    (ret, out) = rgwadmin_rest(admin_conn, ['ratelimit', 'modify'], {'ratelimit-scope' : 'bucket', 'enabled' : 'true'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'modify'], {'ratelimit-scope' : 'bucket', 'enabled' : 'true'})
     assert ret == 400
 
     # TESTCASE 'ratelimit' 'user' 'modifiy' 'enabled' 'max-read-bytes = 2' 'succeeds'
-    (ret, out) = rgwadmin_rest(admin_conn, ['ratelimit', 'modify'], {'ratelimit-scope' : 'user', 'uid' : ratelimit_user, 'enabled' : 'true', 'max-read-bytes' : '2'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'modify'], {'ratelimit-scope' : 'user', 'uid' : ratelimit_user, 'enabled' : 'true', 'max-read-bytes' : '2'})
     assert ret == 200
-    (ret, out) = rgwadmin_rest(admin_conn, ['ratelimit', 'info'], {'ratelimit-scope' : 'user', 'uid' : ratelimit_user})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'info'], {'ratelimit-scope' : 'user', 'uid' : ratelimit_user})
     assert ret == 200
     user_ratelimit = out['user_ratelimit']
     assert user_ratelimit['enabled'] == True
     assert user_ratelimit['max_read_bytes'] ==  2
 
     # TESTCASE 'ratelimit' 'bucket' 'modifiy' 'enabled' 'max-write-bytes = 2' 'succeeds'
-    (ret, out) = rgwadmin_rest(admin_conn, ['ratelimit', 'modify'], {'ratelimit-scope' : 'bucket', 'bucket' : ratelimit_bucket, 'enabled' : 'true', 'max-write-bytes' : '2'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'modify'], {'ratelimit-scope' : 'bucket', 'bucket' : ratelimit_bucket, 'enabled' : 'true', 'max-write-bytes' : '2'})
     assert ret == 200
-    (ret, out) = rgwadmin_rest(admin_conn, ['ratelimit', 'info'], {'ratelimit-scope' : 'bucket', 'bucket' : ratelimit_bucket})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'info'], {'ratelimit-scope' : 'bucket', 'bucket' : ratelimit_bucket})
     assert ret == 200
     bucket_ratelimit = out['bucket_ratelimit']
     assert bucket_ratelimit['enabled'] == True
     assert bucket_ratelimit['max_write_bytes'] == 2
 
     # TESTCASE 'ratelimit' 'global' 'modify' 'anonymous' 'enabled' 'succeeds'
-    (ret, out) = rgwadmin_rest(admin_conn, ['ratelimit', 'modify'], {'ratelimit-scope' : 'bucket', 'global': 'true', 'enabled' : 'true'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'modify'], {'ratelimit-scope' : 'bucket', 'global': 'true', 'enabled' : 'true'})
     assert ret == 200

--- a/qa/tasks/radosgw_admin_rest.py
+++ b/qa/tasks/radosgw_admin_rest.py
@@ -9,21 +9,21 @@ To extract the inventory (in csv format) use the command:
 """
 import logging
 
-
-import boto.exception
-import boto.s3.connection
-import boto.s3.acl
-
 import requests
 import time
 
-from boto.connection import AWSAuthConnection
+import boto3
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+from botocore.credentials import Credentials
+from botocore.exceptions import ClientError
+
 from teuthology import misc as teuthology
 from tasks.util.rgw import get_user_summary, get_user_successful_ops, rgwadmin
 
 log = logging.getLogger(__name__)
 
-def rgwadmin_rest(endpoint, connection, cmd, params=None, headers=None, raw=False):
+def rgwadmin_rest(endpoint, creds, cmd, params=None, raw=False):
     """
     perform a rest command
     """
@@ -77,34 +77,24 @@ def rgwadmin_rest(endpoint, connection, cmd, params=None, headers=None, raw=Fals
             else:
                 return 'zone', cmd[0]
 
-    def build_admin_request(conn, method, resource = '', headers=None, data='',
-            query_args=None, params=None):
-        """
-        Build an administative request adapted from the build_request()
-        method of boto.connection
-        """
-
-        path = conn.calling_format.build_path_base('admin', resource)
-        auth_path = conn.calling_format.build_auth_path('admin', resource)
-        host = conn.calling_format.build_host(conn.server_name(), 'admin')
-        if query_args:
-            path += '?' + query_args
-            boto.log.debug('path=%s' % path)
-            auth_path += '?' + query_args
-            boto.log.debug('auth_path=%s' % auth_path)
-        return AWSAuthConnection.build_base_http_request(conn, method, path,
-                auth_path, params, headers, data, host)
+    def build_admin_request(endpoint, method, resource, query_args, other_params):
+        url = f'{endpoint.url()}admin/{resource}'
+        # subresource param, if given, must be inserted before others
+        params = {query_args: ''} if query_args else {}
+        if other_params:
+            params.update(other_params)
+        headers = {'x-amz-content-sha256': 'UNSIGNED-PAYLOAD'}
+        return AWSRequest(method=method, url=url, params=params, headers=headers)
 
     method, handler = get_cmd_method_and_handler(cmd)
     resource, query_args = get_resource(cmd)
-    request = build_admin_request(connection, method, resource,
-            query_args=query_args, headers=headers)
+    request = build_admin_request(endpoint, method, resource, query_args, params)
 
-    url = '{protocol}://{host}{path}'.format(protocol=request.protocol,
-            host=request.host, path=request.path)
+    auth = SigV4Auth(creds, 's3', 'us-east-1')
+    auth.add_auth(request)
 
-    request.authorize(connection=connection)
-    result = handler(url, params=params, headers=request.headers)
+    request = request.prepare()
+    result = handler(url=request.url, headers=request.headers)
 
     if raw:
         log.info(' text result: %s' % result.text)
@@ -133,16 +123,9 @@ def test_cap_user_info_without_keys_get_user_info_privileged_users(ctx, client, 
     logging.error(err)
     assert not err
 
-    privileged_user_conn = boto.s3.connection.S3Connection(
-        aws_access_key_id=access_key,
-        aws_secret_access_key=secret_key,
-        is_secure=True if endpoint.cert else False,
-        port=endpoint.port,
-        host=endpoint.hostname,
-        calling_format=boto.s3.connection.OrdinaryCallingFormat(),
-        )
+    privileged_creds = Credentials(access_key, secret_key)
 
-    (ret, out) = rgwadmin_rest(endpoint, privileged_user_conn, op, op_args)
+    (ret, out) = rgwadmin_rest(endpoint, privileged_creds, op, op_args)
     # show that even though the cap is set, since the user is privileged the user can still see keys
     assert len(out['keys']) == 1
     assert out['swift_keys'] == []
@@ -155,7 +138,7 @@ def test_cap_user_info_without_keys_get_user_info_privileged_users(ctx, client, 
     logging.error(err)
     assert not err
 
-def test_cap_user_info_without_keys_get_user_info(ctx, client, endpoint, admin_auth, admin_user, op, op_args):
+def test_cap_user_info_without_keys_get_user_info(ctx, client, endpoint, admin_creds, admin_user, op, op_args):
     true_admin_uid = 'a_user'
     true_admin_display_name = 'True Admin User'
     true_admin_access_key = 'true_admin_akey'
@@ -179,7 +162,7 @@ def test_cap_user_info_without_keys_get_user_info(ctx, client, endpoint, admin_a
     logging.error(err)
     assert not err
 
-    (ret, out) = rgwadmin_rest(endpoint, admin_auth, op, op_args)
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, op, op_args)
     assert 'keys' not in out
     assert 'swift_keys' not in out
 
@@ -193,7 +176,7 @@ def test_cap_user_info_without_keys_get_user_info(ctx, client, endpoint, admin_a
     logging.error(err)
     assert not err
 
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, op, op_args)
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, op, op_args)
     assert 'keys' not in out
     assert 'swift_keys' not in out
 
@@ -207,7 +190,7 @@ def test_cap_user_info_without_keys_get_user_info(ctx, client, endpoint, admin_a
     logging.error(err)
     assert not err
 
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, op, op_args)
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, op, op_args)
     assert 'keys' in out
     assert 'swift_keys' in out
 
@@ -230,7 +213,7 @@ def test_cap_user_info_without_keys_get_user_info(ctx, client, endpoint, admin_a
     logging.error(err)
     assert not err
 
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, op, op_args)
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, op, op_args)
     assert ret == 403
 
     # remove cap user-info-without-keys permenantly for future testing
@@ -253,7 +236,7 @@ def test_cap_user_info_without_keys_get_user_info(ctx, client, endpoint, admin_a
     logging.error(err)
     assert not err
 
-def test_cap_user_info_without_keys(ctx, client, endpoint, admin_conn, admin_user, user1):
+def test_cap_user_info_without_keys(ctx, client, endpoint, admin_creds, admin_user, user1):
     (err, out) = rgwadmin(ctx, client, [
             'caps', 'rm',
             '--uid', admin_user,
@@ -265,7 +248,7 @@ def test_cap_user_info_without_keys(ctx, client, endpoint, admin_conn, admin_use
 
     op = ['user', 'info']
     op_args = {'uid' : user1}
-    test_cap_user_info_without_keys_get_user_info(ctx, client, endpoint, admin_conn, admin_user, op, op_args)
+    test_cap_user_info_without_keys_get_user_info(ctx, client, endpoint, admin_creds, admin_user, op, op_args)
 
     # add caps that were removed earlier in the function back in
     (err, out) = rgwadmin(ctx, client, [
@@ -315,7 +298,7 @@ def task(ctx, config):
     access_key2 = 'p5YnriCv1nAtykxBrupQ'
     secret_key2 = 'Q8Tk6Q/27hfbFSYdSkPtUqhqx1GgzvpXa4WARozh'
     swift_secret1 = 'gpS2G9RREMrnbqlp29PP2D36kgPR1tm72n5fPYfL'
-    swift_secret2 = 'ri2VJQcKSYATOY6uaDUX7pxgkW+W1YmC6OCxPHwy'
+    swift_secret2 = 'ri2VJQcKSYATOY6uaDUX7pxgkWOW1YmC6OCxPHwy'
 
     bucket_name = 'myfoo'
 
@@ -339,21 +322,14 @@ def task(ctx, config):
     endpoint = ctx.rgw.role_endpoints.get(client)
     assert endpoint, 'no rgw endpoint for {}'.format(client)
 
-    admin_conn = boto.s3.connection.S3Connection(
-        aws_access_key_id=admin_access_key,
-        aws_secret_access_key=admin_secret_key,
-        is_secure=True if endpoint.cert else False,
-        port=endpoint.port,
-        host=endpoint.hostname,
-        calling_format=boto.s3.connection.OrdinaryCallingFormat(),
-        )
+    admin_creds = Credentials(admin_access_key, admin_secret_key)
 
     # TESTCASE 'info-nosuch','user','info','non-existent user','fails'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'info'], {"uid": user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'info'], {"uid": user1})
     assert ret == 404
 
     # TESTCASE 'create-ok','user','create','w/all valid info','succeeds'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn,
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds,
             ['user', 'create'],
             {'uid' : user1,
              'display-name' :  display_name1,
@@ -366,7 +342,7 @@ def task(ctx, config):
     assert ret == 200
 
     # TESTCASE 'list-no-user','user','list','list user keys','user list object'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'list'], {'list' : '', 'max-entries' : 0})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'list'], {'list' : '', 'max-entries' : 0})
     assert ret == 200
     assert out['count'] == 0
     assert out['truncated'] == True
@@ -374,7 +350,7 @@ def task(ctx, config):
     assert len(out['marker']) > 0
 
     # TESTCASE 'list-user-without-marker','user','list','list user keys','user list object'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'list'], {'list' : '', 'max-entries' : 1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'list'], {'list' : '', 'max-entries' : 1})
     assert ret == 200
     assert out['count'] == 1
     assert out['truncated'] == True
@@ -383,14 +359,14 @@ def task(ctx, config):
     marker = out['marker']
 
     # TESTCASE 'list-user-with-marker','user','list','list user keys','user list object'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'list'], {'list' : '', 'max-entries' : 1, 'marker': marker})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'list'], {'list' : '', 'max-entries' : 1, 'marker': marker})
     assert ret == 200
     assert out['count'] == 1
     assert out['truncated'] == False
     assert len(out['keys']) == 1
 
     # TESTCASE 'info-existing','user','info','existing user','returns correct info'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'info'], {'uid' : user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'info'], {'uid' : user1})
 
     assert out['user_id'] == user1
     assert out['email'] == email
@@ -420,7 +396,7 @@ def task(ctx, config):
     assert out['type'] == 'rgw'
     assert out['mfa_ids'] == []
     # TESTCASE 'info-existing','user','info','existing user query with wrong uid but correct access key','returns correct info'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'info'], {'access-key' : access_key, 'uid': 'uid_not_exist'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'info'], {'access-key' : access_key, 'uid': 'uid_not_exist'})
 
     assert out['user_id'] == user1
     assert out['email'] == email
@@ -451,29 +427,29 @@ def task(ctx, config):
     assert out['mfa_ids'] == []
 
     # TESTCASES for cap user-info-without-keys
-    test_cap_user_info_without_keys(ctx, client, endpoint, admin_conn, admin_user, user1)
+    test_cap_user_info_without_keys(ctx, client, endpoint, admin_creds, admin_user, user1)
 
     # TESTCASE 'suspend-ok','user','suspend','active user','succeeds'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'modify'], {'uid' : user1, 'suspended' : True})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'modify'], {'uid' : user1, 'suspended' : True})
     assert ret == 200
 
     # TESTCASE 'suspend-suspended','user','suspend','suspended user','succeeds w/advisory'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'info'], {'uid' : user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'info'], {'uid' : user1})
     assert ret == 200
     assert out['suspended']
     assert out['email'] == email
 
     # TESTCASE 're-enable','user','enable','suspended user','succeeds'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'modify'], {'uid' : user1, 'suspended' : 'false'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'modify'], {'uid' : user1, 'suspended' : 'false'})
     assert not err
 
     # TESTCASE 'info-re-enabled','user','info','re-enabled user','no longer suspended'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'info'], {'uid' : user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'info'], {'uid' : user1})
     assert ret == 200
     assert not out['suspended']
 
     # TESTCASE 'add-keys','key','create','w/valid info','succeeds'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn,
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds,
             ['key', 'create'],
             {'uid' : user1,
              'access-key' : access_key2,
@@ -484,14 +460,14 @@ def task(ctx, config):
     assert ret == 200
 
     # TESTCASE 'info-new-key','user','info','after key addition','returns all keys'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'info'], {'uid' : user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'info'], {'uid' : user1})
     assert ret == 200
     assert len(out['keys']) == 2
     assert out['keys'][0]['access_key'] == access_key2 or out['keys'][1]['access_key'] == access_key2
     assert out['keys'][0]['secret_key'] == secret_key2 or out['keys'][1]['secret_key'] == secret_key2
 
     # TESTCASE 'rm-key','key','rm','newly added key','succeeds, key is removed'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn,
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds,
             ['key', 'rm'],
             {'uid' : user1,
              'access-key' : access_key2
@@ -499,14 +475,14 @@ def task(ctx, config):
 
     assert ret == 200
 
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'info'], {'uid' : user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'info'], {'uid' : user1})
 
     assert len(out['keys']) == 1
     assert out['keys'][0]['access_key'] == access_key
     assert out['keys'][0]['secret_key'] == secret_key
 
     # TESTCASE 'add-swift-key','key','create','swift key','succeeds'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn,
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds,
             ['subuser', 'create'],
             {'subuser' : subuser1,
              'secret-key' : swift_secret1,
@@ -516,14 +492,14 @@ def task(ctx, config):
     assert ret == 200
 
     # TESTCASE 'info-swift-key','user','info','after key addition','returns all keys'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'info'], {'uid' : user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'info'], {'uid' : user1})
     assert ret == 200
     assert len(out['swift_keys']) == 1
     assert out['swift_keys'][0]['user'] == subuser1
     assert out['swift_keys'][0]['secret_key'] == swift_secret1
 
     # TESTCASE 'add-swift-subuser','key','create','swift sub-user key','succeeds'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn,
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds,
             ['subuser', 'create'],
             {'subuser' : subuser2,
              'secret-key' : swift_secret2,
@@ -533,14 +509,14 @@ def task(ctx, config):
     assert ret == 200
 
     # TESTCASE 'info-swift-subuser','user','info','after key addition','returns all sub-users/keys'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'info'], {'uid' :  user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'info'], {'uid' :  user1})
     assert ret == 200
     assert len(out['swift_keys']) == 2
     assert out['swift_keys'][0]['user'] == subuser2 or out['swift_keys'][1]['user'] == subuser2
     assert out['swift_keys'][0]['secret_key'] == swift_secret2 or out['swift_keys'][1]['secret_key'] == swift_secret2
 
     # TESTCASE 'rm-swift-key1','key','rm','subuser','succeeds, one key is removed'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn,
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds,
             ['key', 'rm'],
             {'subuser' : subuser1,
              'key-type' :'swift'
@@ -548,22 +524,22 @@ def task(ctx, config):
 
     assert ret == 200
 
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'info'], {'uid' :  user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'info'], {'uid' :  user1})
     assert len(out['swift_keys']) == 1
 
     # TESTCASE 'rm-subuser','subuser','rm','subuser','success, subuser is removed'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn,
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds,
             ['subuser', 'rm'],
             {'subuser' : subuser1
             })
 
     assert ret == 200
 
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'info'], {'uid' :  user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'info'], {'uid' :  user1})
     assert len(out['subusers']) == 1
 
     # TESTCASE 'rm-subuser-with-keys','subuser','rm','subuser','succeeds, second subser and key is removed'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn,
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds,
             ['subuser', 'rm'],
             {'subuser' : subuser2,
              'key-type' : 'swift',
@@ -572,41 +548,38 @@ def task(ctx, config):
 
     assert ret == 200
 
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'info'], {'uid' :  user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'info'], {'uid' :  user1})
     assert len(out['swift_keys']) == 0
     assert len(out['subusers']) == 0
 
     # TESTCASE 'bucket-stats','bucket','info','no session/buckets','succeeds, empty list'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['bucket', 'info'], {'uid' :  user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['bucket', 'info'], {'uid' :  user1})
     assert ret == 200
     assert len(out) == 0
 
     # connect to rgw
-    connection = boto.s3.connection.S3Connection(
-        aws_access_key_id=access_key,
-        aws_secret_access_key=secret_key,
-        is_secure=True if endpoint.cert else False,
-        port=endpoint.port,
-        host=endpoint.hostname,
-        calling_format=boto.s3.connection.OrdinaryCallingFormat(),
-        )
+    connection = boto3.client(service_name='s3',
+                              aws_access_key_id=access_key,
+                              aws_secret_access_key=secret_key,
+                              endpoint_url=endpoint.url(),
+                              use_ssl=False)
 
     # TESTCASE 'bucket-stats2','bucket','stats','no buckets','succeeds, empty list'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['bucket', 'info'], {'uid' : user1, 'stats' : True})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['bucket', 'info'], {'uid' : user1, 'stats' : True})
     assert ret == 200
     assert len(out) == 0
 
     # create a first bucket
-    bucket = connection.create_bucket(bucket_name)
+    connection.create_bucket(Bucket=bucket_name)
 
     # TESTCASE 'bucket-list','bucket','list','one bucket','succeeds, expected list'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['bucket', 'info'], {'uid' : user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['bucket', 'info'], {'uid' : user1})
     assert ret == 200
     assert len(out) == 1
     assert out[0] == bucket_name
 
     # TESTCASE 'bucket-stats3','bucket','stats','new empty bucket','succeeds, empty list'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn,
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds,
             ['bucket', 'info'], {'bucket' : bucket_name, 'stats' : True})
 
     assert ret == 200
@@ -615,37 +588,36 @@ def task(ctx, config):
     bucket_id = out['id']
 
     # TESTCASE 'bucket-stats4','bucket','stats','new empty bucket','succeeds, expected bucket ID'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['bucket', 'info'], {'uid' : user1, 'stats' : True})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['bucket', 'info'], {'uid' : user1, 'stats' : True})
     assert ret == 200
     assert len(out) == 1
     assert out[0]['id'] == bucket_id    # does it return the same ID twice in a row?
 
     # use some space
-    key = boto.s3.key.Key(bucket)
-    key.set_contents_from_string('one')
+    connection.put_object(Bucket=bucket_name, Key='one', Body='one')
 
     # TESTCASE 'bucket-stats5','bucket','stats','after creating key','succeeds, lists one non-empty object'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['bucket', 'info'], {'bucket' : bucket_name, 'stats' : True})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['bucket', 'info'], {'bucket' : bucket_name, 'stats' : True})
     assert ret == 200
     assert out['id'] == bucket_id
     assert out['usage']['rgw.main']['num_objects'] == 1
     assert out['usage']['rgw.main']['size_kb'] > 0
 
     # TESTCASE 'bucket-stats6', 'bucket', 'stats', 'non-existent bucket', 'fails, 'bucket not found error'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['bucket', 'info'], {'bucket' : 'doesnotexist'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['bucket', 'info'], {'bucket' : 'doesnotexist'})
     assert ret == 404
     assert out['Code'] == 'NoSuchBucket'
 
     # reclaim it
-    key.delete()
+    connection.delete_object(Bucket=bucket_name, Key='one')
 
     # TESTCASE 'bucket unlink', 'bucket', 'unlink', 'unlink bucket from user', 'fails', 'access denied error'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['bucket', 'unlink'], {'uid' : user1, 'bucket' : bucket_name})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['bucket', 'unlink'], {'uid' : user1, 'bucket' : bucket_name})
 
     assert ret == 200
 
     # create a second user to link the bucket to
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn,
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds,
             ['user', 'create'],
             {'uid' : user2,
             'display-name' :  display_name2,
@@ -658,20 +630,19 @@ def task(ctx, config):
 
     # try creating an object with the first user before the bucket is relinked
     denied = False
-    key = boto.s3.key.Key(bucket)
 
     try:
-        key.set_contents_from_string('two')
-    except boto.exception.S3ResponseError:
+        connection.put_object(Bucket=bucket_name, Key='two', Body='two')
+    except ClientError:
         denied = True
 
     assert not denied
 
     # delete the object
-    key.delete()
+    connection.delete_object(Bucket=bucket_name, Key='two')
 
     # link the bucket to another user
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn,
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds,
             ['bucket', 'link'],
             {'uid' : user2,
              'bucket' : bucket_name,
@@ -681,17 +652,15 @@ def task(ctx, config):
     assert ret == 200
 
     # try creating an object with the first user which should cause an error
-    key = boto.s3.key.Key(bucket)
-
     try:
-        key.set_contents_from_string('three')
-    except boto.exception.S3ResponseError:
+        connection.put_object(Bucket=bucket_name, Key='three', Body='three')
+    except ClientError:
         denied = True
 
     assert denied
 
     # relink the bucket to the first user and delete the second user
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn,
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds,
             ['bucket', 'link'],
             {'uid' : user1,
              'bucket' : bucket_name,
@@ -699,34 +668,33 @@ def task(ctx, config):
             })
     assert ret == 200
 
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'rm'], {'uid' : user2})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'rm'], {'uid' : user2})
     assert ret == 200
 
     # TESTCASE 'object-rm', 'object', 'rm', 'remove object', 'succeeds, object is removed'
 
     # upload an object
-    object_name = 'four'
-    key = boto.s3.key.Key(bucket, object_name)
-    key.set_contents_from_string(object_name)
+    key = 'four'
+    connection.put_object(Bucket=bucket_name, Key=key, Body=key)
 
     # now delete it
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['object', 'rm'], {'bucket' : bucket_name, 'object' : object_name})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['object', 'rm'], {'bucket' : bucket_name, 'object' : key})
     assert ret == 200
 
     # TESTCASE 'bucket-stats6','bucket','stats','after deleting key','succeeds, lists one no objects'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['bucket', 'info'], {'bucket' : bucket_name, 'stats' : True})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['bucket', 'info'], {'bucket' : bucket_name, 'stats' : True})
     assert ret == 200
     assert out['id'] == bucket_id
     assert out['usage']['rgw.main']['num_objects'] == 0
 
     # create a bucket for deletion stats
-    useless_bucket = connection.create_bucket('useless-bucket')
-    useless_key = useless_bucket.new_key('useless_key')
-    useless_key.set_contents_from_string('useless string')
+    useless_bucket = 'useless-bucket'
+    connection.create_bucket(Bucket=useless_bucket)
+    connection.put_object(Bucket=useless_bucket, Key='useless_key', Body='useless string')
 
     # delete it
-    useless_key.delete()
-    useless_bucket.delete()
+    connection.delete_object(Bucket=useless_bucket, Key='useless_key')
+    connection.delete_bucket(Bucket=useless_bucket)
 
     # wait for the statistics to flush
     time.sleep(60)
@@ -734,7 +702,7 @@ def task(ctx, config):
     # need to wait for all usage data to get flushed, should take up to 30 seconds
     timestamp = time.time()
     while time.time() - timestamp <= (20 * 60):      # wait up to 20 minutes
-        (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['usage', 'show'], {'categories' : 'delete_obj'})  # last operation we did is delete obj, wait for it to flush
+        (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['usage', 'show'], {'categories' : 'delete_obj'})  # last operation we did is delete obj, wait for it to flush
 
         if get_user_successful_ops(out, user1) > 0:
             break
@@ -743,7 +711,7 @@ def task(ctx, config):
     assert time.time() - timestamp <= (20 * 60)
 
     # TESTCASE 'usage-show' 'usage' 'show' 'all usage' 'succeeds'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['usage', 'show'])
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['usage', 'show'])
     assert ret == 200
     assert len(out['entries']) > 0
     assert len(out['summary']) > 0
@@ -752,7 +720,7 @@ def task(ctx, config):
     assert total['successful_ops'] > 0
 
     # TESTCASE 'usage-show2' 'usage' 'show' 'user usage' 'succeeds'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['usage', 'show'], {'uid' : user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['usage', 'show'], {'uid' : user1})
     assert ret == 200
     assert len(out['entries']) > 0
     assert len(out['summary']) > 0
@@ -764,7 +732,7 @@ def task(ctx, config):
     # TESTCASE 'usage-show3' 'usage' 'show' 'user usage categories' 'succeeds'
     test_categories = ['create_bucket', 'put_obj', 'delete_obj', 'delete_bucket']
     for cat in test_categories:
-        (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['usage', 'show'], {'uid' : user1, 'categories' : cat})
+        (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['usage', 'show'], {'uid' : user1, 'categories' : cat})
         assert ret == 200
         assert len(out['summary']) > 0
         user_summary = out['summary'][0]
@@ -775,124 +743,113 @@ def task(ctx, config):
         assert entry['successful_ops'] > 0
 
     # TESTCASE 'usage-trim' 'usage' 'trim' 'user usage' 'succeeds, usage removed'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['usage', 'trim'], {'uid' : user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['usage', 'trim'], {'uid' : user1})
     assert ret == 200
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['usage', 'show'], {'uid' : user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['usage', 'show'], {'uid' : user1})
     assert ret == 200
     assert len(out['entries']) == 0
     assert len(out['summary']) == 0
 
     # TESTCASE 'user-suspend2','user','suspend','existing user','succeeds'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'modify'], {'uid' : user1, 'suspended' : True})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'modify'], {'uid' : user1, 'suspended' : True})
     assert ret == 200
 
     # TESTCASE 'user-suspend3','user','suspend','suspended user','cannot write objects'
     try:
-        key = boto.s3.key.Key(bucket)
-        key.set_contents_from_string('five')
-    except boto.exception.S3ResponseError as e:
-        assert e.status == 403
+        connection.put_object(Bucket=bucket_name, Key='five', Body='five')
+    except ClientError as e:
+        assert e.response['ResponseMetadata']['HTTPStatusCode'] == 403
 
     # TESTCASE 'user-renable2','user','enable','suspended user','succeeds'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'modify'], {'uid' :  user1, 'suspended' : 'false'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'modify'], {'uid' :  user1, 'suspended' : 'false'})
     assert ret == 200
 
     # TESTCASE 'user-renable3','user','enable','reenabled user','can write objects'
-    key = boto.s3.key.Key(bucket)
-    key.set_contents_from_string('six')
+    connection.put_object(Bucket=bucket_name, Key='six', Body='six')
 
     # TESTCASE 'garbage-list', 'garbage', 'list', 'get list of objects ready for garbage collection'
 
     # create an object large enough to be split into multiple parts
     test_string = 'foo'*10000000
-
-    big_key = boto.s3.key.Key(bucket)
-    big_key.set_contents_from_string(test_string)
+    connection.put_object(Bucket=bucket_name, Key='big', Body=test_string)
 
     # now delete the head
-    big_key.delete()
+    connection.delete_object(Bucket=bucket_name, Key='big')
 
     # TESTCASE 'rm-user-buckets','user','rm','existing user','fails, still has buckets'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'rm'], {'uid' : user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'rm'], {'uid' : user1})
     assert ret == 409
 
-    # delete should fail because ``key`` still exists
+    # delete should fail because ``six`` still exists
     try:
-        bucket.delete()
-    except boto.exception.S3ResponseError as e:
-        assert e.status == 409
+        connection.delete_bucket(Bucket=bucket_name)
+    except ClientError as e:
+        assert e.response['ResponseMetadata']['HTTPStatusCode'] == 409
 
-    key.delete()
-    bucket.delete()
+    connection.delete_object(Bucket=bucket_name, Key='six')
+    connection.delete_bucket(Bucket=bucket_name)
 
     # TESTCASE 'policy', 'bucket', 'policy', 'get bucket policy', 'returns S3 policy'
-    bucket = connection.create_bucket(bucket_name)
+    connection.create_bucket(Bucket=bucket_name)
 
     # create an object
-    key = boto.s3.key.Key(bucket)
-    key.set_contents_from_string('seven')
+    key = 'seven'
+    connection.put_object(Bucket=bucket_name, Key=key, Body=key, ACL='private')
 
-    # should be private already but guarantee it
-    key.set_acl('private')
-
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['policy', 'show'], {'bucket' : bucket.name, 'object' : key.key})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['policy', 'show'], {'bucket' : bucket_name, 'object' : key})
     assert ret == 200
     assert len(out['acl']['grant_map']) == 1
 
     # add another grantee by making the object public read
-    key.set_acl('public-read')
+    connection.put_object_acl(Bucket=bucket_name, Key=key, ACL='public-read')
 
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['policy', 'show'], {'bucket' : bucket.name, 'object' : key.key})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['policy', 'show'], {'bucket' : bucket_name, 'object' : key})
     assert ret == 200
     assert len(out['acl']['grant_map']) == 2
 
     # TESTCASE 'rm-bucket', 'bucket', 'rm', 'bucket with objects', 'succeeds'
-    bucket = connection.create_bucket(bucket_name)
-    key_name = ['eight', 'nine', 'ten', 'eleven']
-    for i in range(4):
-        key = boto.s3.key.Key(bucket)
-        key.set_contents_from_string(key_name[i])
+    connection.create_bucket(Bucket=bucket_name)
+    for key in ['eight', 'nine', 'ten', 'eleven']:
+        connection.put_object(Bucket=bucket_name, Key=key, Body=key)
 
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['bucket', 'rm'], {'bucket' : bucket_name, 'purge-objects' : True})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['bucket', 'rm'], {'bucket' : bucket_name, 'purge-objects' : True})
     assert ret == 200
 
     # TESTCASE 'rm-bucket', 'bucket', 'rm', 'non-existent bucket', 'correct error'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['bucket', 'rm'], {'bucket' : bucket_name})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['bucket', 'rm'], {'bucket' : bucket_name})
     assert ret == 404
     assert out['Code'] == 'NoSuchBucket'
 
     # TESTCASE 'caps-add', 'caps', 'add', 'add user cap', 'succeeds'
     caps = 'usage=read'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['caps', 'add'], {'uid' :  user1, 'user-caps' : caps})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['caps', 'add'], {'uid' :  user1, 'user-caps' : caps})
     assert ret == 200
     assert out[0]['perm'] == 'read'
 
     # TESTCASE 'caps-rm', 'caps', 'rm', 'remove existing cap from user', 'succeeds'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['caps', 'rm'], {'uid' :  user1, 'user-caps' : caps})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['caps', 'rm'], {'uid' :  user1, 'user-caps' : caps})
     assert ret == 200
     assert not out
 
     # TESTCASE 'rm-user','user','rm','existing user','fails, still has buckets'
-    bucket = connection.create_bucket(bucket_name)
-    key = boto.s3.key.Key(bucket)
+    connection.create_bucket(Bucket=bucket_name)
 
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'rm'], {'uid' : user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'rm'], {'uid' : user1})
     assert ret == 409
 
     # TESTCASE 'rm-user2', 'user', 'rm', user with data', 'succeeds'
-    bucket = connection.create_bucket(bucket_name)
-    key = boto.s3.key.Key(bucket)
-    key.set_contents_from_string('twelve')
+    connection.create_bucket(Bucket=bucket_name)
+    connection.put_object(Bucket=bucket_name, Key='twelve', Body='twelve')
 
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'rm'], {'uid' : user1, 'purge-data' : True})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'rm'], {'uid' : user1, 'purge-data' : True})
     assert ret == 200
 
     # TESTCASE 'rm-user3','user','info','deleted user','fails'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['user', 'info'], {'uid' :  user1})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'info'], {'uid' :  user1})
     assert ret == 404
 
     # TESTCASE 'info' 'display info' 'succeeds'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['info', ''])
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['info', ''])
     assert ret == 200
     info = out['info']
     backends = info['storage_backends']
@@ -905,7 +862,7 @@ def task(ctx, config):
     assert len(fsid) > 0
     
     # TESTCASE 'ratelimit' 'user' 'info' 'succeeds'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn,
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds,
         ['user', 'create'],
         {'uid' : ratelimit_user,
          'display-name' :  display_name1,
@@ -914,69 +871,69 @@ def task(ctx, config):
          'secret-key' : secret_key,
          'max-buckets' : '1000'
         })
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'info'], {'ratelimit-scope' : 'user', 'uid' : ratelimit_user})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['ratelimit', 'info'], {'ratelimit-scope' : 'user', 'uid' : ratelimit_user})
     assert ret == 200
 
     # TESTCASE 'ratelimit' 'user' 'info'  'not existing user' 'fails'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'info'], {'ratelimit-scope' : 'user', 'uid' : ratelimit_user + 'string'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['ratelimit', 'info'], {'ratelimit-scope' : 'user', 'uid' : ratelimit_user + 'string'})
     assert ret == 404
 
     # TESTCASE 'ratelimit' 'user' 'info'  'uid not specified' 'fails'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'info'], {'ratelimit-scope' : 'user'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['ratelimit', 'info'], {'ratelimit-scope' : 'user'})
     assert ret == 400
 
     # TESTCASE 'ratelimit' 'bucket' 'info' 'succeeds'
     ratelimit_bucket = 'ratelimitbucket'
-    connection.create_bucket(ratelimit_bucket)
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'info'], {'ratelimit-scope' : 'bucket', 'bucket' : ratelimit_bucket})
+    connection.create_bucket(Bucket=ratelimit_bucket)
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['ratelimit', 'info'], {'ratelimit-scope' : 'bucket', 'bucket' : ratelimit_bucket})
     assert ret == 200
 
     # TESTCASE 'ratelimit' 'bucket' 'info'  'not existing bucket' 'fails'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'info'], {'ratelimit-scope' : 'bucket', 'bucket' : ratelimit_bucket + 'string'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['ratelimit', 'info'], {'ratelimit-scope' : 'bucket', 'bucket' : ratelimit_bucket + 'string'})
     assert ret == 404
 
     # TESTCASE 'ratelimit' 'bucket' 'info' 'bucket not specified' 'fails'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'info'], {'ratelimit-scope' : 'bucket'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['ratelimit', 'info'], {'ratelimit-scope' : 'bucket'})
     assert ret == 400
 
     # TESTCASE 'ratelimit' 'global' 'info' 'succeeds'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'info'], {'global' : 'true'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['ratelimit', 'info'], {'global' : 'true'})
     assert ret == 200
 
     # TESTCASE 'ratelimit' 'user' 'modify'  'not existing user' 'fails'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'modify'], {'ratelimit-scope' : 'user', 'uid' : ratelimit_user + 'string', 'enabled' : 'true'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['ratelimit', 'modify'], {'ratelimit-scope' : 'user', 'uid' : ratelimit_user + 'string', 'enabled' : 'true'})
     assert ret == 404
 
     # TESTCASE 'ratelimit' 'user' 'modify'  'uid not specified' 'fails'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'modify'], {'ratelimit-scope' : 'user'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['ratelimit', 'modify'], {'ratelimit-scope' : 'user'})
     assert ret == 400
     
     # TESTCASE 'ratelimit' 'bucket' 'modify'  'not existing bucket' 'fails'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'modify'], {'ratelimit-scope' : 'bucket', 'bucket' : ratelimit_bucket + 'string', 'enabled' : 'true'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['ratelimit', 'modify'], {'ratelimit-scope' : 'bucket', 'bucket' : ratelimit_bucket + 'string', 'enabled' : 'true'})
     assert ret == 404
 
     # TESTCASE 'ratelimit' 'bucket' 'modify' 'bucket not specified' 'fails'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'modify'], {'ratelimit-scope' : 'bucket', 'enabled' : 'true'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['ratelimit', 'modify'], {'ratelimit-scope' : 'bucket', 'enabled' : 'true'})
     assert ret == 400
 
     # TESTCASE 'ratelimit' 'user' 'modifiy' 'enabled' 'max-read-bytes = 2' 'succeeds'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'modify'], {'ratelimit-scope' : 'user', 'uid' : ratelimit_user, 'enabled' : 'true', 'max-read-bytes' : '2'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['ratelimit', 'modify'], {'ratelimit-scope' : 'user', 'uid' : ratelimit_user, 'enabled' : 'true', 'max-read-bytes' : '2'})
     assert ret == 200
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'info'], {'ratelimit-scope' : 'user', 'uid' : ratelimit_user})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['ratelimit', 'info'], {'ratelimit-scope' : 'user', 'uid' : ratelimit_user})
     assert ret == 200
     user_ratelimit = out['user_ratelimit']
     assert user_ratelimit['enabled'] == True
     assert user_ratelimit['max_read_bytes'] ==  2
 
     # TESTCASE 'ratelimit' 'bucket' 'modifiy' 'enabled' 'max-write-bytes = 2' 'succeeds'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'modify'], {'ratelimit-scope' : 'bucket', 'bucket' : ratelimit_bucket, 'enabled' : 'true', 'max-write-bytes' : '2'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['ratelimit', 'modify'], {'ratelimit-scope' : 'bucket', 'bucket' : ratelimit_bucket, 'enabled' : 'true', 'max-write-bytes' : '2'})
     assert ret == 200
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'info'], {'ratelimit-scope' : 'bucket', 'bucket' : ratelimit_bucket})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['ratelimit', 'info'], {'ratelimit-scope' : 'bucket', 'bucket' : ratelimit_bucket})
     assert ret == 200
     bucket_ratelimit = out['bucket_ratelimit']
     assert bucket_ratelimit['enabled'] == True
     assert bucket_ratelimit['max_write_bytes'] == 2
 
     # TESTCASE 'ratelimit' 'global' 'modify' 'anonymous' 'enabled' 'succeeds'
-    (ret, out) = rgwadmin_rest(endpoint, admin_conn, ['ratelimit', 'modify'], {'ratelimit-scope' : 'bucket', 'global': 'true', 'enabled' : 'true'})
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['ratelimit', 'modify'], {'ratelimit-scope' : 'bucket', 'global': 'true', 'enabled' : 'true'})
     assert ret == 200

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -865,6 +865,8 @@ int RESTArgs::get_string(req_state *s, const string& name,
     return 0;
   }
 
+  constexpr bool in_query = true; // url-decode query params
+  *val = url_decode(*val, in_query);
   return 0;
 }
 

--- a/src/test/rgw/rgw_multi/tools.py
+++ b/src/test/rgw/rgw_multi/tools.py
@@ -1,5 +1,6 @@
 import json
 import boto
+import boto.s3.user # For UserJSONEncoder
 
 def append_attr_value(d, attr, attrv):
     if attrv and len(str(attrv)) > 0:


### PR DESCRIPTION
Original tracker: https://tracker.ceph.com/issues/74591
Original PR: https://github.com/ceph/ceph/pull/67095
Backport tracker: https://tracker.ceph.com/issues/75224

ffc55a69a05f07935b4cb20118ceca31bf031130 fixes a run-tox-qa failure in make check.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
