### PR TITLE
rgw/auth: lift STS session decoding and identity resolution into reusable helpers

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -7156,55 +7156,7 @@ int
 rgw::auth::s3::STSEngine::get_session_token(const DoutPrefixProvider* dpp, const std::string_view& session_token,
                                             STS::SessionToken& token) const
 {
-  string decodedSessionToken;
-  try {
-    decodedSessionToken = rgw::from_base64(session_token);
-  } catch (...) {
-    ldpp_dout(dpp, 0) << "ERROR: Invalid session token, not base64 encoded." << dendl;
-    return -EINVAL;
-  }
-
-  auto* cryptohandler = cct->get_crypto_handler(CEPH_CRYPTO_AES);
-  if (! cryptohandler) {
-    return -EINVAL;
-  }
-  string secret_s = cct->_conf->rgw_sts_key;
-  if (secret_s.empty()) {
-    ldpp_dout(dpp, 1) << "ERROR: rgw sts key not set" << dendl;
-    return -EINVAL;
-  }
-  buffer::ptr secret(secret_s.c_str(), secret_s.length());
-  int ret = 0;
-  if (ret = cryptohandler->validate_secret(secret); ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: Invalid secret key" << dendl;
-    return -EINVAL;
-  }
-  string error;
-  std::unique_ptr<CryptoKeyHandler> keyhandler(cryptohandler->get_key_handler(secret, error));
-  if (! keyhandler) {
-    return -EINVAL;
-  }
-  error.clear();
-
-  string decrypted_str;
-  buffer::list en_input, dec_output;
-  en_input = buffer::list::static_from_string(decodedSessionToken);
-
-  ret = keyhandler->decrypt(en_input, dec_output, &error);
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: Decryption failed: " << error << dendl;
-    return -EPERM;
-  } else {
-    try {
-      dec_output.append('\0');
-      auto iter = dec_output.cbegin();
-      decode(token, iter);
-    } catch (const buffer::error& e) {
-      ldpp_dout(dpp, 0) << "ERROR: decode SessionToken failed: " << error << dendl;
-      return -EINVAL;
-    }
-  }
-  return 0;
+  return STS::decode_session_token(dpp, cct, session_token, token);
 }
 
 rgw::auth::Engine::result_t
@@ -7295,83 +7247,29 @@ rgw::auth::s3::STSEngine::authenticate(
     return result_t::reject(-ERR_SIGNATURE_NO_MATCH);
   }
 
-  // Get all the authorization info
-  rgw_user user_id;
-  string role_id;
-  rgw::auth::RoleApplier::Role r;
-  rgw::auth::RoleApplier::TokenAttrs t_attrs;
-  if (! token.roleId.empty()) {
-    std::unique_ptr<rgw::sal::RGWRole> role = driver->get_role(token.roleId);
-    if (role->load_by_id(dpp, y) < 0) {
-      return result_t::deny(-EPERM);
-    }
-    r.id = token.roleId;
-    r.name = role->get_name();
-    r.path = role->get_path();
-    r.tenant = role->get_tenant();
-
-    const auto& account_id = role->get_account_id();
-    if (!account_id.empty()) {
-      r.account.emplace();
-      rgw::sal::Attrs attrs; // ignored
-      RGWObjVersionTracker objv; // ignored
-      int ret = driver->load_account_by_id(dpp, y, account_id,
-                                           *r.account, attrs, objv);
-      if (ret < 0) {
-        ldpp_dout(dpp, 1) << "ERROR: failed to load account "
-            << account_id << " for role " << r.name
-            << ": " << cpp_strerror(ret) << dendl;
-        return result_t::deny(-EPERM);
-      }
-    }
-
-    for (auto& [name, policy] : role->get_info().perm_policy_map) {
-      r.inline_policies.push_back(std::move(policy));
-    }
-    for (auto& arn : role->get_info().managed_policies.arns) {
-      r.managed_policies.push_back(std::move(arn));
-    }
+  /* Token is valid; load any role/user info it references. */
+  STS::ResolvedSession resolved;
+  if (int ret = STS::resolve_session(dpp, cct, driver, y, token, resolved);
+      ret < 0) {
+    return result_t::deny(ret);
   }
 
   if (token.acct_type == TYPE_KEYSTONE || token.acct_type == TYPE_LDAP) {
     auto apl = remote_apl_factory->create_apl_remote(cct, s, get_acl_strategy(),
-                                            get_creds_info(token));
+                                                     get_creds_info(token));
     return result_t::grant(std::move(apl), completer_factory(token.secret_access_key));
   } else if (token.acct_type == TYPE_ROLE) {
-    t_attrs.user_id = std::move(token.user); // This is mostly needed to assign the owner of a bucket during its creation
-    t_attrs.token_policy = std::move(token.policy);
-    t_attrs.role_session_name = std::move(token.role_session);
-    t_attrs.token_claims = std::move(token.token_claims);
-    t_attrs.token_issued_at = std::move(token.issued_at);
-    t_attrs.principal_tags = std::move(token.principal_tags);
-    auto apl = role_apl_factory->create_apl_role(cct, s, std::move(r),
-                                                 std::move(t_attrs), is_impersonating);
+    auto apl = role_apl_factory->create_apl_role(cct, s, std::move(resolved.role),
+                                                 std::move(resolved.t_attrs),
+                                                 is_impersonating);
     return result_t::grant(std::move(apl), completer_factory(token.secret_access_key));
-  } else { // This is for all local users of type TYPE_RGW|ROOT|NONE
-    if (token.user.empty()) {
-      ldpp_dout(dpp, 5) << "ERROR: got session token with empty user id" << dendl;
-      return result_t::reject(-EPERM);
-    }
-    // load user info
-    auto user = driver->get_user(token.user);
-    int ret = user->load_user(dpp, y);
-    if (ret < 0) {
-      ldpp_dout(dpp, 5) << "ERROR: failed reading user info: uid=" << token.user << dendl;
-      return result_t::reject(-EPERM);
-    }
-
-    std::optional<RGWAccountInfo> account;
-    std::vector<IAM::Policy> policies;
-    ret = load_account_and_policies(dpp, y, driver, user->get_info(),
-                                    user->get_attrs(), account, policies);
-    if (ret < 0) {
-      return result_t::deny(-EPERM);
-    }
-
+  } else {
     string subuser;
     auto apl = local_apl_factory->create_apl_local(
-        cct, s, std::move(user), std::move(account), std::move(policies),
-        subuser, token.perm_mask, std::string(_access_key_id), false /* is_impersonating */);
+        cct, s, std::move(resolved.user),
+        std::move(resolved.account), std::move(resolved.policies),
+        subuser, token.perm_mask, std::string(_access_key_id),
+        false /* is_impersonating */);
     return result_t::grant(std::move(apl), completer_factory(token.secret_access_key));
   }
 }

--- a/src/rgw/rgw_sts.cc
+++ b/src/rgw/rgw_sts.cc
@@ -159,6 +159,134 @@ int Credentials::generateCredentials(const DoutPrefixProvider *dpp,
   return ret;
 }
 
+int decode_session_token(const DoutPrefixProvider* dpp,
+                         CephContext* cct,
+                         std::string_view session_token,
+                         SessionToken& out)
+{
+  string decoded;
+  try {
+    decoded = rgw::from_base64(session_token);
+  } catch (...) {
+    ldpp_dout(dpp, 0) << "ERROR: Invalid session token, not base64 encoded." << dendl;
+    return -EINVAL;
+  }
+
+  auto* cryptohandler = cct->get_crypto_handler(CEPH_CRYPTO_AES);
+  if (!cryptohandler) {
+    return -EINVAL;
+  }
+  string secret_s = cct->_conf->rgw_sts_key;
+  if (secret_s.empty()) {
+    ldpp_dout(dpp, 1) << "ERROR: rgw sts key not set" << dendl;
+    return -EINVAL;
+  }
+  buffer::ptr secret(secret_s.c_str(), secret_s.length());
+  if (int ret = cryptohandler->validate_secret(secret); ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: Invalid secret key" << dendl;
+    return -EINVAL;
+  }
+  string error;
+  std::unique_ptr<CryptoKeyHandler> keyhandler(
+      cryptohandler->get_key_handler(secret, error));
+  if (!keyhandler) {
+    return -EINVAL;
+  }
+  error.clear();
+
+  buffer::list en_input = buffer::list::static_from_string(decoded);
+  buffer::list dec_output;
+  if (int ret = keyhandler->decrypt(en_input, dec_output, &error); ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: Decryption failed: " << error << dendl;
+    return -EPERM;
+  }
+  try {
+    dec_output.append('\0');
+    auto iter = dec_output.cbegin();
+    decode(out, iter);
+  } catch (const buffer::error& e) {
+    ldpp_dout(dpp, 0) << "ERROR: decode SessionToken failed: " << e.what() << dendl;
+    return -EINVAL;
+  }
+  return 0;
+}
+
+int resolve_session(const DoutPrefixProvider* dpp,
+                    CephContext* cct,
+                    rgw::sal::Driver* driver,
+                    optional_yield y,
+                    const SessionToken& token,
+                    ResolvedSession& out)
+{
+  /* Role-based session: load the referenced role. */
+  if (!token.roleId.empty()) {
+    std::unique_ptr<rgw::sal::RGWRole> role = driver->get_role(token.roleId);
+    if (role->load_by_id(dpp, y) < 0) {
+      return -EPERM;
+    }
+    out.role.id = token.roleId;
+    out.role.name = role->get_name();
+    out.role.path = role->get_path();
+    out.role.tenant = role->get_tenant();
+
+    const auto& account_id = role->get_account_id();
+    if (!account_id.empty()) {
+      out.role.account.emplace();
+      rgw::sal::Attrs attrs; // ignored
+      RGWObjVersionTracker objv; // ignored
+      int ret = driver->load_account_by_id(dpp, y, account_id,
+                                           *out.role.account, attrs, objv);
+      if (ret < 0) {
+        ldpp_dout(dpp, 1) << "ERROR: failed to load account "
+            << account_id << " for role " << out.role.name
+            << ": " << cpp_strerror(ret) << dendl;
+        return -EPERM;
+      }
+    }
+
+    for (auto& [name, policy] : role->get_info().perm_policy_map) {
+      out.role.inline_policies.push_back(std::move(policy));
+    }
+    for (auto& arn : role->get_info().managed_policies.arns) {
+      out.role.managed_policies.push_back(std::move(arn));
+    }
+  }
+
+  if (token.acct_type == TYPE_KEYSTONE || token.acct_type == TYPE_LDAP) {
+    /* Caller builds a RemoteApplier from the token directly. */
+    return 0;
+  }
+
+  if (token.acct_type == TYPE_ROLE) {
+    out.t_attrs.user_id = token.user;
+    out.t_attrs.token_policy = token.policy;
+    out.t_attrs.role_session_name = token.role_session;
+    out.t_attrs.token_claims = token.token_claims;
+    out.t_attrs.token_issued_at = token.issued_at;
+    out.t_attrs.principal_tags = token.principal_tags;
+    return 0;
+  }
+
+  /* TYPE_RGW / TYPE_ROOT / TYPE_NONE: load the local user. */
+  if (token.user.empty()) {
+    ldpp_dout(dpp, 5) << "ERROR: got session token with empty user id" << dendl;
+    return -EPERM;
+  }
+  out.user = driver->get_user(token.user);
+  if (int ret = out.user->load_user(dpp, y); ret < 0) {
+    ldpp_dout(dpp, 5) << "ERROR: failed reading user info: uid="
+                      << token.user << dendl;
+    return -EPERM;
+  }
+  if (int ret = rgw::auth::load_account_and_policies(
+          dpp, y, driver, out.user->get_info(), out.user->get_attrs(),
+          out.account, out.policies);
+      ret < 0) {
+    return -EPERM;
+  }
+  return 0;
+}
+
 void AssumedRoleUser::dump(Formatter *f) const
 {
   encode_json("Arn", arn , f);

--- a/src/rgw/rgw_sts.h
+++ b/src/rgw/rgw_sts.h
@@ -189,6 +189,52 @@ struct SessionToken {
 };
 WRITE_CLASS_ENCODER(SessionToken)
 
+/* Decrypt and decode a base64-encoded STS session token using the
+ * cluster's rgw_sts_key.  Returns 0 on success, a negative POSIX errno
+ * on failure (-EINVAL on bad encoding/missing key, -EPERM on decrypt
+ * failure).  Used by the REST STSEngine and by librgw to validate STS
+ * credentials at mount time without going through the REST auth path.
+ */
+int decode_session_token(const DoutPrefixProvider* dpp,
+                         CephContext* cct,
+                         std::string_view session_token,
+                         SessionToken& out);
+
+/* Components needed to construct an STS-derived Identity.  Populated by
+ * resolve_session() based on the token's acct_type:
+ *   - TYPE_ROLE:      role + t_attrs are populated.
+ *   - TYPE_RGW/ROOT/NONE: user, account, policies are populated.
+ *   - TYPE_KEYSTONE/LDAP: nothing is populated; caller uses get_creds_info
+ *                         on the token directly with a RemoteApplier.
+ */
+struct ResolvedSession {
+  /* Role-based session (token.acct_type == TYPE_ROLE). */
+  rgw::auth::RoleApplier::Role role;
+  rgw::auth::RoleApplier::TokenAttrs t_attrs;
+
+  /* Local-user session (token.acct_type in TYPE_RGW/ROOT/NONE). */
+  std::unique_ptr<rgw::sal::User> user;
+  std::optional<RGWAccountInfo> account;
+  std::vector<rgw::IAM::Policy> policies;
+};
+
+/* Resolve an STS session token into the components needed by either
+ * RoleApplier or LocalApplier.  Caller must have already decoded the
+ * token (see decode_session_token) and verified expiry.  The token is
+ * taken by const-ref; resolve_session copies the few small string/vector
+ * fields it needs.  Returns 0 on success.  Negative on failure: -EPERM
+ * if the role lookup fails or the referenced user can't be loaded;
+ * -EPERM also if the local-user case has an empty user_id.  For
+ * TYPE_KEYSTONE/LDAP this is a noop returning 0; the caller should build
+ * a RemoteApplier from the token directly.
+ */
+int resolve_session(const DoutPrefixProvider* dpp,
+                    CephContext* cct,
+                    rgw::sal::Driver* driver,
+                    optional_yield y,
+                    const SessionToken& token,
+                    ResolvedSession& out);
+
 class Credentials {
   static constexpr int MAX_ACCESS_KEY_LEN = 20;
   static constexpr int MAX_SECRET_KEY_LEN = 40;


### PR DESCRIPTION
Part of the decomposition of #68852 (S3 Files API). A **pure refactor** with no behavior change for existing S3 callers, cherry-picked verbatim from the original branch (provenance line retained). Independent of the other day-one PRs; lands shared auth machinery a later librgw/STS PR builds on.

Lifts two pieces out of `STSEngine` (previously private, only reachable from the REST auth path) into reusable `STS::` helpers:

- `STS::decode_session_token(...)` — the session-token decode, lifted verbatim from `STSEngine::get_session_token`, which now delegates to it.
- `STS::resolve_session(...)` — the post-signature-check role/user resolution, lifted from `STSEngine::authenticate`.

`STSEngine::authenticate` keeps the exact same sequence and applier choice it always produced. Full breakdown in the commit message.

**Validation:** builds clean on the decomposition base (`main`): `radosgw` 367/367, `radosgw --version` OK. The end-to-end vstart check noted in the commit message was performed in the original #68852 context; behavior is unchanged by this pure refactor.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
