### PR TITLE
neorados/cls/log: fix infinite trim loop on empty data log shards

### DIFF
--- a/src/neorados/cls/log.h
+++ b/src/neorados/cls/log.h
@@ -463,8 +463,8 @@ trim(RADOS& r, Object oid, IOContext ioc,
       if (e.code() != no_message_available) {
 	throw;
       }
+      co_return;
     }
-  co_return;
 }
 
 /// \brief Trim entries from the log

--- a/src/neorados/cls/log.h
+++ b/src/neorados/cls/log.h
@@ -494,10 +494,10 @@ trim(RADOS& r, Object oid, IOContext ioc,
 			 ua);
     } catch (const system_error& e) {
       if (e.code() != no_message_available) {
-	co_return e.code();
+	throw;
       }
+      co_return;
     }
-  co_return error_code{};
 }
 
 /// \brief List log entries

--- a/src/rgw/driver/rados/rgw_datalog.cc
+++ b/src/rgw/driver/rados/rgw_datalog.cc
@@ -346,7 +346,15 @@ public:
   }
   asio::awaitable<void> trim(const DoutPrefixProvider *dpp, int index,
 	   std::string_view marker) override {
-    co_await fifos[index].trim(dpp, std::string{marker}, false);
+    try {
+      co_await fifos[index].trim(dpp, std::string{marker}, false);
+    } catch (const sys::system_error& e) {
+      if (e.code() != sys::errc::no_message_available) {
+	ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
+			   << ": trim failed: " << e.what() << dendl;
+	throw;
+      }
+    }
   }
   std::string_view max_marker() const override {
     static const auto max_mark = fifo::FIFO::max_marker();

--- a/src/rgw/driver/rados/rgw_datalog.cc
+++ b/src/rgw/driver/rados/rgw_datalog.cc
@@ -1193,7 +1193,7 @@ asio::awaitable<void> DataLogBackends::trim_entries(
     l.unlock();
     auto c = be->gen_id == target_gen ? cursor : be->max_marker();
     co_await be->trim(dpp, shard_id, c);
-    if (be->gen_id == target_gen)
+    if (be->gen_id == target_gen || be->gen_id >= head_gen)
       break;
     l.lock();
   };

--- a/src/test/cls_log/test_neocls_log.cc
+++ b/src/test/cls_log/test_neocls_log.cc
@@ -474,9 +474,7 @@ CORO_TEST_F(neocls_log, trim_by_marker, NeoRadosTest)
 }
 
 // Test the neorados::trim() loop function (use_awaitable overloads) to verify
-// it terminates. Before any fix in neorados/cls/log.h, the use_awaitable_t
-// overloads had the try-catch for ENODATA inside the for(;;) loop, causing
-// the loop to never exit in certain cluster configs and this CPU hogging.
+// it terminates.
 CORO_TEST_F(neocls_log, trim_loop_all_entries_by_marker, NeoRadosTest)
 {
   co_await create_obj(oid);
@@ -486,8 +484,7 @@ CORO_TEST_F(neocls_log, trim_loop_all_entries_by_marker, NeoRadosTest)
   co_await generate_log(rados(), oid, pool(), 10, start_time, true,
 			asio::use_awaitable);
 
-  // call trim() loop function. Without a fix, this never returns
-  // because of where the try-catch sits relative to the for(;;)
+  // call trim() loop function.
   co_await neorados::cls::log::trim(
     rados(), oid, pool(),
     std::string_view{neorados::cls::log::begin_marker},

--- a/src/test/cls_log/test_neocls_log.cc
+++ b/src/test/cls_log/test_neocls_log.cc
@@ -512,6 +512,32 @@ CORO_TEST_F(neocls_log, trim_loop_empty_log_by_marker, NeoRadosTest)
 }
 
 
+CORO_TEST_F(neocls_log, trim_loop_all_entries_by_time, NeoRadosTest)
+{
+  co_await create_obj(oid);
+  auto start_time = real_clock::now();
+  co_await generate_log(rados(), oid, pool(), 10, start_time, true,
+			asio::use_awaitable);
+
+  auto end_time = start_time + 100s;
+  co_await neorados::cls::log::trim(
+    rados(), oid, pool(), real_time{}, end_time, asio::use_awaitable);
+
+  std::vector<l::entry> entries{neorados::cls::log::max_list_entries};
+  std::span<l::entry> result;
+  co_await list(rados(), oid, pool(), entries, &result, asio::use_awaitable);
+  EXPECT_EQ(0u, result.size());
+}
+
+CORO_TEST_F(neocls_log, trim_loop_empty_log_by_time, NeoRadosTest)
+{
+  co_await create_obj(oid);
+
+  auto end_time = real_clock::now() + 100s;
+  co_await neorados::cls::log::trim(
+    rados(), oid, pool(), real_time{}, end_time, asio::use_awaitable);
+}
+
 #if 0 // Disable until we get rid of GCC11
 TEST(neocls_log_bare, lambdata)
 {

--- a/src/test/cls_log/test_neocls_log.cc
+++ b/src/test/cls_log/test_neocls_log.cc
@@ -473,6 +473,48 @@ CORO_TEST_F(neocls_log, trim_by_marker, NeoRadosTest)
   }
 }
 
+// Test the neorados::trim() loop function (use_awaitable overloads) to verify
+// it terminates. Before any fix in neorados/cls/log.h, the use_awaitable_t
+// overloads had the try-catch for ENODATA inside the for(;;) loop, causing
+// the loop to never exit in certain cluster configs and this CPU hogging.
+CORO_TEST_F(neocls_log, trim_loop_all_entries_by_marker, NeoRadosTest)
+{
+  co_await create_obj(oid);
+  auto start_time = real_clock::now();
+
+  // write 10 cls_log entries into the object
+  co_await generate_log(rados(), oid, pool(), 10, start_time, true,
+			asio::use_awaitable);
+
+  // call trim() loop function. Without a fix, this never returns
+  // because of where the try-catch sits relative to the for(;;)
+  co_await neorados::cls::log::trim(
+    rados(), oid, pool(),
+    std::string_view{neorados::cls::log::begin_marker},
+    std::string_view{neorados::cls::log::end_marker},
+    asio::use_awaitable);
+
+  // Verify all entries are gone
+  std::vector<l::entry> entries{neorados::cls::log::max_list_entries};
+  std::span<l::entry> result;
+  co_await list(rados(), oid, pool(), entries, &result, asio::use_awaitable);
+  EXPECT_EQ(0u, result.size());
+}
+
+CORO_TEST_F(neocls_log, trim_loop_empty_log_by_marker, NeoRadosTest)
+{
+  co_await create_obj(oid);
+
+  // Trim an empty log object. With the bug, cls_log_trim returns ENODATA,
+  // which is caught and swallowed inside the for(;;), looping forever.
+  co_await neorados::cls::log::trim(
+    rados(), oid, pool(),
+    std::string_view{neorados::cls::log::begin_marker},
+    std::string_view{neorados::cls::log::end_marker},
+    asio::use_awaitable);
+}
+
+
 #if 0 // Disable until we get rid of GCC11
 TEST(neocls_log_bare, lambdata)
 {

--- a/src/test/rgw/test_datalog.cc
+++ b/src/test/rgw/test_datalog.cc
@@ -442,6 +442,18 @@ CORO_TEST_F(DataLogBulky, BulkyCycleRecovery, DataLogBulky) {
   co_return;
 }
 
+// trim_entries with max_marker() must not crash on a single-generation cluster.
+// Without the fix, the loop increment would call upper_bound(head_gen)->second,
+// dereferencing end() and causing a SIGSEGV.
+CORO_TEST_F(DataLogBulky, TrimWithMaxMarker, DataLogBulky) {
+  for (const auto& bg : bulky) {
+    co_await add_entry(dpp(), bg);
+  }
+  co_await renew_entries(dpp());
+  co_await datalog->trim_entries(dpp(), 0, datalog->max_marker());
+  co_return;
+}
+
 CORO_TEST_F(DataLogBulky, BulkySemaphoresRecovery, DataLogBulky) {
   for (const auto& bg : bulky) {
     co_await rados().execute(sem_set_oid(bg), loc(),

--- a/src/test/rgw/test_datalog.cc
+++ b/src/test/rgw/test_datalog.cc
@@ -443,8 +443,6 @@ CORO_TEST_F(DataLogBulky, BulkyCycleRecovery, DataLogBulky) {
 }
 
 // trim_entries with max_marker() must not crash on a single-generation cluster.
-// Without the fix, the loop increment would call upper_bound(head_gen)->second,
-// dereferencing end() and causing a SIGSEGV.
 CORO_TEST_F(DataLogBulky, TrimWithMaxMarker, DataLogBulky) {
   for (const auto& bg : bulky) {
     co_await add_entry(dpp(), bg);


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/76563

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
