### PR TITLE
mon: show CRUSH rule name in osd pool ls detail

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -1222,7 +1222,13 @@ Subcommand ``ls`` list pools
 
 Usage::
 
-    ceph osd pool ls {detail}
+    ceph osd pool ls {detail} {--show-rule-names}
+
+With ``detail``, ``--show-rule-names`` renders each pool's CRUSH rule by name
+instead of by numeric id in the text output. In the JSON output the numeric
+``crush_rule`` field is left as-is and a ``crush_rule_name`` field is added
+next to it. If the referenced rule no longer exists, the text output falls back
+to the numeric id and the JSON output omits ``crush_rule_name``.
 
 Subcommand ``mksnap`` makes snapshot <snap> in <pool>.
 

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1128,8 +1128,11 @@ COMMAND("osd pool force-remove-snap "
 	"order to cause OSDs to re-trim them.",
 	"osd", "rw")
 COMMAND("osd pool ls "
-	"name=detail,type=CephChoices,strings=detail,req=false",
-	"list pools", "osd", "r")
+	"name=detail,type=CephChoices,strings=detail,req=false "
+	"name=show_rule_names,type=CephBool,req=false",
+	"list pools (with `detail` and --show-rule-names, render the "
+	"CRUSH rule by name in the text output, and add a "
+	"`crush_rule_name` field to the JSON output)", "osd", "r")
 COMMAND("osd pool create "
 	"name=pool,type=CephPoolname "
 	"name=pg_num,type=CephInt,range=0,req=false "

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -6068,9 +6068,11 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
   } else if (prefix == "osd pool ls") {
     string detail;
     cmd_getval(cmdmap, "detail", detail);
+    bool show_rule_names = false;
+    cmd_getval(cmdmap, "show_rule_names", show_rule_names);
     if (!f && detail == "detail") {
       ostringstream ss;
-      osdmap.print_pools(cct, ss);
+      osdmap.print_pools(cct, ss, show_rule_names);
       rdata.append(ss.str());
     } else {
       if (f)
@@ -6081,7 +6083,7 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
 	    f->open_object_section("pool");
 	    f->dump_int("pool_id", pid);
 	    f->dump_string("pool_name", osdmap.get_pool_name(pid));
-	    pdata.dump(f.get());
+	    pdata.dump(f.get(), osdmap.crush.get(), show_rule_names);
 	    osdmap.dump_read_balance_score(cct, pid, pdata, f.get());
 	    f->close_section();
 	  } else {

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -4411,8 +4411,10 @@ string OSDMap::get_flag_string() const
   return get_flag_string(flags);
 }
 
-void OSDMap::print_pools(CephContext *cct, ostream& out) const
+void OSDMap::print_pools(CephContext *cct, ostream& out,
+                         bool show_rule_names) const
 {
+  const CrushWrapper *crush_for_names = show_rule_names ? crush.get() : nullptr;
   for (const auto &[pid, pdata] : pools) {
     std::string name("<unknown>");
     const auto &pni = pool_name.find(pid);
@@ -4428,10 +4430,9 @@ void OSDMap::print_pools(CephContext *cct, ostream& out) const
 		  " read_balance_score %.2f", rb_info.acting_adj_score);
     }
 
-    out << "pool " << pid
-	<< " '" << name
-	<< "' " << pdata
-	<< rb_score_str << "\n";
+    out << "pool " << pid << " '" << name << "' ";
+    pdata.print(out, crush_for_names);
+    out << rb_score_str << "\n";
     if (rb_info.err_msg.length() > 0) {
       out << (rc < 0 ? " ERROR: " : " Warning: ") << rb_info.err_msg << "\n";
     }

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1830,7 +1830,8 @@ public:
   void print(CephContext *cct, std::ostream& out) const;
   void print_osd(int id, std::ostream& out) const;
   void print_osds(std::ostream& out) const;
-  void print_pools(CephContext *cct, std::ostream& out) const;
+  void print_pools(CephContext *cct, std::ostream& out,
+                   bool show_rule_names = false) const;
   void print_summary(ceph::Formatter *f, std::ostream& out,
 		     const std::string& prefix, bool extra=false) const;
   void print_oneline_summary(std::ostream& out) const;

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1584,7 +1584,8 @@ ostream& operator<<(ostream& out, const pool_opts_t& opts)
 
 // -- pg_pool_t --
 
-void pg_pool_t::dump(Formatter *f) const
+void pg_pool_t::dump(Formatter *f, const CrushWrapper *crush,
+                     bool show_rule_names) const
 {
   f->dump_stream("create_time") << get_create_time();
   f->dump_unsigned("flags", get_flags());
@@ -1592,7 +1593,11 @@ void pg_pool_t::dump(Formatter *f) const
   f->dump_int("type", get_type());
   f->dump_int("size", get_size());
   f->dump_int("min_size", get_min_size());
-  f->dump_int("crush_rule", get_crush_rule());
+  const int rule_id = get_crush_rule();
+  f->dump_int("crush_rule", rule_id);
+  if (show_rule_names && crush && crush->rule_exists(rule_id)) {
+    f->dump_string("crush_rule_name", crush->get_rule_name(rule_id));
+  }
   f->dump_int("peering_crush_bucket_count", peering_crush_bucket_count);
   f->dump_int("peering_crush_bucket_target", peering_crush_bucket_target);
   f->dump_int("peering_crush_bucket_barrier", peering_crush_bucket_barrier);
@@ -2423,16 +2428,23 @@ list<pg_pool_t> pg_pool_t::generate_test_instances()
   return o;
 }
 
-ostream& operator<<(ostream& out, const pg_pool_t& p)
+void pg_pool_t::print(ostream& out, const CrushWrapper *crush) const
 {
+  const pg_pool_t& p = *this;
   out << p.get_type_name();
   if (p.get_type_name() == "erasure") {
     out << " profile " << p.erasure_code_profile;
   }
+  const int rule_id = p.get_crush_rule();
   out << " size " << p.get_size()
       << " min_size " << p.get_min_size()
-      << " crush_rule " << p.get_crush_rule()
-      << " object_hash " << p.get_object_hash_name()
+      << " crush_rule ";
+  if (crush && crush->rule_exists(rule_id)) {
+    out << crush->get_rule_name(rule_id);
+  } else {
+    out << rule_id;
+  }
+  out << " object_hash " << p.get_object_hash_name()
       << " pg_num " << p.get_pg_num()
       << " pgp_num " << p.get_pgp_num();
   if (p.get_pg_num_target() != p.get_pg_num()) {
@@ -2502,6 +2514,11 @@ ostream& operator<<(ostream& out, const pg_pool_t& p)
       out << it->first;
     }
   }
+}
+
+ostream& operator<<(ostream& out, const pg_pool_t& p)
+{
+  p.print(out);
   return out;
 }
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -57,6 +57,8 @@
 #include "pg_features.h"
 #include "ECTypes.h"
 
+class CrushWrapper;
+
 #define CEPH_OSD_ONDISK_MAGIC "ceph osd volume v026"
 
 #define CEPH_OSD_FEATURE_INCOMPAT_BASE CompatSet::Feature(1, "initial feature set(~v.18)")
@@ -1762,7 +1764,20 @@ public:
 
   pg_pool_t() = default;
 
-  void dump(ceph::Formatter *f) const;
+  // When `crush` is non-null, `show_rule_names` is true, and the
+  // pool's crush rule still exists, an extra `crush_rule_name`
+  // string is emitted alongside the (always-int) `crush_rule`
+  // field. Defaults preserve the existing JSON schema.
+  void dump(ceph::Formatter *f,
+            const CrushWrapper *crush = nullptr,
+            bool show_rule_names = false) const;
+
+  // Renders the pool fields used by `pg_pool_t`'s stream operator
+  // (which delegates here with `crush == nullptr`). When `crush`
+  // is non-null and the pool's rule still exists, `crush_rule` is
+  // rendered as the rule name instead of the numeric id; otherwise
+  // the numeric id is used so the output is never misleading.
+  void print(std::ostream& out, const CrushWrapper *crush = nullptr) const;
 
   const utime_t &get_create_time() const { return create_time; }
   uint64_t get_flags() const { return flags; }


### PR DESCRIPTION
## Summary

`ceph osd pool ls detail` shows `crush_rule <id>` for every pool, but
there's no straightforward way to map that id to a rule name from the
same command. `ceph osd crush rule dump <id>` doesn't accept an id,
so users have to dump every rule and search.

This adds a `--show-rule-names` flag, paired with `detail`, that:

- in the text output, renders the CRUSH rule by name in place of the id;
- in the JSON output, leaves `crush_rule` as an int (no schema change)
  and adds a sibling `crush_rule_name` string field.

Before:
```
$ ceph osd pool ls detail
pool 3 'pool_named' replicated size 3 min_size 1 crush_rule 1 ...
```

After (text):
```
$ ceph osd pool ls detail --show-rule-names
pool 3 'pool_named' replicated size 3 min_size 1 crush_rule replica_hdd ...
```

After (JSON):
```
$ ceph osd pool ls detail --show-rule-names --format json
... "crush_rule": 1, "crush_rule_name": "replica_hdd", ...
```

The JSON shape is additive on purpose. The in-tree `balancer` and
`pg_autoscaler` mgr modules pin `crush_rule` to an int (e.g.
`crush.get_rule_by_id(pool['crush_rule'])`), so flipping the field's
type under any flag would break them. The opt-in sibling field is
safe for any consumer that already reads the int.

If the referenced rule no longer exists in CRUSH, the text falls back
to the numeric id and the JSON omits `crush_rule_name`, so the output
is never misleading.

Verified on vstart with a default rule, a named replicated rule, and
pools pointing at each.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [x] No tests

Tracker: https://tracker.ceph.com/issues/76401
