### PR TITLE
rgw: Fix crashes on realm reload

### DIFF
--- a/src/common/async/context_pool.h
+++ b/src/common/async/context_pool.h
@@ -18,7 +18,6 @@
 #define CEPH_COMMON_ASYNC_CONTEXT_POOL_H
 
 #include <concepts>
-#include <cstddef>
 #include <cstdint>
 #include <mutex>
 #include <optional>
@@ -54,7 +53,7 @@ public:
   }
   template<std::invocable<> Init>
   io_context_pool(std::int64_t threadcnt, Init&& init) noexcept {
-    start(threadcnt, std::move(init));
+    start(threadcnt, std::forward<Init>(init));
   }
   ~io_context_pool() {
     stop();
@@ -80,8 +79,8 @@ public:
       ioctx.restart();
       for (std::int16_t i = 0; i < threadcnt; ++i) {
 	threadvec.emplace_back(make_named_thread("io_context_pool",
-						 [this, init=std::move(init)] {
-						   std::move(init)();
+						 [this, init] {
+						   init();
 						   ioctx.run();
 						 }));
       }

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -1371,6 +1371,47 @@ int RGWRados::init_complete(const DoutPrefixProvider *dpp, optional_yield y, rgw
   auto& zone_params = svc.zone->get_zone_params();
   auto& zone = svc.zone->get_zone();
 
+  binfo_cache = new RGWChainedCacheImpl<bucket_info_entry>;
+  binfo_cache->init(svc.cache);
+
+  topic_cache = new RGWChainedCacheImpl<pubsub_bucket_topics_entry>;
+  topic_cache->init(svc.cache);
+
+  lc = new RGWLC();
+  lc->initialize(cct, this->driver);
+
+  restore = make_unique<rgw::restore::Restore>();
+  ret = restore->initialize(cct, this->driver);
+
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: failed to initialize restore thread" << dendl;
+    return ret;
+  }
+
+  quota_handler = RGWQuotaHandler::generate_handler(dpp, this->driver, quota_threads);
+
+  bucket_index_max_shards = (cct->_conf->rgw_override_bucket_index_max_shards ? cct->_conf->rgw_override_bucket_index_max_shards :
+                             zone.bucket_index_max_shards);
+  if (bucket_index_max_shards > get_max_bucket_shards()) {
+    bucket_index_max_shards = get_max_bucket_shards();
+    ldpp_dout(dpp, 1) << __func__ << " bucket index max shards is too large, reset to value: "
+      << get_max_bucket_shards() << dendl;
+  }
+  ldpp_dout(dpp, 20) << __func__ << " bucket index max shards: " << bucket_index_max_shards << dendl;
+
+  bool need_tombstone_cache = !svc.zone->get_zone_data_notify_to_map().empty(); /* have zones syncing from us */
+
+  if (need_tombstone_cache) {
+    obj_tombstone_cache = new tombstone_cache_t(cct->_conf->rgw_obj_tombstone_cache_size);
+  }
+
+  reshard_wait = std::make_shared<RGWReshardWait>();
+
+  reshard = new RGWReshard(this->driver);
+
+  // disable reshard thread based on zone/zonegroup support
+  run_reshard_thread = run_reshard_thread && svc.zone->can_reshard();
+
   /* no point of running sync thread if we don't have a master zone configured
     or there is no rest_master_conn */
   if (!svc.zone->need_to_sync()) {
@@ -1449,52 +1490,11 @@ int RGWRados::init_complete(const DoutPrefixProvider *dpp, optional_yield y, rgw
     data_notifier->start();
   }
 
-  binfo_cache = new RGWChainedCacheImpl<bucket_info_entry>;
-  binfo_cache->init(svc.cache);
-
-  topic_cache = new RGWChainedCacheImpl<pubsub_bucket_topics_entry>;
-  topic_cache->init(svc.cache);
-
-  lc = new RGWLC();
-  lc->initialize(cct, this->driver);
-
   if (use_lc_thread)
     lc->start_processor();
 
-  restore = make_unique<rgw::restore::Restore>();
-  ret = restore->initialize(cct, this->driver);
-
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: failed to initialize restore thread" << dendl;
-    return ret;
-  }
-
   if (use_restore_thread)
     restore->start_processor();
-
-  quota_handler = RGWQuotaHandler::generate_handler(dpp, this->driver, quota_threads);
-
-  bucket_index_max_shards = (cct->_conf->rgw_override_bucket_index_max_shards ? cct->_conf->rgw_override_bucket_index_max_shards :
-                             zone.bucket_index_max_shards);
-  if (bucket_index_max_shards > get_max_bucket_shards()) {
-    bucket_index_max_shards = get_max_bucket_shards();
-    ldpp_dout(dpp, 1) << __func__ << " bucket index max shards is too large, reset to value: "
-      << get_max_bucket_shards() << dendl;
-  }
-  ldpp_dout(dpp, 20) << __func__ << " bucket index max shards: " << bucket_index_max_shards << dendl;
-
-  bool need_tombstone_cache = !svc.zone->get_zone_data_notify_to_map().empty(); /* have zones syncing from us */
-
-  if (need_tombstone_cache) {
-    obj_tombstone_cache = new tombstone_cache_t(cct->_conf->rgw_obj_tombstone_cache_size);
-  }
-
-  reshard_wait = std::make_shared<RGWReshardWait>();
-
-  reshard = new RGWReshard(this->driver);
-
-  // disable reshard thread based on zone/zonegroup support
-  run_reshard_thread = run_reshard_thread && svc.zone->can_reshard();
 
   if (run_reshard_thread)  {
     reshard->start_processor();

--- a/src/rgw/rgw_appmain.cc
+++ b/src/rgw/rgw_appmain.cc
@@ -95,7 +95,7 @@ namespace {
 
 OpsLogFile* rgw::AppMain::ops_log_file;
 
-rgw::AppMain::AppMain(const DoutPrefixProvider* dpp) : dpp(dpp), context_pool_holder(dpp) {}
+rgw::AppMain::AppMain(const DoutPrefixProvider* dpp) : dpp(dpp), context_pool(dpp) {}
 rgw::AppMain::~AppMain() = default;
 
 void rgw::AppMain::init_frontends1(bool nfs) 
@@ -239,7 +239,7 @@ int rgw::AppMain::init_storage()
   DriverManager::Config cfg = DriverManager::get_config(false, g_ceph_context);
   env.driver = DriverManager::get_storage(dpp, dpp->get_cct(),
           cfg,
-          context_pool_holder.get(),
+          *context_pool,
           site,
           run_gc,
           run_lc,
@@ -463,11 +463,11 @@ int rgw::AppMain::init_frontends2(RGWLib* rgwlib)
       fe = new RGWLoadGenFrontend(env, config);
     }
     else if (framework == "beast") {
-      fe = new RGWAsioFrontend(env, config, *sched_ctx, context_pool_holder.get());
+      fe = new RGWAsioFrontend(env, config, *sched_ctx, *context_pool);
       if (g_conf()->rgw_crypt_s3_kms_cache_enabled) {
         env.kms_cache->initialize_ttl_reaper(
             g_conf()->rgw_beast_enable_async
-            ? std::optional(context_pool_holder.get().get_executor())
+            ? std::optional(context_pool->get_executor())
                 : nullopt);
       }
     }
@@ -539,7 +539,7 @@ int rgw::AppMain::init_frontends2(RGWLib* rgwlib)
       rgw_pauser->add_pauser(dedup_background.get());
     }
       reloader = std::make_unique<RGWRealmReloader>(
-          env, *implicit_tenant_context, service_map_meta, rgw_pauser.get(), context_pool_holder.get());
+          env, *implicit_tenant_context, service_map_meta, rgw_pauser.get(), *context_pool);
       realm_watcher->add_watcher(RGWRealmNotify::Reload, *reloader);
     }
   }
@@ -657,7 +657,7 @@ void rgw::AppMain::shutdown(std::function<void(void)> finalize_async_signals)
   env.driver->shutdown();
   // Do this before closing storage so requests don't try to call into
   // closed storage.
-  context_pool_holder.get().finish();
+  context_pool->finish();
 
   cfgstore.reset(); // deletes
   DriverManager::close_storage(env.driver);

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -1174,7 +1174,7 @@ void AsioFrontend::on_accept(Listener& l, tcp::socket stream)
 #endif
     boost::asio::spawn(make_strand(context), std::allocator_arg, make_stack_allocator(),
       [this, s=std::move(stream), ssl_ctx] (boost::asio::yield_context yield) mutable {
-        auto conn = boost::intrusive_ptr{new Connection(std::move(s))};
+        auto conn = boost::intrusive_ptr{new Connection(std::move(s), yield.get_executor())};
         auto c = connections.add(*conn);
         // wrap the tcp stream in an ssl stream
         boost::asio::ssl::stream<tcp::socket&> stream{conn->socket, *ssl_ctx};
@@ -1209,7 +1209,7 @@ void AsioFrontend::on_accept(Listener& l, tcp::socket stream)
 #endif // WITH_RADOSGW_BEAST_OPENSSL
     boost::asio::spawn(make_strand(context), std::allocator_arg, make_stack_allocator(),
       [this, s=std::move(stream)] (boost::asio::yield_context yield) mutable {
-        auto conn = boost::intrusive_ptr{new Connection(std::move(s))};
+        auto conn = boost::intrusive_ptr{new Connection(std::move(s), yield.get_executor())};
         auto c = connections.add(*conn);
         auto timeout = timeout_timer{yield.get_executor(), request_timeout, conn};
         boost::system::error_code ec;
@@ -1254,7 +1254,7 @@ void AsioFrontend::stop()
   }
 
   // close all connections
-  connections.close(ec);
+  connections.close();
   pause_mutex.cancel();
 }
 
@@ -1280,7 +1280,7 @@ void AsioFrontend::pause()
   const bool graceful_stop{ g_ceph_context->_conf->rgw_graceful_stop };
   if (!graceful_stop) {
     // close all connections so outstanding requests fail quickly
-    connections.close(ec);
+    connections.close();
   }
 
   // pause and wait until outstanding requests complete

--- a/src/rgw/rgw_asio_frontend_connection.h
+++ b/src/rgw/rgw_asio_frontend_connection.h
@@ -2,9 +2,12 @@
 
 #include <mutex>
 
+#include <boost/asio/any_io_executor.hpp>
+#include <boost/asio/dispatch.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/beast/core/flat_static_buffer.hpp>
 #include <boost/intrusive/list.hpp>
+#include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ref_counter.hpp>
 
 namespace rgw::asio {
@@ -21,12 +24,19 @@ struct Connection : boost::intrusive::list_base_hook<>,
 {
   tcp::socket socket;
   parse_buffer buffer;
+  // executor of the handle_connection coroutine's strand. used so that close()
+  // from outside the strand (e.g. frontend pause) serializes with coroutine
+  // operations on the socket instead of racing the reactor
+  boost::asio::any_io_executor strand;
+  Connection(tcp::socket&& socket,
+             boost::asio::any_io_executor strand) noexcept
+      : socket(std::move(socket)), strand(std::move(strand)) {}
 
-  explicit Connection(tcp::socket&& socket) noexcept
-      : socket(std::move(socket)) {}
-
-  void close(boost::system::error_code& ec) {
-    socket.close(ec);
+  void close() {
+    boost::asio::dispatch(strand, [c = boost::intrusive_ptr<Connection>{this}] {
+      boost::system::error_code ec;
+      c->socket.close(ec);
+    });
   }
 
   tcp::socket& get_socket() { return socket; }
@@ -60,16 +70,21 @@ class ConnectionList {
     std::lock_guard lock{mutex};
     return connections.size();
   }
-  void close(boost::system::error_code& ec) {
+  void close() {
     std::lock_guard lock{mutex};
     for (auto& conn : connections) {
-      // cancel pending reactor operations which delivers operation_aborted
-      // to completion handlers and then shutdown the transport so any
-      // subsequent I/O attempts fail immediately.
-      conn.socket.cancel(ec);
-      conn.socket.shutdown(tcp::socket::shutdown_both, ec);
+      // dispatch operations to the connection's strand so it serializes with
+      // the handle_connection coroutine.
+      boost::asio::dispatch(
+	  conn.strand, [c = boost::intrusive_ptr<Connection>{&conn}] {
+	    boost::system::error_code ec;
+	    // cancel pending reactor operations which delivers operation_aborted
+	    // to completion handlers and then shutdown the transport so any
+	    // subsequent I/O attempts fail immediately.
+	    c->socket.cancel(ec);
+	    c->socket.shutdown(tcp::socket::shutdown_both, ec);
+	  });
     }
   }
 };
-
 } // namespace rgw::asio

--- a/src/rgw/rgw_coroutine.cc
+++ b/src/rgw/rgw_coroutine.cc
@@ -731,7 +731,15 @@ int RGWCoroutinesManager::run(const DoutPrefixProvider *dpp, list<RGWCoroutinesS
       if (ret < 0) {
        ldout(cct, 5) << "completion_mgr.get_next() returned ret=" << ret << dendl;
       }
-      handle_unblocked_stack(context_stacks, scheduled_stacks, io, &blocked_count, &interval_wait_count);
+      // Without this check, `get_next` will error with -ECANCELED and this loop will never exit.
+      if (going_down) {
+        ldout(cct, 5) << __func__ << "(): was stopped, exiting" << dendl;
+        ret = -ECANCELED;
+        canceled = true;
+        break;
+      }
+      handle_unblocked_stack(context_stacks, scheduled_stacks, io,
+                             &blocked_count, &interval_wait_count);
     }
 
 next:

--- a/src/rgw/rgw_main.h
+++ b/src/rgw/rgw_main.h
@@ -106,9 +106,11 @@ class AppMain {
     IOContextPoolHolder& operator=(const IOContextPoolHolder&) = delete;
 
     ceph::async::io_context_pool& get();
+    ceph::async::io_context_pool& operator*() { return get(); }
+    ceph::async::io_context_pool* operator->() { return std::addressof(get()); }
   };
 
-  IOContextPoolHolder context_pool_holder;
+  IOContextPoolHolder context_pool;
 public:
   AppMain(const DoutPrefixProvider* dpp);
   ~AppMain();

--- a/src/test/rgw/test_rgw_asio_frontend_connection.cc
+++ b/src/test/rgw/test_rgw_asio_frontend_connection.cc
@@ -17,6 +17,8 @@
 
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/strand.hpp>
+#include <boost/asio/spawn.hpp>
 #include <boost/asio/write.hpp>
 #include <boost/intrusive_ptr.hpp>
 
@@ -40,52 +42,64 @@ using rgw::asio::ConnectionList;
 TEST(BeastFrontendShutdown, CloseShutdownsButDoesNotCloseSocket)
 {
   asio::io_context ioctx;
-  ConnectionList connections;
+  asio::spawn(
+      ioctx.get_executor(),
+      [&](asio::yield_context yield) -> void {
+        ConnectionList connections;
 
-  tcp::acceptor acceptor(ioctx, tcp::endpoint(tcp::v4(), 0));
-  acceptor.listen(3);
+        tcp::acceptor acceptor(ioctx, tcp::endpoint(tcp::v4(), 0));
+        acceptor.listen(3);
 
-  tcp::socket c0(ioctx), c1(ioctx), c2(ioctx);
-  c0.connect(acceptor.local_endpoint());
-  auto s0 = acceptor.accept();
-  c1.connect(acceptor.local_endpoint());
-  auto s1 = acceptor.accept();
-  c2.connect(acceptor.local_endpoint());
-  auto s2 = acceptor.accept();
+        tcp::socket c0(ioctx), c1(ioctx), c2(ioctx);
+        c0.async_connect(acceptor.local_endpoint(), yield);
+        auto s0 = acceptor.async_accept(yield);
+        c1.async_connect(acceptor.local_endpoint(), yield);
+        auto s1 = acceptor.async_accept(yield);
+        c2.async_connect(acceptor.local_endpoint(), yield);
+        auto s2 = acceptor.async_accept(yield);
 
-  boost::intrusive_ptr<Connection> conns[] = {
-    new Connection(std::move(s0)),
-    new Connection(std::move(s1)),
-    new Connection(std::move(s2)),
-  };
+        boost::intrusive_ptr<Connection> conns[] = {
+            new Connection(
+                std::move(s0), asio::make_strand(yield.get_executor())),
+            new Connection(
+                std::move(s1), asio::make_strand(yield.get_executor())),
+            new Connection(
+                std::move(s2), asio::make_strand(yield.get_executor())),
+        };
 
-  {
-    auto g0 = connections.add(*conns[0]);
-    auto g1 = connections.add(*conns[1]);
-    auto g2 = connections.add(*conns[2]);
+        {
+          auto g0 = connections.add(*conns[0]);
+          auto g1 = connections.add(*conns[1]);
+          auto g2 = connections.add(*conns[2]);
 
-    ASSERT_EQ(3u, connections.size());
+          ASSERT_EQ(3u, connections.size());
 
-    boost::system::error_code ec;
-    connections.close(ec);
+          connections.close();
 
-    // After close(): sockets must still be "open" from boost::asio's
-    // perspective (fd not released, descriptor_data not zeroed).
-    // socket.close() would have set is_open()=false and fd=-1, which is the
-    // thread-safety violation that causes SIGSEGV.
-    for (auto& conn : conns) {
-      EXPECT_TRUE(conn->socket.is_open());
-      EXPECT_GE(conn->socket.native_handle(), 0);
-    }
+          // After close(): sockets must still be "open" from boost::asio's
+          // perspective (fd not released, descriptor_data not zeroed).
+          // socket.close() would have set is_open()=false and fd=-1, which is the
+          // thread-safety violation that causes SIGSEGV.
+          for (auto& conn : conns) {
+            EXPECT_TRUE(conn->socket.is_open());
+            EXPECT_GE(conn->socket.native_handle(), 0);
+          }
 
-    // But the transport is shut down — writes must fail
-    for (auto& conn : conns) {
-      char buf[] = "test";
-      asio::write(conn->socket, asio::buffer(buf), ec);
-      EXPECT_TRUE(ec.failed())
-          << "Write should fail after shutdown";
-    }
-  } // guards destroyed here — connections removed from list
+          // But the transport is shut down — writes must fail
+          for (auto& conn : conns) {
+            boost::system::error_code ec;
+            char buf[] = "test";
+            asio::async_write(conn->socket, asio::buffer(buf), yield[ec]);
+            EXPECT_TRUE(ec.failed()) << "Write should fail after shutdown";
+          }
+        } // guards destroyed here — connections removed from list
 
-  EXPECT_EQ(0u, connections.size());
+        EXPECT_EQ(0u, connections.size());
+      },
+      [](std::exception_ptr eptr) {
+        if (eptr) {
+          std::rethrow_exception(eptr);
+        }
+      });
+  ioctx.run();
 }


### PR DESCRIPTION
Collection of fixes relevant to reload and shutdown.

Fixes: https://tracker.ceph.com/issues/76094

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
