### PR TITLE
tentacle: osd: prevent OSDMap::check_health() from asserting due to new OSDs found in subtree

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -369,7 +369,7 @@ bool OSDMap::subtree_type_is_down(
 {
   if (id >= 0) {
     bool is_down_ret = is_down(id);
-    if (!is_out(id)) {
+    if (!is_out(id) && !(osd_state[id] & CEPH_OSD_NEW)) {
       if (is_down_ret) {
         down_in_osds->insert(id);
       } else {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/73519

---

backport of https://github.com/ceph/ceph/pull/64009
parent tracker: https://tracker.ceph.com/issues/70869

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh