### PR TITLE
librados/asio: clear cancellation slot in associated executor

### DIFF
--- a/src/librados/librados_asio.h
+++ b/src/librados/librados_asio.h
@@ -85,6 +85,8 @@ struct Invoker<void> {
   }
 };
 
+// handler wrapper that clears the handler's associated cancellation slot
+// before invoking it
 template <typename Handler>
 struct AsyncHandler {
   Handler handler;
@@ -93,6 +95,10 @@ struct AsyncHandler {
 
   template <typename ...Args>
   void operator()(unique_aio_completion_ptr aio_completion, Args&& ...args) {
+    // the cancellation handler refers to the AioCompletion, so needs to be
+    // cleared before the AioCompletion is destroyed
+    auto slot = boost::asio::get_associated_cancellation_slot(handler);
+    slot.clear();
     aio_completion.reset();
     std::move(handler)(std::forward<Args>(args)...);
   }
@@ -136,7 +142,6 @@ struct AsyncOp : Invoker<Result> {
     auto p = std::unique_ptr<Completion>{static_cast<Completion*>(arg)};
     // move result out of Completion memory being freed
     auto op = std::move(p->user_data);
-    op.slot.clear(); // clear our cancellation handler
     // access AioCompletionImpl directly to avoid locking
     const librados::AioCompletionImpl* pc = op.aio_completion->pc;
     const int ret = pc->rval;

--- a/src/librados/librados_asio.h
+++ b/src/librados/librados_asio.h
@@ -16,6 +16,7 @@
 #define LIBRADOS_ASIO_H
 
 #include <boost/asio/associated_cancellation_slot.hpp>
+#include <boost/asio/associator.hpp>
 #include <boost/asio/cancellation_type.hpp>
 #include <boost/asio/execution/executor.hpp>
 
@@ -60,21 +61,66 @@ using unique_aio_completion_ptr =
 template <typename Result>
 struct Invoker {
   using Signature = void(boost::system::error_code, version_t, Result);
+  using InnerSignature = void(unique_aio_completion_ptr, boost::system::error_code, version_t, Result);
   Result result;
   template <typename Completion>
-  void dispatch(Completion&& completion, boost::system::error_code ec, version_t ver) {
-    ceph::async::dispatch(std::move(completion), ec, ver, std::move(result));
+  void dispatch(Completion&& completion, unique_aio_completion_ptr aio_completion,
+                boost::system::error_code ec, version_t ver) {
+    ceph::async::dispatch(std::move(completion),
+                          std::move(aio_completion),
+                          ec, ver, std::move(result));
   }
 };
 // specialization for Result=void
 template <>
 struct Invoker<void> {
   using Signature = void(boost::system::error_code, version_t);
+  using InnerSignature = void(unique_aio_completion_ptr, boost::system::error_code, version_t);
   template <typename Completion>
-  void dispatch(Completion&& completion, boost::system::error_code ec, version_t ver) {
-    ceph::async::dispatch(std::move(completion), ec, ver);
+  void dispatch(Completion&& completion, unique_aio_completion_ptr aio_completion,
+                boost::system::error_code ec, version_t ver) {
+    ceph::async::dispatch(std::move(completion),
+                          std::move(aio_completion),
+                          ec, ver);
   }
 };
+
+template <typename Handler>
+struct AsyncHandler {
+  Handler handler;
+
+  AsyncHandler(Handler&& h) : handler(std::move(h)) {}
+
+  template <typename ...Args>
+  void operator()(unique_aio_completion_ptr aio_completion, Args&& ...args) {
+    aio_completion.reset();
+    std::move(handler)(std::forward<Args>(args)...);
+  }
+};
+
+} // namespace detail
+} // namespace librados
+
+namespace boost::asio {
+// forward associations from wrapped handler
+template <template<typename, typename> class Associator,
+          typename Handler, typename DefaultCandidate>
+struct associator<Associator, ::librados::detail::AsyncHandler<Handler>, DefaultCandidate>
+    : Associator<Handler, DefaultCandidate>
+{
+  static auto get(const ::librados::detail::AsyncHandler<Handler>& h) noexcept {
+    return Associator<Handler, DefaultCandidate>::get(h.handler);
+  }
+
+  static auto get(const ::librados::detail::AsyncHandler<Handler>& h,
+                  const DefaultCandidate& c) noexcept {
+    return Associator<Handler, DefaultCandidate>::get(h.handler, c);
+  }
+};
+} // namespace boost::asio
+
+namespace librados {
+namespace detail {
 
 template <typename Result>
 struct AsyncOp : Invoker<Result> {
@@ -82,7 +128,8 @@ struct AsyncOp : Invoker<Result> {
   boost::asio::cancellation_slot slot;
 
   using Signature = typename Invoker<Result>::Signature;
-  using Completion = ceph::async::Completion<Signature, AsyncOp<Result>>;
+  using InnerSignature = typename Invoker<Result>::InnerSignature;
+  using Completion = ceph::async::Completion<InnerSignature, AsyncOp<Result>>;
 
   static void aio_dispatch(completion_t cb, void *arg) {
     // reclaim ownership of the completion
@@ -98,7 +145,7 @@ struct AsyncOp : Invoker<Result> {
     if (ret < 0) {
       ec.assign(-ret, librados::detail::err_category());
     }
-    op.dispatch(std::move(p), ec, ver);
+    op.dispatch(std::move(p), std::move(op.aio_completion), ec, ver);
   }
 
   struct op_cancellation {
@@ -133,7 +180,7 @@ struct AsyncOp : Invoker<Result> {
       cancel_handler = &slot.template emplace<op_cancellation>();
     }
 
-    auto p = Completion::create(ex1, std::move(handler));
+    auto p = Completion::create(ex1, AsyncHandler{std::move(handler)});
     p->user_data.aio_completion.reset(
         Rados::aio_create_completion(p.get(), aio_dispatch));
     if (cancel_handler) {
@@ -170,7 +217,8 @@ auto async_read(IoExecutor ex, IoCtx& io, const std::string& oid,
         int ret = io.aio_read(oid, op.aio_completion.get(), &op.result, len, off);
         if (ret < 0) {
           auto ec = boost::system::error_code{-ret, librados::detail::err_category()};
-          ceph::async::post(std::move(p), ec, 0, bufferlist{});
+          ceph::async::post(std::move(p), std::move(op.aio_completion),
+                            ec, 0, bufferlist{});
         } else {
           p.release(); // release ownership until completion
         }
@@ -200,7 +248,7 @@ auto async_write(IoExecutor ex, IoCtx& io, const std::string& oid,
         int ret = io.aio_write(oid, op.aio_completion.get(), bl, len, off);
         if (ret < 0) {
           auto ec = boost::system::error_code{-ret, librados::detail::err_category()};
-          ceph::async::post(std::move(p), ec, 0);
+          ceph::async::post(std::move(p), std::move(op.aio_completion), ec, 0);
         } else {
           p.release(); // release ownership until completion
         }
@@ -231,7 +279,8 @@ auto async_operate(IoExecutor ex, IoCtx& io, const std::string& oid,
                                  flags, &op.result);
         if (ret < 0) {
           auto ec = boost::system::error_code{-ret, librados::detail::err_category()};
-          ceph::async::post(std::move(p), ec, 0, bufferlist{});
+          ceph::async::post(std::move(p), std::move(op.aio_completion),
+                            ec, 0, bufferlist{});
         } else {
           p.release(); // release ownership until completion
         }
@@ -262,7 +311,7 @@ auto async_operate(IoExecutor ex, IoCtx& io, const std::string& oid,
         int ret = io.aio_operate(oid, op.aio_completion.get(), &write_op, flags, trace_ctx);
         if (ret < 0) {
           auto ec = boost::system::error_code{-ret, librados::detail::err_category()};
-          ceph::async::post(std::move(p), ec, 0);
+          ceph::async::post(std::move(p), std::move(op.aio_completion), ec, 0);
         } else {
           p.release(); // release ownership until completion
         }
@@ -293,7 +342,7 @@ auto async_watch(IoExecutor ex, IoCtx& io, const std::string& oid,
                                 handle, ctx, timeout_ms);
         if (ret < 0) {
           auto ec = boost::system::error_code{-ret, librados::detail::err_category()};
-          ceph::async::post(std::move(p), ec, 0);
+          ceph::async::post(std::move(p), std::move(op.aio_completion), ec, 0);
         } else {
           p.release(); // release ownership until completion
         }
@@ -321,7 +370,7 @@ auto async_unwatch(IoExecutor ex, IoCtx& io, uint64_t handle,
         int ret = io.aio_unwatch(handle, op.aio_completion.get());
         if (ret < 0) {
           auto ec = boost::system::error_code{-ret, librados::detail::err_category()};
-          ceph::async::post(std::move(p), ec, 0);
+          ceph::async::post(std::move(p), std::move(op.aio_completion), ec, 0);
         } else {
           p.release(); // release ownership until completion
         }
@@ -352,7 +401,8 @@ auto async_notify(IoExecutor ex, IoCtx& io, const std::string& oid,
                                 bl, timeout_ms, &op.result);
         if (ret < 0) {
           auto ec = boost::system::error_code{-ret, librados::detail::err_category()};
-          ceph::async::post(std::move(p), ec, 0, bufferlist{});
+          ceph::async::post(std::move(p), std::move(op.aio_completion),
+                            ec, 0, bufferlist{});
         } else {
           p.release(); // release ownership until completion
         }


### PR DESCRIPTION
the librados callback function `AsyncOp::aio_dispatch()` runs on Objecter's finisher strand executor, and dispatches the completion handler to its associated executor

asio cancellation is not thread-safe, so should be synchronized on that associated executor. move the call to `slot.clear()` from that librados callback into the AsyncHandler wrapper so it doesn't run until we've switched to the correct executor

because our `op_cancellation` handler depends on an `AioCompletion` pointer, we have to clear the cancellation slot before that `AioCompletion` lifetime ends

Fixes: https://tracker.ceph.com/issues/73475

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
