### PR TITLE
mon/AuthMonitor: make auth rotate safe when connection drop

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -87,6 +87,8 @@
   configured ratio of the main OSD data device size. This warning is
   informational and can be muted with:
   ``ceph health mute BLUESTORE_BLUEFS_OVERSIZED``
+* cephx: ``auth rotate`` now keeps the old key valid until ``ceph auth commit-pending <entity>``
+  is called, preventing clients from being permanently locked out if the rotate reply is lost in transit.
 
 >=20.0.0
 

--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -362,6 +362,18 @@
   read-only fsck, gated by the new ``bluestore_accept_corrupted_onode_recovery``
   option (``never`` or ``read-only``, default ``read-only``); mount, repair, and
   ``ceph-bluestore-tool trim`` still abort.
+* cephx: ``auth rotate`` now keeps the old key valid until ``ceph auth commit-pending <entity>``
+  is called, preventing clients from being permanently locked out if the rotate reply is lost in transit.
+* cephx: a new ``AUTH_PENDING_KEY_NOT_COMMITTED`` health warning is raised when
+  a key rotated via ``ceph auth rotate``, ``auth rotate-pending``, or ``auth get-or-create-pending`` is
+  left uncommitted for longer than ``mon_auth_pending_key_ttl`` (default 1 day),
+  and ``mgr/cephadm`` now calls ``auth commit-pending`` once a daemon has been
+  redeployed with its rotated key, instead of leaving the rotation half-finished.
+* cephx: a new ``ceph auth rotate-pending <entity>`` command generates or
+  retrieves an entity's pending key idempotently, same as ``auth rotate``,
+  but reports it honestly as a *pending* key instead of presenting it as the
+  active key. ``mgr/cephadm`` now uses it so a retried rotation can't orphan
+  a key a daemon has already been redeployed with.
 
 >=20.0.0
 

--- a/doc/rados/configuration/auth-config-ref.rst
+++ b/doc/rados/configuration/auth-config-ref.rst
@@ -320,7 +320,12 @@ this upgrade, it's necessary to do the upgrade in several steps.
 
 #. **Rotate the keys for all service daemon credentials.** These include **mon**, **mgr**, **osd**, and **mds**.
 
-   .. warning:: Changing the key will make the existing daemon unable to reauthenticate.
+   .. warning:: ``auth rotate-pending`` only stores the new key as *pending*; the old
+      key keeps working until you run ``auth commit-pending`` below. Restarting
+      a daemon before then is safe, but the rotation -- and its security
+      benefit -- is not complete until you commit it. ``auth rotate-pending`` is
+      idempotent, so re-running it (for example after a mistake) returns the
+      same pending key instead of minting a new one.
 
    .. note:: The ``mon.`` historically has not been managed by the Monitor auth database; it exists soley in each Monitor's keyring inside its data directory. This suggested rotation procedure now puts the authoritative copy in the auth database alongside other keys. The Monitor keyring persists as a fallback or emergency key.
 
@@ -328,7 +333,7 @@ this upgrade, it's necessary to do the upgrade in several steps.
 
    .. code:: bash
 
-       ceph auth rotate --key-type=aes256k mon. | tee mon.keyring
+       ceph auth rotate-pending --key-type=aes256k mon. | tee mon.keyring
 
    Save the ``mon.keyring`` file in a safe place. It should **not** be necessary to update the keyring files for each Monitor.
 
@@ -339,6 +344,12 @@ this upgrade, it's necessary to do the upgrade in several steps.
        systemctl restart ceph-mon@$ID
 
    .. warning:: If a Monitor was out-of-quorum during the Monitor key rotation, it will not have the new key. You must put the saved ``mon.keyring`` in its keyring file so it can authenticate.
+
+   Once every Monitor has been restarted, commit the rotation to retire the old ``mon.`` key:
+
+   .. code:: bash
+
+       ceph auth commit-pending mon.
 
 
    Now, for each other service daemon type (**mgr**, **osd**, and **mds**):
@@ -359,7 +370,7 @@ this upgrade, it's necessary to do the upgrade in several steps.
 
    .. code:: bash
 
-       ceph auth rotate --key-type=aes256k $TYPE.$ID | tee keyring
+       ceph auth rotate-pending --key-type=aes256k $TYPE.$ID | tee keyring
 
    .. note:: If you have updated ``auth_preferred_cipher`` then you can omit ``--key-type``.
 
@@ -397,6 +408,12 @@ this upgrade, it's necessary to do the upgrade in several steps.
    .. code:: bash
 
        systemctl restart ceph-$TYPE@$ID
+
+   Once the daemon is back up and using the new key, commit the rotation to retire the old key:
+
+   .. code:: bash
+
+       ceph auth commit-pending $TYPE.$ID
 
 #. **Confirm the** :ref:`auth-insecure-service-key-type` **is cleared.**
 
@@ -507,11 +524,11 @@ this upgrade, it's necessary to do the upgrade in several steps.
 
    .. code:: bash
 
-       ceph auth rotate --key-type=aes256k client.admin | tee ./client.admin.keyring
+       ceph auth rotate-pending --key-type=aes256k client.admin | tee ./client.admin.keyring
 
    .. note:: If you have updated ``auth_preferred_cipher`` then you can omit ``--key-type``.
 
-   .. warning:: The client.admin key is now changed. You cannot execute new Ceph commands as ``client.admin`` until you import the new key into your keyring.
+   .. note:: The old ``client.admin`` key keeps working until you commit the rotation below, so you are not locked out while you update your keyring file.
 
    Import the new ``client.admin`` key into your system's keyring file:
 
@@ -526,6 +543,12 @@ this upgrade, it's necessary to do the upgrade in several steps.
    .. code:: bash
 
        ceph -n client.admin -k /etc/ceph/ceph.client.admin.keyring ceph auth ls
+
+   Once the new key has been copied to every node that needs it and verified, commit the rotation to retire the old key:
+
+   .. code:: bash
+
+       ceph auth commit-pending client.admin
 
    If everything looks good, remove the backup key:
 
@@ -559,11 +582,17 @@ this upgrade, it's necessary to do the upgrade in several steps.
 
    .. code:: bash
 
-       ceph auth rotate --key-type=aes256k client.$ID | tee ./client.$ID.keyring
+       ceph auth rotate-pending --key-type=aes256k client.$ID | tee ./client.$ID.keyring
 
    .. note:: If you have updated ``auth_preferred_cipher`` then you can omit ``--key-type``.
 
-   Then copy and import the key to each machine using that ``client.$ID`` credential.
+   Then copy and import the key to each machine using that ``client.$ID`` credential. The old key keeps working until you commit the rotation, so clients are not locked out mid-rollout.
+
+   Once the new key has been copied everywhere it is used, commit the rotation to retire the old key:
+
+   .. code:: bash
+
+       ceph auth commit-pending client.$ID
 
    Once all client credentials have been upgraded, you should see the ``AUTH_INSECURE_CLIENT_KEY_TYPE`` health warning clear.
 
@@ -626,7 +655,7 @@ For example:
 
     ceph auth rotate client.fs | tee ./client.fs.keyring
 
-The output of the command is the new key:
+The output of the command shows the new key as if it were already active:
 
 ::
 
@@ -644,6 +673,37 @@ This can be imported into a new keyring using ``ceph-authtool``:
 
 
 .. note:: The key must be distributed to all locations where the key is in use.
+
+.. important:: ``auth rotate`` does **not** replace the old key immediately.
+   It stores the new key as a *pending* key: both the old and the new key are
+   accepted for authentication until the rotation is explicitly finished.
+   The old key remains valid, and the security benefit of the rotation is
+   **not** realized, until you run:
+
+   .. code:: bash
+
+       ceph auth commit-pending $TYPE.$ID
+
+   after every location using this credential has picked up the new key. If
+   you decide not to go through with the rotation, discard the pending key
+   and keep the old one with:
+
+   .. code:: bash
+
+       ceph auth clear-pending $TYPE.$ID
+
+   If a pending key is left uncommitted for longer than
+   ``mon_auth_pending_key_ttl`` (one day, by default), the
+   :ref:`auth-pending-key-not-committed` health warning is raised as a
+   reminder to finish or abandon the rotation.
+
+.. note:: ``auth rotate`` is idempotent: if a pending key already exists for
+   the entity, it is returned unchanged instead of being replaced, so a retry
+   cannot orphan a key a client may have already started using. ``auth
+   rotate-pending`` behaves the same way, but reports the pending key
+   honestly as a *pending* key instead of presenting it as the active key.
+   Scripts or automation that need to inspect whether a rotation is still
+   pending should use ``auth rotate-pending``.
 
 
 .. _auth_emergency_allowed_ciphers:

--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -474,6 +474,37 @@ The warning should resolve immediately.
 .. note:: cephadm and Rook should automate this process for you.
 
 
+.. _auth-pending-key-not-committed:
+
+AUTH_PENDING_KEY_NOT_COMMITTED
+_______________________________
+
+``ceph auth rotate``, ``ceph auth rotate-pending``, and ``ceph auth get-or-create-pending`` all generate a new,
+uncommitted key for an entity: both the old and the new key are accepted for
+authentication until ``ceph auth commit-pending`` promotes the new key, or
+``ceph auth clear-pending`` aborts the rotation. This warning means a pending
+key has been left uncommitted longer than :confval:`mon_auth_pending_key_ttl`,
+which usually indicates an interrupted rotation (for example, a client or
+automation tool that rotated the key but never finished the second step).
+
+.. prompt:: bash $
+
+    ceph health detail
+
+outputs
+
+::
+
+    [WRN] AUTH_PENDING_KEY_NOT_COMMITTED: 1 auth entities have an uncommitted pending key
+    entity client.admin2 has had an uncommitted pending key for 90000.000000
+
+The threshold before this warning is raised can be tuned with:
+
+.. prompt:: bash $
+
+    ceph config set mon mon_auth_pending_key_ttl 1_day
+
+
 .. _auth-insecure-client-key-type:
 
 AUTH_INSECURE_CLIENT_KEY_TYPE

--- a/doc/rados/operations/user-management.rst
+++ b/doc/rados/operations/user-management.rst
@@ -772,6 +772,28 @@ To rotate the secret for an entity, use:
 This avoids the need to delete and recreate the entity when its key is
 compromised, lost, or scheduled for rotation.
 
+The rotation is not immediate. ``auth rotate`` generates a new key and
+stores it as a ``pending_key`` — the old key remains valid until the
+rotation is explicitly committed. This means a client that loses the
+reply can re-authenticate with the old key and retry safely.
+
+To commit the rotation and invalidate the old key:
+
+.. prompt:: bash #
+
+    ceph auth commit-pending <entity>
+
+To cancel the rotation and discard the pending key:
+
+.. prompt:: bash #
+
+    ceph auth clear-pending <entity>
+
+To generate a pending key without using ``auth rotate``:
+
+.. prompt:: bash #
+
+    ceph auth get-or-create-pending <entity>
 
 Command Line Usage
 ==================

--- a/doc/rados/operations/user-management.rst
+++ b/doc/rados/operations/user-management.rst
@@ -781,6 +781,40 @@ To rotate the secret for an entity, use:
 This avoids the need to delete and recreate the entity when its key is
 compromised, lost, or scheduled for rotation.
 
+The rotation is half complete; both the old key and new key are accepted
+for authentication. ``auth rotate`` generates a new key and stores it as
+a ``pending_key`` — the old key remains valid until the rotation is explicitly
+committed. This means a client that loses the reply can re-authenticate with
+the old key and retry safely.
+
+``auth rotate`` is idempotent: if a pending key already exists for the
+entity, it is returned unchanged instead of being replaced, so a retry
+(for example, after a failure partway through applying the new key) cannot
+orphan a key that has already been put into use. To retrieve the same
+pending key but reported honestly as *pending* instead of being presented
+as the active key, use ``auth rotate-pending`` instead:
+
+.. prompt:: bash #
+
+    ceph auth rotate-pending <entity>
+
+To commit the rotation and invalidate the old key:
+
+.. prompt:: bash #
+
+    ceph auth commit-pending <entity>
+
+To cancel the rotation and discard the pending key:
+
+.. prompt:: bash #
+
+    ceph auth clear-pending <entity>
+
+To generate a pending key without using ``auth rotate``:
+
+.. prompt:: bash #
+
+    ceph auth get-or-create-pending <entity>
 
 Command Line Usage
 ==================

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -636,6 +636,66 @@ function test_auth()
   expect_true ceph auth rm client.admin2
   rm keyring[1234]
 
+  # regression test: auth rotate must not invalidate the old key until the client
+  # explicitly commits — guards against the lost-reply deadlock where a client whose
+  # connection was dropped right after rotate could never reconnect to recover
+  ceph auth get-or-create client.admin4 mon 'allow *'
+  ceph auth get client.admin4 >> keyring1
+  # rotate and discard the new keyring simulates the reply and connection both lost
+  env CEPH_KEYRING=keyring1 ceph -n client.admin4 auth rotate client.admin4 > /dev/null
+  # old key must still be valid: the client can reconnect and is not permanently locked out
+  expect_true env CEPH_KEYRING=keyring1 ceph -n client.admin4 auth get client.admin4
+  # the client can now recover: rotate again to get a fresh reply
+  env CEPH_KEYRING=keyring1 ceph -n client.admin4 auth rotate client.admin4 >> keyring2
+  # commit using the new key from the second rotate
+  ceph auth commit-pending client.admin4
+  # new key works, old key is gone
+  expect_true env CEPH_KEYRING=keyring2 ceph -n client.admin4 auth get client.admin4
+  expect_false env CEPH_KEYRING=keyring1 ceph -n client.admin4 auth get client.admin4
+  expect_true ceph auth rm client.admin4
+  rm keyring[12]
+
+  # test get-or-create-pending: explicit two-phase rotation
+  ceph auth get-or-create client.admin3 mon 'allow *'
+  ceph auth get client.admin3 >> keyring1
+  # generate a pending key
+  ceph auth get-or-create-pending client.admin3 >> keyring2
+  # calling it again returns the same result — it does not generate a fresh key each time
+  ceph auth get-or-create-pending client.admin3 >> keyring3
+  expect_true diff -au keyring2 keyring3
+  # auth get shows the pending key in the keyring
+  ceph auth get client.admin3 >> keyring4
+  expect_true grep "pending" keyring4
+  # old key still works before commit
+  expect_true env CEPH_KEYRING=keyring1 ceph -n client.admin3 auth get client.admin3
+  # commit the pending key: promotes pending_key -> active key, invalidates the old one
+  ceph auth commit-pending client.admin3
+  # old key no longer works
+  expect_false env CEPH_KEYRING=keyring1 ceph -n client.admin3 auth get client.admin3
+  # committing when there is no pending key is harmless
+  ceph auth commit-pending client.admin3
+  expect_true ceph auth rm client.admin3
+  rm keyring[1234]
+
+  # test clear-pending: abort a rotation before it commits
+  ceph auth get-or-create client.admin3 mon 'allow *'
+  ceph auth get client.admin3 >> keyring1
+  ceph auth get-or-create-pending client.admin3
+  # auth get shows the pending key
+  ceph auth get client.admin3 >> keyring2
+  expect_true grep "pending" keyring2
+  # cancel the rotation
+  ceph auth clear-pending client.admin3
+  # calling clear-pending again when nothing is pending is harmless
+  ceph auth clear-pending client.admin3
+  # auth get no longer shows a pending key
+  ceph auth get client.admin3 >> keyring3
+  expect_false grep "pending" keyring3
+  # original key still works — clear-pending did not touch it
+  expect_true env CEPH_KEYRING=keyring1 ceph -n client.admin3 auth get client.admin3
+  expect_true ceph auth rm client.admin3
+  rm keyring[123]
+
   # (almost) interactive mode
   echo -e 'auth add client.xx mon "allow *" osd "allow *"\n' | ceph
   ceph auth get client.xx

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -620,10 +620,16 @@ function test_auth()
   env CEPH_KEYRING=keyring1 ceph -n client.admin2 auth rotate client.admin2 >> keyring3
   # only the key has changed:
   diff -au keyring1 keyring3 | grep -E '^[-+][^-+]' | expect_false grep -v key
-  # the key in keyring1 no longer works:
-  expect_false env CEPH_KEYRING=keyring1 ceph -n client.admin2 auth get client.admin2
+  # BEFORE commit: old key must still be valid (pending_key):
+  expect_true env CEPH_KEYRING=keyring1 ceph -n client.admin2 auth get client.admin2
+  # BEFORE commit: new key must also work
+  expect_true env CEPH_KEYRING=keyring3 ceph -n client.admin2 auth get client.admin2
+  # explicitly commit the rotation — promotes pending_key→key, invalidates old key atomically
+  ceph auth commit-pending client.admin2
   # the key in keyring3 should work:
   expect_true env CEPH_KEYRING=keyring3 ceph -n client.admin2 auth get client.admin2
+  # the key in keyring1 no longer works:
+  expect_false env CEPH_KEYRING=keyring1 ceph -n client.admin2 auth get client.admin2
   # now verify the key from `auth get` matches what rotate produced:
   expect_true ceph auth get client.admin2 >> keyring4
   expect_true diff -au keyring3 keyring4

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -620,15 +620,118 @@ function test_auth()
   env CEPH_KEYRING=keyring1 ceph -n client.admin2 auth rotate client.admin2 >> keyring3
   # only the key has changed:
   diff -au keyring1 keyring3 | grep -E '^[-+][^-+]' | expect_false grep -v key
-  # the key in keyring1 no longer works:
-  expect_false env CEPH_KEYRING=keyring1 ceph -n client.admin2 auth get client.admin2
+  # BEFORE commit: old key must still be valid (pending_key):
+  expect_true env CEPH_KEYRING=keyring1 ceph -n client.admin2 auth get client.admin2
+  # BEFORE commit: new key must also work
+  expect_true env CEPH_KEYRING=keyring3 ceph -n client.admin2 auth get client.admin2
+  # explicitly commit the rotation — promotes pending_key→key, invalidates old key atomically
+  ceph auth commit-pending client.admin2
   # the key in keyring3 should work:
   expect_true env CEPH_KEYRING=keyring3 ceph -n client.admin2 auth get client.admin2
+  # the key in keyring1 no longer works:
+  expect_false env CEPH_KEYRING=keyring1 ceph -n client.admin2 auth get client.admin2
   # now verify the key from `auth get` matches what rotate produced:
   expect_true ceph auth get client.admin2 >> keyring4
   expect_true diff -au keyring3 keyring4
   expect_true ceph auth rm client.admin2
   rm keyring[1234]
+
+  # regression test: auth rotate must not invalidate the old key until the client
+  # explicitly commits — guards against the lost-reply deadlock where a client whose
+  # connection was dropped right after rotate could never reconnect to recover
+  ceph auth get-or-create client.admin4 mon 'allow *'
+  ceph auth get client.admin4 >> keyring1
+  # rotate and discard the new keyring simulates the reply and connection both lost
+  env CEPH_KEYRING=keyring1 ceph -n client.admin4 auth rotate client.admin4 >> keyring2
+  # old key must still be valid: the client can reconnect and is not permanently locked out
+  expect_true env CEPH_KEYRING=keyring1 ceph -n client.admin4 auth get client.admin4
+  # the client can now recover: rotate again -- auth rotate is idempotent, so this
+  # must return the SAME pending key as the first call, not orphan it with a fresh one
+  env CEPH_KEYRING=keyring1 ceph -n client.admin4 auth rotate client.admin4 >> keyring3
+  expect_true diff -au keyring2 keyring3
+  # commit using the (same) new key from either rotate call
+  ceph auth commit-pending client.admin4
+  # new key works, old key is gone
+  expect_true env CEPH_KEYRING=keyring3 ceph -n client.admin4 auth get client.admin4
+  expect_false env CEPH_KEYRING=keyring1 ceph -n client.admin4 auth get client.admin4
+  expect_true ceph auth rm client.admin4
+  rm keyring[123]
+
+  # test rotate-pending: same idempotent pending-key generation as auth rotate,
+  # but with an honest reply (new key shown as "pending key", not disguised as
+  # the active "key"). This is what protects an orchestrator's retry (e.g.
+  # after a failed commit-pending call) from orphaning a key a daemon has
+  # already adopted.
+  ceph auth get-or-create client.admin5 mon 'allow *'
+  ceph auth get client.admin5 >> keyring1
+  ceph auth rotate-pending client.admin5 >> keyring2
+  # a retry must return the SAME pending key, not mint a fresh one
+  ceph auth rotate-pending client.admin5 >> keyring3
+  expect_true diff -au keyring2 keyring3
+  # unlike auth rotate, the reply is honest: the new key is shown as "pending
+  # key", not disguised as the active "key"
+  expect_true grep "pending" keyring2
+  # old key still works before commit
+  expect_true env CEPH_KEYRING=keyring1 ceph -n client.admin5 auth get client.admin5
+  ceph auth commit-pending client.admin5
+  expect_false env CEPH_KEYRING=keyring1 ceph -n client.admin5 auth get client.admin5
+  expect_true ceph auth rm client.admin5
+  rm keyring[123]
+
+  # test get-or-create-pending: explicit two-phase rotation
+  ceph auth get-or-create client.admin3 mon 'allow *'
+  ceph auth get client.admin3 >> keyring1
+  # generate a pending key
+  ceph auth get-or-create-pending client.admin3 >> keyring2
+  # calling it again returns the same result — it does not generate a fresh key each time
+  ceph auth get-or-create-pending client.admin3 >> keyring3
+  expect_true diff -au keyring2 keyring3
+  # auth get shows the pending key in the keyring
+  ceph auth get client.admin3 >> keyring4
+  expect_true grep "pending" keyring4
+  # old key still works before commit
+  expect_true env CEPH_KEYRING=keyring1 ceph -n client.admin3 auth get client.admin3
+  # commit the pending key: promotes pending_key -> active key, invalidates the old one
+  ceph auth commit-pending client.admin3
+  # old key no longer works
+  expect_false env CEPH_KEYRING=keyring1 ceph -n client.admin3 auth get client.admin3
+  # committing when there is no pending key is harmless
+  ceph auth commit-pending client.admin3
+  expect_true ceph auth rm client.admin3
+  rm keyring[1234]
+
+  # test clear-pending: abort a rotation before it commits
+  ceph auth get-or-create client.admin3 mon 'allow *'
+  ceph auth get client.admin3 >> keyring1
+  ceph auth get-or-create-pending client.admin3
+  # auth get shows the pending key
+  ceph auth get client.admin3 >> keyring2
+  expect_true grep "pending" keyring2
+  # cancel the rotation
+  ceph auth clear-pending client.admin3
+  # calling clear-pending again when nothing is pending is harmless
+  ceph auth clear-pending client.admin3
+  # auth get no longer shows a pending key
+  ceph auth get client.admin3 >> keyring3
+  expect_false grep "pending" keyring3
+  # original key still works — clear-pending did not touch it
+  expect_true env CEPH_KEYRING=keyring1 ceph -n client.admin3 auth get client.admin3
+  expect_true ceph auth rm client.admin3
+  rm keyring[123]
+
+  # test AUTH_PENDING_KEY_NOT_COMMITTED: a rotation left uncommitted past the
+  # configured TTL must raise a health warning, and it must clear once the
+  # rotation is finished (committed or cleared)
+  ceph config set mon mon_auth_pending_key_ttl 1
+  ceph auth get-or-create client.pendingwarn mon 'allow r'
+  ceph auth rotate client.pendingwarn > /dev/null
+  sleep 2
+  wait_for_health 'AUTH_PENDING_KEY_NOT_COMMITTED'
+  ceph health detail | grep 'client.pendingwarn'
+  ceph auth commit-pending client.pendingwarn
+  wait_for_health_gone 'AUTH_PENDING_KEY_NOT_COMMITTED'
+  ceph auth rm client.pendingwarn
+  ceph config rm mon mon_auth_pending_key_ttl
 
   # (almost) interactive mode
   echo -e 'auth add client.xx mon "allow *" osd "allow *"\n' | ceph

--- a/src/auth/KeyRing.cc
+++ b/src/auth/KeyRing.cc
@@ -110,6 +110,15 @@ int KeyRing::set_modifier(const char *type,
       return -EINVAL;
     }
     set_key(name, key);
+  } else if (strcmp(type, "pending key") == 0) {
+    CryptoKey key;
+    string l(val);
+    try {
+      key.decode_base64(l);
+    } catch (const ceph::buffer::error& err) {
+      return -EINVAL;
+    }
+    set_pending_key(name, key);
   } else if (strncmp(type, "caps ", 5) == 0) {
     const char *caps_entity = type + 5;
     if (!*caps_entity)

--- a/src/auth/KeyRing.cc
+++ b/src/auth/KeyRing.cc
@@ -116,6 +116,15 @@ int KeyRing::set_modifier(const char *type,
       return -EINVAL;
     }
     set_key(name, key);
+  } else if (strcmp(type, "pending key") == 0) {
+    CryptoKey key;
+    string l(val);
+    try {
+      key.decode_base64(l);
+    } catch (const ceph::buffer::error& err) {
+      return -EINVAL;
+    }
+    set_pending_key(name, key);
   } else if (strncmp(type, "caps ", 5) == 0) {
     const char *caps_entity = type + 5;
     if (!*caps_entity)

--- a/src/auth/KeyRing.h
+++ b/src/auth/KeyRing.h
@@ -96,6 +96,9 @@ public:
   void set_key(EntityName& ename, CryptoKey& key) {
     keys[ename].key = key;
   }
+  void set_pending_key(EntityName& ename, CryptoKey& key) {
+    keys[ename].pending_key = key;
+  }
   void import(CephContext *cct, KeyRing& other);
 
   // decode as plaintext

--- a/src/auth/KeyRing.h
+++ b/src/auth/KeyRing.h
@@ -96,6 +96,9 @@ public:
   void set_key(EntityName& ename, CryptoKey& key) {
     keys[ename].key = key;
   }
+  void set_pending_key(const EntityName& ename, const CryptoKey& key) {
+    keys[ename].pending_key = key;
+  }
   void import(CephContext *cct, KeyRing& other);
 
   // decode as plaintext

--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -869,6 +869,21 @@ options:
   flags:
   - startup
   - no_mon_update
+- name: mon_auth_pending_key_ttl
+  type: secs
+  level: advanced
+  desc: how long a pending key may sit uncommitted before a health warning is raised
+  long_desc: >
+    After `ceph auth rotate`, `auth rotate-pending`, or `auth get-or-create-pending` generates a new
+    pending key for an entity, the rotation is not complete until `auth
+    commit-pending` is called to promote it. If a pending key remains
+    uncommitted for longer than this many seconds, the AUTH_PENDING_KEY_NOT_COMMITTED
+    health warning is raised so operators notice a stuck or abandoned rotation.
+  default: 1_day
+  services:
+  - mon
+  flags:
+  - runtime
 - name: mon_auth_validate_all_caps
   type: bool
   level: advanced

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -1866,7 +1866,7 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
       goto done;
     }
 
-    entity_auth.key.create(g_ceph_context, CEPH_CRYPTO_AES);
+    entity_auth.pending_key.create(g_ceph_context, CEPH_CRYPTO_AES);
 
     KeyServerData::Incremental auth_inc;
     auth_inc.op = KeyServerData::AUTH_INC_ADD;
@@ -1874,7 +1874,9 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
     auth_inc.auth = entity_auth;
     push_cephx_inc(auth_inc);
 
-    _encode_auth(entity, entity_auth, rdata, f.get());
+    auth_inc.auth.key = auth_inc.auth.pending_key;
+    auth_inc.auth.pending_key.clear();
+    _encode_auth(entity, auth_inc.auth, rdata, f.get());
     wait_for_commit(op, new Monitor::C_Command(mon, op, 0, rs, rdata,
                                               get_last_committed() + 1));
     return true;

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -649,6 +649,35 @@ bool AuthMonitor::check_health()
     }
   }
 
+  {
+    auto ttl = cct->_conf.get_val<std::chrono::seconds>("mon_auth_pending_key_ttl");
+    auto now = ceph_clock_now();
+    std::vector<std::string> stale_pending_keys;
+    for (auto const& [entity, auth] : mon.get_secrets()) {
+      if (auth.pending_key.empty()) {
+        continue;
+      }
+      if (now < auth.pending_key.get_created()) {
+        continue;
+      }
+      utime_t age = now - auth.pending_key.get_created();
+      if (age.sec() > ttl.count()) {
+        std::ostringstream ss;
+        ss << "entity " << entity << " has had an uncommitted pending key for "
+           << age;
+        stale_pending_keys.push_back(ss.str());
+      }
+    }
+    if (!stale_pending_keys.empty()) {
+      std::ostringstream summary;
+      summary << stale_pending_keys.size() << " auth entities have an uncommitted pending key";
+      auto& check = next.add("AUTH_PENDING_KEY_NOT_COMMITTED", HEALTH_WARN, summary.str(), stale_pending_keys.size());
+      for (auto& detail : stale_pending_keys) {
+        check.detail.push_back(detail);
+      }
+    }
+  }
+
   return next != get_health_checks(); /* should propose */
 }
 

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -1008,6 +1008,7 @@ bool AuthMonitor::preprocess_command(MonOpRequestRef op)
   cmd_getval(cmdmap, "prefix", prefix);
   if (prefix == "auth add" ||
       prefix == "auth rotate" ||
+      prefix == "auth rotate-pending" ||
       prefix == "auth dump-keys" ||
       prefix == "auth wipe-rotating-service-keys" ||
       prefix == "auth del" ||
@@ -1724,6 +1725,7 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
 						   get_last_committed() + 1));
     return true;
   } else if ((prefix == "auth get-or-create-pending" ||
+	      prefix == "auth rotate-pending" ||
 	      prefix == "auth clear-pending" ||
 	      prefix == "auth commit-pending")) {
     if (mon.monmap->min_mon_release < ceph_release_t::quincy) {
@@ -1760,7 +1762,8 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
       }
     }
 
-    if (prefix == "auth get-or-create-pending") {
+    if (prefix == "auth get-or-create-pending" ||
+        prefix == "auth rotate-pending") {
       KeyRing kr;
       bool exists = false;
       if (!entity_auth.pending_key.empty()) {
@@ -2082,7 +2085,36 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
       goto done;
     }
 
-    entity_auth.key.create(g_ceph_context, key_type);
+    // is there an uncommitted pending_key already queued for this entity?
+    // mon.get_auth() above only sees committed state, so a fast retry before
+    // the first rotate's proposal commits would otherwise race past the
+    // pending_key.empty() check below and queue a second, competing
+    // AUTH_INC_ADD -- orphaning whichever key the loser reply carried.
+    for (auto& p : pending_auth) {
+      if (p.inc_type == AUTH_DATA) {
+        KeyServerData::Incremental auth_inc;
+        auto q = p.auth_data.cbegin();
+        decode(auth_inc, q);
+        if (auth_inc.op == KeyServerData::AUTH_INC_ADD &&
+            auth_inc.name == entity) {
+          wait_for_commit(op, new Monitor::C_Command(mon, op, 0, rs,
+                                                get_last_committed() + 1));
+          return true;
+        }
+      }
+    }
+
+    if (!entity_auth.pending_key.empty()) {
+      // idempotent: a retry after a lost reply must not orphan a pending
+      // key the client may have already received and started using
+      EntityAuth reply_auth = entity_auth;
+      reply_auth.key = reply_auth.pending_key;
+      reply_auth.pending_key.clear();
+      _encode_auth(entity, reply_auth, rdata, f.get());
+      err = 0;
+      goto done;
+    }
+    entity_auth.pending_key.create(g_ceph_context, key_type);
 
     KeyServerData::Incremental auth_inc;
     auth_inc.op = KeyServerData::AUTH_INC_ADD;
@@ -2090,7 +2122,9 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
     auth_inc.auth = entity_auth;
     push_cephx_inc(auth_inc);
 
-    _encode_auth(entity, entity_auth, rdata, f.get());
+    auth_inc.auth.key = auth_inc.auth.pending_key;
+    auth_inc.auth.pending_key.clear();
+    _encode_auth(entity, auth_inc.auth, rdata, f.get());
     wait_for_commit(op, new Monitor::C_Command(mon, op, 0, rs, rdata,
                                               get_last_committed() + 1));
     return true;

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -204,6 +204,13 @@ COMMAND("auth get-or-create-pending "
 	"name=entity,type=CephString",
 	"generate and/or retrieve existing pending key (rotated into place on first use)",
 	"auth", "rwx")
+COMMAND("auth rotate-pending"
+	" name=entity,type=CephString"
+        " --"
+	" name=key_type,type=CephString,req=false"
+        ,
+	"generate and/or retrieve existing pending key for entity",
+	"auth", "rwx")
 COMMAND("auth clear-pending "
 	"name=entity,type=CephString",
 	"clear pending key",

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3133,7 +3133,7 @@ Then run the following:
 
     def key_rotate(self, daemon_spec: CephadmDaemonDeploySpec) -> None:
         rc, out, err = self.mon_command({
-            'prefix': 'auth rotate',
+            'prefix': 'auth rotate-pending',
             'entity': daemon_spec.entity_name(),
             'format': 'json',
             'key_type': utils.ROTATION_CIPHER
@@ -3141,6 +3141,18 @@ Then run the following:
         if rc:
             raise OrchestratorError(
                 f'Failed to rotate daemon key for {daemon_spec.entity_name()}.\n'
+                f'Rc: {rc}\nOut: {out}\nErr: {err}'
+            )
+
+    def commit_pending_key(self, daemon_spec: CephadmDaemonDeploySpec) -> None:
+        rc, out, err = self.mon_command({
+            'prefix': 'auth commit-pending',
+            'entity': daemon_spec.entity_name(),
+            'format': 'json',
+        })
+        if rc:
+            raise OrchestratorError(
+                f'Failed to commit rotated key for {daemon_spec.entity_name()}.\n'
                 f'Rc: {rc}\nOut: {out}\nErr: {err}'
             )
 

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1084,6 +1084,13 @@ class CephService(CephadmService):
                 'prefix': 'auth get',
                 'entity': entity,
             })
+            # prefer an uncommitted pending key over the still-active one, same
+            # as get_keyring_with_caps()/simplified_keyring(), so a daemon that
+            # gets redeployed while a key rotation is pending actually picks up
+            # the new key instead of continuing to use the one about to be
+            # invalidated by `auth commit-pending`.
+            if keyring:
+                keyring = simplified_keyring(entity, keyring)
         config = self.mgr.get_minimal_ceph_conf()
 
         if extra_ceph_config:
@@ -1127,6 +1134,11 @@ class MonService(CephService):
             'prefix': 'auth get',
             'entity': daemon_spec.entity_name(),
         })
+        # prefer an uncommitted pending key: without this, a mon redeployed
+        # while a key rotation is pending keeps using the key that's about to
+        # be invalidated by `auth commit-pending` once every mon has the new one
+        if keyring:
+            keyring = simplified_keyring(daemon_spec.entity_name(), keyring)
 
         extra_config = '[mon.%s]\n' % name
         if network:

--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -6,6 +6,7 @@ import pytest
 
 from ceph.deployment.service_spec import PlacementSpec, ServiceSpec
 from cephadm import CephadmOrchestrator
+from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
 from cephadm.upgrade import (
     CephadmUpgrade,
     OkToUpgradeMonReport,
@@ -1209,3 +1210,115 @@ def test_do_upgrade_limit_exhausted_marks_complete_without_scope_check(
 
     mark_complete.assert_called_once()
     filtered_scope.assert_not_called()
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+@mock.patch("cephadm.CephadmOrchestrator.mon_command")
+def test_commit_pending_key(mon_command, cephadm_module: CephadmOrchestrator):
+    daemon_spec = CephadmDaemonDeploySpec(
+        host='host1', daemon_id='0', daemon_type='osd', service_name='osd')
+
+    mon_command.return_value = (0, '', '')
+    cephadm_module.commit_pending_key(daemon_spec)
+    mon_command.assert_called_once_with({
+        'prefix': 'auth commit-pending',
+        'entity': 'osd.0',
+        'format': 'json',
+    })
+
+    mon_command.return_value = (1, '', 'no pending key for osd.0')
+    with pytest.raises(OrchestratorError):
+        cephadm_module.commit_pending_key(daemon_spec)
+
+
+def _osd_daemon() -> DaemonDescription:
+    return DaemonDescription(
+        daemon_type='osd', daemon_id='0', hostname='host1', service_name='osd')
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+@mock.patch("cephadm.CephadmOrchestrator.key_rotate")
+@mock.patch("cephadm.CephadmOrchestrator.commit_pending_key")
+@mock.patch("cephadm.CephadmOrchestrator._daemon_action")
+@mock.patch("cephadm.module.HostCache.get_daemons_by_type")
+@mock.patch("cephadm.upgrade.service_registry")
+@mock.patch.object(CephadmUpgrade, "_detect_need_upgrade")
+def test_osd_key_rotation_commits_only_after_successful_redeploy(
+        _detect_need_upgrade: mock.MagicMock,
+        service_registry_mock: mock.MagicMock,
+        get_daemons_by_type: mock.MagicMock,
+        _daemon_action: mock.MagicMock,
+        commit_pending_key: mock.MagicMock,
+        key_rotate: mock.MagicMock,
+        cephadm_module: CephadmOrchestrator):
+    osd_daemon = _osd_daemon()
+    get_daemons_by_type.side_effect = lambda dtype: [osd_daemon] if dtype == 'osd' else []
+    _detect_need_upgrade.return_value = (False, [], [], 0)
+    service_registry_mock.get_service.return_value.ok_to_stop.return_value = mock.MagicMock(retval=0)
+    cephadm_module.upgrade.upgrade_state = UpgradeState('target_image', 'pid')
+
+    # redeploy succeeds -> the rotated key must be committed
+    cephadm_module.upgrade.handle_osd_mds_key_rotation('target_image', [])
+    key_rotate.assert_called_once()
+    _daemon_action.assert_called_once()
+    commit_pending_key.assert_called_once()
+
+    # redeploy fails -> must NOT commit, leaving the old key valid
+    cephadm_module.upgrade._clear_rotated_daemon_entry()
+    key_rotate.reset_mock()
+    _daemon_action.reset_mock()
+    commit_pending_key.reset_mock()
+    _daemon_action.side_effect = OrchestratorError('redeploy failed')
+    with pytest.raises(OrchestratorError):
+        cephadm_module.upgrade.handle_osd_mds_key_rotation('target_image', [])
+    commit_pending_key.assert_not_called()
+
+
+def _mon_daemons(n: int) -> List[DaemonDescription]:
+    return [
+        DaemonDescription(
+            daemon_type='mon', daemon_id=chr(ord('a') + i),
+            hostname=f'host{i}', service_name='mon')
+        for i in range(n)
+    ]
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+@mock.patch("cephadm.CephadmOrchestrator.key_rotate")
+@mock.patch("cephadm.CephadmOrchestrator.commit_pending_key")
+@mock.patch("cephadm.CephadmOrchestrator._daemon_action_set_image")
+@mock.patch("cephadm.CephadmOrchestrator._daemon_action")
+@mock.patch("cephadm.module.HostCache.get_daemons_by_service")
+@mock.patch.object(CephadmUpgrade, "_detect_need_upgrade")
+def test_shared_mon_key_not_committed_until_every_mon_redeployed(
+        _detect_need_upgrade: mock.MagicMock,
+        get_daemons_by_service: mock.MagicMock,
+        _daemon_action: mock.MagicMock,
+        _daemon_action_set_image: mock.MagicMock,
+        commit_pending_key: mock.MagicMock,
+        key_rotate: mock.MagicMock,
+        cephadm_module: CephadmOrchestrator):
+    # the "mon." cephx entity is shared by every monitor: committing the
+    # rotated key must wait until *all* mons have picked up the new keyring,
+    # not just the first one to redeploy.
+    mon_daemons = _mon_daemons(2)
+    get_daemons_by_service.side_effect = lambda service: mon_daemons if service == 'mon' else []
+    _detect_need_upgrade.return_value = (False, [], [], 0)
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'target_image', 'pid',
+        has_set_cephx_allowed_ciphers=True,
+        rotated_mgr_mon_auth_key_daemons=[],
+    )
+
+    # mon.a redeploys fine, mon.b's redeploy fails
+    _daemon_action.side_effect = [None, OrchestratorError('redeploy failed')]
+    with pytest.raises(OrchestratorError):
+        cephadm_module.upgrade._rotate_mgr_mon_auth_keys('target_image', [])
+    commit_pending_key.assert_not_called()
+
+    # retry: mon.a is already done, mon.b now redeploys successfully ->
+    # every mon has the new key, so the commit fires exactly once
+    _daemon_action.side_effect = None
+    _daemon_action.return_value = None
+    cephadm_module.upgrade._rotate_mgr_mon_auth_keys('target_image', [])
+    commit_pending_key.assert_called_once()

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -57,7 +57,8 @@ MID_UPGRADE_MUTED_WARNINGS = [
     'AUTH_INSECURE_SERVICE_TICKETS',
     'AUTH_INSECURE_CLIENT_KEY_TYPE',
     'AUTH_INSECURE_SERVICE_KEY_TYPE',
-    'AUTH_INSECURE_ROTATING_SERVICE_KEY_TYPE'
+    'AUTH_INSECURE_ROTATING_SERVICE_KEY_TYPE',
+    'AUTH_PENDING_KEY_NOT_COMMITTED'
 ]
 
 
@@ -1692,6 +1693,7 @@ class CephadmUpgrade:
                     CephadmDaemonDeploySpec.from_daemon_description(osd_daemon),
                     action='redeploy'
                 )
+                self.mgr.commit_pending_key(CephadmDaemonDeploySpec.from_daemon_description(osd_daemon))
                 rotated_osd_ids.append(str(osd_daemon.daemon_id))
                 unsaved_rotated_osds.append(str(osd_daemon.daemon_id))
                 save_counter += 1
@@ -1719,6 +1721,7 @@ class CephadmUpgrade:
                     CephadmDaemonDeploySpec.from_daemon_description(mds_daemon),
                     action='redeploy'
                 )
+                self.mgr.commit_pending_key(CephadmDaemonDeploySpec.from_daemon_description(mds_daemon))
                 rotated_mds_ids.append(str(mds_daemon.daemon_id))
                 unsaved_rotated_mdss.append(str(mds_daemon.daemon_id))
                 save_counter += 1
@@ -1790,6 +1793,7 @@ class CephadmUpgrade:
                     )
                     logger.info('Redeploying %s with new keyring', dd.name())
                     self.mgr._daemon_action(daemon_spec, action='redeploy')
+                    self.mgr.commit_pending_key(daemon_spec)
                     self.upgrade_state.rotated_mgr_mon_auth_key_daemons.append(daemon_spec.name())
                     self._save_upgrade_state()
                 # mon daemons share a key, only do one key rotation
@@ -1819,6 +1823,14 @@ class CephadmUpgrade:
                     self.mgr._daemon_action(daemon_spec, action='redeploy')
                     self.upgrade_state.rotated_mgr_mon_auth_key_daemons.append(daemon_spec.name())
                     self._save_upgrade_state()
+                # the "mon." key is shared by every monitor, so only commit it once every
+                # mon in mon_daemons has actually been redeployed with the new keyring --
+                # committing early would invalidate the old key while some mons are still
+                # relying on it.
+                if all(dd.name() in self.upgrade_state.rotated_mgr_mon_auth_key_daemons for dd in mon_daemons):
+                    self.mgr.commit_pending_key(
+                        CephadmDaemonDeploySpec.from_daemon_description(mon_daemons[0])
+                    )
             else:
                 self.mgr.log.debug('Skipping mgr/mon key rotation, mons not upgraded')
             if need_rotate_self:


### PR DESCRIPTION
Before this fix, auth rotate would immediately replace the active key.
If the reply was lost in transit (e.g. due to ms_inject_socket_failures
or any transient network issue), the client was left holding a keyring
with a key that no longer existed on the monitor. There was no way to
recover the client couldn't authenticate to ask for its own key back.

Now rotate stores the new key as pending_key instead. The old key stays
valid until the client explicitly calls auth commit-pending, which does
the atomic swap. During that window both keys are accepted, so a lost
reply is harmless the client can just retry rotate or re-authenticate
with the old key and try again.

The keyring returned by rotate shows the new key as the main key (not
as pending_key) so that it can be dropped straight into a keyring file
without any special handling.

Fixes: https://tracker.ceph.com/issues/70142



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
