### PR TITLE
osdc: asynchronous per-session messenger dispatch and diagnostic visibility

### DIFF
--- a/src/common/ref.h
+++ b/src/common/ref.h
@@ -21,6 +21,14 @@ template<class T, class U>
 cref_t<T> ref_cast(const cref_t<U>& r) noexcept {
   return static_cast<const T*>(r.get());
 }
+template<class T, class U>
+cref_t<T> cref_cast(const ref_t<U>& r) noexcept {
+  return static_cast<const T*>(r.get());
+}
+template<class T, class U>
+cref_t<T> cref_cast(const cref_t<U>& r) noexcept {
+  return static_cast<const T*>(r.get());
+}
 template<class T, typename... Args>
 ceph::ref_t<T> make_ref(Args&&... args) {
   return {new T(std::forward<Args>(args)...), false};

--- a/src/messages/MOSDOpReply.h
+++ b/src/messages/MOSDOpReply.h
@@ -106,6 +106,9 @@ public:
       ops[i].outdata = std::move(o[i].outdata);
     }
   }
+  auto const& get_ops() const {
+    return ops;
+  }
   void claim_ops(std::vector<OSDOp>& o) {
     o.swap(ops);
     bdata_encode = false;

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1080,12 +1080,11 @@ void Objecter::ms_fast_dispatch2(const MessageRef& m)
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
       s->track_enqueue(m, [this, priv, s, m]() {
-        cref_t<MOSDOpReply> msg = ref_cast<MOSDOpReply>(m);
         s->track_dequeue(m);
-        handle_osd_op_reply(std::move(msg));
+        handle_osd_op_reply(cref_cast<MOSDOpReply>(m));
       });
     } else {
-      handle_osd_op_reply(ref_cast<MOSDOpReply>(m));
+      handle_osd_op_reply(cref_cast<MOSDOpReply>(m));
     }
     return;
   }
@@ -1095,12 +1094,11 @@ void Objecter::ms_fast_dispatch2(const MessageRef& m)
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
       s->track_enqueue(m, [this, priv, s, m]() {
-        cref_t<MWatchNotify> msg = ref_cast<MWatchNotify>(m);
         s->track_dequeue(m);
-        handle_watch_notify(std::move(msg));
+        handle_watch_notify(cref_cast<MWatchNotify>(m));
       });
     } else {
-      handle_watch_notify(ref_cast<MWatchNotify>(m));
+      handle_watch_notify(cref_cast<MWatchNotify>(m));
     }
     return;
   }
@@ -1119,12 +1117,11 @@ Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef& m)
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
       s->track_enqueue(m, [this, priv, s, m]() {
-        cref_t<MOSDBackoff> msg = ref_cast<MOSDBackoff>(m);
         s->track_dequeue(m);
-        handle_osd_backoff(std::move(msg));
+        handle_osd_backoff(cref_cast<MOSDBackoff>(m));
       });
     } else {
-      handle_osd_backoff(ref_cast<MOSDBackoff>(m));
+      handle_osd_backoff(cref_cast<MOSDBackoff>(m));
     }
     return Dispatcher::HANDLED();
   }
@@ -1137,12 +1134,11 @@ Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef& m)
       auto s = static_cast<OSDSession*>(priv.get());
       if (s) {
         s->track_enqueue(m, [this, priv, s, m]() {
-          cref_t<MCommandReply> msg = ref_cast<MCommandReply>(m);
           s->track_dequeue(m);
-          handle_command_reply(std::move(msg));
+          handle_command_reply(cref_cast<MCommandReply>(m));
         });
       } else {
-        handle_command_reply(ref_cast<MCommandReply>(m));
+        handle_command_reply(cref_cast<MCommandReply>(m));
       }
       return Dispatcher::HANDLED();
     } else {

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1080,7 +1080,7 @@ void Objecter::ms_fast_dispatch2(const MessageRef& m)
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
       s->track_enqueue(m);
-      boost::asio::dispatch(s->strand, [this, priv, s, m]() {
+      boost::asio::post(s->strand, [this, priv, s, m]() {
         cref_t<MOSDOpReply> msg = ref_cast<MOSDOpReply>(m);
         s->track_dequeue(m);
         handle_osd_op_reply(std::move(msg));
@@ -1096,7 +1096,7 @@ void Objecter::ms_fast_dispatch2(const MessageRef& m)
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
       s->track_enqueue(m);
-      boost::asio::dispatch(s->strand, [this, priv, s, m]() {
+      boost::asio::post(s->strand, [this, priv, s, m]() {
         cref_t<MWatchNotify> msg = ref_cast<MWatchNotify>(m);
         s->track_dequeue(m);
         handle_watch_notify(std::move(msg));
@@ -1121,7 +1121,7 @@ Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef& m)
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
       s->track_enqueue(m);
-      boost::asio::dispatch(s->strand, [this, priv, s, m]() {
+      boost::asio::post(s->strand, [this, priv, s, m]() {
         cref_t<MOSDBackoff> msg = ref_cast<MOSDBackoff>(m);
         s->track_dequeue(m);
         handle_osd_backoff(std::move(msg));
@@ -1140,7 +1140,7 @@ Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef& m)
       auto s = static_cast<OSDSession*>(priv.get());
       if (s) {
         s->track_enqueue(m);
-        boost::asio::dispatch(s->strand, [this, priv, s, m]() {
+        boost::asio::post(s->strand, [this, priv, s, m]() {
           cref_t<MCommandReply> msg = ref_cast<MCommandReply>(m);
           s->track_dequeue(m);
           handle_command_reply(std::move(msg));

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1071,7 +1071,7 @@ void Objecter::_do_watch_notify(boost::intrusive_ptr<LingerOp> info,
   info->finished_async();
 }
 
-Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef& m)
+void Objecter::ms_fast_dispatch2(const MessageRef& m)
 {
   ldout(cct, 10) << __func__ << " " << cct << " " << *m << dendl;
   switch (m->get_type()) {
@@ -1088,8 +1088,33 @@ Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef& m)
     } else {
       handle_osd_op_reply(ref_cast<MOSDOpReply>(m));
     }
-    return Dispatcher::HANDLED();
+    return;
   }
+
+  case CEPH_MSG_WATCH_NOTIFY: {
+    auto priv = m->get_connection()->get_priv();
+    auto s = static_cast<OSDSession*>(priv.get());
+    if (s) {
+      s->track_enqueue(m);
+      boost::asio::dispatch(s->strand, [this, priv, s, m]() {
+        cref_t<MWatchNotify> msg = ref_cast<MWatchNotify>(m);
+        s->track_dequeue(m);
+        handle_watch_notify(std::move(msg));
+      });
+    } else {
+      handle_watch_notify(ref_cast<MWatchNotify>(m));
+    }
+    return;
+  }
+  default: ceph_abort("should be unreachable"); break;
+  }
+}
+
+Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef& m)
+{
+  ldout(cct, 10) << __func__ << " " << cct << " " << *m << dendl;
+  switch (m->get_type()) {
+  case CEPH_MSG_OSD_OPREPLY: ceph_abort("should be fast dispatched"); break;
 
   case CEPH_MSG_OSD_BACKOFF: {
     auto priv = m->get_connection()->get_priv();
@@ -1107,21 +1132,7 @@ Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef& m)
     return Dispatcher::HANDLED();
   }
 
-  case CEPH_MSG_WATCH_NOTIFY: {
-    auto priv = m->get_connection()->get_priv();
-    auto s = static_cast<OSDSession*>(priv.get());
-    if (s) {
-      s->track_enqueue(m);
-      boost::asio::dispatch(s->strand, [this, priv, s, m]() {
-        cref_t<MWatchNotify> msg = ref_cast<MWatchNotify>(m);
-        s->track_dequeue(m);
-        handle_watch_notify(std::move(msg));
-      });
-    } else {
-      handle_watch_notify(ref_cast<MWatchNotify>(m));
-    }
-    return Dispatcher::HANDLED();
-  }
+  case CEPH_MSG_WATCH_NOTIFY: ceph_abort("should be fast dispatched"); break;
 
   case MSG_COMMAND_REPLY:
     if (m->get_source().type() == CEPH_ENTITY_TYPE_OSD) {
@@ -1166,8 +1177,9 @@ Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef& m)
     return Dispatcher::ACKNOWLEDGED();
 
   default:
-    return Dispatcher::UNHANDLED();
+    break;
   }
+  return Dispatcher::UNHANDLED();
 }
 
 void Objecter::_scan_requests(

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -274,6 +274,18 @@ void Objecter::update_crush_location()
 /*
  * initialize only internal data structures, don't initiate cluster interaction
  */
+class Objecter::SessionStrandHook : public AdminSocketHook {
+  Objecter *m_objecter;
+public:
+  explicit SessionStrandHook(Objecter *objecter) : m_objecter(objecter) {}
+  int call(std::string_view command, const cmdmap_t& cmdmap,
+	   const bufferlist&, Formatter *f,
+	   std::ostream& ss, cb::list& out) override {
+    m_objecter->dump_session_strands(f);
+    return 0;
+  }
+};
+
 void Objecter::init()
 {
   ceph_assert(!initialized);
@@ -427,6 +439,16 @@ void Objecter::init()
 	       << cpp_strerror(ret) << dendl;
   }
 
+  m_session_strand_hook = new SessionStrandHook(this);
+  ret = admin_socket->register_command("objecter_session_strands",
+				       m_session_strand_hook,
+				       "dump queued messages in per-OSD session strands");
+
+  if (ret < 0 && ret != -EEXIST) {
+    lderr(cct) << "error registering admin socket command: "
+	       << cpp_strerror(ret) << dendl;
+  }
+
   update_crush_location();
 
   cct->_conf.add_observer(this);
@@ -575,6 +597,13 @@ void Objecter::shutdown()
     admin_socket->unregister_commands(m_request_state_hook);
     delete m_request_state_hook;
     m_request_state_hook = NULL;
+  }
+
+  if (m_session_strand_hook) {
+    auto admin_socket = cct->get_admin_socket();
+    admin_socket->unregister_commands(m_session_strand_hook);
+    delete m_session_strand_hook;
+    m_session_strand_hook = NULL;
   }
 }
 
@@ -1042,63 +1071,71 @@ void Objecter::_do_watch_notify(boost::intrusive_ptr<LingerOp> info,
   info->finished_async();
 }
 
-Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef &m)
+Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef& m)
 {
   ldout(cct, 10) << __func__ << " " << cct << " " << *m << dendl;
   switch (m->get_type()) {
   case CEPH_MSG_OSD_OPREPLY: {
-    cref_t<MOSDOpReply> msg = ref_cast<MOSDOpReply>(m);
-    auto priv = msg->get_connection()->get_priv();
+    auto priv = m->get_connection()->get_priv();
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
-      boost::asio::dispatch(s->strand, [this, msg = std::move(msg)]() {
+      s->track_enqueue(m);
+      boost::asio::dispatch(s->strand, [this, priv, s, m]() {
+        cref_t<MOSDOpReply> msg = ref_cast<MOSDOpReply>(m);
+        s->track_dequeue(m);
         handle_osd_op_reply(std::move(msg));
       });
     } else {
-      handle_osd_op_reply(std::move(msg));
+      handle_osd_op_reply(ref_cast<MOSDOpReply>(m));
     }
     return Dispatcher::HANDLED();
   }
 
   case CEPH_MSG_OSD_BACKOFF: {
-    cref_t<MOSDBackoff> msg = ref_cast<MOSDBackoff>(m);
-    auto priv = msg->get_connection()->get_priv();
+    auto priv = m->get_connection()->get_priv();
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
-      boost::asio::dispatch(s->strand, [this, msg = std::move(msg)]() {
+      s->track_enqueue(m);
+      boost::asio::dispatch(s->strand, [this, priv, s, m]() {
+        cref_t<MOSDBackoff> msg = ref_cast<MOSDBackoff>(m);
+        s->track_dequeue(m);
         handle_osd_backoff(std::move(msg));
       });
     } else {
-      handle_osd_backoff(std::move(msg));
+      handle_osd_backoff(ref_cast<MOSDBackoff>(m));
     }
     return Dispatcher::HANDLED();
   }
 
   case CEPH_MSG_WATCH_NOTIFY: {
-    cref_t<MWatchNotify> msg = ref_cast<MWatchNotify>(m);
-    auto priv = msg->get_connection()->get_priv();
+    auto priv = m->get_connection()->get_priv();
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
-      boost::asio::dispatch(s->strand, [this, msg = std::move(msg)]() {
+      s->track_enqueue(m);
+      boost::asio::dispatch(s->strand, [this, priv, s, m]() {
+        cref_t<MWatchNotify> msg = ref_cast<MWatchNotify>(m);
+        s->track_dequeue(m);
         handle_watch_notify(std::move(msg));
       });
     } else {
-      handle_watch_notify(std::move(msg));
+      handle_watch_notify(ref_cast<MWatchNotify>(m));
     }
     return Dispatcher::HANDLED();
   }
 
   case MSG_COMMAND_REPLY:
     if (m->get_source().type() == CEPH_ENTITY_TYPE_OSD) {
-      cref_t<MCommandReply> msg = ref_cast<MCommandReply>(m);
-      auto priv = msg->get_connection()->get_priv();
+      auto priv = m->get_connection()->get_priv();
       auto s = static_cast<OSDSession*>(priv.get());
       if (s) {
-       boost::asio::dispatch(s->strand, [this, msg = std::move(msg)]() {
+        s->track_enqueue(m);
+        boost::asio::dispatch(s->strand, [this, priv, s, m]() {
+          cref_t<MCommandReply> msg = ref_cast<MCommandReply>(m);
+          s->track_dequeue(m);
           handle_command_reply(std::move(msg));
         });
       } else {
-        handle_command_reply(std::move(msg));
+        handle_command_reply(ref_cast<MCommandReply>(m));
       }
       return Dispatcher::HANDLED();
     } else {
@@ -5195,6 +5232,25 @@ int Objecter::RequestStateHook::call(std::string_view command,
   shared_lock rl(m_objecter->rwlock);
   m_objecter->dump_requests(f);
   return 0;
+}
+
+void Objecter::dump_session_strands(Formatter *f) {
+  shared_lock rl(rwlock);
+  f->open_array_section("osd_sessions");
+  for (const auto& [osd, s] : osd_sessions) {
+    f->open_object_section("session");
+    f->dump_int("osd", osd);
+    std::lock_guard l(s->strand_track_lock);
+    f->open_array_section("queued_messages");
+    for (const auto& msg : s->queued_messages) {
+      CachedStackStringStream css;
+      *css << *msg;
+      f->dump_string("message", css->strv());
+    }
+    f->close_section(); // queued_messages
+    f->close_section(); // session
+  }
+  f->close_section(); // osd_sessions
 }
 
 void Objecter::blocklist_self(bool set)

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1079,8 +1079,7 @@ void Objecter::ms_fast_dispatch2(const MessageRef& m)
     auto priv = m->get_connection()->get_priv();
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
-      s->track_enqueue(m);
-      boost::asio::post(s->strand, [this, priv, s, m]() {
+      s->track_enqueue(m, [this, priv, s, m]() {
         cref_t<MOSDOpReply> msg = ref_cast<MOSDOpReply>(m);
         s->track_dequeue(m);
         handle_osd_op_reply(std::move(msg));
@@ -1095,8 +1094,7 @@ void Objecter::ms_fast_dispatch2(const MessageRef& m)
     auto priv = m->get_connection()->get_priv();
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
-      s->track_enqueue(m);
-      boost::asio::post(s->strand, [this, priv, s, m]() {
+      s->track_enqueue(m, [this, priv, s, m]() {
         cref_t<MWatchNotify> msg = ref_cast<MWatchNotify>(m);
         s->track_dequeue(m);
         handle_watch_notify(std::move(msg));
@@ -1120,8 +1118,7 @@ Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef& m)
     auto priv = m->get_connection()->get_priv();
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
-      s->track_enqueue(m);
-      boost::asio::post(s->strand, [this, priv, s, m]() {
+      s->track_enqueue(m, [this, priv, s, m]() {
         cref_t<MOSDBackoff> msg = ref_cast<MOSDBackoff>(m);
         s->track_dequeue(m);
         handle_osd_backoff(std::move(msg));
@@ -1139,8 +1136,7 @@ Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef& m)
       auto priv = m->get_connection()->get_priv();
       auto s = static_cast<OSDSession*>(priv.get());
       if (s) {
-        s->track_enqueue(m);
-        boost::asio::post(s->strand, [this, priv, s, m]() {
+        s->track_enqueue(m, [this, priv, s, m]() {
           cref_t<MCommandReply> msg = ref_cast<MCommandReply>(m);
           s->track_dequeue(m);
           handle_command_reply(std::move(msg));

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -957,11 +957,11 @@ void Objecter::_linger_submit(LingerOp *info,
 struct CB_DoWatchNotify {
   Objecter *objecter;
   boost::intrusive_ptr<Objecter::LingerOp> info;
-  boost::intrusive_ptr<MWatchNotify> msg;
+  cref_t<MWatchNotify> msg;
   CB_DoWatchNotify(Objecter *o,
                    boost::intrusive_ptr<Objecter::LingerOp> i,
-                   MWatchNotify *m)
-    : objecter(o), info(std::move(i)), msg(m) {
+                   cref_t<MWatchNotify> m)
+    : objecter(o), info(std::move(i)), msg(std::move(m)) {
     info->_queued_async();
   }
   void operator()() {
@@ -969,7 +969,7 @@ struct CB_DoWatchNotify {
   }
 };
 
-void Objecter::handle_watch_notify(MWatchNotify *m)
+void Objecter::handle_watch_notify(cref_t<MWatchNotify> m)
 {
   shared_lock l(rwlock);
   if (!initialized) {
@@ -1002,18 +1002,18 @@ void Objecter::handle_watch_notify(MWatchNotify *m)
       asio::defer(service.get_executor(),
 		  asio::append(std::move(info->on_notify_finish),
 			       osdcode(m->return_code),
-			       std::move(m->get_data())));
+			       bufferlist(m->get_data())));
       // if we race with reconnect we might get a second notify; only
       // notify the caller once!
       info->on_notify_finish = nullptr;
     }
   } else {
-    asio::defer(finish_strand, CB_DoWatchNotify(this, std::move(info), m));
+    asio::defer(finish_strand, CB_DoWatchNotify(this, std::move(info), std::move(m)));
   }
 }
 
 void Objecter::_do_watch_notify(boost::intrusive_ptr<LingerOp> info,
-                                boost::intrusive_ptr<MWatchNotify> m)
+                                cref_t<MWatchNotify> m)
 {
   ldout(cct, 10) << __func__ << " " << *m << dendl;
 
@@ -1034,7 +1034,7 @@ void Objecter::_do_watch_notify(boost::intrusive_ptr<LingerOp> info,
 
   switch (m->opcode) {
   case CEPH_WATCH_EVENT_NOTIFY:
-    info->handle({}, m->notify_id, m->cookie, m->notifier_gid, std::move(m->bl));
+    info->handle({}, m->notify_id, m->cookie, m->notifier_gid, bufferlist{m->bl});
     break;
   }
 
@@ -1046,26 +1046,60 @@ Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef &m)
 {
   ldout(cct, 10) << __func__ << " " << cct << " " << *m << dendl;
   switch (m->get_type()) {
-    // these we exlusively handle
-  case CEPH_MSG_OSD_OPREPLY:
-    m->get(); /* ref to be consumed */
-    handle_osd_op_reply(ref_cast<MOSDOpReply>(m).get());
+  case CEPH_MSG_OSD_OPREPLY: {
+    cref_t<MOSDOpReply> msg = ref_cast<MOSDOpReply>(m);
+    auto priv = msg->get_connection()->get_priv();
+    auto s = static_cast<OSDSession*>(priv.get());
+    if (s) {
+      boost::asio::dispatch(s->strand, [this, msg = std::move(msg)]() {
+        handle_osd_op_reply(std::move(msg));
+      });
+    } else {
+      handle_osd_op_reply(std::move(msg));
+    }
     return Dispatcher::HANDLED();
+  }
 
-  case CEPH_MSG_OSD_BACKOFF:
-    m->get(); /* ref to be consumed */
-    handle_osd_backoff(ref_cast<MOSDBackoff>(m).get());
+  case CEPH_MSG_OSD_BACKOFF: {
+    cref_t<MOSDBackoff> msg = ref_cast<MOSDBackoff>(m);
+    auto priv = msg->get_connection()->get_priv();
+    auto s = static_cast<OSDSession*>(priv.get());
+    if (s) {
+      boost::asio::dispatch(s->strand, [this, msg = std::move(msg)]() {
+        handle_osd_backoff(std::move(msg));
+      });
+    } else {
+      handle_osd_backoff(std::move(msg));
+    }
     return Dispatcher::HANDLED();
+  }
 
-  case CEPH_MSG_WATCH_NOTIFY:
-    /* ref not consumed! */
-    handle_watch_notify(ref_cast<MWatchNotify>(m).get());
+  case CEPH_MSG_WATCH_NOTIFY: {
+    cref_t<MWatchNotify> msg = ref_cast<MWatchNotify>(m);
+    auto priv = msg->get_connection()->get_priv();
+    auto s = static_cast<OSDSession*>(priv.get());
+    if (s) {
+      boost::asio::dispatch(s->strand, [this, msg = std::move(msg)]() {
+        handle_watch_notify(std::move(msg));
+      });
+    } else {
+      handle_watch_notify(std::move(msg));
+    }
     return Dispatcher::HANDLED();
+  }
 
   case MSG_COMMAND_REPLY:
     if (m->get_source().type() == CEPH_ENTITY_TYPE_OSD) {
-      m->get(); /* ref to be consumed */
-      handle_command_reply(ref_cast<MCommandReply>(m).get());
+      cref_t<MCommandReply> msg = ref_cast<MCommandReply>(m);
+      auto priv = msg->get_connection()->get_priv();
+      auto s = static_cast<OSDSession*>(priv.get());
+      if (s) {
+       boost::asio::dispatch(s->strand, [this, msg = std::move(msg)]() {
+          handle_command_reply(std::move(msg));
+        });
+      } else {
+        handle_command_reply(std::move(msg));
+      }
       return Dispatcher::HANDLED();
     } else {
       return Dispatcher::UNHANDLED();
@@ -1942,7 +1976,7 @@ int Objecter::_get_session(int osd, OSDSession **session,
   if (!sul.owns_lock()) {
     return -EAGAIN;
   }
-  auto s = new OSDSession(cct, osd);
+  auto s = new OSDSession(cct, osd, service.get_executor());
   osd_sessions[osd] = s;
   s->con = messenger->connect_to_osd(osdmap->get_addrs(osd));
   s->con->set_priv(RefCountedPtr{s});
@@ -3717,8 +3751,7 @@ int Objecter::take_linger_budget(LingerOp *info)
   return 1;
 }
 
-bs::error_code Objecter::process_op_reply_handlers(Op *op, vector<OSDOp> &out_ops) {
-
+bs::error_code Objecter::process_op_reply_handlers(Op *op, const vector<OSDOp>& out_ops) {
   ceph_assert(op->ops.size() == op->out_bl.size());
   ceph_assert(op->ops.size() == op->out_rval.size());
   ceph_assert(op->ops.size() == op->out_ec.size());
@@ -3793,8 +3826,7 @@ bs::error_code Objecter::process_op_reply_handlers(Op *op, vector<OSDOp> &out_op
 }
 
 
-/* This function DOES put the passed message before returning */
-void Objecter::handle_osd_op_reply(MOSDOpReply *m)
+void Objecter::handle_osd_op_reply(cref_t<MOSDOpReply> m)
 {
   ldout(cct, 10) << "in handle_osd_op_reply" << dendl;
 
@@ -3803,7 +3835,6 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
 
   shunique_lock sul(rwlock, ceph::acquire_shared);
   if (!initialized) {
-    m->put();
     return;
   }
 
@@ -3812,7 +3843,6 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
   auto s = static_cast<OSDSession*>(priv.get());
   if (!s || s->con != con) {
     ldout(cct, 7) << __func__ << " no session on con " << con << dendl;
-    m->put();
     return;
   }
 
@@ -3825,7 +3855,6 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
 						    " onnvram" : " ack"))
 		  << " ... stray" << dendl;
     sl.unlock();
-    m->put();
     return;
   }
 
@@ -3849,7 +3878,6 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
     sl.unlock();
 
     _op_submit(op, sul, NULL);
-    m->put();
     return;
   }
 
@@ -3860,7 +3888,6 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
 		    << " from " << m->get_source_inst()
 		    << "; last attempt " << (op->attempts - 1) << " sent to "
 		    << op->session->con->get_peer_addr() << dendl;
-      m->put();
       sl.unlock();
       return;
     }
@@ -3888,7 +3915,6 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
 			 CEPH_OSD_FLAG_IGNORE_CACHE |
 			 CEPH_OSD_FLAG_IGNORE_OVERLAY);
     _op_submit(op, sul, NULL);
-    m->put();
     return;
   }
 
@@ -3917,7 +3943,6 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
     op->target.flags &= ~CEPH_OSD_FLAG_FORCE_OSD;
     op->target.pgid = pg_t();
     _op_submit(op, sul, NULL);
-    m->put();
     return;
   }
 
@@ -3951,14 +3976,13 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
       bl.begin().copy(bl.length(), t.c_str());
       op->outbl->substr_of(t, 0, bl.length());
     } else {
-      m->claim_data(*op->outbl);
+      *op->outbl = m->get_data();
     }
     op->outbl = 0;
   }
 
   // per-op result demuxing
-  vector<OSDOp> out_ops;
-  m->claim_ops(out_ops);
+  auto& out_ops = m->get_ops();
 
   if (out_ops.size() != op->ops.size())
     ldout(cct, 0) << "WARNING: tid " << op->tid << " reply ops " << out_ops
@@ -3973,7 +3997,6 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
 
   // This function unlocks sl.
   complete_op_reply(op, handler_error, s, sl, rc);
-  m->put();
 }
 
 void Objecter::complete_op_reply(Op *op, bs::error_code handler_error, OSDSession *s, unique_lock<std::shared_mutex> &sl, int rc) {
@@ -4015,12 +4038,11 @@ void Objecter::complete_op_reply(Op *op, bs::error_code handler_error, OSDSessio
   }
 }
 
-void Objecter::handle_osd_backoff(MOSDBackoff *m)
+void Objecter::handle_osd_backoff(cref_t<MOSDBackoff> m)
 {
   ldout(cct, 10) << __func__ << " " << *m << dendl;
   shunique_lock sul(rwlock, ceph::acquire_shared);
   if (!initialized) {
-    m->put();
     return;
   }
 
@@ -4029,7 +4051,6 @@ void Objecter::handle_osd_backoff(MOSDBackoff *m)
   auto s = static_cast<OSDSession*>(priv.get());
   if (!s || s->con != con) {
     ldout(cct, 7) << __func__ << " no session on con " << con << dendl;
-    m->put();
     return;
   }
 
@@ -4110,7 +4131,6 @@ void Objecter::handle_osd_backoff(MOSDBackoff *m)
   sul.unlock();
   sl.unlock();
 
-  m->put();
   put_session(s);
 }
 
@@ -5203,11 +5223,10 @@ void Objecter::blocklist_self(bool set)
 
 // commands
 
-void Objecter::handle_command_reply(MCommandReply *m)
+void Objecter::handle_command_reply(cref_t<MCommandReply> m)
 {
   unique_lock wl(rwlock);
   if (!initialized) {
-    m->put();
     return;
   }
 
@@ -5216,7 +5235,6 @@ void Objecter::handle_command_reply(MCommandReply *m)
   auto s = static_cast<OSDSession*>(priv.get());
   if (!s || s->con != con) {
     ldout(cct, 7) << __func__ << " no session on con " << con << dendl;
-    m->put();
     return;
   }
 
@@ -5225,7 +5243,6 @@ void Objecter::handle_command_reply(MCommandReply *m)
   if (p == s->command_ops.end()) {
     ldout(cct, 10) << "handle_command_reply tid " << m->get_tid()
 		   << " not found" << dendl;
-    m->put();
     sl.unlock();
     return;
   }
@@ -5237,7 +5254,6 @@ void Objecter::handle_command_reply(MCommandReply *m)
 		   << " got reply from wrong connection "
 		   << m->get_connection() << " " << m->get_source_inst()
 		   << dendl;
-    m->put();
     sl.unlock();
     return;
   }
@@ -5249,7 +5265,6 @@ void Objecter::handle_command_reply(MCommandReply *m)
     // we get an updated osdmap and the PG is found to have moved.
     _maybe_request_map();
     _send_command(c);
-    m->put();
     sl.unlock();
     return;
   }
@@ -5258,11 +5273,9 @@ void Objecter::handle_command_reply(MCommandReply *m)
 
   unique_lock sul(s->lock);
   _finish_command(c, m->r < 0 ? bs::error_code(-m->r, osd_category()) :
-		  bs::error_code(), std::move(m->rs),
-		  std::move(m->get_data()));
+		  bs::error_code(), std::string(m->rs),
+		  bufferlist(m->get_data()));
   sul.unlock();
-
-  m->put();
 }
 
 Objecter::LingerOp::LingerOp(Objecter *o, uint64_t linger_id)
@@ -5459,7 +5472,9 @@ Objecter::OSDSession::~OSDSession()
 Objecter::Objecter(CephContext *cct,
 		   Messenger *m, MonClient *mc,
 		   asio::io_context& service) :
-  Dispatcher(cct), messenger(m), monc(mc), service(service)
+  Dispatcher(cct), messenger(m), monc(mc), service(service),
+  homeless_session(new OSDSession(cct, -1, service.get_executor())),
+  splitop_session(new OSDSession(cct, -2, service.get_executor())) // -2 to differentiate from homeless
 {
   mon_timeout = cct->_conf.get_val<std::chrono::seconds>("rados_mon_op_timeout");
   osd_timeout = cct->_conf.get_val<std::chrono::seconds>("rados_osd_op_timeout");

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1080,8 +1080,8 @@ void Objecter::ms_fast_dispatch2(const MessageRef& m)
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
       s->track_enqueue(m, [this, priv, s, m]() {
-        s->track_dequeue(m);
         handle_osd_op_reply(cref_cast<MOSDOpReply>(m));
+        s->track_dequeue(m);
       });
     } else {
       handle_osd_op_reply(cref_cast<MOSDOpReply>(m));
@@ -1094,8 +1094,8 @@ void Objecter::ms_fast_dispatch2(const MessageRef& m)
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
       s->track_enqueue(m, [this, priv, s, m]() {
-        s->track_dequeue(m);
         handle_watch_notify(cref_cast<MWatchNotify>(m));
+        s->track_dequeue(m);
       });
     } else {
       handle_watch_notify(cref_cast<MWatchNotify>(m));
@@ -1117,8 +1117,8 @@ Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef& m)
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
       s->track_enqueue(m, [this, priv, s, m]() {
-        s->track_dequeue(m);
         handle_osd_backoff(cref_cast<MOSDBackoff>(m));
+        s->track_dequeue(m);
       });
     } else {
       handle_osd_backoff(cref_cast<MOSDBackoff>(m));
@@ -1134,8 +1134,8 @@ Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef& m)
       auto s = static_cast<OSDSession*>(priv.get());
       if (s) {
         s->track_enqueue(m, [this, priv, s, m]() {
-          s->track_dequeue(m);
           handle_command_reply(cref_cast<MCommandReply>(m));
+          s->track_dequeue(m);
         });
       } else {
         handle_command_reply(cref_cast<MCommandReply>(m));

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -278,6 +278,18 @@ void Objecter::update_crush_location()
 /*
  * initialize only internal data structures, don't initiate cluster interaction
  */
+class Objecter::SessionStrandHook : public AdminSocketHook {
+  Objecter *m_objecter;
+public:
+  explicit SessionStrandHook(Objecter *objecter) : m_objecter(objecter) {}
+  int call(std::string_view command, const cmdmap_t& cmdmap,
+	   const bufferlist&, Formatter *f,
+	   std::ostream& ss, cb::list& out) override {
+    m_objecter->dump_session_strands(f);
+    return 0;
+  }
+};
+
 void Objecter::init()
 {
   ceph_assert(!initialized);
@@ -444,6 +456,16 @@ void Objecter::init()
 	       << cpp_strerror(ret) << dendl;
   }
 
+  m_session_strand_hook = new SessionStrandHook(this);
+  ret = admin_socket->register_command("objecter_session_strands",
+				       m_session_strand_hook,
+				       "dump queued messages in per-OSD session strands");
+
+  if (ret < 0 && ret != -EEXIST) {
+    lderr(cct) << "error registering admin socket command: "
+	       << cpp_strerror(ret) << dendl;
+  }
+
   update_crush_location();
 
   cct->_conf.add_observer(this);
@@ -592,6 +614,13 @@ void Objecter::shutdown()
     admin_socket->unregister_commands(m_request_state_hook);
     delete m_request_state_hook;
     m_request_state_hook = NULL;
+  }
+
+  if (m_session_strand_hook) {
+    auto admin_socket = cct->get_admin_socket();
+    admin_socket->unregister_commands(m_session_strand_hook);
+    delete m_session_strand_hook;
+    m_session_strand_hook = NULL;
   }
 }
 
@@ -1059,63 +1088,71 @@ void Objecter::_do_watch_notify(boost::intrusive_ptr<LingerOp> info,
   info->finished_async();
 }
 
-Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef &m)
+Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef& m)
 {
   ldout(cct, 10) << __func__ << " " << cct << " " << *m << dendl;
   switch (m->get_type()) {
   case CEPH_MSG_OSD_OPREPLY: {
-    cref_t<MOSDOpReply> msg = ref_cast<MOSDOpReply>(m);
-    auto priv = msg->get_connection()->get_priv();
+    auto priv = m->get_connection()->get_priv();
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
-      boost::asio::dispatch(s->strand, [this, msg = std::move(msg)]() {
+      s->track_enqueue(m);
+      boost::asio::dispatch(s->strand, [this, priv, s, m]() {
+        cref_t<MOSDOpReply> msg = ref_cast<MOSDOpReply>(m);
+        s->track_dequeue(m);
         handle_osd_op_reply(std::move(msg));
       });
     } else {
-      handle_osd_op_reply(std::move(msg));
+      handle_osd_op_reply(ref_cast<MOSDOpReply>(m));
     }
     return Dispatcher::HANDLED();
   }
 
   case CEPH_MSG_OSD_BACKOFF: {
-    cref_t<MOSDBackoff> msg = ref_cast<MOSDBackoff>(m);
-    auto priv = msg->get_connection()->get_priv();
+    auto priv = m->get_connection()->get_priv();
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
-      boost::asio::dispatch(s->strand, [this, msg = std::move(msg)]() {
+      s->track_enqueue(m);
+      boost::asio::dispatch(s->strand, [this, priv, s, m]() {
+        cref_t<MOSDBackoff> msg = ref_cast<MOSDBackoff>(m);
+        s->track_dequeue(m);
         handle_osd_backoff(std::move(msg));
       });
     } else {
-      handle_osd_backoff(std::move(msg));
+      handle_osd_backoff(ref_cast<MOSDBackoff>(m));
     }
     return Dispatcher::HANDLED();
   }
 
   case CEPH_MSG_WATCH_NOTIFY: {
-    cref_t<MWatchNotify> msg = ref_cast<MWatchNotify>(m);
-    auto priv = msg->get_connection()->get_priv();
+    auto priv = m->get_connection()->get_priv();
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
-      boost::asio::dispatch(s->strand, [this, msg = std::move(msg)]() {
+      s->track_enqueue(m);
+      boost::asio::dispatch(s->strand, [this, priv, s, m]() {
+        cref_t<MWatchNotify> msg = ref_cast<MWatchNotify>(m);
+        s->track_dequeue(m);
         handle_watch_notify(std::move(msg));
       });
     } else {
-      handle_watch_notify(std::move(msg));
+      handle_watch_notify(ref_cast<MWatchNotify>(m));
     }
     return Dispatcher::HANDLED();
   }
 
   case MSG_COMMAND_REPLY:
     if (m->get_source().type() == CEPH_ENTITY_TYPE_OSD) {
-      cref_t<MCommandReply> msg = ref_cast<MCommandReply>(m);
-      auto priv = msg->get_connection()->get_priv();
+      auto priv = m->get_connection()->get_priv();
       auto s = static_cast<OSDSession*>(priv.get());
       if (s) {
-       boost::asio::dispatch(s->strand, [this, msg = std::move(msg)]() {
+        s->track_enqueue(m);
+        boost::asio::dispatch(s->strand, [this, priv, s, m]() {
+          cref_t<MCommandReply> msg = ref_cast<MCommandReply>(m);
+          s->track_dequeue(m);
           handle_command_reply(std::move(msg));
         });
       } else {
-        handle_command_reply(std::move(msg));
+        handle_command_reply(ref_cast<MCommandReply>(m));
       }
       return Dispatcher::HANDLED();
     } else {
@@ -5212,6 +5249,25 @@ int Objecter::RequestStateHook::call(std::string_view command,
   shared_lock rl(m_objecter->rwlock);
   m_objecter->dump_requests(f);
   return 0;
+}
+
+void Objecter::dump_session_strands(Formatter *f) {
+  shared_lock rl(rwlock);
+  f->open_array_section("osd_sessions");
+  for (const auto& [osd, s] : osd_sessions) {
+    f->open_object_section("session");
+    f->dump_int("osd", osd);
+    std::lock_guard l(s->strand_track_lock);
+    f->open_array_section("queued_messages");
+    for (const auto& msg : s->queued_messages) {
+      CachedStackStringStream css;
+      *css << *msg;
+      f->dump_string("message", css->strv());
+    }
+    f->close_section(); // queued_messages
+    f->close_section(); // session
+  }
+  f->close_section(); // osd_sessions
 }
 
 void Objecter::blocklist_self(bool set)

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1088,7 +1088,7 @@ void Objecter::_do_watch_notify(boost::intrusive_ptr<LingerOp> info,
   info->finished_async();
 }
 
-Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef& m)
+void Objecter::ms_fast_dispatch2(const MessageRef& m)
 {
   ldout(cct, 10) << __func__ << " " << cct << " " << *m << dendl;
   switch (m->get_type()) {
@@ -1105,8 +1105,33 @@ Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef& m)
     } else {
       handle_osd_op_reply(ref_cast<MOSDOpReply>(m));
     }
-    return Dispatcher::HANDLED();
+    return;
   }
+
+  case CEPH_MSG_WATCH_NOTIFY: {
+    auto priv = m->get_connection()->get_priv();
+    auto s = static_cast<OSDSession*>(priv.get());
+    if (s) {
+      s->track_enqueue(m);
+      boost::asio::dispatch(s->strand, [this, priv, s, m]() {
+        cref_t<MWatchNotify> msg = ref_cast<MWatchNotify>(m);
+        s->track_dequeue(m);
+        handle_watch_notify(std::move(msg));
+      });
+    } else {
+      handle_watch_notify(ref_cast<MWatchNotify>(m));
+    }
+    return;
+  }
+  default: ceph_abort("should be unreachable"); break;
+  }
+}
+
+Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef& m)
+{
+  ldout(cct, 10) << __func__ << " " << cct << " " << *m << dendl;
+  switch (m->get_type()) {
+  case CEPH_MSG_OSD_OPREPLY: ceph_abort("should be fast dispatched"); break;
 
   case CEPH_MSG_OSD_BACKOFF: {
     auto priv = m->get_connection()->get_priv();
@@ -1124,21 +1149,7 @@ Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef& m)
     return Dispatcher::HANDLED();
   }
 
-  case CEPH_MSG_WATCH_NOTIFY: {
-    auto priv = m->get_connection()->get_priv();
-    auto s = static_cast<OSDSession*>(priv.get());
-    if (s) {
-      s->track_enqueue(m);
-      boost::asio::dispatch(s->strand, [this, priv, s, m]() {
-        cref_t<MWatchNotify> msg = ref_cast<MWatchNotify>(m);
-        s->track_dequeue(m);
-        handle_watch_notify(std::move(msg));
-      });
-    } else {
-      handle_watch_notify(ref_cast<MWatchNotify>(m));
-    }
-    return Dispatcher::HANDLED();
-  }
+  case CEPH_MSG_WATCH_NOTIFY: ceph_abort("should be fast dispatched"); break;
 
   case MSG_COMMAND_REPLY:
     if (m->get_source().type() == CEPH_ENTITY_TYPE_OSD) {
@@ -1183,8 +1194,9 @@ Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef& m)
     return Dispatcher::ACKNOWLEDGED();
 
   default:
-    return Dispatcher::UNHANDLED();
+    break;
   }
+  return Dispatcher::UNHANDLED();
 }
 
 void Objecter::_scan_requests(

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1096,8 +1096,7 @@ void Objecter::ms_fast_dispatch2(const MessageRef& m)
     auto priv = m->get_connection()->get_priv();
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
-      s->track_enqueue(m);
-      boost::asio::post(s->strand, [this, priv, s, m]() {
+      s->track_enqueue(m, [this, priv, s, m]() {
         cref_t<MOSDOpReply> msg = ref_cast<MOSDOpReply>(m);
         s->track_dequeue(m);
         handle_osd_op_reply(std::move(msg));
@@ -1112,8 +1111,7 @@ void Objecter::ms_fast_dispatch2(const MessageRef& m)
     auto priv = m->get_connection()->get_priv();
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
-      s->track_enqueue(m);
-      boost::asio::post(s->strand, [this, priv, s, m]() {
+      s->track_enqueue(m, [this, priv, s, m]() {
         cref_t<MWatchNotify> msg = ref_cast<MWatchNotify>(m);
         s->track_dequeue(m);
         handle_watch_notify(std::move(msg));
@@ -1137,8 +1135,7 @@ Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef& m)
     auto priv = m->get_connection()->get_priv();
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
-      s->track_enqueue(m);
-      boost::asio::post(s->strand, [this, priv, s, m]() {
+      s->track_enqueue(m, [this, priv, s, m]() {
         cref_t<MOSDBackoff> msg = ref_cast<MOSDBackoff>(m);
         s->track_dequeue(m);
         handle_osd_backoff(std::move(msg));
@@ -1156,8 +1153,7 @@ Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef& m)
       auto priv = m->get_connection()->get_priv();
       auto s = static_cast<OSDSession*>(priv.get());
       if (s) {
-        s->track_enqueue(m);
-        boost::asio::post(s->strand, [this, priv, s, m]() {
+        s->track_enqueue(m, [this, priv, s, m]() {
           cref_t<MCommandReply> msg = ref_cast<MCommandReply>(m);
           s->track_dequeue(m);
           handle_command_reply(std::move(msg));

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1097,12 +1097,11 @@ void Objecter::ms_fast_dispatch2(const MessageRef& m)
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
       s->track_enqueue(m, [this, priv, s, m]() {
-        cref_t<MOSDOpReply> msg = ref_cast<MOSDOpReply>(m);
         s->track_dequeue(m);
-        handle_osd_op_reply(std::move(msg));
+        handle_osd_op_reply(cref_cast<MOSDOpReply>(m));
       });
     } else {
-      handle_osd_op_reply(ref_cast<MOSDOpReply>(m));
+      handle_osd_op_reply(cref_cast<MOSDOpReply>(m));
     }
     return;
   }
@@ -1112,12 +1111,11 @@ void Objecter::ms_fast_dispatch2(const MessageRef& m)
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
       s->track_enqueue(m, [this, priv, s, m]() {
-        cref_t<MWatchNotify> msg = ref_cast<MWatchNotify>(m);
         s->track_dequeue(m);
-        handle_watch_notify(std::move(msg));
+        handle_watch_notify(cref_cast<MWatchNotify>(m));
       });
     } else {
-      handle_watch_notify(ref_cast<MWatchNotify>(m));
+      handle_watch_notify(cref_cast<MWatchNotify>(m));
     }
     return;
   }
@@ -1136,12 +1134,11 @@ Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef& m)
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
       s->track_enqueue(m, [this, priv, s, m]() {
-        cref_t<MOSDBackoff> msg = ref_cast<MOSDBackoff>(m);
         s->track_dequeue(m);
-        handle_osd_backoff(std::move(msg));
+        handle_osd_backoff(cref_cast<MOSDBackoff>(m));
       });
     } else {
-      handle_osd_backoff(ref_cast<MOSDBackoff>(m));
+      handle_osd_backoff(cref_cast<MOSDBackoff>(m));
     }
     return Dispatcher::HANDLED();
   }
@@ -1154,12 +1151,11 @@ Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef& m)
       auto s = static_cast<OSDSession*>(priv.get());
       if (s) {
         s->track_enqueue(m, [this, priv, s, m]() {
-          cref_t<MCommandReply> msg = ref_cast<MCommandReply>(m);
           s->track_dequeue(m);
-          handle_command_reply(std::move(msg));
+          handle_command_reply(cref_cast<MCommandReply>(m));
         });
       } else {
-        handle_command_reply(ref_cast<MCommandReply>(m));
+        handle_command_reply(cref_cast<MCommandReply>(m));
       }
       return Dispatcher::HANDLED();
     } else {

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1097,7 +1097,7 @@ void Objecter::ms_fast_dispatch2(const MessageRef& m)
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
       s->track_enqueue(m);
-      boost::asio::dispatch(s->strand, [this, priv, s, m]() {
+      boost::asio::post(s->strand, [this, priv, s, m]() {
         cref_t<MOSDOpReply> msg = ref_cast<MOSDOpReply>(m);
         s->track_dequeue(m);
         handle_osd_op_reply(std::move(msg));
@@ -1113,7 +1113,7 @@ void Objecter::ms_fast_dispatch2(const MessageRef& m)
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
       s->track_enqueue(m);
-      boost::asio::dispatch(s->strand, [this, priv, s, m]() {
+      boost::asio::post(s->strand, [this, priv, s, m]() {
         cref_t<MWatchNotify> msg = ref_cast<MWatchNotify>(m);
         s->track_dequeue(m);
         handle_watch_notify(std::move(msg));
@@ -1138,7 +1138,7 @@ Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef& m)
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
       s->track_enqueue(m);
-      boost::asio::dispatch(s->strand, [this, priv, s, m]() {
+      boost::asio::post(s->strand, [this, priv, s, m]() {
         cref_t<MOSDBackoff> msg = ref_cast<MOSDBackoff>(m);
         s->track_dequeue(m);
         handle_osd_backoff(std::move(msg));
@@ -1157,7 +1157,7 @@ Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef& m)
       auto s = static_cast<OSDSession*>(priv.get());
       if (s) {
         s->track_enqueue(m);
-        boost::asio::dispatch(s->strand, [this, priv, s, m]() {
+        boost::asio::post(s->strand, [this, priv, s, m]() {
           cref_t<MCommandReply> msg = ref_cast<MCommandReply>(m);
           s->track_dequeue(m);
           handle_command_reply(std::move(msg));

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1097,8 +1097,8 @@ void Objecter::ms_fast_dispatch2(const MessageRef& m)
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
       s->track_enqueue(m, [this, priv, s, m]() {
-        s->track_dequeue(m);
         handle_osd_op_reply(cref_cast<MOSDOpReply>(m));
+        s->track_dequeue(m);
       });
     } else {
       handle_osd_op_reply(cref_cast<MOSDOpReply>(m));
@@ -1111,8 +1111,8 @@ void Objecter::ms_fast_dispatch2(const MessageRef& m)
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
       s->track_enqueue(m, [this, priv, s, m]() {
-        s->track_dequeue(m);
         handle_watch_notify(cref_cast<MWatchNotify>(m));
+        s->track_dequeue(m);
       });
     } else {
       handle_watch_notify(cref_cast<MWatchNotify>(m));
@@ -1134,8 +1134,8 @@ Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef& m)
     auto s = static_cast<OSDSession*>(priv.get());
     if (s) {
       s->track_enqueue(m, [this, priv, s, m]() {
-        s->track_dequeue(m);
         handle_osd_backoff(cref_cast<MOSDBackoff>(m));
+        s->track_dequeue(m);
       });
     } else {
       handle_osd_backoff(cref_cast<MOSDBackoff>(m));
@@ -1151,8 +1151,8 @@ Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef& m)
       auto s = static_cast<OSDSession*>(priv.get());
       if (s) {
         s->track_enqueue(m, [this, priv, s, m]() {
-          s->track_dequeue(m);
           handle_command_reply(cref_cast<MCommandReply>(m));
+          s->track_dequeue(m);
         });
       } else {
         handle_command_reply(cref_cast<MCommandReply>(m));

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -974,11 +974,11 @@ void Objecter::_linger_submit(LingerOp *info,
 struct CB_DoWatchNotify {
   Objecter *objecter;
   boost::intrusive_ptr<Objecter::LingerOp> info;
-  boost::intrusive_ptr<MWatchNotify> msg;
+  cref_t<MWatchNotify> msg;
   CB_DoWatchNotify(Objecter *o,
                    boost::intrusive_ptr<Objecter::LingerOp> i,
-                   MWatchNotify *m)
-    : objecter(o), info(std::move(i)), msg(m) {
+                   cref_t<MWatchNotify> m)
+    : objecter(o), info(std::move(i)), msg(std::move(m)) {
     info->_queued_async();
   }
   void operator()() {
@@ -986,7 +986,7 @@ struct CB_DoWatchNotify {
   }
 };
 
-void Objecter::handle_watch_notify(MWatchNotify *m)
+void Objecter::handle_watch_notify(cref_t<MWatchNotify> m)
 {
   shared_lock l(rwlock);
   if (!initialized) {
@@ -1019,18 +1019,18 @@ void Objecter::handle_watch_notify(MWatchNotify *m)
       asio::defer(service.get_executor(),
 		  asio::append(std::move(info->on_notify_finish),
 			       osdcode(m->return_code),
-			       std::move(m->get_data())));
+			       bufferlist(m->get_data())));
       // if we race with reconnect we might get a second notify; only
       // notify the caller once!
       info->on_notify_finish = nullptr;
     }
   } else {
-    asio::defer(finish_strand, CB_DoWatchNotify(this, std::move(info), m));
+    asio::defer(finish_strand, CB_DoWatchNotify(this, std::move(info), std::move(m)));
   }
 }
 
 void Objecter::_do_watch_notify(boost::intrusive_ptr<LingerOp> info,
-                                boost::intrusive_ptr<MWatchNotify> m)
+                                cref_t<MWatchNotify> m)
 {
   ldout(cct, 10) << __func__ << " " << *m << dendl;
 
@@ -1051,7 +1051,7 @@ void Objecter::_do_watch_notify(boost::intrusive_ptr<LingerOp> info,
 
   switch (m->opcode) {
   case CEPH_WATCH_EVENT_NOTIFY:
-    info->handle({}, m->notify_id, m->cookie, m->notifier_gid, std::move(m->bl));
+    info->handle({}, m->notify_id, m->cookie, m->notifier_gid, bufferlist{m->bl});
     break;
   }
 
@@ -1063,26 +1063,60 @@ Dispatcher::dispatch_result_t Objecter::ms_dispatch2(const MessageRef &m)
 {
   ldout(cct, 10) << __func__ << " " << cct << " " << *m << dendl;
   switch (m->get_type()) {
-    // these we exlusively handle
-  case CEPH_MSG_OSD_OPREPLY:
-    m->get(); /* ref to be consumed */
-    handle_osd_op_reply(ref_cast<MOSDOpReply>(m).get());
+  case CEPH_MSG_OSD_OPREPLY: {
+    cref_t<MOSDOpReply> msg = ref_cast<MOSDOpReply>(m);
+    auto priv = msg->get_connection()->get_priv();
+    auto s = static_cast<OSDSession*>(priv.get());
+    if (s) {
+      boost::asio::dispatch(s->strand, [this, msg = std::move(msg)]() {
+        handle_osd_op_reply(std::move(msg));
+      });
+    } else {
+      handle_osd_op_reply(std::move(msg));
+    }
     return Dispatcher::HANDLED();
+  }
 
-  case CEPH_MSG_OSD_BACKOFF:
-    m->get(); /* ref to be consumed */
-    handle_osd_backoff(ref_cast<MOSDBackoff>(m).get());
+  case CEPH_MSG_OSD_BACKOFF: {
+    cref_t<MOSDBackoff> msg = ref_cast<MOSDBackoff>(m);
+    auto priv = msg->get_connection()->get_priv();
+    auto s = static_cast<OSDSession*>(priv.get());
+    if (s) {
+      boost::asio::dispatch(s->strand, [this, msg = std::move(msg)]() {
+        handle_osd_backoff(std::move(msg));
+      });
+    } else {
+      handle_osd_backoff(std::move(msg));
+    }
     return Dispatcher::HANDLED();
+  }
 
-  case CEPH_MSG_WATCH_NOTIFY:
-    /* ref not consumed! */
-    handle_watch_notify(ref_cast<MWatchNotify>(m).get());
+  case CEPH_MSG_WATCH_NOTIFY: {
+    cref_t<MWatchNotify> msg = ref_cast<MWatchNotify>(m);
+    auto priv = msg->get_connection()->get_priv();
+    auto s = static_cast<OSDSession*>(priv.get());
+    if (s) {
+      boost::asio::dispatch(s->strand, [this, msg = std::move(msg)]() {
+        handle_watch_notify(std::move(msg));
+      });
+    } else {
+      handle_watch_notify(std::move(msg));
+    }
     return Dispatcher::HANDLED();
+  }
 
   case MSG_COMMAND_REPLY:
     if (m->get_source().type() == CEPH_ENTITY_TYPE_OSD) {
-      m->get(); /* ref to be consumed */
-      handle_command_reply(ref_cast<MCommandReply>(m).get());
+      cref_t<MCommandReply> msg = ref_cast<MCommandReply>(m);
+      auto priv = msg->get_connection()->get_priv();
+      auto s = static_cast<OSDSession*>(priv.get());
+      if (s) {
+       boost::asio::dispatch(s->strand, [this, msg = std::move(msg)]() {
+          handle_command_reply(std::move(msg));
+        });
+      } else {
+        handle_command_reply(std::move(msg));
+      }
       return Dispatcher::HANDLED();
     } else {
       return Dispatcher::UNHANDLED();
@@ -1959,7 +1993,7 @@ int Objecter::_get_session(int osd, OSDSession **session,
   if (!sul.owns_lock()) {
     return -EAGAIN;
   }
-  auto s = new OSDSession(cct, osd);
+  auto s = new OSDSession(cct, osd, service.get_executor());
   osd_sessions[osd] = s;
   s->con = messenger->connect_to_osd(osdmap->get_addrs(osd));
   s->con->set_priv(RefCountedPtr{s});
@@ -3734,8 +3768,7 @@ int Objecter::take_linger_budget(LingerOp *info)
   return 1;
 }
 
-bs::error_code Objecter::process_op_reply_handlers(Op *op, vector<OSDOp> &out_ops) {
-
+bs::error_code Objecter::process_op_reply_handlers(Op *op, const vector<OSDOp>& out_ops) {
   ceph_assert(op->ops.size() == op->out_bl.size());
   ceph_assert(op->ops.size() == op->out_rval.size());
   ceph_assert(op->ops.size() == op->out_ec.size());
@@ -3810,8 +3843,7 @@ bs::error_code Objecter::process_op_reply_handlers(Op *op, vector<OSDOp> &out_op
 }
 
 
-/* This function DOES put the passed message before returning */
-void Objecter::handle_osd_op_reply(MOSDOpReply *m)
+void Objecter::handle_osd_op_reply(cref_t<MOSDOpReply> m)
 {
   ldout(cct, 10) << "in handle_osd_op_reply" << dendl;
 
@@ -3820,7 +3852,6 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
 
   shunique_lock sul(rwlock, ceph::acquire_shared);
   if (!initialized) {
-    m->put();
     return;
   }
 
@@ -3829,7 +3860,6 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
   auto s = static_cast<OSDSession*>(priv.get());
   if (!s || s->con != con) {
     ldout(cct, 7) << __func__ << " no session on con " << con << dendl;
-    m->put();
     return;
   }
 
@@ -3842,7 +3872,6 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
 						    " onnvram" : " ack"))
 		  << " ... stray" << dendl;
     sl.unlock();
-    m->put();
     return;
   }
 
@@ -3866,7 +3895,6 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
     sl.unlock();
 
     _op_submit(op, sul, NULL);
-    m->put();
     return;
   }
 
@@ -3877,7 +3905,6 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
 		    << " from " << m->get_source_inst()
 		    << "; last attempt " << (op->attempts - 1) << " sent to "
 		    << op->session->con->get_peer_addr() << dendl;
-      m->put();
       sl.unlock();
       return;
     }
@@ -3905,7 +3932,6 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
 			 CEPH_OSD_FLAG_IGNORE_CACHE |
 			 CEPH_OSD_FLAG_IGNORE_OVERLAY);
     _op_submit(op, sul, NULL);
-    m->put();
     return;
   }
 
@@ -3934,7 +3960,6 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
     op->target.flags &= ~CEPH_OSD_FLAG_FORCE_OSD;
     op->target.pgid = pg_t();
     _op_submit(op, sul, NULL);
-    m->put();
     return;
   }
 
@@ -3968,14 +3993,13 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
       bl.begin().copy(bl.length(), t.c_str());
       op->outbl->substr_of(t, 0, bl.length());
     } else {
-      m->claim_data(*op->outbl);
+      *op->outbl = m->get_data();
     }
     op->outbl = 0;
   }
 
   // per-op result demuxing
-  vector<OSDOp> out_ops;
-  m->claim_ops(out_ops);
+  auto& out_ops = m->get_ops();
 
   if (out_ops.size() != op->ops.size())
     ldout(cct, 0) << "WARNING: tid " << op->tid << " reply ops " << out_ops
@@ -3990,7 +4014,6 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
 
   // This function unlocks sl.
   complete_op_reply(op, handler_error, s, sl, rc);
-  m->put();
 }
 
 void Objecter::complete_op_reply(Op *op, bs::error_code handler_error, OSDSession *s, unique_lock<std::shared_mutex> &sl, int rc) {
@@ -4032,12 +4055,11 @@ void Objecter::complete_op_reply(Op *op, bs::error_code handler_error, OSDSessio
   }
 }
 
-void Objecter::handle_osd_backoff(MOSDBackoff *m)
+void Objecter::handle_osd_backoff(cref_t<MOSDBackoff> m)
 {
   ldout(cct, 10) << __func__ << " " << *m << dendl;
   shunique_lock sul(rwlock, ceph::acquire_shared);
   if (!initialized) {
-    m->put();
     return;
   }
 
@@ -4046,7 +4068,6 @@ void Objecter::handle_osd_backoff(MOSDBackoff *m)
   auto s = static_cast<OSDSession*>(priv.get());
   if (!s || s->con != con) {
     ldout(cct, 7) << __func__ << " no session on con " << con << dendl;
-    m->put();
     return;
   }
 
@@ -4127,7 +4148,6 @@ void Objecter::handle_osd_backoff(MOSDBackoff *m)
   sul.unlock();
   sl.unlock();
 
-  m->put();
   put_session(s);
 }
 
@@ -5220,11 +5240,10 @@ void Objecter::blocklist_self(bool set)
 
 // commands
 
-void Objecter::handle_command_reply(MCommandReply *m)
+void Objecter::handle_command_reply(cref_t<MCommandReply> m)
 {
   unique_lock wl(rwlock);
   if (!initialized) {
-    m->put();
     return;
   }
 
@@ -5233,7 +5252,6 @@ void Objecter::handle_command_reply(MCommandReply *m)
   auto s = static_cast<OSDSession*>(priv.get());
   if (!s || s->con != con) {
     ldout(cct, 7) << __func__ << " no session on con " << con << dendl;
-    m->put();
     return;
   }
 
@@ -5242,7 +5260,6 @@ void Objecter::handle_command_reply(MCommandReply *m)
   if (p == s->command_ops.end()) {
     ldout(cct, 10) << "handle_command_reply tid " << m->get_tid()
 		   << " not found" << dendl;
-    m->put();
     sl.unlock();
     return;
   }
@@ -5254,7 +5271,6 @@ void Objecter::handle_command_reply(MCommandReply *m)
 		   << " got reply from wrong connection "
 		   << m->get_connection() << " " << m->get_source_inst()
 		   << dendl;
-    m->put();
     sl.unlock();
     return;
   }
@@ -5266,7 +5282,6 @@ void Objecter::handle_command_reply(MCommandReply *m)
     // we get an updated osdmap and the PG is found to have moved.
     _maybe_request_map();
     _send_command(c);
-    m->put();
     sl.unlock();
     return;
   }
@@ -5275,11 +5290,9 @@ void Objecter::handle_command_reply(MCommandReply *m)
 
   unique_lock sul(s->lock);
   _finish_command(c, m->r < 0 ? bs::error_code(-m->r, osd_category()) :
-		  bs::error_code(), std::move(m->rs),
-		  std::move(m->get_data()));
+		  bs::error_code(), std::string(m->rs),
+		  bufferlist(m->get_data()));
   sul.unlock();
-
-  m->put();
 }
 
 Objecter::LingerOp::LingerOp(Objecter *o, uint64_t linger_id)
@@ -5478,7 +5491,9 @@ Objecter::Objecter(CephContext *cct,
 		   asio::io_context& service,
 		   std::string_view admin_socket_name) :
   Dispatcher(cct), messenger(m), monc(mc), service(service),
-  m_admin_socket_name(admin_socket_name)
+  m_admin_socket_name(admin_socket_name),
+  homeless_session(new OSDSession(cct, -1, service.get_executor())),
+  splitop_session(new OSDSession(cct, -2, service.get_executor())) // -2 to differentiate from homeless
 {
   mon_timeout = cct->_conf.get_val<std::chrono::seconds>("rados_mon_op_timeout");
   osd_timeout = cct->_conf.get_val<std::chrono::seconds>("rados_osd_op_timeout");

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -16,6 +16,7 @@
 #ifndef CEPH_OBJECTER_H
 #define CEPH_OBJECTER_H
 
+#include <deque>
 #include <list>
 #include <map>
 #include <mutex>
@@ -1840,8 +1841,13 @@ private:
   void update_crush_location();
 
   class RequestStateHook;
+  class SessionStrandHook;
 
   RequestStateHook *m_request_state_hook = nullptr;
+  SessionStrandHook *m_session_strand_hook = nullptr;
+
+public:
+  void dump_session_strands(ceph::Formatter *f);
 
 public:
   /*** track pending operations ***/
@@ -2508,6 +2514,23 @@ public:
     // that.
     std::shared_mutex lock;
     boost::asio::strand<boost::asio::io_context::executor_type> strand;
+
+    std::mutex strand_track_lock;
+    std::deque<MessageRef> queued_messages;
+
+    void track_enqueue(const MessageRef& m) {
+      std::lock_guard l(strand_track_lock);
+      queued_messages.push_back(m);
+    }
+
+    void track_dequeue(const MessageRef& m) {
+      std::lock_guard l(strand_track_lock);
+      if (!queued_messages.empty()) {
+        auto const& _m = queued_messages.front();
+        ceph_assert(_m == m);
+        queued_messages.pop_front();
+      }
+    }
 
     int incarnation;
     ConnectionRef con;

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -2518,18 +2518,19 @@ public:
     std::mutex strand_track_lock;
     std::deque<MessageRef> queued_messages;
 
-    void track_enqueue(const MessageRef& m) {
+    template <typename Callable>
+    void track_enqueue(const MessageRef& m, Callable&& f) {
       std::lock_guard l(strand_track_lock);
       queued_messages.push_back(m);
+      boost::asio::post(strand, std::forward<Callable>(f));
     }
 
     void track_dequeue(const MessageRef& m) {
       std::lock_guard l(strand_track_lock);
-      if (!queued_messages.empty()) {
-        auto const& _m = queued_messages.front();
-        ceph_assert(_m == m);
-        queued_messages.pop_front();
-      }
+      ceph_assert(!queued_messages.empty());
+      auto const& _m = queued_messages.front();
+      ceph_assert(_m == m);
+      queued_messages.pop_front();
     }
 
     int incarnation;

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -2805,9 +2805,7 @@ private:
       return false;
     }
   }
-  void ms_fast_dispatch2(const MessageRef& m) override {
-    [[maybe_unused]] auto s = ms_dispatch2(m);
-  }
+  void ms_fast_dispatch2(const MessageRef& m) override;
 
   void handle_osd_op_reply(cref_t<MOSDOpReply> m);
   void handle_osd_backoff(cref_t<MOSDBackoff> m);

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -2369,7 +2369,7 @@ public:
 			boost::system::error_code ec);
   void _finish_command(CommandOp *c, boost::system::error_code ec,
 		       std::string&& rs, ceph::buffer::list&& bl);
-  void handle_command_reply(MCommandReply *m);
+  void handle_command_reply(cref_t<MCommandReply> m);
 
   // -- lingering ops --
 
@@ -2507,14 +2507,15 @@ public:
     // lockdep (using std::sharedMutex) because lockdep doesn't know
     // that.
     std::shared_mutex lock;
+    boost::asio::strand<boost::asio::io_context::executor_type> strand;
 
     int incarnation;
     ConnectionRef con;
     int num_locks;
     std::unique_ptr<std::mutex[]> completion_locks;
 
-    OSDSession(CephContext *cct, int o) :
-      osd(o), incarnation(0), con(NULL),
+    OSDSession(CephContext *cct, int o, boost::asio::io_context::executor_type ex) :
+      osd(o), strand(ex), incarnation(0), con(NULL),
       num_locks(cct->_conf->objecter_completion_locks_per_session),
       completion_locks(new std::mutex[num_locks]) {}
 
@@ -2553,9 +2554,8 @@ public:
   std::map<ceph_tid_t,PoolOp*> pool_ops;
   std::atomic<unsigned> num_homeless_ops{0};
 
-  OSDSession* homeless_session = new OSDSession(cct, -1);
-  OSDSession* splitop_session = new OSDSession(cct, -2); // -2 to differentiate from homeless
-
+  OSDSession* homeless_session;
+  OSDSession* splitop_session;
 
   // ops waiting for an osdmap with a new pool or confirmation that
   // the pool does not exist (may be expanded to other uses later)
@@ -2580,7 +2580,7 @@ public:
   void _send_op_account(Op *op);
   void _cancel_linger_op(Op *op);
   void _finish_op(Op *op, int r);
-  boost::system::error_code process_op_reply_handlers(Op *op, std::vector<OSDOp> &out_ops);
+  boost::system::error_code process_op_reply_handlers(Op *op, const std::vector<OSDOp>& out_ops);
   void complete_op_reply(Op *op, boost::system::error_code handler_error, OSDSession *s, std::unique_lock<std::shared_mutex> &sl, int rc);
   static bool is_pg_changed(
     int oldprimary,
@@ -2786,9 +2786,9 @@ private:
     [[maybe_unused]] auto s = ms_dispatch2(m);
   }
 
-  void handle_osd_op_reply(class MOSDOpReply *m);
-  void handle_osd_backoff(class MOSDBackoff *m);
-  void handle_watch_notify(class MWatchNotify *m);
+  void handle_osd_op_reply(cref_t<MOSDOpReply> m);
+  void handle_osd_backoff(cref_t<MOSDBackoff> m);
+  void handle_watch_notify(cref_t<MWatchNotify> m);
   void handle_osd_map(class MOSDMap *m);
   void wait_for_osd_map(epoch_t e=0);
 
@@ -3309,7 +3309,7 @@ public:
  public:
 
   void _do_watch_notify(boost::intrusive_ptr<LingerOp> info,
-                        boost::intrusive_ptr<MWatchNotify> m);
+                        cref_t<MWatchNotify> m);
 
   /**
    * set up initial ops in the op std::vector, and allocate a final op slot.

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -2370,7 +2370,7 @@ public:
 			boost::system::error_code ec);
   void _finish_command(CommandOp *c, boost::system::error_code ec,
 		       std::string&& rs, ceph::buffer::list&& bl);
-  void handle_command_reply(MCommandReply *m);
+  void handle_command_reply(cref_t<MCommandReply> m);
 
   // -- lingering ops --
 
@@ -2508,14 +2508,15 @@ public:
     // lockdep (using std::sharedMutex) because lockdep doesn't know
     // that.
     std::shared_mutex lock;
+    boost::asio::strand<boost::asio::io_context::executor_type> strand;
 
     int incarnation;
     ConnectionRef con;
     int num_locks;
     std::unique_ptr<std::mutex[]> completion_locks;
 
-    OSDSession(CephContext *cct, int o) :
-      osd(o), incarnation(0), con(NULL),
+    OSDSession(CephContext *cct, int o, boost::asio::io_context::executor_type ex) :
+      osd(o), strand(ex), incarnation(0), con(NULL),
       num_locks(cct->_conf->objecter_completion_locks_per_session),
       completion_locks(new std::mutex[num_locks]) {}
 
@@ -2554,9 +2555,8 @@ public:
   std::map<ceph_tid_t,PoolOp*> pool_ops;
   std::atomic<unsigned> num_homeless_ops{0};
 
-  OSDSession* homeless_session = new OSDSession(cct, -1);
-  OSDSession* splitop_session = new OSDSession(cct, -2); // -2 to differentiate from homeless
-
+  OSDSession* homeless_session;
+  OSDSession* splitop_session;
 
   // ops waiting for an osdmap with a new pool or confirmation that
   // the pool does not exist (may be expanded to other uses later)
@@ -2581,7 +2581,7 @@ public:
   void _send_op_account(Op *op);
   void _cancel_linger_op(Op *op);
   void _finish_op(Op *op, int r);
-  boost::system::error_code process_op_reply_handlers(Op *op, std::vector<OSDOp> &out_ops);
+  boost::system::error_code process_op_reply_handlers(Op *op, const std::vector<OSDOp>& out_ops);
   void complete_op_reply(Op *op, boost::system::error_code handler_error, OSDSession *s, std::unique_lock<std::shared_mutex> &sl, int rc);
   static bool is_pg_changed(
     int oldprimary,
@@ -2791,9 +2791,9 @@ private:
     [[maybe_unused]] auto s = ms_dispatch2(m);
   }
 
-  void handle_osd_op_reply(class MOSDOpReply *m);
-  void handle_osd_backoff(class MOSDBackoff *m);
-  void handle_watch_notify(class MWatchNotify *m);
+  void handle_osd_op_reply(cref_t<MOSDOpReply> m);
+  void handle_osd_backoff(cref_t<MOSDBackoff> m);
+  void handle_watch_notify(cref_t<MWatchNotify> m);
   void handle_osd_map(class MOSDMap *m);
   void wait_for_osd_map(epoch_t e=0);
 
@@ -3314,7 +3314,7 @@ public:
  public:
 
   void _do_watch_notify(boost::intrusive_ptr<LingerOp> info,
-                        boost::intrusive_ptr<MWatchNotify> m);
+                        cref_t<MWatchNotify> m);
 
   /**
    * set up initial ops in the op std::vector, and allocate a final op slot.

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -2519,18 +2519,19 @@ public:
     std::mutex strand_track_lock;
     std::deque<MessageRef> queued_messages;
 
-    void track_enqueue(const MessageRef& m) {
+    template <typename Callable>
+    void track_enqueue(const MessageRef& m, Callable&& f) {
       std::lock_guard l(strand_track_lock);
       queued_messages.push_back(m);
+      boost::asio::post(strand, std::forward<Callable>(f));
     }
 
     void track_dequeue(const MessageRef& m) {
       std::lock_guard l(strand_track_lock);
-      if (!queued_messages.empty()) {
-        auto const& _m = queued_messages.front();
-        ceph_assert(_m == m);
-        queued_messages.pop_front();
-      }
+      ceph_assert(!queued_messages.empty());
+      auto const& _m = queued_messages.front();
+      ceph_assert(_m == m);
+      queued_messages.pop_front();
     }
 
     int incarnation;

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -2810,9 +2810,7 @@ private:
       return false;
     }
   }
-  void ms_fast_dispatch2(const MessageRef& m) override {
-    [[maybe_unused]] auto s = ms_dispatch2(m);
-  }
+  void ms_fast_dispatch2(const MessageRef& m) override;
 
   void handle_osd_op_reply(cref_t<MOSDOpReply> m);
   void handle_osd_backoff(cref_t<MOSDBackoff> m);

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -16,6 +16,7 @@
 #ifndef CEPH_OBJECTER_H
 #define CEPH_OBJECTER_H
 
+#include <deque>
 #include <list>
 #include <map>
 #include <mutex>
@@ -1840,9 +1841,14 @@ private:
   void update_crush_location();
 
   class RequestStateHook;
+  class SessionStrandHook;
 
   RequestStateHook *m_request_state_hook = nullptr;
   std::string m_admin_socket_name;
+  SessionStrandHook *m_session_strand_hook = nullptr;
+
+public:
+  void dump_session_strands(ceph::Formatter *f);
 
 public:
   /*** track pending operations ***/
@@ -2509,6 +2515,23 @@ public:
     // that.
     std::shared_mutex lock;
     boost::asio::strand<boost::asio::io_context::executor_type> strand;
+
+    std::mutex strand_track_lock;
+    std::deque<MessageRef> queued_messages;
+
+    void track_enqueue(const MessageRef& m) {
+      std::lock_guard l(strand_track_lock);
+      queued_messages.push_back(m);
+    }
+
+    void track_dequeue(const MessageRef& m) {
+      std::lock_guard l(strand_track_lock);
+      if (!queued_messages.empty()) {
+        auto const& _m = queued_messages.front();
+        ceph_assert(_m == m);
+        queued_messages.pop_front();
+      }
+    }
 
     int incarnation;
     ConnectionRef con;


### PR DESCRIPTION

## Description

This PR updates the Objecter to handle incoming RADOS messages asynchronously and provides new debugging tools to inspect message queuing state.

### Key Changes
* **Asynchronous Messenger Dispatch**: Messenger handler functions are moved from the main dispatcher thread to per-OSD session strands to prevent head-of-line blocking.
* **Per-Session Strands**: Introduces `boost::asio::strand` to `OSDSession` to ensure sequential message execution for each OSD connection.
* **Memory Safety**: Refactors handlers to use `cref_t<T>` smart pointer references and eliminates manual reference counting, such as explicit `m->put()` calls.
* **Const Operations Access**: Adds `get_ops()` to `MOSDOpReply`, allowing handlers to access operations via const reference rather than destructive swaps.
* **Diagnostic Visibility**: Adds a message queue (`deque`) to `OSDSession` to track pending messages waiting in strands.
* **Admin Socket Command**: Introduces `objecter_session_strands` to dump the current state of these message queues for debugging latency issues.

### Performance Impact
Initial benchmarking shows a notable improvement in performance for a single `rados bench` client writing to the LRC cluster:
* **Bandwidth**: Increased from ~3090 MB/sec to ~3801 MB/sec.
* **IOPS**: Improved from an average of 772 to 950.
* **Latency**: Reduced average latency from 0.165s to 0.134s.

I think the performance impact may need more study.

This change is expected to be particularly beneficial when completions involve multiple component boundaries, such as those passing through the Objecter, Filer, and NFS-Ganesha.




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
