### PR TITLE
script/ptl-tool: consolidate conflict reviews

### DIFF
--- a/src/script/ptl-tool.py
+++ b/src/script/ptl-tool.py
@@ -969,6 +969,8 @@ class ConflictSimulationCheck(BaseAuditCheck):
             cp_regex = re.compile(r"\(cherry picked from commit ([0-9a-f]{7,40})\)")
             auto_approve_conflicts = False
             first_conflict = True
+            
+            recorded_deviations = []
     
             for commit in pr_commits:
                 if len(commit.parents) > 1:
@@ -1165,38 +1167,56 @@ class ConflictSimulationCheck(BaseAuditCheck):
                         elif ans == 'p':
                             pass # Already applied backport commit
                         elif ans == 'r':
-                            log.error("Rejecting PR due to unjustified/unapproved change. Adding to draft review...")
+                            log.error(f"Rejecting PR due to unjustified/unapproved change in {commit.hexsha[:8]}. Adding to draft review...")
                             diff_text = diff if 'diff' in locals() else "No range diff available."
                             
-                            md_text = """
-                            ### Automated Backport Parity Review - Backport Deviation Alert
-                            
-                            A conflict or unapproved deviation was detected during the simulation of this backport. The code in this PR does not match a clean cherry-pick of the upstream commits.
-                            
-                            **How to proceed:**
-                            * **Authors (Genuine Conflicts):** If this is a genuine conflict requiring manual resolution, ensure your resolution is correct. You **must** explain the conflict resolution in the commit message (e.g., leave the standard Git `Conflicts:` block intact) and include an explanation for changes.
-                            * **Authors (Need Help?):** Reach out to the Component Lead for technical guidance on complex code conflicts.
-                            * **Component Leads (Review):** Please review the Range Diff below to verify the author's manual conflict resolution is correct for this release branch. If the deviation is intentional, documented, and approved then the component lead or @ceph/ceph-release-manager can bypass this check by commenting `/audit override`.
-
-                            [Be familiar with the rules and guidelines for writing backports.](https://github.com/ceph/ceph/blob/main/SubmittingPatches-backports.rst)
-                            
-                            #### Affected File(s)
-                            """
-                            md_text = textwrap.dedent(md_text)
-                            for f_name in unmerged:
-                                f_hash = hashlib.sha256(f_name.encode('utf-8')).hexdigest()
-                                md_text += f"* `{f_name}`\n"
-                                md_text += f"  * Original: https://github.com/{BASE_PROJECT}/{BASE_REPO}/commit/{c.hexsha}#diff-{f_hash}\n"
-                                md_text += f"  * Backport: https://github.com/{BASE_PROJECT}/{BASE_REPO}/commit/{commit.hexsha}#diff-{f_hash}\n"
-                            
-                            md_text += f"#### Range Diff\n<details><summary>Click to expand</summary>\n\n```diff\n{diff_text}\n```\n</details>\n\n"
-                            
-                            report.add("Conflict/Deviation", md_text)
+                            recorded_deviations.append({
+                                'orig_sha': c.hexsha,
+                                'bp_sha': commit.hexsha,
+                                'unmerged': unmerged,
+                                'diff_text': diff_text
+                            })
                             report.record_failure()
                             continue
                 else:
                     log.info(f"Applying branch-specific commit {commit.hexsha[:8]} ...")
                     wt_repo.git(c=SANDBOX_CFG).cherry_pick("--allow-empty", commit.hexsha)
+            
+            if recorded_deviations:
+                md_text = """
+                ### Automated Backport Parity Review - Backport Deviation Alert
+                
+                A conflict or unapproved deviation was detected during the simulation of this backport. The code in this PR does not match a clean cherry-pick of the upstream commits.
+                
+                """
+                md_text = textwrap.dedent(md_text)
+                
+                for dev in recorded_deviations:
+                    md_text += f"#### Deviation in Backport `{dev['bp_sha'][:8]}` (cherry-pick of `{dev['orig_sha'][:8]}`)\n\n"
+                    
+                    if dev['unmerged']:
+                        md_text += "**Affected File(s)**\n"
+                        for f_name in dev['unmerged']:
+                            f_hash = hashlib.sha256(f_name.encode('utf-8')).hexdigest()
+                            md_text += f"* `{f_name}`\n"
+                            md_text += f"  * Original: https://github.com/{BASE_PROJECT}/{BASE_REPO}/commit/{dev['orig_sha']}#diff-{f_hash}\n"
+                            md_text += f"  * Backport: https://github.com/{BASE_PROJECT}/{BASE_REPO}/commit/{dev['bp_sha']}#diff-{f_hash}\n"
+                        md_text += "\n"
+                        
+                    md_text += f"**Range Diff**\n<details><summary>Click to expand</summary>\n\n```diff\n{dev['diff_text']}\n```\n</details>\n\n"
+
+                footer = """
+                **How to proceed:**
+                * **Authors (Genuine Conflicts):** If this is a genuine conflict requiring manual resolution, ensure your resolution is correct. You **must** explain the conflict resolution in the commit message (e.g., leave the standard Git `Conflicts:` block intact) and include an explanation for changes.
+                * **Authors (Need Help?):** Reach out to the Component Lead for technical guidance on complex code conflicts.
+                * **Component Leads (Review):** Please review the Range Diff(s) above to verify the author's manual conflict resolution is correct for this release branch. If the deviation is intentional, documented, and approved then the component lead or @ceph/ceph-release-manager can bypass this check by commenting `/audit override`.
+
+                [Be familiar with the rules and guidelines for writing backports.](https://github.com/ceph/ceph/blob/main/SubmittingPatches-backports.rst)
+                """
+                md_text += textwrap.dedent(footer)
+                
+                report.add("Conflict/Deviation", md_text)
+
             log.info("Verification of backport cherry-pick for PR #%d is complete.", pr)
         finally:
             log.info("Removing temporary worktree `%s'", wt_dir)


### PR DESCRIPTION
To avoid saying the same things repeatedly.


Example of what we're fixing here: https://github.com/ceph/ceph/pull/68919#pullrequestreview-4293580422


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
