### PR TITLE
  mon: allow stretch mode in ec pools

### DIFF
--- a/doc/rados/operations/stretch-mode.rst
+++ b/doc/rados/operations/stretch-mode.rst
@@ -331,10 +331,6 @@ Two Monitors must be run in each data center, plus a tiebreaker in a third
 will connect only to Monitors within the data center in which they are located.
 OSDs *DO NOT* connect to the tiebreaker monitor.
 
-Erasure-coded pools cannot be used with stretch mode. Attempts to use erasure
-coded pools with stretch mode will fail. Erasure coded pools cannot be created
-while in stretch mode. 
-
 To use stretch mode, you will need to create a CRUSH rule that provides two
 replicas in each data center. Ensure that there are four total replicas: two in
 each data center. If pools exist in the cluster that do not have the default
@@ -358,10 +354,6 @@ data centers has been restored. This reduces the potential for data loss.
                  step chooseleaf firstn 2 type host
                  step emit
       }
-
-In the future, stretch mode could support erasure-coded pools,
-enable deployments across more than two data centers,
-and accommodate multiple CRUSH device classes.
 
 Other commands
 ==============

--- a/src/common/bitset_set.h
+++ b/src/common/bitset_set.h
@@ -490,6 +490,123 @@ class bitset_set {
 
     return std::strong_ordering::equal;
   }
+
+  /** Left shift operator - shifts all bits left by n positions.
+   * Bits that shift beyond max_bits are lost.
+   */
+  friend bitset_set operator<<(const bitset_set &lhs, unsigned int n) {
+    bitset_set result;
+    if (n == 0) {
+      result.copy(lhs);
+      return result;
+    }
+    if (n >= max_bits) {
+      // All bits shifted out
+      return result;
+    }
+
+    unsigned int word_shift = n / bits_per_uint64_t;
+    unsigned int bit_shift = n % bits_per_uint64_t;
+
+    if (bit_shift == 0) {
+      // Simple word-aligned shift
+      for (size_t i = word_count - 1; i >= word_shift; --i) {
+        result.words[i] = lhs.words[i - word_shift];
+      }
+    } else {
+      // Shift with bit offset
+      unsigned int complement_shift = bits_per_uint64_t - bit_shift;
+      for (size_t i = word_count - 1; i > word_shift; --i) {
+        result.words[i] = (lhs.words[i - word_shift] << bit_shift) |
+                          (lhs.words[i - word_shift - 1] >> complement_shift);
+      }
+      result.words[word_shift] = lhs.words[0] << bit_shift;
+    }
+
+    return result;
+  }
+
+  /** Right shift operator - shifts all bits right by n positions.
+   * Bits that shift below 0 are lost.
+   */
+  friend bitset_set operator>>(const bitset_set &lhs, unsigned int n) {
+    bitset_set result;
+    if (n == 0) {
+      result.copy(lhs);
+      return result;
+    }
+    if (n >= max_bits) {
+      // All bits shifted out
+      return result;
+    }
+
+    unsigned int word_shift = n / bits_per_uint64_t;
+    unsigned int bit_shift = n % bits_per_uint64_t;
+
+    if (bit_shift == 0) {
+      // Simple word-aligned shift
+      for (size_t i = 0; i < word_count - word_shift; ++i) {
+        result.words[i] = lhs.words[i + word_shift];
+      }
+    } else {
+      // Shift with bit offset
+      unsigned int complement_shift = bits_per_uint64_t - bit_shift;
+      for (size_t i = 0; i < word_count - word_shift - 1; ++i) {
+        result.words[i] = (lhs.words[i + word_shift] >> bit_shift) |
+                          (lhs.words[i + word_shift + 1] << complement_shift);
+      }
+      result.words[word_count - word_shift - 1] =
+        lhs.words[word_count - 1] >> bit_shift;
+    }
+
+    return result;
+  }
+
+  /** Left shift assignment operator */
+  bitset_set &operator<<=(unsigned int n) {
+    *this = *this << n;
+    return *this;
+  }
+
+  /** Right shift assignment operator */
+  bitset_set &operator>>=(unsigned int n) {
+    *this = *this >> n;
+    return *this;
+  }
+
+  /** Bitwise AND operator - returns intersection of two sets */
+  friend bitset_set operator&(const bitset_set &lhs, const bitset_set &rhs) {
+    bitset_set result;
+    for (size_t i = 0; i < word_count; ++i) {
+      result.words[i] = lhs.words[i] & rhs.words[i];
+    }
+    return result;
+  }
+
+  /** Bitwise OR operator - returns union of two sets */
+  friend bitset_set operator|(const bitset_set &lhs, const bitset_set &rhs) {
+    bitset_set result;
+    for (size_t i = 0; i < word_count; ++i) {
+      result.words[i] = lhs.words[i] | rhs.words[i];
+    }
+    return result;
+  }
+
+  /** Bitwise AND assignment operator - sets this to intersection with other */
+  bitset_set &operator&=(const bitset_set &other) {
+    for (size_t i = 0; i < word_count; ++i) {
+      words[i] &= other.words[i];
+    }
+    return *this;
+  }
+
+  /** Bitwise OR assignment operator - sets this to union with other */
+  bitset_set &operator|=(const bitset_set &other) {
+    for (size_t i = 0; i < word_count; ++i) {
+      words[i] |= other.words[i];
+    }
+    return *this;
+  }
 };
 
 // make sure fmt::range would not try (and fail) to treat bitset_set as a range

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -2629,7 +2629,7 @@ options:
   type: str
   level: advanced
   desc: Default EC profile for new erasure-coded pools
-  default: plugin=isa technique=reed_sol_van k=2 m=2
+  default: plugin=isa technique=reed_sol_van k=2 m=2 num_zones=1
   services:
   - mon
   flags:

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7799,18 +7799,33 @@ int OSDMonitor::prepare_pool_size(const unsigned pool_type,
   case pg_pool_t::TYPE_ERASURE:
     {
       if (osdmap.stretch_mode_enabled) {
-	*ss << "prepare_pool_size: we are in stretch mode; cannot create EC pools!";
-	return -EINVAL;
+ *ss << "prepare_pool_size: we are in stretch mode; cannot create EC pools!";
+ return -EINVAL;
       }
       ErasureCodeInterfaceRef erasure_code;
       err = get_erasure_code(erasure_code_profile, &erasure_code, ss);
       if (err == 0) {
-	*size = erasure_code->get_chunk_count();
-	*min_size =
-	  erasure_code->get_data_chunk_count() +
-	  std::min<int>(1, erasure_code->get_coding_chunk_count() - 1);
-	ceph_assert(*min_size <= *size);
-	ceph_assert(*min_size >= erasure_code->get_data_chunk_count());
+ unsigned base_size = erasure_code->get_chunk_count();
+ 
+ // Get num_zones from the EC profile, default to 1
+ ErasureCodeProfile profile = osdmap.get_erasure_code_profile(erasure_code_profile);
+ int num_zones = 1;
+ auto it = profile.find("num_zones");
+ if (it != profile.end()) {
+   std::string err_str;
+   num_zones = strict_strtol(it->second.c_str(), 10, &err_str);
+   if (!err_str.empty() || num_zones < 1) {
+     *ss << "invalid num_zones value in erasure code profile: " << it->second;
+     return -EINVAL;
+   }
+ }
+ 
+ *size = num_zones * base_size;
+ *min_size =
+   erasure_code->get_data_chunk_count() +
+   std::min<int>(1, erasure_code->get_coding_chunk_count() - 1);
+ ceph_assert(*min_size <= *size);
+ ceph_assert(*min_size >= erasure_code->get_data_chunk_count());
       }
     }
     break;
@@ -8331,6 +8346,20 @@ int OSDMonitor::prepare_new_pool(string& name,
 
   if (pool_type == pg_pool_t::TYPE_ERASURE) {
       pi->erasure_code_profile = erasure_code_profile;
+      
+      // Set NUM_ZONES from the EC profile
+      ErasureCodeProfile profile = osdmap.get_erasure_code_profile(erasure_code_profile);
+      auto it = profile.find("num_zones");
+      if (it != profile.end()) {
+        std::string err_str;
+        int num_zones = strict_strtol(it->second.c_str(), 10, &err_str);
+        if (err_str.empty() && num_zones >= 1) {
+          pi->opts.set(pool_opts_t::NUM_ZONES, static_cast<int64_t>(num_zones));
+        }
+      } else {
+        // Default to 1 if not specified
+        pi->opts.set(pool_opts_t::NUM_ZONES, static_cast<int64_t>(1));
+      }
   } else {
       pi->erasure_code_profile = "";
   }
@@ -8439,19 +8468,38 @@ int OSDMonitor::enable_pool_ec_optimizations(pg_pool_t &p,
       return -EINVAL;
     }
     // Restrict the set of shards that can be a primary to the 1st data
-    // raw_shard (raw_shard 0) and the coding parity raw_shards because§
+    // raw_shard (raw_shard 0) and the coding parity raw_shards because
     // the other shards (including local parity for LRC) may not have
     // up to date copies of xattrs including OI
+    // For multi-zone configurations, we need to mark non-primary shards
+    // across all zones: shard + (k+m)*zone for each zone
     p.nonprimary_shards.clear();
-    for (raw_shard_id_t raw_shard; raw_shard < k + m; ++raw_shard) {
+    
+    // Get num_zones from the EC profile, default to 1
+    ErasureCodeProfile profile = osdmap.get_erasure_code_profile(p.erasure_code_profile);
+    int num_zones = 1;
+    auto it = profile.find("num_zones");
+    if (it != profile.end()) {
+      std::string err_str;
+      num_zones = strict_strtol(it->second.c_str(), 10, &err_str);
+      if (!err_str.empty() || num_zones < 1) {
+        num_zones = 1;
+      }
+    }
+    
+    for (raw_shard_id_t raw_shard(0); raw_shard < k + m; ++raw_shard) {
       if (raw_shard > 0 && raw_shard < k) {
-	shard_id_t shard;
-	if (erasure_code->get_chunk_mapping().size() > raw_shard ) {
-	  shard = shard_id_t(erasure_code->get_chunk_mapping().at(int(raw_shard)));
-	} else {
-	  shard = shard_id_t(int(raw_shard));
-	}
-        p.nonprimary_shards.insert(shard);
+       shard_id_t rel_shard;
+       if (erasure_code->get_chunk_mapping().size() > static_cast<size_t>(int(raw_shard))) {
+         rel_shard = erasure_code->get_chunk_mapping().at(int(raw_shard));
+       } else {
+         rel_shard = shard_id_t(int8_t(raw_shard));
+       }
+       // Add this shard across all zones
+       for (int zone = 0; zone < num_zones; ++zone) {
+         shard_id_t shard = shard_id_t(int8_t(rel_shard) + (k + m) * zone);
+         p.nonprimary_shards.insert(shard);
+       }
       }
     }
     p.flags |= pg_pool_t::FLAG_EC_OPTIMIZATIONS;
@@ -9275,6 +9323,22 @@ int OSDMonitor::prepare_command_pool_set(const cmdmap_t& cmdmap,
         ss << "read_ratio must be between 0 and 100";
         return -ERANGE;
       }
+    } else if (var == "num_zones") {
+      if (interr.length()) {
+        ss << "error parsing int value '" << val << "': " << interr;
+        return -EINVAL;
+      }
+      if (n < 0) {
+        ss << "num_zones must be non-negative";
+        return -EINVAL;
+      }
+      // For EC pools, validate that num_zones is compatible with pool
+      if (p.type == pg_pool_t::TYPE_ERASURE) {
+        if (n < 1) {
+          ss << "num_zones must be at least 1 for erasure coded pools";
+          return -EINVAL;
+        }
+      }
     }
 
     pool_opts_t::opt_desc_t desc = pool_opts_t::get_opt_desc(var);
@@ -9315,6 +9379,40 @@ int OSDMonitor::prepare_command_pool_set(const cmdmap_t& cmdmap,
     ss << "unrecognized variable '" << var << "'";
     return -EINVAL;
   }
+  
+  // For EC pools, adjust pool size when num_zones is set
+  if (var == "num_zones" && p.type == pg_pool_t::TYPE_ERASURE) {
+    int64_t num_zones = 0;
+    p.opts.get(pool_opts_t::NUM_ZONES, &num_zones);
+    
+    if (num_zones > 0) {
+      // Get the base EC pool size (k + m)
+      ErasureCodeInterfaceRef erasure_code;
+      stringstream tmp;
+      int err = get_erasure_code(p.erasure_code_profile, &erasure_code, &tmp);
+      if (err == 0) {
+        unsigned base_size = erasure_code->get_chunk_count();
+        unsigned new_size = num_zones * base_size;
+        
+        // Check if pool size is changing (increasing)
+        if (new_size > p.size) {
+          // Validate the new size with pg_num
+          int r = check_pg_num(pool, p.get_pg_num(), new_size, p.get_crush_rule(), &ss);
+          if (r < 0) {
+            return r;
+          }
+        }
+        
+        // Set pool size = num_zones * (k + m)
+        p.size = new_size;
+        ss << "; pool size adjusted to " << (int)p.size
+           << " (" << num_zones << " zones * " << base_size << " chunks)";
+      } else {
+        ss << "; warning: could not adjust pool size: " << tmp.str();
+      }
+    }
+  }
+  
   if (val != "unset") {
     ss << "set pool " << pool << " " << var << " to " << val;
   } else {

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -15674,37 +15674,90 @@ void OSDMonitor::try_disable_stretch_mode(stringstream& ss,
   return;
 }
 
+void OSDMonitor::validate_stretch_mode_pools(
+    const CrushWrapper& crush,
+    const mempool::osdmap::map<int64_t, string>& pool_names,
+    const mempool::osdmap::map<int64_t, pg_pool_t>& pools,
+    stringstream& ss,
+    bool *okay,
+    int *errcode,
+    const string& new_crush_rule)
+{
+  *okay = false;
+  
+  // Validate CRUSH rule exists
+  int new_crush_rule_result = crush.get_rule_id(new_crush_rule);
+  if (new_crush_rule_result < 0) {
+    ss << "unrecognized crush rule " << new_crush_rule;
+    *errcode = new_crush_rule_result;
+    return;
+  }
+  
+  __u8 new_rule = static_cast<__u8>(new_crush_rule_result);
+  int crush_rule_type = crush.get_rule_type(new_rule);
+  if (crush_rule_type < 0) {
+    ss << "unable to get type for crush rule " << new_crush_rule;
+    *errcode = -EINVAL;
+    return;
+  }
+
+  // Validate each pool
+  for (const auto& pooli : pools) {
+    int64_t poolid = pooli.first;
+    const pg_pool_t& p = pooli.second;
+    
+    // Validate that pool type matches crush rule type
+    if (p.is_replicated() && crush_rule_type != pg_pool_t::TYPE_REPLICATED) {
+      ss << "pool '" << pool_names.at(poolid) << "' is replicated but crush rule '"
+         << new_crush_rule << "' is not a replicated rule";
+      *errcode = -EINVAL;
+      return;
+    }
+    if (p.is_erasure() && crush_rule_type != pg_pool_t::TYPE_ERASURE) {
+      ss << "pool '" << pool_names.at(poolid) << "' is erasure-coded but crush rule '"
+         << new_crush_rule << "' is not an erasure-coded rule";
+      *errcode = -EINVAL;
+      return;
+    }
+
+    // For replicated pools, validate size/min_size to start out with the default values
+    if (p.is_replicated()) {
+      uint8_t default_size = g_conf().get_val<uint64_t>("osd_pool_default_size");
+      if ((p.get_size() != default_size ||
+           (p.get_min_size() != g_conf().get_osd_pool_default_min_size(default_size))) &&
+          (p.get_crush_rule() != new_rule)) {
+        ss << "we currently require stretch mode pools start out with the"
+           " default size/min_size, which '" << pool_names.at(poolid) << "' does not";
+        *errcode = -EINVAL;
+        return;
+      }
+    }
+    // else for erasure-coded pools size validation happens through the EC profile
+  }
+
+  *okay = true;
+  *errcode = 0;
+}
+
 void OSDMonitor::try_enable_stretch_mode_pools(stringstream& ss, bool *okay,
 					       int *errcode,
 					       set<pg_pool_t*>* pools,
 					       const string& new_crush_rule)
 {
   dout(20) << __func__ << dendl;
-  *okay = false;
-  int new_crush_rule_result = osdmap.crush->get_rule_id(new_crush_rule);
-  if (new_crush_rule_result < 0) {
-    ss << "unrecognized crush rule " << new_crush_rule_result;
-    *errcode = new_crush_rule_result;
+  
+  // Validate stretch mode pools
+  validate_stretch_mode_pools(*osdmap.crush, osdmap.pool_name, osdmap.pools,
+                              ss, okay, errcode, new_crush_rule);
+  
+  if (!*okay) {
     return;
   }
-  __u8 new_rule = static_cast<__u8>(new_crush_rule_result);
+  
+  // Populate the pools after validation passed
   for (const auto& pooli : osdmap.pools) {
     int64_t poolid = pooli.first;
     const pg_pool_t *p = &pooli.second;
-    if (!p->is_replicated()) {
-      ss << "stretched pools must be replicated; '" << osdmap.pool_name[poolid] << "' is erasure-coded";
-      *errcode = -EINVAL;
-      return;
-    }
-    uint8_t default_size = g_conf().get_val<uint64_t>("osd_pool_default_size");
-    if ((p->get_size() != default_size ||
-	 (p->get_min_size() != g_conf().get_osd_pool_default_min_size(default_size))) &&
-	(p->get_crush_rule() != new_rule)) {
-      ss << "we currently require stretch mode pools start out with the"
-	" default size/min_size, which '" << osdmap.pool_name[poolid] << "' does not";
-      *errcode = -EINVAL;
-      return;
-    }
     pg_pool_t *pp = pending_inc.get_new_pool(poolid, p);
     // TODO: The part where we unconditionally copy the pools into pending_inc is bad
     // the attempt may fail and then we have these pool updates...but they won't do anything
@@ -15783,8 +15836,14 @@ void OSDMonitor::try_enable_stretch_mode(stringstream& ss, bool *okay,
       pool->peering_crush_bucket_target = bucket_count;
       pool->peering_crush_bucket_barrier = dividing_id;
       pool->peering_crush_mandatory_member = CRUSH_ITEM_NONE;
-      pool->size = g_conf().get_val<uint64_t>("mon_stretch_pool_size");
-      pool->min_size = g_conf().get_val<uint64_t>("mon_stretch_pool_min_size");
+
+      // Set size/min_size for replicated pools
+      if (pool->is_replicated()) {
+        pool->size = g_conf().get_val<uint64_t>("mon_stretch_pool_size");
+        pool->min_size = g_conf().get_val<uint64_t>("mon_stretch_pool_min_size");
+      }
+      // else for erasure-coded pools, size is determined by the erasure code profile
+
     }
     pending_inc.change_stretch_mode = true;
     pending_inc.stretch_mode_enabled = true;

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -830,6 +830,26 @@ public:
 				     int *errcode,
 				     std::set<pg_pool_t*>* pools,
 				     const std::string& new_crush_rule);
+
+  /**
+   * Static helper for validating pools for stretch mode.
+   * Extracted for testability - can be called from unit tests.
+   * @param crush: CrushWrapper to validate rule against
+   * @param pool_names: Map of pool IDs to names (for error messages)
+   * @param pools: Map of pool IDs to pool objects to validate
+   * @param ss: stringstream for error messages
+   * @param okay: Set to true if validation passes
+   * @param errcode: Set to error code if validation fails
+   * @param new_crush_rule: Name of the CRUSH rule to validate
+   */
+  static void validate_stretch_mode_pools(
+      const CrushWrapper& crush,
+      const mempool::osdmap::map<int64_t, std::string>& pool_names,
+      const mempool::osdmap::map<int64_t, pg_pool_t>& pools,
+      std::stringstream& ss,
+      bool *okay,
+      int *errcode,
+      const std::string& new_crush_rule);
   /**
    * Check validity of inputs and OSD/CRUSH state to
    * engage stretch mode. Designed to be used with

--- a/src/os/Transaction.cc
+++ b/src/os/Transaction.cc
@@ -52,6 +52,30 @@ void decode_str_set_to_bl(bufferlist::const_iterator& p,
 
 namespace ceph::os {
 
+void Transaction::remap_shard(shard_id_t new_shard) {
+  std::map<ghobject_t, uint32_t> new_object_index;
+  for (auto& [obj, idx] : object_index) {
+    ghobject_t new_obj = obj;
+    new_obj.shard_id = new_shard;
+    new_object_index[std::move(new_obj)] = idx;
+  }
+  object_index = std::move(new_object_index);
+  std::map<coll_t, uint32_t> new_coll_index;
+  for (auto& [coll, idx] : coll_index) {
+    spg_t pgid;
+    if (coll.is_pg(&pgid)) {
+      pgid.shard = new_shard;
+      new_coll_index[coll_t(pgid)] = idx;
+    } else if (coll.is_temp(&pgid)) {
+      pgid.shard = new_shard;
+      new_coll_index[coll_t(pgid).get_temp()] = idx;
+    } else {
+      new_coll_index[coll] = idx;
+    }
+  }
+  coll_index = std::move(new_coll_index);
+}
+
 void Transaction::dump(ceph::Formatter *f)
 {
   f->open_array_section("ops");

--- a/src/os/Transaction.h
+++ b/src/os/Transaction.h
@@ -408,6 +408,12 @@ public:
     data_misaligned_bl.swap(other.data_misaligned_bl);
   }
 
+  /// Remap all shard identifiers in this transaction's index tables
+  /// using extract()/reinsert. The op buffer and data buffers are
+  /// unaffected since they store indices, not identities.
+  /// Does NOT touch callbacks (on_applied, on_commit, on_applied_sync).
+  void remap_shard(shard_id_t new_shard);
+
   void _update_op(Op* op,
     std::vector<uint32_t> &cm,
     std::vector<uint32_t> &om) {

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -621,6 +621,7 @@ void ECBackend::handle_sub_read_reply(
     pg_shard_t from,
     ECSubReadReply &op,
     const ZTracer::Trace &trace) {
+  auto from_rel_shard = sinfo.get_rel_shard(from.shard);
   trace.event("ec sub read reply");
   dout(10) << __func__ << ": reply " << op << dendl;
   map<ceph_tid_t, ReadOp>::iterator iter = read_pipeline.tid_to_read_map.
@@ -663,13 +664,13 @@ void ECBackend::handle_sub_read_reply(
 
     auto &buffers_read = rop.complete.at(hoid).buffers_read;
     for (auto &&[offset, buffer_list]: offset_buffer_map) {
-      buffers_read.insert_in_shard(from.shard, offset, buffer_list);
+      buffers_read.insert_in_shard(sinfo.get_rel_shard(from_rel_shard), offset, buffer_list);
     }
     rop.debug_log.emplace_back(ECUtil::READ_DONE, op.from, buffers_read);
 
     // zero length reads may need to be zero padded during recovery
-    if (!buffers_read.contains_shard(from.shard)) {
-      rop.complete.at(hoid).zero_length_reads.insert(from.shard);
+    if (!buffers_read.contains_shard(from_rel_shard)) {
+      rop.complete.at(hoid).zero_length_reads.insert(from_rel_shard);
     }
   }
   for (auto &&[hoid, req]: rop.to_read) {
@@ -677,13 +678,13 @@ void ECBackend::handle_sub_read_reply(
       rop.complete.emplace(hoid, &sinfo);
     }
     auto &complete = rop.complete.at(hoid);
-    if (!req.shard_reads.contains(from.shard)) {
+    if (!req.shard_reads.contains(from_rel_shard)) {
       continue;
     }
-    const shard_read_t &read = req.shard_reads.at(from.shard);
+    const shard_read_t &read = req.shard_reads.at(from_rel_shard);
     if (!complete.errors.contains(from)) {
       dout(20) << __func__ <<" read:" << read << dendl;
-      complete.processed_read_requests[from.shard].union_of(read.extents);
+      complete.processed_read_requests[from_rel_shard].union_of(read.extents);
     }
   }
   for (auto &&[hoid, attr]: op.attrs_read) {
@@ -707,12 +708,12 @@ void ECBackend::handle_sub_read_reply(
     auto &complete = rop.complete.at(hoid);
     complete.errors.emplace(from, err);
     rop.debug_log.emplace_back(ECUtil::ERROR, op.from, complete.buffers_read);
-    complete.buffers_read.erase_shard(from.shard);
-    complete.processed_read_requests.erase(from.shard);
+    complete.buffers_read.erase_shard(from_rel_shard);
+    complete.processed_read_requests.erase(from_rel_shard);
     // If there was an error for non-zero data on this shard, then we must also
     // ignore all zeros, or minimum_to_decode may conclude that it has enough
     // shards available.
-    rop.to_read.at(hoid).zeros_for_decode.erase(from.shard);
+    rop.to_read.at(hoid).zeros_for_decode.erase(from_rel_shard);
     dout(20) << __func__ << " shard=" << from << " error=" << err << dendl;
   }
 

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -290,7 +290,7 @@ public:
     bool operator()(const std::set<pg_shard_t> &_have) const override {
       shard_id_set have;
       for (pg_shard_t p: _have) {
-        have.insert(p.shard);
+        have.insert(sinfo->get_rel_shard(p.shard));
       }
       std::unique_ptr<shard_id_map<std::vector<std::pair<int, int>>>>
           min_sub_chunks = nullptr;

--- a/src/osd/ECCommon.cc
+++ b/src/osd/ECCommon.cc
@@ -18,6 +18,7 @@
 #include <iostream>
 #include <sstream>
 #include <ranges>
+#include <expected>
 #include <fmt/ostream.h>
 
 #include "ECInject.h"
@@ -150,87 +151,133 @@ void ECCommon::ReadPipeline::get_all_avail_shards(
     shard_id_set &have,
     shard_id_map<pg_shard_t> &shards,
     const bool for_recovery,
+    int local_zone,
+    bool allow_remote_zone,
     const std::optional<set<pg_shard_t>> &error_shards) {
   for (auto &&pg_shard: get_parent()->get_acting_shards()) {
-    dout(10) << __func__ << ": checking acting " << pg_shard << dendl;
-    const pg_missing_t &missing = get_parent()->get_shard_missing(pg_shard);
-    if (error_shards && error_shards->contains(pg_shard)) {
+    const auto [rel_shard, zone] = sinfo.get_rel_shard_and_zone(pg_shard.shard);
+    if (!allow_remote_zone && zone != local_zone) {
+      dout(10) << __func__ << ": skipping acting " << pg_shard
+               << " (rel_shard=" << rel_shard << ") - wrong zone " << zone
+               << " (local=" << local_zone << ")" << dendl;
       continue;
     }
-    const shard_id_t &shard = pg_shard.shard;
+    dout(10) << __func__ << ": checking acting " << pg_shard
+             << " (rel_shard=" << rel_shard << ")" << dendl;
+    const pg_missing_t &missing = get_parent()->get_shard_missing(pg_shard);
+    if (error_shards && error_shards->contains(pg_shard)) {
+d      dout(10) << __func__ << ": skipping acting " << pg_shard
+               << " (rel_shard=" << rel_shard << ") - in error_shards" << dendl;
+      continue;
+    }
 #ifndef WITH_CRIMSON
     if (cct->_conf->bluestore_debug_inject_read_err &&
-      ECInject::test_read_error1(ghobject_t(hoid, ghobject_t::NO_GEN, shard))) {
-      dout(0) << __func__ << " Error inject - Missing shard " << shard << dendl;
+      ECInject::test_read_error1(ghobject_t(hoid, ghobject_t::NO_GEN, rel_shard))) {
+      dout(0) << __func__ << " Error inject - Missing shard " << rel_shard << dendl;
       continue;
     }
 #endif
     if (!missing.is_missing(hoid)) {
-      ceph_assert(!have.contains(shard));
-      have.insert(shard);
-      ceph_assert(!shards.contains(shard));
-      shards.insert(shard, pg_shard);
+      if (have.contains(rel_shard)) {
+        ceph_assert(allow_remote_zone);
+        // With zones, multiple pg_shards can map to the same relative shard
+        // Skip if we already have this relative shard
+        dout(10) << __func__ << ": skipping acting " << pg_shard
+                 << " (rel_shard=" << rel_shard << ") - already have this shard" << dendl;
+        continue;
+      }
+      dout(10) << __func__ << ": adding acting " << pg_shard
+               << " (rel_shard=" << rel_shard << ") - object not missing" << dendl;
+      have.insert(rel_shard);
+      ceph_assert(!shards.contains(rel_shard));
+      shards.insert(rel_shard, pg_shard);
+    } else {
+      dout(10) << __func__ << ": skipping acting " << pg_shard
+               << " (rel_shard=" << rel_shard << ") - object is missing" << dendl;
     }
   }
 
   if (for_recovery) {
     for (auto &&pg_shard: get_parent()->get_backfill_shards()) {
       if (error_shards && error_shards->contains(pg_shard)) {
+        dout(10) << __func__ << ": skipping backfill " << pg_shard
+                 << " - in error_shards" << dendl;
         continue;
       }
-      const shard_id_t &shard = pg_shard.shard;
-      if (have.contains(shard)) {
-        ceph_assert(shards.contains(shard));
+      const auto [rel_shard, zone] = sinfo.get_rel_shard_and_zone(pg_shard.shard);
+      if (!allow_remote_zone && zone != local_zone) {
+        dout(10) << __func__ << ": skipping backfill " << pg_shard
+                 << " (rel_shard=" << rel_shard << ") - wrong zone " << zone
+                 << " (local=" << local_zone << ")" << dendl;
         continue;
       }
-      dout(10) << __func__ << ": checking backfill " << pg_shard << dendl;
-      ceph_assert(!shards.count(shard));
+      if (have.contains(rel_shard)) {
+        ceph_assert(shards.contains(rel_shard));
+        dout(10) << __func__ << ": skipping backfill " << pg_shard
+                 << " (rel_shard=" << rel_shard << ") - already have this shard" << dendl;
+        continue;
+      }
+      dout(10) << __func__ << ": checking backfill " << pg_shard
+               << " (rel_shard=" << rel_shard << ")" << dendl;
+      ceph_assert(!shards.count(rel_shard));
       const pg_info_t &info = get_parent()->get_shard_info(pg_shard);
       if (hoid < info.last_backfill &&
         !get_parent()->get_shard_missing(pg_shard).is_missing(hoid)) {
-        have.insert(shard);
-        shards.insert(shard, pg_shard);
+        dout(10) << __func__ << ": adding backfill " << pg_shard
+                 << " (rel_shard=" << rel_shard << ") - hoid < last_backfill and not missing" << dendl;
+        have.insert(rel_shard);
+        shards.insert(rel_shard, pg_shard);
+      } else {
+        dout(10) << __func__ << ": skipping backfill " << pg_shard
+                 << " (rel_shard=" << rel_shard << ") - hoid=" << hoid
+                 << " last_backfill=" << info.last_backfill
+                 << " is_missing=" << get_parent()->get_shard_missing(pg_shard).is_missing(hoid) << dendl;
       }
     }
 
     auto miter = get_parent()->get_missing_loc_shards().find(hoid);
     if (miter != get_parent()->get_missing_loc_shards().end()) {
       for (auto &&pg_shard: miter->second) {
+
         dout(10) << __func__ << ": checking missing_loc " << pg_shard << dendl;
         if (const auto m = get_parent()->maybe_get_shard_missing(pg_shard)) {
           ceph_assert(!m->is_missing(hoid));
         }
         if (error_shards && error_shards->contains(pg_shard)) {
+          dout(10) << __func__ << ": skipping missing_loc " << pg_shard
+                   << " - in error_shards" << dendl;
           continue;
         }
-        have.insert(pg_shard.shard);
-        shards.insert(pg_shard.shard, pg_shard);
+        const auto [rel_shard, zone] = sinfo.get_rel_shard_and_zone(pg_shard.shard);
+        if (!allow_remote_zone && zone != local_zone) {
+          dout(10) << __func__ << ": skipping missing_loc " << pg_shard
+                   << " (rel_shard=" << rel_shard << ") - wrong zone " << zone
+                   << " (local=" << local_zone << ")" << dendl;
+          continue;
+        }
+        dout(10) << __func__ << ": adding missing_loc " << pg_shard
+                 << " (rel_shard=" << rel_shard << ")" << dendl;
+        have.insert(rel_shard);
+        shards.insert(rel_shard, pg_shard);
       }
     }
   }
 }
 
-int ECCommon::ReadPipeline::get_min_avail_to_read_shards(
+std::expected<std::tuple<shard_id_set, shard_id_map<pg_shard_t>, shard_id_set>, int>
+ECCommon::ReadPipeline::select_shards_for_read(
     const hobject_t &hoid,
+    const shard_id_set &want,
     bool for_recovery,
-    bool do_redundant_reads,
-    read_request_t &read_request,
-    const std::optional<set<pg_shard_t>> &error_shards) {
-  // Make sure we don't do redundant reads for recovery
-  ceph_assert(!for_recovery || !do_redundant_reads);
-
-  if (read_request.object_size == 0) {
-    dout(10) << __func__ << " empty read" << dendl;
-    return 0;
-  }
-
+    bool allow_remote_zone,
+    const std::optional<set<pg_shard_t>> &error_shards)
+{
   shard_id_set have;
   shard_id_map<pg_shard_t> shards(sinfo.get_k_plus_m());
+  auto zone = sinfo.get_shard_zone(get_parent()->whoami_shard().shard);
+  get_all_avail_shards(hoid, have, shards, for_recovery, zone, allow_remote_zone, error_shards);
 
   shard_id_set need_set;
-  shard_id_set want;
-
-  read_request.shard_want_to_read.populate_shard_id_set(want);
 
   int r = 0;
   auto kth_iter = want.find_nth(sinfo.get_k());
@@ -248,10 +295,41 @@ int ECCommon::ReadPipeline::get_min_avail_to_read_shards(
   }
 
   if (r < 0) {
-    dout(20) << "minimum_to_decode_failed r: " << r << "want: " << want
+    dout(20) << "minimum_to_decode_failed r: " << r << " want: " << want
       << " have: " << have << " need: " << need_set << dendl;
-    return r;
+    return std::unexpected(r);
   }
+
+  return std::make_tuple(std::move(have), std::move(shards), std::move(need_set));
+}
+
+int ECCommon::ReadPipeline::  get_min_avail_to_read_shards(
+    const hobject_t &hoid,
+    bool for_recovery,
+    bool do_redundant_reads,
+    read_request_t &read_request,
+    const std::optional<set<pg_shard_t>> &error_shards) {
+  // Make sure we don't do redundant reads for recovery
+  ceph_assert(!for_recovery || !do_redundant_reads);
+
+  if (read_request.object_size == 0) {
+    dout(10) << __func__ << " empty read" << dendl;
+    return 0;
+  }
+  shard_id_set want;
+  read_request.shard_want_to_read.populate_shard_id_set(want);
+
+  // Try to get shards from local zone first, fall back to remote zone if needed
+  auto result = select_shards_for_read(hoid, want, for_recovery, false, error_shards);
+  if (!result && sinfo.get_num_zones() > 1) {
+    result = select_shards_for_read(hoid, want, for_recovery, true, error_shards);
+  }
+  if (!result) {
+    return result.error();
+  }
+
+  // Extract the values from the expected result
+  auto& [have, shards, need_set] = result.value();
 
   if (do_redundant_reads) {
     need_set.insert(have);
@@ -291,9 +369,6 @@ int ECCommon::ReadPipeline::get_min_avail_to_read_shards(
     shard_id_t shard_id(shard);
     extent_set extents = extra_extents;
     shard_read_t shard_read;
-    if (need_sub_chunks) {
-      shard_read.subchunk = need_sub_chunks->at(shard_id);
-    }
     shard_read.pg_shard = shards[shard_id];
 
     if (read_request.shard_want_to_read.contains(shard)) {
@@ -401,7 +476,7 @@ int ECCommon::ReadPipeline::get_remaining_shards(
     // empty read!
     shard_id_set have;
     shard_id_map<pg_shard_t> pg_shards(sinfo.get_k_plus_m());
-    get_all_avail_shards(hoid, have, pg_shards, for_recovery, error_shards);
+    get_all_avail_shards(hoid, have, pg_shards, for_recovery, 0, 0, error_shards);
     for (auto shard : have) {
       if (!sinfo.is_nonprimary_shard(shard)) {
         shard_read_t shard_read;
@@ -816,8 +891,8 @@ void ECCommon::RMWPipeline::cache_ready(Op &op) {
     op.delta_stats);
 
   shard_id_map<ObjectStore::Transaction> trans(sinfo.get_k_plus_m());
-  for (auto &&shard: get_parent()->
-       get_acting_recovery_backfill_shard_id_set()) {
+  for (auto &&shard : sinfo.zones_or(get_parent()->
+           get_acting_recovery_backfill_shard_id_set())) {
     trans[shard];
   }
 
@@ -850,14 +925,28 @@ void ECCommon::RMWPipeline::cache_ready(Op &op) {
     oid_to_version[op.hoid] = op.version;
   }
   for (auto &&pg_shard: get_parent()->get_acting_recovery_backfill_shards()) {
-    ObjectStore::Transaction &transaction = trans.at(pg_shard.shard);
-    shard_id_t shard = pg_shard.shard;
+    // Use shard % (k+m) to get the relative shard for zone duplication
+    shard_id_t abs_shard = pg_shard.shard;
+    shard_id_t rel_shard = sinfo.get_rel_shard(abs_shard);
+
+    // Skip if relative shard transaction doesn't exist (relative shard not in acting set)
+    if (!trans.contains(rel_shard)) {
+      dout(20) << __func__ << " Skipping shard " << abs_shard
+               << " - relative shard " << rel_shard << " not in acting set" << dendl;
+      continue;
+    }
+
+    // FIXME: We can avoid copying the last copy here.
+    ObjectStore::Transaction transaction = trans.at(rel_shard);
+    if (abs_shard != rel_shard) {
+      transaction.remap_shard(abs_shard);
+    }
     if (transaction.empty()) {
-      dout(20) << __func__ << " Transaction for osd." << pg_shard.osd << " shard " << shard << " is empty" << dendl;
+      dout(20) << __func__ << " Transaction for osd." << pg_shard.osd << " shard " << pg_shard.shard << " is empty" << dendl;
     } else {
       // NOTE: All code between dout and dendl is executed conditionally on
       //       debug level.
-      dout(20) << __func__ << " Transaction for osd." << pg_shard.osd << " shard " << shard << " contents ";
+      dout(20) << __func__ << " Transaction for osd." << pg_shard.osd << " shard " << pg_shard.shard << " contents ";
       Formatter *f = Formatter::create("json");
       f->open_object_section("t");
       transaction.dump(f);
@@ -873,14 +962,14 @@ void ECCommon::RMWPipeline::cache_ready(Op &op) {
      * As such we must never skip a transaction completely.  Note that if
      * should_send is false, then an empty transaction is sent.
      */
-    if (!next_write_all_shards && should_send && op.skip_transaction(pending_roll_forward, shard, transaction)) {
+    if (!next_write_all_shards && should_send && op.skip_transaction(pending_roll_forward, pg_shard.shard, transaction)) {
       // Must be an empty transaction
       ceph_assert(transaction.empty());
-      dout(20) << __func__ << " Skipping transaction for shard " << shard << dendl;
+      dout(20) << __func__ << " Skipping transaction for shard " << pg_shard.shard << dendl;
       continue;
     }
     if (!should_send || transaction.empty()) {
-      dout(20) << __func__ << " Sending empty transaction for shard " << shard << dendl;
+      dout(20) << __func__ << " Sending empty transaction for shard " << pg_shard.shard << dendl;
     }
     op.pending_commits++;
     const pg_stat_t &stats =
@@ -1423,8 +1512,10 @@ void ECCommon::RecoveryBackend::continue_recovery_op(
 
       op.recovery_progress.data_recovered_to += read_size;
 
+      shard_id_set missing_for_read = sinfo.zones_or(op.missing_on_shards);
+
       // We only need to recover shards that are missing.
-      for (auto shard : shard_id_set::difference(sinfo.get_all_shards(), op.missing_on_shards)) {
+      for (auto shard : shard_id_set::difference(sinfo.get_all_shards(), missing_for_read)) {
         want.erase(shard);
       }
 
@@ -1495,7 +1586,7 @@ void ECCommon::RecoveryBackend::continue_recovery_op(
         pop.soid = op.hoid;
         pop.version = op.recovery_info.oi.get_version_for_shard(pg_shard.shard);
 
-        op.returned_data->get_sparse_buffer(pg_shard.shard, pop.data, pop.data_included);
+        op.returned_data->get_sparse_buffer(sinfo.get_rel_shard(pg_shard.shard), pop.data, pop.data_included);
         ceph_assert(pop.data.length() == pop.data_included.size());
 
         dout(10) << __func__ << ": pop shard=" << pg_shard

--- a/src/osd/ECCommon.cc
+++ b/src/osd/ECCommon.cc
@@ -166,7 +166,7 @@ void ECCommon::ReadPipeline::get_all_avail_shards(
              << " (rel_shard=" << rel_shard << ")" << dendl;
     const pg_missing_t &missing = get_parent()->get_shard_missing(pg_shard);
     if (error_shards && error_shards->contains(pg_shard)) {
-d      dout(10) << __func__ << ": skipping acting " << pg_shard
+      dout(10) << __func__ << ": skipping acting " << pg_shard
                << " (rel_shard=" << rel_shard << ") - in error_shards" << dendl;
       continue;
     }

--- a/src/osd/ECCommon.cc
+++ b/src/osd/ECCommon.cc
@@ -227,14 +227,6 @@ int ECCommon::ReadPipeline::get_min_avail_to_read_shards(
   shard_id_set have;
   shard_id_map<pg_shard_t> shards(sinfo.get_k_plus_m());
 
-  get_all_avail_shards(hoid, have, shards, for_recovery, error_shards);
-
-  std::unique_ptr<shard_id_map<vector<pair<int, int>>>> need_sub_chunks =
-      nullptr;
-  if (sinfo.supports_sub_chunks()) {
-    need_sub_chunks = std::make_unique<shard_id_map<vector<pair<int, int>>>>(
-      sinfo.get_k_plus_m());
-  }
   shard_id_set need_set;
   shard_id_set want;
 
@@ -250,11 +242,9 @@ int ECCommon::ReadPipeline::get_min_avail_to_read_shards(
     shard_id_set want_for_plugin = want;
     shard_id_t kth = *kth_iter;
     want_for_plugin.erase_range(kth, sinfo.get_k_plus_m() - (int)kth);
-    r = ec_impl->minimum_to_decode(want_for_plugin, have, need_set,
-                                     need_sub_chunks.get());
+    r = ec_impl->minimum_to_decode(want_for_plugin, have, need_set, nullptr);
   } else {
-    r = ec_impl->minimum_to_decode(want, have, need_set,
-                                     need_sub_chunks.get());
+    r = ec_impl->minimum_to_decode(want, have, need_set, nullptr);
   }
 
   if (r < 0) {
@@ -264,13 +254,6 @@ int ECCommon::ReadPipeline::get_min_avail_to_read_shards(
   }
 
   if (do_redundant_reads) {
-    if (need_sub_chunks) {
-      vector<pair<int, int>> subchunks_list;
-      subchunks_list.push_back(make_pair(0, ec_impl->get_sub_chunk_count()));
-      for (auto &&i: have) {
-        (*need_sub_chunks)[i] = subchunks_list;
-      }
-    }
     need_set.insert(have);
   }
 

--- a/src/osd/ECCommon.h
+++ b/src/osd/ECCommon.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <expected>
 #include <boost/intrusive/list.hpp>
 #include <fmt/format.h>
 
@@ -417,6 +418,8 @@ struct ECCommon {
         shard_id_set &have,
         shard_id_map<pg_shard_t> &shards,
         bool for_recovery,
+        int local_zone,
+        bool allow_remote_zone,
         const std::optional<std::set<pg_shard_t>> &error_shards = std::nullopt);
 
     std::pair<const shard_id_set, const shard_id_set> get_readable_writable_shard_id_sets();
@@ -434,6 +437,15 @@ struct ECCommon {
         ECUtil::shard_extent_map_t buffers_read,
         ec_align_t read,
         bufferlist *outbl);
+
+    /// Helper function to select available shards for reading
+    std::expected<std::tuple<shard_id_set, shard_id_map<pg_shard_t>, shard_id_set>, int>
+    select_shards_for_read(
+        const hobject_t &hoid,
+        const shard_id_set &want,
+        bool for_recovery,
+        bool allow_remote_zone,
+        const std::optional<std::set<pg_shard_t>> &error_shards);
 
     /// Returns to_read replicas sufficient to reconstruct want
     int get_min_avail_to_read_shards(

--- a/src/osd/ECUtil.h
+++ b/src/osd/ECUtil.h
@@ -708,17 +708,90 @@ public:
     return k + m;
   }
 
+  unsigned int get_pool_size() const {
+    ceph_assert(pool);
+    return pool->size;
+  }
+
+  unsigned int get_num_zones() const {
+    ceph_assert(pool);
+    int64_t num_zones = 0;
+    pool->opts.get(pool_opts_t::NUM_ZONES, &num_zones);
+    return num_zones > 0 ? num_zones : 0;
+  }
+
   const shard_id_t get_shard(const raw_shard_id_t raw_shard) const {
     return chunk_mapping[int(raw_shard)];
   }
 
   raw_shard_id_t get_raw_shard(shard_id_t shard) const {
-    return chunk_mapping_reverse.at(int(shard));
+    return chunk_mapping_reverse.at((int)get_rel_shard(shard));
+  }
+
+  // Get the relative shard (shard ID relative to zone 0)
+  // For absolute shard ID = rel_shard + zone * (k+m)
+  shard_id_t get_rel_shard(shard_id_t shard) const {
+    int k_plus_m = get_k_plus_m();
+    // Fast path for common case (id < k+m), also handles negative shards
+    if (std::cmp_less(shard.id, k_plus_m)) {
+      return shard;
+    }
+    // Modern compilers optimize % well on recent CPUs
+    return shard_id_t(shard.id % k_plus_m);
+  }
+
+  // Get the zone number for a shard
+  int get_shard_zone(shard_id_t shard) const {
+    int k_plus_m = get_k_plus_m();
+    // Fast path for common case (id < k+m)
+    if (std::cmp_less(shard.id, k_plus_m)) {
+      return 0;
+    }
+    // Modern compilers optimize / well on recent CPUs
+    return shard.id / k_plus_m;
+  }
+
+  // Get both the relative shard and zone
+  // For absolute shard ID = rel_shard + zone * (k+m)
+  std::pair<shard_id_t, int> get_rel_shard_and_zone(shard_id_t shard) const {
+    int k_plus_m = get_k_plus_m();
+    // Fast path for common case (id < k+m), also handles negative shards
+    if (std::cmp_less(shard.id, k_plus_m)) {
+      return std::make_pair(shard, 0);
+    }
+    // Modern compilers optimize % and / well on recent CPUs
+    return std::make_pair(shard_id_t(shard.id % k_plus_m), shard.id / k_plus_m);
+  }
+
+  shard_id_set zones_or(shard_id_set in) const {
+    shard_id_set out;
+    shard_id_set mask;
+    mask.insert_range(shard_id_t(0), get_k_plus_m());
+
+    while (!in.empty()) {
+      out |= (in & mask);
+      in >>= get_k_plus_m();
+    }
+
+    return out;
   }
 
   /* Return a "span" - which can be iterated over */
   auto get_data_shards() const {
     return data_shards;
+  }
+
+  /* Return data shards repeated across all zones */
+  shard_id_set get_data_shards_all_zones() const {
+    shard_id_set result = data_shards;
+    
+    // Repeat data_shards every k+m shards across all zones
+    for (unsigned int zone = 1; zone < get_num_zones(); ++zone) {
+      result <<= get_k_plus_m();
+      result.insert(data_shards);
+    }
+    
+    return result;
   }
 
   auto get_parity_shards() const {

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3021,46 +3021,32 @@ const std::vector<int> OSDMap::pgtemp_undo_primaryfirst(const pg_pool_t& pool,
   return acting;
 }
 
-const shard_id_t OSDMap::pgtemp_primaryfirst(const pg_pool_t& pool,
-	const pg_t pg, const shard_id_t shard) const
-{
-  if ((shard == shard_id_t::NO_SHARD) ||
-      (shard == shard_id_t(0))) {
-    return shard;
-  }
-  shard_id_t result = shard;
-  if (pool.allows_ecoptimizations()) {
-    if (has_pgtemp(pool.raw_pg_to_pg(pg))) {
-      int num_parity_shards = pool.size - pool.nonprimary_shards.size() - 1;
-      if (shard >= pool.size - num_parity_shards) {
-	result = shard_id_t(result + num_parity_shards + 1 - pool.size);
-      } else {
-	result = shard_id_t(result + num_parity_shards);
-      }
-    }
-  }
-  return result;
-}
-
 shard_id_t OSDMap::pgtemp_undo_primaryfirst(const pg_pool_t& pool,
-	const pg_t pg, const shard_id_t shard) const
+	const pg_t pg, const shard_id_t primary_first_pos) const
 {
-  if ((shard == shard_id_t::NO_SHARD) ||
-      (shard == shard_id_t(0))) {
-    return shard;
+  if ((primary_first_pos == shard_id_t::NO_SHARD) ||
+      (primary_first_pos == shard_id_t(0)) ||
+      !pool.allows_ecoptimizations() ||
+      !has_pgtemp(pool.raw_pg_to_pg(pg))) {
+    return primary_first_pos;
   }
-  shard_id_t result = shard;
-  if (pool.allows_ecoptimizations()) {
-    if (has_pgtemp(pool.raw_pg_to_pg(pg))) {
-      int num_parity_shards = pool.size - pool.nonprimary_shards.size() - 1;
-      if (shard > num_parity_shards) {
-	result = shard_id_t(result - num_parity_shards);
-      } else {
-	result = shard_id_t(result + pool.size - num_parity_shards - 1);
+  shard_id_t i(0);
+  shard_id_t j(pool.size - pool.nonprimary_shards.size());
+  for (shard_id_t shard(0); shard < pool.size; ++shard) {
+    if (pool.is_nonprimary_shard(shard_id_t(shard))) {
+      if (j == primary_first_pos) {
+        return shard;
       }
+      ++j;
+    } else {
+      if (i == primary_first_pos) {
+        return shard;
+      }
+      ++i;
     }
   }
-  return result;
+  ceph_abort("Shard out of range!");
+  return shard_id_t::NO_SHARD;
 }
 
 void OSDMap::_get_temp_osds(const pg_pool_t& pool, pg_t pg,

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1374,9 +1374,6 @@ public:
   const std::vector<int> pgtemp_undo_primaryfirst(const pg_pool_t& pool,
 			   const pg_t pg,
 			   const std::vector<int>& acting) const;
-  const shard_id_t pgtemp_primaryfirst(const pg_pool_t& pool,
-				       const pg_t pg,
-				       const shard_id_t shard) const;
   shard_id_t pgtemp_undo_primaryfirst(const pg_pool_t& pool,
 					    const pg_t pg,
 					    const shard_id_t shard) const;

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1409,7 +1409,9 @@ static opt_mapping_t opt_mapping = boost::assign::map_list_of
 	   ("read_ratio", pool_opts_t::opt_desc_t(
              pool_opts_t::READ_RATIO, pool_opts_t::INT))
 	   ("pct_update_delay", pool_opts_t::opt_desc_t(
-             pool_opts_t::PCT_UPDATE_DELAY, pool_opts_t::INT));
+             pool_opts_t::PCT_UPDATE_DELAY, pool_opts_t::INT))
+	   ("num_zones", pool_opts_t::opt_desc_t(
+             pool_opts_t::NUM_ZONES, pool_opts_t::INT));
 
 bool pool_opts_t::is_opt_name(const std::string& name)
 {

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1142,6 +1142,7 @@ public:
      * completion if there are no other in progress writes.
      */
     PCT_UPDATE_DELAY,
+    NUM_ZONES,  // number of zones for the pool
   };
 
   enum type_t {

--- a/src/osd/scrubber/scrub_backend.cc
+++ b/src/osd/scrubber/scrub_backend.cc
@@ -854,8 +854,47 @@ void ScrubBackend::setup_ec_digest_map(auth_selection_t& auth_selection,
             m_pg.get_ec_sinfo().get_chunk_size());
         b.copy_in(0, digest_length, crc_bytes);
 
-        this_chunk->m_ec_digest_map[srd.shard] = bufferlist{};
-        this_chunk->m_ec_digest_map.at(srd.shard).append(b);
+        // Convert absolute shard to relative shard for multi-zone EC
+        shard_id_t rel_shard = m_pg.get_ec_sinfo().get_rel_shard(srd.shard);
+
+        // Check if this relative shard already has a digest entry
+        if (this_chunk->m_ec_digest_map.contains(rel_shard)) {
+          // Compare the existing digest with the current one
+          const auto& existing_bl = this_chunk->m_ec_digest_map.at(rel_shard);
+          bool digests_match = true;
+          
+          if (existing_bl.length() >= digest_length) {
+            for (std::size_t i = 0; i < digest_length; i++) {
+              if (existing_bl[i] != b[i]) {
+                digests_match = false;
+                break;
+              }
+            }
+          } else {
+            digests_match = false;
+          }
+
+          if (!digests_match) {
+            // Digests don't match - this is a scrub error
+            auth_selection.digest_match = false;
+
+            bufferlist new_bl;
+            new_bl.append(b);
+            
+            dout(10) << fmt::format(
+                            "{}: {} - Conflicting CRCs for relative shard {}. "
+                            "Absolute shard {} has CRC {}, but another zone's "
+                            "shard already has CRC {}",
+                            __func__, ho, rel_shard, srd.shard,
+                            extract_crc_from_bufferlist(new_bl),
+                            extract_crc_from_bufferlist(existing_bl))
+                     << dendl;
+          }
+        } else {
+          // First time seeing this relative shard, add it to the map
+          this_chunk->m_ec_digest_map[rel_shard] = bufferlist{};
+          this_chunk->m_ec_digest_map.at(rel_shard).append(b);
+        }
       }
     }
 
@@ -1290,8 +1329,47 @@ ScrubBackend::auth_and_obj_errs_t ScrubBackend::match_in_shards(
             m_pg.get_ec_sinfo().get_chunk_size());
         b.copy_in(0, length, crc_bytes);
 
-        digests[srd.shard] = bufferlist{};
-        digests[srd.shard].append(b);
+        // Convert absolute shard to relative shard for multi-zone EC
+        shard_id_t rel_shard = m_pg.get_ec_sinfo().get_rel_shard(srd.shard);
+
+        // Check if this relative shard already has a digest entry
+        if (digests.contains(rel_shard)) {
+          // Compare the existing digest with the current one
+          const auto& existing_bl = digests.at(rel_shard);
+          bool digests_match = true;
+          
+          if (existing_bl.length() >= length) {
+            for (std::size_t i = 0; i < length; i++) {
+              if (existing_bl[i] != b[i]) {
+                digests_match = false;
+                break;
+              }
+            }
+          } else {
+            digests_match = false;
+          }
+
+          if (!digests_match) {
+            // Digests don't match - this is a scrub error
+            auth_sel.digest_match = false;
+
+            bufferlist new_bl;
+            new_bl.append(b);
+            
+            dout(10) << fmt::format(
+                            "{}: {} - Conflicting CRCs for relative shard {}. "
+                            "Absolute shard {} has CRC {}, but another zone's "
+                            "shard already has CRC {}",
+                            __func__, ho, rel_shard, srd.shard,
+                            extract_crc_from_bufferlist(new_bl),
+                            extract_crc_from_bufferlist(existing_bl))
+                     << dendl;
+          }
+        } else {
+          // First time seeing this relative shard, add it to the map
+          digests[rel_shard] = bufferlist{};
+          digests[rel_shard].append(b);
+        }
       }
 
       dout(20) << fmt::format(
@@ -1567,7 +1645,10 @@ bool ScrubBackend::compare_obj_details(pg_shard_t auth_shard,
     ceph_assert(can_attr != candidate.attrs.end());
     const bufferlist& can_bl = can_attr->second;
 
-    if (auth_oi.get_version_for_shard(shard.shard) == auth_oi.version) {
+    // For EC pools, convert absolute shard to relative shard (shard % (k+m))
+    shard_id_t rel_shard = m_is_replicated ? shard.shard : m_pg.get_ec_sinfo().get_rel_shard(shard.shard);
+
+    if (auth_oi.get_version_for_shard(rel_shard) == auth_oi.version) {
       // The expected version of the shard and the authoritative shard are the
       // same, so we can do a simple memcmp of the OI attr.
       auto auth_attr = auth.attrs.find(OI_ATTR);
@@ -1588,7 +1669,7 @@ bool ScrubBackend::compare_obj_details(pg_shard_t auth_shard,
       // also check the size, as that is the only other piece of data that the
       // nonprimary OIs require.
       object_info_t oi(can_bl);
-      if (oi.version != auth_oi.get_version_for_shard(shard.shard) ||
+      if (oi.version != auth_oi.get_version_for_shard(rel_shard) ||
             oi.size != auth_oi.size) {
         fmt::format_to(std::back_inserter(out),
                        "{}object info version incorrect auth_oi={} candidate_oi={}",

--- a/src/test/common/test_bitset_set.cc
+++ b/src/test/common/test_bitset_set.cc
@@ -262,3 +262,599 @@ TEST(bitset_set, find_nth) {
   }
   ASSERT_EQ(bitset.end(), bitset.find_nth(range) );
 }
+
+TEST(bitset_set, left_shift) {
+  bitset_set<128, Key> bitset;
+  
+  // Test shift by 0 (no change)
+  bitset.insert(0);
+  bitset.insert(5);
+  bitset.insert(10);
+  auto result = bitset << 0;
+  ASSERT_EQ(bitset, result);
+  
+  // Test simple left shift
+  bitset.clear();
+  bitset.insert(0);
+  bitset.insert(1);
+  bitset.insert(2);
+  result = bitset << 3;
+  ASSERT_TRUE(result.contains(3));
+  ASSERT_TRUE(result.contains(4));
+  ASSERT_TRUE(result.contains(5));
+  ASSERT_FALSE(result.contains(0));
+  ASSERT_FALSE(result.contains(1));
+  ASSERT_FALSE(result.contains(2));
+  
+  // Test shift across word boundary (64 bits)
+  bitset.clear();
+  bitset.insert(0);
+  bitset.insert(63);
+  result = bitset << 1;
+  ASSERT_TRUE(result.contains(1));
+  ASSERT_TRUE(result.contains(64));
+  ASSERT_FALSE(result.contains(0));
+  ASSERT_FALSE(result.contains(63));
+  
+  // Test word-aligned shift
+  bitset.clear();
+  bitset.insert(0);
+  bitset.insert(1);
+  result = bitset << 64;
+  ASSERT_TRUE(result.contains(64));
+  ASSERT_TRUE(result.contains(65));
+  ASSERT_FALSE(result.contains(0));
+  ASSERT_FALSE(result.contains(1));
+  
+  // Test shift beyond max_bits
+  bitset.clear();
+  bitset.insert(0);
+  result = bitset << 128;
+  ASSERT_TRUE(result.empty());
+  
+  // Test shift that loses some bits
+  bitset.clear();
+  bitset.insert(120);
+  bitset.insert(127);
+  result = bitset << 5;
+  ASSERT_TRUE(result.contains(125));
+  ASSERT_FALSE(result.contains(132)); // Would be out of range
+  ASSERT_EQ(1, result.size());
+}
+
+TEST(bitset_set, right_shift) {
+  bitset_set<128, Key> bitset;
+  
+  // Test shift by 0 (no change)
+  bitset.insert(5);
+  bitset.insert(10);
+  bitset.insert(15);
+  auto result = bitset >> 0;
+  ASSERT_EQ(bitset, result);
+  
+  // Test simple right shift
+  bitset.clear();
+  bitset.insert(3);
+  bitset.insert(4);
+  bitset.insert(5);
+  result = bitset >> 3;
+  ASSERT_TRUE(result.contains(0));
+  ASSERT_TRUE(result.contains(1));
+  ASSERT_TRUE(result.contains(2));
+  ASSERT_FALSE(result.contains(3));
+  ASSERT_FALSE(result.contains(4));
+  ASSERT_FALSE(result.contains(5));
+  
+  // Test shift across word boundary (64 bits)
+  bitset.clear();
+  bitset.insert(1);
+  bitset.insert(64);
+  result = bitset >> 1;
+  ASSERT_TRUE(result.contains(0));
+  ASSERT_TRUE(result.contains(63));
+  ASSERT_FALSE(result.contains(1));
+  ASSERT_FALSE(result.contains(64));
+  
+  // Test word-aligned shift
+  bitset.clear();
+  bitset.insert(64);
+  bitset.insert(65);
+  result = bitset >> 64;
+  ASSERT_TRUE(result.contains(0));
+  ASSERT_TRUE(result.contains(1));
+  ASSERT_FALSE(result.contains(64));
+  ASSERT_FALSE(result.contains(65));
+  
+  // Test shift beyond max_bits
+  bitset.clear();
+  bitset.insert(127);
+  result = bitset >> 128;
+  ASSERT_TRUE(result.empty());
+  
+  // Test shift that loses some bits
+  bitset.clear();
+  bitset.insert(0);
+  bitset.insert(7);
+  result = bitset >> 5;
+  ASSERT_TRUE(result.contains(2));
+  ASSERT_FALSE(result.contains(0)); // Lost
+  ASSERT_EQ(1, result.size());
+}
+
+TEST(bitset_set, shift_assignment) {
+  bitset_set<128, Key> bitset;
+  
+  // Test left shift assignment
+  bitset.insert(0);
+  bitset.insert(1);
+  bitset <<= 3;
+  ASSERT_TRUE(bitset.contains(3));
+  ASSERT_TRUE(bitset.contains(4));
+  ASSERT_FALSE(bitset.contains(0));
+  ASSERT_FALSE(bitset.contains(1));
+  
+  // Test right shift assignment
+  bitset.clear();
+  bitset.insert(5);
+  bitset.insert(6);
+  bitset >>= 2;
+  ASSERT_TRUE(bitset.contains(3));
+  ASSERT_TRUE(bitset.contains(4));
+  ASSERT_FALSE(bitset.contains(5));
+  ASSERT_FALSE(bitset.contains(6));
+}
+
+TEST(bitset_set, shift_multiple_words) {
+  bitset_set<128, Key> bitset;
+  
+  // Test pattern across multiple words
+  for (int i = 0; i < 128; i += 8) {
+    bitset.insert(i);
+  }
+  
+  auto result = bitset << 4;
+  for (int i = 0; i < 128; i += 8) {
+    if (i + 4 < 128) {
+      ASSERT_TRUE(result.contains(i + 4));
+    }
+    ASSERT_FALSE(result.contains(i));
+  }
+  
+  result = bitset >> 4;
+  for (int i = 0; i < 128; i += 8) {
+    if (i >= 4) {
+      ASSERT_TRUE(result.contains(i - 4));
+    }
+  }
+}
+
+TEST(bitset_set, shift_edge_cases) {
+  bitset_set<128, Key> bitset;
+  
+  // Empty set
+  auto result = bitset << 5;
+  ASSERT_TRUE(result.empty());
+  result = bitset >> 5;
+  ASSERT_TRUE(result.empty());
+  
+  // Full set left shift
+  bitset.insert_range(0, 128);
+  result = bitset << 10;
+  ASSERT_EQ(118, result.size()); // 128 - 10 bits remain
+  for (int i = 10; i < 128; ++i) {
+    ASSERT_TRUE(result.contains(i));
+  }
+  
+  // Full set right shift
+  result = bitset >> 10;
+  ASSERT_EQ(118, result.size()); // 128 - 10 bits remain
+  for (int i = 0; i < 118; ++i) {
+    ASSERT_TRUE(result.contains(i));
+  }
+}
+
+TEST(bitset_set, shift_boundary_behavior) {
+  bitset_set<128, Key> bitset;
+  
+  // Test that shift-left followed by shift-right zeros bits that went out of range
+  bitset.insert(0);
+  bitset.insert(64);
+  bitset.insert(120);
+  bitset.insert(127);
+  
+  // Shift left by 10, then right by 10 - bits at 120 and 127 should be lost
+  auto result = (bitset << 10) >> 10;
+  ASSERT_TRUE(result.contains(0));
+  ASSERT_TRUE(result.contains(64));
+  ASSERT_FALSE(result.contains(120)); // Lost when shifted left
+  ASSERT_FALSE(result.contains(127)); // Lost when shifted left
+  ASSERT_EQ(2, result.size());
+  
+  // Test that shift-right followed by shift-left zeros bits that went out of range
+  bitset.clear();
+  bitset.insert(0);
+  bitset.insert(5);
+  bitset.insert(64);
+  bitset.insert(127);
+  
+  result = (bitset >> 10) << 10;
+  ASSERT_FALSE(result.contains(0));  // Lost when shifted right
+  ASSERT_FALSE(result.contains(5));  // Lost when shifted right
+  ASSERT_TRUE(result.contains(64));
+  ASSERT_TRUE(result.contains(127));
+  ASSERT_EQ(2, result.size());
+  
+  // Test large shift that loses everything
+  bitset.clear();
+  bitset.insert_range(0, 128);
+  result = (bitset << 64) >> 64;
+  ASSERT_EQ(64, result.size()); // Only lower 64 bits remain
+  for (int i = 0; i < 64; ++i) {
+    ASSERT_TRUE(result.contains(i));
+  }
+  for (int i = 64; i < 128; ++i) {
+    ASSERT_FALSE(result.contains(i));
+  }
+  
+  // Test shift beyond range
+  bitset.clear();
+  bitset.insert_range(0, 128);
+  result = (bitset << 200) >> 200;
+  ASSERT_TRUE(result.empty()); // Everything lost
+}
+
+
+TEST(bitset_set, bitwise_and) {
+  bitset_set<128, Key> bitset1;
+  bitset_set<128, Key> bitset2;
+  
+  // Test empty sets
+  auto result = bitset1 & bitset2;
+  ASSERT_TRUE(result.empty());
+  
+  // Test one empty, one non-empty
+  bitset1.insert(5);
+  bitset1.insert(10);
+  result = bitset1 & bitset2;
+  ASSERT_TRUE(result.empty());
+  
+  // Test no overlap
+  bitset2.insert(15);
+  bitset2.insert(20);
+  result = bitset1 & bitset2;
+  ASSERT_TRUE(result.empty());
+  
+  // Test partial overlap
+  bitset2.insert(10);
+  result = bitset1 & bitset2;
+  ASSERT_EQ(1, result.size());
+  ASSERT_TRUE(result.contains(10));
+  ASSERT_FALSE(result.contains(5));
+  ASSERT_FALSE(result.contains(15));
+  ASSERT_FALSE(result.contains(20));
+  
+  // Test complete overlap
+  bitset1.clear();
+  bitset2.clear();
+  bitset1.insert(1);
+  bitset1.insert(2);
+  bitset1.insert(3);
+  bitset2.insert(1);
+  bitset2.insert(2);
+  bitset2.insert(3);
+  result = bitset1 & bitset2;
+  ASSERT_EQ(3, result.size());
+  ASSERT_TRUE(result.contains(1));
+  ASSERT_TRUE(result.contains(2));
+  ASSERT_TRUE(result.contains(3));
+  
+  // Test across word boundaries
+  bitset1.clear();
+  bitset2.clear();
+  bitset1.insert(0);
+  bitset1.insert(63);
+  bitset1.insert(64);
+  bitset1.insert(127);
+  bitset2.insert(63);
+  bitset2.insert(64);
+  result = bitset1 & bitset2;
+  ASSERT_EQ(2, result.size());
+  ASSERT_TRUE(result.contains(63));
+  ASSERT_TRUE(result.contains(64));
+  ASSERT_FALSE(result.contains(0));
+  ASSERT_FALSE(result.contains(127));
+}
+
+TEST(bitset_set, bitwise_or) {
+  bitset_set<128, Key> bitset1;
+  bitset_set<128, Key> bitset2;
+  
+  // Test empty sets
+  auto result = bitset1 | bitset2;
+  ASSERT_TRUE(result.empty());
+  
+  // Test one empty, one non-empty
+  bitset1.insert(5);
+  bitset1.insert(10);
+  result = bitset1 | bitset2;
+  ASSERT_EQ(2, result.size());
+  ASSERT_TRUE(result.contains(5));
+  ASSERT_TRUE(result.contains(10));
+  
+  // Test no overlap
+  bitset2.insert(15);
+  bitset2.insert(20);
+  result = bitset1 | bitset2;
+  ASSERT_EQ(4, result.size());
+  ASSERT_TRUE(result.contains(5));
+  ASSERT_TRUE(result.contains(10));
+  ASSERT_TRUE(result.contains(15));
+  ASSERT_TRUE(result.contains(20));
+  
+  // Test partial overlap
+  bitset2.insert(10);
+  result = bitset1 | bitset2;
+  ASSERT_EQ(4, result.size());
+  ASSERT_TRUE(result.contains(5));
+  ASSERT_TRUE(result.contains(10));
+  ASSERT_TRUE(result.contains(15));
+  ASSERT_TRUE(result.contains(20));
+  
+  // Test complete overlap
+  bitset1.clear();
+  bitset2.clear();
+  bitset1.insert(1);
+  bitset1.insert(2);
+  bitset1.insert(3);
+  bitset2.insert(1);
+  bitset2.insert(2);
+  bitset2.insert(3);
+  result = bitset1 | bitset2;
+  ASSERT_EQ(3, result.size());
+  ASSERT_TRUE(result.contains(1));
+  ASSERT_TRUE(result.contains(2));
+  ASSERT_TRUE(result.contains(3));
+  
+  // Test across word boundaries
+  bitset1.clear();
+  bitset2.clear();
+  bitset1.insert(0);
+  bitset1.insert(63);
+  bitset2.insert(64);
+  bitset2.insert(127);
+  result = bitset1 | bitset2;
+  ASSERT_EQ(4, result.size());
+  ASSERT_TRUE(result.contains(0));
+  ASSERT_TRUE(result.contains(63));
+  ASSERT_TRUE(result.contains(64));
+  ASSERT_TRUE(result.contains(127));
+}
+
+TEST(bitset_set, bitwise_and_assignment) {
+  bitset_set<128, Key> bitset1;
+  bitset_set<128, Key> bitset2;
+  
+  // Test empty sets
+  bitset1 &= bitset2;
+  ASSERT_TRUE(bitset1.empty());
+  
+  // Test one empty, one non-empty
+  bitset1.insert(5);
+  bitset1.insert(10);
+  bitset1 &= bitset2;
+  ASSERT_TRUE(bitset1.empty());
+  
+  // Test no overlap
+  bitset1.insert(5);
+  bitset1.insert(10);
+  bitset2.insert(15);
+  bitset2.insert(20);
+  bitset1 &= bitset2;
+  ASSERT_TRUE(bitset1.empty());
+  
+  // Test partial overlap
+  bitset1.clear();
+  bitset2.clear();
+  bitset1.insert(5);
+  bitset1.insert(10);
+  bitset1.insert(15);
+  bitset2.insert(10);
+  bitset2.insert(15);
+  bitset2.insert(20);
+  bitset1 &= bitset2;
+  ASSERT_EQ(2, bitset1.size());
+  ASSERT_TRUE(bitset1.contains(10));
+  ASSERT_TRUE(bitset1.contains(15));
+  ASSERT_FALSE(bitset1.contains(5));
+  ASSERT_FALSE(bitset1.contains(20));
+  
+  // Test complete overlap
+  bitset1.clear();
+  bitset2.clear();
+  bitset1.insert(1);
+  bitset1.insert(2);
+  bitset1.insert(3);
+  bitset2.insert(1);
+  bitset2.insert(2);
+  bitset2.insert(3);
+  bitset1 &= bitset2;
+  ASSERT_EQ(3, bitset1.size());
+  ASSERT_TRUE(bitset1.contains(1));
+  ASSERT_TRUE(bitset1.contains(2));
+  ASSERT_TRUE(bitset1.contains(3));
+  
+  // Test across word boundaries
+  bitset1.clear();
+  bitset2.clear();
+  bitset1.insert(0);
+  bitset1.insert(63);
+  bitset1.insert(64);
+  bitset1.insert(127);
+  bitset2.insert(63);
+  bitset2.insert(64);
+  bitset1 &= bitset2;
+  ASSERT_EQ(2, bitset1.size());
+  ASSERT_TRUE(bitset1.contains(63));
+  ASSERT_TRUE(bitset1.contains(64));
+  ASSERT_FALSE(bitset1.contains(0));
+  ASSERT_FALSE(bitset1.contains(127));
+}
+
+TEST(bitset_set, bitwise_or_assignment) {
+  bitset_set<128, Key> bitset1;
+  bitset_set<128, Key> bitset2;
+  
+  // Test empty sets
+  bitset1 |= bitset2;
+  ASSERT_TRUE(bitset1.empty());
+  
+  // Test one empty, one non-empty
+  bitset2.insert(5);
+  bitset2.insert(10);
+  bitset1 |= bitset2;
+  ASSERT_EQ(2, bitset1.size());
+  ASSERT_TRUE(bitset1.contains(5));
+  ASSERT_TRUE(bitset1.contains(10));
+  
+  // Test no overlap
+  bitset1.clear();
+  bitset2.clear();
+  bitset1.insert(5);
+  bitset1.insert(10);
+  bitset2.insert(15);
+  bitset2.insert(20);
+  bitset1 |= bitset2;
+  ASSERT_EQ(4, bitset1.size());
+  ASSERT_TRUE(bitset1.contains(5));
+  ASSERT_TRUE(bitset1.contains(10));
+  ASSERT_TRUE(bitset1.contains(15));
+  ASSERT_TRUE(bitset1.contains(20));
+  
+  // Test partial overlap
+  bitset1.clear();
+  bitset2.clear();
+  bitset1.insert(5);
+  bitset1.insert(10);
+  bitset2.insert(10);
+  bitset2.insert(15);
+  bitset1 |= bitset2;
+  ASSERT_EQ(3, bitset1.size());
+  ASSERT_TRUE(bitset1.contains(5));
+  ASSERT_TRUE(bitset1.contains(10));
+  ASSERT_TRUE(bitset1.contains(15));
+  
+  // Test complete overlap
+  bitset1.clear();
+  bitset2.clear();
+  bitset1.insert(1);
+  bitset1.insert(2);
+  bitset1.insert(3);
+  bitset2.insert(1);
+  bitset2.insert(2);
+  bitset2.insert(3);
+  bitset1 |= bitset2;
+  ASSERT_EQ(3, bitset1.size());
+  ASSERT_TRUE(bitset1.contains(1));
+  ASSERT_TRUE(bitset1.contains(2));
+  ASSERT_TRUE(bitset1.contains(3));
+  
+  // Test across word boundaries
+  bitset1.clear();
+  bitset2.clear();
+  bitset1.insert(0);
+  bitset1.insert(63);
+  bitset2.insert(64);
+  bitset2.insert(127);
+  bitset1 |= bitset2;
+  ASSERT_EQ(4, bitset1.size());
+  ASSERT_TRUE(bitset1.contains(0));
+  ASSERT_TRUE(bitset1.contains(63));
+  ASSERT_TRUE(bitset1.contains(64));
+  ASSERT_TRUE(bitset1.contains(127));
+}
+
+TEST(bitset_set, bitwise_operators_combined) {
+  bitset_set<128, Key> bitset1;
+  bitset_set<128, Key> bitset2;
+  bitset_set<128, Key> bitset3;
+  
+  // Test combination: (A | B) & C
+  bitset1.insert(1);
+  bitset1.insert(2);
+  bitset2.insert(2);
+  bitset2.insert(3);
+  bitset3.insert(2);
+  bitset3.insert(4);
+  
+  auto result = (bitset1 | bitset2) & bitset3;
+  ASSERT_EQ(1, result.size());
+  ASSERT_TRUE(result.contains(2));
+  
+  // Test combination: (A & B) | C
+  bitset1.clear();
+  bitset2.clear();
+  bitset3.clear();
+  bitset1.insert(1);
+  bitset1.insert(2);
+  bitset2.insert(2);
+  bitset2.insert(3);
+  bitset3.insert(4);
+  bitset3.insert(5);
+  
+  result = (bitset1 & bitset2) | bitset3;
+  ASSERT_EQ(3, result.size());
+  ASSERT_TRUE(result.contains(2));
+  ASSERT_TRUE(result.contains(4));
+  ASSERT_TRUE(result.contains(5));
+  
+  // Test chained assignment operators
+  bitset1.clear();
+  bitset2.clear();
+  bitset3.clear();
+  bitset1.insert(1);
+  bitset1.insert(2);
+  bitset1.insert(3);
+  bitset2.insert(2);
+  bitset2.insert(3);
+  bitset2.insert(4);
+  bitset3.insert(3);
+  bitset3.insert(4);
+  bitset3.insert(5);
+  
+  bitset1 &= bitset2;  // bitset1 now has {2, 3}
+  bitset1 |= bitset3;  // bitset1 now has {2, 3, 4, 5}
+  ASSERT_EQ(4, bitset1.size());
+  ASSERT_TRUE(bitset1.contains(2));
+  ASSERT_TRUE(bitset1.contains(3));
+  ASSERT_TRUE(bitset1.contains(4));
+  ASSERT_TRUE(bitset1.contains(5));
+}
+
+TEST(bitset_set, bitwise_operators_consistency_with_static_methods) {
+  bitset_set<128, Key> bitset1;
+  bitset_set<128, Key> bitset2;
+  
+  // Populate sets
+  bitset1.insert(1);
+  bitset1.insert(2);
+  bitset1.insert(3);
+  bitset1.insert(64);
+  bitset2.insert(2);
+  bitset2.insert(3);
+  bitset2.insert(4);
+  bitset2.insert(64);
+  
+  // Test that & operator matches intersection static method
+  auto and_result = bitset1 & bitset2;
+  auto intersection_result = bitset_set<128, Key>::intersection(bitset1, bitset2);
+  ASSERT_EQ(and_result, intersection_result);
+  
+  // Test that | operator produces union (no static method exists, but verify behavior)
+  auto or_result = bitset1 | bitset2;
+  ASSERT_EQ(5, or_result.size());
+  ASSERT_TRUE(or_result.contains(1));
+  ASSERT_TRUE(or_result.contains(2));
+  ASSERT_TRUE(or_result.contains(3));
+  ASSERT_TRUE(or_result.contains(4));
+  ASSERT_TRUE(or_result.contains(64));
+}

--- a/src/test/common/test_bitset_set.cc
+++ b/src/test/common/test_bitset_set.cc
@@ -265,14 +265,14 @@ TEST(bitset_set, find_nth) {
 
 TEST(bitset_set, left_shift) {
   bitset_set<128, Key> bitset;
-  
+
   // Test shift by 0 (no change)
   bitset.insert(0);
   bitset.insert(5);
   bitset.insert(10);
   auto result = bitset << 0;
   ASSERT_EQ(bitset, result);
-  
+
   // Test simple left shift
   bitset.clear();
   bitset.insert(0);
@@ -285,7 +285,7 @@ TEST(bitset_set, left_shift) {
   ASSERT_FALSE(result.contains(0));
   ASSERT_FALSE(result.contains(1));
   ASSERT_FALSE(result.contains(2));
-  
+
   // Test shift across word boundary (64 bits)
   bitset.clear();
   bitset.insert(0);
@@ -295,7 +295,7 @@ TEST(bitset_set, left_shift) {
   ASSERT_TRUE(result.contains(64));
   ASSERT_FALSE(result.contains(0));
   ASSERT_FALSE(result.contains(63));
-  
+
   // Test word-aligned shift
   bitset.clear();
   bitset.insert(0);
@@ -305,33 +305,33 @@ TEST(bitset_set, left_shift) {
   ASSERT_TRUE(result.contains(65));
   ASSERT_FALSE(result.contains(0));
   ASSERT_FALSE(result.contains(1));
-  
+
   // Test shift beyond max_bits
   bitset.clear();
   bitset.insert(0);
   result = bitset << 128;
   ASSERT_TRUE(result.empty());
-  
+
   // Test shift that loses some bits
   bitset.clear();
   bitset.insert(120);
   bitset.insert(127);
   result = bitset << 5;
   ASSERT_TRUE(result.contains(125));
-  ASSERT_FALSE(result.contains(132)); // Would be out of range
+  ASSERT_FALSE(result.contains(Key(int8_t(132)))); // Would be out of range (132 wraps to -124)
   ASSERT_EQ(1, result.size());
 }
 
 TEST(bitset_set, right_shift) {
   bitset_set<128, Key> bitset;
-  
+
   // Test shift by 0 (no change)
   bitset.insert(5);
   bitset.insert(10);
   bitset.insert(15);
   auto result = bitset >> 0;
   ASSERT_EQ(bitset, result);
-  
+
   // Test simple right shift
   bitset.clear();
   bitset.insert(3);
@@ -344,7 +344,7 @@ TEST(bitset_set, right_shift) {
   ASSERT_FALSE(result.contains(3));
   ASSERT_FALSE(result.contains(4));
   ASSERT_FALSE(result.contains(5));
-  
+
   // Test shift across word boundary (64 bits)
   bitset.clear();
   bitset.insert(1);
@@ -354,7 +354,7 @@ TEST(bitset_set, right_shift) {
   ASSERT_TRUE(result.contains(63));
   ASSERT_FALSE(result.contains(1));
   ASSERT_FALSE(result.contains(64));
-  
+
   // Test word-aligned shift
   bitset.clear();
   bitset.insert(64);
@@ -364,13 +364,13 @@ TEST(bitset_set, right_shift) {
   ASSERT_TRUE(result.contains(1));
   ASSERT_FALSE(result.contains(64));
   ASSERT_FALSE(result.contains(65));
-  
+
   // Test shift beyond max_bits
   bitset.clear();
   bitset.insert(127);
   result = bitset >> 128;
   ASSERT_TRUE(result.empty());
-  
+
   // Test shift that loses some bits
   bitset.clear();
   bitset.insert(0);
@@ -383,7 +383,7 @@ TEST(bitset_set, right_shift) {
 
 TEST(bitset_set, shift_assignment) {
   bitset_set<128, Key> bitset;
-  
+
   // Test left shift assignment
   bitset.insert(0);
   bitset.insert(1);
@@ -392,7 +392,7 @@ TEST(bitset_set, shift_assignment) {
   ASSERT_TRUE(bitset.contains(4));
   ASSERT_FALSE(bitset.contains(0));
   ASSERT_FALSE(bitset.contains(1));
-  
+
   // Test right shift assignment
   bitset.clear();
   bitset.insert(5);
@@ -406,12 +406,12 @@ TEST(bitset_set, shift_assignment) {
 
 TEST(bitset_set, shift_multiple_words) {
   bitset_set<128, Key> bitset;
-  
+
   // Test pattern across multiple words
   for (int i = 0; i < 128; i += 8) {
     bitset.insert(i);
   }
-  
+
   auto result = bitset << 4;
   for (int i = 0; i < 128; i += 8) {
     if (i + 4 < 128) {
@@ -419,7 +419,7 @@ TEST(bitset_set, shift_multiple_words) {
     }
     ASSERT_FALSE(result.contains(i));
   }
-  
+
   result = bitset >> 4;
   for (int i = 0; i < 128; i += 8) {
     if (i >= 4) {
@@ -430,13 +430,13 @@ TEST(bitset_set, shift_multiple_words) {
 
 TEST(bitset_set, shift_edge_cases) {
   bitset_set<128, Key> bitset;
-  
+
   // Empty set
   auto result = bitset << 5;
   ASSERT_TRUE(result.empty());
   result = bitset >> 5;
   ASSERT_TRUE(result.empty());
-  
+
   // Full set left shift
   bitset.insert_range(0, 128);
   result = bitset << 10;
@@ -444,7 +444,7 @@ TEST(bitset_set, shift_edge_cases) {
   for (int i = 10; i < 128; ++i) {
     ASSERT_TRUE(result.contains(i));
   }
-  
+
   // Full set right shift
   result = bitset >> 10;
   ASSERT_EQ(118, result.size()); // 128 - 10 bits remain
@@ -455,13 +455,13 @@ TEST(bitset_set, shift_edge_cases) {
 
 TEST(bitset_set, shift_boundary_behavior) {
   bitset_set<128, Key> bitset;
-  
+
   // Test that shift-left followed by shift-right zeros bits that went out of range
   bitset.insert(0);
   bitset.insert(64);
   bitset.insert(120);
   bitset.insert(127);
-  
+
   // Shift left by 10, then right by 10 - bits at 120 and 127 should be lost
   auto result = (bitset << 10) >> 10;
   ASSERT_TRUE(result.contains(0));
@@ -469,21 +469,21 @@ TEST(bitset_set, shift_boundary_behavior) {
   ASSERT_FALSE(result.contains(120)); // Lost when shifted left
   ASSERT_FALSE(result.contains(127)); // Lost when shifted left
   ASSERT_EQ(2, result.size());
-  
+
   // Test that shift-right followed by shift-left zeros bits that went out of range
   bitset.clear();
   bitset.insert(0);
   bitset.insert(5);
   bitset.insert(64);
   bitset.insert(127);
-  
+
   result = (bitset >> 10) << 10;
   ASSERT_FALSE(result.contains(0));  // Lost when shifted right
   ASSERT_FALSE(result.contains(5));  // Lost when shifted right
   ASSERT_TRUE(result.contains(64));
   ASSERT_TRUE(result.contains(127));
   ASSERT_EQ(2, result.size());
-  
+
   // Test large shift that loses everything
   bitset.clear();
   bitset.insert_range(0, 128);
@@ -495,7 +495,7 @@ TEST(bitset_set, shift_boundary_behavior) {
   for (int i = 64; i < 128; ++i) {
     ASSERT_FALSE(result.contains(i));
   }
-  
+
   // Test shift beyond range
   bitset.clear();
   bitset.insert_range(0, 128);
@@ -507,23 +507,23 @@ TEST(bitset_set, shift_boundary_behavior) {
 TEST(bitset_set, bitwise_and) {
   bitset_set<128, Key> bitset1;
   bitset_set<128, Key> bitset2;
-  
+
   // Test empty sets
   auto result = bitset1 & bitset2;
   ASSERT_TRUE(result.empty());
-  
+
   // Test one empty, one non-empty
   bitset1.insert(5);
   bitset1.insert(10);
   result = bitset1 & bitset2;
   ASSERT_TRUE(result.empty());
-  
+
   // Test no overlap
   bitset2.insert(15);
   bitset2.insert(20);
   result = bitset1 & bitset2;
   ASSERT_TRUE(result.empty());
-  
+
   // Test partial overlap
   bitset2.insert(10);
   result = bitset1 & bitset2;
@@ -532,7 +532,7 @@ TEST(bitset_set, bitwise_and) {
   ASSERT_FALSE(result.contains(5));
   ASSERT_FALSE(result.contains(15));
   ASSERT_FALSE(result.contains(20));
-  
+
   // Test complete overlap
   bitset1.clear();
   bitset2.clear();
@@ -547,7 +547,7 @@ TEST(bitset_set, bitwise_and) {
   ASSERT_TRUE(result.contains(1));
   ASSERT_TRUE(result.contains(2));
   ASSERT_TRUE(result.contains(3));
-  
+
   // Test across word boundaries
   bitset1.clear();
   bitset2.clear();
@@ -568,11 +568,11 @@ TEST(bitset_set, bitwise_and) {
 TEST(bitset_set, bitwise_or) {
   bitset_set<128, Key> bitset1;
   bitset_set<128, Key> bitset2;
-  
+
   // Test empty sets
   auto result = bitset1 | bitset2;
   ASSERT_TRUE(result.empty());
-  
+
   // Test one empty, one non-empty
   bitset1.insert(5);
   bitset1.insert(10);
@@ -580,7 +580,7 @@ TEST(bitset_set, bitwise_or) {
   ASSERT_EQ(2, result.size());
   ASSERT_TRUE(result.contains(5));
   ASSERT_TRUE(result.contains(10));
-  
+
   // Test no overlap
   bitset2.insert(15);
   bitset2.insert(20);
@@ -590,7 +590,7 @@ TEST(bitset_set, bitwise_or) {
   ASSERT_TRUE(result.contains(10));
   ASSERT_TRUE(result.contains(15));
   ASSERT_TRUE(result.contains(20));
-  
+
   // Test partial overlap
   bitset2.insert(10);
   result = bitset1 | bitset2;
@@ -599,7 +599,7 @@ TEST(bitset_set, bitwise_or) {
   ASSERT_TRUE(result.contains(10));
   ASSERT_TRUE(result.contains(15));
   ASSERT_TRUE(result.contains(20));
-  
+
   // Test complete overlap
   bitset1.clear();
   bitset2.clear();
@@ -614,7 +614,7 @@ TEST(bitset_set, bitwise_or) {
   ASSERT_TRUE(result.contains(1));
   ASSERT_TRUE(result.contains(2));
   ASSERT_TRUE(result.contains(3));
-  
+
   // Test across word boundaries
   bitset1.clear();
   bitset2.clear();
@@ -633,17 +633,17 @@ TEST(bitset_set, bitwise_or) {
 TEST(bitset_set, bitwise_and_assignment) {
   bitset_set<128, Key> bitset1;
   bitset_set<128, Key> bitset2;
-  
+
   // Test empty sets
   bitset1 &= bitset2;
   ASSERT_TRUE(bitset1.empty());
-  
+
   // Test one empty, one non-empty
   bitset1.insert(5);
   bitset1.insert(10);
   bitset1 &= bitset2;
   ASSERT_TRUE(bitset1.empty());
-  
+
   // Test no overlap
   bitset1.insert(5);
   bitset1.insert(10);
@@ -651,7 +651,7 @@ TEST(bitset_set, bitwise_and_assignment) {
   bitset2.insert(20);
   bitset1 &= bitset2;
   ASSERT_TRUE(bitset1.empty());
-  
+
   // Test partial overlap
   bitset1.clear();
   bitset2.clear();
@@ -667,7 +667,7 @@ TEST(bitset_set, bitwise_and_assignment) {
   ASSERT_TRUE(bitset1.contains(15));
   ASSERT_FALSE(bitset1.contains(5));
   ASSERT_FALSE(bitset1.contains(20));
-  
+
   // Test complete overlap
   bitset1.clear();
   bitset2.clear();
@@ -682,7 +682,7 @@ TEST(bitset_set, bitwise_and_assignment) {
   ASSERT_TRUE(bitset1.contains(1));
   ASSERT_TRUE(bitset1.contains(2));
   ASSERT_TRUE(bitset1.contains(3));
-  
+
   // Test across word boundaries
   bitset1.clear();
   bitset2.clear();
@@ -703,11 +703,11 @@ TEST(bitset_set, bitwise_and_assignment) {
 TEST(bitset_set, bitwise_or_assignment) {
   bitset_set<128, Key> bitset1;
   bitset_set<128, Key> bitset2;
-  
+
   // Test empty sets
   bitset1 |= bitset2;
   ASSERT_TRUE(bitset1.empty());
-  
+
   // Test one empty, one non-empty
   bitset2.insert(5);
   bitset2.insert(10);
@@ -715,7 +715,7 @@ TEST(bitset_set, bitwise_or_assignment) {
   ASSERT_EQ(2, bitset1.size());
   ASSERT_TRUE(bitset1.contains(5));
   ASSERT_TRUE(bitset1.contains(10));
-  
+
   // Test no overlap
   bitset1.clear();
   bitset2.clear();
@@ -729,7 +729,7 @@ TEST(bitset_set, bitwise_or_assignment) {
   ASSERT_TRUE(bitset1.contains(10));
   ASSERT_TRUE(bitset1.contains(15));
   ASSERT_TRUE(bitset1.contains(20));
-  
+
   // Test partial overlap
   bitset1.clear();
   bitset2.clear();
@@ -742,7 +742,7 @@ TEST(bitset_set, bitwise_or_assignment) {
   ASSERT_TRUE(bitset1.contains(5));
   ASSERT_TRUE(bitset1.contains(10));
   ASSERT_TRUE(bitset1.contains(15));
-  
+
   // Test complete overlap
   bitset1.clear();
   bitset2.clear();
@@ -757,7 +757,7 @@ TEST(bitset_set, bitwise_or_assignment) {
   ASSERT_TRUE(bitset1.contains(1));
   ASSERT_TRUE(bitset1.contains(2));
   ASSERT_TRUE(bitset1.contains(3));
-  
+
   // Test across word boundaries
   bitset1.clear();
   bitset2.clear();
@@ -777,7 +777,7 @@ TEST(bitset_set, bitwise_operators_combined) {
   bitset_set<128, Key> bitset1;
   bitset_set<128, Key> bitset2;
   bitset_set<128, Key> bitset3;
-  
+
   // Test combination: (A | B) & C
   bitset1.insert(1);
   bitset1.insert(2);
@@ -785,11 +785,11 @@ TEST(bitset_set, bitwise_operators_combined) {
   bitset2.insert(3);
   bitset3.insert(2);
   bitset3.insert(4);
-  
+
   auto result = (bitset1 | bitset2) & bitset3;
   ASSERT_EQ(1, result.size());
   ASSERT_TRUE(result.contains(2));
-  
+
   // Test combination: (A & B) | C
   bitset1.clear();
   bitset2.clear();
@@ -800,13 +800,13 @@ TEST(bitset_set, bitwise_operators_combined) {
   bitset2.insert(3);
   bitset3.insert(4);
   bitset3.insert(5);
-  
+
   result = (bitset1 & bitset2) | bitset3;
   ASSERT_EQ(3, result.size());
   ASSERT_TRUE(result.contains(2));
   ASSERT_TRUE(result.contains(4));
   ASSERT_TRUE(result.contains(5));
-  
+
   // Test chained assignment operators
   bitset1.clear();
   bitset2.clear();
@@ -820,7 +820,7 @@ TEST(bitset_set, bitwise_operators_combined) {
   bitset3.insert(3);
   bitset3.insert(4);
   bitset3.insert(5);
-  
+
   bitset1 &= bitset2;  // bitset1 now has {2, 3}
   bitset1 |= bitset3;  // bitset1 now has {2, 3, 4, 5}
   ASSERT_EQ(4, bitset1.size());
@@ -833,7 +833,7 @@ TEST(bitset_set, bitwise_operators_combined) {
 TEST(bitset_set, bitwise_operators_consistency_with_static_methods) {
   bitset_set<128, Key> bitset1;
   bitset_set<128, Key> bitset2;
-  
+
   // Populate sets
   bitset1.insert(1);
   bitset1.insert(2);
@@ -843,12 +843,12 @@ TEST(bitset_set, bitwise_operators_consistency_with_static_methods) {
   bitset2.insert(3);
   bitset2.insert(4);
   bitset2.insert(64);
-  
+
   // Test that & operator matches intersection static method
   auto and_result = bitset1 & bitset2;
   auto intersection_result = bitset_set<128, Key>::intersection(bitset1, bitset2);
   ASSERT_EQ(and_result, intersection_result);
-  
+
   // Test that | operator produces union (no static method exists, but verify behavior)
   auto or_result = bitset1 | bitset2;
   ASSERT_EQ(5, or_result.size());

--- a/src/test/mon/CMakeLists.txt
+++ b/src/test/mon/CMakeLists.txt
@@ -88,3 +88,10 @@ add_executable(unittest_mon_election
   )
 add_ceph_unittest(unittest_mon_election)
 target_link_libraries(unittest_mon_election mon global)
+
+# unittest_osd_monitor
+add_executable(unittest_osd_monitor
+  test_osd_monitor.cc
+  )
+add_ceph_unittest(unittest_osd_monitor)
+target_link_libraries(unittest_osd_monitor mon global)

--- a/src/test/mon/test_osd_monitor.cc
+++ b/src/test/mon/test_osd_monitor.cc
@@ -1,0 +1,295 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+/*
+ * Test stretch mode logic in OSDMonitor
+ * 
+ * Tests pool validation for stretch mode enablement via the static
+ * validate_stretch_mode_pools() function.
+ */
+
+#include "gtest/gtest.h"
+#include "mon/OSDMonitor.h"
+#include "osd/osd_types.h"
+#include "crush/CrushWrapper.h"
+#include "common/ceph_context.h"
+#include "common/common_init.h"
+#include "global/global_context.h"
+
+#include <memory>
+#include <sstream>
+#include <map>
+#include "include/mempool.h"
+
+using namespace std;
+
+class OSDMonitorStretchTest : public ::testing::Test {
+protected:
+  unique_ptr<CephContext> cct;
+  CrushWrapper crush;
+  mempool::osdmap::map<int64_t, string> pool_names;
+  mempool::osdmap::map<int64_t, pg_pool_t> pools;
+  
+  void SetUp() override {
+    vector<const char*> args;
+    cct.reset(new CephContext(CEPH_ENTITY_TYPE_MON));
+    g_ceph_context = cct.get();
+    common_init_finish(g_ceph_context);
+    
+    // Set up basic CRUSH map with minimal rules
+    setup_basic_crush();
+  }
+  
+  void TearDown() override {
+    g_ceph_context = nullptr;
+  }
+
+  void setup_basic_crush() {
+    crush.create();
+    crush.set_max_devices(4);
+    
+    // Set up minimal type hierarchy
+    crush.set_type_name(10, "root");
+    crush.set_type_name(1, "host");
+    crush.set_type_name(0, "osd");
+    
+    // Create simple replicated rule (TYPE_REPLICATED) - this is the stretch mode rule
+    int rule_id = 0;
+    crush_rule *rep_rule = crush_make_rule(2, CEPH_PG_TYPE_REPLICATED);  // 2 steps
+    crush_rule_set_step(rep_rule, 0, CRUSH_RULE_TAKE, -1, 0);
+    crush_rule_set_step(rep_rule, 1, CRUSH_RULE_EMIT, 0, 0);
+    crush_add_rule(crush.get_crush_map(), rep_rule, rule_id);
+    crush.set_rule_name(rule_id, "replicated_rule");
+    
+    // Create simple erasure rule (TYPE_ERASURE)
+    rule_id = 1;
+    crush_rule *ec_rule = crush_make_rule(2, CEPH_PG_TYPE_ERASURE);  // 2 steps
+    crush_rule_set_step(ec_rule, 0, CRUSH_RULE_TAKE, -1, 0);
+    crush_rule_set_step(ec_rule, 1, CRUSH_RULE_EMIT, 0, 0);
+    crush_add_rule(crush.get_crush_map(), ec_rule, rule_id);
+    crush.set_rule_name(rule_id, "ec_rule");
+    
+    // Create another replicated rule to use as "old" rule before stretch mode
+    rule_id = 2;
+    crush_rule *old_rule = crush_make_rule(2, CEPH_PG_TYPE_REPLICATED);  // 2 steps
+    crush_rule_set_step(old_rule, 0, CRUSH_RULE_TAKE, -1, 0);
+    crush_rule_set_step(old_rule, 1, CRUSH_RULE_EMIT, 0, 0);
+    crush_add_rule(crush.get_crush_map(), old_rule, rule_id);
+    crush.set_rule_name(rule_id, "old_replicated_rule");
+  }
+
+  pg_pool_t create_replicated_pool(int64_t pool_id, const string& pool_name, 
+                                     uint32_t size = 3, uint32_t min_size = 2,
+                                     int crush_rule = 0) {
+    pg_pool_t pool;
+    pool.type = pg_pool_t::TYPE_REPLICATED;
+    pool.size = size;
+    pool.min_size = min_size;
+    pool.crush_rule = crush_rule;
+    pool.set_pg_num(32);
+    pool.set_pgp_num(32);
+    
+    pools[pool_id] = pool;
+    pool_names[pool_id] = pool_name;
+    
+    return pool;
+  }
+
+  pg_pool_t create_ec_pool(int64_t pool_id, const string& pool_name,
+                            uint32_t k = 2, uint32_t m = 1, int crush_rule = 1) {
+    pg_pool_t pool;
+    pool.type = pg_pool_t::TYPE_ERASURE;
+    pool.size = k + m;
+    pool.min_size = k;
+    pool.crush_rule = crush_rule;
+    pool.set_pg_num(32);
+    pool.set_pgp_num(32);
+    
+    // Set erasure code profile name
+    pool.erasure_code_profile = "testprofile";
+    
+    pools[pool_id] = pool;
+    pool_names[pool_id] = pool_name;
+    
+    return pool;
+  }
+
+  void validate_pools(const string& rule_name, bool *okay, int *errcode, stringstream& ss) {
+    OSDMonitor::validate_stretch_mode_pools(crush, pool_names, pools, ss, okay, errcode, rule_name);
+  }
+};
+
+// Test success when replicated pool has default size=3 and min_size=2
+TEST_F(OSDMonitorStretchTest, ReplicatedPoolDefaultSizeSuccess) {
+  create_replicated_pool(1, "test_pool", 3, 2, 0);
+  
+  bool okay = false;
+  int errcode = 0;
+  stringstream ss;
+  
+  validate_pools("replicated_rule", &okay, &errcode, ss);
+  
+  EXPECT_TRUE(okay) << "Validation failed: " << ss.str();
+  EXPECT_EQ(errcode, 0);
+}
+
+// Test failure when replicated pool has non-default size
+TEST_F(OSDMonitorStretchTest, ReplicatedPoolWrongSizeFails) {
+  create_replicated_pool(1, "test_pool", 5, 2, 2);  // Use old_replicated_rule (ID 2)
+  
+  bool okay = false;
+  int errcode = 0;
+  stringstream ss;
+  
+  validate_pools("replicated_rule", &okay, &errcode, ss);
+  
+  EXPECT_FALSE(okay) << "Should have failed with size != 3";
+  EXPECT_EQ(errcode, -EINVAL);
+  EXPECT_NE(ss.str().find("default size/min_size"), string::npos);
+}
+
+// Test failure when replicated pool has non-default min_size
+TEST_F(OSDMonitorStretchTest, ReplicatedPoolWrongMinSizeFails) {
+  create_replicated_pool(1, "test_pool", 3, 1, 2);  // Use old_replicated_rule (ID 2)
+  
+  bool okay = false;
+  int errcode = 0;
+  stringstream ss;
+  
+  validate_pools("replicated_rule", &okay, &errcode, ss);
+  
+  EXPECT_FALSE(okay) << "Should have failed with min_size != 2";
+  EXPECT_EQ(errcode, -EINVAL);
+  EXPECT_NE(ss.str().find("default size/min_size"), string::npos);
+}
+
+// Test success when EC pool is used (EC pools are allowed in stretch mode)
+TEST_F(OSDMonitorStretchTest, ECPoolSuccess) {
+  create_ec_pool(1, "test_ec_pool", 2, 1, 1);
+  
+  bool okay = false;
+  int errcode = 0;
+  stringstream ss;
+  
+  validate_pools("ec_rule", &okay, &errcode, ss);
+  
+  EXPECT_TRUE(okay) << "EC pool validation failed: " << ss.str();
+  EXPECT_EQ(errcode, 0);
+}
+
+// Test failure when specified CRUSH rule does not exist
+TEST_F(OSDMonitorStretchTest, NonexistentCrushRuleFails) {
+  create_replicated_pool(1, "test_pool", 3, 2, 0);
+  
+  bool okay = false;
+  int errcode = 0;
+  stringstream ss;
+  
+  validate_pools("nonexistent_rule", &okay, &errcode, ss);
+  
+  EXPECT_FALSE(okay) << "Should fail with nonexistent rule";
+  EXPECT_LT(errcode, 0) << "Should have negative error code";
+  EXPECT_NE(ss.str().find("unrecognized crush rule"), string::npos);
+}
+
+// Test failure when replicated pool is paired with erasure-coded CRUSH rule
+TEST_F(OSDMonitorStretchTest, WrongRuleTypeReplicatedPoolFails) {
+  create_replicated_pool(1, "test_pool", 3, 2, 0);
+  
+  bool okay = false;
+  int errcode = 0;
+  stringstream ss;
+  
+  // Try to use EC rule for replicated pool
+  validate_pools("ec_rule", &okay, &errcode, ss);
+  
+  EXPECT_FALSE(okay) << "Should fail with rule type mismatch";
+  EXPECT_EQ(errcode, -EINVAL);
+  EXPECT_NE(ss.str().find("replicated but crush rule"), string::npos);
+  EXPECT_NE(ss.str().find("not a replicated rule"), string::npos);
+}
+
+// Test failure when EC pool is paired with replicated CRUSH rule
+TEST_F(OSDMonitorStretchTest, WrongRuleTypeECPoolFails) {
+  create_ec_pool(1, "ec_pool", 2, 1, 1);
+  
+  bool okay = false;
+  int errcode = 0;
+  stringstream ss;
+  
+  // Try to use replicated rule for EC pool
+  validate_pools("replicated_rule", &okay, &errcode, ss);
+  
+  EXPECT_FALSE(okay) << "Should fail with rule type mismatch";
+  EXPECT_EQ(errcode, -EINVAL);
+  EXPECT_NE(ss.str().find("erasure-coded but crush rule"), string::npos);
+  EXPECT_NE(ss.str().find("not an erasure-coded rule"), string::npos);
+}
+
+// Test success when multiple replicated pools all have correct configuration
+TEST_F(OSDMonitorStretchTest, MultipleReplicatedPoolsSuccess) {
+  create_replicated_pool(1, "pool1", 3, 2, 0);
+  create_replicated_pool(2, "pool2", 3, 2, 0);
+  create_replicated_pool(3, "pool3", 3, 2, 0);
+  
+  bool okay = false;
+  int errcode = 0;
+  stringstream ss;
+  
+  validate_pools("replicated_rule", &okay, &errcode, ss);
+  
+  EXPECT_TRUE(okay) << "Multiple pools validation failed: " << ss.str();
+  EXPECT_EQ(errcode, 0);
+}
+
+// Test success when multiple EC pools all have correct configuration
+TEST_F(OSDMonitorStretchTest, MultipleECPoolsSuccess) {
+  create_ec_pool(1, "ec_pool1", 2, 1, 1);
+  create_ec_pool(2, "ec_pool2", 4, 2, 1);
+  create_ec_pool(3, "ec_pool3", 3, 2, 1);
+  
+  bool okay = false;
+  int errcode = 0;
+  stringstream ss;
+  
+  validate_pools("ec_rule", &okay, &errcode, ss);
+  
+  EXPECT_TRUE(okay) << "Multiple EC pools validation failed: " << ss.str();
+  EXPECT_EQ(errcode, 0);
+}
+
+// Test failure when one pool has invalid configuration in a set of pools
+TEST_F(OSDMonitorStretchTest, OneBadPoolFailsAll) {
+  create_replicated_pool(1, "good_pool1", 3, 2, 0);
+  create_replicated_pool(2, "bad_pool", 5, 2, 2);  // Wrong size, using old_replicated_rule
+  create_replicated_pool(3, "good_pool2", 3, 2, 0);
+  
+  bool okay = false;
+  int errcode = 0;
+  stringstream ss;
+  
+  validate_pools("replicated_rule", &okay, &errcode, ss);
+  
+  EXPECT_FALSE(okay) << "Should fail due to one bad pool";
+  EXPECT_EQ(errcode, -EINVAL);
+  EXPECT_NE(ss.str().find("bad_pool"), string::npos);
+}
+
+// Test success when validating an empty set of pools
+TEST_F(OSDMonitorStretchTest, EmptyPoolSetSuccess) {
+  // Don't create any pools
+  
+  bool okay = false;
+  int errcode = 0;
+  stringstream ss;
+  
+  validate_pools("replicated_rule", &okay, &errcode, ss);
+  
+  EXPECT_TRUE(okay) << "Empty pool set should succeed: " << ss.str();
+  EXPECT_EQ(errcode, 0);
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/test/objectstore/test_transaction.cc
+++ b/src/test/objectstore/test_transaction.cc
@@ -1309,3 +1309,76 @@ TEST(Transaction, AppendOpTypes)
   cout << "Checking encoded/decoded with 2 buffers transaction1" << std::endl;
   check_content_transaction1(decode2);
 }
+
+TEST(Transaction, RemapShard)
+{
+  shard_id_t old_shard(2);
+  shard_id_t new_shard(5);
+
+  spg_t old_spg(pg_t(1, 2), old_shard);
+  coll_t cid(old_spg);
+
+  ghobject_t oid(hobject_t("testobj", "", CEPH_NOSNAP, 0x42, 2, ""),
+                 ghobject_t::NO_GEN, old_shard);
+
+  // Build source transaction with several op types
+  ObjectStore::Transaction src;
+  src.create_collection(cid, 12);
+  src.touch(cid, oid);
+
+  bufferlist write_data;
+  write_data.append("hello world");
+  src.write(cid, oid, 0, write_data.length(), write_data);
+
+  // Copy and remap
+  ObjectStore::Transaction dst(src);
+  dst.remap_shard(new_shard);
+
+  // Verify op count preserved
+  ASSERT_EQ(dst.get_num_ops(), src.get_num_ops());
+
+  auto it = dst.begin();
+
+  // Op 1: create_collection
+  {
+    auto* op = it.decode_op();
+    ASSERT_EQ(op->op, ObjectStore::Transaction::OP_MKCOLL);
+    spg_t result_pgid;
+    coll_t result_cid = it.get_cid(op->cid);
+    ASSERT_TRUE(result_cid.is_pg(&result_pgid));
+    EXPECT_EQ(result_pgid.shard, new_shard);
+  }
+
+  // Op 2: touch
+  {
+    auto* op = it.decode_op();
+    ASSERT_EQ(op->op, ObjectStore::Transaction::OP_TOUCH);
+    EXPECT_EQ(it.get_oid(op->oid).shard_id, new_shard);
+    spg_t result_pgid;
+    ASSERT_TRUE(it.get_cid(op->cid).is_pg(&result_pgid));
+    EXPECT_EQ(result_pgid.shard, new_shard);
+  }
+
+  // Op 3: write — also verify data integrity
+  {
+    auto* op = it.decode_op();
+    ASSERT_EQ(op->op, ObjectStore::Transaction::OP_WRITE);
+    EXPECT_EQ(it.get_oid(op->oid).shard_id, new_shard);
+    bufferlist read_data;
+    it.decode_bl(read_data);
+    EXPECT_TRUE(read_data.contents_equal(write_data));
+  }
+
+  // Verify no more ops
+  EXPECT_FALSE(it.have_op());
+
+  // Verify source transaction is unchanged
+  auto src_it = src.begin();
+  {
+    auto* op = src_it.decode_op();
+    ASSERT_EQ(op->op, ObjectStore::Transaction::OP_MKCOLL);
+    spg_t result_pgid;
+    ASSERT_TRUE(src_it.get_cid(op->cid).is_pg(&result_pgid));
+    EXPECT_EQ(result_pgid.shard, old_shard);
+  }
+}

--- a/src/test/osd/ECPeeringTestFixture.cc
+++ b/src/test/osd/ECPeeringTestFixture.cc
@@ -70,7 +70,7 @@ void ECPeeringTestFixture::SetUp() {
     osdmap->apply_incremental(inc);
   }
 
-  for (int i = 0; i < k + m; i++) {
+  for (int i = 0; i < (k + m) * num_zones; i++) {
     create_peering_state(i);
   }
   
@@ -146,7 +146,7 @@ void ECPeeringTestFixture::set_config(const std::string& option, const std::stri
 }
 
 PeeringState* ECPeeringTestFixture::get_peering_state(int shard) {
-  ceph_assert(shard >= 0 && shard < k + m);
+  ceph_assert(shard >= 0 && shard < (k + m) * num_zones);
   auto it = shard_peering_states.find(shard);
   ceph_assert(it != shard_peering_states.end());
   ceph_assert(it->second != nullptr);
@@ -154,7 +154,7 @@ PeeringState* ECPeeringTestFixture::get_peering_state(int shard) {
 }
 
 PeeringCtx* ECPeeringTestFixture::get_peering_ctx(int shard) {
-  ceph_assert(shard >= 0 && shard < k + m);
+  ceph_assert(shard >= 0 && shard < (k + m) * num_zones);
   auto it = shard_peering_ctxs.find(shard);
   ceph_assert(it != shard_peering_ctxs.end());
   ceph_assert(it->second != nullptr);
@@ -162,7 +162,7 @@ PeeringCtx* ECPeeringTestFixture::get_peering_ctx(int shard) {
 }
 
 MockPeeringListener* ECPeeringTestFixture::get_peering_listener(int shard) {
-  ceph_assert(shard >= 0 && shard < k + m);
+  ceph_assert(shard >= 0 && shard < (k + m) * num_zones);
   auto it = shard_peering_listeners.find(shard);
   ceph_assert(it != shard_peering_listeners.end());
   ceph_assert(it->second != nullptr);
@@ -579,6 +579,15 @@ void ECPeeringTestFixture::mark_osds_down(const std::vector<int>& osd_ids)
   new_osdmap->deepish_copy_from(*osdmap);
   OSDMapTestHelpers::mark_osds_down(new_osdmap, osd_ids);
   
+  update_osdmap_with_peering(new_osdmap);
+}
+
+void ECPeeringTestFixture::set_pool_min_size(unsigned new_min_size)
+{
+  auto new_osdmap = std::make_shared<OSDMap>();
+  new_osdmap->deepish_copy_from(*osdmap);
+  OSDMapTestHelpers::set_pool_min_size(new_osdmap, pool_id, new_min_size);
+
   update_osdmap_with_peering(new_osdmap);
 }
 

--- a/src/test/osd/ECPeeringTestFixture.h
+++ b/src/test/osd/ECPeeringTestFixture.h
@@ -94,7 +94,7 @@ public:
    * @param value The value to set
    */
   void set_config(const std::string& option, const std::string& value);
-  
+
 private:
   /**
    * dispatch_buffered_messages - Check for and dispatch any buffered messages
@@ -138,6 +138,14 @@ public:
    */
   void mark_osds_down(const std::vector<int>& osd_ids);
   
+  /**
+   * Set the pool min_size.
+   * Creates a new OSDMap epoch and triggers peering.
+   *
+   * @param new_min_size The new min_size value
+   */
+  void set_pool_min_size(unsigned new_min_size);
+
   /**
    * Advance to a new epoch without changing OSD states.
    * Useful for testing re-peering scenarios.

--- a/src/test/osd/OSDMapTestHelpers.h
+++ b/src/test/osd/OSDMapTestHelpers.h
@@ -178,14 +178,22 @@ public:
     int k,
     int m,
     uint64_t stripe_width,
-    uint64_t flags)
+    uint64_t flags,
+    int64_t pool_id = 0,
+    int num_zones = 1)
   {
+    ceph_assert(num_zones > 0);
+
     pg_pool_t pool;
     pool.type = pg_pool_t::TYPE_ERASURE;
 
-    pool.size = k + m;
+    // size = num_zones * (k + m)
+    pool.size = num_zones * (k + m);
+    pool.opts.set(pool_opts_t::NUM_ZONES, num_zones);
     
-    pool.min_size = k;
+    // For multi-zone configurations, set min_size to allow up to m failures
+    // min_size = num_zones * (k+m) - m
+    pool.min_size = num_zones * (k + m) - m;
     pool.crush_rule = 0;
     pool.erasure_code_profile = "default";
     pool.stripe_width = stripe_width;
@@ -272,6 +280,33 @@ public:
     clear_pool_flag(*osdmap, pool_id, flag);
   }
 
+  /**
+   * Set the min_size for a pool.
+   * Creates a new epoch.
+   *
+   * @param osdmap The OSDMap to modify
+   * @param pool_id The pool ID
+   * @param new_min_size The new min_size value
+   */
+  static void set_pool_min_size(OSDMap& osdmap, int64_t pool_id, unsigned new_min_size)
+  {
+    const pg_pool_t* existing = osdmap.get_pg_pool(pool_id);
+    ceph_assert(existing != nullptr);
+
+    pg_pool_t updated = *existing;
+    updated.min_size = new_min_size;
+
+    OSDMap::Incremental inc(osdmap.get_epoch() + 1);
+    inc.fsid = osdmap.get_fsid();
+    inc.new_pools[pool_id] = updated;
+    osdmap.apply_incremental(inc);
+  }
+
+  static void set_pool_min_size(std::shared_ptr<OSDMap> osdmap, int64_t pool_id, unsigned new_min_size)
+  {
+    set_pool_min_size(*osdmap, pool_id, new_min_size);
+  }
+
   // OSD state manipulation methods
   
   /**
@@ -312,12 +347,12 @@ public:
     OSDMap::Incremental inc(osdmap.get_epoch() + 1);
     inc.fsid = osdmap.get_fsid();
     inc.new_state[osd_id] = CEPH_OSD_EXISTS | CEPH_OSD_UP;
-    
+
     // Preserve xinfo features when marking OSD up
     // This is critical for peering to work correctly with feature checks
     const osd_xinfo_t& existing_xinfo = osdmap.get_xinfo(osd_id);
     inc.new_xinfo[osd_id] = existing_xinfo;
-    
+
     osdmap.apply_incremental(inc);
   }
   

--- a/src/test/osd/PGBackendTestFixture.cc
+++ b/src/test/osd/PGBackendTestFixture.cc
@@ -28,7 +28,7 @@ void PGBackendTestFixture::setup_ec_pool()
 {
   CephContext *cct = g_ceph_context;
 
-  int num_osds = k + m;
+  int num_osds = (num_zones > 0) ? (num_zones * (k + m)) : (k + m);
 
   osdmap = std::make_shared<OSDMap>();
   osdmap->set_max_osd(num_osds);
@@ -62,7 +62,7 @@ void PGBackendTestFixture::setup_ec_pool()
   // This will properly calculate up_osd_features
   osdmap->apply_incremental(inc);
 
-  pg_pool_t pool = OSDMapTestHelpers::create_ec_pool(k, m, stripe_unit * k, pool_flags);
+  pg_pool_t pool = OSDMapTestHelpers::create_ec_pool(k, m, stripe_unit * k, pool_flags, pool_id, num_zones);
   OSDMapTestHelpers::add_pool(osdmap, pool_id, pool);
 
   pgid = pg_t(0, pool_id);
@@ -663,12 +663,12 @@ void PGBackendTestFixture::verify_object(
   bufferlist read_data;
   int read_result = read_object(obj_name, offset, expected_data.length(), read_data, object_size);
 
-  EXPECT_GE(read_result, 0) << "Read should complete successfully";
-  EXPECT_EQ(read_data.length(), expected_data.length()) << "Read data length should match";
-  
+  ASSERT_GE(read_result, 0) << "Read should complete successfully";
+  ASSERT_EQ(read_data.length(), expected_data.length()) << "Read data length should match";
+
   if (read_data.length() == expected_data.length()) {
     std::string read_string(read_data.c_str(), read_data.length());
-    EXPECT_EQ(read_string, expected_data) << "Data should match";
+    ASSERT_EQ(read_string, expected_data) << "Data should match";
   }
 }
 
@@ -677,9 +677,9 @@ void PGBackendTestFixture::create_and_write_verify(
   const std::string& data)
 {
   int result = create_and_write(obj_name, data);
-  
-  EXPECT_GE(result, 0) << "Write should complete successfully";
-  
+
+  ASSERT_GE(result, 0) << "Write should complete successfully";
+
   // Always verify - tests should only use this helper when success is expected
   verify_object(obj_name, data, 0, data.length());
 }
@@ -692,21 +692,21 @@ void PGBackendTestFixture::write_verify(
   const std::string& context_msg)
 {
   int result = write(obj_name, offset, data, object_size);
-  
+
   std::string msg_suffix = context_msg.empty() ? "" : " (" + context_msg + ")";
-  EXPECT_GE(result, 0) << "Write should complete successfully" << msg_suffix;
-  
+  ASSERT_GE(result, 0) << "Write should complete successfully" << msg_suffix;
+
   // Always verify - tests should only use this helper when success is expected
   bufferlist read_data;
   int read_result = read_object(obj_name, offset, data.length(), read_data,
                                  std::max(object_size, offset + data.length()));
-  
-  EXPECT_GE(read_result, 0) << "Read should complete successfully" << msg_suffix;
-  EXPECT_EQ(read_data.length(), data.length()) << "Read data length should match" << msg_suffix;
-  
+
+  ASSERT_GE(read_result, 0) << "Read should complete successfully" << msg_suffix;
+  ASSERT_EQ(read_data.length(), data.length()) << "Read data length should match" << msg_suffix;
+
   if (read_data.length() == data.length()) {
     std::string read_string(read_data.c_str(), read_data.length());
-    EXPECT_EQ(read_string, data) << "Written data should match" << msg_suffix;
+    ASSERT_EQ(read_string, data) << "Written data should match" << msg_suffix;
   }
 }
 

--- a/src/test/osd/PGBackendTestFixture.h
+++ b/src/test/osd/PGBackendTestFixture.h
@@ -78,15 +78,15 @@ protected:
   /// across sequential operations on the same object. This is critical for
   /// EC attr_cache continuity.
   std::map<hobject_t, ObjectContextRef> object_contexts;
-  
+
   /// Track outstanding writes per object. When this reaches 0, we can safely
   /// clear attr_cache (as there are no in-flight writes that might have stale
   /// cached OI data).
   std::map<hobject_t, int> outstanding_writes;
-  
+
   // OpTracker for wrapping messages in OpRequestRef
   std::shared_ptr<OpTracker> op_tracker;
-  
+
   ceph::ErasureCodeInterfaceRef ec_impl;
   std::map<int, std::unique_ptr<ECExtentCache::LRU>> lrus;
   int k = 4;  // data chunks
@@ -94,6 +94,7 @@ protected:
   uint64_t stripe_unit = 4096;  // aka chunk_size
   std::string ec_plugin = "isa";
   std::string ec_technique = "reed_sol_van";
+  int num_zones = 0;
 
   int num_replicas = 3;
   int min_size = 2;
@@ -104,11 +105,11 @@ protected:
   
   // Transaction ID counter - increments with each transaction
   ceph_tid_t next_tid = 1;
-  
+
   // Version counter for auto-generating versions in write* functions
   // The epoch comes from osdmap, this tracks the second version number
   uint64_t next_version = 1;
-  
+
   class TestDpp : public NoDoutPrefix {
   public:
     TestDpp(CephContext *cct) : NoDoutPrefix(cct, ceph_subsys_osd) {}
@@ -188,7 +189,7 @@ public:
     backends.clear();
     object_contexts.clear();
     outstanding_writes.clear();
-    
+
     if (pool_type == EC) {
       lrus.clear();
       ec_impl.reset();

--- a/src/test/osd/PGBackendTestFixture.h
+++ b/src/test/osd/PGBackendTestFixture.h
@@ -94,7 +94,7 @@ protected:
   uint64_t stripe_unit = 4096;  // aka chunk_size
   std::string ec_plugin = "isa";
   std::string ec_technique = "reed_sol_van";
-  int num_zones = 0;
+  int num_zones = 1;
 
   int num_replicas = 3;
   int min_size = 2;

--- a/src/test/osd/TestBackendBasics.cc
+++ b/src/test/osd/TestBackendBasics.cc
@@ -70,6 +70,7 @@ public:
       ec_plugin = config.ec_plugin;
       ec_technique = config.ec_technique;
       pool_flags = config.pool_flags;
+      num_zones = config.num_zones;
     } else {
       num_replicas = 3;
       min_size = 2;
@@ -91,34 +92,34 @@ public:
 
     // Build new acting set with failed OSDs replaced by CRUSH_ITEM_NONE
     std::vector<int> new_acting;
-    int total_osds = k + m;
-    
+    int total_osds = (num_zones > 0) ? (num_zones * (k + m)) : (k + m);
+
     for (int i = 0; i < total_osds; i++) {
       bool is_failed = std::find(failed_osds.begin(), failed_osds.end(), i) != failed_osds.end();
       new_acting.push_back(is_failed ? CRUSH_ITEM_NONE : i);
     }
-    
+
     // Get the pool to use pgtemp_primaryfirst transformation
     const pg_pool_t* pool = new_osdmap->get_pg_pool(pgid.pool());
     ceph_assert(pool != nullptr);
-    
+
     // For EC pools with optimizations, pgtemp_primaryfirst reorders the acting set
     std::vector<int> transformed_acting = new_osdmap->pgtemp_primaryfirst(*pool, new_acting);
-    
+
     // Use OSDMap::Incremental to set pg_temp and mark OSDs as down
     OSDMap::Incremental inc(new_osdmap->get_epoch() + 1);
     inc.fsid = new_osdmap->get_fsid();
-    
+
     for (int failed_osd : failed_osds) {
       inc.new_state[failed_osd] = CEPH_OSD_EXISTS;  // Mark as down (exists but not UP)
     }
-    
+
     // Convert to mempool vector for pg_temp
     mempool::osdmap::vector<int> pg_temp_vec(transformed_acting.begin(), transformed_acting.end());
     inc.new_pg_temp[pgid] = pg_temp_vec;
 
     new_osdmap->apply_incremental(inc);
-    
+
     // Finalize the CRUSH map
     new_osdmap->crush->finalize();
 
@@ -378,25 +379,184 @@ TEST_P(TestBackendBasics, DirectRead) {
 }
 
 // ---------------------------------------------------------------------------
+// TestBackendBasics: MultiZoneWriteThenRead
+// ---------------------------------------------------------------------------
+
+/**
+ * MultiZoneWriteThenRead - test write then read with multiple zones.
+ *
+ * This test verifies that EC pools configured with multiple zones (num_zones > 0)
+ * can successfully write and read data. The test:
+ * 1. Skips non-EC backends and EC backends without zones
+ * 2. Writes data to an object
+ * 3. Reads the data back
+ * 4. Verifies data integrity
+ *
+ * With zones enabled, the pool size is num_zones * (k+m), so there are more
+ * shards distributed across multiple failure domains.
+ */
+TEST_P(TestBackendBasics, MultiZoneWriteThenRead) {
+  const auto& param = GetParam().write_read;
+  const auto& backend_config = GetParam().backend;
+
+  // Skip test for non-EC backends
+  if (backend_config.pool_type != EC) {
+    GTEST_SKIP() << "MultiZoneWriteThenRead test only applies to EC backends";
+  }
+
+  // Skip test if zones are not configured
+  if (backend_config.num_zones == 0) {
+    GTEST_SKIP() << "MultiZoneWriteThenRead test requires num_zones > 0";
+  }
+
+  std::string test_data(param.size, param.fill);
+  std::string obj_name = "test_multizone_" + backend_config.label + "_" + param.label;
+
+  // Execute create+write operation and verify
+  create_and_write_verify(obj_name, test_data);
+
+  // Verify messages were sent to shards across zones
+  auto* primary_listener = get_primary_listener();
+  ASSERT_TRUE(primary_listener != nullptr) << "Primary listener should exist";
+  ASSERT_GT(primary_listener->sent_messages.size(), 0u)
+    << "Should send messages to shards across zones";
+
+  // Verify EC write messages were sent
+  int write_messages_sent = 0;
+  for (auto msg : primary_listener->sent_messages) {
+    if (msg->get_type() == MSG_OSD_EC_WRITE) {
+      write_messages_sent++;
+    }
+  }
+  ASSERT_GT(write_messages_sent, 0) << "Should send EC write messages to multiple zones";
+
+  // With zones, we expect messages to be sent to num_zones * (k+m) shards
+  // However, the actual number of messages may vary based on the write pattern
+  // and optimization flags, so we just verify that messages were sent
+
+  // Clear sent messages before read to distinguish read messages
+  primary_listener->sent_messages.clear();
+  primary_listener->sent_messages_with_dest.clear();
+
+  // Verify object can be read back correctly across zones
+  verify_object(obj_name, test_data, 0, test_data.size());
+
+  // Verify read messages were sent to shards across zones
+  primary_listener = get_primary_listener();
+  ASSERT_TRUE(primary_listener != nullptr) << "Primary listener should exist";
+  ASSERT_GT(primary_listener->sent_messages.size(), 0u)
+    << "Should send read messages to EC shards across zones";
+
+  // All events should be processed by now
+  ASSERT_FALSE(event_loop->has_events()) << "Event loop should be idle after read";
+
+  primary_listener = get_primary_listener();
+  if (primary_listener) {
+    primary_listener->sent_messages.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// TestBackendBasics: MultiZoneFailover
+// ---------------------------------------------------------------------------
+
+/**
+ * MultiZoneFailover - test write, fail first half of OSDs, then degraded read.
+ *
+ * This test verifies that EC pools with multiple zones can handle zone failures
+ * and perform degraded reads with EC reconstruction. The test:
+ * 1. Requires num_zones > 1 (multiple zones)
+ * 2. Writes data to an object
+ * 3. Fails the first half of the OSDs (simulating a zone failure)
+ * 4. Performs a degraded read and verifies data integrity via EC reconstruction
+ *
+ * With 2 zones and k=4, m=2, we have 12 total shards (2 zones × 6 shards).
+ * Failing the first 6 OSDs (one complete zone) should still allow reads
+ * because we have k=4 data chunks and m=2 coding chunks, and the remaining
+ * 6 shards provide sufficient redundancy.
+ */
+TEST_P(TestBackendBasics, MultiZoneFailover) {
+  const auto& param = GetParam().write_read;
+  const auto& backend_config = GetParam().backend;
+
+  // Skip test for non-EC backends
+  if (backend_config.pool_type != EC) {
+    GTEST_SKIP() << "MultiZoneFailover test only applies to EC backends";
+  }
+
+  // Skip test if zones are not configured or only one zone
+  if (backend_config.num_zones <= 1) {
+    GTEST_SKIP() << "MultiZoneFailover test requires num_zones > 1";
+  }
+
+  std::string test_data(param.size, param.fill);
+  std::string obj_name = "test_zone_failover_" + backend_config.label + "_" + param.label;
+
+  // Write data before failure and verify
+  create_and_write_verify(obj_name, test_data);
+
+  // Calculate how many OSDs to fail (first half)
+  int total_osds = backend_config.num_zones * (k + m);
+  int osds_to_fail = total_osds / 2;
+
+  // Build list of OSDs to fail (first half)
+  std::vector<int> failed_osds;
+  for (int i = 0; i < osds_to_fail; i++) {
+    failed_osds.push_back(i);
+  }
+
+  // Simulate failure of first half of OSDs
+  simulate_multiple_osd_failures(failed_osds);
+
+  // Verify the primary has changed (OSD 0 was in the first half)
+  auto* new_primary_listener = get_primary_listener();
+  ASSERT_TRUE(new_primary_listener != nullptr) << "Should have a primary after failover";
+
+  // The new primary should not be one of the failed OSDs
+  bool primary_is_valid = true;
+  for (auto& [instance_id, listener] : listeners) {
+    if (listener.get() == new_primary_listener) {
+      primary_is_valid = (std::find(failed_osds.begin(), failed_osds.end(), instance_id) == failed_osds.end());
+      break;
+    }
+  }
+  EXPECT_TRUE(primary_is_valid) << "New primary should not be a failed OSD";
+
+  // Perform degraded read after failover and verify data integrity
+  verify_object(obj_name, test_data, 0, test_data.size());
+
+  // Verify OSDMap epoch incremented
+  EXPECT_GT(new_primary_listener->osdmap->get_epoch(), 1)
+    << "OSDMap epoch should have incremented after failover";
+
+  // Clean up
+  if (new_primary_listener) {
+    new_primary_listener->sent_messages.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Backend configurations and size parameters
 // ---------------------------------------------------------------------------
 
 namespace {
 
 const std::vector<BackendConfig> kBackendConfigs = {
-  {PGBackendTestFixture::REPLICATED, "", "", 0, 4096, 4, 2, "Replicated"},
-  {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  4, 2, "EC_ISA_Opt_k4m2_su4k"},
-  {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  8192,  4, 2, "EC_ISA_Opt_k4m2_su8k"},
-  {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  16384, 4, 2, "EC_ISA_Opt_k4m2_su16k"},
-  {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  2, 1, "EC_ISA_Opt_k2m1_su4k"},
-  {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  8, 3, "EC_ISA_Opt_k8m3_su4k"},
-  {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES, 4096,  4, 2, "EC_ISA_NonOpt_k4m2_su4k"},
-  {PGBackendTestFixture::EC, "jerasure", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  4, 2, "EC_Jerasure_Opt_k4m2_su4k"},
-  {PGBackendTestFixture::EC, "jerasure", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  8192,  4, 2, "EC_Jerasure_Opt_k4m2_su8k"},
-  {PGBackendTestFixture::EC, "jerasure", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  16384, 4, 2, "EC_Jerasure_Opt_k4m2_su16k"},
-  {PGBackendTestFixture::EC, "jerasure", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  2, 1, "EC_Jerasure_Opt_k2m1_su4k"},
-  {PGBackendTestFixture::EC, "jerasure", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  8, 3, "EC_Jerasure_Opt_k8m3_su4k"},
-  {PGBackendTestFixture::EC, "jerasure", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES, 4096,  4, 2, "EC_Jerasure_NonOpt_k4m2_su4k"},
+  {PGBackendTestFixture::REPLICATED, "", "", 0, 4096, 4, 2, 0, "Replicated"},
+  {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  4, 2, 1, "EC_ISA_Opt_k4m2_su4k"},
+  {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  8192,  4, 2, 1, "EC_ISA_Opt_k4m2_su8k"},
+  {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  16384, 4, 2, 1, "EC_ISA_Opt_k4m2_su16k"},
+  {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  2, 1, 1, "EC_ISA_Opt_k2m1_su4k"},
+  {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  8, 3, 1, "EC_ISA_Opt_k8m3_su4k"},
+  {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES, 4096,  4, 2, 0, "EC_ISA_NonOpt_k4m2_su4k"},
+  {PGBackendTestFixture::EC, "jerasure", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  4, 2, 1, "EC_Jerasure_Opt_k4m2_su4k"},
+  {PGBackendTestFixture::EC, "jerasure", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  8192,  4, 2, 1, "EC_Jerasure_Opt_k4m2_su8k"},
+  {PGBackendTestFixture::EC, "jerasure", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  16384, 4, 2, 1, "EC_Jerasure_Opt_k4m2_su16k"},
+  {PGBackendTestFixture::EC, "jerasure", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  2, 1, 1, "EC_Jerasure_Opt_k2m1_su4k"},
+  {PGBackendTestFixture::EC, "jerasure", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  8, 3, 1, "EC_Jerasure_Opt_k8m3_su4k"},
+  {PGBackendTestFixture::EC, "jerasure", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES, 4096,  4, 2, 0, "EC_Jerasure_NonOpt_k4m2_su4k"},
+  // Test configuration with num_zones set to 2 (size will be 2 * (4+2) = 12)
+  {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  4, 2, 2, "EC_ISA_Opt_k4m2_zones2"},
 };
 
 const std::vector<WriteReadParam> kSizeParams = {

--- a/src/test/osd/TestBackendBasics.cc
+++ b/src/test/osd/TestBackendBasics.cc
@@ -548,13 +548,13 @@ const std::vector<BackendConfig> kBackendConfigs = {
   {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  16384, 4, 2, 1, "EC_ISA_Opt_k4m2_su16k"},
   {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  2, 1, 1, "EC_ISA_Opt_k2m1_su4k"},
   {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  8, 3, 1, "EC_ISA_Opt_k8m3_su4k"},
-  {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES, 4096,  4, 2, 0, "EC_ISA_NonOpt_k4m2_su4k"},
+  {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES, 4096,  4, 2, 1, "EC_ISA_NonOpt_k4m2_su4k"},
   {PGBackendTestFixture::EC, "jerasure", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  4, 2, 1, "EC_Jerasure_Opt_k4m2_su4k"},
   {PGBackendTestFixture::EC, "jerasure", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  8192,  4, 2, 1, "EC_Jerasure_Opt_k4m2_su8k"},
   {PGBackendTestFixture::EC, "jerasure", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  16384, 4, 2, 1, "EC_Jerasure_Opt_k4m2_su16k"},
   {PGBackendTestFixture::EC, "jerasure", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  2, 1, 1, "EC_Jerasure_Opt_k2m1_su4k"},
   {PGBackendTestFixture::EC, "jerasure", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  8, 3, 1, "EC_Jerasure_Opt_k8m3_su4k"},
-  {PGBackendTestFixture::EC, "jerasure", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES, 4096,  4, 2, 0, "EC_Jerasure_NonOpt_k4m2_su4k"},
+  {PGBackendTestFixture::EC, "jerasure", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES, 4096,  4, 2, 1, "EC_Jerasure_NonOpt_k4m2_su4k"},
   // Test configuration with num_zones set to 2 (size will be 2 * (4+2) = 12)
   {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  4, 2, 2, "EC_ISA_Opt_k4m2_zones2"},
 };

--- a/src/test/osd/TestCommon.h
+++ b/src/test/osd/TestCommon.h
@@ -47,6 +47,7 @@ struct BackendConfig {
   uint64_t stripe_unit = 4096;  // aka chunk_size; stripe_width = stripe_unit * k
   int k = 4;  // data chunks (EC only)
   int m = 2;  // coding chunks (EC only)
+  int num_zones = 0;  // number of zones (0 = default, size = k+m)
   // Label for test naming
   std::string label;
 };

--- a/src/test/osd/TestCommon.h
+++ b/src/test/osd/TestCommon.h
@@ -47,7 +47,7 @@ struct BackendConfig {
   uint64_t stripe_unit = 4096;  // aka chunk_size; stripe_width = stripe_unit * k
   int k = 4;  // data chunks (EC only)
   int m = 2;  // coding chunks (EC only)
-  int num_zones = 0;  // number of zones (0 = default, size = k+m)
+  int num_zones = 1;  // number of zones (1 = single-zone, size = k+m)
   // Label for test naming
   std::string label;
 };

--- a/src/test/osd/TestECBackend.cc
+++ b/src/test/osd/TestECBackend.cc
@@ -563,7 +563,6 @@ TEST(ECCommon, get_min_avail_to_read_shards) {
     ECCommon::read_request_t ref(to_read_list, false, object_size);
     for (shard_id_t shard_id; shard_id < k; ++shard_id) {
       ref.shard_reads[shard_id].extents = to_read_list[shard_id];
-      ref.shard_reads[shard_id].subchunk = ecode->default_sub_chunk;
       ref.shard_reads[shard_id].pg_shard = pg_shard_t(int(shard_id));
       ref.shard_reads[shard_id].pg_shard = pg_shard_t(int(shard_id), shard_id);
     }
@@ -587,7 +586,6 @@ TEST(ECCommon, get_min_avail_to_read_shards) {
     for (shard_id_t i; i<k; ++i) {
       shard_id_t shard_id(i);
       ref.shard_reads[shard_id].extents = to_read_list[i];
-      ref.shard_reads[shard_id].subchunk = ecode->default_sub_chunk;
       ref.shard_reads[shard_id].pg_shard = pg_shard_t(int(i), shard_id);
     }
 
@@ -608,7 +606,6 @@ TEST(ECCommon, get_min_avail_to_read_shards) {
     for (int i=0; i < (int)k; i++) {
       shard_id_t shard_id(i);
       ECCommon::shard_read_t &ref_shard_read = ref.shard_reads[shard_id];
-      ref_shard_read.subchunk = ecode->default_sub_chunk;
       ref_shard_read.extents.insert(i*2*align_size, align_size);
       ref_shard_read.pg_shard = pg_shard_t(i, shard_id_t(i));
     }
@@ -638,15 +635,13 @@ TEST(ECCommon, get_min_avail_to_read_shards) {
     for (shard_id_t i; i<k; ++i) {
       if (i != missing_shard) {
         shard_id_t shard_id(i);
-	to_read_list[i].union_of(to_read_list[missing_shard]);
-        ref.shard_reads[shard_id].subchunk = ecode->default_sub_chunk;
-	ref.shard_reads[shard_id].extents = to_read_list[i];
+        to_read_list[i].union_of(to_read_list[missing_shard]);
+        ref.shard_reads[shard_id].extents = to_read_list[i];
         ref.shard_reads[shard_id].pg_shard = pg_shard_t(int(i), shard_id);
       } else {
-	ECCommon::shard_read_t parity_shard_read;
-	parity_shard_read.subchunk = ecode->default_sub_chunk;
-	parity_shard_read.extents.union_of(to_read_list[i]);
-	ref.shard_reads[shard_id_t(parity_shard)] = parity_shard_read;
+        ECCommon::shard_read_t parity_shard_read;
+        parity_shard_read.extents.union_of(to_read_list[i]);
+        ref.shard_reads[shard_id_t(parity_shard)] = parity_shard_read;
         ref.shard_reads[shard_id_t(parity_shard)].pg_shard = pg_shard_t(parity_shard, shard_id_t(parity_shard));
       }
     }
@@ -680,12 +675,6 @@ TEST(ECCommon, get_min_avail_to_read_shards) {
     ref.shard_reads[shard_id_t(2)].pg_shard = pg_shard_t(2, shard_id_t(2));
     ref.shard_reads[shard_id_t(3)].pg_shard = pg_shard_t(3, shard_id_t(3));
     ref.shard_reads[shard_id_t(4)].pg_shard = pg_shard_t(4, shard_id_t(4));
-    for (unsigned int i=0; i<k+1; i++) {
-      if (i==missing_shard) {
-	continue;
-      }
-      ref.shard_reads[shard_id_t(i)].subchunk = ecode->default_sub_chunk;
-    }
 
     listenerStub.acting_shards.erase(pg_shard_t(missing_shard, shard_id_t(missing_shard)));
 
@@ -713,7 +702,6 @@ TEST(ECCommon, get_min_avail_to_read_shards) {
     ECCommon::read_request_t ref(to_read_list, false, object_size);
     for (unsigned int i=0; i<k+2; i++) {
       ECCommon::shard_read_t shard_read;
-      shard_read.subchunk = ecode->default_sub_chunk;
       shard_read.extents = extents_to_read;
       shard_read.pg_shard = pg_shard_t(i, shard_id_t(i));
       ref.shard_reads[shard_id_t(i)] = shard_read;
@@ -744,14 +732,12 @@ TEST(ECCommon, get_min_avail_to_read_shards) {
     std::vector<ECCommon::shard_read_t> want_to_read(empty_shard_vector);
     for (shard_id_t i; i<k; ++i) {
       if (i != missing_shard) {
-        want_to_read[int(i)].subchunk = ecode->default_sub_chunk;
         want_to_read[int(i)].extents.union_of(to_read_list[missing_shard]);
         want_to_read[int(i)].extents.union_of(to_read_list[i]);
         want_to_read[int(i)].pg_shard = pg_shard_t(int(i), shard_id_t(i));
         ref.shard_reads[shard_id_t(i)] = want_to_read[int(i)];
       } else {
         ECCommon::shard_read_t parity_shard_read;
-        parity_shard_read.subchunk = ecode->default_sub_chunk;
         parity_shard_read.extents.union_of(to_read_list[missing_shard]);
         parity_shard_read.pg_shard = pg_shard_t(parity_shard, shard_id_t(parity_shard));
         ref.shard_reads[shard_id_t(parity_shard)] = parity_shard_read;
@@ -800,14 +786,12 @@ TEST(ECCommon, shard_read_combo_tests)
     ECCommon::read_request_t ref(want_to_read, false, object_size);
     {
       ECCommon::shard_read_t shard_read;
-      shard_read.subchunk = ecode->default_sub_chunk;
       shard_read.extents.insert(20*1024, 4*1024);
       shard_read.pg_shard = pg_shard_t(0, shard_id_t(0));
       ref.shard_reads[shard_id_t(0)] = shard_read;
     }
     {
       ECCommon::shard_read_t shard_read;
-      shard_read.subchunk = ecode->default_sub_chunk;
       shard_read.extents.insert(16*1024, 8*1024);
       shard_read.pg_shard = pg_shard_t(1, shard_id_t(1));
       ref.shard_reads[shard_id_t(1)] = shard_read;
@@ -827,14 +811,12 @@ TEST(ECCommon, shard_read_combo_tests)
     ECCommon::read_request_t ref(want_to_read, false, object_size);
     {
       ECCommon::shard_read_t shard_read;
-      shard_read.subchunk = ecode->default_sub_chunk;
       shard_read.extents.insert(8*1024, 4*1024);
       shard_read.pg_shard = pg_shard_t(0, shard_id_t(0));
       ref.shard_reads[shard_id_t(0)] = shard_read;
     }
     {
       ECCommon::shard_read_t shard_read;
-      shard_read.subchunk = ecode->default_sub_chunk;
       shard_read.extents.insert(4*1024, 8*1024);
       shard_read.pg_shard = pg_shard_t(1, shard_id_t(1));
       ref.shard_reads[shard_id_t(1)] = shard_read;
@@ -934,7 +916,6 @@ TEST(ECCommon, get_remaining_shards)
     int parity_shard = 4;
     for (unsigned int i=0; i<k; i++) {
       ECCommon::shard_read_t shard_read;
-      shard_read.subchunk = ecode->default_sub_chunk;
       shard_read.extents.insert(0,4096);
       unsigned int shard_id = std::cmp_equal(i, missing_shard) ? parity_shard : i;
       shard_read.pg_shard = pg_shard_t(shard_id, shard_id_t(shard_id));
@@ -969,7 +950,6 @@ TEST(ECCommon, get_remaining_shards)
     int parity_shard = 4;
     for (unsigned int i=0; i<k; i++) {
       ECCommon::shard_read_t shard_read;
-      shard_read.subchunk = ecode->default_sub_chunk;
       unsigned int shard_id = i==missing_shard?parity_shard:i;
       ref.shard_reads[shard_id_t(shard_id)] = shard_read;
     }
@@ -1236,4 +1216,406 @@ TEST(ECCommon, decode8) {
   acting_set.insert_range(shard_id_t(2), 2);
 
   test_decode(k, m, chunk_size, object_size, want, acting_set);
+}
+
+// Zone support tests for get_min_avail_to_read_shards
+TEST(ECCommon, get_min_avail_to_read_shards_zones_local_zone_available) {
+  // Test that when all shards are available in local zone, they are preferred
+  const uint64_t align_size = EC_ALIGN_SIZE;
+  const uint64_t swidth = 64*align_size;
+  const unsigned int k = 4;
+  const unsigned int m = 2;
+  const int nshards = 6;
+  const uint64_t object_size = swidth * 1024;
+
+  pg_pool_t pool;
+  pool.size = 12; // 2 zones with k+m shards each
+  pool.opts.set(pool_opts_t::NUM_ZONES, 2);
+
+  ECUtil::stripe_info_t s(k, m, swidth, &pool);
+  ECListenerStub listenerStub;
+  
+  MockErasureCode *ecode = new MockErasureCode();
+  ErasureCodeInterfaceRef ec_impl(ecode);
+  ECCommon::ReadPipeline pipeline(g_ceph_context, ec_impl, s, &listenerStub);
+
+  // Set up shards in both zones (0-5 in zone 0, 6-11 in zone 1)
+  for (int i = 0; i < 12; i++) {
+    listenerStub.acting_shards.insert(pg_shard_t(i, shard_id_t(i)));
+  }
+
+  hobject_t hoid;
+  ECUtil::shard_extent_set_t to_read_list(s.get_k_plus_m());
+  
+  // Request reads from data shards in zone 0
+  for (shard_id_t i; i < k; ++i) {
+    to_read_list[i].insert(int(i) * 2 * align_size, align_size);
+  }
+
+  ECCommon::read_request_t read_request(to_read_list, false, object_size);
+  int r = pipeline.get_min_avail_to_read_shards(hoid, false, false, read_request);
+  
+  ASSERT_EQ(r, 0);
+  
+  // Verify that only local zone shards (0-5) are used
+  for (auto &[shard_id, shard_read] : read_request.shard_reads) {
+    ASSERT_LT(int(shard_id), nshards) << "Should only use local zone shards";
+    ASSERT_EQ(shard_read.pg_shard.shard, shard_id);
+  }
+}
+
+TEST(ECCommon, get_min_avail_to_read_shards_zones_fallback_to_remote) {
+  // Test that when local zone shards are missing, remote zone shards are used
+  const uint64_t align_size = EC_ALIGN_SIZE;
+  const uint64_t swidth = 64*align_size;
+  const unsigned int k = 4;
+  const unsigned int m = 2;
+  const uint64_t object_size = swidth * 1024;
+
+  pg_pool_t pool;
+  pool.size = 12; // 2 zones
+  pool.opts.set(pool_opts_t::NUM_ZONES, 2);
+
+  ECUtil::stripe_info_t s(k, m, swidth, &pool);
+  ECListenerStub listenerStub;
+  
+  MockErasureCode *ecode = new MockErasureCode();
+  ErasureCodeInterfaceRef ec_impl(ecode);
+  ECCommon::ReadPipeline pipeline(g_ceph_context, ec_impl, s, &listenerStub);
+
+  // Only add shards from remote zone (6-11) and one from local zone
+  listenerStub.acting_shards.insert(pg_shard_t(0, shard_id_t(0))); // Local zone
+  for (int i = 6; i < 12; i++) {
+    listenerStub.acting_shards.insert(pg_shard_t(i, shard_id_t(i))); // Remote zone
+  }
+
+  hobject_t hoid;
+  ECUtil::shard_extent_set_t to_read_list(s.get_k_plus_m());
+  
+  // Request reads from all data shards
+  for (shard_id_t i; i < k; ++i) {
+    to_read_list[i].insert(int(i) * 2 * align_size, align_size);
+  }
+
+  ECCommon::read_request_t read_request(to_read_list, false, object_size);
+  int r = pipeline.get_min_avail_to_read_shards(hoid, false, false, read_request);
+  
+  ASSERT_EQ(r, 0);
+  
+  // Verify that remote zone shards are used (should have shards >= 6)
+  bool has_remote_shard = false;
+  for (auto &[shard_id, shard_read] : read_request.shard_reads) {
+    if (int(shard_read.pg_shard.shard) >= 6) {
+      has_remote_shard = true;
+      break;
+    }
+  }
+  ASSERT_TRUE(has_remote_shard) << "Should use remote zone shards when local unavailable";
+}
+
+TEST(ECCommon, get_min_avail_to_read_shards_zones_missing_shard_local) {
+  // Test handling of missing shard in local zone with zones enabled
+  const uint64_t align_size = EC_ALIGN_SIZE;
+  const uint64_t swidth = 64*align_size;
+  const unsigned int k = 4;
+  const unsigned int m = 2;
+  const uint64_t object_size = swidth * 1024;
+
+  pg_pool_t pool;
+  pool.size = 12;
+  pool.opts.set(pool_opts_t::NUM_ZONES, 2);
+
+  ECUtil::stripe_info_t s(k, m, swidth, &pool);
+  ECListenerStub listenerStub;
+  
+  MockErasureCode *ecode = new MockErasureCode();
+  ErasureCodeInterfaceRef ec_impl(ecode);
+  ECCommon::ReadPipeline pipeline(g_ceph_context, ec_impl, s, &listenerStub);
+
+  // Add all local zone shards except shard 1
+  for (int i = 0; i < 6; i++) {
+    if (i != 1) {
+      listenerStub.acting_shards.insert(pg_shard_t(i, shard_id_t(i)));
+    }
+  }
+
+  hobject_t hoid;
+  ECUtil::shard_extent_set_t to_read_list(s.get_k_plus_m());
+  
+  for (shard_id_t i; i < k; ++i) {
+    to_read_list[i].insert(int(i) * 2 * align_size, align_size);
+  }
+
+  ECCommon::read_request_t read_request(to_read_list, false, object_size);
+  int r = pipeline.get_min_avail_to_read_shards(hoid, false, false, read_request);
+  
+  ASSERT_EQ(r, 0);
+  
+  // Should use parity shard to recover missing data shard
+  bool has_parity = false;
+  for (auto &[shard_id, shard_read] : read_request.shard_reads) {
+    if (std::cmp_greater_equal(int(shard_id), k)) {
+      has_parity = true;
+    }
+  }
+  ASSERT_TRUE(has_parity) << "Should use parity shard when data shard missing";
+}
+
+TEST(ECCommon, get_min_avail_to_read_shards_zones_error_shards) {
+  // Test that error_shards parameter works correctly with zones
+  const uint64_t align_size = EC_ALIGN_SIZE;
+  const uint64_t swidth = 64*align_size;
+  const unsigned int k = 4;
+  const unsigned int m = 2;
+  const uint64_t object_size = swidth * 1024;
+
+  pg_pool_t pool;
+  pool.size = 12;
+  pool.opts.set(pool_opts_t::NUM_ZONES, 2);
+
+  ECUtil::stripe_info_t s(k, m, swidth, &pool);
+  ECListenerStub listenerStub;
+  
+  MockErasureCode *ecode = new MockErasureCode();
+  ErasureCodeInterfaceRef ec_impl(ecode);
+  ECCommon::ReadPipeline pipeline(g_ceph_context, ec_impl, s, &listenerStub);
+
+  // Add all shards from both zones
+  for (int i = 0; i < 12; i++) {
+    listenerStub.acting_shards.insert(pg_shard_t(i, shard_id_t(i)));
+  }
+
+  hobject_t hoid;
+  ECUtil::shard_extent_set_t to_read_list(s.get_k_plus_m());
+  
+  for (shard_id_t i; i < k; ++i) {
+    to_read_list[i].insert(int(i) * 2 * align_size, align_size);
+  }
+
+  // Mark shard 1 as having an error
+  std::set<pg_shard_t> error_shards;
+  error_shards.emplace(1, shard_id_t(1));
+
+  ECCommon::read_request_t read_request(to_read_list, false, object_size);
+  int r = pipeline.get_min_avail_to_read_shards(hoid, false, false, read_request, error_shards);
+  
+  ASSERT_EQ(r, 0);
+  
+  // Verify shard 1 is not in the read request
+  ASSERT_EQ(read_request.shard_reads.count(shard_id_t(1)), 0u) 
+    << "Error shard should not be in read request";
+}
+
+TEST(ECCommon, get_min_avail_to_read_shards_zones_three_zones) {
+  // Test with 3 zones
+  const uint64_t align_size = EC_ALIGN_SIZE;
+  const uint64_t swidth = 64*align_size;
+  const unsigned int k = 4;
+  const unsigned int m = 2;
+  const uint64_t object_size = swidth * 1024;
+
+  pg_pool_t pool;
+  pool.size = 18; // 3 zones
+  pool.opts.set(pool_opts_t::NUM_ZONES, 3);
+
+  ECUtil::stripe_info_t s(k, m, swidth, &pool);
+  ECListenerStub listenerStub;
+  
+  MockErasureCode *ecode = new MockErasureCode();
+  ErasureCodeInterfaceRef ec_impl(ecode);
+  ECCommon::ReadPipeline pipeline(g_ceph_context, ec_impl, s, &listenerStub);
+
+  // Add shards from all three zones
+  for (int i = 0; i < 18; i++) {
+    listenerStub.acting_shards.insert(pg_shard_t(i, shard_id_t(i)));
+  }
+
+  hobject_t hoid;
+  ECUtil::shard_extent_set_t to_read_list(s.get_k_plus_m());
+  
+  for (shard_id_t i; i < k; ++i) {
+    to_read_list[i].insert(int(i) * 2 * align_size, align_size);
+  }
+
+  ECCommon::read_request_t read_request(to_read_list, false, object_size);
+  int r = pipeline.get_min_avail_to_read_shards(hoid, false, false, read_request);
+  
+  ASSERT_EQ(r, 0);
+  
+  // Should prefer local zone (0-5)
+  for (auto &[shard_id, shard_read] : read_request.shard_reads) {
+    ASSERT_LT(int(shard_id), 6) << "Should prefer local zone shards";
+  }
+}
+
+TEST(ECCommon, get_min_avail_to_read_shards_zones_insufficient_shards) {
+  // Test error case when not enough shards available even with zones
+  const uint64_t align_size = EC_ALIGN_SIZE;
+  const uint64_t swidth = 64*align_size;
+  const unsigned int k = 4;
+  const unsigned int m = 2;
+  const uint64_t object_size = swidth * 1024;
+
+  pg_pool_t pool;
+  pool.size = 12;
+  pool.opts.set(pool_opts_t::NUM_ZONES, 2);
+
+  ECUtil::stripe_info_t s(k, m, swidth, &pool);
+  ECListenerStub listenerStub;
+  
+  MockErasureCode *ecode = new MockErasureCode();
+  ErasureCodeInterfaceRef ec_impl(ecode);
+  ECCommon::ReadPipeline pipeline(g_ceph_context, ec_impl, s, &listenerStub);
+
+  // Only add 2 shards - not enough to decode
+  listenerStub.acting_shards.insert(pg_shard_t(0, shard_id_t(0)));
+  listenerStub.acting_shards.insert(pg_shard_t(1, shard_id_t(1)));
+
+  hobject_t hoid;
+  ECUtil::shard_extent_set_t to_read_list(s.get_k_plus_m());
+  
+  for (shard_id_t i; i < k; ++i) {
+    to_read_list[i].insert(int(i) * 2 * align_size, align_size);
+  }
+
+  ECCommon::read_request_t read_request(to_read_list, false, object_size);
+  int r = pipeline.get_min_avail_to_read_shards(hoid, false, false, read_request);
+  
+  ASSERT_NE(r, 0) << "Should fail when insufficient shards available";
+}
+
+TEST(ECCommon, get_min_avail_to_read_shards_zones_redundant_reads) {
+  // Test redundant reads with zones enabled
+  const uint64_t align_size = EC_ALIGN_SIZE;
+  const uint64_t swidth = 64*align_size;
+  const unsigned int k = 4;
+  const unsigned int m = 2;
+  const uint64_t object_size = swidth * 1024;
+
+  pg_pool_t pool;
+  pool.size = 12;
+  pool.opts.set(pool_opts_t::NUM_ZONES, 2);
+
+  ECUtil::stripe_info_t s(k, m, swidth, &pool);
+  ECListenerStub listenerStub;
+  
+  MockErasureCode *ecode = new MockErasureCode();
+  ErasureCodeInterfaceRef ec_impl(ecode);
+  ECCommon::ReadPipeline pipeline(g_ceph_context, ec_impl, s, &listenerStub);
+
+  // Add all local zone shards
+  for (int i = 0; i < 6; i++) {
+    listenerStub.acting_shards.insert(pg_shard_t(i, shard_id_t(i)));
+  }
+
+  hobject_t hoid;
+  ECUtil::shard_extent_set_t to_read_list(s.get_k_plus_m());
+  
+  for (shard_id_t i; i < k; ++i) {
+    to_read_list[i].insert(int(i) * 2 * align_size, align_size);
+  }
+
+  ECCommon::read_request_t read_request(to_read_list, false, object_size);
+  // Enable redundant reads
+  int r = pipeline.get_min_avail_to_read_shards(hoid, false, true, read_request);
+  
+  ASSERT_EQ(r, 0);
+  
+  // With redundant reads, should read from all available shards
+  ASSERT_EQ(read_request.shard_reads.size(), 6u) 
+    << "Redundant reads should use all available shards";
+}
+
+TEST(ECCommon, get_min_avail_to_read_shards_zones_recovery_mode) {
+  // Test recovery mode with zones
+  const uint64_t align_size = EC_ALIGN_SIZE;
+  const uint64_t swidth = 64*align_size;
+  const unsigned int k = 4;
+  const unsigned int m = 2;
+  const uint64_t object_size = swidth * 1024;
+
+  pg_pool_t pool;
+  pool.size = 12;
+  pool.opts.set(pool_opts_t::NUM_ZONES, 2);
+
+  ECUtil::stripe_info_t s(k, m, swidth, &pool);
+  ECListenerStub listenerStub;
+  
+  MockErasureCode *ecode = new MockErasureCode();
+  ErasureCodeInterfaceRef ec_impl(ecode);
+  ECCommon::ReadPipeline pipeline(g_ceph_context, ec_impl, s, &listenerStub);
+
+  // Add shards from both zones
+  for (int i = 0; i < 12; i++) {
+    listenerStub.acting_shards.insert(pg_shard_t(i, shard_id_t(i)));
+  }
+
+  hobject_t hoid;
+  ECUtil::shard_extent_set_t to_read_list(s.get_k_plus_m());
+  
+  for (shard_id_t i; i < k; ++i) {
+    to_read_list[i].insert(int(i) * 2 * align_size, align_size);
+  }
+
+  ECCommon::read_request_t read_request(to_read_list, false, object_size);
+  // Enable recovery mode (for_recovery = true)
+  int r = pipeline.get_min_avail_to_read_shards(hoid, true, false, read_request);
+  
+  ASSERT_EQ(r, 0);
+  
+  // In recovery mode, should still prefer local zone
+  for (auto &[shard_id, shard_read] : read_request.shard_reads) {
+    ASSERT_LT(int(shard_id), 6) << "Recovery should prefer local zone";
+  }
+}
+
+TEST(ECCommon, get_min_avail_to_read_shards_zones_mixed_availability) {
+  // Test with mixed shard availability across zones
+  const uint64_t align_size = EC_ALIGN_SIZE;
+  const uint64_t swidth = 64*align_size;
+  const unsigned int k = 4;
+  const unsigned int m = 2;
+  const uint64_t object_size = swidth * 1024;
+
+  pg_pool_t pool;
+  pool.size = 12;
+  pool.opts.set(pool_opts_t::NUM_ZONES, 2);
+
+  ECUtil::stripe_info_t s(k, m, swidth, &pool);
+  ECListenerStub listenerStub;
+  
+  MockErasureCode *ecode = new MockErasureCode();
+  ErasureCodeInterfaceRef ec_impl(ecode);
+  ECCommon::ReadPipeline pipeline(g_ceph_context, ec_impl, s, &listenerStub);
+
+  // Add some shards from local zone (0, 2, 4) and some from remote (7, 9, 11)
+  listenerStub.acting_shards.insert(pg_shard_t(0, shard_id_t(0)));
+  listenerStub.acting_shards.insert(pg_shard_t(2, shard_id_t(2)));
+  listenerStub.acting_shards.insert(pg_shard_t(4, shard_id_t(4)));
+  listenerStub.acting_shards.insert(pg_shard_t(7, shard_id_t(7)));
+  listenerStub.acting_shards.insert(pg_shard_t(9, shard_id_t(9)));
+  listenerStub.acting_shards.insert(pg_shard_t(11, shard_id_t(11)));
+
+  hobject_t hoid;
+  ECUtil::shard_extent_set_t to_read_list(s.get_k_plus_m());
+  
+  for (shard_id_t i; i < k; ++i) {
+    to_read_list[i].insert(int(i) * 2 * align_size, align_size);
+  }
+
+  ECCommon::read_request_t read_request(to_read_list, false, object_size);
+  int r = pipeline.get_min_avail_to_read_shards(hoid, false, false, read_request);
+  
+  ASSERT_EQ(r, 0);
+  
+  // Should use a mix, but prefer local when possible
+  int remote_count = 0;
+  for (auto &[shard_id, shard_read] : read_request.shard_reads) {
+    if (int(shard_read.pg_shard.shard) >= 6) {
+      remote_count++;
+    }
+  }
+  
+  // Should have used some remote shards since local doesn't have enough
+  ASSERT_GT(remote_count, 0) << "Should use remote shards when local insufficient";
 }

--- a/src/test/osd/TestECFailoverWithPeering.cc
+++ b/src/test/osd/TestECFailoverWithPeering.cc
@@ -38,10 +38,158 @@ public:
     ec_plugin = config.ec_plugin;
     ec_technique = config.ec_technique;
     pool_flags = config.pool_flags;
+    num_zones = config.num_zones;
   }
   
   void SetUp() override {
     ECPeeringTestFixture::SetUp();
+  }
+
+  /**
+   * Helper method to run zone recovery test with specified zone failure order.
+   *
+   * @param first_zone_to_fail The zone to fail first (0 or 1)
+   * @param obj_name_suffix Suffix for the object name to make it unique
+   */
+  void run_zone_recovery_test(int first_zone_to_fail, const std::string& obj_name_suffix) {
+    int second_zone_to_fail = 1 - first_zone_to_fail;  // The other zone
+
+    std::cout << "\n=== Testing zone-level recovery (failing zone "
+              << first_zone_to_fail << " first, then zone "
+              << second_zone_to_fail << ") ===" << std::endl;
+
+    const std::string obj_name = "test_zone_recovery_" + obj_name_suffix;
+    const size_t data_size = stripe_unit * k;  // One full stripe
+    std::string pattern_a(data_size, 'A');
+    std::string pattern_b(data_size, 'B');
+
+    // Step 1: Create and write object with pattern A
+    std::cout << "Step 1: Writing pattern A" << std::endl;
+    create_and_write_verify(obj_name, pattern_a);
+
+    // Step 2: Fail all OSDs in the first zone
+    std::cout << "Step 2: Failing all OSDs in zone " << first_zone_to_fail << std::endl;
+    std::vector<int> first_zone_osds;
+    int first_zone_start = first_zone_to_fail * (k + m);
+    int first_zone_end = first_zone_start + (k + m);
+    for (int i = first_zone_start; i < first_zone_end; i++) {
+      first_zone_osds.push_back(i);
+    }
+    mark_osds_down(first_zone_osds);
+
+    // When we fail a zone, we must reduce min_size by (k+m)
+    // Original min_size = num_zones * (k+m) - m
+    // After one zone fails: min_size = (num_zones-1) * (k+m) - m
+    unsigned new_min_size = (num_zones - 1) * (k + m) - m;
+    std::cout << "  Reducing min_size to " << new_min_size
+              << " after zone " << first_zone_to_fail << " failure" << std::endl;
+    set_pool_min_size(new_min_size);
+
+    // Verify the primary has changed (should be from the second zone)
+    int new_primary_after_first_fail = get_primary_shard_from_osdmap();
+    int second_zone_start = second_zone_to_fail * (k + m);
+    int second_zone_end = second_zone_start + (k + m);
+    ASSERT_GE(new_primary_after_first_fail, second_zone_start)
+      << "New primary should be from zone " << second_zone_to_fail
+      << " (>= " << second_zone_start << ") after zone " << first_zone_to_fail << " failure";
+    ASSERT_LT(new_primary_after_first_fail, second_zone_end)
+      << "New primary should be from zone " << second_zone_to_fail
+      << " (< " << second_zone_end << ") after zone " << first_zone_to_fail << " failure";
+
+    // Step 3: Write and verify pattern B (with first zone down)
+    std::cout << "Step 3: Writing pattern B with zone " << first_zone_to_fail << " down" << std::endl;
+    write_verify(obj_name, 0, pattern_b, data_size);
+
+    // Step 4: Un-fail all OSDs in the first zone (bring them back up)
+    std::cout << "Step 4: Bringing zone " << first_zone_to_fail << " OSDs back up" << std::endl;
+    for (int osd : first_zone_osds) {
+      mark_osd_up(osd);
+    }
+
+    // Step 5: Run recovery
+    // After bringing the first zone back up, the OSDs should be marked as having missing objects
+    std::cout << "Step 5: Running recovery" << std::endl;
+
+    // Get the current primary (should still be from the second zone or could have changed)
+    int current_primary = get_primary_shard_from_osdmap();
+    ASSERT_GE(current_primary, 0) << "Should have a valid primary";
+
+    auto primary_ps = get_peering_state(current_primary);
+
+    // Ensure the PG is active before checking peer_missing
+    ASSERT_TRUE(primary_ps->is_active())
+      << "Primary should be active before checking peer_missing. State: "
+      << primary_ps->get_current_state();
+
+    const auto& peer_missing_map = primary_ps->get_peer_missing();
+
+    // Debug: Print peer_missing_map contents
+    std::cout << "  peer_missing_map has " << peer_missing_map.size() << " entries:" << std::endl;
+    for (const auto& [shard, missing] : peer_missing_map) {
+      std::cout << "    OSD " << shard.osd << ": " << missing.num_missing() << " missing objects" << std::endl;
+    }
+
+    // Verify that first zone OSDs have the object missing
+    hobject_t hoid = make_test_object(obj_name);
+    bool found_missing = false;
+    std::vector<int> osds_with_missing;
+
+    for (int first_zone_osd : first_zone_osds) {
+      pg_shard_t first_zone_shard(first_zone_osd, shard_id_t(first_zone_osd));
+      auto peer_missing_it = peer_missing_map.find(first_zone_shard);
+      if (peer_missing_it != peer_missing_map.end()) {
+        const pg_missing_t& peer_missing = peer_missing_it->second;
+        std::cout << "  Checking OSD " << first_zone_osd << " for object " << hoid << std::endl;
+        if (peer_missing.is_missing(hoid)) {
+          found_missing = true;
+          osds_with_missing.push_back(first_zone_osd);
+          std::cout << "  OSD " << first_zone_osd << " is missing the object" << std::endl;
+        } else {
+          std::cout << "  OSD " << first_zone_osd << " is NOT missing the object" << std::endl;
+        }
+      } else {
+        std::cout << "  OSD " << first_zone_osd << " not in peer_missing_map" << std::endl;
+      }
+    }
+    ASSERT_TRUE(found_missing)
+      << "At least one zone " << first_zone_to_fail
+      << " OSD should have the object missing after coming back up";
+
+    // Get the first OSD with missing object to use for recovery
+    int first_missing_osd = osds_with_missing[0];
+    std::cout << "  Using OSD " << first_missing_osd << " as the recovery target" << std::endl;
+
+    // Use the fixture helper to run recovery and verify callbacks
+    // This will recover the object to all missing OSDs in the first zone
+    run_recovery_and_verify_callbacks(obj_name, first_missing_osd, pattern_b);
+
+    // Step 6: Verify data is readable after recovery
+    std::cout << "Step 6: Verifying data after recovery" << std::endl;
+
+    // Step 7: Fail all OSDs in the second zone
+    std::cout << "Step 7: Failing all OSDs in zone " << second_zone_to_fail << std::endl;
+    std::vector<int> second_zone_osds;
+    for (int i = second_zone_start; i < second_zone_end; i++) {
+      second_zone_osds.push_back(i);
+    }
+    mark_osds_down(second_zone_osds);
+
+    // Verify the primary has changed back to the first zone
+    int new_primary_after_second_fail = get_primary_shard_from_osdmap();
+    ASSERT_GE(new_primary_after_second_fail, first_zone_start)
+      << "New primary should be from zone " << first_zone_to_fail
+      << " (>= " << first_zone_start << ") after zone " << second_zone_to_fail << " failure";
+    ASSERT_LT(new_primary_after_second_fail, first_zone_end)
+      << "New primary should be from zone " << first_zone_to_fail
+      << " (< " << first_zone_end << ") after zone " << second_zone_to_fail << " failure";
+
+    // Step 8: Read data - should again read pattern B (from recovered first zone)
+    std::cout << "Step 8: Reading data with zone " << second_zone_to_fail
+              << " down (from recovered zone " << first_zone_to_fail << ")" << std::endl;
+    verify_object(obj_name, pattern_b, 0, pattern_b.length());
+
+    std::cout << "=== Zone-level recovery test (zone " << first_zone_to_fail
+              << " first) completed successfully ===" << std::endl;
   }
 };
 
@@ -51,15 +199,15 @@ TEST_P(TestECFailoverWithPeering, BasicPeeringCycle) {
   int acting_primary = -1;
   osdmap->pg_to_acting_osds(pgid, &acting_osds, &acting_primary);
   
-  EXPECT_TRUE(get_peering_state(acting_primary)->is_clean())
+  ASSERT_TRUE(get_peering_state(acting_primary)->is_clean())
     << "Primary should be clean after peering";
   
   // Verify primary is shard 0
-  EXPECT_TRUE(get_peering_listener(0)->backend_listener->pgb_is_primary())
+  ASSERT_TRUE(get_peering_listener(0)->backend_listener->pgb_is_primary())
     << "Shard 0 should be primary";
   
   for (int i = 1; i < k + m; i++) {
-    EXPECT_FALSE(get_peering_listener(i)->backend_listener->pgb_is_primary())
+    ASSERT_FALSE(get_peering_listener(i)->backend_listener->pgb_is_primary())
       << "Shard " << i << " should not be primary";
   }
 }
@@ -72,7 +220,7 @@ TEST_P(TestECFailoverWithPeering, WriteWithPeering) {
   create_and_write_verify(obj_name, test_data);
 
   auto* primary_ps = get_peering_state(0);
-  EXPECT_GT(primary_ps->get_pg_log().get_log().log.size(), 0)
+  ASSERT_GT(primary_ps->get_pg_log().get_log().log.size(), 0)
     << "Primary should have log entries after write";
 }
 
@@ -90,7 +238,7 @@ TEST_P(TestECFailoverWithPeering, OSDFailureWithPeering) {
   event_loop->reset_stats();
   bufferlist pre_failover_read;
   verify_object(obj_name, test_data_read, 0, object_size);
-  EXPECT_EQ(4, event_loop->get_stats_by_type().at(EventLoop::EventType::OSD_MESSAGE));
+  ASSERT_EQ(4, event_loop->get_stats_by_type().at(EventLoop::EventType::OSD_MESSAGE));
 
   // Use fixture helper to mark OSD as down
   mark_osd_down(failed_osd);
@@ -98,7 +246,7 @@ TEST_P(TestECFailoverWithPeering, OSDFailureWithPeering) {
   // Reset EventLoop stats before post-failover read
   event_loop->reset_stats();
   verify_object(obj_name, test_data_read, 0, object_size);
-  EXPECT_EQ(k * 2, event_loop->get_stats_by_type().at(EventLoop::EventType::OSD_MESSAGE));
+  ASSERT_EQ(k * 2, event_loop->get_stats_by_type().at(EventLoop::EventType::OSD_MESSAGE));
 }
 
 TEST_P(TestECFailoverWithPeering, PrimaryFailoverWithPeering) {
@@ -121,25 +269,25 @@ TEST_P(TestECFailoverWithPeering, PrimaryFailoverWithPeering) {
   // For a non-optimized pool, it would be shard 1
   const pg_pool_t& pool = get_pool();
   if (pool.allows_ecoptimizations()) {
-    EXPECT_GE(new_primary_shard, k)
+    ASSERT_GE(new_primary_shard, k)
       << "New primary should be a coding shard (>= k) for optimized pool";
   } else {
-    EXPECT_EQ(new_primary_shard, 1)
+    ASSERT_EQ(new_primary_shard, 1)
       << "New primary should be shard 1 for non-optimized pool";
   }
   
-  EXPECT_TRUE(get_peering_listener(new_primary_shard)->backend_listener->pgb_is_primary())
+  ASSERT_TRUE(get_peering_listener(new_primary_shard)->backend_listener->pgb_is_primary())
     << "Shard " << new_primary_shard << " should be new primary";
   
-  EXPECT_FALSE(get_peering_listener(0)->backend_listener->pgb_is_primary())
+  ASSERT_FALSE(get_peering_listener(0)->backend_listener->pgb_is_primary())
     << "Failed shard should not be primary";
   
   std::string state = get_state_name(new_primary_shard);
-  EXPECT_TRUE(state.find("Active") != std::string::npos)
+  ASSERT_TRUE(state.find("Active") != std::string::npos)
     << "New primary should be Active after failover, got: " << state;
   
   // Verify the PG reached Active state
-  EXPECT_TRUE(get_peering_state(new_primary_shard)->is_active())
+  ASSERT_TRUE(get_peering_state(new_primary_shard)->is_active())
     << "New primary should be in Active state";
   
   // Verify reads work after primary failover (with EC reconstruction)
@@ -147,11 +295,11 @@ TEST_P(TestECFailoverWithPeering, PrimaryFailoverWithPeering) {
 }
 
 TEST_P(TestECFailoverWithPeering, MultipleOSDFailuresWithPeering) {
-  // This test only runs for configurations with m=2
-  if (m != 2) {
-    GTEST_SKIP() << "MultipleOSDFailuresWithPeering only runs for m=2";
+  // This test only runs for configurations with m=2 and num_zones=1
+  if (m != 2 || num_zones != 1) {
+    GTEST_SKIP() << "MultipleOSDFailuresWithPeering only runs for m=2, num_zones=1";
   }
-  
+
   ASSERT_TRUE(all_shards_active()) << "Initial peering must complete";
   
   const std::string obj_name = "test_multiple_failures";
@@ -168,13 +316,13 @@ TEST_P(TestECFailoverWithPeering, MultipleOSDFailuresWithPeering) {
   
   auto* primary_ps = get_peering_state(0);
   for (int failed_osd : failed_osds) {
-    EXPECT_TRUE(primary_ps->get_acting_recovery_backfill().count(
+    ASSERT_TRUE(primary_ps->get_acting_recovery_backfill().count(
       pg_shard_t(failed_osd, shard_id_t(failed_osd))) == 0)
       << "Failed OSD " << failed_osd << " should not be in acting set";
   }
   
   std::string primary_state = get_state_name(0);
-  EXPECT_TRUE(primary_state.find("Peering") != std::string::npos ||
+  ASSERT_TRUE(primary_state.find("Peering") != std::string::npos ||
               primary_state.find("Active") != std::string::npos ||
               primary_state.find("Recovery") != std::string::npos)
     << "Primary should be operational, got: " << primary_state;
@@ -190,16 +338,16 @@ TEST_P(TestECFailoverWithPeering, RecoveryWithPeering) {
   const std::string obj2_data = "Second object data for recovery test";
   
   int result = create_and_write(obj1_name, obj1_data);
-  EXPECT_EQ(result, 0) << "First pre-failure write should complete";
+  ASSERT_EQ(result, 0) << "First pre-failure write should complete";
   
   result = create_and_write(obj2_name, obj2_data);
-  EXPECT_EQ(result, 0) << "Second pre-failure write should complete";
+  ASSERT_EQ(result, 0) << "Second pre-failure write should complete";
   
-  EXPECT_TRUE(all_shards_clean()) << "All shards should be clean before recovery test";
+  ASSERT_TRUE(all_shards_clean()) << "All shards should be clean before recovery test";
   
   auto* primary_ps = get_peering_state(0);
   eversion_t pre_failure_log_head = primary_ps->get_pg_log().get_log().head;
-  EXPECT_GT(pre_failure_log_head.version, 0u)
+  ASSERT_GT(pre_failure_log_head.version, 0u)
     << "Primary should have log entries before failure";
   
   int failed_osd = k - 1;  // Last data shard
@@ -218,24 +366,24 @@ TEST_P(TestECFailoverWithPeering, RecoveryWithPeering) {
   bufferlist obj1_read;
   int read_result = read_object(obj1_name, 0, obj1_data.length(),
                                 obj1_read, obj1_data.length());
-  EXPECT_GE(read_result, 0) << "First object should be readable after OSD failure";
+  ASSERT_GE(read_result, 0) << "First object should be readable after OSD failure";
   ASSERT_EQ(obj1_read.length(), obj1_data.length())
     << "First object read length should match after failure";
   {
     std::string read_str(obj1_read.c_str(), obj1_read.length());
-    EXPECT_EQ(read_str, obj1_data)
+    ASSERT_EQ(read_str, obj1_data)
       << "First object data should be correct after OSD failure (EC reconstruction)";
   }
   
   bufferlist obj2_read;
   read_result = read_object(obj2_name, 0, obj2_data.length(),
                             obj2_read, obj2_data.length());
-  EXPECT_GE(read_result, 0) << "Second object should be readable after OSD failure";
+  ASSERT_GE(read_result, 0) << "Second object should be readable after OSD failure";
   ASSERT_EQ(obj2_read.length(), obj2_data.length())
     << "Second object read length should match after failure";
   {
     std::string read_str(obj2_read.c_str(), obj2_read.length());
-    EXPECT_EQ(read_str, obj2_data)
+    ASSERT_EQ(read_str, obj2_data)
       << "Second object data should be correct after OSD failure (EC reconstruction)";
   }
   
@@ -243,41 +391,91 @@ TEST_P(TestECFailoverWithPeering, RecoveryWithPeering) {
   const std::string post_recovery_data = "Data written after OSD failure and recovery";
   
   result = create_and_write(post_recovery_obj, post_recovery_data);
-  EXPECT_EQ(result, 0) << "Write after OSD failure should complete successfully";
+  ASSERT_EQ(result, 0) << "Write after OSD failure should complete successfully";
   
   bufferlist post_recovery_read;
   read_result = read_object(post_recovery_obj, 0, post_recovery_data.length(),
                             post_recovery_read, post_recovery_data.length());
-  EXPECT_GE(read_result, 0) << "Post-recovery object should be readable";
+  ASSERT_GE(read_result, 0) << "Post-recovery object should be readable";
   ASSERT_EQ(post_recovery_read.length(), post_recovery_data.length())
     << "Post-recovery read length should match";
   {
     std::string read_str(post_recovery_read.c_str(), post_recovery_read.length());
-    EXPECT_EQ(read_str, post_recovery_data)
+    ASSERT_EQ(read_str, post_recovery_data)
       << "Post-recovery data should match what was written";
   }
   
   eversion_t post_recovery_log_head = primary_ps->get_pg_log().get_log().head;
-  EXPECT_GT(post_recovery_log_head.version, pre_failure_log_head.version)
+  ASSERT_GT(post_recovery_log_head.version, pre_failure_log_head.version)
     << "Primary PG log head should advance after post-recovery write";
   
   // Even though the OSD is "down", its PeeringState still holds the log
   // from before it went down.
   auto* failed_ps = get_peering_state(failed_osd);
-  EXPECT_TRUE(failed_ps != nullptr) << "Failed OSD's PeeringState should still exist";
+  ASSERT_TRUE(failed_ps != nullptr) << "Failed OSD's PeeringState should still exist";
   
   size_t primary_log_size = primary_ps->get_pg_log().get_log().log.size();
   size_t failed_log_size = failed_ps->get_pg_log().get_log().log.size();
-  EXPECT_LE(failed_log_size, primary_log_size)
+  ASSERT_LE(failed_log_size, primary_log_size)
     << "Failed OSD's PG log size should not exceed primary's log size";
   // The primary wrote 3 objects (obj1, obj2, post_recovery_obj), so its log must be non-empty.
-  EXPECT_GT(primary_log_size, 0u)
+  ASSERT_GT(primary_log_size, 0u)
     << "Primary PG log should have entries after 3 writes";
   
   auto* listener_ptr = get_peering_listener(0);
-  EXPECT_TRUE(listener_ptr != nullptr) << "Peering listener should exist";
-  EXPECT_TRUE(listener_ptr->activate_complete_called)
+  ASSERT_TRUE(listener_ptr != nullptr) << "Peering listener should exist";
+  ASSERT_TRUE(listener_ptr->activate_complete_called)
     << "on_activate_complete should have been called during peering";
+}
+TEST_P(TestECFailoverWithPeering, MultiZoneFailoverWithPeering) {
+  const auto& config = GetParam();
+
+  // Skip test if zones are not configured or only one zone
+  if (config.num_zones <= 1) {
+    GTEST_SKIP() << "MultiZoneFailoverWithPeering test requires num_zones > 1";
+  }
+
+  ASSERT_TRUE(all_shards_active()) << "Initial peering must complete";
+
+  const std::string obj_name = "test_multizone_failover";
+  const std::string test_data = "Data for multi-zone failover test";
+
+  // Write data before failure and verify
+  create_and_write_verify(obj_name, test_data);
+
+  // Fail the first k+m OSDs (entire first zone)
+  // With num_zones=2 and k=4, m=2, we have 12 total OSDs
+  // Failing the first 6 (k+m) simulates losing an entire zone
+  std::vector<int> failed_osds;
+  for (int i = 0; i < k + m; i++) {
+    failed_osds.push_back(i);
+  }
+
+  // Use fixture helper to mark multiple OSDs as down
+  mark_osds_down(failed_osds);
+
+  // Verify the primary has changed (OSD 0 was in the failed zone)
+  int new_primary_shard = get_primary_shard_from_osdmap();
+  ASSERT_GE(new_primary_shard, k + m)
+    << "New primary should be from the second zone (>= k+m)";
+
+  auto* primary_ps = get_peering_state(new_primary_shard);
+  for (int failed_osd : failed_osds) {
+    ASSERT_TRUE(primary_ps->get_acting_recovery_backfill().count(
+      pg_shard_t(failed_osd, shard_id_t(failed_osd))) == 0)
+      << "Failed OSD " << failed_osd << " should not be in acting set";
+  }
+
+  std::string primary_state = get_state_name(new_primary_shard);
+  ASSERT_TRUE(primary_state.find("Peering") != std::string::npos ||
+              primary_state.find("Active") != std::string::npos ||
+              primary_state.find("Recovery") != std::string::npos)
+    << "New primary should be operational, got: " << primary_state;
+
+  // Perform degraded read after failover
+  // With 2 zones of k=4,m=2 each, losing one zone (6 OSDs) leaves us with
+  // 6 remaining OSDs, which is exactly k+m and sufficient for EC reconstruction
+  verify_object(obj_name, test_data, 0, test_data.length());
 }
 
 // ---------------------------------------------------------------------------
@@ -297,18 +495,21 @@ namespace {
  */
 const std::vector<BackendConfig> kECPeeringConfigs = {
   // ISA plugin with optimizations (modern EC)
-  {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  4, 2, "EC_ISA_Opt_k4m2_su4k"},
-  {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  8192,  4, 2, "EC_ISA_Opt_k4m2_su8k"},
-  {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  16384, 4, 2, "EC_ISA_Opt_k4m2_su16k"},
-  {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  2, 1, "EC_ISA_Opt_k2m1_su4k"},
-  {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  8, 3, "EC_ISA_Opt_k8m3_su4k"},
-  
+  {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  4, 2, 1, "EC_ISA_Opt_k4m2_su4k"},
+  {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  8192,  4, 2, 1, "EC_ISA_Opt_k4m2_su8k"},
+  {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  16384, 4, 2, 1, "EC_ISA_Opt_k4m2_su16k"},
+  {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  2, 1, 1, "EC_ISA_Opt_k2m1_su4k"},
+  {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  8, 3, 1, "EC_ISA_Opt_k8m3_su4k"},
+
   // Jerasure plugin with optimizations (modern EC)
-  {PGBackendTestFixture::EC, "jerasure", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  4, 2, "EC_Jerasure_Opt_k4m2_su4k"},
-  {PGBackendTestFixture::EC, "jerasure", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  8192,  4, 2, "EC_Jerasure_Opt_k4m2_su8k"},
-  {PGBackendTestFixture::EC, "jerasure", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  16384, 4, 2, "EC_Jerasure_Opt_k4m2_su16k"},
-  {PGBackendTestFixture::EC, "jerasure", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  2, 1, "EC_Jerasure_Opt_k2m1_su4k"},
-  {PGBackendTestFixture::EC, "jerasure", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  8, 3, "EC_Jerasure_Opt_k8m3_su4k"},
+  {PGBackendTestFixture::EC, "jerasure", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  4, 2, 1, "EC_Jerasure_Opt_k4m2_su4k"},
+  {PGBackendTestFixture::EC, "jerasure", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  8192,  4, 2, 1, "EC_Jerasure_Opt_k4m2_su8k"},
+  {PGBackendTestFixture::EC, "jerasure", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  16384, 4, 2, 1, "EC_Jerasure_Opt_k4m2_su16k"},
+  {PGBackendTestFixture::EC, "jerasure", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  2, 1, 1, "EC_Jerasure_Opt_k2m1_su4k"},
+  {PGBackendTestFixture::EC, "jerasure", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  8, 3, 1, "EC_Jerasure_Opt_k8m3_su4k"},
+
+  // Multi-zone configuration (num_zones = 2)
+  {PGBackendTestFixture::EC, "isa", "reed_sol_van", pg_pool_t::FLAG_EC_OVERWRITES | pg_pool_t::FLAG_EC_OPTIMIZATIONS,  4096,  4, 2, 2, "EC_ISA_Opt_k4m2_zones2"},
 };
 
 }  // namespace
@@ -351,10 +552,10 @@ TEST_P(
   mark_osd_down(failing_shard);
   unsuspend_primary_to_osd(blocked_shard);
   event_loop->run_until_idle();
-  
+
   // Ensure all shards have completed peering and applied rollback transactions
   ASSERT_TRUE(all_shards_active()) << "All shards should be active after peering";
-  
+
   verify_object(obj_name, pattern_a, 0, pattern_a.length());
 
   std::cout << "\n=== RollbackAfterOSDFailure Test Complete ===" << std::endl;
@@ -376,10 +577,16 @@ TEST_P(
 TEST_P(TestECFailoverWithPeering, ECRecoveryTest) {
   ASSERT_TRUE(all_shards_active()) << "Initial peering must complete";
 
+  // Determine which OSDs to test based on num_zones
   std::vector<int> osds_to_test;
   osds_to_test.push_back(1); // Non-primary
   osds_to_test.push_back(0); // Primary
   osds_to_test.push_back(k); // First coding shard
+
+  if (num_zones > 1) {
+    osds_to_test.push_back(k + m + 1);  // k + m + 1
+    osds_to_test.push_back(2 * k + m);  // 2k + m
+  }
 
   // Run the test for each OSD
   for (int removed_osd : osds_to_test) {
@@ -417,16 +624,18 @@ TEST_P(TestECFailoverWithPeering, ECRecoveryTest) {
  * this test performs a new write to the same object on each cycle.
  */
 TEST_P(TestECFailoverWithPeering, ECSequentialOSDFailoverTest) {
+  std::cout << "\n=== Sequential OSD failover test completed successfully ===" << std::endl;
+
   ASSERT_TRUE(all_shards_active()) << "Initial peering must complete";
 
   const std::string obj_name = "test_sequential_failover";
   const size_t data_size = stripe_unit * k;  // One full stripe
 
   // Calculate total number of OSDs to test
-  int total_osds = (k + m);
+  int total_osds = (k + m) * num_zones;
 
   std::cout << "\n=== Testing sequential OSD failover for " << total_osds
-            << " OSDs (k=" << k << ", m=" << m << ") ===" << std::endl;
+            << " OSDs (k=" << k << ", m=" << m << ", zones=" << num_zones << ") ===" << std::endl;
 
   // Create object with initial pattern
   std::string initial_pattern(data_size, 'A');
@@ -441,8 +650,6 @@ TEST_P(TestECFailoverWithPeering, ECSequentialOSDFailoverTest) {
     mark_osd_up(osd_to_fail);
     run_recovery_and_verify_callbacks(obj_name, osd_to_fail, cycle_pattern);
   }
-
-  std::cout << "\n=== Sequential OSD failover test completed successfully ===" << std::endl;
 }
 
 /**
@@ -805,6 +1012,183 @@ TEST_P(
   // Now run the recovery - the target shard asserts it is being written with
   // the object version it is expecting. In the defect, this assert failed.
   run_recovery_and_verify_callbacks(obj_name, recovery_target_shard, pattern_p1);
+}
+
+/**
+ * ECZoneRecoveryTest - Test zone-level EC recovery scenario (zone 0 fails first)
+ *
+ * This test verifies the EC recovery mechanism at the zone level by:
+ * 1. Writing and verifying an object with pattern A
+ * 2. Failing all OSDs in zone 0 (simulating zone failure)
+ * 3. Writing and verifying pattern B (overwrite with zone 0 down)
+ * 4. Bringing zone 0 OSDs back up
+ * 5. Running recovery to sync zone 0 with the new data
+ * 6. Reading data - should get pattern B (latest write)
+ * 7. Failing all OSDs in zone 1
+ * 8. Reading data again - should still get pattern B (from recovered zone 0)
+ *
+ * This test only runs for multi-zone configurations (num_zones > 1).
+ */
+TEST_P(TestECFailoverWithPeering, ECZoneRecoveryTest) {
+  // Skip test if zones are not configured or only one zone
+  if (num_zones <= 1) {
+    GTEST_SKIP() << "ECZoneRecoveryTest requires num_zones > 1";
+  }
+
+  ASSERT_TRUE(all_shards_active()) << "Initial peering must complete";
+
+  // Run test with zone 0 failing first
+  run_zone_recovery_test(0, "zone0_first");
+}
+
+/**
+ * ECZoneRecoveryTestReverse - Test zone-level EC recovery scenario (zone 1 fails first)
+ *
+ * This test verifies the EC recovery mechanism at the zone level by:
+ * 1. Writing and verifying an object with pattern A
+ * 2. Failing all OSDs in zone 1 (simulating zone failure)
+ * 3. Writing and verifying pattern B (overwrite with zone 1 down)
+ * 4. Bringing zone 1 OSDs back up
+ * 5. Running recovery to sync zone 1 with the new data
+ * 6. Reading data - should get pattern B (latest write)
+ * 7. Failing all OSDs in zone 0
+ * 8. Reading data again - should still get pattern B (from recovered zone 1)
+ *
+ * This test only runs for multi-zone configurations (num_zones > 1).
+ */
+TEST_P(TestECFailoverWithPeering, ECZoneRecoveryTestReverse) {
+  // Skip test if zones are not configured or only one zone
+  if (num_zones <= 1) {
+    GTEST_SKIP() << "ECZoneRecoveryTestReverse requires num_zones > 1";
+  }
+
+  ASSERT_TRUE(all_shards_active()) << "Initial peering must complete";
+
+  // Run test with zone 1 failing first (opposite order)
+  run_zone_recovery_test(1, "zone1_first");
+}
+
+/**
+ * ECMinAvailableTest - Test minimum available shards for PG activation
+ *
+ * This test verifies that a PG does not go active when too many shards
+ * are offline, even across multiple zones. The test:
+ * 1. Writes an object
+ * 2. Takes m shards offline in zone 0, starting at shard 1
+ * 3. Takes an additional shard offline in zone 0 - PG should NOT go active
+ * 4. Takes shard k+m+1 offline (from zone 1)
+ * 5. Brings back shard 1
+ * 6. Asserts there is no recovery scheduled
+ *
+ * This test only runs for multi-zone configurations (num_zones > 1).
+ */
+TEST_P(TestECFailoverWithPeering, ECMinAvailableTest) {
+  // Skip test if zones are not configured or only one zone
+  if (num_zones <= 1) {
+    GTEST_SKIP() << "ECMinAvailableTest requires num_zones > 1";
+  }
+
+  ASSERT_TRUE(all_shards_active()) << "Initial peering must complete";
+
+  const std::string obj_name = "test_min_available";
+  const size_t data_size = stripe_unit * k;  // One full stripe
+  std::string test_data(data_size, 'X');
+
+  // Get min_size from the pool
+  const pg_pool_t* pool = osdmap->get_pg_pool(pool_id);
+  ASSERT_NE(pool, nullptr);
+  unsigned int min_size = pool->min_size;
+
+  std::cout << "\n=== Testing minimum available shards (k=" << k
+            << ", m=" << m << ", zones=" << num_zones
+            << ", min_size=" << min_size << ") ===" << std::endl;
+
+  // Step 1: Write an object
+  std::cout << "Step 1: Writing object" << std::endl;
+  create_and_write_verify(obj_name, test_data);
+
+  // Step 2: Take m shards offline in zone 0, starting at shard 1
+  std::cout << "Step 2: Taking " << m << " shards offline in zone 0, starting at shard 1" << std::endl;
+  std::vector<int> failed_shards_zone0;
+  for (int i = 1; i <= m; i++) {
+    failed_shards_zone0.push_back(i);
+  }
+  mark_osds_down(failed_shards_zone0);
+
+  // With min_size = num_zones * (k+m) - m, we now have num_zones * (k+m) - m shards available
+  // which is exactly min_size, so PG should still be active
+  ASSERT_TRUE(all_shards_active())
+    << "PG should still be active with " << m << " shards down in zone 0";
+
+  // Step 3: Take an additional shard offline in zone 0
+  int additional_shard_zone0 = m + 1;  // Next shard after the m we already failed
+  std::cout << "Step 3: Taking additional shard " << additional_shard_zone0
+            << " offline in zone 0" << std::endl;
+  mark_osd_down(additional_shard_zone0);
+
+  // Now we have m+1 shards down, leaving num_zones * (k+m) - (m+1) shards
+  // which is less than min_size, so PG should NOT be active
+  std::cout << "Step 3: Checking that PG is NOT active" << std::endl;
+  ASSERT_FALSE(all_shards_active())
+    << "PG should NOT be active with " << (m + 1) << " shards down in zone 0";
+
+  // Step 4: Take shard k+m+1 offline (first shard in zone 1, after shard k+m which is zone 0's last)
+  int shard_zone1 = k + m + 1;
+  std::cout << "Step 4: Taking shard " << shard_zone1 << " offline (zone 1)" << std::endl;
+  mark_osd_down(shard_zone1);
+
+  // PG should still not be active
+  ASSERT_FALSE(all_shards_active())
+    << "PG should still NOT be active after taking zone 1 shard offline";
+
+  // Step 5: Bring back shard 1
+  std::cout << "Step 5: Bringing shard 1 back online" << std::endl;
+  mark_osd_up(1);
+
+  // Step 6: Assert there is no recovery scheduled
+  // After bringing shard 1 back, we now have k shards in zone 0 again
+  // (shard 0, shard 1, and shards m+2 to k+m-1)
+  // The PG should become active, but since shard 1 was down during the write,
+  // it should be marked for recovery
+  std::cout << "Step 6: Checking recovery state" << std::endl;
+
+  // Get the current primary
+  int current_primary = get_primary_shard_from_osdmap();
+  ASSERT_GE(current_primary, 0) << "Should have a valid primary";
+
+  auto primary_ps = get_peering_state(current_primary);
+
+  // The PG might be active now with k shards available
+  // But we need to check if recovery is scheduled
+  if (primary_ps->is_active()) {
+    std::cout << "  PG is active" << std::endl;
+
+    // Check peer_missing to see if shard 1 has missing objects
+    const auto& peer_missing_map = primary_ps->get_peer_missing();
+
+    hobject_t hoid = make_test_object(obj_name);
+    pg_shard_t shard1(1, shard_id_t(1));
+
+    auto peer_missing_it = peer_missing_map.find(shard1);
+    if (peer_missing_it != peer_missing_map.end()) {
+      const pg_missing_t& peer_missing = peer_missing_it->second;
+      bool is_missing = peer_missing.is_missing(hoid);
+
+      std::cout << "  Shard 1 missing status for object: " << (is_missing ? "MISSING" : "NOT MISSING") << std::endl;
+
+      // Since shard 1 was down when we wrote the object, it should NOT be missing
+      // because we never successfully wrote to it in the first place
+      // Recovery should not be scheduled for objects that were never written
+      ASSERT_FALSE(is_missing)
+        << "Shard 1 should not have the object marked as missing since it was down during write";
+    } else {
+      std::cout << "  Shard 1 not in peer_missing_map (no recovery needed)" << std::endl;
+    }
+  } else {
+    std::cout << "  PG is not active yet" << std::endl;
+  }
+
+  std::cout << "=== ECMinAvailableTest completed successfully ===" << std::endl;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/test/osd/TestECUtil.cc
+++ b/src/test/osd/TestECUtil.cc
@@ -1616,3 +1616,43 @@ TEST(ECUtil, erase_after_ro_offset_single_byte)
   // Shard 1 should be empty
   ASSERT_FALSE(semap.contains_shard(shard_id_t(1)));
 }
+
+
+// Test get_base_shard and get_shard_zone
+TEST(ECUtil, get_base_shard)
+{
+  int k = 2;
+  int m = 1;
+  stripe_info_t sinfo(k, m, 4096 * k);
+  
+  // Basic: k+m=3, so shard % 3
+  ASSERT_EQ(shard_id_t(0), sinfo.get_rel_shard(shard_id_t(0)));
+  ASSERT_EQ(shard_id_t(2), sinfo.get_rel_shard(shard_id_t(2)));
+  ASSERT_EQ(shard_id_t(0), sinfo.get_rel_shard(shard_id_t(3)));
+  ASSERT_EQ(shard_id_t(1), sinfo.get_rel_shard(shard_id_t(100)));
+  
+  // Zone: shard / 3
+  ASSERT_EQ(0, sinfo.get_shard_zone(shard_id_t(2)));
+  ASSERT_EQ(1, sinfo.get_shard_zone(shard_id_t(3)));
+  ASSERT_EQ(33, sinfo.get_shard_zone(shard_id_t(100)));
+}
+
+
+
+// Verify consistency: abs_shard == zone * (k+m) + rel_shard
+TEST(ECUtil, get_shard_zone_consistency_with_get_rel_shard)
+{
+  int k = 4;
+  int m = 2;
+  int chunk_size = 4096;
+  stripe_info_t sinfo(k, m, chunk_size * k);
+
+  // Test a few examples
+  for (int shard_id = 0; shard_id < 20; shard_id++) {
+    shard_id_t abs_shard(shard_id);
+    int zone = sinfo.get_shard_zone(abs_shard);
+    shard_id_t rel_shard = sinfo.get_rel_shard(abs_shard);
+    int reconstructed = zone * sinfo.get_k_plus_m() + rel_shard.id;
+    ASSERT_EQ(shard_id, reconstructed);
+  }
+}

--- a/src/test/osd/TestOSDMap.cc
+++ b/src/test/osd/TestOSDMap.cc
@@ -3297,26 +3297,161 @@ TEST_F(OSDMapTest, pgtemp_primaryfirst) {
 	// non-primary shards last
 	ASSERT_TRUE(pool.is_nonprimary_shard(shard_id_t(encoded[osd])));
       }
-      std::cout << osd << " " << seed << " " << osdmap.pgtemp_primaryfirst(pool, pgid, shard_id_t(osd)) << std::endl;
-      // Encode and decode should be equivalent
-      ASSERT_EQ(osdmap.pgtemp_undo_primaryfirst(pool, pgid,
-		  osdmap.pgtemp_primaryfirst(pool, pgid, shard_id_t(osd))),
-		shard_id_t(osd));
-      // Shard 0 never changes, seed 62 is a special case because all the other
-      // shards are non-primary
-      if ((osd != 0) && (seed != 62)) {
-	// Encode should be different
-	ASSERT_NE(osdmap.pgtemp_primaryfirst(pool, pgid, shard_id_t(osd)),
-		  shard_id_t(osd));
-      } else {
-	// Encode should not change
-	ASSERT_EQ(osdmap.pgtemp_primaryfirst(pool, pgid, shard_id_t(osd)),
-		  shard_id_t(osd));
-      }
     }
     decoded = osdmap.pgtemp_undo_primaryfirst(pool, pgid, encoded);
     ASSERT_EQ(set, decoded);
   }
+}
+
+// Helper function to test primaryfirst mapping with pg_shard_t array
+// Takes an osdmap, pool configuration, and array of pg_shard_t
+// Verifies forward and reverse mapping consistency
+void test_primaryfirst_mapping(
+  OSDMap& osdmap,
+  pg_pool_t& pool,
+  pg_t pgid,
+  const vector<pg_shard_t>& shards)
+{
+  // Convert pg_shard_t array to vector<int> for forward mapping
+  vector<int> osd_vec;
+  for (const auto& shard : shards) {
+    osd_vec.push_back(shard.osd);
+  }
+
+  // Perform forward mapping using pgtemp_primaryfirst
+  vector<int> encoded = osdmap.pgtemp_primaryfirst(pool, osd_vec);
+  
+  // Verify pgtemp_undo_primaryfirst returns back to original map
+  vector<int> decoded = osdmap.pgtemp_undo_primaryfirst(pool, pgid, encoded);
+  ASSERT_EQ(osd_vec, decoded) << "Forward/reverse mapping mismatch for full vector";
+  
+  // Verify pgtemp_undo_primaryfirst (shard variation) does the correct thing for each shard
+  // For each position in the encoded array, verify undo returns the correct original shard
+  for (size_t i = 0; i < encoded.size(); i++) {
+    shard_id_t original_shard = osdmap.pgtemp_undo_primaryfirst(pool, pgid, shard_id_t(i));
+    // Verify the decoded OSD matches the original OSD at this shard position
+    ASSERT_LT(original_shard.id, osd_vec.size()) << "Decoded shard " << original_shard << " out of range";
+    ASSERT_EQ(encoded[i], osd_vec[original_shard.id])
+      << "OSD mismatch: encoded[" << i << "]=" << encoded[i]
+      << " but osd_vec[" << original_shard << "]=" << osd_vec[original_shard.id];
+  }
+}
+
+// Wrapper function that generates test patterns for given k, m, num_zones
+void test_primaryfirst_patterns(
+  OSDMap& osdmap,
+  pg_t pgid,
+  int k,
+  int m,
+  int num_zones)
+{
+  int total_shards = (k + m) * num_zones;
+  pg_pool_t pool;
+  pool.size = total_shards;
+  pool.set_flag(pg_pool_t::FLAG_EC_OPTIMIZATIONS);
+  
+  // Set up pg_temp for this pool
+  OSDMap::Incremental pgtemp_map(osdmap.get_epoch() + 1);
+  vector<int> temp_osds;
+  for (int i = 0; i < total_shards; i++) {
+    temp_osds.push_back(i);
+  }
+  pgtemp_map.new_pg_temp[pgid] = mempool::osdmap::vector<int>(
+    temp_osds.begin(), temp_osds.end());
+  osdmap.apply_incremental(pgtemp_map);
+  
+  // Mark some shards as non-primary (data shards 1 through k-1 are non-primary)
+  for (int i = 1; i < k; i++) {
+    for (int z = 0; z < num_zones; z++) {
+      pool.nonprimary_shards.insert(shard_id_t(i + (k + m) * z));
+    }
+  }
+  
+  // Pattern 1: shard == osd (simple case)
+  {
+    vector<pg_shard_t> shards;
+    for (int i = 0; i < total_shards; i++) {
+      shards.push_back(pg_shard_t(i, shard_id_t(i)));
+    }
+    test_primaryfirst_mapping(osdmap, pool, pgid, shards);
+  }
+  
+  // Pattern 2: large OSDs that won't fit in an int8
+  {
+    vector<pg_shard_t> shards;
+    int base_osd = 1000 * num_zones; // Large OSD numbers
+    for (int i = 0; i < total_shards; i++) {
+      shards.push_back(pg_shard_t(base_osd + i, shard_id_t(i)));
+    }
+    test_primaryfirst_mapping(osdmap, pool, pgid, shards);
+  }
+  
+  // Pattern 3: Overlapping OSDs - shards 0,1 same OSD
+  {
+    vector<pg_shard_t> shards;
+    shards.push_back(pg_shard_t(100, shard_id_t(0)));
+    shards.push_back(pg_shard_t(100, shard_id_t(1))); // Same OSD as shard 0
+    for (int i = 2; i < total_shards; i++) {
+      shards.push_back(pg_shard_t(100 + i, shard_id_t(i)));
+    }
+    test_primaryfirst_mapping(osdmap, pool, pgid, shards);
+  }
+  
+  // Pattern 4: Overlapping OSDs - shards 0,k same OSD
+  if (k < total_shards) {
+    vector<pg_shard_t> shards;
+    shards.push_back(pg_shard_t(200, shard_id_t(0)));
+    for (int i = 1; i < k; i++) {
+      shards.push_back(pg_shard_t(200 + i, shard_id_t(i)));
+    }
+    shards.push_back(pg_shard_t(200, shard_id_t(k))); // Same OSD as shard 0
+    for (int i = k + 1; i < total_shards; i++) {
+      shards.push_back(pg_shard_t(200 + i, shard_id_t(i)));
+    }
+    test_primaryfirst_mapping(osdmap, pool, pgid, shards);
+  }
+  
+  // Pattern 5: Overlapping OSDs - shards 1,2 same OSD
+  if (total_shards > 2) {
+    vector<pg_shard_t> shards;
+    shards.push_back(pg_shard_t(300, shard_id_t(0)));
+    shards.push_back(pg_shard_t(301, shard_id_t(1)));
+    shards.push_back(pg_shard_t(301, shard_id_t(2))); // Same OSD as shard 1
+    for (int i = 3; i < total_shards; i++) {
+      shards.push_back(pg_shard_t(300 + i, shard_id_t(i)));
+    }
+    test_primaryfirst_mapping(osdmap, pool, pgid, shards);
+  }
+  
+  // Pattern 6: All shards same OSD
+  {
+    vector<pg_shard_t> shards;
+    for (int i = 0; i < total_shards; i++) {
+      shards.push_back(pg_shard_t(400, shard_id_t(i)));
+    }
+    test_primaryfirst_mapping(osdmap, pool, pgid, shards);
+  }
+}
+
+// Main test: test all combinations of k, m, num_zones
+TEST_F(OSDMapTest, pgtemp_primaryfirst_comprehensive) {
+  set_up_map();
+  
+  pg_t rawpg(0, my_ec_pool);
+  pg_t pgid = osdmap.raw_pg_to_pg(rawpg);
+  
+  // Test all combinations:
+  // k = 2 to 5 inclusive
+  // m = 1 to 3 inclusive  
+  // num_zones = 1 to 3 inclusive
+  for (int k = 2; k <= 5; k++) {
+    for (int m = 1; m <= 3; m++) {
+      for (int num_zones = 1; num_zones <= 3; num_zones++) {
+        std::cout << "Testing k=" << k << " m=" << m << " num_zones=" << num_zones << std::endl;
+        test_primaryfirst_patterns(osdmap, pgid, k, m, num_zones);
+      }
+    }
+}
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/test/osd/TestPeeringState.cc
+++ b/src/test/osd/TestPeeringState.cc
@@ -558,6 +558,8 @@ protected:
     dpp[osd] = make_unique<DppHelper>(g_ceph_context, dout_subsys, this, osd, shard);
     spg_t spgid = spg_t(pg_t(0, pool_id), pg_whoami.shard);
     listeners[osd] = make_unique<MockPeeringListener>(osdmap, pool_id, get_dpp(osd), pg_whoami);
+    // Note: TestPeeringState doesn't use MockMessenger for cluster messages
+    // Cluster messages go directly into the messages map for manual dispatch
     get_listener(osd)->current_epoch = osdmap->get_epoch();
     unique_ptr<PeeringState> ps = make_unique<PeeringState>(
       g_ceph_context,


### PR DESCRIPTION
Get rid of ec pool restrictions, allowing user to enter
stretch mode with EC pool.
    
Refactor OSDMonitor::try_enable_stretch_mode_pools() to extract
validation logic into static validate_stretch_mode_pools() function,
making it testable without requiring a full OSDMonitor instance.

Adds unittest_osd_monitor.cc with 11 test cases validating pool
configuration requirements for stretch mode enablement.

Tests cover:
- Replicated pools must have default size/min_size
- Pool type must match CRUSH rule type (replicated vs erasure)
- CRUSH rule must exist
- All pools in a set must pass validation

Modified the stretch cluster docs

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
