### PR TITLE
cephadm: let extra_entrypoint_args override built-in flags

### DIFF
--- a/src/cephadm/cephadmlib/deployment_utils.py
+++ b/src/cephadm/cephadmlib/deployment_utils.py
@@ -1,8 +1,58 @@
 import os
 
+from collections import Counter
+from typing import List, Optional
+
 from .container_types import CephContainer, BasicContainer
 from .context import CephadmContext
 from cephadmlib.context_getters import fetch_custom_config_files
+
+
+def _entrypoint_flag_name(arg: str) -> Optional[str]:
+    """Return the flag name (e.g. ``--web.external-url``) from an entrypoint
+    arg, or None for non-flag tokens. The name is the prefix before the
+    first ``=`` or whitespace separator, matching how callers expect
+    ``--name=value`` and ``--name value`` to behave; a bare ``--name`` token
+    returns its own name unchanged.
+    """
+    if not arg.startswith('--'):
+        return None
+    for sep in '= \t':
+        idx = arg.find(sep)
+        if idx > 0:
+            return arg[:idx]
+    return arg
+
+
+def _drop_overridden_flags(args: List[str], overrides: List[str]) -> List[str]:
+    """Filter ``args`` to drop a cephadm-injected ``--flag`` when the user
+    supplies the same flag in ``overrides``, so the user's value wins
+    instead of producing a duplicate-flag error from the container's
+    binary (Prometheus refuses to start on two ``--web.external-url``).
+
+    Only single-instance built-in flags are dropped. If cephadm itself
+    emitted the same flag more than once (alertmanager's per-peer
+    ``--cluster.peer``), the flag is treated as multi-valued and the
+    built-in copies are kept; the user's extras still ``append`` and
+    accumulate, which matches the typical "I want to add a peer"
+    intent.
+    """
+    override_names = {
+        name for name in (_entrypoint_flag_name(a) for a in overrides)
+        if name is not None
+    }
+    if not override_names:
+        return args
+    name_counts = Counter(
+        name for name in (_entrypoint_flag_name(a) for a in args)
+        if name is not None
+    )
+    filter_names = {
+        name for name in override_names if name_counts.get(name, 0) == 1
+    }
+    if not filter_names:
+        return args
+    return [a for a in args if _entrypoint_flag_name(a) not in filter_names]
 
 
 def enhance_container(ctx: CephadmContext, ctr: BasicContainer) -> None:
@@ -14,6 +64,11 @@ def enhance_container(ctx: CephadmContext, ctr: BasicContainer) -> None:
     if 'extra_container_args' in ctx and ctx.extra_container_args:
         ctr.container_args.extend(ctx.extra_container_args)
     if 'extra_entrypoint_args' in ctx and ctx.extra_entrypoint_args:
+        # Where a user-supplied flag name collides with one cephadm injected,
+        # drop the built-in copy so the user's value wins. Without this, the
+        # container engine sees ``--flag X --flag Y`` and tools like
+        # Prometheus refuse to start ("flag 'X' cannot be repeated").
+        ctr.args = _drop_overridden_flags(ctr.args, ctx.extra_entrypoint_args)
         ctr.args.extend(ctx.extra_entrypoint_args)
     ccfiles = fetch_custom_config_files(ctx)
     assert ctr.identity

--- a/src/cephadm/tests/test_deploy.py
+++ b/src/cephadm/tests/test_deploy.py
@@ -329,6 +329,42 @@ def test_deploy_a_monitoring_container(cephadm_fs, funkypatch):
         assert (si.st_uid, si.st_gid) == (8765, 8765)
 
 
+def test_deploy_prometheus_overrides_web_external_url(cephadm_fs, funkypatch):
+    # Reverse-proxy users (tracker #76438) need the rendered Prometheus
+    # cmdline to carry their --web.external-url and not cephadm's internal
+    # one, otherwise Prometheus refuses to start with "flag cannot be repeated".
+    mocks = _common_patches(funkypatch)
+    _get_ip_addresses = funkypatch.patch('cephadmlib.net_utils.get_ip_addresses')
+    _get_ip_addresses.return_value = (['10.10.10.10'], [])
+    fsid = 'b01dbeef-701d-9abe-0000-e1e5a47004a7'
+    public_url = 'https://prom.example.com/prometheus'
+    with with_cephadm_ctx([]) as ctx:
+        ctx.container_engine = mock_podman()
+        ctx.fsid = fsid
+        ctx.name = 'prometheus.fire'
+        ctx.image = 'quay.io/titans/prometheus:latest'
+        ctx.reconfig = False
+        ctx.config_blobs = {
+            'config': 'XXXXXXX',
+            'keyring': 'YYYYYY',
+            'files': {
+                'prometheus.yml': 'bettercallherc',
+            },
+            'ip_to_bind_to': '1.2.3.4',
+        }
+        ctx.extra_entrypoint_args = [
+            f'--web.external-url={public_url}',
+        ]
+        _cephadm._common_deploy(ctx)
+
+    basedir = pathlib.Path(f'/var/lib/ceph/{fsid}/prometheus.fire')
+    with open(basedir / 'unit.run') as f:
+        runline = f.read().splitlines()[-1]
+    assert f'--web.external-url={public_url}' in runline
+    assert '--web.external-url=http://10.10.10.10:9095' not in runline
+    assert runline.count('--web.external-url') == 1
+
+
 def test_deploy_a_tracing_container(cephadm_fs, funkypatch):
     mocks = _common_patches(funkypatch)
     _firewalld = mocks['Firewalld']

--- a/src/cephadm/tests/test_util_funcs.py
+++ b/src/cephadm/tests/test_util_funcs.py
@@ -992,3 +992,84 @@ def test_enable_shared_namespaces():
         '--uts=container:c001d00d',
         '--network=container:badd33d5',
     ]
+
+
+class TestEntrypointFlagOverride:
+    """Cover the helpers that let extra_entrypoint_args replace
+    cephadm-injected entrypoint flags (tracker #76438, Prometheus
+    --web.external-url override for reverse-proxy deployments)."""
+
+    def test_flag_name_long_form(self):
+        from cephadmlib.deployment_utils import _entrypoint_flag_name
+        assert _entrypoint_flag_name('--web.external-url=http://x') == '--web.external-url'
+        assert _entrypoint_flag_name('--web.external-url http://x') == '--web.external-url'
+        assert _entrypoint_flag_name('--web.external-url\thttp://x') == '--web.external-url'
+        assert _entrypoint_flag_name('--config.file=/foo') == '--config.file'
+
+    def test_flag_name_bare(self):
+        from cephadmlib.deployment_utils import _entrypoint_flag_name
+        assert _entrypoint_flag_name('--dry-run') == '--dry-run'
+
+    def test_flag_name_non_flag(self):
+        from cephadmlib.deployment_utils import _entrypoint_flag_name
+        assert _entrypoint_flag_name('positional') is None
+        assert _entrypoint_flag_name('-short') is None  # only -- is recognized
+        assert _entrypoint_flag_name('') is None
+
+    def test_drop_overridden_replaces_built_in(self):
+        from cephadmlib.deployment_utils import _drop_overridden_flags
+        built_in = [
+            '--config.file=/etc/prometheus/prometheus.yml',
+            '--storage.tsdb.path=/prometheus',
+            '--web.listen-address=1.2.3.4:9095',
+            '--web.external-url=http://internal:9095',
+        ]
+        overrides = ['--web.external-url=https://prom.example.com']
+        kept = _drop_overridden_flags(built_in, overrides)
+        assert '--web.external-url=http://internal:9095' not in kept
+        assert '--config.file=/etc/prometheus/prometheus.yml' in kept
+        assert '--storage.tsdb.path=/prometheus' in kept
+        assert '--web.listen-address=1.2.3.4:9095' in kept
+
+    def test_drop_overridden_keeps_multi_value_built_ins(self):
+        # alertmanager appends one --cluster.peer per peer; treating
+        # those as overridable would silently wipe the cephadm-managed
+        # peer set when the user only wants to add a peer. Multi-instance
+        # cephadm flags are kept; extras still extend afterwards.
+        from cephadmlib.deployment_utils import _drop_overridden_flags
+        built_in = ['--cluster.peer=a', '--cluster.peer=b', '--config.file=/x']
+        overrides = ['--cluster.peer=c']
+        assert _drop_overridden_flags(built_in, overrides) == built_in
+
+    def test_drop_overridden_mixes_multi_and_single(self):
+        # Single-instance --web.external-url is dropped on collision; the
+        # multi-instance --cluster.peer flags are left alone.
+        from cephadmlib.deployment_utils import _drop_overridden_flags
+        built_in = [
+            '--cluster.peer=a',
+            '--cluster.peer=b',
+            '--web.external-url=http://internal:9095',
+        ]
+        overrides = [
+            '--cluster.peer=c',
+            '--web.external-url=https://prom.example.com',
+        ]
+        kept = _drop_overridden_flags(built_in, overrides)
+        assert kept == ['--cluster.peer=a', '--cluster.peer=b']
+
+    def test_drop_overridden_no_overrides_is_noop(self):
+        from cephadmlib.deployment_utils import _drop_overridden_flags
+        built_in = ['--a=1', '--b=2']
+        assert _drop_overridden_flags(built_in, []) == built_in
+        # positional-only overrides are ignored (no flag name to match)
+        assert _drop_overridden_flags(built_in, ['positional']) == built_in
+
+    def test_drop_overridden_handles_space_separated_form(self):
+        from cephadmlib.deployment_utils import _drop_overridden_flags
+        built_in = ['--web.external-url=http://internal']
+        # user wrote `--web.external-url http://prom.example.com` as two list
+        # items, which list.extend keeps as one string per item; supporting
+        # the single-string-with-space form keeps it safe either way.
+        overrides = ['--web.external-url https://prom.example.com']
+        kept = _drop_overridden_flags(built_in, overrides)
+        assert kept == []


### PR DESCRIPTION
## Summary

Cephadm injects entrypoint flags for the monitoring stack, e.g.
`--web.external-url=http://<internal>:9095` for Prometheus, and
unconditionally appends the user's `extra_entrypoint_args` afterwards.
When a user tries to point Prometheus at a public URL for a
reverse-proxy deployment via:

```yaml
service_type: prometheus
extra_entrypoint_args:
  - "--web.external-url=https://prom.example.com"
```

the container refuses to start with:

```
Error parsing command line arguments: flag 'web.external-url' cannot be repeated
```

This makes the reverse-proxy story for Prometheus and Alertmanager
unworkable because the dashboard, alert links, and federation URLs all
end up pointing at an internal address the client can't reach.

## Change

In `enhance_container`, before extending with `extra_entrypoint_args`,
drop any cephadm-injected `--flag` whose name also appears in the
overrides. The user's value then wins.

Only single-instance built-in flags are dropped. If cephadm itself
emitted the same flag multiple times (alertmanager's per-peer
`--cluster.peer={peer}`), the flag is treated as multi-valued and the
built-in copies are kept; the user's extras still `append`, so adding
a peer doesn't silently wipe the cephadm-managed peer set.

Rendered cmdline diff for Prometheus with `extra_entrypoint_args:
['--web.external-url=https://prom.example.com']`:

```
- ... --web.external-url=http://10.10.10.10:9095 --web.external-url=https://prom.example.com
+ ... --web.external-url=https://prom.example.com
```

Alertmanager with `extra_entrypoint_args: ['--cluster.peer=peer-c']`
keeps both `peer-a` and `peer-b` and adds `peer-c`.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [ ] No tests

Tracker: https://tracker.ceph.com/issues/76438