### PR TITLE
tentacle: ceph-volume: fallback to default for empty get_file_contents values

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_system.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_system.py
@@ -208,6 +208,16 @@ class TestGetFileContents(object):
         result = system.get_file_contents(interesting_file.path)
         assert result == "0\n1"
 
+    def test_path_empty_returns_default(self, fake_filesystem):
+        interesting_file = fake_filesystem.create_file('/tmp/fake-file', contents="")
+        result = system.get_file_contents(interesting_file.path, 'default')
+        assert result == 'default'
+
+    def test_path_whitespace_returns_default(self, fake_filesystem):
+        interesting_file = fake_filesystem.create_file('/tmp/fake-file', contents="   \n\t")
+        result = system.get_file_contents(interesting_file.path, 'default')
+        assert result == 'default'
+
     def test_exception_returns_default(self):
         with patch('builtins.open') as mocked_open:
             mocked_open.side_effect = Exception()

--- a/src/ceph-volume/ceph_volume/util/system.py
+++ b/src/ceph-volume/ceph_volume/util/system.py
@@ -122,7 +122,7 @@ def get_file_contents(path, default=''):
         return contents
     try:
         with open(path, 'r') as open_file:
-            contents = open_file.read().strip()
+            contents = open_file.read().strip() or default
     except Exception:
         logger.exception('Failed to read contents from: %s' % path)
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76569

---

backport of https://github.com/ceph/ceph/pull/68765
parent tracker: https://tracker.ceph.com/issues/76431

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh