### PR TITLE
ceph-volume: fix re-deployment of OSD issues with disk selection filters and DB Devices

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -77,6 +77,14 @@ def get_physical_fast_allocs(devices: List[device.Device], type_: str, fast_slot
             # way
             abs_size = disk.Size(b=int(dev_size / slots_for_vg))
             free_size = dev.vg_free[0]
+            # When a fast device VG is partially used (e.g. one OSD's DB/WAL
+            # is still live while its partner is being replaced), slots_for_vg
+            # can undercount the true slot capacity, making abs_size larger
+            # than free_size so the while loop never fires.  Fall back to
+            # dividing the actual free space by the number of slots we still
+            # want to allocate.
+            if abs_size > free_size and fast_slots_per_device > 0:
+                abs_size = disk.Size(b=int(free_size / fast_slots_per_device))
             relative_size = int(abs_size) / dev_size
             if requested_size:
                 if requested_size <= abs_size:
@@ -90,9 +98,17 @@ def get_physical_fast_allocs(devices: List[device.Device], type_: str, fast_slot
                             abs_size,
                         ))
                     exit(1)
-            while abs_size <= free_size and len(ret) < new_osds and occupied_slots < fast_slots_per_device:
+            # Track new allocations separately from pre-existing ones.
+            # fast_slots_per_device caps how many *new* slots this batch may
+            # add per device (distribution); requested_slots caps the *total*
+            # occupancy a device may carry (the spec's db_slots).
+            new_slots = 0
+            while (abs_size <= free_size
+                   and len(ret) < new_osds
+                   and new_slots < fast_slots_per_device
+                   and occupied_slots + new_slots < requested_slots):
                 free_size -= abs_size.b
-                occupied_slots += 1
+                new_slots += 1
                 ret.append((dev.path, relative_size, abs_size, requested_slots))
     return ret
 

--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -90,6 +90,17 @@ def get_physical_fast_allocs(devices: List[device.Device], type_: str, fast_slot
                 if requested_size <= abs_size:
                     abs_size = requested_size
                     relative_size = int(abs_size) / dev_size
+                elif (int(requested_size) > 0 and
+                      (int(requested_size) - int(abs_size)) / int(requested_size) <= 0.01):
+                    # Tolerance: if the requested size overshoots what can be
+                    # fulfilled by <= 1% (e.g. 1GiB vs 1023.3MiB lost to PE
+                    # alignment), silently scale down to abs_size instead of
+                    # failing the whole batch.
+                    mlogger.info(
+                        '{} was requested for {}, fulfilling with {} (within 1 percent tolerance)'.format(
+                            requested_size, '{}_size'.format(type_), abs_size,
+                        ))
+                    relative_size = int(abs_size) / dev_size
                 else:
                     mlogger.error(
                         '{} was requested for {}, but only {} can be fulfilled'.format(

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
@@ -314,6 +314,33 @@ class TestBatch(object):
         db_device = [mock_device_generator()]
         fast = b.fast_allocations(db_device, 1, 1, 'block_db')
         assert len(fast) == 1
+        # Layout: the allocation must reference the fast device, not the
+        # data device, with a non-trivial slot size.
+        assert fast[0][0] == db_device[0].path
+        assert int(fast[0][2]) > 0
+
+    def test_batch_fast_allocations_one_block_db_partial_vg(self,
+                                                            factory, conf_ceph_stub,
+                                                            mock_device_generator):
+        # Single-OSD redeploy at the Batch.fast_allocations() level (the
+        # one-call-up integration of get_physical_fast_allocs that exercises
+        # fast_slots_per_device recompute). When the fast device's VG already
+        # carries surviving DB LVs from sibling OSDs, fast_allocations must
+        # still produce one allocation on that fast device — not silently
+        # return [], which would let cephadm fall back to a co-located OSD.
+        #
+        # The spec sets db_slots: 6 (the per-device occupancy cap); only one
+        # OSD is being deployed in this batch, so fast_slots_per_device gets
+        # recomputed to 1, and the fast device already has 5 sibling LVs.
+        conf_ceph_stub('[global]\nfsid=asdf-lkjh')
+
+        b = batch.Batch([])
+        b.args.block_db_slots = 6
+        db_device = [mock_device_generator(number_lvs=5)]
+        fast = b.fast_allocations(db_device, 1, 1, 'block_db')
+        assert len(fast) == 1
+        assert fast[0][0] == db_device[0].path
+        assert int(fast[0][2]) > 0
 
     @pytest.mark.parametrize('occupied_prior', range(7))
     @pytest.mark.parametrize('slots,num_devs',
@@ -347,6 +374,26 @@ class TestBatch(object):
         expected_assignment_on_used_devices = sum([slots - len(d.lvs) for d in fast_devs if len(d.lvs) > 0])
         assert len([f for f in fast if f[0] == '/dev/bar']) == expected_assignment_on_used_devices
         assert len([f for f in fast if f[0] != '/dev/bar']) == expected_num_osds - expected_assignment_on_used_devices
+
+    def test_get_physical_fast_allocs_redeploy_partial_vg(self, factory,
+                                                          conf_ceph_stub,
+                                                          mock_device_generator):
+        # Single-OSD redeploy where the fast-device VG already hosts
+        # surviving DB LVs for sibling OSDs must still produce one allocation.
+        # Reproducer: db_slots=6 in the spec, 5 LVs already on the fast
+        # device, one new OSD being deployed in this batch, so
+        # Batch.fast_allocations() recomputes fast_slots_per_device down to 1.
+        # With the original `occupied_slots < fast_slots_per_device` loop
+        # guard, occupied_slots==5 >= 1 short-circuited the loop and
+        # get_physical_fast_allocs() returned an empty list.
+        conf_ceph_stub('[global]\nfsid=asdf-lkjh')
+        fast_dev = mock_device_generator(number_lvs=5)
+        args = factory(block_db_slots=6, block_db_size=None,
+                       devices=['/dev/data'])
+        fast = batch.get_physical_fast_allocs([fast_dev], 'block_db',
+                                              1, 1, args)
+        assert len(fast) == 1
+        assert fast[0][0] == fast_dev.path
 
     def test_get_lvm_osds_return_len(self, factory,
                                      mock_lv_device_generator,

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
@@ -395,6 +395,46 @@ class TestBatch(object):
         assert len(fast) == 1
         assert fast[0][0] == fast_dev.path
 
+    def test_get_physical_fast_allocs_tolerance_within_1_percent(self, factory,
+                                                                 conf_ceph_stub,
+                                                                 mock_device_generator):
+        # When requested_size overshoots the achievable abs_size by <=1%
+        # (e.g. PE alignment rounding 1 GiB down to ~1023.3 MiB), the
+        # allocator must scale down to abs_size silently instead of calling
+        # exit(1).
+        conf_ceph_stub('[global]\nfsid=asdf-lkjh')
+        # 20 GiB / 20 slots = 1 GiB abs_size; request 1 GiB + 100 KiB → ~0.01%
+        vg_size = 21474836480
+        fast_dev = mock_device_generator()
+        fast_dev.vg_size = [vg_size]
+        fast_dev.vg_free = [vg_size]
+        requested = disk.Size(b=int(vg_size / 20) + 100 * 1024)
+        args = factory(block_db_slots=20, block_db_size=requested,
+                       devices=['/dev/data'])
+        fast = batch.get_physical_fast_allocs([fast_dev], 'block_db',
+                                              20, 1, args)
+        assert len(fast) == 1
+        # abs_size is the achievable size, not the over-requested one
+        assert fast[0][2] == disk.Size(b=int(vg_size / 20))
+
+    def test_get_physical_fast_allocs_tolerance_over_1_percent(self, factory,
+                                                               conf_ceph_stub,
+                                                               mock_device_generator):
+        # Over the 1% threshold still aborts via exit(1).
+        conf_ceph_stub('[global]\nfsid=asdf-lkjh')
+        vg_size = 21474836480
+        fast_dev = mock_device_generator()
+        fast_dev.vg_size = [vg_size]
+        fast_dev.vg_free = [vg_size]
+        # Request 2 GiB on a 1 GiB slot — ~100% overshoot.
+        requested = disk.Size(b=int(vg_size / 20) * 2)
+        args = factory(block_db_slots=20, block_db_size=requested,
+                       devices=['/dev/data'])
+        with pytest.raises(SystemExit) as err:
+            batch.get_physical_fast_allocs([fast_dev], 'block_db',
+                                           20, 1, args)
+        assert err.value.code == 1
+
     def test_get_lvm_osds_return_len(self, factory,
                                      mock_lv_device_generator,
                                      conf_ceph_stub,

--- a/src/python-common/ceph/deployment/drive_selection/selector.py
+++ b/src/python-common/ceph/deployment/drive_selection/selector.py
@@ -162,9 +162,24 @@ class DriveSelection(object):
 
             # break on this condition.
             if self._limit_reached(device_filter, devices, disk.path):
-                logger.debug("Ignoring disk {}. Limit reached".format(
-                    disk.path))
-                break
+                # Check if this device has an existing OSD for this spec.
+                # If so, we still want to include it (don't break) as it will
+                # be needed for the ceph-volume lvm batch command.
+                is_existing_osd_for_spec = False
+                if disk.ceph_device_lvm and disk.lvs:
+                    for lv in disk.lvs:
+                        if 'osdspec_affinity' in lv.keys():
+                            if lv['osdspec_affinity'] == str(self.spec.service_id):
+                                is_existing_osd_for_spec = True
+                                break
+
+                if not is_existing_osd_for_spec:
+                    logger.debug("Ignoring disk {}. Limit reached".format(
+                        disk.path))
+                    continue
+                # else: fall through to include this device even though the
+                # limit is reached — existing-OSD-for-spec devices are
+                # already accounted for via existing_daemons.
 
             if disk in devices:
                 continue

--- a/src/python-common/ceph/tests/test_disk_selector.py
+++ b/src/python-common/ceph/tests/test_disk_selector.py
@@ -597,3 +597,61 @@ class TestDeviceSelectionLimit:
         # DriveSelection does device assignment on initialization. Let's check
         # it picked up the expected devices
         assert ds._data == [dev_a, dev_b]
+
+    def test_assign_devices_keeps_existing_osd_past_limit(self):
+        # When _limit_reached() fires part-way through the disk iteration,
+        # assign_devices() used to break unconditionally, which dropped any
+        # subsequent device that is already an OSD for the current spec.
+        # ceph-volume's `lvm batch` then doesn't see those devices and the
+        # drive group goes out of sync.
+        #
+        # Shape: limit=2, three candidate disks. /dev/sda and /dev/sdb are
+        # fresh (not yet OSDs); they fill the limit. /dev/sdc is already an
+        # OSD for this spec — it must still be included in the selection.
+        existing_lv = {'osd_id': '0', 'osdspec_affinity': 'my_osd_spec'}
+        dev_a = Device('/dev/sda', ceph_device_lvm=False, available=True)
+        dev_b = Device('/dev/sdb', ceph_device_lvm=False, available=True)
+        dev_c = Device('/dev/sdc', ceph_device_lvm=True, available=False,
+                       lvs=[existing_lv])
+        all_devices: List[Device] = [dev_a, dev_b, dev_c]
+        filter = DeviceSelection(all=True, limit=2)
+        dgs = DriveGroupSpec(service_id='my_osd_spec', data_devices=filter)
+        ds = drive_selection.DriveSelection(dgs, all_devices)
+
+        # /dev/sdc must survive the limit because it is already an OSD for
+        # this spec; existing_daemons accounts for it.
+        assert dev_c in ds._data
+
+    def test_assign_devices_continues_past_non_osd_at_limit(self):
+        # Iteration-order regression: when a non-this-spec device is the
+        # one that trips _limit_reached(), assign_devices() must not stop
+        # the disk loop entirely — later disks may be existing-OSD-for-this-
+        # spec and must still be included.
+        #
+        # Shape: limit=2, existing_daemons=1. Three candidate disks in
+        # this order:
+        #   /dev/sda — fresh, fills the new-device budget (limit - existing
+        #              = 1 new disk allowed). After adding it, the limit is
+        #              reached for any subsequent non-this-spec disk.
+        #   /dev/sdb — fresh, hits _limit_reached and is *not* an existing
+        #              OSD for the spec. Must be skipped without terminating
+        #              the loop.
+        #   /dev/sdc — existing OSD for this spec. Must be included because
+        #              existing-OSD-for-spec devices bypass the limit cap.
+        existing_lv = {'osd_id': '0', 'osdspec_affinity': 'my_osd_spec'}
+        dev_a = Device('/dev/sda', ceph_device_lvm=False, available=True)
+        dev_b = Device('/dev/sdb', ceph_device_lvm=False, available=True)
+        dev_c = Device('/dev/sdc', ceph_device_lvm=True, available=False,
+                       lvs=[existing_lv])
+        all_devices: List[Device] = [dev_a, dev_b, dev_c]
+        filter = DeviceSelection(all=True, limit=2)
+        dgs = DriveGroupSpec(service_id='my_osd_spec', data_devices=filter)
+        ds = drive_selection.DriveSelection(dgs, all_devices,
+                                            existing_daemons=1)
+
+        # dev_a fits in the new-device budget; dev_b is over the limit and
+        # not for this spec; dev_c is for this spec and must not be lost
+        # to an over-aggressive break.
+        assert dev_a in ds._data
+        assert dev_b not in ds._data
+        assert dev_c in ds._data


### PR DESCRIPTION
I created three commits, which should address an OSD deployment failure

a single-OSD redeploy ("ceph orch osd rm <id> --zap --replace")
on a fast-device VG that has other DB LVs fails to deploy.

1. ceph-volume: allocate db/wal slot on partial fast-device VG
2. python-common/drive_selection: keep existing-OSD devices past limit
3. ceph-volume: tolerate <=1% short-fall on requested db/wal size


The failure surfaced after upstream 5c700ed7d64 (#72696) was
applied — that fix stopped the orchestrator from silently dropping
fast devices from drive selection, which in turn let `ceph-volume lvm
batch` actually get all devices on the commandline. After that, the allocator
bugs in get_physical_fast_allocs() became visible. Without commit 1, batch
returns no allocation and (with 262175b107a in place) exits 1, so the
redeploy fails outright.


Commit 2 is a separate but related selector.py bug uncovered while
testing the limit policy. Complements d3f1a0e1c0b: that fix
prevented existing-OSD devices from contributing to the limit count;
this one keeps the iteration from breaking on those devices when
_limit_reached does fire in some corner cases when one uses `limit` in
the spec but has much more devices available.

Commit 3 is a small fix, in my tests a 1GB DB size request on a 6GB disk
can't deploy because of a size mis-alignment, it can only deploy 1023.3 MB
and the batch is aborted. Now within 1% we scale down silently. However,
this will need testing, not sure about the 1% size (might be good to be
smaller).


## Testing done:

- Lab cluster (RHCS 8.1z5, 3 hosts x 12 HDD + 4 SSD, db_slots: 6,
  encrypted), disk selection `rotational:1` and `limit:4`: redeploy of the first
  OSD  after `osd rm 1 --zap --replace` fails.
- Unit tests: three new regression tests, one per commit, all of
  which fail on main and pass with the corresponding commit applied.


Fixes: https://tracker.ceph.com/issues/76522
Signed-off-by: Raimund Sacherer <rsachere@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [X] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [X] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
