### PR TITLE
rgw/oidc: Add support for global OIDC providers.

### DIFF
--- a/doc/man/8/radosgw-admin.rst
+++ b/doc/man/8/radosgw-admin.rst
@@ -477,6 +477,24 @@ as follows:
 :command:`role-policy delete`
   Remove the policy attached to a role
 
+:command:`oidc-provider create`
+  Create an OIDC provider. If ``account-id`` is not specified,
+  the provider is created in the global scope.
+
+:command:`oidc-provider modify`
+  Update thumbprints and/or client-ids of an OIDC provider. The provided list
+  fully replaces the existing list for that field; unspecified fields are left
+  unchanged.
+
+:command:`oidc-provider get`
+  Get information about an OIDC provider.
+
+:command:`oidc-provider delete`
+  Delete an OIDC provider.
+
+:command:`oidc-provider list`
+  List OIDC providers.
+
 :command:`reshard add`
   Schedule a resharding of a bucket
 
@@ -984,6 +1002,22 @@ Role Options
 .. option:: --path-prefix
 
    The path prefix for filtering the roles.
+
+
+OIDC Provider Options
+=====================
+
+.. option:: --provider-url
+
+   URL of the OIDC provider.
+
+.. option:: --client-ids
+
+   Comma-separated list of client IDs.
+
+.. option:: --thumbprints
+
+   Comma-separated list of thumbprints.
 
 
 Bucket Notifications/PubSub Options

--- a/doc/radosgw/oidc.rst
+++ b/doc/radosgw/oidc.rst
@@ -4,6 +4,152 @@
 
 An entity describing the OpenID Connect Provider needs to be created in RGW, in order to establish trust between the two.
 
+OIDC providers can be created at two scopes:
+
+- **Account-level**: Created via the IAM REST API, scoped to a specific account.
+- **Global**: Created via ``radosgw-admin``, available to all accounts as a fallback.
+
+When ``AssumeRoleWithWebIdentity`` is called, RGW first looks for an OIDC provider
+in the role's account. If none is found, it falls back to the global OIDC provider
+with the same URL. Account-level providers always take precedence over global ones.
+
+.. note::
+
+   Global OIDC providers are only supported with account-based identities, not with
+   legacy tenant-based namespaces.
+
+
+Global OIDC Providers via radosgw-admin
+=======================================
+
+Global OIDC providers are managed via ``radosgw-admin`` and are available to all
+accounts without requiring each account to register the provider individually.
+
+Create a Global OIDC Provider
+-----------------------------
+
+.. prompt:: bash #
+
+   radosgw-admin oidc-provider create --provider-url https://accounts.google.com \
+     --client-ids app1,app2 --thumbprints F7D7B3515DD0D319DD219A43A9EA727AD6065287
+
+If ``--account-id`` is specified, the provider is created in that account's scope
+instead of globally. Account-scoped providers should normally be created via the
+IAM REST API (``CreateOpenIDConnectProvider``); the ``radosgw-admin`` command is
+intended for managing global providers.
+
+Get a Global OIDC Provider
+--------------------------
+
+.. prompt:: bash #
+
+   radosgw-admin oidc-provider get --provider-url https://accounts.google.com
+
+Modify a Global OIDC Provider
+------------------------------
+
+Update thumbprints, client-ids, or both. The provided list fully replaces the
+existing list for that field; unspecified fields are left unchanged. To add a
+single entry, include the existing values along with the new one.
+
+.. prompt:: bash #
+
+   radosgw-admin oidc-provider modify --provider-url https://accounts.google.com \
+     --thumbprints NEWTHUMB1,NEWTHUMB2
+
+   radosgw-admin oidc-provider modify --provider-url https://accounts.google.com \
+     --client-ids newapp1,newapp2
+
+Delete a Global OIDC Provider
+-----------------------------
+
+.. prompt:: bash #
+
+   radosgw-admin oidc-provider delete --provider-url https://accounts.google.com
+
+List Global OIDC Providers
+--------------------------
+
+.. prompt:: bash #
+
+   radosgw-admin oidc-provider list
+
+
+Trust Policy for Roles Using OIDC Providers
+===========================================
+
+A role's trust policy must reference the OIDC provider in the ``Principal.Federated``
+field. The format differs depending on whether the role uses a global or account-scoped
+OIDC provider.
+
+Trust Policy for Global OIDC Providers
+--------------------------------------
+
+When using a global OIDC provider, the trust policy uses the **bare provider URL**
+as the federated principal::
+
+  {
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": ["<provider-url>"]
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "<provider-url>:sub": "<allowed-subject>"
+        }
+      }
+    }]
+  }
+
+For example, if the global OIDC provider URL is
+``localhost:8080/auth/realms/demorealm``::
+
+  "Principal": {"Federated": ["localhost:8080/auth/realms/demorealm"]}
+
+Trust Policy for Account-Scoped OIDC Providers
+----------------------------------------------
+
+When using an account-scoped OIDC provider (created via the S3 IAM API), the trust
+policy uses the full **ARN** as the federated principal::
+
+  {
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": ["arn:aws:iam::<account-id>:oidc-provider/<provider-url>"]
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "<provider-url>:sub": "<allowed-subject>",
+          "<provider-url>:app_id": "<allowed-client-id>"
+        }
+      }
+    }]
+  }
+
+The ``<account-id>`` in the ARN must match the account that owns the role.
+
+.. note::
+
+   The trust policy principal format must match the provider scope:
+
+   - A role using a **global** provider must use the bare URL form.
+   - A role using an **account-scoped** provider must use the ARN form.
+
+   If there is a mismatch (for example, ARN form with a non-matching account while the
+   global provider is loaded), the trust policy evaluation will deny the request.
+
+   The global OIDC provider does not bypass trust policy evaluation. Every role must
+   still have a trust policy that explicitly allows the OIDC provider. The global
+   provider only determines where the provider configuration (thumbprints, client IDs)
+   is loaded from during JWT signature validation.
+
+
 REST APIs for Manipulating an OpenID Connect Provider
 =====================================================
 

--- a/qa/tasks/keycloak.py
+++ b/qa/tasks/keycloak.py
@@ -209,7 +209,7 @@ def run_admin_cmds(ctx,config):
                 'create', 'realms',
                 '-s', realm,
                 '-s', 'enabled=true',
-                '-s', 'accessTokenLifespan=1800',
+                '-s', 'accessTokenLifespan=3600',
                 '-o',
             ],
         )

--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -244,9 +244,61 @@ def create_users(ctx, config, s3tests_conf):
         conf['webidentity'].setdefault('thumbprint',os.environ['THUMBPRINT'])
         conf['webidentity'].setdefault('KC_REALM',os.environ['KC_REALM'])
 
+    # Create a global OIDC provider for fallback tests. Global providers are
+    # replicated by metadata sync, so a single creation propagates to all zones
+    # in a multisite configuration.
+    global_oidc_created = False
+    if "TOKEN" in os.environ:
+        for client in config.keys():
+            cluster_name, daemon_type, client_id = teuthology.split_role(client)
+            client_with_id = daemon_type + '.' + client_id
+            realm_name = os.environ.get('KC_REALM', '')
+            thumbprint = os.environ.get('THUMBPRINT', '')
+            aud = os.environ.get('AUD', '')
+            if realm_name and thumbprint:
+                ctx.cluster.only(client).run(
+                    args=[
+                        'adjust-ulimits',
+                        'ceph-coverage',
+                        '{tdir}/archive/coverage'.format(tdir=testdir),
+                        'radosgw-admin',
+                        '-n', client_with_id,
+                        '--cluster', cluster_name,
+                        'oidc-provider', 'create',
+                        '--provider-url',
+                        'http://localhost:8080/auth/realms/{}'.format(realm_name),
+                        '--thumbprints', thumbprint,
+                        '--client-ids', aud,
+                    ],
+                )
+                global_oidc_created = True
+            break  # only need to create once on one client
+
     try:
         yield
     finally:
+        # Delete global OIDC provider if we created one
+        if global_oidc_created:
+            for client in config.keys():
+                cluster_name, daemon_type, client_id = teuthology.split_role(client)
+                client_with_id = daemon_type + '.' + client_id
+                realm_name = os.environ.get('KC_REALM', '')
+                if realm_name:
+                    ctx.cluster.only(client).run(
+                        args=[
+                            'adjust-ulimits',
+                            'ceph-coverage',
+                            '{tdir}/archive/coverage'.format(tdir=testdir),
+                            'radosgw-admin',
+                            '-n', client_with_id,
+                            '--cluster', cluster_name,
+                            'oidc-provider', 'delete',
+                            '--provider-url',
+                            'http://localhost:8080/auth/realms/{}'.format(realm_name),
+                        ],
+                        check_status=False,
+                    )
+                break
         for client in config.keys():
             for section, user in users.items():
                 # don't need to delete keystone users

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -86,6 +86,7 @@ extern "C" {
 #include "rgw_sal_config.h"
 #include "rgw_data_access.h"
 #include "rgw_account.h"
+#include "rgw_oidc_provider.h"
 #include "rgw_bucket_logging.h"
 #include "rgw_dedup_cluster.h"
 #include "rgw_dedup_filter.h"
@@ -339,6 +340,11 @@ void usage()
   cout << "  role policy detach               detach a managed policy\n";
   cout << "  role policy list attached        list attached managed policies\n";
   cout << "  role update                      update max_session_duration of a role\n";
+  cout << "  oidc-provider create             create an OIDC provider (global if no --account-id)\n";
+  cout << "  oidc-provider modify             update thumbprints and/or client-ids of an OIDC provider\n";
+  cout << "  oidc-provider get                get an OIDC provider\n";
+  cout << "  oidc-provider delete             delete an OIDC provider\n";
+  cout << "  oidc-provider list               list OIDC providers\n";
   cout << "  reshard add                      schedule a resharding of a bucket\n";
   cout << "  reshard list                     list all bucket resharding or scheduled to be resharded\n";
   cout << "  reshard status                   read bucket resharding status\n";
@@ -549,6 +555,10 @@ void usage()
   cout << "   --path-prefix                 path prefix for filtering roles\n";
   cout << "   --description                 Role description\n";
   cout << "   --policy-arn                  ARN of a managed policy\n";
+  cout << "\nOIDC Provider options:\n";
+  cout << "   --provider-url                URL of the OIDC provider\n";
+  cout << "   --client-ids                  comma-separated list of client IDs\n";
+  cout << "   --thumbprints                 comma-separated list of thumbprints\n";
 #ifdef WITH_RADOSGW_RADOS
   cout << "\nMFA options:\n";
 #endif
@@ -955,6 +965,11 @@ enum class OPT {
   ROLE_POLICY_DETACH,
   ROLE_POLICY_LIST_ATTACHED,
   ROLE_UPDATE,
+  OIDC_PROVIDER_CREATE,
+  OIDC_PROVIDER_MODIFY,
+  OIDC_PROVIDER_GET,
+  OIDC_PROVIDER_DELETE,
+  OIDC_PROVIDER_LIST,
 #ifdef WITH_RADOSGW_RADOS
   RESHARD_ADD,
   RESHARD_LIST,
@@ -1255,6 +1270,11 @@ static SimpleCmd::Commands all_cmds = {
   { "role policy detach", OPT::ROLE_POLICY_DETACH },
   { "role policy list attached", OPT::ROLE_POLICY_LIST_ATTACHED },
   { "role update", OPT::ROLE_UPDATE },
+  { "oidc-provider create", OPT::OIDC_PROVIDER_CREATE },
+  { "oidc-provider modify", OPT::OIDC_PROVIDER_MODIFY },
+  { "oidc-provider get", OPT::OIDC_PROVIDER_GET },
+  { "oidc-provider delete", OPT::OIDC_PROVIDER_DELETE },
+  { "oidc-provider list", OPT::OIDC_PROVIDER_LIST },
 #ifdef WITH_RADOSGW_RADOS
   { "reshard bucket", OPT::BUCKET_RESHARD },
   { "reshard add", OPT::RESHARD_ADD },
@@ -3773,6 +3793,7 @@ int main(int argc, const char **argv)
   std::optional<string> opt_zonegroup_name, opt_zonegroup_id;
   std::string api_name;
   std::string role_name, path, assume_role_doc, policy_name, perm_policy_doc, path_prefix, max_session_duration;
+  std::string provider_url, client_ids_str, thumbprints_str;
   std::string description;
   std::string policy_arn;
   std::string redirect_zone;
@@ -4550,6 +4571,12 @@ int main(int argc, const char **argv)
       policy_arn = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--max-session-duration", (char*)NULL)) {
       max_session_duration = val;
+    } else if (ceph_argparse_witharg(args, i, &val, "--provider-url", (char*)NULL)) {
+      provider_url = val;
+    } else if (ceph_argparse_witharg(args, i, &val, "--client-ids", (char*)NULL)) {
+      client_ids_str = val;
+    } else if (ceph_argparse_witharg(args, i, &val, "--thumbprints", (char*)NULL)) {
+      thumbprints_str = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--description", (char*)NULL)) {
       description = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--totp-serial", (char*)NULL)) {
@@ -4863,6 +4890,8 @@ int main(int argc, const char **argv)
 #endif
 			 OPT::ROLE_GET,
 			 OPT::ROLE_LIST,
+			 OPT::OIDC_PROVIDER_GET,
+			 OPT::OIDC_PROVIDER_LIST,
 			 OPT::ROLE_POLICY_LIST,
 			 OPT::ROLE_POLICY_GET,
 			 OPT::ROLE_POLICY_LIST_ATTACHED,
@@ -4978,6 +5007,11 @@ int main(int argc, const char **argv)
                           && opt_cmd != OPT::ROLE_POLICY_DETACH
                           && opt_cmd != OPT::ROLE_POLICY_LIST_ATTACHED
                           && opt_cmd != OPT::ROLE_UPDATE
+                          && opt_cmd != OPT::OIDC_PROVIDER_CREATE
+                          && opt_cmd != OPT::OIDC_PROVIDER_MODIFY
+                          && opt_cmd != OPT::OIDC_PROVIDER_GET
+                          && opt_cmd != OPT::OIDC_PROVIDER_DELETE
+                          && opt_cmd != OPT::OIDC_PROVIDER_LIST
 #ifdef WITH_RADOSGW_RADOS
                           && opt_cmd != OPT::RESHARD_ADD
                           && opt_cmd != OPT::RESHARD_CANCEL
@@ -7038,6 +7072,8 @@ int main(int argc, const char **argv)
 #endif
                                         OPT::CAPS_ADD, OPT::CAPS_RM,
                                         OPT::ROLE_CREATE, OPT::ROLE_DELETE,
+                                        OPT::OIDC_PROVIDER_CREATE, OPT::OIDC_PROVIDER_MODIFY,
+                                        OPT::OIDC_PROVIDER_DELETE,
                                         OPT::ROLE_POLICY_PUT, OPT::ROLE_POLICY_DELETE,
                                         OPT::ROLE_POLICY_ATTACH, OPT::ROLE_POLICY_DETACH,
                                         OPT::USER_POLICY_ATTACH, OPT::USER_POLICY_DETACH,
@@ -7181,6 +7217,27 @@ int main(int argc, const char **argv)
   std::string err_msg;
 
   bool output_user_info = true;
+
+  // Helper: resolve OIDC scope from --account-id or global fallback.
+  // Returns negative error code if --tenant is used (not supported for OIDC).
+  auto resolve_oidc_tenant = [&]() -> std::pair<int, std::string> {
+    if (!tenant.empty()) {
+      cerr << "ERROR: --tenant is not supported for OIDC providers. "
+           << "Use --account-id for account-scoped providers, "
+           << "or omit for global providers." << std::endl;
+      return {-EINVAL, {}};
+    }
+    if (!account_id.empty()) {
+      std::string err_msg;
+      if (!rgw::account::validate_id(account_id, &err_msg)) {
+        cerr << "ERROR: invalid --account-id '" << account_id << "': "
+             << err_msg << std::endl;
+        return {-EINVAL, {}};
+      }
+      return {0, account_id};
+    }
+    return {0, std::string(global_oidc_id)};
+  };
 
   switch (opt_cmd) {
   case OPT::USER_INFO:
@@ -7520,6 +7577,157 @@ int main(int argc, const char **argv)
         }
         formatter->close_section(); // result
       }
+      formatter->flush(cout);
+      return 0;
+    }
+  case OPT::OIDC_PROVIDER_CREATE:
+    {
+      if (provider_url.empty()) {
+        cerr << "ERROR: --provider-url is required" << std::endl;
+        return EINVAL;
+      }
+
+      const auto [oidc_ret, oidc_tenant] = resolve_oidc_tenant();
+      if (oidc_ret < 0) return -oidc_ret;
+
+      RGWOIDCProviderInfo info;
+      info.provider_url = provider_url;
+      info.tenant = oidc_tenant;
+      info.creation_date = format_creation_date(ceph::real_clock::now());
+
+      // parse comma-separated client IDs
+      if (!client_ids_str.empty()) {
+        get_str_vec(client_ids_str, ",", info.client_ids);
+      }
+      // parse comma-separated thumbprints
+      if (!thumbprints_str.empty()) {
+        get_str_vec(thumbprints_str, ",", info.thumbprints);
+      }
+
+      // Account-scoped providers persist an arn (matching the IAM create path);
+      // global providers derive their arn from the url at dump time.
+      if (!is_global_oidc_provider(info)) {
+        info.arn = rgw::ARN(url_remove_prefix(info.provider_url),
+                            "oidc-provider/", info.tenant, true).to_string();
+      }
+
+      ret = driver->store_oidc_provider(dpp(), null_yield, info,
+                                        /*exclusive=*/true, nullptr);
+      if (ret < 0) {
+        cerr << "ERROR: failed to create OIDC provider: " << cpp_strerror(-ret) << std::endl;
+        return -ret;
+      }
+
+      encode_json("oidc_provider", info, formatter.get());
+      formatter->flush(cout);
+      return 0;
+    }
+  case OPT::OIDC_PROVIDER_MODIFY:
+    {
+      if (provider_url.empty()) {
+        cerr << "ERROR: --provider-url is required" << std::endl;
+        return EINVAL;
+      }
+
+      if (client_ids_str.empty() && thumbprints_str.empty()) {
+        cerr << "ERROR: at least one of --client-ids or --thumbprints is required" << std::endl;
+        return EINVAL;
+      }
+
+      const auto [oidc_ret, oidc_tenant] = resolve_oidc_tenant();
+      if (oidc_ret < 0) return -oidc_ret;
+
+      RGWOIDCProviderInfo info;
+      RGWObjVersionTracker objv_tracker;
+      ret = driver->load_oidc_provider(dpp(), null_yield, oidc_tenant,
+                                       url_remove_prefix(provider_url),
+                                       info, &objv_tracker);
+      if (ret < 0) {
+        cerr << "ERROR: failed to load OIDC provider: " << cpp_strerror(-ret) << std::endl;
+        return -ret;
+      }
+
+      if (!client_ids_str.empty()) {
+        info.client_ids.clear();
+        get_str_vec(client_ids_str, ",", info.client_ids);
+      }
+      if (!thumbprints_str.empty()) {
+        info.thumbprints.clear();
+        get_str_vec(thumbprints_str, ",", info.thumbprints);
+      }
+
+      constexpr bool exclusive = false;
+      ret = driver->store_oidc_provider(dpp(), null_yield, info,
+                                        exclusive, &objv_tracker);
+      if (ret < 0) {
+        cerr << "ERROR: failed to modify OIDC provider: " << cpp_strerror(-ret) << std::endl;
+        return -ret;
+      }
+
+      encode_json("oidc_provider", info, formatter.get());
+      formatter->flush(cout);
+      return 0;
+    }
+  case OPT::OIDC_PROVIDER_GET:
+    {
+      if (provider_url.empty()) {
+        cerr << "ERROR: --provider-url is required" << std::endl;
+        return EINVAL;
+      }
+
+      const auto [oidc_ret, oidc_tenant] = resolve_oidc_tenant();
+      if (oidc_ret < 0) return -oidc_ret;
+
+      RGWOIDCProviderInfo info;
+      ret = driver->load_oidc_provider(dpp(), null_yield, oidc_tenant,
+                                       url_remove_prefix(provider_url),
+                                       info, nullptr);
+      if (ret < 0) {
+        cerr << "ERROR: failed to get OIDC provider: " << cpp_strerror(-ret) << std::endl;
+        return -ret;
+      }
+
+      encode_json("oidc_provider", info, formatter.get());
+      formatter->flush(cout);
+      return 0;
+    }
+  case OPT::OIDC_PROVIDER_DELETE:
+    {
+      if (provider_url.empty()) {
+        cerr << "ERROR: --provider-url is required" << std::endl;
+        return EINVAL;
+      }
+
+      const auto [oidc_ret, oidc_tenant] = resolve_oidc_tenant();
+      if (oidc_ret < 0) return -oidc_ret;
+
+      ret = driver->delete_oidc_provider(dpp(), null_yield, oidc_tenant,
+                                         url_remove_prefix(provider_url));
+      if (ret < 0) {
+        cerr << "ERROR: failed to delete OIDC provider: " << cpp_strerror(-ret) << std::endl;
+        return -ret;
+      }
+
+      cout << "OIDC provider successfully deleted" << std::endl;
+      return 0;
+    }
+  case OPT::OIDC_PROVIDER_LIST:
+    {
+      const auto [oidc_ret, oidc_tenant] = resolve_oidc_tenant();
+      if (oidc_ret < 0) return -oidc_ret;
+
+      std::vector<RGWOIDCProviderInfo> providers;
+      ret = driver->get_oidc_providers(dpp(), null_yield, oidc_tenant, providers);
+      if (ret < 0) {
+        cerr << "ERROR: failed to list OIDC providers: " << cpp_strerror(-ret) << std::endl;
+        return -ret;
+      }
+
+      formatter->open_array_section("oidc_providers");
+      for (const auto& p : providers) {
+        encode_json("oidc_provider", p, formatter.get());
+      }
+      formatter->close_section();
       formatter->flush(cout);
       return 0;
     }

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -800,8 +800,16 @@ void rgw::auth::WebIdentityApplier::modify_request_state(const DoutPrefixProvide
 
 bool rgw::auth::WebIdentityApplier::is_identity(const Principal& p) const
 {
-  return p.is_oidc_provider()
-      && p.get_idp_url() == get_idp_url();
+  if (!p.is_oidc_provider())
+    return false;
+  if (p.get_idp_url() != get_idp_url())
+    return false;
+
+  if (is_global_oidc) {
+    return p.get_account() == ".global";
+  }
+  const std::string& acct = account ? account->id : role_tenant;
+  return p.get_account() == acct;
 }
 
 const std::string rgw::auth::RemoteApplier::AuthInfo::NO_SUBUSER;

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -415,6 +415,7 @@ protected:
   boost::optional<std::multimap<std::string,std::string>> role_tags;
   boost::optional<std::set<std::pair<std::string, std::string>>> principal_tags;
   std::optional<RGWAccountInfo> account;
+  bool is_global_oidc;
 
   std::string get_idp_url() const;
 
@@ -431,7 +432,8 @@ public:
                       const std::unordered_multimap<std::string, std::string>& token_claims,
                       boost::optional<std::multimap<std::string,std::string>> role_tags,
                       boost::optional<std::set<std::pair<std::string, std::string>>> principal_tags,
-                      std::optional<RGWAccountInfo> account)
+                      std::optional<RGWAccountInfo> account,
+                      bool is_global_oidc = false)
       : cct(cct),
       driver(driver),
       role_id(role_id),
@@ -440,7 +442,8 @@ public:
       token_claims(token_claims),
       role_tags(role_tags),
       principal_tags(principal_tags),
-      account(std::move(account))
+      account(std::move(account)),
+      is_global_oidc(is_global_oidc)
   {
       const auto& sub = token_claims.find("sub");
       if(sub != token_claims.end()) {
@@ -540,7 +543,8 @@ public:
                                               const std::unordered_multimap<std::string, std::string>& token,
                                               boost::optional<std::multimap<std::string, std::string>>,
                                               boost::optional<std::set<std::pair<std::string, std::string>>> principal_tags,
-                                              std::optional<RGWAccountInfo> account) const = 0;
+                                              std::optional<RGWAccountInfo> account,
+                                              bool is_global_oidc) const = 0;
   };
 };
 

--- a/src/rgw/rgw_basic_types.h
+++ b/src/rgw/rgw_basic_types.h
@@ -157,8 +157,8 @@ class Principal {
   Principal(types t, std::string&& n, std::string i)
     : t(t), u(std::move(n), std::move(i)) {}
 
-  Principal(std::string&& idp_url)
-    : t(OidcProvider), idp_url(std::move(idp_url)) {}
+  Principal(std::string&& account, std::string&& idp_url)
+    : t(OidcProvider), u(std::move(account), {}), idp_url(std::move(idp_url)) {}
 
 public:
 
@@ -178,8 +178,8 @@ public:
     return Principal(Account, std::move(t), {});
   }
 
-  static Principal oidc_provider(std::string&& idp_url) {
-    return Principal(std::move(idp_url));
+  static Principal oidc_provider(std::string&& account, std::string&& idp_url) {
+    return Principal(std::move(account), std::move(idp_url));
   }
 
   static Principal assumed_role(std::string&& t, std::string&& u) {
@@ -245,11 +245,13 @@ public:
   }
 
   bool operator ==(const Principal& o) const {
-    return (t == o.t) && (u == o.u);
+    return (t == o.t) && (u == o.u) && (idp_url == o.idp_url);
   }
 
   bool operator <(const Principal& o) const {
-    return (t < o.t) || ((t == o.t) && (u < o.u));
+    if (t != o.t) return t < o.t;
+    if (u != o.u) return u < o.u;
+    return idp_url < o.idp_url;
   }
 };
 

--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -19,6 +19,7 @@
 
 #include "rgw_auth.h"
 #include "rgw_iam_policy.h"
+#include "rgw_oidc_provider.h"
 
 
 inline constexpr int dout_subsys = ceph_subsys_rgw;
@@ -381,16 +382,23 @@ parse_principal_(const struct Keyword* w, std::string&& s,
 	}
 
         if (match[1] == "oidc-provider") {
-                return Principal::oidc_provider(std::move(match[2]));
+                return Principal::oidc_provider(std::move(a->account), std::move(match[2]));
         }
 	if (match[1] == "assumed-role") {
 	  return Principal::assumed_role(std::move(a->account), match[2]);
 	}
       }
+    } else if (w->id == TokenID::Federated &&
+               (s.find('/') != string::npos || s.find('.') != string::npos)) {
+      // bare URL like "example.com" or "localhost:8080/auth/realms/myrealm"
+      // used for global OIDC providers in trust policies. Restricted to
+      // Principal.Federated so bare account/tenant names under Principal.AWS
+      // (which may contain a '.') keep matching as accounts.
+      return Principal::oidc_provider(std::string{global_oidc_id}, std::string{s});
     } else if (std::none_of(s.begin(), s.end(),
-		       [](const char& c) {
-			 return (c == ':') || (c == '/');
-		       })) {
+           [](const char& c) {
+       return (c == ':') || (c == '/');
+           })) {
       // Since tenants are simply prefixes, there's no really good
       // way to see if one exists or not. So we return the thing and
       // let them try to match against it.

--- a/src/rgw/rgw_oidc_provider.cc
+++ b/src/rgw/rgw_oidc_provider.cc
@@ -2,14 +2,38 @@
 // vim: ts=8 sw=2 sts=2 expandtab ft=cpp
 
 #include "rgw_oidc_provider.h"
+#include "rgw_common.h"
+
+#include <cstring>
+#include <ctime>
 
 #define dout_subsys ceph_subsys_rgw
+
+std::string format_creation_date(ceph::real_time now)
+{
+  struct timeval tv;
+  ceph::real_clock::to_timeval(now, tv);
+
+  struct tm result;
+  gmtime_r(&tv.tv_sec, &result);
+  char buf[30];
+  strftime(buf, 30, "%Y-%m-%dT%H:%M:%S", &result);
+  sprintf(buf + strlen(buf), ".%03dZ", (int)tv.tv_usec / 1000);
+  return buf;
+}
 
 void RGWOIDCProviderInfo::dump(Formatter *f) const
 {
   encode_json("id", id, f);
   encode_json("provider_url", provider_url, f);
-  encode_json("arn", arn, f);
+  if (is_global_oidc_provider(*this)) {
+    // arn == provider url for global providers, but scheme-normalized so the
+    // returned value can be used directly as Principal.Federated (trust-policy
+    // matching compares against the scheme-stripped issuer).
+    encode_json("arn", url_remove_prefix(provider_url), f);
+  } else {
+    encode_json("arn", arn, f);
+  }
   encode_json("creation_date", creation_date, f);
   encode_json("tenant", tenant, f);
   encode_json("client_ids", client_ids, f);

--- a/src/rgw/rgw_oidc_provider.h
+++ b/src/rgw/rgw_oidc_provider.h
@@ -5,9 +5,11 @@
 
 #include <list>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "common/ceph_json.h"
+#include "common/ceph_time.h"
 
 struct RGWOIDCProviderInfo
 {
@@ -48,3 +50,15 @@ struct RGWOIDCProviderInfo
   static std::list<RGWOIDCProviderInfo> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(RGWOIDCProviderInfo)
+
+// Reserved identifier for global OIDC providers (not tied to any account).
+// Uses '.' prefix which is invalid in account names and does not conflict with
+// metadata separators ('$' for key, ':' for section).
+static constexpr std::string_view global_oidc_id = ".global";
+
+inline bool is_global_oidc_provider(const RGWOIDCProviderInfo& info) {
+  return info.tenant == global_oidc_id;
+}
+
+// Format a timestamp as ISO 8601 for OIDC provider creation_date field.
+std::string format_creation_date(ceph::real_time now);

--- a/src/rgw/rgw_rest_oidc_provider.cc
+++ b/src/rgw/rgw_rest_oidc_provider.cc
@@ -64,20 +64,7 @@ void RGWRestOIDCProvider::send_response()
 }
 
 
-static std::string format_creation_date(ceph::real_time now)
-{
-  struct timeval tv;
-  real_clock::to_timeval(now, tv);
-
-  struct tm result;
-  gmtime_r(&tv.tv_sec, &result);
-  char buf[30];
-  strftime(buf,30,"%Y-%m-%dT%H:%M:%S", &result);
-  sprintf(buf + strlen(buf),".%03dZ",(int)tv.tv_usec/1000);
-  return buf;
-}
-
-
+// format_creation_date() moved to rgw_oidc_provider.cc for reuse
 
 inline constexpr int MAX_OIDC_NUM_CLIENT_IDS = 100;
 inline constexpr int MAX_OIDC_CLIENT_ID_LEN = 255;

--- a/src/rgw/rgw_rest_sts.cc
+++ b/src/rgw/rgw_rest_sts.cc
@@ -90,9 +90,11 @@ WebTokenEngine::get_role_name(const string& role_arn) const
 
 int WebTokenEngine::load_provider(const DoutPrefixProvider* dpp, optional_yield y,
                                   const string& role_arn, const string& iss,
-                                  RGWOIDCProviderInfo& info) const
+                                  RGWOIDCProviderInfo& info,
+                                  bool& is_global_oidc) const
 {
   string tenant = get_role_tenant(role_arn);
+  is_global_oidc = false;
 
   string idp_url = iss;
   auto pos = idp_url.find("http://");
@@ -119,6 +121,9 @@ int WebTokenEngine::load_provider(const DoutPrefixProvider* dpp, optional_yield 
     ldpp_dout(dpp, 20) << "no OIDC provider found for tenant '" << tenant
         << "' and url '" << idp_url << "', trying global" << dendl;
     r = driver->load_oidc_provider(dpp, y, global_oidc_id, idp_url, info, nullptr);
+    if (r == 0) {
+      is_global_oidc = true;
+    }
   }
   return r;
 }
@@ -223,10 +228,11 @@ WebTokenEngine::get_token_claims(const jwt::decoded_jwt& decoded) const
 }
 
 //Offline validation of incoming Web Token which is a signed JWT (JSON Web Token)
-std::tuple<boost::optional<WebTokenEngine::token_t>, boost::optional<WebTokenEngine::principal_tags_t>>
+std::tuple<boost::optional<WebTokenEngine::token_t>, boost::optional<WebTokenEngine::principal_tags_t>, bool>
 WebTokenEngine::get_from_jwt(const DoutPrefixProvider* dpp, const std::string& token, const req_state* const s,
 			     optional_yield y) const
 {
+  bool is_global_oidc = false;
   WebTokenEngine::token_t t;
   WebTokenEngine::principal_tags_t principal_tags;
   try {
@@ -261,7 +267,7 @@ WebTokenEngine::get_from_jwt(const DoutPrefixProvider* dpp, const std::string& t
 
     string role_arn = s->info.args.get("RoleArn");
     RGWOIDCProviderInfo provider;
-    int r = load_provider(dpp, y, role_arn, iss, provider);
+    int r = load_provider(dpp, y, role_arn, iss, provider, is_global_oidc);
     if (r < 0) {
       ldpp_dout(dpp, 0) << "Couldn't get oidc provider info using input iss" << iss << dendl;
       throw std::system_error(EACCES, std::system_category());
@@ -300,13 +306,13 @@ WebTokenEngine::get_from_jwt(const DoutPrefixProvider* dpp, const std::string& t
         throw std::system_error(EACCES, std::system_category());
       }
     } else {
-      return {boost::none, boost::none};
+      return {boost::none, boost::none, false};
     }
   } catch (const std::exception& e) {
     ldpp_dout(dpp, 5) << "Invalid JWT token" << dendl;
-    return {boost::none, boost::none};
+    return {boost::none, boost::none, false};
   }
-  return {t, principal_tags};
+  return {t, principal_tags, is_global_oidc};
 }
 
 std::string
@@ -794,7 +800,7 @@ WebTokenEngine::authenticate( const DoutPrefixProvider* dpp,
   }
 
   try {
-    auto [t, princ_tags] = get_from_jwt(dpp, token, s, y);
+    auto [t, princ_tags, is_global_oidc] = get_from_jwt(dpp, token, s, y);
     if (t) {
       string role_session = s->info.args.get("RoleSessionName");
       if (role_session.empty()) {
@@ -834,7 +840,7 @@ WebTokenEngine::authenticate( const DoutPrefixProvider* dpp,
       boost::optional<multimap<string,string>> role_tags = role->get_tags();
       auto apl = apl_factory->create_apl_web_identity(
           cct, s, role->get_id(), role_session, role_tenant,
-          *t, role_tags, princ_tags, std::move(account));
+          *t, role_tags, princ_tags, std::move(account), is_global_oidc);
       return result_t::grant(std::move(apl));
     }
     return result_t::deny(-EACCES);

--- a/src/rgw/rgw_rest_sts.cc
+++ b/src/rgw/rgw_rest_sts.cc
@@ -110,7 +110,17 @@ int WebTokenEngine::load_provider(const DoutPrefixProvider* dpp, optional_yield 
     idp_url.erase(pos, 7);
   }
 
-  return driver->load_oidc_provider(dpp, y, tenant, idp_url, info, nullptr);
+  int r = driver->load_oidc_provider(dpp, y, tenant, idp_url, info, nullptr);
+  // Global providers are account-scoped only: fall back only when the role's
+  // tenant is a valid account id. Legacy tenant-based roles must not be able
+  // to consume global providers.
+  if (r == -ENOENT && tenant != global_oidc_id &&
+      rgw::account::validate_id(tenant)) {
+    ldpp_dout(dpp, 20) << "no OIDC provider found for tenant '" << tenant
+        << "' and url '" << idp_url << "', trying global" << dendl;
+    r = driver->load_oidc_provider(dpp, y, global_oidc_id, idp_url, info, nullptr);
+  }
+  return r;
 }
 
 bool

--- a/src/rgw/rgw_rest_sts.h
+++ b/src/rgw/rgw_rest_sts.h
@@ -42,7 +42,8 @@ class WebTokenEngine : public rgw::auth::Engine {
 
   int load_provider(const DoutPrefixProvider *dpp, optional_yield y,
                     const std::string& role_arn, const std::string& iss,
-                    RGWOIDCProviderInfo& info) const;
+                    RGWOIDCProviderInfo& info,
+                    bool& is_global_oidc) const;
 
   std::string get_role_tenant(const std::string& role_arn) const;
 
@@ -50,7 +51,7 @@ class WebTokenEngine : public rgw::auth::Engine {
 
   std::string get_cert_url(const std::string& iss, const DoutPrefixProvider *dpp,optional_yield y) const;
 
-  std::tuple<boost::optional<WebTokenEngine::token_t>, boost::optional<WebTokenEngine::principal_tags_t>>
+  std::tuple<boost::optional<WebTokenEngine::token_t>, boost::optional<WebTokenEngine::principal_tags_t>, bool>
   get_from_jwt(const DoutPrefixProvider* dpp, const std::string& token, const req_state* const s, optional_yield y) const;
 
  bool validate_signature_using_n_e(const DoutPrefixProvider* dpp, const jwt::decoded_jwt& decoded, const std::string &algorithm, const std::string& n, const std::string& e) const;
@@ -117,11 +118,13 @@ class DefaultStrategy : public rgw::auth::Strategy,
                                     const std::unordered_multimap<std::string, std::string>& token,
                                     boost::optional<std::multimap<std::string, std::string>> role_tags,
                                     boost::optional<std::set<std::pair<std::string, std::string>>> principal_tags,
-                                    std::optional<RGWAccountInfo> account) const override {
+                                    std::optional<RGWAccountInfo> account,
+                                    bool is_global_oidc) const override {
     auto apl = rgw::auth::add_sysreq(cct, driver, s,
       rgw::auth::WebIdentityApplier(cct, driver, role_id, role_session,
                                     role_tenant, token, role_tags,
-                                    principal_tags, std::move(account)));
+                                    principal_tags, std::move(account),
+                                    is_global_oidc));
     return aplptr_t(new decltype(apl)(std::move(apl)));
   }
 

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -190,6 +190,11 @@
     role policy detach               detach a managed policy
     role policy list attached        list attached managed policies
     role update                      update max_session_duration of a role
+    oidc-provider create             create an OIDC provider (global if no --account-id)
+    oidc-provider modify             update thumbprints and/or client-ids of an OIDC provider
+    oidc-provider get                get an OIDC provider
+    oidc-provider delete             delete an OIDC provider
+    oidc-provider list               list OIDC providers
     reshard add                      schedule a resharding of a bucket
     reshard list                     list all bucket resharding or scheduled to be resharded
     reshard status                   read bucket resharding status
@@ -406,6 +411,11 @@
      --description                 Role description
      --policy-arn                  ARN of a managed policy
   
+  OIDC Provider options:
+     --provider-url                URL of the OIDC provider
+     --client-ids                  comma-separated list of client IDs
+     --thumbprints                 comma-separated list of thumbprints
+  
   MFA options:
      --totp-serial                 a string that represents the ID of a TOTP token
      --totp-seed                   the secret seed that is used to calculate the TOTP
@@ -448,3 +458,4 @@
     --setgroup GROUP  set gid to group or gid
     --version         show version and quit
   
+

--- a/src/test/rgw/s3-tests/s3tests/functional/test_sts.py
+++ b/src/test/rgw/s3-tests/s3tests/functional/test_sts.py
@@ -31,6 +31,8 @@ from email.header import decode_header
 from . import(
     configfile,
     setup_teardown,
+    get_iam_root_client,
+    get_iam_root_account_id,
     get_iam_client,
     get_sts_client,
     get_client,
@@ -49,7 +51,10 @@ from . import(
     get_iam_secret_key,
     get_sub,
     get_azp,
-    get_user_token
+    get_user_token,
+    get_tenant_iam_client,
+    get_tenant_aws_access_key,
+    get_tenant_aws_secret_key,
     )
 
 log = logging.getLogger(__name__)
@@ -71,7 +76,7 @@ def put_role_policy(iam_client,rolename,policyname,role_policy):
     role_err=None
     role_response = None
     if policyname is None:
-        policyname=get_parameter_name() 
+        policyname=get_parameter_name()
     try:
         role_response = iam_client.put_role_policy(RoleName=rolename,PolicyName=policyname,PolicyDocument=role_policy)
     except ClientError as e:
@@ -158,14 +163,14 @@ def test_get_session_token():
     sts_client=get_sts_client()
     sts_user_id=get_alt_user_id()
     default_endpoint=get_config_endpoint()
-    
+
     user_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Deny\",\"Action\":\"s3:*\",\"Resource\":[\"*\"],\"Condition\":{\"BoolIfExists\":{\"sts:authentication\":\"false\"}}},{\"Effect\":\"Allow\",\"Action\":\"sts:GetSessionToken\",\"Resource\":\"*\",\"Condition\":{\"BoolIfExists\":{\"sts:authentication\":\"false\"}}}]}"
     (resp_err,resp,policy_name)=put_user_policy(iam_client,sts_user_id,None,user_policy)
     assert resp['ResponseMetadata']['HTTPStatusCode'] == 200
-    
+
     response=sts_client.get_session_token()
     assert response['ResponseMetadata']['HTTPStatusCode'] == 200
-    
+
     s3_client=boto3.client('s3',
                 aws_access_key_id = response['Credentials']['AccessKeyId'],
 		aws_secret_access_key = response['Credentials']['SecretAccessKey'],
@@ -184,29 +189,29 @@ def test_get_session_token():
 @pytest.mark.test_of_sts
 @pytest.mark.fails_on_dbstore
 def test_assume_role_allow():
-    iam_client=get_iam_client()    
+    iam_client=get_iam_client()
     sts_client=get_sts_client()
     sts_user_id=get_alt_user_id()
     default_endpoint=get_config_endpoint()
     role_session_name=get_parameter_name()
-    
+
     policy_document = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":[\"arn:aws:iam:::user/"+sts_user_id+"\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
     (role_error,role_response,general_role_name)=create_role(iam_client,'/',None,policy_document,None,None,None)
     if role_response:
         assert role_response['Role']['Arn'] == 'arn:aws:iam:::role/'+general_role_name+''
     else:
         assert False, role_error
-    
+
     role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"s3:*\",\"Resource\":\"arn:aws:s3:::*\"}}"
     (role_err,response)=put_role_policy(iam_client,general_role_name,None,role_policy)
     if response:
         assert response['ResponseMetadata']['HTTPStatusCode'] == 200
     else:
         assert False, role_err
-    
+
     resp=sts_client.assume_role(RoleArn=role_response['Role']['Arn'],RoleSessionName=role_session_name)
     assert resp['ResponseMetadata']['HTTPStatusCode'] == 200
-    
+
     s3_client = boto3.client('s3',
 		aws_access_key_id = resp['Credentials']['AccessKeyId'],
 		aws_secret_access_key = resp['Credentials']['SecretAccessKey'],
@@ -224,29 +229,29 @@ def test_assume_role_allow():
 @pytest.mark.fails_on_dbstore
 def test_assume_role_deny():
     s3bucket_error=None
-    iam_client=get_iam_client()    
+    iam_client=get_iam_client()
     sts_client=get_sts_client()
     sts_user_id=get_alt_user_id()
     default_endpoint=get_config_endpoint()
     role_session_name=get_parameter_name()
-    
+
     policy_document = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":[\"arn:aws:iam:::user/"+sts_user_id+"\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
     (role_error,role_response,general_role_name)=create_role(iam_client,'/',None,policy_document,None,None,None)
     if role_response:
         assert role_response['Role']['Arn'] == 'arn:aws:iam:::role/'+general_role_name+''
     else:
         assert False, role_error
-    
+
     role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Deny\",\"Action\":\"s3:*\",\"Resource\":\"arn:aws:s3:::*\"}}"
     (role_err,response)=put_role_policy(iam_client,general_role_name,None,role_policy)
     if response:
         assert response['ResponseMetadata']['HTTPStatusCode'] == 200
     else:
         assert False, role_err
-    
+
     resp=sts_client.assume_role(RoleArn=role_response['Role']['Arn'],RoleSessionName=role_session_name)
     assert resp['ResponseMetadata']['HTTPStatusCode'] == 200
-    
+
     s3_client = boto3.client('s3',
 		aws_access_key_id = resp['Credentials']['AccessKeyId'],
 		aws_secret_access_key = resp['Credentials']['SecretAccessKey'],
@@ -264,30 +269,30 @@ def test_assume_role_deny():
 @pytest.mark.test_of_sts
 @pytest.mark.fails_on_dbstore
 def test_assume_role_creds_expiry():
-    iam_client=get_iam_client()    
+    iam_client=get_iam_client()
     sts_client=get_sts_client()
     sts_user_id=get_alt_user_id()
     default_endpoint=get_config_endpoint()
     role_session_name=get_parameter_name()
-    
+
     policy_document = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":[\"arn:aws:iam:::user/"+sts_user_id+"\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
     (role_error,role_response,general_role_name)=create_role(iam_client,'/',None,policy_document,None,None,None)
     if role_response:
         assert role_response['Role']['Arn'] == 'arn:aws:iam:::role/'+general_role_name+''
     else:
         assert False, role_error
-    
+
     role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"s3:*\",\"Resource\":\"arn:aws:s3:::*\"}}"
     (role_err,response)=put_role_policy(iam_client,general_role_name,None,role_policy)
     if response:
         assert response['ResponseMetadata']['HTTPStatusCode'] == 200
     else:
         assert False, role_err
-    
+
     resp=sts_client.assume_role(RoleArn=role_response['Role']['Arn'],RoleSessionName=role_session_name,DurationSeconds=900)
     assert resp['ResponseMetadata']['HTTPStatusCode'] == 200
     time.sleep(900)
-    
+
     s3_client = boto3.client('s3',
 		aws_access_key_id = resp['Credentials']['AccessKeyId'],
 		aws_secret_access_key = resp['Credentials']['SecretAccessKey'],
@@ -398,7 +403,7 @@ def test_assume_role_allow_head_nonexistent():
 @pytest.mark.fails_on_dbstore
 def test_assume_role_with_web_identity():
     check_webidentity()
-    iam_client=get_iam_client()    
+    iam_client=get_iam_client()
     sts_client=get_sts_client()
     default_endpoint=get_config_endpoint()
     role_session_name=get_parameter_name()
@@ -406,28 +411,28 @@ def test_assume_role_with_web_identity():
     aud=get_aud()
     token=get_token()
     realm=get_realm_name()
-    
+
     oidc_response = iam_client.create_open_id_connect_provider(
     Url='http://localhost:8080/auth/realms/{}'.format(realm),
     ThumbprintList=[
         thumbprint,
     ],
     )
-    
+
     policy_document = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Federated\":[\""+oidc_response["OpenIDConnectProviderArn"]+"\"]},\"Action\":[\"sts:AssumeRoleWithWebIdentity\"],\"Condition\":{\"StringEquals\":{\"localhost:8080/auth/realms/"+realm+":app_id\":\""+aud+"\"}}}]}"
     (role_error,role_response,general_role_name)=create_role(iam_client,'/',None,policy_document,None,None,None)
     assert role_response['Role']['Arn'] == 'arn:aws:iam:::role/'+general_role_name+''
-    
+
     role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"s3:*\",\"Resource\":\"arn:aws:s3:::*\"}}"
     (role_err,response)=put_role_policy(iam_client,general_role_name,None,role_policy)
     if response:
         assert response['ResponseMetadata']['HTTPStatusCode'] == 200
     else:
         assert False, role_err
-    
+
     resp=sts_client.assume_role_with_web_identity(RoleArn=role_response['Role']['Arn'],RoleSessionName=role_session_name,WebIdentityToken=token)
     assert resp['ResponseMetadata']['HTTPStatusCode'] == 200
-    
+
     s3_client = boto3.client('s3',
 		aws_access_key_id = resp['Credentials']['AccessKeyId'],
 		aws_secret_access_key = resp['Credentials']['SecretAccessKey'],
@@ -440,7 +445,7 @@ def test_assume_role_with_web_identity():
     assert s3bucket['ResponseMetadata']['HTTPStatusCode'] == 200
     bkt = s3_client.delete_bucket(Bucket=bucket_name)
     assert bkt['ResponseMetadata']['HTTPStatusCode'] == 204
-    
+
     oidc_remove=iam_client.delete_open_id_connect_provider(
     OpenIDConnectProviderArn=oidc_response["OpenIDConnectProviderArn"]
     )
@@ -2070,4 +2075,253 @@ def test_assume_role_with_web_identity_role_resource_tag():
 
     oidc_remove=iam_client.delete_open_id_connect_provider(
     OpenIDConnectProviderArn=oidc_response["OpenIDConnectProviderArn"]
+    )
+
+@pytest.mark.webidentity_test
+@pytest.mark.fails_on_dbstore
+def test_assume_role_with_global_oidc_provider_local_override():
+    """Test global OIDC provider fallback and account-level precedence.
+
+    Requires a global OIDC provider to be pre-created by the test task
+    (qa/tasks/s3tests.py) via 'radosgw-admin oidc-provider create' with
+    the correct thumbprint and client_ids.
+
+    Phase 1: No account-level provider exists.
+      AssumeRoleWithWebIdentity should SUCCEED via global fallback.
+
+    Phase 2: Create account-level provider with WRONG client_id.
+      AssumeRoleWithWebIdentity should FAIL, proving account-level
+      takes precedence over global (client_id mismatch always validated).
+
+    Phase 3: Delete account-level provider.
+      AssumeRoleWithWebIdentity should SUCCEED again via global fallback.
+    """
+    check_webidentity()
+    iam_client=get_iam_root_client()
+    sts_client=get_sts_client()
+    default_endpoint=get_config_endpoint()
+    role_session_name=get_parameter_name()
+    thumbprint=get_thumbprint()
+    aud=get_aud()
+    token=get_token()
+    realm=get_realm_name()
+    sub=get_sub()
+
+    idp_url = 'localhost:8080/auth/realms/' + realm
+
+    # Use bare URL as the Federated principal for global OIDC providers
+    policy_document = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Federated\":[\""+idp_url+"\"]},\"Action\":[\"sts:AssumeRoleWithWebIdentity\"],\"Condition\":{\"StringEquals\":{\""+idp_url+":sub\":\""+sub+"\"}}}]}"
+    (role_error,role_response,general_role_name)=create_role(iam_client,'/',None,policy_document,None,None,None)
+    assert role_response['Role']['Arn'] == 'arn:aws:iam::'+get_iam_root_account_id()+':role/'+general_role_name+''
+
+    role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"s3:*\",\"Resource\":\"arn:aws:s3:::*\"}}"
+    (role_err,response)=put_role_policy(iam_client,general_role_name,None,role_policy)
+    if response:
+        assert response['ResponseMetadata']['HTTPStatusCode'] == 200
+    else:
+        assert False, role_err
+
+    # Phase 1: No account-level provider — should SUCCEED via global fallback
+    resp=sts_client.assume_role_with_web_identity(RoleArn=role_response['Role']['Arn'],RoleSessionName=role_session_name,WebIdentityToken=token)
+    assert resp['ResponseMetadata']['HTTPStatusCode'] == 200
+
+    # Verify temp credentials work for S3 operations
+    s3_client = boto3.client('s3',
+		aws_access_key_id = resp['Credentials']['AccessKeyId'],
+		aws_secret_access_key = resp['Credentials']['SecretAccessKey'],
+		aws_session_token = resp['Credentials']['SessionToken'],
+		endpoint_url=default_endpoint,
+		region_name='',
+		)
+    bucket_name = get_new_bucket_name()
+    s3bucket = s3_client.create_bucket(Bucket=bucket_name)
+    assert s3bucket['ResponseMetadata']['HTTPStatusCode'] == 200
+    bkt = s3_client.delete_bucket(Bucket=bucket_name)
+    assert bkt['ResponseMetadata']['HTTPStatusCode'] == 204
+
+    # Phase 2: Create account-level provider with WRONG client_id (same URL as global)
+    # client_id is always validated against the JWT's aud/azp claim regardless of TLS
+    oidc_response = iam_client.create_open_id_connect_provider(
+    Url='http://localhost:8080/auth/realms/{}'.format(realm),
+    ThumbprintList=[
+        thumbprint,
+    ],
+    ClientIDList=[
+        'wrong_client_id',
+    ],
+    )
+
+    # Should FAIL — account-level has wrong client_id, proving it takes precedence over global
+    token=get_token()
+    try:
+        resp=sts_client.assume_role_with_web_identity(RoleArn=role_response['Role']['Arn'],RoleSessionName=role_session_name,WebIdentityToken=token)
+        assert False, "Expected failure due to wrong client_id in account-level provider"
+    except ClientError as e:
+        assert e.response['Error']['Code'] in ('AccessDenied', 'InvalidIdentityToken')
+
+    # Phase 3: Delete account-level provider, fallback should resume
+    iam_client.delete_open_id_connect_provider(
+    OpenIDConnectProviderArn=oidc_response["OpenIDConnectProviderArn"]
+    )
+
+    token=get_token()
+    resp=sts_client.assume_role_with_web_identity(RoleArn=role_response['Role']['Arn'],RoleSessionName=role_session_name,WebIdentityToken=token)
+    assert resp['ResponseMetadata']['HTTPStatusCode'] == 200
+
+@pytest.mark.webidentity_test
+@pytest.mark.fails_on_dbstore
+def test_assume_role_with_global_oidc_trust_policy_scope():
+    """Test trust policy principal matching with global and account-scoped providers.
+
+    Requires a global OIDC provider to be pre-created by the test task.
+
+    Case 1: Bare URL in trust policy + global provider → SUCCEED
+    Case 2: Mismatched tenant ARN in trust policy + global provider → FAIL
+    Case 3: Account-scoped ARN in trust policy + account provider → SUCCEED
+    Case 4: Bare URL in trust policy + account provider → FAIL
+      (bare URL sets account=".global", which doesn't match account-scoped provider)
+    """
+    check_webidentity()
+    iam_client=get_iam_root_client()
+    sts_client=get_sts_client()
+    default_endpoint=get_config_endpoint()
+    role_session_name=get_parameter_name()
+    thumbprint=get_thumbprint()
+    aud=get_aud()
+    token=get_token()
+    realm=get_realm_name()
+    sub=get_sub()
+
+    idp_url = 'localhost:8080/auth/realms/' + realm
+    oidc_arn = 'arn:aws:iam::'+get_iam_root_account_id()+':oidc-provider/' + idp_url
+
+    role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"s3:*\",\"Resource\":\"arn:aws:s3:::*\"}}"
+
+    # Case 1: Bare URL in trust policy + global provider → SUCCEED
+    policy_bare_url = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Federated\":[\""+idp_url+"\"]},\"Action\":[\"sts:AssumeRoleWithWebIdentity\"],\"Condition\":{\"StringEquals\":{\""+idp_url+":sub\":\""+sub+"\"}}}]}"
+    (role_error,role_response_1,role_name_1)=create_role(iam_client,'/',None,policy_bare_url,None,None,None)
+    assert role_response_1['Role']['Arn'] == 'arn:aws:iam::'+get_iam_root_account_id()+':role/'+role_name_1
+
+    (role_err,response)=put_role_policy(iam_client,role_name_1,None,role_policy)
+    assert response['ResponseMetadata']['HTTPStatusCode'] == 200
+
+    resp=sts_client.assume_role_with_web_identity(RoleArn=role_response_1['Role']['Arn'],RoleSessionName=role_session_name,WebIdentityToken=token)
+    assert resp['ResponseMetadata']['HTTPStatusCode'] == 200
+
+    # Case 2: Mismatched tenant ARN in trust policy + global provider → FAIL
+    wrong_arn = 'arn:aws:iam::wrongTenant:oidc-provider/' + idp_url
+    policy_wrong_tenant = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Federated\":[\""+wrong_arn+"\"]},\"Action\":[\"sts:AssumeRoleWithWebIdentity\"],\"Condition\":{\"StringEquals\":{\""+idp_url+":sub\":\""+sub+"\"}}}]}"
+    (role_error,role_response_2,role_name_2)=create_role(iam_client,'/',None,policy_wrong_tenant,None,None,None)
+    assert role_response_2['Role']['Arn'] == 'arn:aws:iam::'+get_iam_root_account_id()+':role/'+role_name_2
+
+    (role_err,response)=put_role_policy(iam_client,role_name_2,None,role_policy)
+    assert response['ResponseMetadata']['HTTPStatusCode'] == 200
+
+    token=get_token()
+    try:
+        resp=sts_client.assume_role_with_web_identity(RoleArn=role_response_2['Role']['Arn'],RoleSessionName=role_session_name,WebIdentityToken=token)
+        assert False, "Expected failure: mismatched tenant ARN in trust policy with global provider"
+    except ClientError as e:
+        assert e.response['Error']['Code'] in ('AccessDenied', 'InvalidIdentityToken')
+
+    # Case 3: Create account-level provider, ARN trust policy → SUCCEED
+    oidc_response = iam_client.create_open_id_connect_provider(
+        Url='http://localhost:8080/auth/realms/{}'.format(realm),
+        ThumbprintList=[thumbprint],
+        ClientIDList=[aud],
+    )
+
+    policy_scoped_arn = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Federated\":[\""+oidc_arn+"\"]},\"Action\":[\"sts:AssumeRoleWithWebIdentity\"],\"Condition\":{\"StringEquals\":{\""+idp_url+":sub\":\""+sub+"\"}}}]}"
+    (role_error,role_response_3,role_name_3)=create_role(iam_client,'/',None,policy_scoped_arn,None,None,None)
+    assert role_response_3['Role']['Arn'] == 'arn:aws:iam::'+get_iam_root_account_id()+':role/'+role_name_3
+
+    (role_err,response)=put_role_policy(iam_client,role_name_3,None,role_policy)
+    assert response['ResponseMetadata']['HTTPStatusCode'] == 200
+
+    token=get_token()
+    resp=sts_client.assume_role_with_web_identity(RoleArn=role_response_3['Role']['Arn'],RoleSessionName=role_session_name,WebIdentityToken=token)
+    assert resp['ResponseMetadata']['HTTPStatusCode'] == 200
+
+    # Case 4: Bare URL trust policy + account provider → FAIL
+    # Bare URL sets account=".global" in the principal, which won't match
+    # the account-scoped provider (is_global_oidc=false, role_tenant="")
+    token=get_token()
+    try:
+        resp=sts_client.assume_role_with_web_identity(RoleArn=role_response_1['Role']['Arn'],RoleSessionName=role_session_name,WebIdentityToken=token)
+        assert False, "Expected failure: bare URL in trust policy with account-scoped provider"
+    except ClientError as e:
+        assert e.response['Error']['Code'] in ('AccessDenied', 'InvalidIdentityToken')
+
+    # Cleanup
+    iam_client.delete_open_id_connect_provider(
+        OpenIDConnectProviderArn=oidc_response["OpenIDConnectProviderArn"]
+    )
+
+@pytest.mark.webidentity_test
+@pytest.mark.fails_on_dbstore
+def test_assume_role_with_web_identity_uid_based_non_account_user():
+    """AssumeRoleWithWebIdentity for a uid-based non-account user (empty tenant).
+
+    Uses the [s3 tenant] user (testid), whose tenant is empty and who has no
+    account. The OIDC provider and role are created under that same empty
+    tenant, so ARNs come back as arn:aws:iam:::role/... and
+    arn:aws:iam:::oidc-provider/... (no tenant or account slot).
+
+    Verifies the non-account, uid-based STS flow end-to-end: create provider,
+    create role with trust policy referencing the empty-tenant provider,
+    assume role with a Keycloak-issued JWT, and use the temp credentials to
+    create/delete a bucket.
+    """
+    check_webidentity()
+    iam_client=get_iam_client()
+    sts_client=get_sts_client()
+    default_endpoint=get_config_endpoint()
+    role_session_name=get_parameter_name()
+    thumbprint=get_thumbprint()
+    aud=get_aud()
+    realm=get_realm_name()
+    sub=get_sub()
+
+    idp_url = 'localhost:8080/auth/realms/' + realm
+    oidc_arn = 'arn:aws:iam:::oidc-provider/' + idp_url
+
+    oidc_response = iam_client.create_open_id_connect_provider(
+        Url='http://' + idp_url,
+        ThumbprintList=[thumbprint],
+        ClientIDList=[aud],
+    )
+    assert oidc_response['ResponseMetadata']['HTTPStatusCode'] == 200
+
+    policy_document = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Federated\":[\""+oidc_arn+"\"]},\"Action\":[\"sts:AssumeRoleWithWebIdentity\"],\"Condition\":{\"StringEquals\":{\""+idp_url+":sub\":\""+sub+"\"}}}]}"
+    (role_error,role_response,role_name)=create_role(iam_client,'/',None,policy_document,None,None,None)
+    assert role_response is not None, role_error
+    assert role_response['Role']['Arn'] == 'arn:aws:iam:::role/'+role_name
+
+    role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"s3:*\",\"Resource\":\"arn:aws:s3:::*\"}}"
+    policy_name = get_parameter_name()
+    (role_err,response)=put_role_policy(iam_client,role_name,policy_name,role_policy)
+    assert response['ResponseMetadata']['HTTPStatusCode'] == 200
+
+    token=get_token()
+    resp=sts_client.assume_role_with_web_identity(RoleArn=role_response['Role']['Arn'],RoleSessionName=role_session_name,WebIdentityToken=token)
+    assert resp['ResponseMetadata']['HTTPStatusCode'] == 200
+
+    s3_client = boto3.client('s3',
+        aws_access_key_id = resp['Credentials']['AccessKeyId'],
+        aws_secret_access_key = resp['Credentials']['SecretAccessKey'],
+        aws_session_token = resp['Credentials']['SessionToken'],
+        endpoint_url=default_endpoint,
+        region_name='',
+    )
+    bucket_name = get_new_bucket_name()
+    s3bucket = s3_client.create_bucket(Bucket=bucket_name)
+    assert s3bucket['ResponseMetadata']['HTTPStatusCode'] == 200
+    bkt = s3_client.delete_bucket(Bucket=bucket_name)
+    assert bkt['ResponseMetadata']['HTTPStatusCode'] == 204
+
+    # Cleanup
+    iam_client.delete_role_policy(RoleName=role_name, PolicyName=policy_name)
+    iam_client.delete_role(RoleName=role_name)
+    iam_client.delete_open_id_connect_provider(
+        OpenIDConnectProviderArn=oidc_response["OpenIDConnectProviderArn"]
     )


### PR DESCRIPTION
 Fixes:  https://tracker.ceph.com/issues/76069

based on design doc--> https://docs.google.com/document/d/1SWfTGOP4xVV5GsSx0DhqerblozVSAzE4kEz5VHBk8Co/edit?pli=1&tab=t.0

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
