### PR TITLE
rgw/spec/aws: vendor the AWS S3 Files (EFS-shaped) Smithy model

### DIFF
--- a/src/rgw/spec/aws/LICENSE
+++ b/src/rgw/spec/aws/LICENSE
@@ -1,0 +1,175 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/src/rgw/spec/aws/NOTICE
+++ b/src/rgw/spec/aws/NOTICE
@@ -1,0 +1,1 @@
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/src/rgw/spec/aws/README.md
+++ b/src/rgw/spec/aws/README.md
@@ -1,0 +1,62 @@
+# Vendored AWS Smithy API models
+
+This directory holds AWS Smithy API models that RGW tracks for
+control-plane shape compatibility with AWS-shape services. The models
+are vendored from `aws/api-models-aws` (Apache-2.0; see `LICENSE` and
+`NOTICE`). They serve as:
+
+- A pinned reference for in-progress design work (the model at the
+  time of implementation, immune to upstream-side mutation).
+- A source artifact for documentation and conformance-test
+  generation as that tooling lands.
+
+## Layout
+
+```
+<service>/
+  README.md
+  <version>/
+    <service>-<version>.json
+```
+
+Where `<version>` matches the AWS Smithy `service` shape's
+`version` trait (a date string like `2025-05-05`). Multiple
+versions can coexist under one service; the *currently-tracked*
+version is documented in each service's `README.md`.
+
+## Currently vendored
+
+| Service   | Tracked version | Notes                                   |
+|-----------|-----------------|-----------------------------------------|
+| s3files   | 2025-05-05      | AWS S3 Files API; full surface targeted |
+
+## Future direction
+
+A separate design proposal will cover broader vendoring for AWS-shape
+services that RGW already implements (`s3`, `iam`, `sts`, etc.). For
+those services, RGW does not implement the entire AWS surface, and
+the vendored model would be **curated** against what Ceph actually
+supports — pruning unimplemented operations and shapes — rather than
+held verbatim. That curation effort is out of scope for this directory
+in its initial form; only verbatim-tracked services live here today.
+
+## Updating
+
+When bumping a tracked service to a newer upstream version:
+
+1. Fetch the new model from
+   `https://raw.githubusercontent.com/aws/api-models-aws/main/models/<service>/service/<new-version>/<service>-<new-version>.json`.
+2. Drop it into `<service>/<new-version>/`. Leave the previously
+   tracked version in place to preserve diff visibility for at least
+   one cycle.
+3. Update the `Tracked version` row above and the service's
+   `README.md`.
+4. Audit downstream references (design docs, op-mapping tables,
+   generated artifacts) for shape changes and update accordingly.
+
+## License and attribution
+
+Models in this directory are distributed under Apache-2.0. The
+upstream `LICENSE` and `NOTICE` files are reproduced alongside this
+README. Ceph contributions to this directory (READMEs, curation
+overlays, tooling) are licensed under Ceph's standard terms.

--- a/src/rgw/spec/aws/s3files/2025-05-05/s3files-2025-05-05.json
+++ b/src/rgw/spec/aws/s3files/2025-05-05/s3files-2025-05-05.json
@@ -1,0 +1,3244 @@
+{
+  "smithy": "2.0",
+  "shapes": {
+    "com.amazonaws.s3files#AccessPointArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "max": 256
+        },
+        "smithy.api#pattern": "^arn:aws[-a-z]*:s3files:[0-9a-z-:]+:file-system/fs-[0-9a-f]{17,40}/access-point/fsap-[0-9a-f]{17,40}$"
+      }
+    },
+    "com.amazonaws.s3files#AccessPointId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "max": 256
+        },
+        "smithy.api#pattern": "^(arn:aws[-a-z]*:s3files:[0-9a-z-:]+:file-system/fs-[0-9a-f]{17,40}/access-point/fsap-[0-9a-f]{17,40}|fsap-[0-9a-f]{17,40})$"
+      }
+    },
+    "com.amazonaws.s3files#AccessPoints": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.s3files#ListAccessPointsDescription"
+      }
+    },
+    "com.amazonaws.s3files#AvailabilityZoneId": {
+      "type": "string"
+    },
+    "com.amazonaws.s3files#AwsAccountId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "max": 12
+        },
+        "smithy.api#pattern": "^(\\d{12})|(\\d{4}-{4}-\\d{4})$"
+      }
+    },
+    "com.amazonaws.s3files#BucketArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#pattern": "^(arn:aws[a-zA-Z0-9-]*:s3:::.+)$"
+      }
+    },
+    "com.amazonaws.s3files#ClientToken": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 64
+        },
+        "smithy.api#pattern": "^(.+)$"
+      }
+    },
+    "com.amazonaws.s3files#ConflictException": {
+      "type": "structure",
+      "members": {
+        "errorCode": {
+          "target": "com.amazonaws.s3files#ErrorCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The error code associated with the exception.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "message": {
+          "target": "smithy.api#String"
+        },
+        "resourceId": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the resource that caused the conflict.</p>"
+          }
+        },
+        "resourceType": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the resource that caused the conflict.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The request conflicts with the current state of the resource. This can occur when trying to create a resource that already exists or delete a resource that is in use.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
+      }
+    },
+    "com.amazonaws.s3files#CreateAccessPoint": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.s3files#CreateAccessPointRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.s3files#CreateAccessPointResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.s3files#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.s3files#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ServiceQuotaExceededException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates an S3 File System Access Point for application-specific access with POSIX user identity and root directory enforcement. Access points provide a way to manage access to shared datasets in multi-tenant scenarios.</p>",
+        "smithy.api#http": {
+          "code": 200,
+          "method": "PUT",
+          "uri": "/access-points"
+        },
+        "smithy.api#idempotent": {}
+      }
+    },
+    "com.amazonaws.s3files#CreateAccessPointRequest": {
+      "type": "structure",
+      "members": {
+        "clientToken": {
+          "target": "com.amazonaws.s3files#ClientToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique, case-sensitive identifier to ensure that the operation completes no more than one time. If this token matches a previous request, Amazon Web Services ignores the request, but does not return an error.</p>",
+            "smithy.api#idempotencyToken": {}
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.s3files#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of key-value pairs to apply to the access point for resource tagging.</p>"
+          }
+        },
+        "fileSystemId": {
+          "target": "com.amazonaws.s3files#FileSystemId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID or Amazon Resource Name (ARN) of the S3 File System.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "posixUser": {
+          "target": "com.amazonaws.s3files#PosixUser",
+          "traits": {
+            "smithy.api#documentation": "<p>The POSIX identity with uid, gid, and secondary group IDs for user enforcement when accessing the file system through this access point.</p>"
+          }
+        },
+        "rootDirectory": {
+          "target": "com.amazonaws.s3files#RootDirectory",
+          "traits": {
+            "smithy.api#documentation": "<p>The root directory path for the access point, with optional creation permissions for newly created directories.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.s3files#CreateAccessPointResponse": {
+      "type": "structure",
+      "members": {
+        "accessPointArn": {
+          "target": "com.amazonaws.s3files#AccessPointArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the access point.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "accessPointId": {
+          "target": "com.amazonaws.s3files#AccessPointId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the access point.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "clientToken": {
+          "target": "com.amazonaws.s3files#ClientToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The client token that was provided in the request.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "fileSystemId": {
+          "target": "com.amazonaws.s3files#FileSystemId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the S3 File System.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "status": {
+          "target": "com.amazonaws.s3files#LifeCycleState",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the access point.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ownerId": {
+          "target": "com.amazonaws.s3files#AwsAccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Web Services account ID of the access point owner.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "posixUser": {
+          "target": "com.amazonaws.s3files#PosixUser",
+          "traits": {
+            "smithy.api#documentation": "<p>The POSIX identity configured for this access point.</p>"
+          }
+        },
+        "rootDirectory": {
+          "target": "com.amazonaws.s3files#RootDirectory",
+          "traits": {
+            "smithy.api#documentation": "<p>The root directory configuration for this access point.</p>"
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.s3files#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags associated with the access point.</p>"
+          }
+        },
+        "name": {
+          "target": "com.amazonaws.s3files#TagValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the access point.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.s3files#CreateFileSystem": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.s3files#CreateFileSystemRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.s3files#CreateFileSystemResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.s3files#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.s3files#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ServiceQuotaExceededException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates an S3 File System resource scoped to a bucket or prefix within a bucket, enabling file system access to S3 data. To create a file system, you need an S3 bucket and an IAM role that grants the service permission to access the bucket.</p>",
+        "smithy.api#http": {
+          "code": 201,
+          "method": "PUT",
+          "uri": "/file-systems"
+        },
+        "smithy.api#idempotent": {}
+      }
+    },
+    "com.amazonaws.s3files#CreateFileSystemRequest": {
+      "type": "structure",
+      "members": {
+        "bucket": {
+          "target": "com.amazonaws.s3files#BucketArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the S3 bucket that will be accessible through the file system. The bucket must exist and be in the same Amazon Web Services Region as the file system.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "prefix": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "<p>An optional prefix within the S3 bucket to scope the file system access. If specified, the file system provides access only to objects with keys that begin with this prefix. If not specified, the file system provides access to the entire bucket.</p>",
+            "smithy.api#length": {
+              "min": 0,
+              "max": 1024
+            },
+            "smithy.api#pattern": "^(|.*/)$"
+          }
+        },
+        "clientToken": {
+          "target": "com.amazonaws.s3files#CreationToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique, case-sensitive identifier that you provide to ensure idempotent creation. Up to 64 ASCII characters are allowed. If you don't specify a client token, the Amazon Web Services SDK automatically generates one.</p>",
+            "smithy.api#idempotencyToken": {}
+          }
+        },
+        "kmsKeyId": {
+          "target": "com.amazonaws.s3files#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN, key ID, or alias of the KMS key to use for encryption. If not specified, the service uses a service-owned key for encryption. You can specify a KMS key using the following formats: key ID, ARN, key alias, or key alias ARN. If you use <code>KmsKeyId</code>, the file system will be encrypted.</p>"
+          }
+        },
+        "roleArn": {
+          "target": "com.amazonaws.s3files#RoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the IAM role that grants the S3 Files service permission to read and write data between the file system and the S3 bucket. This role must have the necessary permissions to access the specified bucket and prefix.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.s3files#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of key-value pairs to apply as tags to the file system resource. Each tag is a user-defined key-value pair. You can use tags to categorize and manage your file systems. Each key must be unique for the resource.</p>"
+          }
+        },
+        "acceptBucketWarning": {
+          "target": "smithy.api#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Set to true to acknowledge and accept any warnings about the bucket configuration. If not specified, the operation may fail if there are bucket configuration warnings.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.s3files#CreateFileSystemResponse": {
+      "type": "structure",
+      "members": {
+        "creationTime": {
+          "target": "smithy.api#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when the file system was created, in seconds since 1970-01-01T00:00:00Z (Unix epoch time).</p>"
+          }
+        },
+        "fileSystemArn": {
+          "target": "com.amazonaws.s3files#FileSystemArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN for the S3 file system, in the format <code>arn:aws:s3files:region:account-id:file-system/file-system-id</code>.</p>"
+          }
+        },
+        "fileSystemId": {
+          "target": "com.amazonaws.s3files#FileSystemId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the file system, assigned by S3 Files. This ID is used to reference the file system in subsequent API calls.</p>"
+          }
+        },
+        "bucket": {
+          "target": "com.amazonaws.s3files#BucketArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the S3 bucket associated with the file system.</p>"
+          }
+        },
+        "prefix": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#addedDefault": {},
+            "smithy.api#default": "",
+            "smithy.api#documentation": "<p>The prefix within the S3 bucket that scopes the file system access.</p>"
+          }
+        },
+        "clientToken": {
+          "target": "com.amazonaws.s3files#ClientToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The client token used for idempotency.</p>"
+          }
+        },
+        "kmsKeyId": {
+          "target": "com.amazonaws.s3files#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN or alias of the KMS key used for encryption.</p>"
+          }
+        },
+        "status": {
+          "target": "com.amazonaws.s3files#LifeCycleState",
+          "traits": {
+            "smithy.api#documentation": "<p>The lifecycle state of the file system. Valid values are: <code>AVAILABLE</code> (the file system is available for use), <code>CREATING</code> (the file system is being created), <code>DELETING</code> (the file system is being deleted), <code>DELETED</code> (the file system has been deleted), <code>ERROR</code> (the file system is in an error state), or <code>UPDATING</code> (the file system is being updated).</p>"
+          }
+        },
+        "statusMessage": {
+          "target": "com.amazonaws.s3files#StatusMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Additional information about the file system status. This field provides more details when the status is <code>ERROR</code>, or during state transitions.</p>"
+          }
+        },
+        "roleArn": {
+          "target": "com.amazonaws.s3files#RoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the IAM role used for S3 access.</p>"
+          }
+        },
+        "ownerId": {
+          "target": "com.amazonaws.s3files#AwsAccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Web Services account ID of the file system owner.</p>"
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.s3files#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags associated with the file system.</p>"
+          }
+        },
+        "name": {
+          "target": "com.amazonaws.s3files#TagValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the file system, derived from the <code>Name</code> tag if present.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.s3files#CreateMountTarget": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.s3files#CreateMountTargetRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.s3files#CreateMountTargetResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.s3files#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.s3files#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ServiceQuotaExceededException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a mount target resource as an endpoint for mounting the S3 File System from compute resources in a specific Availability Zone and VPC. Mount targets provide network access to the file system.</p>",
+        "smithy.api#http": {
+          "code": 200,
+          "method": "PUT",
+          "uri": "/mount-targets"
+        },
+        "smithy.api#idempotent": {}
+      }
+    },
+    "com.amazonaws.s3files#CreateMountTargetRequest": {
+      "type": "structure",
+      "members": {
+        "fileSystemId": {
+          "target": "com.amazonaws.s3files#FileSystemId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID or Amazon Resource Name (ARN) of the S3 File System to create the mount target for.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "subnetId": {
+          "target": "com.amazonaws.s3files#SubnetId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the subnet where the mount target will be created. The subnet must be in the same Amazon Web Services Region as the file system. For file systems with regional availability, you can create mount targets in any subnet within the Region. The subnet determines the Availability Zone where the mount target will be located.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ipv4Address": {
+          "target": "com.amazonaws.s3files#Ipv4Address",
+          "traits": {
+            "smithy.api#documentation": "<p>A specific IPv4 address to assign to the mount target. If not specified and the IP address type supports IPv4, an address is automatically assigned from the subnet's available IPv4 address range. The address must be within the subnet's CIDR block and not already in use.</p>"
+          }
+        },
+        "ipv6Address": {
+          "target": "com.amazonaws.s3files#Ipv6Address",
+          "traits": {
+            "smithy.api#documentation": "<p>A specific IPv6 address to assign to the mount target. If not specified and the IP address type supports IPv6, an address is automatically assigned from the subnet's available IPv6 address range. The address must be within the subnet's IPv6 CIDR block and not already in use.</p>"
+          }
+        },
+        "ipAddressType": {
+          "target": "com.amazonaws.s3files#IpAddressType",
+          "traits": {
+            "smithy.api#documentation": "<p>The IP address type for the mount target. If not specified, <code>IPV4_ONLY</code> is used. The IP address type must match the IP configuration of the specified subnet.</p>"
+          }
+        },
+        "securityGroups": {
+          "target": "com.amazonaws.s3files#SecurityGroups",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of VPC security group IDs to associate with the mount target's network interface. These security groups control network access to the mount target. If not specified, the default security group for the subnet's VPC is used. All security groups must belong to the same VPC as the subnet.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.s3files#CreateMountTargetResponse": {
+      "type": "structure",
+      "members": {
+        "availabilityZoneId": {
+          "target": "com.amazonaws.s3files#AvailabilityZoneId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique and consistent identifier of the Availability Zone where the mount target is located. For example, <code>use1-az1</code> is an Availability Zone ID for the <code>us-east-1</code> Amazon Web Services Region, and it has the same location in every Amazon Web Services account.</p>"
+          }
+        },
+        "ownerId": {
+          "target": "com.amazonaws.s3files#AwsAccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Web Services account ID of the mount target owner.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "mountTargetId": {
+          "target": "com.amazonaws.s3files#MountTargetId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the mount target, assigned by S3 Files. This ID is used to reference the mount target in subsequent API calls.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "fileSystemId": {
+          "target": "com.amazonaws.s3files#FileSystemId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the S3 File System associated with the mount target.</p>"
+          }
+        },
+        "subnetId": {
+          "target": "com.amazonaws.s3files#SubnetId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the subnet where the mount target is located.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ipv4Address": {
+          "target": "com.amazonaws.s3files#Ipv4Address",
+          "traits": {
+            "smithy.api#documentation": "<p>The IPv4 address assigned to the mount target.</p>"
+          }
+        },
+        "ipv6Address": {
+          "target": "com.amazonaws.s3files#Ipv6Address",
+          "traits": {
+            "smithy.api#documentation": "<p>The IPv6 address assigned to the mount target.</p>"
+          }
+        },
+        "networkInterfaceId": {
+          "target": "com.amazonaws.s3files#NetworkInterfaceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the network interface that S3 Files created when it created the mount target. This network interface is managed by the service.</p>"
+          }
+        },
+        "vpcId": {
+          "target": "com.amazonaws.s3files#VpcId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the VPC where the mount target is located.</p>"
+          }
+        },
+        "securityGroups": {
+          "target": "com.amazonaws.s3files#SecurityGroups",
+          "traits": {
+            "smithy.api#documentation": "<p>The security groups associated with the mount target's network interface.</p>"
+          }
+        },
+        "status": {
+          "target": "com.amazonaws.s3files#LifeCycleState",
+          "traits": {
+            "smithy.api#documentation": "<p>The lifecycle state of the mount target. Valid values are: <code>AVAILABLE</code> (the mount target is available for use), <code>CREATING</code> (the mount target is being created), <code>DELETING</code> (the mount target is being deleted), <code>DELETED</code> (the mount target has been deleted), or <code>ERROR</code> (the mount target is in an error state), or <code>UPDATING</code> (the mount target is being updated).</p>"
+          }
+        },
+        "statusMessage": {
+          "target": "com.amazonaws.s3files#StatusMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Additional information about the mount target status. This field provides more details when the status is <code>ERROR</code>, or during state transitions.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.s3files#CreationPermissions": {
+      "type": "structure",
+      "members": {
+        "ownerUid": {
+          "target": "com.amazonaws.s3files#OwnerUid",
+          "traits": {
+            "smithy.api#documentation": "<p>The POSIX user ID to assign to newly created directories.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ownerGid": {
+          "target": "com.amazonaws.s3files#OwnerGid",
+          "traits": {
+            "smithy.api#documentation": "<p>The POSIX group ID to assign to newly created directories.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "permissions": {
+          "target": "com.amazonaws.s3files#Permissions",
+          "traits": {
+            "smithy.api#documentation": "<p>The octal permissions to assign to newly created directories.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies the permissions to set on newly created directories within the file system.</p>"
+      }
+    },
+    "com.amazonaws.s3files#CreationToken": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 64
+        },
+        "smithy.api#pattern": "^(.+)$"
+      }
+    },
+    "com.amazonaws.s3files#DeleteAccessPoint": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.s3files#DeleteAccessPointRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.s3files#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.s3files#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes an S3 File System Access Point. This operation is irreversible.</p>",
+        "smithy.api#http": {
+          "code": 204,
+          "method": "DELETE",
+          "uri": "/access-points/{accessPointId}"
+        },
+        "smithy.api#idempotent": {}
+      }
+    },
+    "com.amazonaws.s3files#DeleteAccessPointRequest": {
+      "type": "structure",
+      "members": {
+        "accessPointId": {
+          "target": "com.amazonaws.s3files#AccessPointId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID or Amazon Resource Name (ARN) of the access point to delete.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.s3files#DeleteFileSystem": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.s3files#DeleteFileSystemRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.s3files#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.s3files#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes an S3 File System. You can optionally force deletion of a file system that has pending export data.</p>",
+        "smithy.api#http": {
+          "code": 204,
+          "method": "DELETE",
+          "uri": "/file-systems/{fileSystemId}"
+        },
+        "smithy.api#idempotent": {}
+      }
+    },
+    "com.amazonaws.s3files#DeleteFileSystemPolicy": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.s3files#DeleteFileSystemPolicyRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.s3files#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes the IAM resource policy of an S3 File System.</p>",
+        "smithy.api#http": {
+          "code": 204,
+          "method": "DELETE",
+          "uri": "/file-systems/{fileSystemId}/policy"
+        },
+        "smithy.api#idempotent": {}
+      }
+    },
+    "com.amazonaws.s3files#DeleteFileSystemPolicyRequest": {
+      "type": "structure",
+      "members": {
+        "fileSystemId": {
+          "target": "com.amazonaws.s3files#FileSystemId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID or Amazon Resource Name (ARN) of the S3 File System whose resource policy to delete.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.s3files#DeleteFileSystemRequest": {
+      "type": "structure",
+      "members": {
+        "fileSystemId": {
+          "target": "com.amazonaws.s3files#FileSystemId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID or Amazon Resource Name (ARN) of the S3 File System to delete.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "forceDelete": {
+          "target": "smithy.api#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>If true, allows deletion of a file system that contains data pending export to S3. If false (the default), the deletion will fail if there is data that has not yet been exported to the S3 bucket. Use this parameter with caution as it may result in data loss.</p>",
+            "smithy.api#httpQuery": "forceDelete"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.s3files#DeleteMountTarget": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.s3files#DeleteMountTargetRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.s3files#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.s3files#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes the specified mount target. This operation is irreversible.</p>",
+        "smithy.api#http": {
+          "code": 204,
+          "method": "DELETE",
+          "uri": "/mount-targets/{mountTargetId}"
+        },
+        "smithy.api#idempotent": {}
+      }
+    },
+    "com.amazonaws.s3files#DeleteMountTargetRequest": {
+      "type": "structure",
+      "members": {
+        "mountTargetId": {
+          "target": "com.amazonaws.s3files#MountTargetId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the mount target to delete.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.s3files#ErrorCode": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.s3files#ExpirationDataRule": {
+      "type": "structure",
+      "members": {
+        "daysAfterLastAccess": {
+          "target": "smithy.api#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of days after last access before cached data expires from the file system.</p>",
+            "smithy.api#jsonName": "daysAfterLastAccess",
+            "smithy.api#range": {
+              "min": 1,
+              "max": 365
+            },
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies a rule that controls when cached data expires from the file system based on last access time.</p>"
+      }
+    },
+    "com.amazonaws.s3files#ExpirationDataRuleList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.s3files#ExpirationDataRule"
+      }
+    },
+    "com.amazonaws.s3files#FileSystemArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#pattern": "^(arn:aws[-a-z]*:s3files:[0-9a-z-:]+:file-system/fs-[0-9a-f]{17,40})$"
+      }
+    },
+    "com.amazonaws.s3files#FileSystemId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "max": 128
+        },
+        "smithy.api#pattern": "^(arn:aws[-a-z]*:s3files:[0-9a-z-:]+:file-system/fs-[0-9a-f]{17,40}|fs-[0-9a-f]{17,40})$"
+      }
+    },
+    "com.amazonaws.s3files#FileSystems": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.s3files#ListFileSystemsDescription"
+      }
+    },
+    "com.amazonaws.s3files#GetAccessPoint": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.s3files#GetAccessPointRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.s3files#GetAccessPointResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.s3files#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns resource information for an S3 File System Access Point.</p>",
+        "smithy.api#http": {
+          "code": 200,
+          "method": "GET",
+          "uri": "/access-points/{accessPointId}"
+        },
+        "smithy.api#readonly": {}
+      }
+    },
+    "com.amazonaws.s3files#GetAccessPointRequest": {
+      "type": "structure",
+      "members": {
+        "accessPointId": {
+          "target": "com.amazonaws.s3files#AccessPointId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID or Amazon Resource Name (ARN) of the access point to retrieve information for.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.s3files#GetAccessPointResponse": {
+      "type": "structure",
+      "members": {
+        "accessPointArn": {
+          "target": "com.amazonaws.s3files#AccessPointArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the access point.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "accessPointId": {
+          "target": "com.amazonaws.s3files#AccessPointId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the access point.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "clientToken": {
+          "target": "com.amazonaws.s3files#ClientToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The client token used for idempotency when the access point was created.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "fileSystemId": {
+          "target": "com.amazonaws.s3files#FileSystemId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the S3 File System.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "status": {
+          "target": "com.amazonaws.s3files#LifeCycleState",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the access point.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ownerId": {
+          "target": "com.amazonaws.s3files#AwsAccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Web Services account ID of the access point owner.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "posixUser": {
+          "target": "com.amazonaws.s3files#PosixUser",
+          "traits": {
+            "smithy.api#documentation": "<p>The POSIX identity configured for this access point.</p>"
+          }
+        },
+        "rootDirectory": {
+          "target": "com.amazonaws.s3files#RootDirectory",
+          "traits": {
+            "smithy.api#documentation": "<p>The root directory configuration for this access point.</p>"
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.s3files#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags associated with the access point.</p>"
+          }
+        },
+        "name": {
+          "target": "com.amazonaws.s3files#TagValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the access point.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.s3files#GetFileSystem": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.s3files#GetFileSystemRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.s3files#GetFileSystemResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.s3files#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns resource information for the specified S3 File System including status, configuration, and metadata.</p>",
+        "smithy.api#http": {
+          "code": 200,
+          "method": "GET",
+          "uri": "/file-systems/{fileSystemId}"
+        },
+        "smithy.api#readonly": {},
+        "smithy.test#smokeTests": [
+          {
+            "id": "GetFileSystemFailure",
+            "params": {
+              "fileSystemId": "fs-00000000000000000"
+            },
+            "expect": {
+              "failure": {
+                "errorId": "com.amazonaws.s3files#ResourceNotFoundException"
+              }
+            },
+            "vendorParamsShape": "aws.test#AwsVendorParams",
+            "vendorParams": {
+              "region": "us-east-1"
+            }
+          }
+        ]
+      }
+    },
+    "com.amazonaws.s3files#GetFileSystemPolicy": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.s3files#GetFileSystemPolicyRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.s3files#GetFileSystemPolicyResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.s3files#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the IAM resource policy of an S3 File System.</p>",
+        "smithy.api#http": {
+          "code": 200,
+          "method": "GET",
+          "uri": "/file-systems/{fileSystemId}/policy"
+        },
+        "smithy.api#readonly": {}
+      }
+    },
+    "com.amazonaws.s3files#GetFileSystemPolicyRequest": {
+      "type": "structure",
+      "members": {
+        "fileSystemId": {
+          "target": "com.amazonaws.s3files#FileSystemId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID or Amazon Resource Name (ARN) of the S3 File System whose resource policy to retrieve.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.s3files#GetFileSystemPolicyResponse": {
+      "type": "structure",
+      "members": {
+        "fileSystemId": {
+          "target": "com.amazonaws.s3files#FileSystemId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the file system.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "policy": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The JSON-formatted resource policy for the file system.</p>",
+            "smithy.api#jsonName": "policy",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.s3files#GetFileSystemRequest": {
+      "type": "structure",
+      "members": {
+        "fileSystemId": {
+          "target": "com.amazonaws.s3files#FileSystemId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID or Amazon Resource Name (ARN) of the S3 File System to retrieve information for.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.s3files#GetFileSystemResponse": {
+      "type": "structure",
+      "members": {
+        "creationTime": {
+          "target": "smithy.api#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when the file system was created.</p>"
+          }
+        },
+        "fileSystemArn": {
+          "target": "com.amazonaws.s3files#FileSystemArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the file system.</p>"
+          }
+        },
+        "fileSystemId": {
+          "target": "com.amazonaws.s3files#FileSystemId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the file system.</p>"
+          }
+        },
+        "bucket": {
+          "target": "com.amazonaws.s3files#BucketArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the S3 bucket.</p>"
+          }
+        },
+        "prefix": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#addedDefault": {},
+            "smithy.api#default": "",
+            "smithy.api#documentation": "<p>The prefix in the S3 bucket that the file system provides access to.</p>"
+          }
+        },
+        "clientToken": {
+          "target": "com.amazonaws.s3files#ClientToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The client token used for idempotency when the file system was created.</p>"
+          }
+        },
+        "kmsKeyId": {
+          "target": "com.amazonaws.s3files#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon Web Services KMS key used for encryption.</p>"
+          }
+        },
+        "status": {
+          "target": "com.amazonaws.s3files#LifeCycleState",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the file system.</p>"
+          }
+        },
+        "statusMessage": {
+          "target": "com.amazonaws.s3files#StatusMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Additional information about the file system status.</p>"
+          }
+        },
+        "roleArn": {
+          "target": "com.amazonaws.s3files#RoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role used for S3 access.</p>"
+          }
+        },
+        "ownerId": {
+          "target": "com.amazonaws.s3files#AwsAccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Web Services account ID of the file system owner.</p>"
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.s3files#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags associated with the file system.</p>"
+          }
+        },
+        "name": {
+          "target": "com.amazonaws.s3files#TagValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the file system.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.s3files#GetMountTarget": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.s3files#GetMountTargetRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.s3files#GetMountTargetResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.s3files#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns detailed resource information for the specified mount target including network configuration.</p>",
+        "smithy.api#http": {
+          "code": 200,
+          "method": "GET",
+          "uri": "/mount-targets/{mountTargetId}"
+        },
+        "smithy.api#readonly": {}
+      }
+    },
+    "com.amazonaws.s3files#GetMountTargetRequest": {
+      "type": "structure",
+      "members": {
+        "mountTargetId": {
+          "target": "com.amazonaws.s3files#MountTargetId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the mount target to retrieve information for.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.s3files#GetMountTargetResponse": {
+      "type": "structure",
+      "members": {
+        "availabilityZoneId": {
+          "target": "com.amazonaws.s3files#AvailabilityZoneId",
+          "traits": {
+            "smithy.api#documentation": "<p>The Availability Zone ID where the mount target is located.</p>"
+          }
+        },
+        "ownerId": {
+          "target": "com.amazonaws.s3files#AwsAccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Web Services account ID of the mount target owner.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "mountTargetId": {
+          "target": "com.amazonaws.s3files#MountTargetId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the mount target.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "fileSystemId": {
+          "target": "com.amazonaws.s3files#FileSystemId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the file system.</p>"
+          }
+        },
+        "subnetId": {
+          "target": "com.amazonaws.s3files#SubnetId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the subnet where the mount target is located.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ipv4Address": {
+          "target": "com.amazonaws.s3files#Ipv4Address",
+          "traits": {
+            "smithy.api#documentation": "<p>The IPv4 address of the mount target.</p>"
+          }
+        },
+        "ipv6Address": {
+          "target": "com.amazonaws.s3files#Ipv6Address",
+          "traits": {
+            "smithy.api#documentation": "<p>The IPv6 address of the mount target.</p>"
+          }
+        },
+        "networkInterfaceId": {
+          "target": "com.amazonaws.s3files#NetworkInterfaceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the network interface associated with the mount target.</p>"
+          }
+        },
+        "vpcId": {
+          "target": "com.amazonaws.s3files#VpcId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the VPC where the mount target is located.</p>"
+          }
+        },
+        "securityGroups": {
+          "target": "com.amazonaws.s3files#SecurityGroups",
+          "traits": {
+            "smithy.api#documentation": "<p>The security groups associated with the mount target.</p>"
+          }
+        },
+        "status": {
+          "target": "com.amazonaws.s3files#LifeCycleState",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the mount target.</p>"
+          }
+        },
+        "statusMessage": {
+          "target": "com.amazonaws.s3files#StatusMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Additional information about the mount target status.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.s3files#GetSynchronizationConfiguration": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.s3files#GetSynchronizationConfigurationRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.s3files#GetSynchronizationConfigurationResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.s3files#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the synchronization configuration for the specified S3 File System, including import data rules and expiration data rules.</p>",
+        "smithy.api#http": {
+          "code": 200,
+          "method": "GET",
+          "uri": "/file-systems/{fileSystemId}/synchronization-configuration"
+        },
+        "smithy.api#readonly": {}
+      }
+    },
+    "com.amazonaws.s3files#GetSynchronizationConfigurationRequest": {
+      "type": "structure",
+      "members": {
+        "fileSystemId": {
+          "target": "com.amazonaws.s3files#FileSystemId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID or Amazon Resource Name (ARN) of the S3 File System to retrieve the synchronization configuration for.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.s3files#GetSynchronizationConfigurationResponse": {
+      "type": "structure",
+      "members": {
+        "latestVersionNumber": {
+          "target": "smithy.api#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The version number of the synchronization configuration. Use this value with <code>PutSynchronizationConfiguration</code> to ensure optimistic concurrency control.</p>",
+            "smithy.api#jsonName": "latestVersionNumber"
+          }
+        },
+        "importDataRules": {
+          "target": "com.amazonaws.s3files#ImportDataRuleList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of import data rules that control how data is imported from S3 into the file system.</p>",
+            "smithy.api#jsonName": "importDataRules",
+            "smithy.api#length": {
+              "min": 1,
+              "max": 10
+            },
+            "smithy.api#required": {}
+          }
+        },
+        "expirationDataRules": {
+          "target": "com.amazonaws.s3files#ExpirationDataRuleList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of expiration data rules that control when cached data expires from the file system.</p>",
+            "smithy.api#jsonName": "expirationDataRules",
+            "smithy.api#length": {
+              "min": 1,
+              "max": 1
+            },
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.s3files#Gid": {
+      "type": "long",
+      "traits": {
+        "smithy.api#range": {
+          "min": 0,
+          "max": 4294967295
+        }
+      }
+    },
+    "com.amazonaws.s3files#ImportDataRule": {
+      "type": "structure",
+      "members": {
+        "prefix": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The S3 key prefix that scopes this import rule. Only objects with keys beginning with this prefix are subject to the rule.</p>",
+            "smithy.api#jsonName": "prefix",
+            "smithy.api#pattern": "^(|.*/)$",
+            "smithy.api#required": {}
+          }
+        },
+        "trigger": {
+          "target": "com.amazonaws.s3files#ImportTrigger",
+          "traits": {
+            "smithy.api#documentation": "<p>The event that triggers data import. Valid values are <code>ON_DIRECTORY_FIRST_ACCESS</code> (import when a directory is first accessed) and <code>ON_FILE_ACCESS</code> (import when a file is accessed).</p>",
+            "smithy.api#jsonName": "trigger",
+            "smithy.api#required": {}
+          }
+        },
+        "sizeLessThan": {
+          "target": "smithy.api#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The upper size limit in bytes for this import rule. Only objects with a size strictly less than this value will have data imported into the file system.</p>",
+            "smithy.api#jsonName": "sizeLessThan",
+            "smithy.api#range": {
+              "min": 0,
+              "max": 52673613135872
+            },
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies a rule that controls how data is imported from S3 into the file system.</p>"
+      }
+    },
+    "com.amazonaws.s3files#ImportDataRuleList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.s3files#ImportDataRule"
+      }
+    },
+    "com.amazonaws.s3files#ImportTrigger": {
+      "type": "enum",
+      "members": {
+        "ON_DIRECTORY_FIRST_ACCESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ON_DIRECTORY_FIRST_ACCESS"
+          }
+        },
+        "ON_FILE_ACCESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ON_FILE_ACCESS"
+          }
+        }
+      }
+    },
+    "com.amazonaws.s3files#InternalServerException": {
+      "type": "structure",
+      "members": {
+        "errorCode": {
+          "target": "com.amazonaws.s3files#ErrorCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The error code associated with the exception.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "message": {
+          "target": "smithy.api#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An internal server error occurred. Retry your request.</p>",
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
+      }
+    },
+    "com.amazonaws.s3files#IpAddressType": {
+      "type": "enum",
+      "members": {
+        "IPV4_ONLY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IPV4_ONLY"
+          }
+        },
+        "IPV6_ONLY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IPV6_ONLY"
+          }
+        },
+        "DUAL_STACK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DUAL_STACK"
+          }
+        }
+      }
+    },
+    "com.amazonaws.s3files#Ipv4Address": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 7,
+          "max": 15
+        },
+        "smithy.api#pattern": "^[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}$"
+      }
+    },
+    "com.amazonaws.s3files#Ipv6Address": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 3,
+          "max": 39
+        }
+      }
+    },
+    "com.amazonaws.s3files#KmsKeyId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "max": 2048
+        },
+        "smithy.api#pattern": "^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|mrk-[0-9a-f]{32}|alias/[a-zA-Z0-9/_-]+|(arn:aws[-a-z]*:kms:[a-z0-9-]+:\\d{12}:((key/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})|(key/mrk-[0-9a-f]{32})|(alias/[a-zA-Z0-9/_-]+))))$"
+      }
+    },
+    "com.amazonaws.s3files#LifeCycleState": {
+      "type": "enum",
+      "members": {
+        "available": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "available",
+            "smithy.api#suppress": [
+              "EnumShape"
+            ]
+          }
+        },
+        "creating": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "creating",
+            "smithy.api#suppress": [
+              "EnumShape"
+            ]
+          }
+        },
+        "deleting": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "deleting",
+            "smithy.api#suppress": [
+              "EnumShape"
+            ]
+          }
+        },
+        "deleted": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "deleted",
+            "smithy.api#suppress": [
+              "EnumShape"
+            ]
+          }
+        },
+        "error": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "error",
+            "smithy.api#suppress": [
+              "EnumShape"
+            ]
+          }
+        },
+        "updating": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "updating",
+            "smithy.api#suppress": [
+              "EnumShape"
+            ]
+          }
+        }
+      }
+    },
+    "com.amazonaws.s3files#ListAccessPoints": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.s3files#ListAccessPointsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.s3files#ListAccessPointsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.s3files#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns resource information for all S3 File System Access Points associated with the specified S3 File System.</p>",
+        "smithy.api#http": {
+          "code": 200,
+          "method": "GET",
+          "uri": "/access-points"
+        },
+        "smithy.api#paginated": {
+          "inputToken": "nextToken",
+          "outputToken": "nextToken",
+          "pageSize": "maxResults",
+          "items": "accessPoints"
+        },
+        "smithy.api#readonly": {}
+      }
+    },
+    "com.amazonaws.s3files#ListAccessPointsDescription": {
+      "type": "structure",
+      "members": {
+        "accessPointArn": {
+          "target": "com.amazonaws.s3files#AccessPointArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the access point.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "accessPointId": {
+          "target": "com.amazonaws.s3files#AccessPointId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the access point.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "fileSystemId": {
+          "target": "com.amazonaws.s3files#FileSystemId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the S3 File System.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "status": {
+          "target": "com.amazonaws.s3files#LifeCycleState",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the access point.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ownerId": {
+          "target": "com.amazonaws.s3files#AwsAccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Web Services account ID of the access point owner.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "posixUser": {
+          "target": "com.amazonaws.s3files#PosixUser",
+          "traits": {
+            "smithy.api#documentation": "<p>The POSIX identity configured for this access point.</p>"
+          }
+        },
+        "rootDirectory": {
+          "target": "com.amazonaws.s3files#RootDirectory",
+          "traits": {
+            "smithy.api#documentation": "<p>The root directory configuration for this access point.</p>"
+          }
+        },
+        "name": {
+          "target": "com.amazonaws.s3files#TagValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the access point.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains information about an S3 File System Access Point returned in list operations.</p>"
+      }
+    },
+    "com.amazonaws.s3files#ListAccessPointsRequest": {
+      "type": "structure",
+      "members": {
+        "fileSystemId": {
+          "target": "com.amazonaws.s3files#FileSystemId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID or Amazon Resource Name (ARN) of the S3 File System to list access points for.</p>",
+            "smithy.api#httpQuery": "fileSystemId",
+            "smithy.api#required": {}
+          }
+        },
+        "maxResults": {
+          "target": "smithy.api#Integer",
+          "traits": {
+            "smithy.api#default": 100,
+            "smithy.api#documentation": "<p>The maximum number of access points to return in a single response.</p>",
+            "smithy.api#httpQuery": "maxResults",
+            "smithy.api#range": {
+              "min": 1,
+              "max": 1000
+            }
+          }
+        },
+        "nextToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A pagination token returned from a previous call to continue listing access points.</p>",
+            "smithy.api#httpQuery": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.s3files#ListAccessPointsResponse": {
+      "type": "structure",
+      "members": {
+        "nextToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A pagination token to use in a subsequent request if more results are available.</p>"
+          }
+        },
+        "accessPoints": {
+          "target": "com.amazonaws.s3files#AccessPoints",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of access point descriptions.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.s3files#ListFileSystems": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.s3files#ListFileSystemsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.s3files#ListFileSystemsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.s3files#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a list of all S3 File Systems owned by the account with optional filtering by bucket.</p>",
+        "smithy.api#http": {
+          "code": 200,
+          "method": "GET",
+          "uri": "/file-systems"
+        },
+        "smithy.api#paginated": {
+          "inputToken": "nextToken",
+          "outputToken": "nextToken",
+          "pageSize": "maxResults",
+          "items": "fileSystems"
+        },
+        "smithy.api#readonly": {},
+        "smithy.test#smokeTests": [
+          {
+            "id": "ListFileSystemsSuccess",
+            "params": {},
+            "expect": {
+              "success": {}
+            },
+            "vendorParamsShape": "aws.test#AwsVendorParams",
+            "vendorParams": {
+              "region": "us-east-1"
+            }
+          }
+        ]
+      }
+    },
+    "com.amazonaws.s3files#ListFileSystemsDescription": {
+      "type": "structure",
+      "members": {
+        "creationTime": {
+          "target": "smithy.api#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when the file system was created.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "fileSystemArn": {
+          "target": "com.amazonaws.s3files#FileSystemArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the file system.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "fileSystemId": {
+          "target": "com.amazonaws.s3files#FileSystemId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the file system.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "name": {
+          "target": "com.amazonaws.s3files#TagValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the file system.</p>"
+          }
+        },
+        "bucket": {
+          "target": "com.amazonaws.s3files#BucketArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the S3 bucket.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "status": {
+          "target": "com.amazonaws.s3files#LifeCycleState",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the file system.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "statusMessage": {
+          "target": "com.amazonaws.s3files#StatusMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Additional information about the file system status.</p>"
+          }
+        },
+        "roleArn": {
+          "target": "com.amazonaws.s3files#RoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role used for S3 access.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ownerId": {
+          "target": "com.amazonaws.s3files#AwsAccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Web Services account ID of the file system owner.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains information about an S3 File System returned in list operations.</p>"
+      }
+    },
+    "com.amazonaws.s3files#ListFileSystemsRequest": {
+      "type": "structure",
+      "members": {
+        "bucket": {
+          "target": "com.amazonaws.s3files#BucketArn",
+          "traits": {
+            "smithy.api#documentation": "<p>Optional filter to list only file systems associated with the specified S3 bucket Amazon Resource Name (ARN). If provided, only file systems that provide access to this bucket will be returned in the response.</p>",
+            "smithy.api#httpQuery": "bucket"
+          }
+        },
+        "maxResults": {
+          "target": "smithy.api#Integer",
+          "traits": {
+            "smithy.api#default": 100,
+            "smithy.api#documentation": "<p>The maximum number of file systems to return in a single response. If not specified, up to 100 file systems are returned.</p>",
+            "smithy.api#httpQuery": "maxResults",
+            "smithy.api#range": {
+              "min": 1,
+              "max": 100
+            }
+          }
+        },
+        "nextToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A pagination token returned from a previous call to continue listing file systems.</p>",
+            "smithy.api#httpQuery": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.s3files#ListFileSystemsResponse": {
+      "type": "structure",
+      "members": {
+        "nextToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A pagination token to use in a subsequent request if more results are available.</p>"
+          }
+        },
+        "fileSystems": {
+          "target": "com.amazonaws.s3files#FileSystems",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of file system descriptions.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.s3files#ListMountTargets": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.s3files#ListMountTargetsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.s3files#ListMountTargetsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.s3files#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns resource information for all mount targets with optional filtering by file system, access point, and VPC.</p>",
+        "smithy.api#http": {
+          "code": 200,
+          "method": "GET",
+          "uri": "/mount-targets"
+        },
+        "smithy.api#paginated": {
+          "inputToken": "nextToken",
+          "outputToken": "nextToken",
+          "pageSize": "maxResults",
+          "items": "mountTargets"
+        },
+        "smithy.api#readonly": {}
+      }
+    },
+    "com.amazonaws.s3files#ListMountTargetsDescription": {
+      "type": "structure",
+      "members": {
+        "availabilityZoneId": {
+          "target": "com.amazonaws.s3files#AvailabilityZoneId",
+          "traits": {
+            "smithy.api#documentation": "<p>The Availability Zone ID where the mount target is located.</p>"
+          }
+        },
+        "fileSystemId": {
+          "target": "com.amazonaws.s3files#FileSystemId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the S3 File System.</p>"
+          }
+        },
+        "ipv4Address": {
+          "target": "com.amazonaws.s3files#Ipv4Address",
+          "traits": {
+            "smithy.api#documentation": "<p>The IPv4 address of the mount target.</p>"
+          }
+        },
+        "ipv6Address": {
+          "target": "com.amazonaws.s3files#Ipv6Address",
+          "traits": {
+            "smithy.api#documentation": "<p>The IPv6 address of the mount target.</p>"
+          }
+        },
+        "status": {
+          "target": "com.amazonaws.s3files#LifeCycleState",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the mount target.</p>"
+          }
+        },
+        "statusMessage": {
+          "target": "com.amazonaws.s3files#StatusMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Additional information about the mount target status.</p>"
+          }
+        },
+        "mountTargetId": {
+          "target": "com.amazonaws.s3files#MountTargetId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the mount target.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "networkInterfaceId": {
+          "target": "com.amazonaws.s3files#NetworkInterfaceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the network interface associated with the mount target.</p>"
+          }
+        },
+        "ownerId": {
+          "target": "com.amazonaws.s3files#AwsAccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Web Services account ID of the mount target owner.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "subnetId": {
+          "target": "com.amazonaws.s3files#SubnetId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the subnet where the mount target is located.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "vpcId": {
+          "target": "com.amazonaws.s3files#VpcId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the VPC where the mount target is located.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains information about a mount target returned in list operations.</p>"
+      }
+    },
+    "com.amazonaws.s3files#ListMountTargetsRequest": {
+      "type": "structure",
+      "members": {
+        "fileSystemId": {
+          "target": "com.amazonaws.s3files#FileSystemId",
+          "traits": {
+            "smithy.api#documentation": "<p>Optional filter to list only mount targets associated with the specified S3 File System ID or Amazon Resource Name (ARN). If provided, only mount targets for this file system will be returned in the response.</p>",
+            "smithy.api#httpQuery": "fileSystemId"
+          }
+        },
+        "accessPointId": {
+          "target": "com.amazonaws.s3files#AccessPointId",
+          "traits": {
+            "smithy.api#documentation": "<p>Optional filter to list only mount targets associated with the specified access point ID or Amazon Resource Name (ARN).</p>",
+            "smithy.api#httpQuery": "accessPointId"
+          }
+        },
+        "maxResults": {
+          "target": "smithy.api#Integer",
+          "traits": {
+            "smithy.api#default": 100,
+            "smithy.api#documentation": "<p>The maximum number of mount targets to return in a single response.</p>",
+            "smithy.api#httpQuery": "maxResults",
+            "smithy.api#range": {
+              "min": 1,
+              "max": 100
+            }
+          }
+        },
+        "nextToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A pagination token returned from a previous call to continue listing mount targets.</p>",
+            "smithy.api#httpQuery": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.s3files#ListMountTargetsResponse": {
+      "type": "structure",
+      "members": {
+        "nextToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A pagination token to use in a subsequent request if more results are available.</p>"
+          }
+        },
+        "mountTargets": {
+          "target": "com.amazonaws.s3files#MountTargets",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of mount target descriptions.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.s3files#ListTagsForResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.s3files#ListTagsForResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.s3files#ListTagsForResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.s3files#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Lists all tags for S3 Files resources.</p>",
+        "smithy.api#http": {
+          "code": 200,
+          "method": "GET",
+          "uri": "/resource-tags/{resourceId}"
+        },
+        "smithy.api#paginated": {
+          "inputToken": "nextToken",
+          "outputToken": "nextToken",
+          "pageSize": "maxResults",
+          "items": "tags"
+        },
+        "smithy.api#readonly": {}
+      }
+    },
+    "com.amazonaws.s3files#ListTagsForResourceRequest": {
+      "type": "structure",
+      "members": {
+        "resourceId": {
+          "target": "com.amazonaws.s3files#ResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID or Amazon Resource Name (ARN) of the resource to list tags for.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "maxResults": {
+          "target": "smithy.api#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of tags to return in a single response.</p>",
+            "smithy.api#httpQuery": "MaxResults",
+            "smithy.api#range": {
+              "min": 1,
+              "max": 50
+            }
+          }
+        },
+        "nextToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A pagination token returned from a previous call to continue listing tags.</p>",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.s3files#ListTagsForResourceResponse": {
+      "type": "structure",
+      "members": {
+        "tags": {
+          "target": "com.amazonaws.s3files#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of tags associated with the resource.</p>"
+          }
+        },
+        "nextToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A pagination token to use in a subsequent request if more results are available.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.s3files#MountTargetId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 22,
+          "max": 45
+        },
+        "smithy.api#pattern": "^fsmt-[0-9a-f]{17,40}$"
+      }
+    },
+    "com.amazonaws.s3files#MountTargets": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.s3files#ListMountTargetsDescription"
+      }
+    },
+    "com.amazonaws.s3files#NetworkInterfaceId": {
+      "type": "string"
+    },
+    "com.amazonaws.s3files#OwnerGid": {
+      "type": "long",
+      "traits": {
+        "smithy.api#range": {
+          "min": 0,
+          "max": 4294967295
+        }
+      }
+    },
+    "com.amazonaws.s3files#OwnerUid": {
+      "type": "long",
+      "traits": {
+        "smithy.api#range": {
+          "min": 0,
+          "max": 4294967295
+        }
+      }
+    },
+    "com.amazonaws.s3files#Path": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 100
+        },
+        "smithy.api#pattern": "^(\\/|(\\/(?!\\.)+[^$#<>;;`|&?{}^*/\\n]+){1,4})$"
+      }
+    },
+    "com.amazonaws.s3files#Permissions": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 3,
+          "max": 4
+        },
+        "smithy.api#pattern": "^[0-7]{3,4}$"
+      }
+    },
+    "com.amazonaws.s3files#PosixUser": {
+      "type": "structure",
+      "members": {
+        "uid": {
+          "target": "com.amazonaws.s3files#Uid",
+          "traits": {
+            "smithy.api#documentation": "<p>The POSIX user ID.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "gid": {
+          "target": "com.amazonaws.s3files#Gid",
+          "traits": {
+            "smithy.api#documentation": "<p>The POSIX group ID.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "secondaryGids": {
+          "target": "com.amazonaws.s3files#SecondaryGids",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of secondary POSIX group IDs.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies the POSIX identity with uid, gid, and secondary group IDs for user enforcement.</p>"
+      }
+    },
+    "com.amazonaws.s3files#PutFileSystemPolicy": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.s3files#PutFileSystemPolicyRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.s3files#PutFileSystemPolicyResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.s3files#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates or replaces the IAM resource policy for an S3 File System to control access permissions.</p>",
+        "smithy.api#http": {
+          "code": 200,
+          "method": "PUT",
+          "uri": "/file-systems/{fileSystemId}/policy"
+        },
+        "smithy.api#idempotent": {}
+      }
+    },
+    "com.amazonaws.s3files#PutFileSystemPolicyRequest": {
+      "type": "structure",
+      "members": {
+        "fileSystemId": {
+          "target": "com.amazonaws.s3files#FileSystemId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID or Amazon Resource Name (ARN) of the S3 File System to apply the resource policy to.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "policy": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The JSON-formatted resource policy to apply to the file system. The policy defines the permissions for accessing the file system. The policy must be a valid JSON document that follows IAM policy syntax.</p>",
+            "smithy.api#jsonName": "policy",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.s3files#PutFileSystemPolicyResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.s3files#PutSynchronizationConfiguration": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.s3files#PutSynchronizationConfigurationRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.s3files#PutSynchronizationConfigurationResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.s3files#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.s3files#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates or updates the synchronization configuration for the specified S3 File System, including import data rules and expiration data rules.</p>",
+        "smithy.api#http": {
+          "code": 200,
+          "method": "PUT",
+          "uri": "/file-systems/{fileSystemId}/synchronization-configuration"
+        },
+        "smithy.api#idempotent": {}
+      }
+    },
+    "com.amazonaws.s3files#PutSynchronizationConfigurationRequest": {
+      "type": "structure",
+      "members": {
+        "fileSystemId": {
+          "target": "com.amazonaws.s3files#FileSystemId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID or Amazon Resource Name (ARN) of the S3 File System to configure synchronization for.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "latestVersionNumber": {
+          "target": "smithy.api#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The version number of the current synchronization configuration. Omit this value when creating a synchronization configuration for the first time. For subsequent updates, provide this value for optimistic concurrency control. If the version number does not match the current configuration, the request fails with a <code>ConflictException</code>.</p>",
+            "smithy.api#jsonName": "latestVersionNumber"
+          }
+        },
+        "importDataRules": {
+          "target": "com.amazonaws.s3files#ImportDataRuleList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of import data rules that control how data is imported from S3 into the file system.</p>",
+            "smithy.api#jsonName": "importDataRules",
+            "smithy.api#length": {
+              "min": 1,
+              "max": 10
+            },
+            "smithy.api#required": {}
+          }
+        },
+        "expirationDataRules": {
+          "target": "com.amazonaws.s3files#ExpirationDataRuleList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of expiration data rules that control when cached data expires from the file system.</p>",
+            "smithy.api#jsonName": "expirationDataRules",
+            "smithy.api#length": {
+              "min": 1,
+              "max": 1
+            },
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.s3files#PutSynchronizationConfigurationResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.s3files#ResourceId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "max": 256
+        },
+        "smithy.api#pattern": "^(arn:aws[-a-z]*:s3files:[0-9a-z-:]+:file-system/fs-[0-9a-f]{17,40}(/access-point/fsap-[0-9a-f]{17,40})?|fs(ap)?-[0-9a-f]{17,40})$"
+      }
+    },
+    "com.amazonaws.s3files#ResourceNotFoundException": {
+      "type": "structure",
+      "members": {
+        "errorCode": {
+          "target": "com.amazonaws.s3files#ErrorCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The error code associated with the exception.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "message": {
+          "target": "smithy.api#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The specified resource was not found. Verify that the resource exists and that you have permission to access it.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
+      }
+    },
+    "com.amazonaws.s3files#RoleArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "max": 2048
+        },
+        "smithy.api#pattern": "^arn:(aws[a-zA-Z-]*)?:iam::\\d{12}:role/?[a-zA-Z_0-9+=,.@\\-_/]+$"
+      }
+    },
+    "com.amazonaws.s3files#RootDirectory": {
+      "type": "structure",
+      "members": {
+        "path": {
+          "target": "com.amazonaws.s3files#Path",
+          "traits": {
+            "smithy.api#documentation": "<p>The path to use as the root directory for the access point.</p>"
+          }
+        },
+        "creationPermissions": {
+          "target": "com.amazonaws.s3files#CreationPermissions",
+          "traits": {
+            "smithy.api#documentation": "<p>The permissions to set on newly created directories.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies the root directory path and optional creation permissions for newly created directories.</p>"
+      }
+    },
+    "com.amazonaws.s3files#S3Files": {
+      "type": "service",
+      "version": "2025-05-05",
+      "operations": [
+        {
+          "target": "com.amazonaws.s3files#CreateAccessPoint"
+        },
+        {
+          "target": "com.amazonaws.s3files#CreateFileSystem"
+        },
+        {
+          "target": "com.amazonaws.s3files#CreateMountTarget"
+        },
+        {
+          "target": "com.amazonaws.s3files#DeleteAccessPoint"
+        },
+        {
+          "target": "com.amazonaws.s3files#DeleteFileSystem"
+        },
+        {
+          "target": "com.amazonaws.s3files#DeleteFileSystemPolicy"
+        },
+        {
+          "target": "com.amazonaws.s3files#DeleteMountTarget"
+        },
+        {
+          "target": "com.amazonaws.s3files#GetAccessPoint"
+        },
+        {
+          "target": "com.amazonaws.s3files#GetFileSystem"
+        },
+        {
+          "target": "com.amazonaws.s3files#GetFileSystemPolicy"
+        },
+        {
+          "target": "com.amazonaws.s3files#GetMountTarget"
+        },
+        {
+          "target": "com.amazonaws.s3files#GetSynchronizationConfiguration"
+        },
+        {
+          "target": "com.amazonaws.s3files#ListAccessPoints"
+        },
+        {
+          "target": "com.amazonaws.s3files#ListFileSystems"
+        },
+        {
+          "target": "com.amazonaws.s3files#ListMountTargets"
+        },
+        {
+          "target": "com.amazonaws.s3files#ListTagsForResource"
+        },
+        {
+          "target": "com.amazonaws.s3files#PutFileSystemPolicy"
+        },
+        {
+          "target": "com.amazonaws.s3files#PutSynchronizationConfiguration"
+        },
+        {
+          "target": "com.amazonaws.s3files#TagResource"
+        },
+        {
+          "target": "com.amazonaws.s3files#UntagResource"
+        },
+        {
+          "target": "com.amazonaws.s3files#UpdateMountTarget"
+        }
+      ],
+      "errors": [
+        {
+          "target": "com.amazonaws.s3files#ThrottlingException"
+        }
+      ],
+      "traits": {
+        "aws.api#service": {
+          "sdkId": "S3Files",
+          "endpointPrefix": "s3files",
+          "arnNamespace": "s3files"
+        },
+        "aws.auth#sigv4": {
+          "name": "s3files"
+        },
+        "aws.endpoints#dualStackOnlyEndpoints": {},
+        "aws.endpoints#standardRegionalEndpoints": {},
+        "aws.protocols#restJson1": {},
+        "smithy.api#documentation": "<p>S3 Files makes S3 buckets accessible as high-performance file systems powered by EFS. This service enables file system interface access to S3 data with sub-millisecond latencies through mount targets, supporting AI/ML workloads, media processing, and hybrid storage workflows that require both file system and object storage access to the same data.</p>",
+        "smithy.api#title": "Amazon S3 Files",
+        "smithy.api#xmlNamespace": {
+          "uri": "s3files"
+        },
+        "smithy.rules#endpointRuleSet": {
+          "version": "1.0",
+          "parameters": {
+            "UseFIPS": {
+              "builtIn": "AWS::UseFIPS",
+              "required": true,
+              "default": false,
+              "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+              "type": "boolean"
+            },
+            "Endpoint": {
+              "builtIn": "SDK::Endpoint",
+              "required": false,
+              "documentation": "Override the endpoint used to send this request",
+              "type": "string"
+            },
+            "Region": {
+              "builtIn": "AWS::Region",
+              "required": false,
+              "documentation": "The AWS region used to dispatch the request.",
+              "type": "string"
+            }
+          },
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "Endpoint"
+                    }
+                  ]
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        {
+                          "ref": "UseFIPS"
+                        },
+                        true
+                      ]
+                    }
+                  ],
+                  "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                  "type": "error"
+                },
+                {
+                  "conditions": [],
+                  "endpoint": {
+                    "url": {
+                      "ref": "Endpoint"
+                    },
+                    "properties": {},
+                    "headers": {}
+                  },
+                  "type": "endpoint"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "isSet",
+                      "argv": [
+                        {
+                          "ref": "Region"
+                        }
+                      ]
+                    }
+                  ],
+                  "rules": [
+                    {
+                      "conditions": [
+                        {
+                          "fn": "aws.partition",
+                          "argv": [
+                            {
+                              "ref": "Region"
+                            }
+                          ],
+                          "assign": "PartitionResult"
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                {
+                                  "ref": "UseFIPS"
+                                },
+                                true
+                              ]
+                            }
+                          ],
+                          "endpoint": {
+                            "url": "https://s3files-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                            "properties": {},
+                            "headers": {}
+                          },
+                          "type": "endpoint"
+                        },
+                        {
+                          "conditions": [],
+                          "endpoint": {
+                            "url": "https://s3files.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                            "properties": {},
+                            "headers": {}
+                          },
+                          "type": "endpoint"
+                        }
+                      ],
+                      "type": "tree"
+                    }
+                  ],
+                  "type": "tree"
+                },
+                {
+                  "conditions": [],
+                  "error": "Invalid Configuration: Missing Region",
+                  "type": "error"
+                }
+              ],
+              "type": "tree"
+            }
+          ]
+        },
+        "smithy.rules#endpointTests": {
+          "testCases": [
+            {
+              "documentation": "For custom endpoint with region not set and fips disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://example.com"
+                }
+              },
+              "params": {
+                "Endpoint": "https://example.com",
+                "UseFIPS": false
+              }
+            },
+            {
+              "documentation": "For custom endpoint with fips enabled",
+              "expect": {
+                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+              },
+              "params": {
+                "Endpoint": "https://example.com",
+                "UseFIPS": true
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://s3files-fips.us-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://s3files.us-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false
+              }
+            },
+            {
+              "documentation": "For region cn-northwest-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://s3files-fips.cn-northwest-1.api.amazonwebservices.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-northwest-1",
+                "UseFIPS": true
+              }
+            },
+            {
+              "documentation": "For region cn-northwest-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://s3files.cn-northwest-1.api.amazonwebservices.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-northwest-1",
+                "UseFIPS": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://s3files-fips.us-gov-west-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-west-1",
+                "UseFIPS": true
+              }
+            },
+            {
+              "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://s3files.us-gov-west-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-west-1",
+                "UseFIPS": false
+              }
+            },
+            {
+              "documentation": "Missing region",
+              "expect": {
+                "error": "Invalid Configuration: Missing Region"
+              }
+            }
+          ],
+          "version": "1.0"
+        }
+      }
+    },
+    "com.amazonaws.s3files#SecondaryGids": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.s3files#Gid"
+      }
+    },
+    "com.amazonaws.s3files#SecurityGroup": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 11,
+          "max": 43
+        },
+        "smithy.api#pattern": "^(sg-[0-9a-f]{8,40})$"
+      }
+    },
+    "com.amazonaws.s3files#SecurityGroups": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.s3files#SecurityGroup"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.s3files#ServiceQuotaExceededException": {
+      "type": "structure",
+      "members": {
+        "errorCode": {
+          "target": "com.amazonaws.s3files#ErrorCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The error code associated with the exception.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "message": {
+          "target": "smithy.api#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The request would exceed a service quota. Review your service quotas and either delete resources or request a quota increase.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 402
+      }
+    },
+    "com.amazonaws.s3files#StatusMessage": {
+      "type": "string"
+    },
+    "com.amazonaws.s3files#SubnetId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 15,
+          "max": 47
+        },
+        "smithy.api#pattern": "^subnet-[0-9a-f]{8,40}$"
+      }
+    },
+    "com.amazonaws.s3files#Tag": {
+      "type": "structure",
+      "members": {
+        "key": {
+          "target": "com.amazonaws.s3files#TagKey",
+          "traits": {
+            "smithy.api#documentation": "<p>The tag key. The key can't start with <code>aws:</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "value": {
+          "target": "com.amazonaws.s3files#TagValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The tag value.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A key-value pair for resource tagging.</p>"
+      }
+    },
+    "com.amazonaws.s3files#TagKey": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        },
+        "smithy.api#pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]+)$"
+      }
+    },
+    "com.amazonaws.s3files#TagKeys": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.s3files#TagKey"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 50
+        }
+      }
+    },
+    "com.amazonaws.s3files#TagList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.s3files#Tag"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 50
+        }
+      }
+    },
+    "com.amazonaws.s3files#TagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.s3files#TagResourceRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.s3files#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates tags for S3 Files resources using standard Amazon Web Services tagging APIs.</p>",
+        "smithy.api#http": {
+          "code": 200,
+          "method": "POST",
+          "uri": "/resource-tags/{resourceId}"
+        }
+      }
+    },
+    "com.amazonaws.s3files#TagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "resourceId": {
+          "target": "com.amazonaws.s3files#ResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID or Amazon Resource Name (ARN) of the resource to add tags to.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.s3files#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of key-value pairs to add as tags to the resource.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.s3files#TagValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "max": 256
+        },
+        "smithy.api#pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+      }
+    },
+    "com.amazonaws.s3files#ThrottlingException": {
+      "type": "structure",
+      "members": {
+        "errorCode": {
+          "target": "com.amazonaws.s3files#ErrorCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The error code associated with the exception.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "message": {
+          "target": "smithy.api#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The request was throttled. Retry your request using exponential backoff.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
+      }
+    },
+    "com.amazonaws.s3files#Uid": {
+      "type": "long",
+      "traits": {
+        "smithy.api#range": {
+          "min": 0,
+          "max": 4294967295
+        }
+      }
+    },
+    "com.amazonaws.s3files#UntagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.s3files#UntagResourceRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.s3files#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Removes tags from S3 Files resources.</p>",
+        "smithy.api#http": {
+          "code": 200,
+          "method": "DELETE",
+          "uri": "/resource-tags/{resourceId}"
+        },
+        "smithy.api#idempotent": {}
+      }
+    },
+    "com.amazonaws.s3files#UntagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "resourceId": {
+          "target": "com.amazonaws.s3files#ResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID or Amazon Resource Name (ARN) of the resource to remove tags from.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "tagKeys": {
+          "target": "com.amazonaws.s3files#TagKeys",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of tag keys to remove from the resource.</p>",
+            "smithy.api#httpQuery": "tagKeys",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.s3files#UpdateMountTarget": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.s3files#UpdateMountTargetRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.s3files#UpdateMountTargetResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.s3files#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.s3files#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates the mount target resource, specifically security group configurations.</p>",
+        "smithy.api#http": {
+          "code": 200,
+          "method": "PUT",
+          "uri": "/mount-targets/{mountTargetId}"
+        },
+        "smithy.api#idempotent": {}
+      }
+    },
+    "com.amazonaws.s3files#UpdateMountTargetRequest": {
+      "type": "structure",
+      "members": {
+        "mountTargetId": {
+          "target": "com.amazonaws.s3files#MountTargetId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the mount target to update.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "securityGroups": {
+          "target": "com.amazonaws.s3files#SecurityGroups",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of VPC security group IDs to associate with the mount target's network interface. This replaces the existing security groups. All security groups must belong to the same VPC as the mount target's subnet.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.s3files#UpdateMountTargetResponse": {
+      "type": "structure",
+      "members": {
+        "availabilityZoneId": {
+          "target": "com.amazonaws.s3files#AvailabilityZoneId",
+          "traits": {
+            "smithy.api#documentation": "<p>The Availability Zone ID where the mount target is located.</p>"
+          }
+        },
+        "ownerId": {
+          "target": "com.amazonaws.s3files#AwsAccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Web Services account ID of the mount target owner.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "mountTargetId": {
+          "target": "com.amazonaws.s3files#MountTargetId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the mount target.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "fileSystemId": {
+          "target": "com.amazonaws.s3files#FileSystemId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the S3 File System.</p>"
+          }
+        },
+        "subnetId": {
+          "target": "com.amazonaws.s3files#SubnetId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the subnet where the mount target is located.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ipv4Address": {
+          "target": "com.amazonaws.s3files#Ipv4Address",
+          "traits": {
+            "smithy.api#documentation": "<p>The IPv4 address of the mount target.</p>"
+          }
+        },
+        "ipv6Address": {
+          "target": "com.amazonaws.s3files#Ipv6Address",
+          "traits": {
+            "smithy.api#documentation": "<p>The IPv6 address of the mount target.</p>"
+          }
+        },
+        "networkInterfaceId": {
+          "target": "com.amazonaws.s3files#NetworkInterfaceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the network interface associated with the mount target.</p>"
+          }
+        },
+        "vpcId": {
+          "target": "com.amazonaws.s3files#VpcId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the VPC where the mount target is located.</p>"
+          }
+        },
+        "securityGroups": {
+          "target": "com.amazonaws.s3files#SecurityGroups",
+          "traits": {
+            "smithy.api#documentation": "<p>The security groups associated with the mount target.</p>"
+          }
+        },
+        "status": {
+          "target": "com.amazonaws.s3files#LifeCycleState",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the mount target.</p>"
+          }
+        },
+        "statusMessage": {
+          "target": "com.amazonaws.s3files#StatusMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Additional information about the mount target status.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.s3files#ValidationException": {
+      "type": "structure",
+      "members": {
+        "errorCode": {
+          "target": "com.amazonaws.s3files#ErrorCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The error code associated with the exception.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "message": {
+          "target": "smithy.api#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The input parameters are not valid. Check the parameter values and try again.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.s3files#VpcId": {
+      "type": "string"
+    }
+  }
+}

--- a/src/rgw/spec/aws/s3files/README.md
+++ b/src/rgw/spec/aws/s3files/README.md
@@ -1,0 +1,35 @@
+# AWS S3 Files API — Smithy model
+
+Vendored Smithy 2.0 model for the AWS S3 Files API service. RGW's
+implementation targets the **full** API surface, so the model is held
+**verbatim** with no Ceph-side curation.
+
+## Tracked version
+
+`2025-05-05` — see `2025-05-05/s3files-2025-05-05.json`.
+
+## Source
+
+`https://github.com/aws/api-models-aws/blob/main/models/s3files/service/2025-05-05/s3files-2025-05-05.json`
+
+License: Apache-2.0 (see `../LICENSE` and `../NOTICE`).
+
+## Reconciliation policy
+
+The model is the **design target** for the RGW S3 Files API
+implementation. Where Ceph diverges from AWS semantics — for
+example, reinterpreting `subnetId` as a Ceph zone-id, ignoring
+caller-supplied IP fields, putting access-point ids in the NFS
+pseudo-path — those divergences are documented in
+`doc/dev/radosgw/s3_files_api.rst`, **not** in the model itself.
+The model stays verbatim; the divergences are described in prose
+alongside.
+
+## Consumers
+
+- `doc/dev/radosgw/s3_files_api.rst` — design doc references this
+  model as the reference target.
+- `doc/dev/radosgw/s3_files_api_ops.rst` (planned) — op-mapping
+  table; eventually a candidate for generation from the model.
+- Future: conformance-test fixture generator (when the broader
+  Smithy-driven test workflow lands).


### PR DESCRIPTION
Part of the decomposition of #68852 (S3 Files API). The **vendored upstream API-contract** slice — data only, no code, no build, no behavior change. Kept on its own PR so the third-party provenance/licensing review stays independent of the implementation.

- `src/rgw/spec/aws/s3files/2025-05-05/s3files-2025-05-05.json` — the AWS Smithy JSON AST the S3 Files surface conforms to (shapes, operations, traits, the restJson1 protocol binding), pinned to the 2025-05-05 service date. The REST handlers and conformance tests in later PRs are written against this.
- `src/rgw/spec/aws/LICENSE` (Apache-2.0), `NOTICE` (Amazon copyright), and `README.md` / `s3files/README.md` documenting what the model is, where it came from, and how it is consumed.

Independent of the other day-one PRs.

**Validation:** vendored data only — no build.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
