### PR TITLE
mon: surface data dir + db size as perf counters

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -16,6 +16,12 @@
   to throttle client metadata requests (e.g., create, mkdir, lookup, and so on) to
   subvolumes, where each subvolume QoS is shared among multiple client sessions at
   that time.
+* MON: Each monitor now reports four new perf counters covering its data
+  directory: ``data_disk_total_bytes``, ``data_disk_avail_bytes``,
+  ``data_disk_avail_percent``, and ``db_total_bytes`` (estimated on-disk size
+  of the key/value store). They surface automatically as ``ceph_mon_*``
+  Prometheus metrics via the ``prometheus`` mgr module and ``ceph-exporter``,
+  enabling trending of mon DB growth and filesystem free space.
 
 * librados/neorados: The C++ APIs for executing Ceph Class (CLS) methods
   have undergone a breaking change to enforce compile-time type safety, replacing

--- a/src/mon/HealthMonitor.cc
+++ b/src/mon/HealthMonitor.cc
@@ -605,6 +605,13 @@ bool HealthMonitor::check_member_health()
 	   << ", used " << byte_u_t(stats.fs_stats.byte_used)
 	   << ", avail " << byte_u_t(stats.fs_stats.byte_avail) << dendl;
 
+  if (mon.logger) {
+    mon.logger->set(l_mon_data_disk_total_bytes, stats.fs_stats.byte_total);
+    mon.logger->set(l_mon_data_disk_avail_bytes, stats.fs_stats.byte_avail);
+    mon.logger->set(l_mon_data_disk_avail_percent, stats.fs_stats.avail_percent);
+    mon.logger->set(l_mon_db_total_bytes, stats.store_stats.bytes_total);
+  }
+
   // MON_DISK_{LOW,CRIT,BIG}
   health_check_map_t next;
   if (stats.fs_stats.avail_percent <= g_conf()->mon_data_avail_crit) {

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -902,6 +902,18 @@ int Monitor::preinit()
         nullptr, PerfCountersBuilder::PRIO_INTERESTING);
     pcb.add_u64(l_mon_backup_cleanup_deleted, "backup_cleanup_deleted", "Mon backup cleanup deleted backups",
         nullptr, PerfCountersBuilder::PRIO_INTERESTING);
+    pcb.add_u64(l_mon_data_disk_total_bytes, "data_disk_total_bytes",
+        "Total size of the filesystem hosting the monitor data directory",
+        "dtot", PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
+    pcb.add_u64(l_mon_data_disk_avail_bytes, "data_disk_avail_bytes",
+        "Available space on the filesystem hosting the monitor data directory",
+        "davb", PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
+    pcb.add_u64(l_mon_data_disk_avail_percent, "data_disk_avail_percent",
+        "Available space on the filesystem hosting the monitor data directory, as a percentage",
+        "dpct", PerfCountersBuilder::PRIO_USEFUL);
+    pcb.add_u64(l_mon_db_total_bytes, "db_total_bytes",
+        "Estimated on-disk size of the monitor key/value store",
+        "dbsz", PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
     logger = pcb.create_perf_counters();
     cct->get_perfcounters_collection()->add(logger);
   }

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -120,6 +120,10 @@ enum {
   l_mon_backup_cleanup_duration,
   l_mon_backup_cleanup_freed,
   l_mon_backup_cleanup_deleted,
+  l_mon_data_disk_total_bytes,
+  l_mon_data_disk_avail_bytes,
+  l_mon_data_disk_avail_percent,
+  l_mon_db_total_bytes,
   l_mon_last,
 };
 


### PR DESCRIPTION
## Summary

`HealthMonitor::check_member_health()` already collects filesystem stats for the data directory and the estimated on-disk size of the monitor key/value store every tick, and uses them to raise `MON_DISK_LOW`/`CRIT`/`BIG`. The values aren't surfaced anywhere else, so there's no way to trend monitor DB growth or available space on the filesystem hosting `mon_data`.

This adds four counters to the existing `mon` perf-counter group, set from `check_member_health()` after the stats are populated:

- `data_disk_total_bytes` — filesystem total
- `data_disk_avail_bytes` — filesystem available
- `data_disk_avail_percent` — filesystem available, as a percentage
- `db_total_bytes` — estimated on-disk size of the key/value store

They're tagged `PRIO_USEFUL`, so they propagate to the `prometheus` mgr module and `ceph-exporter` (both consume daemon perf counters at that priority) and appear as `ceph_mon_*` metrics with the `ceph_daemon` label.

No new config option, no admin-socket additions, no API change.

Tracker: https://tracker.ceph.com/issues/76589

## Verification

Built on a vstart cluster, 1 mon + 1 mgr + 1 osd.

`ceph daemon mon.a perf dump mon`:

```json
{
  "mon": {
    "num_sessions": 6,
    "session_add": 1,
    "session_rm": 26,
    "session_trim": 0,
    "num_elections": 2,
    "election_call": 0,
    "election_win": 2,
    "election_lose": 0,
    "data_disk_total_bytes": 211483705344,
    "data_disk_avail_bytes": 99612540928,
    "data_disk_avail_percent": 47,
    "db_total_bytes": 932419
  }
}
```

`ceph daemon mon.a perf schema` (new entries only):

```json
"data_disk_total_bytes": {
  "type": 2, "metric_type": "gauge", "value_type": "integer",
  "description": "Total size of the filesystem hosting the monitor data directory",
  "nick": "dtot", "priority": 5, "units": "bytes"
},
"data_disk_avail_bytes": {
  "type": 2, "metric_type": "gauge", "value_type": "integer",
  "description": "Available space on the filesystem hosting the monitor data directory",
  "nick": "davb", "priority": 5, "units": "bytes"
},
"data_disk_avail_percent": {
  "type": 2, "metric_type": "gauge", "value_type": "integer",
  "description": "Available space on the filesystem hosting the monitor data directory, as a percentage",
  "nick": "dpct", "priority": 5, "units": "none"
},
"db_total_bytes": {
  "type": 2, "metric_type": "gauge", "value_type": "integer",
  "description": "Estimated on-disk size of the monitor key/value store",
  "nick": "dbsz", "priority": 5, "units": "bytes"
}
```

`prometheus` mgr module endpoint (`exclude_perf_counters=false`):

```
# HELP ceph_mon_data_disk_total_bytes Total size of the filesystem hosting the monitor data directory
# TYPE ceph_mon_data_disk_total_bytes gauge
ceph_mon_data_disk_total_bytes{ceph_daemon="mon.a"} 211483705344.0
# HELP ceph_mon_data_disk_avail_bytes Available space on the filesystem hosting the monitor data directory
# TYPE ceph_mon_data_disk_avail_bytes gauge
ceph_mon_data_disk_avail_bytes{ceph_daemon="mon.a"} 99607396352.0
# HELP ceph_mon_data_disk_avail_percent Available space on the filesystem hosting the monitor data directory, as a percentage
# TYPE ceph_mon_data_disk_avail_percent gauge
ceph_mon_data_disk_avail_percent{ceph_daemon="mon.a"} 47.0
# HELP ceph_mon_db_total_bytes Estimated on-disk size of the monitor key/value store
# TYPE ceph_mon_db_total_bytes gauge
ceph_mon_db_total_bytes{ceph_daemon="mon.a"} 2148576.0
```

`ceph-exporter` endpoint (same names, same descriptions, since both scrape the same schema):

```
ceph_mon_data_disk_total_bytes{ceph_daemon="mon.a"} 211483705344
ceph_mon_data_disk_avail_bytes{ceph_daemon="mon.a"} 99506790400
ceph_mon_data_disk_avail_percent{ceph_daemon="mon.a"} 47
ceph_mon_db_total_bytes{ceph_daemon="mon.a"} 2607983
```

`db_total_bytes` is visibly growing across scrapes (932 419 → 2 148 576 → 2 607 983 bytes over a few minutes) as the mon writes maps/keys, which is what trending is meant to expose.

## Checklist

- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [x] No tests