### PR TITLE
crimson/osd: inline log file stream setup to fix dangling pointer

### DIFF
--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -74,20 +74,6 @@ seastar::future<> make_keyring()
   });
 }
 
-static std::ofstream maybe_set_logger()
-{
-  std::ofstream log_file_stream;
-  if (auto log_file = local_conf()->log_file; !log_file.empty()) {
-    log_file_stream.open(log_file, std::ios::app | std::ios::out);
-    try {
-      seastar::throw_system_error_on(log_file_stream.fail());
-    } catch (const std::system_error& e) {
-      ceph_abort_msg(fmt::format("unable to open log file: {}", e.what()));
-    }
-    logger().set_ostream(log_file_stream);
-  }
-  return log_file_stream;
-}
 
 int main(int argc, const char* argv[])
 {
@@ -171,7 +157,16 @@ int main(int argc, const char* argv[])
           local_conf().parse_argv(config_proxy_args).get();
 
           DEBUG("initializing logger output");
-          auto log_file_stream = maybe_set_logger();
+          std::ofstream log_file_stream;
+          if (auto log_file = local_conf()->log_file; !log_file.empty()) {
+            log_file_stream.open(log_file, std::ios::app | std::ios::out);
+            try {
+              seastar::throw_system_error_on(log_file_stream.fail());
+            } catch (const std::system_error& e) {
+              ceph_abort_msg(fmt::format("unable to open log file: {}", e.what()));
+            }
+            logger().set_ostream(log_file_stream);
+          }
           auto reset_logger = seastar::defer([] {
             logger().set_ostream(std::cerr);
           });

--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -165,6 +165,11 @@ int main(int argc, const char* argv[])
             } catch (const std::system_error& e) {
               ceph_abort_msg(fmt::format("unable to open log file: {}", e.what()));
             }
+            // seastar::logger::do_log() writes to _out from every shard's thread
+            // with no lock. std::cerr is safe because it is unbuffered; a buffered
+            // ofstream is not. Disable buffering so each write() is a single syscall,
+            // matching cerr's thread-safety guarantee.
+            log_file_stream.rdbuf()->pubsetbuf(nullptr, 0);
             logger().set_ostream(log_file_stream);
           }
           auto reset_logger = seastar::defer([] {

--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -159,17 +159,17 @@ int main(int argc, const char* argv[])
           DEBUG("initializing logger output");
           std::ofstream log_file_stream;
           if (auto log_file = local_conf()->log_file; !log_file.empty()) {
+            // seastar::logger::do_log() writes to _out from every shard's thread
+            // with no lock. std::cerr is safe because it is unbuffered; a buffered
+            // ofstream is not. Disable buffering so each write() is a single syscall,
+            // matching cerr's thread-safety guarantee.
+            log_file_stream.rdbuf()->pubsetbuf(nullptr, 0);
             log_file_stream.open(log_file, std::ios::app | std::ios::out);
             try {
               seastar::throw_system_error_on(log_file_stream.fail());
             } catch (const std::system_error& e) {
               ceph_abort_msg(fmt::format("unable to open log file: {}", e.what()));
             }
-            // seastar::logger::do_log() writes to _out from every shard's thread
-            // with no lock. std::cerr is safe because it is unbuffered; a buffered
-            // ofstream is not. Disable buffering so each write() is a single syscall,
-            // matching cerr's thread-safety guarantee.
-            log_file_stream.rdbuf()->pubsetbuf(nullptr, 0);
             logger().set_ostream(log_file_stream);
           }
           auto reset_logger = seastar::defer([] {


### PR DESCRIPTION
`maybe_set_logger()` called `logger().set_ostream()` with a reference to a local ofstream before returning it by value. Correctness relied on NRVO: without it, _out would point to a moved-from object on a dead stack frame, causing undefined behaviour that manifests as a heap-buffer-overflow under ASan with GCC 14 (libasan.so.8).

Inline the setup so `log_file_stream` and `reset_logger` share the same scope. `set_ostream()` is now called with an unambiguously live object, with no dependence on copy elision.

Fixes: 66c923d70354415cd1746c4f57cf31f3d55cc1bd
Fixes: https://tracker.ceph.com/issues/76524





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
