### PR TITLE
tools/cephfs_mirror: Fix transition from 'failed' to 'syncing'

### DIFF
--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -443,16 +443,17 @@ void PeerReplayer::update_directory_current_sync_perf_counters(
     perf->set(l_cephfs_mirror_directory_current_eta_seconds, 0);
   };
 
-  if (sync_stat.failed) {
+  switch (get_dir_sync_state(sync_stat)) {
+  case DirSyncState::Failed:
     perf->set(l_cephfs_mirror_directory_dir_state, 2);
     clear_current();
     return;
-  }
-
-  if (!sync_stat.current_syncing_snap) {
+  case DirSyncState::Idle:
     perf->set(l_cephfs_mirror_directory_dir_state, 0);
     clear_current();
     return;
+  case DirSyncState::Syncing:
+    break;
   }
 
   perf->set(l_cephfs_mirror_directory_dir_state, 1);
@@ -972,7 +973,8 @@ void PeerReplayer::remove_persisted_dir_sync_stat(const std::string &dir_root) {
 
 void PeerReplayer::add_live_sync_metrics_to_persist(json_spirit::mObject &obj,
                                                     SnapSyncStat &sync_stat) {
-  if (sync_stat.current_syncing_snap) {
+  switch (get_dir_sync_state(sync_stat)) {
+  case DirSyncState::Syncing: {
     json_spirit::mObject snap;
     snap["id"] =
       json_spirit::mValue(static_cast<boost::uint64_t>(sync_stat.current_syncing_snap->first));
@@ -1055,13 +1057,17 @@ void PeerReplayer::add_live_sync_metrics_to_persist(json_spirit::mObject &obj,
 
     obj["state"] = json_spirit::mValue("syncing");
     obj["current_syncing_snap"] = json_spirit::mValue(snap);
-  } else if (sync_stat.failed) {
+    break;
+  }
+  case DirSyncState::Failed:
     obj["state"] = json_spirit::mValue("failed");
     if (sync_stat.last_failed_reason) {
       obj["failure_reason"] = json_spirit::mValue(*sync_stat.last_failed_reason);
     }
-  } else {
+    break;
+  case DirSyncState::Idle:
     obj["state"] = json_spirit::mValue("idle");
+    break;
   }
 }
 
@@ -3736,14 +3742,17 @@ double PeerReplayer::compute_eta(const PeerReplayer::SnapSyncStat& sync_stat) {
 }
 
 void PeerReplayer::dump_sync_stat(Formatter *f, const SnapSyncStat &sync_stat) {
-  if (sync_stat.failed) {
+  switch (get_dir_sync_state(sync_stat)) {
+  case DirSyncState::Failed:
     f->dump_string("state", "failed");
     if (sync_stat.last_failed_reason) {
       f->dump_string("failure_reason", *sync_stat.last_failed_reason);
     }
-  } else if (!sync_stat.current_syncing_snap) {
+    break;
+  case DirSyncState::Idle:
     f->dump_string("state", "idle");
-  } else {
+    break;
+  case DirSyncState::Syncing:
     f->dump_string("state", "syncing");
     f->open_object_section("current_syncing_snap");
     f->dump_unsigned("id", (*sync_stat.current_syncing_snap).first);
@@ -3815,6 +3824,7 @@ void PeerReplayer::dump_sync_stat(Formatter *f, const SnapSyncStat &sync_stat) {
     else
       f->dump_string("eta", format_time(compute_eta(sync_stat)));
     f->close_section(); //current_syncing_snap
+    break;
   }
   if (sync_stat.last_synced_snap) {
     f->open_object_section("last_synced_snap");

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -440,6 +440,22 @@ private:
     boost::optional<monotime> datasync_queue_wait_start_time; // until first pop; for in-progress display
   };
 
+  enum class DirSyncState {
+    Idle,
+    Syncing,
+    Failed,
+  };
+
+  static DirSyncState get_dir_sync_state(const SnapSyncStat &sync_stat) {
+    if (sync_stat.current_syncing_snap) {
+      return DirSyncState::Syncing;
+    }
+    if (sync_stat.failed) {
+      return DirSyncState::Failed;
+    }
+    return DirSyncState::Idle;
+  }
+
   void _inc_failed_count(const std::string &dir_root) {
     auto max_failures = g_ceph_context->_conf.get_val<uint64_t>(
     "cephfs_mirror_max_consecutive_failures_per_directory");


### PR DESCRIPTION
tools/cephfs_mirror: Fix transition from 'failed' to 'syncing' in peer_status

When a mirrored directory hits the consecutive failure threshold, the
failed flag stays set until the next successful sync. On retry, the
directory can be actively syncing while failed remains true, but
dump_sync_stat() and update_directory_current_sync_perf_counters()
checked failed before current_syncing_snap and kept reporting "failed".

Introduce get_dir_sync_state() and use it in peer_status, omap
persistence, and per-directory perf counters so syncing takes precedence
over the sticky failed flag.

Fixes: https://tracker.ceph.com/issues/76616





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
