### PR TITLE
mgr: fix OpHistory shutdown race condition

### DIFF
--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -109,13 +109,17 @@ OpHistory::~OpHistory() {
 
 void OpHistory::on_shutdown()
 {
+  if (shutdown.exchange(true)) {   // idempotent; join is reached exactly once
+    return;
+  }
   opsvc.break_thread();
-  opsvc.join();
+  if (opsvc.is_started()) {
+    opsvc.join();
+  }
   std::lock_guard history_lock(ops_history_lock);
   arrived.clear();
   duration.clear();
   slow_op.clear();
-  shutdown = true;
 }
 
 void OpHistory::_insert_delayed(const utime_t& now, TrackedOpRef op)
@@ -211,6 +215,13 @@ OpTracker::OpTracker(CephContext *cct_, bool tracking, uint32_t num_shards):
 }
 
 OpTracker::~OpTracker() {
+  // NOTE: on_shutdown() must be called before OpTracker destruction.
+  // This ensures the OpHistory service thread is stopped and all tracked
+  // operations are properly cleared before the OpTracker is destroyed.
+  // See usages in OSD::shutdown(), Monitor::shutdown(), MDSRank::~MDSRank(),
+  // and DaemonServer::~DaemonServer() for examples. This addition is a failsafe
+  history.on_shutdown();
+
   while (!sharded_in_flight_list.empty()) {
     ShardedTrackingData* sdata = sharded_in_flight_list.back();
     ceph_assert(NULL != sdata);

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -139,9 +139,22 @@ DaemonServer::DaemonServer(MonClient *monc_,
                                                     cct->_conf->mgr_op_history_slow_op_threshold);
 }
 
-DaemonServer::~DaemonServer() {
+void DaemonServer::shutdown()
+{
+  bool expected = false;
+  if (!shutting_down.compare_exchange_strong(expected, true)) {
+    return;
+  }
+
+  op_tracker.on_shutdown();
+
   delete msgr;
+  msgr = nullptr;
   g_conf().remove_observer(this);
+}
+
+DaemonServer::~DaemonServer() {
+  shutdown();
 }
 
 class DaemonServerHook : public AdminSocketHook {

--- a/src/mgr/DaemonServer.h
+++ b/src/mgr/DaemonServer.h
@@ -249,6 +249,7 @@ private:
   void tick();
   void maybe_adjust_stats_period();
   void schedule_tick_locked(double delay_sec);
+  std::atomic<bool> shutting_down = false;
 
   class OSDPerfMetricCollectorListener : public MetricListener {
   public:
@@ -318,11 +319,12 @@ public:
 
   DaemonServer(MonClient *monc_,
                Finisher &finisher_,
-	       DaemonStateIndex &daemon_state_,
-	       ClusterState &cluster_state_,
-	       PyModuleRegistry &py_modules_,
-	       LogChannelRef cl,
-	       LogChannelRef auditcl);
+        DaemonStateIndex &daemon_state_,
+        ClusterState &cluster_state_,
+        PyModuleRegistry &py_modules_,
+        LogChannelRef cl,
+        LogChannelRef auditcl);
+  void shutdown();
   ~DaemonServer() override;
 
   Dispatcher::dispatch_result_t ms_dispatch2(const ceph::ref_t<Message>& m) override;

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -81,6 +81,18 @@ Mgr::Mgr(MonClient *monc_, const MgrMap& mgrmap,
 
 Mgr::~Mgr()
 {
+}
+
+void Mgr::shutdown()
+{
+  if (initialized) {
+    AdminSocket *admin_socket = g_ceph_context->get_admin_socket();
+    admin_socket->unregister_commands(this);
+  }
+
+  finisher.wait_for_empty();
+  finisher.stop();
+
   server.shutdown();
 }
 

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -81,6 +81,7 @@ Mgr::Mgr(MonClient *monc_, const MgrMap& mgrmap,
 
 Mgr::~Mgr()
 {
+  server.shutdown();
 }
 
 static std::string crush_hostname_for_osd(ClusterState& cluster_state, int osd_id)

--- a/src/mgr/Mgr.h
+++ b/src/mgr/Mgr.h
@@ -75,6 +75,7 @@ public:
       Messenger *clientm_, Objecter *objecter_,
       LogChannelRef clog_, LogChannelRef audit_clog_);
   ~Mgr();
+  void shutdown();
 
   bool is_initialized() const {return initialized;}
   bool exceeded_initialization_expiration();

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -94,6 +94,10 @@ MgrStandby::MgrStandby(int argc, const char **argv) :
 }
 
 MgrStandby::~MgrStandby() {
+  if (active_mgr) {
+    active_mgr->shutdown();
+    active_mgr.reset();
+  }
   if (asok_hook) {
     g_ceph_context->get_admin_socket()->unregister_commands(asok_hook.get());
     asok_hook.reset();


### PR DESCRIPTION

Fixes a race condition where the OpHistory thread could access freed memory during OpTracker destruction, causing segfaults and ‘pure virtual method called’ errors. These could both be seen during unit testing of the mgr, where the objects are very quickly stood up and torn down, stemming from DaemonServer's destruction at the end of testing.

The three changes:

Make OpHistory::on_shutdown() thread-safe:
   - Add early return if already shut down
   - Add is_started() check before joining the opsvc thread, this prevents a monitor that is rapidly created and destroyed during –mkfs on cluster startup from attempting to join a thread that hasn’t started during OpHistory shutdown.

Call history.on_shutdown() in OpTracker destructor:
   - Ensures OpHistory service thread is stopped before destruction, preventing the thread from accessing a partially destroyed OpTracker object

Add explicit op_tracker.on_shutdown() to DaemonServer destructor:
   - Makes DaemonServer consistent with MDS/OSD/Monitor shutdown patterns

Fixes: https://tracker.ceph.com/issues/76334

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
