### PR TITLE
rgw/cloud-tier: retry on 503 from remote endpoint

### DIFF
--- a/doc/radosgw/cloud-transition.rst
+++ b/doc/radosgw/cloud-transition.rst
@@ -472,6 +472,19 @@ The objects transitioned to cloud can now be restored. For more information, ref
 :ref:`Restoring Objects from Cloud <radosgw-cloud-restore>`.
 
 
+Retry Behavior
+--------------
+When the remote cloud endpoint reports a transient error, RGW retries the
+request with backoff rather than failing the lifecycle action immediately.
+
+If the retry budget is exhausted the operation is not completed and is
+retried on the next lifecycle pass.
+
+.. confval:: rgw_cloud_tier_retry_limit
+.. confval:: rgw_cloud_tier_retry_delay_ms
+.. confval:: rgw_cloud_tier_retry_max_ms
+
+
 Future Work
 -----------
 

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -557,6 +557,40 @@ options:
   see_also:
   - rgw_lc_counters_cache
   with_legacy: true
+- name: rgw_cloud_tier_retry_limit
+  type: int
+  level: advanced
+  desc: Cloud-tier retry attempt limit
+  long_desc: Maximum number of retry attempts when a remote cloud-tier endpoint
+    signals throttling.
+  default: 8
+  min: 1
+  services:
+  - rgw
+  with_legacy: true
+- name: rgw_cloud_tier_retry_delay_ms
+  type: int
+  level: advanced
+  desc: Cloud-tier retry initial delay
+  long_desc: Number of milliseconds to wait before the first retry of a throttled
+    cloud-tier request. Subsequent retries grow this delay exponentially up to
+    rgw_cloud_tier_retry_max_ms.
+  default: 500
+  min: 1
+  services:
+  - rgw
+  with_legacy: true
+- name: rgw_cloud_tier_retry_max_ms
+  type: int
+  level: advanced
+  desc: Cloud-tier retry maximum delay
+  long_desc: Maximum number of milliseconds to wait between retries of a throttled
+    cloud-tier request after exponential backoff.
+  default: 30000
+  min: 1
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_restore_debug_interval
   type: int
   level: dev

--- a/src/rgw/driver/rados/rgw_lc_tier.cc
+++ b/src/rgw/driver/rados/rgw_lc_tier.cc
@@ -2,8 +2,14 @@
 // vim: ts=8 sw=2 sts=2 expandtab ft=cpp
 
 #include <string.h>
+#include <algorithm>
+#include <chrono>
 #include <iostream>
 #include <map>
+#include <random>
+#include <thread>
+
+#include <boost/asio/steady_timer.hpp>
 
 #include "common/XMLFormatter.h"
 #include <common/errno.h>
@@ -24,6 +30,41 @@
 #define dout_subsys ceph_subsys_rgw
 
 using namespace std;
+
+int retry_on_busy(optional_yield y, const DoutPrefixProvider *dpp,
+                  CephContext *cct, const char *op_name,
+                  std::function<int()> op)
+{
+  const int max_attempts = cct->_conf.get_val<int64_t>("rgw_cloud_tier_retry_limit");
+  const int64_t initial_ms = cct->_conf.get_val<int64_t>("rgw_cloud_tier_retry_delay_ms");
+  const int64_t max_ms = cct->_conf.get_val<int64_t>("rgw_cloud_tier_retry_max_ms");
+  thread_local std::mt19937 rng{std::random_device{}()};
+
+  int ret = 0;
+  for (int i = 0; i < max_attempts; i++) {
+    ret = op();
+    if (ret != -EBUSY || i == max_attempts - 1) return ret;
+
+    int64_t base = std::min(initial_ms << std::min(i, 30), max_ms);
+    int delay_ms = base - std::uniform_int_distribution<int>(0, base / 10)(rng);
+
+    ldpp_dout(dpp, 1) << op_name << ": -EBUSY, attempt " << (i + 1) << "/"
+                      << max_attempts << "; retrying after " << delay_ms
+                      << "ms" << dendl;
+
+    if (y) {
+      auto& yc = y.get_yield_context();
+      boost::asio::steady_timer t(yc.get_executor());
+      t.expires_after(std::chrono::milliseconds(delay_ms));
+      boost::system::error_code ec;
+      t.async_wait(yc[ec]);
+      if (ec) return ret;
+    } else {
+      std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
+    }
+  }
+  return ret;
+}
 
 struct rgw_lc_multipart_part_info {
   int part_num{0};
@@ -283,44 +324,44 @@ int rgw_cloud_tier_restore_object(RGWLCCloudTierCtx& tier_ctx,
   dest_bucket.name = tier_ctx.target_bucket_name;
   target_obj_name = make_target_obj_name(tier_ctx);
 
-  if (!in_progress) { // first time. Send RESTORE req.
+  rgw_obj dest_obj(dest_bucket, rgw_obj_key(target_obj_name));
 
-    rgw_obj dest_obj(dest_bucket, rgw_obj_key(target_obj_name));
-    ret = cloud_tier_restore(tier_ctx.dpp, tier_ctx.conn, dest_obj, days, glacier_params, tier_ctx.y);
-
-    ldpp_dout(tier_ctx.dpp, 20) << __func__ << "Restoring object=" << target_obj_name << "returned ret = " << ret << dendl;
-
-    if (ret < 0 ) {
-      ldpp_dout(tier_ctx.dpp, -1) << __func__ << "ERROR: failed to restore object=" << dest_obj << "; ret = " << ret << dendl;
-      return ret;
-    }
-    in_progress = true;
-  }
-
-  // now send HEAD request and verify if restore is complete on glacier/tape endpoint
-  static constexpr int MAX_RETRIES = 2;
-  uint32_t retries = 0;
-  do {
-    ret = rgw_cloud_tier_get_object(tier_ctx, true, headers, nullptr, etag,
-                                    accounted_size, attrs, nullptr);
-
-    if (ret < 0) {
-      ldpp_dout(tier_ctx.dpp, 0) << __func__ << "ERROR: failed to fetch HEAD from cloud for obj=" << tier_ctx.obj << " , ret = " << ret << dendl;
-      return ret;
+  ret = retry_on_busy(tier_ctx.y, tier_ctx.dpp, tier_ctx.cct, __func__, [&]() -> int {
+    if (!in_progress) { // first time. Send RESTORE req.
+      ret = cloud_tier_restore(tier_ctx.dpp, tier_ctx.conn, dest_obj, days, glacier_params, tier_ctx.y);
+      ldpp_dout(tier_ctx.dpp, 20) << __func__ << "Restoring object=" << target_obj_name << "returned ret = " << ret << dendl;
+      if (ret < 0 ) {
+        ldpp_dout(tier_ctx.dpp, -1) << __func__ << "ERROR: failed to restore object=" << dest_obj << "; ret = " << ret << dendl;
+        return ret;
+      }
+      in_progress = true;
     }
 
-    in_progress = is_restore_in_progress(tier_ctx.dpp, headers);
-
-  } while(retries++ < MAX_RETRIES && in_progress);
+    // now send HEAD request and verify if restore is complete on glacier/tape endpoint
+    static constexpr int MAX_RETRIES = 2;
+    uint32_t retries = 0;
+    do {
+      ret = rgw_cloud_tier_get_object(tier_ctx, true, headers, nullptr, etag,
+                                      accounted_size, attrs, nullptr);
+      if (ret < 0) {
+        ldpp_dout(tier_ctx.dpp, 0) << __func__ << "ERROR: failed to fetch HEAD from cloud for obj=" << tier_ctx.obj << " , ret = " << ret << dendl;
+        return ret;
+      }
+      in_progress = is_restore_in_progress(tier_ctx.dpp, headers);
+    } while(retries++ < MAX_RETRIES && in_progress);
+    return 0;
+  });
+  if (ret < 0) return ret;
 
   if (in_progress) {
     ldpp_dout(tier_ctx.dpp, 20) << __func__ << "Restoring object=" << target_obj_name << " still in progress; returning " << dendl;
     return 0;
-  } 
+  }
 
-  // now do the actual GET
-  ret = rgw_cloud_tier_get_object(tier_ctx, false, headers, pset_mtime, etag,
-                                  accounted_size, attrs, cb);
+  ret = retry_on_busy(tier_ctx.y, tier_ctx.dpp, tier_ctx.cct, __func__, [&]() {
+    return rgw_cloud_tier_get_object(tier_ctx, false, headers, pset_mtime,
+                                     etag, accounted_size, attrs, cb);
+  });
 
   ldpp_dout(tier_ctx.dpp, 20) << __func__ << "(): fetching object from cloud bucket:" << dest_bucket << ", object: " << target_obj_name << " returned ret:" << ret << dendl;
 
@@ -987,29 +1028,20 @@ static int cloud_tier_send_multipart_part(RGWLCCloudTierCtx& tier_ctx,
 
   tier_ctx.obj->set_atomic(true);
 
-  /* TODO: Define readf, writef as stack variables. For some reason,
-   * when used as stack variables (esp., readf), the transition seems to
-   * be taking lot of time eventually erroring out at times. */
-  std::shared_ptr<RGWLCStreamRead> readf;
-  readf.reset(new RGWLCStreamRead(tier_ctx.cct, tier_ctx.dpp,
-        tier_ctx.obj, tier_ctx.o.meta.mtime, tier_ctx.y));
-
-  std::shared_ptr<RGWLCCloudStreamPut> writef;
-  writef.reset(new RGWLCCloudStreamPut(tier_ctx.dpp, obj_properties, tier_ctx.conn,
-               dest_obj, tier_ctx.y));
-
-  /* Prepare Read from source */
   end = part_info.ofs + part_info.size - 1;
-  readf->set_multipart(part_info.size, part_info.ofs, end);
-
-  /* Prepare write */
-  writef->set_multipart(upload_id, part_info.part_num, part_info.size);
-
-  /* actual Read & Write */
-  ret = cloud_tier_transfer_object(tier_ctx.dpp, readf.get(), writef.get());
-  if (ret < 0) {
-    return ret;
-  }
+  std::shared_ptr<RGWLCCloudStreamPut> writef;
+  ret = retry_on_busy(tier_ctx.y, tier_ctx.dpp, tier_ctx.cct, __func__, [&]() {
+    auto rf = std::make_shared<RGWLCStreamRead>(tier_ctx.cct, tier_ctx.dpp,
+          tier_ctx.obj, tier_ctx.o.meta.mtime, tier_ctx.y);
+    auto wf = std::make_shared<RGWLCCloudStreamPut>(tier_ctx.dpp,
+          obj_properties, tier_ctx.conn, dest_obj, tier_ctx.y);
+    rf->set_multipart(part_info.size, part_info.ofs, end);
+    wf->set_multipart(upload_id, part_info.part_num, part_info.size);
+    int r = cloud_tier_transfer_object(tier_ctx.dpp, rf.get(), wf.get());
+    if (r == 0) writef = wf;
+    return r;
+  });
+  if (ret < 0) return ret;
 
   if (!(writef->get_etag(petag))) {
     ldpp_dout(tier_ctx.dpp, 0) << "ERROR: failed to get etag from PUT request" << dendl;
@@ -1071,6 +1103,7 @@ int cloud_tier_restore(const DoutPrefixProvider *dpp, RGWRESTConn& dest_conn,
   ret = dest_conn.send_resource(dpp, "POST", resource, params, nullptr,
                                 out_bl, &bl, nullptr, y);
 
+  if (ret == -EBUSY) return ret;
   if (ret < 0) {
     ldpp_dout(dpp, 0) << __func__ << "ERROR: failed to send Restore request to cloud for obj=" << dest_obj << " , ret = " << ret << dendl;
   } else {
@@ -1413,6 +1446,7 @@ static int cloud_tier_multipart_transfer(RGWLCCloudTierCtx& tier_ctx) {
             cur_part_info,
             &cur_part_info.etag);
 
+    if (ret == -EBUSY) return ret;
     if (ret < 0) {
       ldpp_dout(tier_ctx.dpp, 0) << "ERROR: failed to send multipart part of obj=" << tier_ctx.obj << ", sync via multipart upload, upload_id=" << status.upload_id << " part number " << cur_part << " (error: " << cpp_strerror(-ret) << ")" << dendl;
       cloud_tier_abort_multipart_upload(tier_ctx, dest_obj, status_obj, status.upload_id);
@@ -1422,6 +1456,7 @@ static int cloud_tier_multipart_transfer(RGWLCCloudTierCtx& tier_ctx) {
   }
 
   ret = cloud_tier_complete_multipart(tier_ctx.dpp, tier_ctx.conn, dest_obj, status.upload_id, parts, tier_ctx.y);
+  if (ret == -EBUSY) return ret;
   if (ret < 0) {
     ldpp_dout(tier_ctx.dpp, 0) << "ERROR: failed to complete multipart upload of obj=" << tier_ctx.obj << " (error: " << cpp_strerror(-ret) << ")" << dendl;
     cloud_tier_abort_multipart_upload(tier_ctx, dest_obj, status_obj, status.upload_id);
@@ -1525,7 +1560,8 @@ static int cloud_tier_create_bucket(RGWLCCloudTierCtx& tier_ctx) {
   ret = tier_ctx.conn.send_resource(tier_ctx.dpp, "PUT", resource, nullptr, nullptr,
                                     out_bl, &bl, nullptr, tier_ctx.y);
 
-  if (ret < 0 ) {
+  if (ret == -EBUSY) return ret;
+  if (ret < 0) {
     ldpp_dout(tier_ctx.dpp, 0) << "create target bucket : " << tier_ctx.target_bucket_name << " returned ret:" << ret << dendl;
   }
   if (out_bl.length() > 0) {
@@ -1558,7 +1594,7 @@ static int cloud_tier_create_bucket(RGWLCCloudTierCtx& tier_ctx) {
   return 0;
 }
 
-int rgw_cloud_tier_transfer_object(RGWLCCloudTierCtx& tier_ctx, std::set<std::string>& cloud_targets) {
+static int do_cloud_tier_transfer_object(RGWLCCloudTierCtx& tier_ctx, std::set<std::string>& cloud_targets) {
   int ret = 0;
 
   // check if target bucket is in local cache
@@ -1589,6 +1625,7 @@ int rgw_cloud_tier_transfer_object(RGWLCCloudTierCtx& tier_ctx, std::set<std::st
   bool already_tiered = false;
   ret = cloud_tier_check_object(tier_ctx, already_tiered);
 
+  if (ret == -EBUSY) return ret;
   if (ret < 0) {
     ldpp_dout(tier_ctx.dpp, 0) << "ERROR: failed to check object on the cloud endpoint ret=" << ret << dendl;
   }
@@ -1617,4 +1654,9 @@ int rgw_cloud_tier_transfer_object(RGWLCCloudTierCtx& tier_ctx, std::set<std::st
   }
 
   return ret;
+}
+
+int rgw_cloud_tier_transfer_object(RGWLCCloudTierCtx& tier_ctx, std::set<std::string>& cloud_targets) {
+  return retry_on_busy(tier_ctx.y, tier_ctx.dpp, tier_ctx.cct, __func__,
+      [&]() { return do_cloud_tier_transfer_object(tier_ctx, cloud_targets); });
 }

--- a/src/rgw/driver/rados/rgw_lc_tier.cc
+++ b/src/rgw/driver/rados/rgw_lc_tier.cc
@@ -31,7 +31,7 @@
 
 using namespace std;
 
-int retry_on_busy(optional_yield y, const DoutPrefixProvider *dpp,
+int retry_on_transient_error(optional_yield y, const DoutPrefixProvider *dpp,
                   CephContext *cct, const char *op_name,
                   std::function<int()> op)
 {
@@ -42,19 +42,20 @@ int retry_on_busy(optional_yield y, const DoutPrefixProvider *dpp,
   int ret = 0;
   for (int i = 0; i < max_attempts; i++) {
     ret = op();
-    if (ret != -EBUSY) return ret;
+    // 503 -> -EBUSY and 500 -> -ERR_INTERNAL_ERROR are transient on S3 backends
+    if (ret != -EBUSY && ret != -ERR_INTERNAL_ERROR) return ret;
     if (i == max_attempts - 1) {
       ldpp_dout(dpp, 0) << op_name << ": exhausted " << max_attempts
-                        << " -EBUSY retries, giving up" << dendl;
+                        << " transient-error retries (ret=" << ret << "), giving up" << dendl;
       return ret;
     }
 
     int64_t base = std::min(initial_ms << std::min(i, 30), max_ms);
     int delay_ms = base - ceph::util::generate_random_number<int>(0, base / 10);
 
-    ldpp_dout(dpp, 1) << op_name << ": -EBUSY, attempt " << (i + 1) << "/"
-                      << max_attempts << "; retrying after " << delay_ms
-                      << "ms" << dendl;
+    ldpp_dout(dpp, 1) << op_name << ": transient error (ret=" << ret << "), attempt "
+                      << (i + 1) << "/" << max_attempts << "; retrying after "
+                      << delay_ms << "ms" << dendl;
 
     if (y) {
       auto& yc = y.get_yield_context();
@@ -330,7 +331,7 @@ int rgw_cloud_tier_restore_object(RGWLCCloudTierCtx& tier_ctx,
 
   rgw_obj dest_obj(dest_bucket, rgw_obj_key(target_obj_name));
 
-  ret = retry_on_busy(tier_ctx.y, tier_ctx.dpp, tier_ctx.cct, __func__, [&]() -> int {
+  ret = retry_on_transient_error(tier_ctx.y, tier_ctx.dpp, tier_ctx.cct, __func__, [&]() -> int {
     if (!in_progress) { // first time. Send RESTORE req.
       ret = cloud_tier_restore(tier_ctx.dpp, tier_ctx.conn, dest_obj, days, glacier_params, tier_ctx.y);
       ldpp_dout(tier_ctx.dpp, 20) << __func__ << "Restoring object=" << target_obj_name << "returned ret = " << ret << dendl;
@@ -362,7 +363,7 @@ int rgw_cloud_tier_restore_object(RGWLCCloudTierCtx& tier_ctx,
     return 0;
   }
 
-  ret = retry_on_busy(tier_ctx.y, tier_ctx.dpp, tier_ctx.cct, __func__, [&]() {
+  ret = retry_on_transient_error(tier_ctx.y, tier_ctx.dpp, tier_ctx.cct, __func__, [&]() {
     return rgw_cloud_tier_get_object(tier_ctx, false, headers, pset_mtime,
                                      etag, accounted_size, attrs, cb);
   });
@@ -1036,7 +1037,7 @@ static int cloud_tier_send_multipart_part(RGWLCCloudTierCtx& tier_ctx,
   std::shared_ptr<RGWLCCloudStreamPut> writef;
   // per-part retry: the outer retry restarts from part 1 since upload state
   // doesn't persist which parts have been sent
-  ret = retry_on_busy(tier_ctx.y, tier_ctx.dpp, tier_ctx.cct, __func__, [&]() {
+  ret = retry_on_transient_error(tier_ctx.y, tier_ctx.dpp, tier_ctx.cct, __func__, [&]() {
     auto rf = std::make_shared<RGWLCStreamRead>(tier_ctx.cct, tier_ctx.dpp,
           tier_ctx.obj, tier_ctx.o.meta.mtime, tier_ctx.y);
     auto wf = std::make_shared<RGWLCCloudStreamPut>(tier_ctx.dpp,
@@ -1327,7 +1328,7 @@ static int cloud_tier_abort_multipart_upload(RGWLCCloudTierCtx& tier_ctx,
       const std::string& upload_id) {
   int ret;
 
-  ret = retry_on_busy(tier_ctx.y, tier_ctx.dpp, tier_ctx.cct, __func__, [&]() {
+  ret = retry_on_transient_error(tier_ctx.y, tier_ctx.dpp, tier_ctx.cct, __func__, [&]() {
     return cloud_tier_abort_multipart(tier_ctx.dpp, tier_ctx.conn, dest_obj, upload_id, tier_ctx.y);
   });
 
@@ -1570,7 +1571,14 @@ static int cloud_tier_create_bucket(RGWLCCloudTierCtx& tier_ctx) {
   ret = tier_ctx.conn.send_resource(tier_ctx.dpp, "PUT", resource, nullptr, nullptr,
                                     out_bl, &bl, nullptr, tier_ctx.y);
 
-  if (ret == -EBUSY) return ret;
+  /*
+   * Transient remote errors (503 -> -EBUSY, 500 -> -ERR_INTERNAL_ERROR) are
+   * retried by the caller's retry_on_transient_error wrapper, so surface them
+   * as-is rather than flattening to -EIO.
+   */
+  if (ret == -EBUSY || ret == -ERR_INTERNAL_ERROR) {
+    return ret;
+  }
   if (ret < 0) {
     ldpp_dout(tier_ctx.dpp, 0) << "create target bucket : " << tier_ctx.target_bucket_name << " returned ret:" << ret << dendl;
   }
@@ -1597,11 +1605,14 @@ static int cloud_tier_create_bucket(RGWLCCloudTierCtx& tier_ctx) {
 
     if (result.code != "BucketAlreadyOwnedByYou" && result.code != "BucketAlreadyExists") {
       ldpp_dout(tier_ctx.dpp, 0) << "ERROR: Creating target bucket failed with error: " << result.code << dendl;
-      return -EIO;
+      return (ret < 0) ? ret : -EIO;
     }
+    // benign "already owned/exists" response
+    return 0;
   }
 
-  return 0;
+  // no response body: propagate any transport error instead of masking as success
+  return ret;
 }
 
 static int do_cloud_tier_transfer_object(RGWLCCloudTierCtx& tier_ctx, std::set<std::string>& cloud_targets) {
@@ -1669,6 +1680,6 @@ static int do_cloud_tier_transfer_object(RGWLCCloudTierCtx& tier_ctx, std::set<s
 }
 
 int rgw_cloud_tier_transfer_object(RGWLCCloudTierCtx& tier_ctx, std::set<std::string>& cloud_targets) {
-  return retry_on_busy(tier_ctx.y, tier_ctx.dpp, tier_ctx.cct, __func__,
+  return retry_on_transient_error(tier_ctx.y, tier_ctx.dpp, tier_ctx.cct, __func__,
       [&]() { return do_cloud_tier_transfer_object(tier_ctx, cloud_targets); });
 }

--- a/src/rgw/driver/rados/rgw_lc_tier.cc
+++ b/src/rgw/driver/rados/rgw_lc_tier.cc
@@ -6,13 +6,13 @@
 #include <chrono>
 #include <iostream>
 #include <map>
-#include <random>
 #include <thread>
 
 #include <boost/asio/steady_timer.hpp>
 
 #include "common/XMLFormatter.h"
 #include <common/errno.h>
+#include "include/random.h"
 #include "rgw_lc.h"
 #include "rgw_lc_tier.h"
 #include "rgw_string.h"
@@ -38,7 +38,6 @@ int retry_on_busy(optional_yield y, const DoutPrefixProvider *dpp,
   const int max_attempts = cct->_conf.get_val<int64_t>("rgw_cloud_tier_retry_limit");
   const int64_t initial_ms = cct->_conf.get_val<int64_t>("rgw_cloud_tier_retry_delay_ms");
   const int64_t max_ms = cct->_conf.get_val<int64_t>("rgw_cloud_tier_retry_max_ms");
-  thread_local std::mt19937 rng{std::random_device{}()};
 
   int ret = 0;
   for (int i = 0; i < max_attempts; i++) {
@@ -46,7 +45,7 @@ int retry_on_busy(optional_yield y, const DoutPrefixProvider *dpp,
     if (ret != -EBUSY || i == max_attempts - 1) return ret;
 
     int64_t base = std::min(initial_ms << std::min(i, 30), max_ms);
-    int delay_ms = base - std::uniform_int_distribution<int>(0, base / 10)(rng);
+    int delay_ms = base - ceph::util::generate_random_number<int>(0, base / 10);
 
     ldpp_dout(dpp, 1) << op_name << ": -EBUSY, attempt " << (i + 1) << "/"
                       << max_attempts << "; retrying after " << delay_ms

--- a/src/rgw/driver/rados/rgw_lc_tier.cc
+++ b/src/rgw/driver/rados/rgw_lc_tier.cc
@@ -42,7 +42,12 @@ int retry_on_busy(optional_yield y, const DoutPrefixProvider *dpp,
   int ret = 0;
   for (int i = 0; i < max_attempts; i++) {
     ret = op();
-    if (ret != -EBUSY || i == max_attempts - 1) return ret;
+    if (ret != -EBUSY) return ret;
+    if (i == max_attempts - 1) {
+      ldpp_dout(dpp, 0) << op_name << ": exhausted " << max_attempts
+                        << " -EBUSY retries, giving up" << dendl;
+      return ret;
+    }
 
     int64_t base = std::min(initial_ms << std::min(i, 30), max_ms);
     int delay_ms = base - ceph::util::generate_random_number<int>(0, base / 10);
@@ -1029,6 +1034,8 @@ static int cloud_tier_send_multipart_part(RGWLCCloudTierCtx& tier_ctx,
 
   end = part_info.ofs + part_info.size - 1;
   std::shared_ptr<RGWLCCloudStreamPut> writef;
+  // per-part retry: the outer retry restarts from part 1 since upload state
+  // doesn't persist which parts have been sent
   ret = retry_on_busy(tier_ctx.y, tier_ctx.dpp, tier_ctx.cct, __func__, [&]() {
     auto rf = std::make_shared<RGWLCStreamRead>(tier_ctx.cct, tier_ctx.dpp,
           tier_ctx.obj, tier_ctx.o.meta.mtime, tier_ctx.y);
@@ -1156,6 +1163,7 @@ static int cloud_tier_abort_multipart(const DoutPrefixProvider *dpp,
       out_bl, &bl, nullptr, y);
 
 
+  if (ret == -EBUSY) return ret;
   if (ret < 0) {
     ldpp_dout(dpp, 0) << "ERROR: failed to abort multipart upload for dest object=" << dest_obj << " (ret=" << ret << ")" << dendl;
     return ret;
@@ -1191,6 +1199,7 @@ static int cloud_tier_init_multipart(const DoutPrefixProvider *dpp,
   ret = dest_conn.send_resource(dpp, "POST", resource, params, &attrs,
       out_bl, &bl, nullptr, y);
 
+  if (ret == -EBUSY) return ret;
   if (ret < 0) {
     ldpp_dout(dpp, 0) << "ERROR: failed to initialize multipart upload for dest object=" << dest_obj << dendl;
     return ret;
@@ -1318,7 +1327,9 @@ static int cloud_tier_abort_multipart_upload(RGWLCCloudTierCtx& tier_ctx,
       const std::string& upload_id) {
   int ret;
 
-  ret = cloud_tier_abort_multipart(tier_ctx.dpp, tier_ctx.conn, dest_obj, upload_id, tier_ctx.y);
+  ret = retry_on_busy(tier_ctx.y, tier_ctx.dpp, tier_ctx.cct, __func__, [&]() {
+    return cloud_tier_abort_multipart(tier_ctx.dpp, tier_ctx.conn, dest_obj, upload_id, tier_ctx.y);
+  });
 
   if (ret < 0) {
     ldpp_dout(tier_ctx.dpp, 0) << "ERROR: failed to abort multipart upload dest obj=" << dest_obj << " upload_id=" << upload_id << " ret=" << ret << dendl;
@@ -1603,8 +1614,10 @@ static int do_cloud_tier_transfer_object(RGWLCCloudTierCtx& tier_ctx, std::set<s
   if (!tier_ctx.target_bucket_created) {
     // not in cache; check if bucket exists on remote
     ret = cloud_tier_bucket_exists(tier_ctx);
+    if (ret == -EBUSY) return ret;
     if (ret == -ENOENT) {
       ret = cloud_tier_create_bucket(tier_ctx);
+      if (ret == -EBUSY) return ret;
       if (ret < 0) {
         ldpp_dout(tier_ctx.dpp, 0) << "ERROR: failed to create target bucket on the cloud endpoint ret=" << ret << dendl;
         return ret;

--- a/src/rgw/driver/rados/rgw_lc_tier.h
+++ b/src/rgw/driver/rados/rgw_lc_tier.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <functional>
+
 #include "rgw_lc.h"
 #include "rgw_rest_conn.h"
 #include "rgw_rados.h"
@@ -80,3 +82,6 @@ int cloud_tier_restore(const DoutPrefixProvider *dpp,
 
 bool is_restore_in_progress(const DoutPrefixProvider *dpp,
                             std::map<std::string, std::string>& headers);
+
+int retry_on_busy(optional_yield y, const DoutPrefixProvider *dpp, CephContext *cct,
+                  const char *op_name, std::function<int()> op);

--- a/src/rgw/driver/rados/rgw_lc_tier.h
+++ b/src/rgw/driver/rados/rgw_lc_tier.h
@@ -83,5 +83,5 @@ int cloud_tier_restore(const DoutPrefixProvider *dpp,
 bool is_restore_in_progress(const DoutPrefixProvider *dpp,
                             std::map<std::string, std::string>& headers);
 
-int retry_on_busy(optional_yield y, const DoutPrefixProvider *dpp, CephContext *cct,
+int retry_on_transient_error(optional_yield y, const DoutPrefixProvider *dpp, CephContext *cct,
                   const char *op_name, std::function<int()> op);

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -3852,6 +3852,10 @@ public:
   }
 
   int handle_headers(const map<string, string>& headers, int http_status) override {
+    if (http_status == 503) {
+      return -EBUSY;
+    }
+
     if (src_bucket_perms && http_status != 403 && http_status != 401) {
       auto iter = headers.find("RGWX_PERM_CHECKED");
       // if the header is not present, we need to check the ACL
@@ -5649,9 +5653,11 @@ int RGWRados::restore_obj_from_cloud(RGWLCCloudTierCtx& tier_ctx,
                                 attrs, days, glacier_params, in_progress, &cb);
   } else {
     ldpp_dout(dpp, 20) << "Fetching  object:" << dest_obj << "from the cloud" <<  dendl;
-    ret = rgw_cloud_tier_get_object(tier_ctx, false,  headers,
-                                &set_mtime, etag, accounted_size,
-                                attrs, &cb);
+    ret = retry_on_busy(tier_ctx.y, dpp, cct, __func__, [&]() {
+      return rgw_cloud_tier_get_object(tier_ctx, false, headers,
+                                       &set_mtime, etag, accounted_size,
+                                       attrs, &cb);
+    });
     in_progress = false;
   }
 

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -5653,7 +5653,7 @@ int RGWRados::restore_obj_from_cloud(RGWLCCloudTierCtx& tier_ctx,
                                 attrs, days, glacier_params, in_progress, &cb);
   } else {
     ldpp_dout(dpp, 20) << "Fetching  object:" << dest_obj << "from the cloud" <<  dendl;
-    ret = retry_on_busy(tier_ctx.y, dpp, cct, __func__, [&]() {
+    ret = retry_on_transient_error(tier_ctx.y, dpp, cct, __func__, [&]() {
       return rgw_cloud_tier_get_object(tier_ctx, false, headers,
                                        &set_mtime, etag, accounted_size,
                                        attrs, &cb);


### PR DESCRIPTION
This continues https://github.com/ceph/ceph/pull/68726, which was closed in favor of a more complete approach here.

When RGW transitions an object out to a cloud tier or restores one back, the remote endpoint occasionally tells us to slow down which is the standard S3 throttling signal meaning "wait a bit and try again." We weren't honoring it. A single throttling response was enough to abort a lifecycle transition (the object stays in its current storage class until the next LC pass, which would usually hit the same rate limit), and on the restore side it would mark the object as failed locally leaving the user to re-issue the request again.

A retry helper now wraps every remote cloud-tier call. It backs off exponentially with jitter, sleeps cooperatively in coroutines, and gives up cleanly when the budget is exhausted.

There was also a related issue on the streamed restore download: a throttling response body would get pushed through the put pipeline before the caller noticed anything had gone wrong. The fix catches the failure at the response-headers layer instead, which also helps the multi-zone fetch path since both go through the same put pipeline

Tunable via three new options: rgw_cloud_tier_retry_limit (8), rgw_cloud_tier_retry_delay_ms (500), and rgw_cloud_tier_retry_max_ms (30000).

Fixes: https://tracker.ceph.com/issues/76406

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [X] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
