### PR TITLE
mgr/cephadm: Control cephadm files logging based on a mgr flag

### DIFF
--- a/doc/cephadm/operations.rst
+++ b/doc/cephadm/operations.rst
@@ -393,6 +393,34 @@ For example:
    ``--log-dest`` options described in the bootstrap section above.
 
 
+Setting Cephadm Log Verbosity
+-----------------------------
+
+The verbosity of cephadm's persistent logging (``/var/log/ceph/cephadm.log``
+and syslog, when enabled) can be controlled separately from its terminal
+output. Valid levels are ``info``, ``debug``, ``error``, and ``warning``.
+The default is ``debug``.
+
+When the cephadm orchestration module runs ``cephadm`` on cluster hosts, it
+uses the :confval:`mgr/cephadm/cephadm_binary_logging_level` configuration
+value:
+
+.. prompt:: bash #
+
+  ceph config set mgr mgr/cephadm/cephadm_binary_logging_level info
+
+For manual invocations, pass ``--logging-level`` on the command line:
+
+.. prompt:: bash #
+
+  cephadm --logging-level info check-host
+
+.. note:: The logging level applies only to persistent log destinations
+   (the log file and syslog). Console output during bootstrap and other
+   interactive use is unchanged. When you run ``cephadm`` directly, the
+   mgr configuration does not apply; use ``--logging-level`` as shown above.
+
+
 Data Location
 =============
 

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -4977,6 +4977,11 @@ def _get_parser():
         action='store_true',
         default=False,
         help='Do not run containers with --cgroups=split (currently only relevant when using podman)')
+    parser.add_argument(
+        '--logging-level',
+        choices=['info', 'debug', 'error', 'warning'],
+        default='debug',
+        help='Tunable log level for cephadm binary: info, debug, error, warning (default: debug)')
 
     subparsers = parser.add_subparsers(help='sub-command')
 

--- a/src/cephadm/cephadmlib/context.py
+++ b/src/cephadm/cephadmlib/context.py
@@ -31,6 +31,7 @@ class BaseConfig:
         self.memory_request: Optional[int] = None
         self.memory_limit: Optional[int] = None
         self.log_to_journald: Optional[bool] = None
+        self.logging_level: str = 'debug'
 
         self.container_init: bool = CONTAINER_INIT
         # FIXME(refactor) : should be Optional[ContainerEngine]

--- a/src/cephadm/cephadmlib/logging.py
+++ b/src/cephadm/cephadmlib/logging.py
@@ -173,7 +173,9 @@ def _copy(obj: Any) -> Any:
 
 
 def _complete_logging_config(
-    interactive: bool, destinations: Optional[List[str]]
+    interactive: bool,
+    destinations: Optional[List[str]],
+    logging_level: str = 'debug',
 ) -> Dict[str, Any]:
     """Return a logging configuration dict, based on the runtime parameters
     cephadm was invoked with.
@@ -182,6 +184,12 @@ def _complete_logging_config(
     lc = _copy(_logging_config)
     if interactive:
         lc = _copy(_interactive_logging_config)
+
+    # Apply logging level to persistent destinations only (cephadm.log, syslog).
+    # Console handlers keep their template defaults for terminal UX.
+    level_upper = logging_level.upper()
+    lc['handlers']['log_file']['level'] = level_upper
+    lc['handlers']['syslog']['level'] = level_upper
 
     handlers = lc['loggers']['']['handlers']
     if not destinations:
@@ -206,9 +214,11 @@ def cephadm_init_logging(
     if not os.path.exists(LOG_DIR):
         os.makedirs(LOG_DIR)
 
+    logging_level = getattr(ctx, 'logging_level', 'debug').lower()
     lc = _complete_logging_config(
         any(op in args for op in _INTERACTIVE_CMDS),
         getattr(ctx, 'log_dest', None),
+        logging_level=logging_level,
     )
     logging.config.dictConfig(lc)
 
@@ -228,6 +238,7 @@ def cephadm_init_logging(
         # option is set
         if ctx.verbose and handler.name in _VERBOSE_HANDLERS:
             handler.setLevel(QUIET_LOG_LEVEL)
+
     logger.debug('%s\ncephadm %s' % ('-' * 80, args))
 
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -510,6 +510,13 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             enum_allowed=['file', 'syslog', 'file,syslog'],
         ),
         Option(
+            'cephadm_binary_logging_level',
+            type='str',
+            default='debug',
+            desc='Logging verbosity for the cephadm binary when invoked by the mgr (e.g. check-host, gather-facts).',
+            enum_allowed=['info', 'debug', 'error', 'warning']
+        ),
+        Option(
             'oob_default_addr',
             type='str',
             default='169.254.1.1',
@@ -622,6 +629,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             self.certificate_automated_rotation_enabled = False
             self.certificate_check_debug_mode = False
             self.certificate_check_period = 0
+            self.cephadm_binary_logging_level = 'debug'
 
         self.notify(NotifyType.mon_map, None)
         self.config_notify()

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1738,6 +1738,9 @@ class CephadmServe:
         if image:
             final_args.extend(['--image', image])
 
+        cephadm_log_level = self.mgr.cephadm_binary_logging_level or 'debug'
+        final_args.extend(['--logging-level', cephadm_log_level])
+
         if not self.mgr.container_init:
             final_args += ['--no-container-init']
 

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -3117,3 +3117,112 @@ Traceback (most recent call last):
                 assert wait(cephadm_module, c) == ['Scheduled osd.foo update...']
 
                 cephadm_module.set_osd_spec('osd.foo', ['1'])
+
+
+class TestCephadmBinaryLoggingLevel:
+    """Test that host-status / cephadm binary logs are suppressed based on
+    mgr/cephadm/cephadm_binary_logging_level.
+    """
+    @pytest.mark.parametrize("logging_level", ['info', 'debug', 'error', 'warning'])
+    @mock.patch("cephadm.ssh.SSHManager._remote_connection")
+    @mock.patch("cephadm.ssh.SSHManager._execute_command")
+    @mock.patch("cephadm.ssh.SSHManager._check_execute_command")
+    def test_check_host_invokes_cephadm_with_logging_level(
+        self, check_execute_command, execute_command, remote_connection, cephadm_module, logging_level
+    ):
+        """Cephadm binary must be invoked with --logging-level matching
+        mgr/cephadm/cephadm_binary_logging_level (info, debug, error, warning).
+        Check that mgr builds the cephadm command with appropriate --logging-level flag
+        Use check-host as a sample command although all cephadm commands receive the flag.
+        """
+        remote_connection.side_effect = async_side_effect(mock.Mock())
+        check_execute_command.side_effect = async_side_effect('/usr/bin/python3')
+        captured_commands = []
+
+        async def capture_execute(host, cmd, *args, **kwargs):
+            if hasattr(cmd, 'args'):
+                if 'check-host' in cmd.args:
+                    captured_commands.append(cmd)
+                # Return valid JSON for commands that use _run_cephadm_json
+                if 'ls' in cmd.args:
+                    return ('[]', '', 0)
+                if 'gather-facts' in cmd.args:
+                    return ('{}', '', 0)
+                if 'list-networks' in cmd.args:
+                    return ('[]', '', 0)
+            return ('', '', 0)
+
+        execute_command.side_effect = capture_execute
+
+        cephadm_module.cephadm_binary_logging_level = logging_level
+        with with_host(cephadm_module, 'test'):
+            pass
+
+        check_host_cmds = [c for c in captured_commands if 'check-host' in c.args]
+        assert len(check_host_cmds) >= 1, (
+            f'expected at least one check-host invocation for level {logging_level!r}'
+        )
+        cmd = check_host_cmds[0]
+        assert '--logging-level' in cmd.args, (
+            f'cephadm should be called with --logging-level when level is {logging_level!r}'
+        )
+        idx = cmd.args.index('--logging-level')
+        assert cmd.args[idx + 1] == logging_level, (
+            f'cephadm should be called with --logging-level {logging_level!r}'
+        )
+
+
+class TestCephadmLogDestination:
+    """Test that cephadm is invoked with --log-dest matching
+    mgr/cephadm/cephadm_log_destination.
+    """
+    @pytest.mark.parametrize(
+        "log_destination,expected_log_dests",
+        [
+            ('file', ['file']),
+            ('syslog', ['syslog']),
+            ('file,syslog', ['file', 'syslog']),
+        ],
+    )
+    @mock.patch("cephadm.ssh.SSHManager._remote_connection")
+    @mock.patch("cephadm.ssh.SSHManager._execute_command")
+    @mock.patch("cephadm.ssh.SSHManager._check_execute_command")
+    def test_check_host_invokes_cephadm_with_log_dest(
+        self, check_execute_command, execute_command, remote_connection,
+        cephadm_module, log_destination, expected_log_dests,
+    ):
+        """check-host must be invoked with --log-dest matching
+        mgr/cephadm/cephadm_log_destination (file, syslog, or both).
+        """
+        remote_connection.side_effect = async_side_effect(mock.Mock())
+        check_execute_command.side_effect = async_side_effect('/usr/bin/python3')
+        captured_commands = []
+
+        async def capture_execute(host, cmd, *args, **kwargs):
+            if hasattr(cmd, 'args'):
+                if 'check-host' in cmd.args:
+                    captured_commands.append(cmd)
+                if 'ls' in cmd.args:
+                    return ('[]', '', 0)
+                if 'gather-facts' in cmd.args:
+                    return ('{}', '', 0)
+                if 'list-networks' in cmd.args:
+                    return ('[]', '', 0)
+            return ('', '', 0)
+
+        execute_command.side_effect = capture_execute
+
+        cephadm_module.cephadm_log_destination = log_destination
+        with with_host(cephadm_module, 'test'):
+            pass
+
+        check_host_cmds = [c for c in captured_commands if 'check-host' in c.args]
+        assert len(check_host_cmds) >= 1, (
+            f'expected at least one check-host invocation for dest {log_destination!r}'
+        )
+        cmd = check_host_cmds[0]
+        for dest in expected_log_dests:
+            assert f'--log-dest={dest}' in cmd.args, (
+                f'cephadm should be called with --log-dest={dest!r} '
+                f'when cephadm_log_destination is {log_destination!r}'
+            )


### PR DESCRIPTION
Supersedes/continues #67300 after branch rename.

User wants to disable the host check-hosts, or gather-facts logs that is being captured every minute in the cephadm.log file. The existing mgr flag mgr/cephadm/log_to_cluster_level does not control the logging by cephadm binary. This patch adds a new mgr flag cephadm_binary_logging_level to control the logging in cephadm.log. The default behaviour would have 'debug' level set, and the repetative messages can be turned off by setting mgr/cephadm/cephadm_binary_logging_level to 'info'. The cephadm_binary_logging_level logging level applies to all cephadm binary invocations by mgr.

Fixes: https://tracker.ceph.com/issues/74872
Signed-off-by: Ashwin M. Joshi <ashjosh1@in.ibm.com>


1. The per minute gather-facts repetitive logs continue to appear with default ‘debug’ setting of the flag, and error or warning levels if set.
```
[ceph: root@ceph-node-0 /]# ceph config get mgr mgr/cephadm/cephadm_binary_logging_level
debug
[ceph: root@ceph-node-0 /]#

2026-02-11 07:14:54,680 7fd4e73d3740 DEBUG --------------------------------------------------------------------------------
cephadm ['--logging-level', 'debug', '--timeout', '895', 'gather-facts']
2026-02-11 07:15:59,977 7fb582bd8740 DEBUG --------------------------------------------------------------------------------
cephadm ['--logging-level', 'debug', '--timeout', '895', 'gather-facts']
```

2. The above logs stop with the ‘info’ setting for cephadm_binary_logging_level 
```
[ceph: root@ceph-node-0 /]# ceph config set mgr mgr/cephadm/cephadm_binary_logging_level info
[ceph: root@ceph-node-0 /]# ceph config get mgr mgr/cephadm/cephadm_binary_logging_level
info
[ceph: root@ceph-node-0 /]# 
```

3. Command line invocation work as expected with all new logging levels:
```
[root@ceph-node-0 ~]# cephadm --logging-level info check-host
podman (/usr/bin/podman) version 4.9.4 is present
systemctl is present
lvcreate is present
Unit chronyd.service is enabled and running
Host looks OK
[root@ceph-node-0 ~]# cephadm --logging-level debug check-host
podman (/usr/bin/podman) version 4.9.4 is present
systemctl is present
lvcreate is present
Unit chronyd.service is enabled and running
Host looks OK
[root@ceph-node-0 ~]# cephadm --logging-level warning check-host
podman (/usr/bin/podman) version 4.9.4 is present
systemctl is present
lvcreate is present
Unit chronyd.service is enabled and running
Host looks OK
[root@ceph-node-0 ~]# cephadm --logging-level error check-host
podman (/usr/bin/podman) version 4.9.4 is present
systemctl is present
lvcreate is present
Unit chronyd.service is enabled and running
Host looks OK
[root@ceph-node-0 ~]# 

```

4. Other commands work as expected with default debug level 
```
[root@ceph-node-0 ~]# cephadm ceph-volume inventory
Inferring fsid 750dc53a-0b3e-11f1-a55c-525400515ad4

Device Path               Size         Device nodes    rotates available Model name
/dev/sr0                  2.26 MB      sr0             True    False     QEMU DVD-ROM
/dev/vda                  100.00 GB    vda             True    False     
/dev/vdb                  10.00 GB     vdb             True    False     
/dev/zram0                5.77 GB      zram0           False   False     
[root@ceph-node-0 ~]#
```

And with higher logging levels
```
[root@ceph-node-0 ~]# cephadm  --logging-level error ceph-volume inventory 
Inferring fsid 750dc53a-0b3e-11f1-a55c-525400515ad4

Device Path               Size         Device nodes    rotates available Model name
/dev/sr0                  2.26 MB      sr0             True    False     QEMU DVD-ROM
/dev/vda                  100.00 GB    vda             True    False     
/dev/vdb                  10.00 GB     vdb             True    False     
/dev/zram0                5.77 GB      zram0           False   False     
[root@ceph-node-0 ~]#
```


**Syslog tests:**

```
[ceph: root@ceph-node-0 /]# ceph config get mgr mgr/cephadm/cephadm_binary_logging_level     
info
[ceph: root@ceph-node-0 /]# ceph config get mgr mgr/cephadm/cephadm_log_destination
syslog

[ceph: root@ceph-node-0 /]# ceph cephadm check-host ceph-node-0
ceph-node-0 (None) ok
podman (/usr/bin/podman) version 4.9.4 is present
systemctl is present
lvcreate is present
Unit chronyd.service is enabled and running
Hostname "ceph-node-0" matches what is expected.
Host looks OK
```

shows no debug logs in _journalctl -t cephadm -f_
```
Jun 08 09:56:42 ceph-node-0 cephadm[36949]: 2026-06-08 09:56:42,166 7f534375d740 INFO lvcreate is present
Jun 08 09:56:42 ceph-node-0 cephadm[36949]: 2026-06-08 09:56:42,291 7f534375d740 INFO Unit chronyd.service is enabled and running
Jun 08 09:56:42 ceph-node-0 cephadm[36949]: 2026-06-08 09:56:42,292 7f534375d740 INFO Hostname "ceph-node-0" matches what is expected.
Jun 08 09:56:42 ceph-node-0 cephadm[36949]: 2026-06-08 09:56:42,292 7f534375d740 INFO Host looks OK
```

Whereas 

```
[ceph: root@ceph-node-0 /]# ceph config set mgr mgr/cephadm/cephadm_binary_logging_level debug
```

shows the following with debug logs as expected:

```
Jun 08 09:57:11 ceph-node-0 cephadm[37060]: 2026-06-08 09:57:11,295 7fb168570740 DEBUG --------------------------------------------------------------------------------
                                            cephadm ['--logging-level', 'debug', '--timeout', '895', '--log-dest=syslog', 'check-host', '--expect-hostname', 'ceph-node-0']
Jun 08 09:57:11 ceph-node-0 cephadm[37060]: 2026-06-08 09:57:11,401 7fb168570740 INFO podman (/usr/bin/podman) version 4.9.4 is present
Jun 08 09:57:11 ceph-node-0 cephadm[37060]: 2026-06-08 09:57:11,402 7fb168570740 INFO systemctl is present
Jun 08 09:57:11 ceph-node-0 cephadm[37060]: 2026-06-08 09:57:11,403 7fb168570740 INFO lvcreate is present
Jun 08 09:57:11 ceph-node-0 cephadm[37060]: 2026-06-08 09:57:11,524 7fb168570740 INFO Unit chronyd.service is enabled and running
Jun 08 09:57:11 ceph-node-0 cephadm[37060]: 2026-06-08 09:57:11,524 7fb168570740 INFO Hostname "ceph-node-0" matches what is expected.
Jun 08 09:57:11 ceph-node-0 cephadm[37060]: 2026-06-08 09:57:11,525 7fb168570740 INFO Host looks OK
```


Note that ceph config get mgr mgr/cephadm/cephadm_binary_logging_level as "info" only applies when the mgr runs cephadm over SSH (internal orchestration), not when cephadm is run directly on the host.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
