### PR TITLE
common: Add more functionality to bitset set

### DIFF
--- a/src/common/bitset_set.h
+++ b/src/common/bitset_set.h
@@ -490,6 +490,123 @@ class bitset_set {
 
     return std::strong_ordering::equal;
   }
+
+  /** Left shift operator - shifts all bits left by n positions.
+   * Bits that shift beyond max_bits are lost.
+   */
+  friend bitset_set operator<<(const bitset_set &lhs, unsigned int n) {
+    bitset_set result;
+    if (n == 0) {
+      result.copy(lhs);
+      return result;
+    }
+    if (n >= max_bits) {
+      // All bits shifted out
+      return result;
+    }
+
+    unsigned int word_shift = n / bits_per_uint64_t;
+    unsigned int bit_shift = n % bits_per_uint64_t;
+
+    if (bit_shift == 0) {
+      // Simple word-aligned shift
+      for (size_t i = word_count - 1; i >= word_shift; --i) {
+        result.words[i] = lhs.words[i - word_shift];
+      }
+    } else {
+      // Shift with bit offset
+      unsigned int complement_shift = bits_per_uint64_t - bit_shift;
+      for (size_t i = word_count - 1; i > word_shift; --i) {
+        result.words[i] = (lhs.words[i - word_shift] << bit_shift) |
+                          (lhs.words[i - word_shift - 1] >> complement_shift);
+      }
+      result.words[word_shift] = lhs.words[0] << bit_shift;
+    }
+
+    return result;
+  }
+
+  /** Right shift operator - shifts all bits right by n positions.
+   * Bits that shift below 0 are lost.
+   */
+  friend bitset_set operator>>(const bitset_set &lhs, unsigned int n) {
+    bitset_set result;
+    if (n == 0) {
+      result.copy(lhs);
+      return result;
+    }
+    if (n >= max_bits) {
+      // All bits shifted out
+      return result;
+    }
+
+    unsigned int word_shift = n / bits_per_uint64_t;
+    unsigned int bit_shift = n % bits_per_uint64_t;
+
+    if (bit_shift == 0) {
+      // Simple word-aligned shift
+      for (size_t i = 0; i < word_count - word_shift; ++i) {
+        result.words[i] = lhs.words[i + word_shift];
+      }
+    } else {
+      // Shift with bit offset
+      unsigned int complement_shift = bits_per_uint64_t - bit_shift;
+      for (size_t i = 0; i < word_count - word_shift - 1; ++i) {
+        result.words[i] = (lhs.words[i + word_shift] >> bit_shift) |
+                          (lhs.words[i + word_shift + 1] << complement_shift);
+      }
+      result.words[word_count - word_shift - 1] =
+        lhs.words[word_count - 1] >> bit_shift;
+    }
+
+    return result;
+  }
+
+  /** Left shift assignment operator */
+  bitset_set &operator<<=(unsigned int n) {
+    *this = *this << n;
+    return *this;
+  }
+
+  /** Right shift assignment operator */
+  bitset_set &operator>>=(unsigned int n) {
+    *this = *this >> n;
+    return *this;
+  }
+
+  /** Bitwise AND operator - returns intersection of two sets */
+  friend bitset_set operator&(const bitset_set &lhs, const bitset_set &rhs) {
+    bitset_set result;
+    for (size_t i = 0; i < word_count; ++i) {
+      result.words[i] = lhs.words[i] & rhs.words[i];
+    }
+    return result;
+  }
+
+  /** Bitwise OR operator - returns union of two sets */
+  friend bitset_set operator|(const bitset_set &lhs, const bitset_set &rhs) {
+    bitset_set result;
+    for (size_t i = 0; i < word_count; ++i) {
+      result.words[i] = lhs.words[i] | rhs.words[i];
+    }
+    return result;
+  }
+
+  /** Bitwise AND assignment operator - sets this to intersection with other */
+  bitset_set &operator&=(const bitset_set &other) {
+    for (size_t i = 0; i < word_count; ++i) {
+      words[i] &= other.words[i];
+    }
+    return *this;
+  }
+
+  /** Bitwise OR assignment operator - sets this to union with other */
+  bitset_set &operator|=(const bitset_set &other) {
+    for (size_t i = 0; i < word_count; ++i) {
+      words[i] |= other.words[i];
+    }
+    return *this;
+  }
 };
 
 // make sure fmt::range would not try (and fail) to treat bitset_set as a range

--- a/src/test/common/test_bitset_set.cc
+++ b/src/test/common/test_bitset_set.cc
@@ -262,3 +262,598 @@ TEST(bitset_set, find_nth) {
   }
   ASSERT_EQ(bitset.end(), bitset.find_nth(range) );
 }
+
+TEST(bitset_set, left_shift) {
+  bitset_set<128, Key> bitset;
+  
+  // Test shift by 0 (no change)
+  bitset.insert(0);
+  bitset.insert(5);
+  bitset.insert(10);
+  auto result = bitset << 0;
+  ASSERT_EQ(bitset, result);
+  
+  // Test simple left shift
+  bitset.clear();
+  bitset.insert(0);
+  bitset.insert(1);
+  bitset.insert(2);
+  result = bitset << 3;
+  ASSERT_TRUE(result.contains(3));
+  ASSERT_TRUE(result.contains(4));
+  ASSERT_TRUE(result.contains(5));
+  ASSERT_FALSE(result.contains(0));
+  ASSERT_FALSE(result.contains(1));
+  ASSERT_FALSE(result.contains(2));
+  
+  // Test shift across word boundary (64 bits)
+  bitset.clear();
+  bitset.insert(0);
+  bitset.insert(63);
+  result = bitset << 1;
+  ASSERT_TRUE(result.contains(1));
+  ASSERT_TRUE(result.contains(64));
+  ASSERT_FALSE(result.contains(0));
+  ASSERT_FALSE(result.contains(63));
+  
+  // Test word-aligned shift
+  bitset.clear();
+  bitset.insert(0);
+  bitset.insert(1);
+  result = bitset << 64;
+  ASSERT_TRUE(result.contains(64));
+  ASSERT_TRUE(result.contains(65));
+  ASSERT_FALSE(result.contains(0));
+  ASSERT_FALSE(result.contains(1));
+  
+  // Test shift beyond max_bits
+  bitset.clear();
+  bitset.insert(0);
+  result = bitset << 128;
+  ASSERT_TRUE(result.empty());
+  
+  // Test shift that loses some bits
+  bitset.clear();
+  bitset.insert(120);
+  bitset.insert(127);
+  result = bitset << 5;
+  ASSERT_TRUE(result.contains(125));
+  ASSERT_EQ(1, result.size()); // 127+5=132 is out of range, so only bit 125 survives
+}
+
+TEST(bitset_set, right_shift) {
+  bitset_set<128, Key> bitset;
+  
+  // Test shift by 0 (no change)
+  bitset.insert(5);
+  bitset.insert(10);
+  bitset.insert(15);
+  auto result = bitset >> 0;
+  ASSERT_EQ(bitset, result);
+  
+  // Test simple right shift
+  bitset.clear();
+  bitset.insert(3);
+  bitset.insert(4);
+  bitset.insert(5);
+  result = bitset >> 3;
+  ASSERT_TRUE(result.contains(0));
+  ASSERT_TRUE(result.contains(1));
+  ASSERT_TRUE(result.contains(2));
+  ASSERT_FALSE(result.contains(3));
+  ASSERT_FALSE(result.contains(4));
+  ASSERT_FALSE(result.contains(5));
+  
+  // Test shift across word boundary (64 bits)
+  bitset.clear();
+  bitset.insert(1);
+  bitset.insert(64);
+  result = bitset >> 1;
+  ASSERT_TRUE(result.contains(0));
+  ASSERT_TRUE(result.contains(63));
+  ASSERT_FALSE(result.contains(1));
+  ASSERT_FALSE(result.contains(64));
+  
+  // Test word-aligned shift
+  bitset.clear();
+  bitset.insert(64);
+  bitset.insert(65);
+  result = bitset >> 64;
+  ASSERT_TRUE(result.contains(0));
+  ASSERT_TRUE(result.contains(1));
+  ASSERT_FALSE(result.contains(64));
+  ASSERT_FALSE(result.contains(65));
+  
+  // Test shift beyond max_bits
+  bitset.clear();
+  bitset.insert(127);
+  result = bitset >> 128;
+  ASSERT_TRUE(result.empty());
+  
+  // Test shift that loses some bits
+  bitset.clear();
+  bitset.insert(0);
+  bitset.insert(7);
+  result = bitset >> 5;
+  ASSERT_TRUE(result.contains(2));
+  ASSERT_FALSE(result.contains(0)); // Lost
+  ASSERT_EQ(1, result.size());
+}
+
+TEST(bitset_set, shift_assignment) {
+  bitset_set<128, Key> bitset;
+  
+  // Test left shift assignment
+  bitset.insert(0);
+  bitset.insert(1);
+  bitset <<= 3;
+  ASSERT_TRUE(bitset.contains(3));
+  ASSERT_TRUE(bitset.contains(4));
+  ASSERT_FALSE(bitset.contains(0));
+  ASSERT_FALSE(bitset.contains(1));
+  
+  // Test right shift assignment
+  bitset.clear();
+  bitset.insert(5);
+  bitset.insert(6);
+  bitset >>= 2;
+  ASSERT_TRUE(bitset.contains(3));
+  ASSERT_TRUE(bitset.contains(4));
+  ASSERT_FALSE(bitset.contains(5));
+  ASSERT_FALSE(bitset.contains(6));
+}
+
+TEST(bitset_set, shift_multiple_words) {
+  bitset_set<128, Key> bitset;
+  
+  // Test pattern across multiple words
+  for (int i = 0; i < 128; i += 8) {
+    bitset.insert(i);
+  }
+  
+  auto result = bitset << 4;
+  for (int i = 0; i < 128; i += 8) {
+    if (i + 4 < 128) {
+      ASSERT_TRUE(result.contains(i + 4));
+    }
+    ASSERT_FALSE(result.contains(i));
+  }
+  
+  result = bitset >> 4;
+  for (int i = 0; i < 128; i += 8) {
+    if (i >= 4) {
+      ASSERT_TRUE(result.contains(i - 4));
+    }
+  }
+}
+
+TEST(bitset_set, shift_edge_cases) {
+  bitset_set<128, Key> bitset;
+  
+  // Empty set
+  auto result = bitset << 5;
+  ASSERT_TRUE(result.empty());
+  result = bitset >> 5;
+  ASSERT_TRUE(result.empty());
+  
+  // Full set left shift
+  bitset.insert_range(0, 128);
+  result = bitset << 10;
+  ASSERT_EQ(118, result.size()); // 128 - 10 bits remain
+  for (int i = 10; i < 128; ++i) {
+    ASSERT_TRUE(result.contains(i));
+  }
+  
+  // Full set right shift
+  result = bitset >> 10;
+  ASSERT_EQ(118, result.size()); // 128 - 10 bits remain
+  for (int i = 0; i < 118; ++i) {
+    ASSERT_TRUE(result.contains(i));
+  }
+}
+
+TEST(bitset_set, shift_boundary_behavior) {
+  bitset_set<128, Key> bitset;
+  
+  // Test that shift-left followed by shift-right zeros bits that went out of range
+  bitset.insert(0);
+  bitset.insert(64);
+  bitset.insert(120);
+  bitset.insert(127);
+  
+  // Shift left by 10, then right by 10 - bits at 120 and 127 should be lost
+  auto result = (bitset << 10) >> 10;
+  ASSERT_TRUE(result.contains(0));
+  ASSERT_TRUE(result.contains(64));
+  ASSERT_FALSE(result.contains(120)); // Lost when shifted left
+  ASSERT_FALSE(result.contains(127)); // Lost when shifted left
+  ASSERT_EQ(2, result.size());
+  
+  // Test that shift-right followed by shift-left zeros bits that went out of range
+  bitset.clear();
+  bitset.insert(0);
+  bitset.insert(5);
+  bitset.insert(64);
+  bitset.insert(127);
+  
+  result = (bitset >> 10) << 10;
+  ASSERT_FALSE(result.contains(0));  // Lost when shifted right
+  ASSERT_FALSE(result.contains(5));  // Lost when shifted right
+  ASSERT_TRUE(result.contains(64));
+  ASSERT_TRUE(result.contains(127));
+  ASSERT_EQ(2, result.size());
+  
+  // Test large shift that loses everything
+  bitset.clear();
+  bitset.insert_range(0, 128);
+  result = (bitset << 64) >> 64;
+  ASSERT_EQ(64, result.size()); // Only lower 64 bits remain
+  for (int i = 0; i < 64; ++i) {
+    ASSERT_TRUE(result.contains(i));
+  }
+  for (int i = 64; i < 128; ++i) {
+    ASSERT_FALSE(result.contains(i));
+  }
+  
+  // Test shift beyond range
+  bitset.clear();
+  bitset.insert_range(0, 128);
+  result = (bitset << 200) >> 200;
+  ASSERT_TRUE(result.empty()); // Everything lost
+}
+
+
+TEST(bitset_set, bitwise_and) {
+  bitset_set<128, Key> bitset1;
+  bitset_set<128, Key> bitset2;
+  
+  // Test empty sets
+  auto result = bitset1 & bitset2;
+  ASSERT_TRUE(result.empty());
+  
+  // Test one empty, one non-empty
+  bitset1.insert(5);
+  bitset1.insert(10);
+  result = bitset1 & bitset2;
+  ASSERT_TRUE(result.empty());
+  
+  // Test no overlap
+  bitset2.insert(15);
+  bitset2.insert(20);
+  result = bitset1 & bitset2;
+  ASSERT_TRUE(result.empty());
+  
+  // Test partial overlap
+  bitset2.insert(10);
+  result = bitset1 & bitset2;
+  ASSERT_EQ(1, result.size());
+  ASSERT_TRUE(result.contains(10));
+  ASSERT_FALSE(result.contains(5));
+  ASSERT_FALSE(result.contains(15));
+  ASSERT_FALSE(result.contains(20));
+  
+  // Test complete overlap
+  bitset1.clear();
+  bitset2.clear();
+  bitset1.insert(1);
+  bitset1.insert(2);
+  bitset1.insert(3);
+  bitset2.insert(1);
+  bitset2.insert(2);
+  bitset2.insert(3);
+  result = bitset1 & bitset2;
+  ASSERT_EQ(3, result.size());
+  ASSERT_TRUE(result.contains(1));
+  ASSERT_TRUE(result.contains(2));
+  ASSERT_TRUE(result.contains(3));
+  
+  // Test across word boundaries
+  bitset1.clear();
+  bitset2.clear();
+  bitset1.insert(0);
+  bitset1.insert(63);
+  bitset1.insert(64);
+  bitset1.insert(127);
+  bitset2.insert(63);
+  bitset2.insert(64);
+  result = bitset1 & bitset2;
+  ASSERT_EQ(2, result.size());
+  ASSERT_TRUE(result.contains(63));
+  ASSERT_TRUE(result.contains(64));
+  ASSERT_FALSE(result.contains(0));
+  ASSERT_FALSE(result.contains(127));
+}
+
+TEST(bitset_set, bitwise_or) {
+  bitset_set<128, Key> bitset1;
+  bitset_set<128, Key> bitset2;
+  
+  // Test empty sets
+  auto result = bitset1 | bitset2;
+  ASSERT_TRUE(result.empty());
+  
+  // Test one empty, one non-empty
+  bitset1.insert(5);
+  bitset1.insert(10);
+  result = bitset1 | bitset2;
+  ASSERT_EQ(2, result.size());
+  ASSERT_TRUE(result.contains(5));
+  ASSERT_TRUE(result.contains(10));
+  
+  // Test no overlap
+  bitset2.insert(15);
+  bitset2.insert(20);
+  result = bitset1 | bitset2;
+  ASSERT_EQ(4, result.size());
+  ASSERT_TRUE(result.contains(5));
+  ASSERT_TRUE(result.contains(10));
+  ASSERT_TRUE(result.contains(15));
+  ASSERT_TRUE(result.contains(20));
+  
+  // Test partial overlap
+  bitset2.insert(10);
+  result = bitset1 | bitset2;
+  ASSERT_EQ(4, result.size());
+  ASSERT_TRUE(result.contains(5));
+  ASSERT_TRUE(result.contains(10));
+  ASSERT_TRUE(result.contains(15));
+  ASSERT_TRUE(result.contains(20));
+  
+  // Test complete overlap
+  bitset1.clear();
+  bitset2.clear();
+  bitset1.insert(1);
+  bitset1.insert(2);
+  bitset1.insert(3);
+  bitset2.insert(1);
+  bitset2.insert(2);
+  bitset2.insert(3);
+  result = bitset1 | bitset2;
+  ASSERT_EQ(3, result.size());
+  ASSERT_TRUE(result.contains(1));
+  ASSERT_TRUE(result.contains(2));
+  ASSERT_TRUE(result.contains(3));
+  
+  // Test across word boundaries
+  bitset1.clear();
+  bitset2.clear();
+  bitset1.insert(0);
+  bitset1.insert(63);
+  bitset2.insert(64);
+  bitset2.insert(127);
+  result = bitset1 | bitset2;
+  ASSERT_EQ(4, result.size());
+  ASSERT_TRUE(result.contains(0));
+  ASSERT_TRUE(result.contains(63));
+  ASSERT_TRUE(result.contains(64));
+  ASSERT_TRUE(result.contains(127));
+}
+
+TEST(bitset_set, bitwise_and_assignment) {
+  bitset_set<128, Key> bitset1;
+  bitset_set<128, Key> bitset2;
+  
+  // Test empty sets
+  bitset1 &= bitset2;
+  ASSERT_TRUE(bitset1.empty());
+  
+  // Test one empty, one non-empty
+  bitset1.insert(5);
+  bitset1.insert(10);
+  bitset1 &= bitset2;
+  ASSERT_TRUE(bitset1.empty());
+  
+  // Test no overlap
+  bitset1.insert(5);
+  bitset1.insert(10);
+  bitset2.insert(15);
+  bitset2.insert(20);
+  bitset1 &= bitset2;
+  ASSERT_TRUE(bitset1.empty());
+  
+  // Test partial overlap
+  bitset1.clear();
+  bitset2.clear();
+  bitset1.insert(5);
+  bitset1.insert(10);
+  bitset1.insert(15);
+  bitset2.insert(10);
+  bitset2.insert(15);
+  bitset2.insert(20);
+  bitset1 &= bitset2;
+  ASSERT_EQ(2, bitset1.size());
+  ASSERT_TRUE(bitset1.contains(10));
+  ASSERT_TRUE(bitset1.contains(15));
+  ASSERT_FALSE(bitset1.contains(5));
+  ASSERT_FALSE(bitset1.contains(20));
+  
+  // Test complete overlap
+  bitset1.clear();
+  bitset2.clear();
+  bitset1.insert(1);
+  bitset1.insert(2);
+  bitset1.insert(3);
+  bitset2.insert(1);
+  bitset2.insert(2);
+  bitset2.insert(3);
+  bitset1 &= bitset2;
+  ASSERT_EQ(3, bitset1.size());
+  ASSERT_TRUE(bitset1.contains(1));
+  ASSERT_TRUE(bitset1.contains(2));
+  ASSERT_TRUE(bitset1.contains(3));
+  
+  // Test across word boundaries
+  bitset1.clear();
+  bitset2.clear();
+  bitset1.insert(0);
+  bitset1.insert(63);
+  bitset1.insert(64);
+  bitset1.insert(127);
+  bitset2.insert(63);
+  bitset2.insert(64);
+  bitset1 &= bitset2;
+  ASSERT_EQ(2, bitset1.size());
+  ASSERT_TRUE(bitset1.contains(63));
+  ASSERT_TRUE(bitset1.contains(64));
+  ASSERT_FALSE(bitset1.contains(0));
+  ASSERT_FALSE(bitset1.contains(127));
+}
+
+TEST(bitset_set, bitwise_or_assignment) {
+  bitset_set<128, Key> bitset1;
+  bitset_set<128, Key> bitset2;
+  
+  // Test empty sets
+  bitset1 |= bitset2;
+  ASSERT_TRUE(bitset1.empty());
+  
+  // Test one empty, one non-empty
+  bitset2.insert(5);
+  bitset2.insert(10);
+  bitset1 |= bitset2;
+  ASSERT_EQ(2, bitset1.size());
+  ASSERT_TRUE(bitset1.contains(5));
+  ASSERT_TRUE(bitset1.contains(10));
+  
+  // Test no overlap
+  bitset1.clear();
+  bitset2.clear();
+  bitset1.insert(5);
+  bitset1.insert(10);
+  bitset2.insert(15);
+  bitset2.insert(20);
+  bitset1 |= bitset2;
+  ASSERT_EQ(4, bitset1.size());
+  ASSERT_TRUE(bitset1.contains(5));
+  ASSERT_TRUE(bitset1.contains(10));
+  ASSERT_TRUE(bitset1.contains(15));
+  ASSERT_TRUE(bitset1.contains(20));
+  
+  // Test partial overlap
+  bitset1.clear();
+  bitset2.clear();
+  bitset1.insert(5);
+  bitset1.insert(10);
+  bitset2.insert(10);
+  bitset2.insert(15);
+  bitset1 |= bitset2;
+  ASSERT_EQ(3, bitset1.size());
+  ASSERT_TRUE(bitset1.contains(5));
+  ASSERT_TRUE(bitset1.contains(10));
+  ASSERT_TRUE(bitset1.contains(15));
+  
+  // Test complete overlap
+  bitset1.clear();
+  bitset2.clear();
+  bitset1.insert(1);
+  bitset1.insert(2);
+  bitset1.insert(3);
+  bitset2.insert(1);
+  bitset2.insert(2);
+  bitset2.insert(3);
+  bitset1 |= bitset2;
+  ASSERT_EQ(3, bitset1.size());
+  ASSERT_TRUE(bitset1.contains(1));
+  ASSERT_TRUE(bitset1.contains(2));
+  ASSERT_TRUE(bitset1.contains(3));
+  
+  // Test across word boundaries
+  bitset1.clear();
+  bitset2.clear();
+  bitset1.insert(0);
+  bitset1.insert(63);
+  bitset2.insert(64);
+  bitset2.insert(127);
+  bitset1 |= bitset2;
+  ASSERT_EQ(4, bitset1.size());
+  ASSERT_TRUE(bitset1.contains(0));
+  ASSERT_TRUE(bitset1.contains(63));
+  ASSERT_TRUE(bitset1.contains(64));
+  ASSERT_TRUE(bitset1.contains(127));
+}
+
+TEST(bitset_set, bitwise_operators_combined) {
+  bitset_set<128, Key> bitset1;
+  bitset_set<128, Key> bitset2;
+  bitset_set<128, Key> bitset3;
+  
+  // Test combination: (A | B) & C
+  bitset1.insert(1);
+  bitset1.insert(2);
+  bitset2.insert(2);
+  bitset2.insert(3);
+  bitset3.insert(2);
+  bitset3.insert(4);
+  
+  auto result = (bitset1 | bitset2) & bitset3;
+  ASSERT_EQ(1, result.size());
+  ASSERT_TRUE(result.contains(2));
+  
+  // Test combination: (A & B) | C
+  bitset1.clear();
+  bitset2.clear();
+  bitset3.clear();
+  bitset1.insert(1);
+  bitset1.insert(2);
+  bitset2.insert(2);
+  bitset2.insert(3);
+  bitset3.insert(4);
+  bitset3.insert(5);
+  
+  result = (bitset1 & bitset2) | bitset3;
+  ASSERT_EQ(3, result.size());
+  ASSERT_TRUE(result.contains(2));
+  ASSERT_TRUE(result.contains(4));
+  ASSERT_TRUE(result.contains(5));
+  
+  // Test chained assignment operators
+  bitset1.clear();
+  bitset2.clear();
+  bitset3.clear();
+  bitset1.insert(1);
+  bitset1.insert(2);
+  bitset1.insert(3);
+  bitset2.insert(2);
+  bitset2.insert(3);
+  bitset2.insert(4);
+  bitset3.insert(3);
+  bitset3.insert(4);
+  bitset3.insert(5);
+  
+  bitset1 &= bitset2;  // bitset1 now has {2, 3}
+  bitset1 |= bitset3;  // bitset1 now has {2, 3, 4, 5}
+  ASSERT_EQ(4, bitset1.size());
+  ASSERT_TRUE(bitset1.contains(2));
+  ASSERT_TRUE(bitset1.contains(3));
+  ASSERT_TRUE(bitset1.contains(4));
+  ASSERT_TRUE(bitset1.contains(5));
+}
+
+TEST(bitset_set, bitwise_operators_consistency_with_static_methods) {
+  bitset_set<128, Key> bitset1;
+  bitset_set<128, Key> bitset2;
+  
+  // Populate sets
+  bitset1.insert(1);
+  bitset1.insert(2);
+  bitset1.insert(3);
+  bitset1.insert(64);
+  bitset2.insert(2);
+  bitset2.insert(3);
+  bitset2.insert(4);
+  bitset2.insert(64);
+  
+  // Test that & operator matches intersection static method
+  auto and_result = bitset1 & bitset2;
+  auto intersection_result = bitset_set<128, Key>::intersection(bitset1, bitset2);
+  ASSERT_EQ(and_result, intersection_result);
+  
+  // Test that | operator produces union (no static method exists, but verify behavior)
+  auto or_result = bitset1 | bitset2;
+  ASSERT_EQ(5, or_result.size());
+  ASSERT_TRUE(or_result.contains(1));
+  ASSERT_TRUE(or_result.contains(2));
+  ASSERT_TRUE(or_result.contains(3));
+  ASSERT_TRUE(or_result.contains(4));
+  ASSERT_TRUE(or_result.contains(64));
+}


### PR DESCRIPTION
Previously bitset set did not exploit its bit-set nature by providing bitshift and other logical operators.

Here we add <<, >>, <<=, >>=, &, |, &=

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
