### PR TITLE
monitoring: Add metrics for last state change metrics for PGs

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -22,6 +22,7 @@ from orchestrator import OrchestratorClientMixin, raise_if_exception, Orchestrat
 from rbd import RBD
 
 from typing import DefaultDict, Optional, Dict, Any, Set, cast, Tuple, Union, List, Callable, IO, TypeVar, Iterator
+import time
 LabelValues = Tuple[str, ...]
 Number = Union[int, float]
 MetricValue = Dict[LabelValues, Number]
@@ -1298,6 +1299,83 @@ class Module(MgrModule, OrchestratorClientMixin):
                     self.metrics["pg_{}".format(state)].set(num, (pool,))
                 except KeyError:
                     self.log.warning("skipping pg in unknown state {}".format(state))
+
+        # Collect PG timing metrics from pg_dump
+        self.get_pg_timing_metrics()
+
+    def get_pg_timing_metrics(self) -> None:
+        """Collect all PG timing metrics from pg_dump and aggregate per pool."""
+        try:
+            from datetime import datetime
+            dump = self.get('pg_dump')
+            # Initialize pool timing metrics
+            pool_timing: Dict[int, Dict[str, float]] = {}
+            timing_metric_names: Set[str] = set()
+
+            for pg_stat in dump.get('pg_stats', []):
+                # Extract pool_id from pgid string (format: "pool.pg_num")
+                pgid = pg_stat.get('pgid')
+                if not pgid:
+                    continue
+                try:
+                    pool_id = int(str(pgid).split('.')[0])
+                except (ValueError, IndexError):
+                    continue
+
+                if pool_id not in pool_timing:
+                    pool_timing[pool_id] = {}
+
+                # Dynamically extract all timing fields (those starting with 'last_')
+                # and keep the maximum value per pool
+                for key, value in pg_stat.items():
+                    if key.startswith('last_'):
+                        # Convert ISO 8601 date string to timestamp if it's a string
+                        try:
+                            if isinstance(value, str):
+                                # Parse ISO 8601 format: "2026-05-15T05:40:24.630640+0000"
+                                # Convert +0000 to +00:00 for fromisoformat compatibility
+                                iso_str = value
+                                if '+' in iso_str and ':' not in iso_str.split('+')[1]:
+                                    # Fix timezone format: +0000 -> +00:00
+                                    tz = iso_str.split('+')[1]
+                                    if len(tz) == 4:
+                                        iso_str = iso_str.replace(tz, tz[:2] + ':' + tz[2:])
+                                
+                                dt = datetime.fromisoformat(iso_str.replace('Z', '+00:00'))
+                                numeric_value = dt.timestamp()
+                            elif isinstance(value, (int, float)):
+                                numeric_value = float(value)
+                            else:
+                                continue
+                            
+                            timing_metric_names.add(key)
+                            current_max = pool_timing[pool_id].get(key, 0.0)
+                            pool_timing[pool_id][key] = max(current_max, numeric_value)
+                        except (ValueError, AttributeError, IndexError):
+                            # Skip if we can't convert the value
+                            continue
+
+            # Create metrics dynamically for any new timing fields discovered
+            for timing_metric in timing_metric_names:
+                metric_name = "pg_{}".format(timing_metric)
+                if metric_name not in self.metrics:
+                    self.metrics[metric_name] = Metric(
+                        'gauge',
+                        metric_name,
+                        'PG {} (seconds since epoch)'.format(timing_metric),
+                        ('pool_id',)
+                    )
+
+            # Set metrics for each pool
+            for pool_id, timing_values in pool_timing.items():
+                for timing_metric, value in timing_values.items():
+                    metric_name = "pg_{}".format(timing_metric)
+                    try:
+                        self.metrics[metric_name].set(value, (pool_id,))
+                    except Exception as e:
+                        self.log.debug(f"Failed to set metric {metric_name} for pool {pool_id}: {e}")
+        except Exception as e:
+            self.log.error(f"Failed to collect PG timing metrics: {e}")
 
     @profile_method()
     def get_osd_stats(self) -> None:


### PR DESCRIPTION
- [ ] Create a tracker for the enhancement request
- [ ]  Validate which PG lifecycle metrics should be exported via Prometheus
- [ ]  Test new metrics end-to-end with Grafana dashboards
- [ ]  Determine whether to export:
    - [ ] All PG state transition timestamps (last_clean, last_peered, etc.)
    - [ ] Or only degraded-focused metrics (last_degraded, degraded duration)
- [ ]  Review Prometheus cardinality impact for per-PG exports
- [ ]  Evaluate aggregated alternatives if full export is too expensive
- [ ]  Verify metric naming conventions and dashboard compatibility

ref: https://github.com/ceph/ceph/pull/68910

```
[root@ceph ceph]# curl http://localhost:9283/metrics 2>/dev/null | grep "ceph_pg_last"

# HELP ceph_pg_last_change PG last_change (seconds since epoch)
# TYPE ceph_pg_last_change gauge
ceph_pg_last_change{pool_id="4"} 1778822365.345149
ceph_pg_last_change{pool_id="15"} 1778822337.246371
ceph_pg_last_change{pool_id="14"} 1778824559.236373
ceph_pg_last_change{pool_id="13"} 1778822354.8742
ceph_pg_last_change{pool_id="12"} 1778822348.40026
ceph_pg_last_change{pool_id="11"} 1778825371.312632
ceph_pg_last_change{pool_id="10"} 1778825434.805402
ceph_pg_last_change{pool_id="9"} 1778827592.079699
ceph_pg_last_change{pool_id="8"} 1778822352.429309
ceph_pg_last_change{pool_id="7"} 1778822586.189698
ceph_pg_last_change{pool_id="1"} 1778825679.836782
ceph_pg_last_change{pool_id="5"} 1778822369.308406
ceph_pg_last_change{pool_id="6"} 1778822348.860168
ceph_pg_last_change{pool_id="3"} 1778822291.290091
ceph_pg_last_change{pool_id="2"} 1778822291.216271
# HELP ceph_pg_last_deep_scrub_stamp PG last_deep_scrub_stamp (seconds since epoch)
# TYPE ceph_pg_last_deep_scrub_stamp gauge
ceph_pg_last_deep_scrub_stamp{pool_id="4"} 1778822361.974311
ceph_pg_last_deep_scrub_stamp{pool_id="15"} 1778590549.616256
ceph_pg_last_deep_scrub_stamp{pool_id="14"} 1778588745.347755
ceph_pg_last_deep_scrub_stamp{pool_id="13"} 1778822306.867568
ceph_pg_last_deep_scrub_stamp{pool_id="12"} 1778822348.400183
ceph_pg_last_deep_scrub_stamp{pool_id="11"} 1778822325.794856
ceph_pg_last_deep_scrub_stamp{pool_id="10"} 1778822304.011127
ceph_pg_last_deep_scrub_stamp{pool_id="9"} 1778822316.783449
ceph_pg_last_deep_scrub_stamp{pool_id="8"} 1778822346.383933
ceph_pg_last_deep_scrub_stamp{pool_id="7"} 1778822309.891362
ceph_pg_last_deep_scrub_stamp{pool_id="1"} 1778795771.921403
ceph_pg_last_deep_scrub_stamp{pool_id="5"} 1778822330.466469
ceph_pg_last_deep_scrub_stamp{pool_id="6"} 1778822341.081687
ceph_pg_last_deep_scrub_stamp{pool_id="3"} 1778810114.554529
ceph_pg_last_deep_scrub_stamp{pool_id="2"} 1778665115.83861
# HELP ceph_pg_last_became_active PG last_became_active (seconds since epoch)
# TYPE ceph_pg_last_became_active gauge
ceph_pg_last_became_active{pool_id="4"} 1778822291.210698
ceph_pg_last_became_active{pool_id="15"} 1778822291.210481
ceph_pg_last_became_active{pool_id="14"} 1778822291.210545
ceph_pg_last_became_active{pool_id="13"} 1778822291.210316
ceph_pg_last_became_active{pool_id="12"} 1778822291.210527
ceph_pg_last_became_active{pool_id="11"} 1778822291.210707
ceph_pg_last_became_active{pool_id="10"} 1778822291.210599
ceph_pg_last_became_active{pool_id="9"} 1778822291.210594
ceph_pg_last_became_active{pool_id="8"} 1778822291.210545
ceph_pg_last_became_active{pool_id="7"} 1778822291.210709
ceph_pg_last_became_active{pool_id="1"} 1778822291.207882
ceph_pg_last_became_active{pool_id="5"} 1778822291.210498
ceph_pg_last_became_active{pool_id="6"} 1778822291.210427
ceph_pg_last_became_active{pool_id="3"} 1778822291.210381
ceph_pg_last_became_active{pool_id="2"} 1778822291.206053
# HELP ceph_pg_last_became_peered PG last_became_peered (seconds since epoch)
# TYPE ceph_pg_last_became_peered gauge
ceph_pg_last_became_peered{pool_id="4"} 1778822291.210698
ceph_pg_last_became_peered{pool_id="15"} 1778822291.210481
ceph_pg_last_became_peered{pool_id="14"} 1778822291.210545
ceph_pg_last_became_peered{pool_id="13"} 1778822291.210316
ceph_pg_last_became_peered{pool_id="12"} 1778822291.210527
ceph_pg_last_became_peered{pool_id="11"} 1778822291.210707
ceph_pg_last_became_peered{pool_id="10"} 1778822291.210599
ceph_pg_last_became_peered{pool_id="9"} 1778822291.210594
ceph_pg_last_became_peered{pool_id="8"} 1778822291.210545
ceph_pg_last_became_peered{pool_id="7"} 1778822291.210709
ceph_pg_last_became_peered{pool_id="1"} 1778822291.207882
ceph_pg_last_became_peered{pool_id="5"} 1778822291.210498
ceph_pg_last_became_peered{pool_id="6"} 1778822291.210427
ceph_pg_last_became_peered{pool_id="3"} 1778822291.210381
ceph_pg_last_became_peered{pool_id="2"} 1778822291.206053
```

<img width="1922" height="894" alt="image" src="https://github.com/user-attachments/assets/f60b626d-7b6f-4da3-ad9c-ff771b456bb7" />

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
