### PR TITLE
tentacle: mds: for an irreparable hard link scrub is not able to identify the damage

### DIFF
--- a/doc/cephfs/scrub.rst
+++ b/doc/cephfs/scrub.rst
@@ -150,6 +150,8 @@ These above named MDS damages can be repaired by using the following command::
 If scrub is able to repair the damage, the corresponding entry is automatically
 removed from the damage table.
 
+Note: A scrub invoked with the ``repair`` option can identify an damaged hard link but not repair it.
+
 
 Evaluate strays using recursive scrub
 =====================================

--- a/qa/suites/fs/functional/tasks/scrub.yaml
+++ b/qa/suites/fs/functional/tasks/scrub.yaml
@@ -8,6 +8,7 @@ overrides:
       - bad backtrace on inode
       - overall HEALTH_
       - \(MDS_TRIM\)
+      - object missing on disk
     conf:
       mds:
         mds log max segments: 1

--- a/qa/tasks/cephfs/test_scrub_checks.py
+++ b/qa/tasks/cephfs/test_scrub_checks.py
@@ -477,6 +477,44 @@ class TestScrubChecks(CephFSTestCase):
             timeout=30
         )
 
+    def test_scrub_remote_link(self):
+        """
+        test scrub remote link
+        """
+        test_dir_path = "test_dir"
+        self.mount_a.run_shell(["mkdir", test_dir_path])
+        file_dir_path = os.path.join(test_dir_path, "file_dir")
+        self.mount_a.run_shell(["mkdir", file_dir_path])
+        file_path = os.path.join(file_dir_path, "test_file.txt")
+        link_path = os.path.join(test_dir_path, "test_link")
+        abs_link_path = "/" + link_path
+        self.mount_a.run_shell(["touch", file_path])
+        self.mount_a.run_shell(["ln", file_path, link_path])
+        file_ino = self.mount_a.path_to_ino(file_path)
+        dir_ino = self.mount_a.path_to_ino(file_dir_path)
+        rados_obj_file = "{ino:x}.00000000".format(ino=file_ino)
+        rados_obj_dir = "{ino:x}.00000000".format(ino=dir_ino)
+        self.fs.flush()
+        self.fs.rados(["rm", rados_obj_file], pool=self.fs.get_data_pool_name())
+        self.fs.rados(["rm", rados_obj_dir], pool=self.fs.get_metadata_pool_name())
+        self.fs.mds_fail_restart()
+        self.fs.wait_for_daemons()
+        status = self.fs.mds_asok(['status'])
+        self.assertEqual("up:active", str(status['state']))
+        mds_rank = self.fs.get_rank()['rank']
+        success_validator = lambda j, r: self.json_validator(j, r, "return_code", 0)
+        scrub_json = self.tell_command(mds_rank, 
+            "scrub start /{0} recursive force".format(test_dir_path), 
+                success_validator)
+        self.assertEqual(
+            self.fs.wait_until_scrub_complete(tag=scrub_json["scrub_tag"]), True)
+        damage_json = self.tell_command(mds_rank, "damage ls")
+        found_remote_link_damage = False
+        for entry in damage_json:
+            if entry["path"] == abs_link_path :
+                found_remote_link_damage = True
+        self.assertEqual(found_remote_link_damage, True)
+
     def test_stray_evaluation_with_scrub(self):
         """
         test that scrub can iterate over ~mdsdir and evaluate strays
@@ -501,7 +539,7 @@ class TestScrubChecks(CephFSTestCase):
                 jv=element_value, ev=expected_value)
         return True, "Succeeded"
 
-    def tell_command(self, mds_rank, command, validator):
+    def tell_command(self, mds_rank, command, validator=None):
         log.info("Running command '{command}'".format(command=command))
 
         command_list = command.split()
@@ -510,9 +548,10 @@ class TestScrubChecks(CephFSTestCase):
         log.info("command '{command}' returned '{jout}'".format(
                      command=command, jout=jout))
 
-        success, errstring = validator(jout, 0)
-        if not success:
-            raise AsokCommandFailedError(command, 0, jout, errstring)
+        if validator:
+            success, errstring = validator(jout, 0)
+            if not success:
+                raise AsokCommandFailedError(command, 0, jout, errstring)
         return jout
 
     @staticmethod

--- a/src/mds/ScrubStack.cc
+++ b/src/mds/ScrubStack.cc
@@ -487,6 +487,19 @@ void ScrubStack::scrub_dir_inode_final(CInode *in)
   return;
 }
 
+void ScrubStack::identify_remote_link_damage(CDentry *dn) {
+
+  CDentry::linkage_t *dnl = dn->get_linkage();
+  CInode *remote_inode = mdcache->get_inode(dnl->get_remote_ino());
+  if (!remote_inode) {
+    if (mdcache->mds->damage_table.is_remote_damaged(dnl->get_remote_ino())) {
+      dout(4) << "scrub: remote dentry points to damaged ino " << *dn << dendl;
+      return;
+    }
+    mdcache->open_remote_dentry(dn, true, new C_MDSInternalNoop());
+  }
+}
+
 void ScrubStack::scrub_dirfrag(CDir *dir, bool *added_children, bool *done)
 {
   ceph_assert(dir != NULL);
@@ -531,7 +544,7 @@ void ScrubStack::scrub_dirfrag(CDir *dir, bool *added_children, bool *done)
   *added_children = true;
 	_enqueue(dnl->get_inode(), header, true);
       } else if (dnl->is_remote()) {
-	// TODO: check remote linkage
+        identify_remote_link_damage(dn);
       }
     }
   }

--- a/src/mds/ScrubStack.h
+++ b/src/mds/ScrubStack.h
@@ -213,6 +213,12 @@ private:
   void scrub_file_inode(CInode *in);
 
   /**
+   * Scrub a file inode.
+   * @param dn The remote dentry to identify
+   */
+  void identify_remote_link_damage(CDentry *dn);
+
+  /**
    * Callback from completion of CInode::validate_disk_state
    * @param in The inode we were validating
    * @param r The return status from validate_disk_state


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
