### PR TITLE
doc/rgw: warn about rgw_usage_max_shards consistency

### DIFF
--- a/doc/man/8/radosgw.rst
+++ b/doc/man/8/radosgw.rst
@@ -213,6 +213,15 @@ configures the number of seconds between log flushes, and the flush
 threshold specify how many entries can be kept before resorting to
 synchronous flush.
 
+.. warning:: All RGW instances and ``radosgw-admin`` commands must use the
+   same value for ``rgw_usage_max_shards``. If values differ between daemons
+   or between the cluster and the admin tool, usage log reads and trims
+   will target different objects than where data was written, causing
+   seemingly empty results or failed cleanup. Use
+   ``ceph config set global rgw_usage_max_shards <N>`` to enforce a
+   consistent value across the cluster. Alternatively, ``radosgw-admin``
+   supports the ``--rgw-usage-max-shards`` command-line parameter.
+
 
 Availability
 ============

--- a/doc/radosgw/admin.rst
+++ b/doc/radosgw/admin.rst
@@ -944,6 +944,14 @@ ID, as in the following example command:
 
    radosgw-admin usage show --show-log-entries=false
 
+.. note:: If ``usage show`` returns empty results even though usage logging is
+   enabled and the cluster is active, verify that ``rgw_usage_max_shards`` is
+   set consistently across all RGW daemons and for ``radosgw-admin``.
+   A mismatch causes reads to target different objects than where data was
+   written. Use ``ceph config set global rgw_usage_max_shards <N>`` to enforce
+   a consistent value. Alternatively, ``radosgw-admin`` supports the
+   ``--rgw-usage-max-shards`` command-line parameter.
+
 
 Trim Usage
 ----------
@@ -958,6 +966,15 @@ example commands:
    radosgw-admin usage trim --start-date=2010-01-01 --end-date=2010-12-31
    radosgw-admin usage trim --uid=johndoe	
    radosgw-admin usage trim --uid=johndoe --end-date=2013-12-31
+
+.. note:: If ``usage trim`` appears to have no effect (e.g., ``usage show`` still
+   returns data or omap keys are not reduced), verify that
+   ``rgw_usage_max_shards`` is set consistently across all RGW daemons and for
+   ``radosgw-admin``. A mismatch causes trim operations to target different
+   objects than where data was written. Use
+   ``ceph config set global rgw_usage_max_shards <N>`` to enforce a consistent
+   value. Alternatively, ``radosgw-admin`` supports the
+   ``--rgw-usage-max-shards`` command-line parameter.
 
 Usage Log Key Transition
 -------------------------

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -1684,7 +1684,12 @@ options:
   level: advanced
   desc: Number of shards for usage log.
   long_desc: The number of RADOS objects that RGW will use in order to store the usage
-    log data.
+    log data. All RGW daemons and radosgw-admin commands must use the same value
+    for this option. If values differ, writes and reads/clears will target
+    different objects, causing usage data to appear empty or not be cleared.
+    Use ``ceph config set global rgw_usage_max_shards <N>`` to ensure consistency
+    across the cluster. Alternatively, ``radosgw-admin`` supports the
+    ``--rgw-usage-max-shards`` command-line parameter.
   fmt_desc: The maximum number of shards for usage logging.
   default: 32
   services:


### PR DESCRIPTION
doc/rgw: warn about rgw_usage_max_shards consistency

Add documentation warnings explaining that all RGW daemons and
radosgw-admin commands must use the same rgw_usage_max_shards value.
Mismatched shard counts cause writes and reads/trim to target different
objects, resulting in seemingly empty usage logs or failed cleanup.
Also document the --rgw-usage-max-shards command-line parameter for
radosgw-admin as an alternative to global config.

Fixes: https://tracker.ceph.com/issues/76459
Signed-off-by: Olivier Chaze <olivier.chaze@infomaniak.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
