### PR TITLE
mgr: show CRUSH device class in OSDSPEC dry-run preview

### DIFF
--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -332,6 +332,31 @@ class OSDService(CephService):
                         osdspec.service_name()))
                     continue
 
+                # crush device class that would be assigned per data device:
+                # explicit per-device override, else spec-level override, else
+                # the rotational-derived default (matches what the OSD picks at
+                # activation time from bluestore_bdev_type).
+                # When the spec selects devices by path, the Device objects in
+                # ds.data_devices() carry no sys_api, so fall back to the
+                # cached host inventory to look up rotational.
+                inv_by_path: Dict[str, Device] = {
+                    inv.path: inv
+                    for inv in self.mgr.cache.devices.get(host, [])
+                    if inv.path
+                }
+                path_to_class: Dict[str, str] = {}
+                for d in ds.data_devices():
+                    if d.path is None:
+                        continue
+                    derived = d.human_readable_type
+                    if derived == 'unknown' and d.path in inv_by_path:
+                        derived = inv_by_path[d.path].human_readable_type
+                    path_to_class[d.path] = (
+                        d.crush_device_class
+                        or osdspec.crush_device_class
+                        or derived
+                    )
+
                 # get preview data from ceph-volume
                 for cmd in cmds:
                     with self.mgr.async_timeout_handler(host, f'cephadm ceph-volume -- {cmd}'):
@@ -342,6 +367,12 @@ class OSDService(CephService):
                         except ValueError:
                             logger.exception('Cannot decode JSON: \'%s\'' % ' '.join(out))
                             concat_out = {}
+                        for osd_entry in concat_out:
+                            if not isinstance(osd_entry, dict):
+                                continue
+                            data_path = osd_entry.get('data')
+                            if data_path in path_to_class:
+                                osd_entry['crush_device_class'] = path_to_class[data_path]
                         notes = []
                         if (
                             osdspec.data_devices is not None

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -1411,6 +1411,117 @@ class TestCephadm(object):
             assert f1[0] == 'test'
             assert isinstance(f1[1], DriveSelection)
 
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    @mock.patch('cephadm.services.osd.OSDService._run_ceph_volume_command')
+    @mock.patch('cephadm.services.osd.OSDService.driveselection_to_ceph_volume')
+    @mock.patch('cephadm.services.osd.OSDService.prepare_drivegroup')
+    @mock.patch('cephadm.services.osd.OsdIdClaims.refresh', lambda _: None)
+    @mock.patch('cephadm.services.osd.OsdIdClaims.get', lambda _: {})
+    def test_preview_crush_device_class_rotational_and_override(
+            self, _prepare_dg, d_to_cv, _run_cv_cmd, cephadm_module):
+        # No spec-level class: per-device override beats the rotational
+        # fallback ('hdd' for rotational=1, 'ssd' otherwise).
+        with with_host(cephadm_module, 'test'):
+            # filter-based selection (all=True) returns the Devices passed to
+            # DriveSelection, with their sys_api intact.
+            dg = DriveGroupSpec(placement=PlacementSpec(host_pattern='test'),
+                                data_devices=DeviceSelection(all=True),
+                                service_id='mixed')
+            disks = [
+                Device('/dev/sdb', sys_api={'rotational': '1'}, available=True),
+                Device('/dev/sdc', sys_api={'rotational': '0'},
+                       crush_device_class='nvme', available=True),
+                Device('/dev/sdd', sys_api={'rotational': '0'}, available=True),
+            ]
+            ds = DriveSelection(dg, disks)
+            _prepare_dg.return_value = [('test', ds)]
+            d_to_cv.return_value = ['some-cv-cmd']
+            cv_json = (
+                '[{"data": "/dev/sdb", "data_size": "300 GB"},'
+                ' {"data": "/dev/sdc", "data_size": "300 GB"},'
+                ' {"data": "/dev/sdd", "data_size": "300 GB"}]'
+            )
+            _run_cv_cmd.side_effect = async_side_effect(([cv_json], '', 0))
+
+            preview = cephadm_module.osd_service.generate_previews([dg], 'test')
+            assert len(preview) == 1
+            by_path = {o['data']: o.get('crush_device_class')
+                       for o in preview[0]['data']}
+            assert by_path == {'/dev/sdb': 'hdd',
+                               '/dev/sdc': 'nvme',
+                               '/dev/sdd': 'ssd'}
+
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    @mock.patch('cephadm.services.osd.OSDService._run_ceph_volume_command')
+    @mock.patch('cephadm.services.osd.OSDService.driveselection_to_ceph_volume')
+    @mock.patch('cephadm.services.osd.OSDService.prepare_drivegroup')
+    @mock.patch('cephadm.services.osd.OsdIdClaims.refresh', lambda _: None)
+    @mock.patch('cephadm.services.osd.OsdIdClaims.get', lambda _: {})
+    def test_preview_crush_device_class_paths_spec_uses_inventory(
+            self, _prepare_dg, d_to_cv, _run_cv_cmd, cephadm_module):
+        # When the spec selects devices by path, the Device objects in
+        # ds.data_devices() carry no sys_api; the rotational fallback must
+        # come from the cached host inventory.
+        with with_host(cephadm_module, 'test'):
+            dg = DriveGroupSpec(placement=PlacementSpec(host_pattern='test'),
+                                data_devices=DeviceSelection(paths=[
+                                    '/dev/sdb', '/dev/sdc']),
+                                service_id='by_paths')
+            ds = DriveSelection(dg, Devices([
+                Device('/dev/sdb'), Device('/dev/sdc')]))
+            cephadm_module.cache.devices['test'] = [
+                Device('/dev/sdb', sys_api={'rotational': '1'}),
+                Device('/dev/sdc', sys_api={'rotational': '0'}),
+            ]
+            _prepare_dg.return_value = [('test', ds)]
+            d_to_cv.return_value = ['some-cv-cmd']
+            cv_json = (
+                '[{"data": "/dev/sdb", "data_size": "300 GB"},'
+                ' {"data": "/dev/sdc", "data_size": "300 GB"}]'
+            )
+            _run_cv_cmd.side_effect = async_side_effect(([cv_json], '', 0))
+
+            preview = cephadm_module.osd_service.generate_previews([dg], 'test')
+            by_path = {o['data']: o.get('crush_device_class')
+                       for o in preview[0]['data']}
+            assert by_path == {'/dev/sdb': 'hdd', '/dev/sdc': 'ssd'}
+
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    @mock.patch('cephadm.services.osd.OSDService._run_ceph_volume_command')
+    @mock.patch('cephadm.services.osd.OSDService.driveselection_to_ceph_volume')
+    @mock.patch('cephadm.services.osd.OSDService.prepare_drivegroup')
+    @mock.patch('cephadm.services.osd.OsdIdClaims.refresh', lambda _: None)
+    @mock.patch('cephadm.services.osd.OsdIdClaims.get', lambda _: {})
+    def test_preview_crush_device_class_spec_override(
+            self, _prepare_dg, d_to_cv, _run_cv_cmd, cephadm_module):
+        # Spec-level crush_device_class applies to devices without their own
+        # override, regardless of rotational.
+        with with_host(cephadm_module, 'test'):
+            dg = DriveGroupSpec(placement=PlacementSpec(host_pattern='test'),
+                                data_devices=DeviceSelection(all=True),
+                                service_id='spec_class',
+                                crush_device_class='hdd')
+            disks = [
+                Device('/dev/sdb', sys_api={'rotational': '0'}, available=True),
+                Device('/dev/sdc', sys_api={'rotational': '0'},
+                       crush_device_class='nvme', available=True),
+            ]
+            ds = DriveSelection(dg, disks)
+            _prepare_dg.return_value = [('test', ds)]
+            d_to_cv.return_value = ['some-cv-cmd']
+            cv_json = (
+                '[{"data": "/dev/sdb", "data_size": "300 GB"},'
+                ' {"data": "/dev/sdc", "data_size": "300 GB"}]'
+            )
+            _run_cv_cmd.side_effect = async_side_effect(([cv_json], '', 0))
+
+            preview = cephadm_module.osd_service.generate_previews([dg], 'test')
+            assert len(preview) == 1
+            by_path = {o['data']: o.get('crush_device_class')
+                       for o in preview[0]['data']}
+            assert by_path == {'/dev/sdb': 'hdd',
+                               '/dev/sdc': 'nvme'}
+
     @pytest.mark.parametrize(
         "devices, preview, exp_commands",
         [

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -312,7 +312,7 @@ OSDSPEC PREVIEWS
 
 def preview_table_osd(data: List) -> str:
     table = PrettyTable(header_style='upper', title='OSDSPEC PREVIEWS', border=True)
-    table.field_names = "service name host data db wal".split()
+    table.field_names = "service name host data db wal crush_device_class".split()
     table.align = 'l'
     table.left_padding_width = 0
     table.right_padding_width = 2
@@ -331,9 +331,11 @@ def preview_table_osd(data: List) -> str:
                     db_path = osd.get('block_db', '-')
                     wal_path = osd.get('block_wal', '-')
                     block_data = osd.get('data', '')
+                    crush_device_class = osd.get('crush_device_class', '-')
                     if not block_data:
                         continue
-                    table.add_row(('osd', dg_name, host, block_data, db_path, wal_path))
+                    table.add_row(('osd', dg_name, host, block_data, db_path,
+                                   wal_path, crush_device_class))
     return notes + table.get_string()
 
 

--- a/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
+++ b/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
@@ -270,19 +270,54 @@ def test_preview_table_osd_smoke():
                                 "block_db_size": "66.67 GB",
                                 "data": "/dev/sdb",
                                 "data_size": "300.00 GB",
-                                "encryption": "None"
+                                "encryption": "None",
+                                "crush_device_class": "hdd",
                             },
                             {
                                 "block_db": "/dev/nvme0n1",
                                 "block_db_size": "66.67 GB",
                                 "data": "/dev/sdc",
                                 "data_size": "300.00 GB",
-                                "encryption": "None"
+                                "encryption": "None",
+                                "crush_device_class": "hdd",
                             },
                             {
                                 "block_db": "/dev/nvme0n1",
                                 "block_db_size": "66.67 GB",
                                 "data": "/dev/sdd",
+                                "data_size": "300.00 GB",
+                                "encryption": "None",
+                                "crush_device_class": "nvme",
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    ]
+    out = preview_table_osd(data)
+    assert 'CRUSH_DEVICE_CLASS' in out
+    assert 'hdd' in out
+    assert 'nvme' in out
+
+
+def test_preview_table_osd_missing_crush_class():
+    # Backward compat: older preview payloads with no crush_device_class
+    # render '-' rather than crashing.
+    data = [
+        {
+            'service_type': 'osd',
+            'data':
+            {
+                'foo host':
+                [
+                    {
+                        'osdspec': 'foo',
+                        'error': '',
+                        'data':
+                        [
+                            {
+                                "data": "/dev/sdb",
                                 "data_size": "300.00 GB",
                                 "encryption": "None"
                             }
@@ -292,7 +327,8 @@ def test_preview_table_osd_smoke():
             }
         }
     ]
-    preview_table_osd(data)
+    out = preview_table_osd(data)
+    assert 'CRUSH_DEVICE_CLASS' in out
 
 
 @mock.patch("orchestrator.module.OrchestratorCli.release_name", new_callable=mock.PropertyMock)


### PR DESCRIPTION
## Summary

`ceph orch apply --dry-run` for an OSD service shows the OSDSPEC
PREVIEWS table, but offered no way to see which CRUSH device class
each new OSD would land on. On hosts with mixed device types, or
with `paths:` specs that rely on the rotational-derived default,
the class isn't predictable from the spec alone.

A new `CRUSH_DEVICE_CLASS` column is computed on the cephadm side
with the same precedence the OSD picks at activation time:

1. `crush_device_class` set on the device entry in the spec
2. `crush_device_class` set at the spec level
3. The rotational-derived default (`hdd` for `rotational=1`, `ssd`
   otherwise) from the host inventory

The third rule reads from the cached host inventory because devices
selected by `paths:` arrive without `sys_api` on the
`DriveSelection`, so the per-path `Device` objects cannot resolve
rotational on their own.

Older preview payloads, or non-cephadm orchestrators that don't
populate the new key, render `-`.

Example with a `paths:` spec like the one in the tracker:

```
$ ceph orch apply --dry-run -i osd.yml
+---------+---------------+---------+-----------+----+-----+--------------------+
|SERVICE  |NAME           |HOST     |DATA       |DB  |WAL  |CRUSH_DEVICE_CLASS  |
+---------+---------------+---------+-----------+----+-----+--------------------+
|osd      |osd_nooffload  |dd13-29  |/dev/sdah  |-   |-    |hdd                 |
|osd      |osd_nooffload  |dd13-29  |/dev/sdai  |-   |-    |hdd                 |
|osd      |osd_nooffload  |dd13-29  |/dev/sdaj  |-   |-    |nvme                |
|osd      |osd_nooffload  |dd13-29  |/dev/sdak  |-   |-    |ssd                 |
+---------+---------------+---------+-----------+----+-----+--------------------+
```

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [ ] No tests

Tracker: https://tracker.ceph.com/issues/76518