### PR TITLE
rgw/logging: use assumed-role ARN as Requester for STS requests

### DIFF
--- a/qa/suites/rgw/bucket-logging/overrides.yaml
+++ b/qa/suites/rgw/bucket-logging/overrides.yaml
@@ -6,6 +6,8 @@ overrides:
         setgroup: ceph
         debug rgw: 20
         rgw bucket logging obj roll time: 5
+        rgw sts key: abcdefghijklmnop
+        rgw s3 auth use sts: true
   rgw:
     storage classes:
       LUKEWARM:

--- a/src/rgw/rgw_bucket_logging.cc
+++ b/src/rgw/rgw_bucket_logging.cc
@@ -550,9 +550,19 @@ int log_record(rgw::sal::Driver* driver,
   const auto tt = ceph::coarse_real_time::clock::to_time_t(s->time);
   std::tm t{};
   localtime_r(&tt, &t);
-  auto user_or_account = s->account_name;
+  // AWS S3 spec: log the assumed-role ARN for STS-credentialed requests.
+  std::string user_or_account;
+  if (s->auth.identity && s->auth.identity->get_identity_type() == TYPE_ROLE) {
+    if (auto caller_arn = s->auth.identity->get_caller_identity(); caller_arn) {
+      user_or_account = caller_arn->to_string();
+    }
+  }
   if (user_or_account.empty()) {
-    s->user->get_id().to_str(user_or_account);
+    if (s->account_name.empty()) {
+      s->user->get_id().to_str(user_or_account);
+    } else {
+      user_or_account = s->account_name;
+    }
   }
   auto fqdn = s->info.host;
   if (!s->info.domain.empty() && !fqdn.empty()) {


### PR DESCRIPTION
When a request is made with STS temporary credentials, the bucket logging Requester field was being set to the underlying user ID instead of the assumed-role ARN. Per the [AWS S3 server-access-log spec](https://docs.aws.amazon.com/AmazonS3/latest/userguide/LogFormat.html#log-record-fields), the Requester field should contain the assumed-role ARN (e.g. `arn:aws:sts::<account>:assumed-role/<role>/<session>`) for STS-credentialed requests.

Detect `TYPE_ROLE` identities via `s->auth.identity->get_identity_type()` and use the ARN returned by `Identity::get_caller_identity()` (already implemented by `RoleApplier` in the expected AWS format) instead of falling straight through to `s->user->get_id()`. Existing behavior for account- and user-scoped requests is unchanged.

Verified locally against a vstart cluster: a PUT made with `sts:AssumeRole` credentials now produces a log record whose Requester field exactly matches the `AssumedRoleUser.Arn` returned by STS.

Fixes: https://tracker.ceph.com/issues/71742

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

Tests for this fix will be added in a separate PR against [ceph/s3-tests](https://github.com/ceph/s3-tests) as agreed with the maintainer; that PR will link back here.