### PR TITLE
mgr daemon ports list grows unbounded across redeploys

### DIFF
--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1196,10 +1196,11 @@ class MgrService(CephService):
                 if port:
                     ports.append(int(port[0][1:-1]))
 
-        if ports:
-            daemon_spec.ports = ports
-
-        daemon_spec.ports.append(self.mgr.service_discovery_port)
+        # Always replace ports (do not append onto a list rehydrated from the
+        # persisted host cache). When ``mgr services`` is empty, ``ports`` is
+        # empty and we must not retain old entries + append service discovery
+        # again
+        daemon_spec.ports = ports + [self.mgr.service_discovery_port]
         daemon_spec.keyring = keyring
 
         daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)

--- a/src/pybind/mgr/cephadm/tests/services/test_mgr.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_mgr.py
@@ -1,0 +1,67 @@
+from unittest import mock
+
+from cephadm.module import CephadmOrchestrator
+from cephadm.services.cephadmservice import (
+    CephadmDaemonDeploySpec,
+    MgrService,
+)
+
+
+class TestMgrService:
+    def _prepare(self, cephadm_module: CephadmOrchestrator,
+                 mgr_services_payload: str,
+                 carried_over_ports: list) -> CephadmDaemonDeploySpec:
+        """Build a daemon_spec that mimics rehydration from the persisted
+        DaemonDescription (which copies `ports=dd.ports`), then call
+        MgrService.prepare_create with `mgr services` returning the supplied
+        payload.
+        """
+        svc = MgrService(cephadm_module)
+        daemon_spec = CephadmDaemonDeploySpec(
+            host='ceph-1',
+            daemon_id='ceph-1.xyz',
+            service_name='mgr',
+            daemon_type='mgr',
+            ports=list(carried_over_ports),
+        )
+        with mock.patch.object(cephadm_module, 'check_mon_command',
+                               return_value=(0, mgr_services_payload, '')), \
+             mock.patch.object(svc, 'get_keyring_with_caps',
+                               return_value='[mgr.ceph-1.xyz]\n\tkey = X\n'), \
+             mock.patch.object(svc, 'generate_config',
+                               return_value=({}, [])):
+            return svc.prepare_create(daemon_spec)
+
+    def test_prepare_create_empty_mgr_services_discards_carryover(
+            self, cephadm_module: CephadmOrchestrator):
+        # Regression for https://tracker.ceph.com/issues/76564
+        # When `mgr services` returns no endpoints (e.g. dashboard module not
+        # yet listening during an upgrade), the carried-over daemon_spec.ports
+        # list from the persisted DaemonDescription must be discarded; the
+        # final list must contain exactly one service_discovery_port entry.
+        carried = [
+            cephadm_module.service_discovery_port,
+            cephadm_module.service_discovery_port,
+            cephadm_module.service_discovery_port,
+            cephadm_module.service_discovery_port,
+            cephadm_module.service_discovery_port,
+        ]
+        out = self._prepare(cephadm_module, '', carried)
+        assert out.ports == [cephadm_module.service_discovery_port]
+
+    def test_prepare_create_with_mgr_services_includes_module_port(
+            self, cephadm_module: CephadmOrchestrator):
+        # When `mgr services` reports a module endpoint (e.g. prometheus on
+        # 9283), the result must include that port plus exactly one
+        # service_discovery_port — with no duplicates from the carried-over
+        # daemon_spec.ports.
+        carried = [
+            cephadm_module.service_discovery_port,
+            cephadm_module.service_discovery_port,
+        ]
+        out = self._prepare(
+            cephadm_module,
+            '{"prometheus": "http://192.0.2.10:9283/"}',
+            carried,
+        )
+        assert out.ports == [9283, cephadm_module.service_discovery_port]


### PR DESCRIPTION
cephadm: fix mgr ports list growth; add unit tests (#76564)

Problem
-------
MgrService.prepare_create built module ports from ``mgr services`` but
only assigned them when non-empty, then always appended
service_discovery_port. After rehydration from mgr/cephadm/host.*, an
empty ``mgr services`` response left stale ports in place and appended
another 8765 each redeploy (https://tracker.ceph.com/issues/76564).

Fix
---
Always set ``daemon_spec.ports = ports + [service_discovery_port]`` so
each prepare uses a fresh list plus exactly one discovery port.

Tests
-----
Add src/pybind/mgr/cephadm/tests/services/test_mgr.py: empty vs
non-empty ``mgr services`` with carried-over duplicate ports. Cases
consolidated from parallel PR https://github.com/ceph/ceph/pull/68879 .

Authors
-------
Kobi Ginon (@kginonredhat) — fix + test integration for this PR.
Raimund Sacherer (@rsacherer) — original fix + tests in #68879;
coordinated to land a single PR (#68915).

Fixes: https://tracker.ceph.com/issues/76564
Signed-off-by: Kobi Ginon <kginon@redhat.com>
Signed-off-by: Raimund Sacherer <rsachere@redhat.com>

### verifications 
#disabled the dashboard and promethues

[ceph: root@ceph-node-0 /]# ceph mgr module disable prometheus
[ceph: root@ceph-node-0 /]# ceph mgr module disable dashboard

[ceph: root@ceph-node-0 /]# ceph orch ps --daemon-type mgr
NAME                    HOST         PORTS                            STATUS        REFRESHED  AGE  MEM USE  MEM LIM  VERSION                IMAGE ID      CONTAINER ID
mgr.ceph-node-0.ndtijm  ceph-node-0  *:8443,9283,8765,8765,8765,8765  running (3m)     3m ago  36m     164M        -  21.0.0-1204-g3295cda6  e197eb02a5eb  ce9414d655b4
mgr.ceph-node-1.anakfs  ceph-node-1  *:8443,8765                      running (9m)     3m ago  27m     144M        -  21.0.0-1204-g3295cda6  d343613cc363  3d8614f0d9af


[ceph: root@ceph-node-0 /]# MGR=MGR=mgr.ceph-node-0.ndtijm
[ceph: root@ceph-node-0 /]# HOST=ceph-node-0

[ceph: root@ceph-node-0 /]# for i in $(seq 1 10); do
  ceph orch daemon redeploy "$MGR"
  # wait until redeploy finishes (watch: ceph orch ps --daemon-type mgr)
  sleep 30
done


#at the end of the run and during no duplicates
[ceph: root@ceph-node-0 /]# ceph config-key get mgr/cephadm/host."$HOST" | jq '.daemons["'"$MGR"'"].ports'
[
  8765
]
#end verification


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
