### PR TITLE
mgr/cephadm: stop unbounded growth of mgr daemon ports list

### DIFF
--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1196,10 +1196,7 @@ class MgrService(CephService):
                 if port:
                     ports.append(int(port[0][1:-1]))
 
-        if ports:
-            daemon_spec.ports = ports
-
-        daemon_spec.ports.append(self.mgr.service_discovery_port)
+        daemon_spec.ports = ports + [self.mgr.service_discovery_port]
         daemon_spec.keyring = keyring
 
         daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)

--- a/src/pybind/mgr/cephadm/tests/services/test_mgr.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_mgr.py
@@ -1,0 +1,67 @@
+from unittest import mock
+
+from cephadm.module import CephadmOrchestrator
+from cephadm.services.cephadmservice import (
+    CephadmDaemonDeploySpec,
+    MgrService,
+)
+
+
+class TestMgrService:
+    def _prepare(self, cephadm_module: CephadmOrchestrator,
+                 mgr_services_payload: str,
+                 carried_over_ports: list) -> CephadmDaemonDeploySpec:
+        """Build a daemon_spec that mimics rehydration from the persisted
+        DaemonDescription (which copies `ports=dd.ports`), then call
+        MgrService.prepare_create with `mgr services` returning the supplied
+        payload.
+        """
+        svc = MgrService(cephadm_module)
+        daemon_spec = CephadmDaemonDeploySpec(
+            host='ceph-1',
+            daemon_id='ceph-1.xyz',
+            service_name='mgr',
+            daemon_type='mgr',
+            ports=list(carried_over_ports),
+        )
+        with mock.patch.object(cephadm_module, 'check_mon_command',
+                               return_value=(0, mgr_services_payload, '')), \
+             mock.patch.object(svc, 'get_keyring_with_caps',
+                               return_value='[mgr.ceph-1.xyz]\n\tkey = X\n'), \
+             mock.patch.object(svc, 'generate_config',
+                               return_value=({}, [])):
+            return svc.prepare_create(daemon_spec)
+
+    def test_prepare_create_empty_mgr_services_discards_carryover(
+            self, cephadm_module: CephadmOrchestrator):
+        # Regression for https://tracker.ceph.com/issues/76564
+        # When `mgr services` returns no endpoints (e.g. dashboard module not
+        # yet listening during an upgrade), the carried-over daemon_spec.ports
+        # list from the persisted DaemonDescription must be discarded; the
+        # final list must contain exactly one service_discovery_port entry.
+        carried = [
+            cephadm_module.service_discovery_port,
+            cephadm_module.service_discovery_port,
+            cephadm_module.service_discovery_port,
+            cephadm_module.service_discovery_port,
+            cephadm_module.service_discovery_port,
+        ]
+        out = self._prepare(cephadm_module, '', carried)
+        assert out.ports == [cephadm_module.service_discovery_port]
+
+    def test_prepare_create_with_mgr_services_includes_module_port(
+            self, cephadm_module: CephadmOrchestrator):
+        # When `mgr services` reports a module endpoint (e.g. prometheus on
+        # 9283), the result must include that port plus exactly one
+        # service_discovery_port — with no duplicates from the carried-over
+        # daemon_spec.ports.
+        carried = [
+            cephadm_module.service_discovery_port,
+            cephadm_module.service_discovery_port,
+        ]
+        out = self._prepare(
+            cephadm_module,
+            '{"prometheus": "http://192.0.2.10:9283/"}',
+            carried,
+        )
+        assert out.ports == [9283, cephadm_module.service_discovery_port]


### PR DESCRIPTION
`MgrService.prepare_create` builds a fresh local `ports` list from `mgr services` output, but only assigns it onto `daemon_spec.ports` when non-empty. It then unconditionally appends `service_discovery_port`.

`daemon_spec` is updated from the persisted `DaemonDescription` via `CephadmDaemonDeploySpec.from_daemon_description()`, which copies `ports=dd.ports` from the host-inventory cache. When `mgr services` returns no endpoints (e.g. dashboard module not yet listening during an upgrade/downgrade window), the carried-over `daemon_spec.ports` is not reset, and the unconditional append adds yet another `service_discovery_port` entry to the already-persisted list. Every subsequent redeploy in this state grows the list by one.

Observed on a 2-mgr cluster after repeated upgrade cycles: 42 copies of 8765 in a single `mgr/cephadm/host.<host>` entry, visible in `ceph orch ps`.

Always build `daemon_spec.ports` fresh from the locally-computed list to guarantee exactly one `service_discovery_port` entry and to discard any stale duplicates already in the cache. Self-heals on the next mgr redeploy.

Fixes: https://tracker.ceph.com/issues/76564



I'll raise another tracker because it seems that the ports as seen in ceph orch ps (so ports seen in the inventory) get only re-configured on re-deploy. So if we enable or disable grafana for example, the ports in the inventory don't change and we are stuck with the previous state in the inventory and ceph orch ps output until we re-deploy, at least, that's what I can see, I have not debugged that part thoroughly.




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [X] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [X] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
