### PR TITLE
rgw/file_state: add the S3 Files state substrate (Store/MemoryStore/ChangeFeed)

### DIFF
--- a/src/rgw/file_state/change_feed.cc
+++ b/src/rgw/file_state/change_feed.cc
@@ -1,0 +1,53 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "change_feed.h"
+
+#include <utility>
+#include <vector>
+
+namespace rgw::file_state {
+
+ChangeFeed::Handle InProcessChangeFeed::subscribe(Callback cb) {
+  std::lock_guard lock(mu_);
+  Handle h = next_++;
+  subs_.emplace(h, std::move(cb));
+  return h;
+}
+
+void InProcessChangeFeed::unsubscribe(Handle h) {
+  std::lock_guard lock(mu_);
+  subs_.erase(h);
+}
+
+void InProcessChangeFeed::fire() {
+  // Snapshot under the lock so callbacks don't see a torn map
+  // if someone subscribes/unsubscribes while we're iterating,
+  // and so callbacks don't call back into the feed under our
+  // mutex.
+  std::vector<Callback> snapshot;
+  {
+    std::lock_guard lock(mu_);
+    snapshot.reserve(subs_.size());
+    for (const auto& [_, cb] : subs_) {
+      snapshot.push_back(cb);
+    }
+  }
+  for (const auto& cb : snapshot) {
+    cb();
+  }
+}
+
+}  // namespace rgw::file_state

--- a/src/rgw/file_state/change_feed.h
+++ b/src/rgw/file_state/change_feed.h
@@ -1,0 +1,117 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+// Pluggable "tell me when control-plane state has changed"
+// abstraction for the s3files reconciler.
+//
+// The reconciler runs a worker loop that re-evaluates the desired
+// Ganesha export set whenever (a) the change feed signals a
+// mutation, or (b) a safety-net timer fires. Both paths converge
+// on the same idempotent "read all state, render, reload" cycle,
+// so the feed is a *latency optimization* — correctness is
+// recovered by the timer regardless of feed reliability.
+//
+// Implementations:
+//   NoopChangeFeed       — never signals; reconciler relies
+//                          entirely on the safety-net timer. Used
+//                          in unit tests against MemoryStore where
+//                          timed re-evaluation is sufficient.
+//   InProcessChangeFeed  — same-process callback bus. MemoryStore
+//                          (which lives in the same RGW process)
+//                          fires post-mutation; the feed forwards
+//                          to the reconciler immediately. Used
+//                          for end-to-end demos that want
+//                          sub-second latency without a separate
+//                          reconciler service or a real backend
+//                          watch primitive.
+//   RadosChangeFeed      — librados watch/notify on the per-realm
+//                          resource omap objects. Future commit.
+//   FdbChangeFeed        — FDB watches on tuple-prefix keys.
+//                          Future commit, deferred until #65535
+//                          (chardan's FDB plumbing) lands.
+//
+// The interface is deliberately coarse: a callback fires meaning
+// "something changed, re-evaluate." Granular per-resource
+// notifications could be added later if reconcile-everything
+// becomes too expensive, but for tens-to-hundreds of FileSystems
+// per zone the full re-read is bounded and predictable.
+
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+
+namespace rgw::file_state {
+
+class ChangeFeed {
+ public:
+  using Handle = std::size_t;
+  using Callback = std::function<void()>;
+
+  virtual ~ChangeFeed() = default;
+
+  // Register `cb` to fire whenever the feed observes a change.
+  // The implementation may invoke `cb` from any thread; the
+  // callback must be thread-safe and should marshal work onto
+  // the reconciler's own thread (typically by enqueueing an
+  // evaluation event).
+  //
+  // Returns a handle usable for unsubscribe(). Multiple
+  // subscribers are supported; each is called per change event.
+  virtual Handle subscribe(Callback cb) = 0;
+
+  // Cancel a prior subscribe(). Idempotent; unknown handles are
+  // silently ignored.
+  virtual void unsubscribe(Handle h) = 0;
+};
+
+// Stub feed that never signals. The reconciler still functions
+// correctly when paired with a NoopChangeFeed because the
+// safety-net timer drives reconciliation regardless of feed
+// activity — just at coarser latency than a live feed would
+// provide. Useful in unit tests where deterministic, time-driven
+// progression is preferable to event-driven.
+class NoopChangeFeed final : public ChangeFeed {
+ public:
+  Handle subscribe(Callback) override { return 0; }
+  void unsubscribe(Handle) override {}
+};
+
+// Same-process broadcaster. Producers (MemoryStore) call
+// `fire()` post-mutation; subscribers (reconciler) get invoked
+// synchronously on the producer's thread.
+//
+// Synchronization: subscriber registration is mutex-guarded so
+// concurrent subscribe/unsubscribe/fire from RGW handler threads
+// + a reconciler thread is safe. Subscribers run inline on the
+// fire() caller's thread; they should not block on I/O.
+class InProcessChangeFeed final : public ChangeFeed {
+ public:
+  Handle subscribe(Callback cb) override;
+  void unsubscribe(Handle h) override;
+
+  // Producer side: notify all current subscribers.
+  void fire();
+
+ private:
+  mutable std::mutex mu_;
+  std::unordered_map<Handle, Callback> subs_;
+  Handle next_{1};
+};
+
+}  // namespace rgw::file_state

--- a/src/rgw/file_state/memory_store.cc
+++ b/src/rgw/file_state/memory_store.cc
@@ -1,0 +1,731 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "memory_store.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <random>
+
+#include "rgw_s3files_errors.h"
+
+namespace rgw::file_state {
+
+namespace {
+
+using namespace ::rgw::s3files;  // ERR_* errorCode constants
+
+constexpr std::string_view kRegion = "default";
+
+std::int64_t now_unix_seconds() {
+  using namespace std::chrono;
+  return duration_cast<seconds>(
+      system_clock::now().time_since_epoch()).count();
+}
+
+// Apply ListOptions {max_results, next_token} to an already-collected
+// + sorted vector of items. Returns a PagedResult containing at most
+// `max_results` items, with `next_token` set to the id of the last
+// item in the page when more items remain.
+//
+// `id_of` extracts the sort key / token from an item; the same key
+// is used for ordering and for the next-token boundary, so callers
+// must hand in a vector already sorted ascending by id_of.
+template <typename T, typename IdFn>
+PagedResult<T> apply_pagination(
+    std::vector<T>&& sorted, const ListOptions& opts, IdFn id_of) {
+  PagedResult<T> out;
+  // start_after: skip past entries whose id_of(item) <= next_token.
+  auto it = sorted.begin();
+  if (!opts.next_token.empty()) {
+    it = std::upper_bound(
+        sorted.begin(), sorted.end(), opts.next_token,
+        [&](const std::string& tok, const T& item) {
+          return tok < id_of(item);
+        });
+  }
+  const std::int32_t cap = opts.max_results > 0 ? opts.max_results : 100;
+  for (; it != sorted.end() && static_cast<std::int32_t>(out.items.size()) < cap;
+       ++it) {
+    out.items.push_back(std::move(*it));
+  }
+  if (it != sorted.end() && !out.items.empty()) {
+    out.next_token = std::string(id_of(out.items.back()));
+  }
+  return out;
+}
+
+StoreError not_found(std::string_view code, std::string message) {
+  return StoreError{
+      .kind = StoreError::Kind::NotFound,
+      .error_code = std::string(code),
+      .message = std::move(message),
+  };
+}
+
+StoreError conflict(std::string_view code, std::string message) {
+  return StoreError{
+      .kind = StoreError::Kind::Conflict,
+      .error_code = std::string(code),
+      .message = std::move(message),
+  };
+}
+
+StoreError invalid(std::string_view code, std::string message) {
+  return StoreError{
+      .kind = StoreError::Kind::InvalidArgument,
+      .error_code = std::string(code),
+      .message = std::move(message),
+  };
+}
+
+}  // namespace
+
+MemoryStore::MemoryStore() = default;
+
+void MemoryStore::set_on_change(std::function<void()> cb) {
+  std::lock_guard lock(mu_);
+  on_change_ = std::move(cb);
+}
+
+std::string MemoryStore::make_id(std::string_view prefix) {
+  // AWS EFS-style resource id: `<prefix><17 random hex chars>`
+  // (e.g. "fs-0123456789abcdef0").  17 hex = 68 bits of entropy,
+  // which is plenty for global uniqueness within an account.
+  // A thread-local PRNG seeded from random_device keeps this
+  // self-contained -- the file_state library doesn't need to
+  // drag in libcommon for uuid_d.
+  static thread_local std::mt19937_64 rng{std::random_device{}()};
+  const std::uint64_t lo = rng();
+  const std::uint64_t hi = rng() & 0xfu;
+  char buf[18];
+  std::snprintf(buf, sizeof(buf), "%016llx%llx",
+                static_cast<unsigned long long>(lo),
+                static_cast<unsigned long long>(hi));
+  return std::string(prefix) + buf;
+}
+
+std::string MemoryStore::make_fs_arn(
+    std::string_view account_id, std::string_view fs_id) {
+  std::string arn;
+  arn.reserve(64 + account_id.size() + fs_id.size());
+  arn.append("arn:aws:s3files:");
+  arn.append(kRegion);
+  arn.append(":");
+  arn.append(account_id);
+  arn.append(":file-system/");
+  arn.append(fs_id);
+  return arn;
+}
+
+std::string MemoryStore::make_ap_arn(
+    std::string_view account_id, std::string_view fs_id,
+    std::string_view ap_id) {
+  std::string arn = make_fs_arn(account_id, fs_id);
+  arn.append("/access-point/");
+  arn.append(ap_id);
+  return arn;
+}
+
+// =================================================================
+// FileSystem
+// =================================================================
+
+StoreResult<FileSystemView> MemoryStore::create_file_system(
+    const CreateFileSystemRequest& req) {
+  if (req.bucket_arn.empty()) {
+    return invalid(ERR_INVALID_BUCKET_ARN, "bucket is required");
+  }
+  if (req.role_arn.empty()) {
+    return invalid(ERR_INVALID_ROLE_ARN, "roleArn is required");
+  }
+
+  ChangeNotify notify(*this);  // fires after lock releases, only if commit()ed
+  std::lock_guard lock(mu_);
+
+  // Idempotency by client_token.
+  if (!req.client_token.empty()) {
+    auto it = fs_client_tokens_.find({req.owner_account_id, req.client_token});
+    if (it != fs_client_tokens_.end()) {
+      auto fs_it = file_systems_.find(it->second);
+      if (fs_it != file_systems_.end()) {
+        return FileSystemView{fs_it->second.spec, fs_it->second.status};
+      }
+    }
+  }
+
+  // Bucket-already-in-use check.
+  for (const auto& [_, rec] : file_systems_) {
+    if (rec.spec.owner_account_id == req.owner_account_id &&
+        rec.spec.bucket_arn == req.bucket_arn) {
+      return conflict(ERR_BUCKET_ALREADY_IN_USE,
+                       "bucket is already bound to a file system");
+    }
+  }
+
+  FileSystemRecord rec;
+  rec.spec.id = make_id("fs-");
+  rec.spec.arn = make_fs_arn(req.owner_account_id, rec.spec.id);
+  rec.spec.owner_account_id = req.owner_account_id;
+  rec.spec.bucket_arn = req.bucket_arn;
+  rec.spec.prefix = req.prefix;
+  rec.spec.role_arn = req.role_arn;
+  rec.spec.kms_key_id = req.kms_key_id;
+  rec.spec.placement = req.placement;
+  rec.spec.client_token = req.client_token;
+  rec.spec.accept_bucket_warning = req.accept_bucket_warning;
+  rec.spec.tags = req.tags;
+  rec.spec.creation_time_unix_seconds = now_unix_seconds();
+  // Memory backend transitions to Available immediately.
+  rec.status.state = LifecycleState::Available;
+
+  if (!req.client_token.empty()) {
+    fs_client_tokens_.emplace(
+        std::make_pair(req.owner_account_id, req.client_token),
+        rec.spec.id);
+  }
+
+  std::string id = rec.spec.id;
+  auto [it, _] = file_systems_.emplace(id, std::move(rec));
+  notify.commit();
+  return FileSystemView{it->second.spec, it->second.status};
+}
+
+StoreResult<FileSystemView> MemoryStore::get_file_system(
+    std::string_view account_id, std::string_view filesystem_id) {
+  std::lock_guard lock(mu_);
+  auto it = file_systems_.find(std::string(filesystem_id));
+  if (it == file_systems_.end() ||
+      it->second.spec.owner_account_id != account_id) {
+    return not_found(ERR_FILE_SYSTEM_NOT_FOUND, "file system not found");
+  }
+  return FileSystemView{it->second.spec, it->second.status};
+}
+
+StoreResult<PagedResult<FileSystemView>> MemoryStore::list_file_systems(
+    std::string_view account_id, const ListOptions& opts) {
+  std::lock_guard lock(mu_);
+  std::vector<FileSystemView> all;
+  for (const auto& [_, rec] : file_systems_) {
+    if (rec.spec.owner_account_id == account_id) {
+      all.push_back(FileSystemView{rec.spec, rec.status});
+    }
+  }
+  std::sort(all.begin(), all.end(), [](const auto& a, const auto& b) {
+    return a.spec.id < b.spec.id;
+  });
+  return apply_pagination(std::move(all), opts,
+      [](const FileSystemView& v) { return v.spec.id; });
+}
+
+StoreResult<Unit> MemoryStore::delete_file_system(
+    std::string_view account_id, std::string_view filesystem_id) {
+  ChangeNotify notify(*this);
+  std::lock_guard lock(mu_);
+  auto it = file_systems_.find(std::string(filesystem_id));
+  if (it == file_systems_.end() ||
+      it->second.spec.owner_account_id != account_id) {
+    return not_found(ERR_FILE_SYSTEM_NOT_FOUND, "file system not found");
+  }
+
+  // Cascade rejection: refuse if any AP or MT references this FS.
+  for (const auto& [_, ap] : access_points_) {
+    if (ap.spec.parent_filesystem_id == filesystem_id) {
+      return conflict(ERR_FILE_SYSTEM_HAS_CHILDREN,
+                       "file system has active access points");
+    }
+  }
+  for (const auto& [_, mt] : mount_targets_) {
+    if (mt.spec.parent_filesystem_id == filesystem_id) {
+      return conflict(ERR_FILE_SYSTEM_HAS_CHILDREN,
+                       "file system has active mount targets");
+    }
+  }
+
+  // Drop client_token mapping if any.
+  if (!it->second.spec.client_token.empty()) {
+    fs_client_tokens_.erase(
+        {it->second.spec.owner_account_id, it->second.spec.client_token});
+  }
+  file_systems_.erase(it);
+  notify.commit();
+  return Unit{};
+}
+
+// =================================================================
+// FileSystem policy
+// =================================================================
+
+StoreResult<Unit> MemoryStore::put_file_system_policy(
+    std::string_view account_id, std::string_view filesystem_id,
+    std::string_view policy_json) {
+  ChangeNotify notify(*this);
+  std::lock_guard lock(mu_);
+  auto it = file_systems_.find(std::string(filesystem_id));
+  if (it == file_systems_.end() ||
+      it->second.spec.owner_account_id != account_id) {
+    return not_found(ERR_FILE_SYSTEM_NOT_FOUND, "file system not found");
+  }
+  // Minimal JSON-shape check: must start with '{'.
+  if (policy_json.empty() || policy_json.front() != '{') {
+    return invalid(ERR_INVALID_POLICY_DOCUMENT,
+                    "policy must be a JSON object");
+  }
+  it->second.policy = std::string(policy_json);
+  notify.commit();
+  return Unit{};
+}
+
+StoreResult<std::string> MemoryStore::get_file_system_policy(
+    std::string_view account_id, std::string_view filesystem_id) {
+  std::lock_guard lock(mu_);
+  auto it = file_systems_.find(std::string(filesystem_id));
+  if (it == file_systems_.end() ||
+      it->second.spec.owner_account_id != account_id) {
+    return not_found(ERR_FILE_SYSTEM_NOT_FOUND, "file system not found");
+  }
+  if (!it->second.policy) {
+    return not_found(ERR_POLICY_NOT_FOUND, "no policy set");
+  }
+  return *it->second.policy;
+}
+
+StoreResult<Unit> MemoryStore::delete_file_system_policy(
+    std::string_view account_id, std::string_view filesystem_id) {
+  ChangeNotify notify(*this);
+  std::lock_guard lock(mu_);
+  auto it = file_systems_.find(std::string(filesystem_id));
+  if (it == file_systems_.end() ||
+      it->second.spec.owner_account_id != account_id) {
+    return not_found(ERR_FILE_SYSTEM_NOT_FOUND, "file system not found");
+  }
+  if (!it->second.policy) {
+    return not_found(ERR_POLICY_NOT_FOUND, "no policy set");
+  }
+  it->second.policy.reset();
+  notify.commit();
+  return Unit{};
+}
+
+// =================================================================
+// FileSystem synchronization configuration
+// =================================================================
+
+StoreResult<Unit> MemoryStore::put_synchronization_configuration(
+    std::string_view account_id, std::string_view filesystem_id,
+    const SyncConfig& cfg, std::optional<std::int64_t> expected_version) {
+  ChangeNotify notify(*this);
+  std::lock_guard lock(mu_);
+  auto it = file_systems_.find(std::string(filesystem_id));
+  if (it == file_systems_.end() ||
+      it->second.spec.owner_account_id != account_id) {
+    return not_found(ERR_FILE_SYSTEM_NOT_FOUND, "file system not found");
+  }
+
+  std::int64_t current_version = it->second.sync_config
+      ? it->second.sync_config->latest_version_number
+      : 0;
+  if (expected_version && *expected_version != current_version) {
+    return conflict(ERR_FILE_SYSTEM_IN_INVALID_STATE,
+                     "latestVersionNumber does not match current configuration");
+  }
+
+  SyncConfig stored = cfg;
+  stored.latest_version_number = current_version + 1;
+  it->second.sync_config = std::move(stored);
+  notify.commit();
+  return Unit{};
+}
+
+StoreResult<SyncConfig> MemoryStore::get_synchronization_configuration(
+    std::string_view account_id, std::string_view filesystem_id) {
+  std::lock_guard lock(mu_);
+  auto it = file_systems_.find(std::string(filesystem_id));
+  if (it == file_systems_.end() ||
+      it->second.spec.owner_account_id != account_id) {
+    return not_found(ERR_FILE_SYSTEM_NOT_FOUND, "file system not found");
+  }
+  if (!it->second.sync_config) {
+    return not_found(ERR_FILE_SYSTEM_IN_INVALID_STATE,
+                      "no synchronization configuration set");
+  }
+  return *it->second.sync_config;
+}
+
+// =================================================================
+// AccessPoint
+// =================================================================
+
+StoreResult<AccessPointView> MemoryStore::create_access_point(
+    const CreateAccessPointRequest& req) {
+  if (req.filesystem_id.empty()) {
+    return invalid(ERR_INVALID_ROOT_DIRECTORY, "fileSystemId is required");
+  }
+  if (req.posix_user) {
+    // posixUser must include both uid and gid (>= 0).
+    if (req.posix_user->uid < 0 || req.posix_user->gid < 0) {
+      return invalid(ERR_INVALID_POSIX_USER,
+                      "posixUser uid and gid must be non-negative");
+    }
+  }
+
+  ChangeNotify notify(*this);
+  std::lock_guard lock(mu_);
+
+  // Verify parent FS exists and belongs to caller.
+  auto fs_it = file_systems_.find(req.filesystem_id);
+  if (fs_it == file_systems_.end() ||
+      fs_it->second.spec.owner_account_id != req.owner_account_id) {
+    return not_found(ERR_FILE_SYSTEM_NOT_FOUND, "file system not found");
+  }
+
+  // Idempotency by client_token.
+  if (!req.client_token.empty()) {
+    auto it = ap_client_tokens_.find({req.owner_account_id, req.client_token});
+    if (it != ap_client_tokens_.end()) {
+      auto ap_it = access_points_.find(it->second);
+      if (ap_it != access_points_.end()) {
+        return AccessPointView{ap_it->second.spec, ap_it->second.status};
+      }
+    }
+  }
+
+  AccessPointRecord rec;
+  rec.spec.id = make_id("fsap-");
+  rec.spec.arn = make_ap_arn(
+      req.owner_account_id, req.filesystem_id, rec.spec.id);
+  rec.spec.parent_filesystem_id = req.filesystem_id;
+  rec.spec.owner_account_id = req.owner_account_id;
+  rec.spec.client_token = req.client_token;
+  rec.spec.posix_user = req.posix_user;
+  rec.spec.root_directory = req.root_directory;
+  rec.spec.tags = req.tags;
+  rec.status.state = LifecycleState::Available;
+
+  if (!req.client_token.empty()) {
+    ap_client_tokens_.emplace(
+        std::make_pair(req.owner_account_id, req.client_token),
+        rec.spec.id);
+  }
+
+  std::string id = rec.spec.id;
+  auto [it, _] = access_points_.emplace(id, std::move(rec));
+  notify.commit();
+  return AccessPointView{it->second.spec, it->second.status};
+}
+
+StoreResult<AccessPointView> MemoryStore::get_access_point(
+    std::string_view account_id, std::string_view access_point_id) {
+  std::lock_guard lock(mu_);
+  auto it = access_points_.find(std::string(access_point_id));
+  if (it == access_points_.end() ||
+      it->second.spec.owner_account_id != account_id) {
+    return not_found(ERR_ACCESS_POINT_NOT_FOUND, "access point not found");
+  }
+  return AccessPointView{it->second.spec, it->second.status};
+}
+
+StoreResult<PagedResult<AccessPointView>> MemoryStore::list_access_points(
+    std::string_view account_id, std::string_view filesystem_id,
+    const ListOptions& opts) {
+  std::lock_guard lock(mu_);
+
+  // The parent FS must exist.
+  auto fs_it = file_systems_.find(std::string(filesystem_id));
+  if (fs_it == file_systems_.end() ||
+      fs_it->second.spec.owner_account_id != account_id) {
+    return not_found(ERR_FILE_SYSTEM_NOT_FOUND, "file system not found");
+  }
+
+  std::vector<AccessPointView> all;
+  for (const auto& [_, rec] : access_points_) {
+    if (rec.spec.parent_filesystem_id == filesystem_id &&
+        rec.spec.owner_account_id == account_id) {
+      all.push_back(AccessPointView{rec.spec, rec.status});
+    }
+  }
+  std::sort(all.begin(), all.end(), [](const auto& a, const auto& b) {
+    return a.spec.id < b.spec.id;
+  });
+  return apply_pagination(std::move(all), opts,
+      [](const AccessPointView& v) { return v.spec.id; });
+}
+
+StoreResult<Unit> MemoryStore::delete_access_point(
+    std::string_view account_id, std::string_view access_point_id) {
+  ChangeNotify notify(*this);
+  std::lock_guard lock(mu_);
+  auto it = access_points_.find(std::string(access_point_id));
+  if (it == access_points_.end() ||
+      it->second.spec.owner_account_id != account_id) {
+    return not_found(ERR_ACCESS_POINT_NOT_FOUND, "access point not found");
+  }
+  if (!it->second.spec.client_token.empty()) {
+    ap_client_tokens_.erase(
+        {it->second.spec.owner_account_id, it->second.spec.client_token});
+  }
+  access_points_.erase(it);
+  notify.commit();
+  return Unit{};
+}
+
+// =================================================================
+// MountTarget
+// =================================================================
+
+StoreResult<MountTargetView> MemoryStore::create_mount_target(
+    const CreateMountTargetRequest& req) {
+  if (req.filesystem_id.empty()) {
+    return invalid(ERR_INVALID_ZONE_ID, "fileSystemId is required");
+  }
+  if (req.zone_id.empty()) {
+    return invalid(ERR_INVALID_ZONE_ID, "zone_id (subnetId) is required");
+  }
+
+  ChangeNotify notify(*this);
+  std::lock_guard lock(mu_);
+
+  auto fs_it = file_systems_.find(req.filesystem_id);
+  if (fs_it == file_systems_.end() ||
+      fs_it->second.spec.owner_account_id != req.owner_account_id) {
+    return not_found(ERR_FILE_SYSTEM_NOT_FOUND, "file system not found");
+  }
+
+  // One MT per (FS, zone).
+  for (const auto& [_, mt] : mount_targets_) {
+    if (mt.spec.parent_filesystem_id == req.filesystem_id &&
+        mt.spec.zone_id == req.zone_id) {
+      return conflict(ERR_MOUNT_TARGET_ALREADY_IN_ZONE,
+                       "mount target already exists in this zone");
+    }
+  }
+
+  MountTargetRecord rec;
+  rec.spec.id = make_id("fsmt-");
+  rec.spec.parent_filesystem_id = req.filesystem_id;
+  rec.spec.owner_account_id = req.owner_account_id;
+  rec.spec.zone_id = req.zone_id;
+  rec.spec.ip_address_type = req.ip_address_type.empty()
+      ? "IPV4_ONLY"
+      : req.ip_address_type;
+  rec.spec.security_groups = req.security_groups;
+  rec.status.state = LifecycleState::Available;
+  // ipv4_address remains empty until a reconciler populates it.
+
+  std::string id = rec.spec.id;
+  auto [it, _] = mount_targets_.emplace(id, std::move(rec));
+  notify.commit();
+  return MountTargetView{it->second.spec, it->second.status};
+}
+
+StoreResult<MountTargetView> MemoryStore::get_mount_target(
+    std::string_view account_id, std::string_view mount_target_id) {
+  std::lock_guard lock(mu_);
+  auto it = mount_targets_.find(std::string(mount_target_id));
+  if (it == mount_targets_.end() ||
+      it->second.spec.owner_account_id != account_id) {
+    return not_found(ERR_MOUNT_TARGET_NOT_FOUND, "mount target not found");
+  }
+  return MountTargetView{it->second.spec, it->second.status};
+}
+
+StoreResult<PagedResult<MountTargetView>> MemoryStore::list_mount_targets(
+    std::string_view account_id,
+    std::optional<std::string_view> filesystem_id,
+    std::optional<std::string_view> access_point_id,
+    const ListOptions& opts) {
+  std::lock_guard lock(mu_);
+
+  // Resolve the filter target. If filesystem_id is supplied, that FS
+  // must exist (and belong to the caller). access_point_id, if
+  // supplied, is resolved to its parent FS.
+  std::optional<std::string> required_fs_id;
+  if (filesystem_id) {
+    auto fs_it = file_systems_.find(std::string(*filesystem_id));
+    if (fs_it == file_systems_.end() ||
+        fs_it->second.spec.owner_account_id != account_id) {
+      return not_found(ERR_FILE_SYSTEM_NOT_FOUND, "file system not found");
+    }
+    required_fs_id = std::string(*filesystem_id);
+  }
+  if (access_point_id) {
+    auto ap_it = access_points_.find(std::string(*access_point_id));
+    if (ap_it == access_points_.end() ||
+        ap_it->second.spec.owner_account_id != account_id) {
+      return not_found(ERR_ACCESS_POINT_NOT_FOUND, "access point not found");
+    }
+    if (required_fs_id && *required_fs_id != ap_it->second.spec.parent_filesystem_id) {
+      // Both filters supplied but inconsistent → empty result.
+      return PagedResult<MountTargetView>{};
+    }
+    required_fs_id = ap_it->second.spec.parent_filesystem_id;
+  }
+
+  std::vector<MountTargetView> all;
+  for (const auto& [_, rec] : mount_targets_) {
+    if (rec.spec.owner_account_id != account_id) continue;
+    if (required_fs_id && rec.spec.parent_filesystem_id != *required_fs_id) {
+      continue;
+    }
+    all.push_back(MountTargetView{rec.spec, rec.status});
+  }
+  std::sort(all.begin(), all.end(), [](const auto& a, const auto& b) {
+    return a.spec.id < b.spec.id;
+  });
+  return apply_pagination(std::move(all), opts,
+      [](const MountTargetView& v) { return v.spec.id; });
+}
+
+StoreResult<MountTargetView> MemoryStore::update_mount_target(
+    std::string_view account_id, const UpdateMountTargetRequest& req) {
+  ChangeNotify notify(*this);
+  std::lock_guard lock(mu_);
+  auto it = mount_targets_.find(req.id);
+  if (it == mount_targets_.end() ||
+      it->second.spec.owner_account_id != account_id) {
+    return not_found(ERR_MOUNT_TARGET_NOT_FOUND, "mount target not found");
+  }
+  it->second.spec.security_groups = req.security_groups;
+  notify.commit();
+  return MountTargetView{it->second.spec, it->second.status};
+}
+
+StoreResult<Unit> MemoryStore::delete_mount_target(
+    std::string_view account_id, std::string_view mount_target_id) {
+  ChangeNotify notify(*this);
+  std::lock_guard lock(mu_);
+  auto it = mount_targets_.find(std::string(mount_target_id));
+  if (it == mount_targets_.end() ||
+      it->second.spec.owner_account_id != account_id) {
+    return not_found(ERR_MOUNT_TARGET_NOT_FOUND, "mount target not found");
+  }
+  mount_targets_.erase(it);
+  notify.commit();
+  return Unit{};
+}
+
+// =================================================================
+// Tagging
+// =================================================================
+
+std::vector<Tag>* MemoryStore::tags_target(
+    std::string_view account_id, std::string_view resource_id) {
+  if (auto it = file_systems_.find(std::string(resource_id));
+      it != file_systems_.end()) {
+    if (it->second.spec.owner_account_id != account_id) return nullptr;
+    return &it->second.spec.tags;
+  }
+  if (auto it = access_points_.find(std::string(resource_id));
+      it != access_points_.end()) {
+    if (it->second.spec.owner_account_id != account_id) return nullptr;
+    return &it->second.spec.tags;
+  }
+  return nullptr;
+}
+
+StoreResult<PagedResult<Tag>> MemoryStore::list_tags_for_resource(
+    std::string_view account_id, std::string_view resource_id,
+    const ListOptions& opts) {
+  std::lock_guard lock(mu_);
+  std::vector<Tag>* tags = tags_target(account_id, resource_id);
+  if (!tags) {
+    return not_found(ERR_FILE_SYSTEM_NOT_FOUND, "resource not found");
+  }
+  std::vector<Tag> all = *tags;
+  std::sort(all.begin(), all.end(), [](const Tag& a, const Tag& b) {
+    return a.key < b.key;
+  });
+  return apply_pagination(std::move(all), opts,
+      [](const Tag& t) { return t.key; });
+}
+
+StoreResult<Unit> MemoryStore::tag_resource(
+    std::string_view account_id, std::string_view resource_id,
+    const std::vector<Tag>& tags) {
+  ChangeNotify notify(*this);
+  std::lock_guard lock(mu_);
+  std::vector<Tag>* existing = tags_target(account_id, resource_id);
+  if (!existing) {
+    return not_found(ERR_FILE_SYSTEM_NOT_FOUND, "resource not found");
+  }
+  for (const auto& t : tags) {
+    auto it = std::find_if(existing->begin(), existing->end(),
+                            [&](const Tag& e) { return e.key == t.key; });
+    if (it != existing->end()) {
+      it->value = t.value;
+    } else {
+      existing->push_back(t);
+    }
+  }
+  notify.commit();
+  return Unit{};
+}
+
+StoreResult<Unit> MemoryStore::untag_resource(
+    std::string_view account_id, std::string_view resource_id,
+    const std::vector<std::string>& tag_keys) {
+  ChangeNotify notify(*this);
+  std::lock_guard lock(mu_);
+  std::vector<Tag>* existing = tags_target(account_id, resource_id);
+  if (!existing) {
+    return not_found(ERR_FILE_SYSTEM_NOT_FOUND, "resource not found");
+  }
+  existing->erase(
+      std::remove_if(existing->begin(), existing->end(),
+                      [&](const Tag& t) {
+                        return std::find(tag_keys.begin(), tag_keys.end(),
+                                          t.key) != tag_keys.end();
+                      }),
+      existing->end());
+  notify.commit();
+  return Unit{};
+}
+
+// =================================================================
+// Admin / reconciler scans
+// =================================================================
+
+std::vector<FileSystemView> MemoryStore::scan_file_systems() {
+  std::lock_guard lock(mu_);
+  std::vector<FileSystemView> out;
+  out.reserve(file_systems_.size());
+  for (const auto& [_, rec] : file_systems_) {
+    out.push_back(FileSystemView{rec.spec, rec.status});
+  }
+  return out;
+}
+
+std::vector<AccessPointView> MemoryStore::scan_access_points() {
+  std::lock_guard lock(mu_);
+  std::vector<AccessPointView> out;
+  out.reserve(access_points_.size());
+  for (const auto& [_, rec] : access_points_) {
+    out.push_back(AccessPointView{rec.spec, rec.status});
+  }
+  return out;
+}
+
+std::vector<MountTargetView> MemoryStore::scan_mount_targets() {
+  std::lock_guard lock(mu_);
+  std::vector<MountTargetView> out;
+  out.reserve(mount_targets_.size());
+  for (const auto& [_, rec] : mount_targets_) {
+    out.push_back(MountTargetView{rec.spec, rec.status});
+  }
+  return out;
+}
+
+}  // namespace rgw::file_state

--- a/src/rgw/file_state/memory_store.h
+++ b/src/rgw/file_state/memory_store.h
@@ -1,0 +1,242 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+// In-memory backend for rgw::file_state::Store.
+//
+// Used during day-1 development (before the FDB-backed
+// implementation lands) and as the test backend for the gtest
+// suite. Mirrors the eventual FdbStore semantics — spec/status
+// separation, client-token idempotency on creates, lifecycle
+// state transitions, cascade-rejection on FileSystem delete with
+// active children, optimistic concurrency on
+// SynchronizationConfiguration via latest_version_number — so
+// that handlers written against this backend behave the same
+// against FdbStore.
+
+#pragma once
+
+#include <functional>
+#include <map>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+#include "store.h"
+
+namespace rgw::file_state {
+
+class MemoryStore : public Store {
+ public:
+  MemoryStore();
+  ~MemoryStore() override = default;
+
+  MemoryStore(const MemoryStore&) = delete;
+  MemoryStore& operator=(const MemoryStore&) = delete;
+
+  // Register a callback to fire after every successful mutation
+  // (create/update/delete/tag/policy/sync-config). Used by the
+  // in-process ChangeFeed to wake the reconciler with sub-second
+  // latency. The callback runs on the mutating handler's thread,
+  // so it should be cheap — typically just nudging a bus or
+  // condvar that the reconciler is waiting on.
+  //
+  // At most one callback at a time. Pass `nullptr` to clear.
+  // Reads (Get/List) do not fire.
+  void set_on_change(std::function<void()> cb) override;
+
+  // FileSystem ------------------------------------------------------
+
+  StoreResult<FileSystemView> create_file_system(
+      const CreateFileSystemRequest& req) override;
+
+  StoreResult<FileSystemView> get_file_system(
+      std::string_view account_id,
+      std::string_view filesystem_id) override;
+
+  StoreResult<PagedResult<FileSystemView>> list_file_systems(
+      std::string_view account_id,
+      const ListOptions& opts) override;
+
+  StoreResult<Unit> delete_file_system(
+      std::string_view account_id,
+      std::string_view filesystem_id) override;
+
+  // FileSystem policy ----------------------------------------------
+
+  StoreResult<Unit> put_file_system_policy(
+      std::string_view account_id,
+      std::string_view filesystem_id,
+      std::string_view policy_json) override;
+
+  StoreResult<std::string> get_file_system_policy(
+      std::string_view account_id,
+      std::string_view filesystem_id) override;
+
+  StoreResult<Unit> delete_file_system_policy(
+      std::string_view account_id,
+      std::string_view filesystem_id) override;
+
+  // FileSystem synchronization configuration -----------------------
+
+  StoreResult<Unit> put_synchronization_configuration(
+      std::string_view account_id,
+      std::string_view filesystem_id,
+      const SyncConfig& cfg,
+      std::optional<std::int64_t> expected_version) override;
+
+  StoreResult<SyncConfig> get_synchronization_configuration(
+      std::string_view account_id,
+      std::string_view filesystem_id) override;
+
+  // AccessPoint -----------------------------------------------------
+
+  StoreResult<AccessPointView> create_access_point(
+      const CreateAccessPointRequest& req) override;
+
+  StoreResult<AccessPointView> get_access_point(
+      std::string_view account_id,
+      std::string_view access_point_id) override;
+
+  StoreResult<PagedResult<AccessPointView>> list_access_points(
+      std::string_view account_id,
+      std::string_view filesystem_id,
+      const ListOptions& opts) override;
+
+  StoreResult<Unit> delete_access_point(
+      std::string_view account_id,
+      std::string_view access_point_id) override;
+
+  // MountTarget -----------------------------------------------------
+
+  StoreResult<MountTargetView> create_mount_target(
+      const CreateMountTargetRequest& req) override;
+
+  StoreResult<MountTargetView> get_mount_target(
+      std::string_view account_id,
+      std::string_view mount_target_id) override;
+
+  StoreResult<PagedResult<MountTargetView>> list_mount_targets(
+      std::string_view account_id,
+      std::optional<std::string_view> filesystem_id,
+      std::optional<std::string_view> access_point_id,
+      const ListOptions& opts) override;
+
+  StoreResult<MountTargetView> update_mount_target(
+      std::string_view account_id,
+      const UpdateMountTargetRequest& req) override;
+
+  StoreResult<Unit> delete_mount_target(
+      std::string_view account_id,
+      std::string_view mount_target_id) override;
+
+  // Tagging --------------------------------------------------------
+
+  StoreResult<PagedResult<Tag>> list_tags_for_resource(
+      std::string_view account_id,
+      std::string_view resource_id,
+      const ListOptions& opts) override;
+
+  StoreResult<Unit> tag_resource(
+      std::string_view account_id,
+      std::string_view resource_id,
+      const std::vector<Tag>& tags) override;
+
+  StoreResult<Unit> untag_resource(
+      std::string_view account_id,
+      std::string_view resource_id,
+      const std::vector<std::string>& tag_keys) override;
+
+  // Reconciler scans (cross-account; no notify firing).
+  std::vector<FileSystemView> scan_file_systems() override;
+  std::vector<AccessPointView> scan_access_points() override;
+  std::vector<MountTargetView> scan_mount_targets() override;
+
+ private:
+  struct FileSystemRecord {
+    FileSystemSpec spec;
+    FileSystemStatus status;
+    std::optional<std::string> policy;
+    std::optional<SyncConfig> sync_config;
+  };
+
+  struct AccessPointRecord {
+    AccessPointSpec spec;
+    AccessPointStatus status;
+  };
+
+  struct MountTargetRecord {
+    MountTargetSpec spec;
+    MountTargetStatus status;
+  };
+
+  // Storage. All access goes through `mu_`.
+  mutable std::mutex mu_;
+  std::unordered_map<std::string, FileSystemRecord> file_systems_;
+  std::unordered_map<std::string, AccessPointRecord> access_points_;
+  std::unordered_map<std::string, MountTargetRecord> mount_targets_;
+
+  // Idempotency mappings: (account_id, client_token) -> existing id.
+  std::map<std::pair<std::string, std::string>, std::string>
+      fs_client_tokens_;
+  std::map<std::pair<std::string, std::string>, std::string>
+      ap_client_tokens_;
+
+  // ID generation: AWS EFS-style 17-char random hex (e.g.
+  // "fs-0123456789abcdef0"), seeded from uuid_d for entropy.
+  std::string make_id(std::string_view prefix);
+
+  // ARN format mirrors AWS:
+  //   arn:aws:s3files:<region>:<account>:file-system/<fs>
+  //   arn:aws:s3files:<region>:<account>:file-system/<fs>/access-point/<ap>
+  static std::string make_fs_arn(
+      std::string_view account_id, std::string_view fs_id);
+  static std::string make_ap_arn(
+      std::string_view account_id, std::string_view fs_id,
+      std::string_view ap_id);
+
+  // Locate either a FileSystem or an AccessPoint record by id and
+  // owner. Returns a pointer to the underlying tag list, or
+  // nullptr when the resource doesn't exist or isn't owned by
+  // `account_id`. Caller must hold `mu_`.
+  std::vector<Tag>* tags_target(
+      std::string_view account_id, std::string_view resource_id);
+
+  // RAII helper for firing the on-change callback after a
+  // mutation commits. Construct this BEFORE the lock_guard in a
+  // mutator. On scope exit, destruction order (lock first,
+  // then notifier) ensures the callback runs after the mutex
+  // is released, so the subscriber can safely re-enter the
+  // store. Notify only fires if commit() is called — early
+  // returns / errors leave it as a no-op.
+  class ChangeNotify {
+   public:
+    explicit ChangeNotify(MemoryStore& s) : store_(s) {}
+    ~ChangeNotify() {
+      if (committed_ && store_.on_change_) {
+        store_.on_change_();
+      }
+    }
+    void commit() { committed_ = true; }
+    ChangeNotify(const ChangeNotify&) = delete;
+    ChangeNotify& operator=(const ChangeNotify&) = delete;
+   private:
+    MemoryStore& store_;
+    bool committed_ = false;
+  };
+
+  std::function<void()> on_change_;
+};
+
+}  // namespace rgw::file_state

--- a/src/rgw/file_state/store.h
+++ b/src/rgw/file_state/store.h
@@ -1,0 +1,443 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+// rgw::file_state::Store — backend interface for the S3 Files API.
+//
+// REST handlers consume this interface; concrete backends (MemoryStore
+// for development and tests, FdbStore for production) implement it.
+// See doc/dev/radosgw/s3_files_api.rst for the design.
+//
+// Errors are returned as StoreResult<T> (a variant of T or StoreError).
+// StoreError carries an errorCode string from src/rgw/rgw_s3files_errors.h
+// — REST handlers map these to AWS-shape exception types.
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+namespace rgw::file_state {
+
+// ---------------------------------------------------------------- Lifecycle
+
+enum class LifecycleState : std::uint8_t {
+  Available,
+  Creating,
+  Updating,
+  Deleting,
+  Deleted,
+  Error,
+};
+
+inline std::string_view to_string(LifecycleState s) {
+  switch (s) {
+    case LifecycleState::Available: return "AVAILABLE";
+    case LifecycleState::Creating:  return "CREATING";
+    case LifecycleState::Updating:  return "UPDATING";
+    case LifecycleState::Deleting:  return "DELETING";
+    case LifecycleState::Deleted:   return "DELETED";
+    case LifecycleState::Error:     return "ERROR";
+  }
+  return "UNKNOWN";
+}
+
+// ---------------------------------------------------------------- Errors
+
+struct StoreError {
+  enum class Kind : std::uint8_t {
+    NotFound,            // → ResourceNotFoundException (HTTP 404)
+    Conflict,            // → ConflictException (HTTP 409)
+    InvalidArgument,     // → ValidationException (HTTP 400)
+    QuotaExceeded,       // → ServiceQuotaExceededException (HTTP 402)
+    Throttled,           // → ThrottlingException (HTTP 429)
+    Internal,            // → InternalServerException (HTTP 500)
+  };
+  Kind kind;
+  std::string error_code;     // from rgw_s3files_errors.h, e.g. "FILE_SYSTEM_NOT_FOUND"
+  std::string message;        // human-readable, surfaced in the AWS message field
+};
+
+// Placeholder for void-returning methods — keeps StoreResult uniform.
+struct Unit {};
+
+template <typename T>
+using StoreResult = std::variant<T, StoreError>;
+
+template <typename T>
+inline bool ok(const StoreResult<T>& r) {
+  return std::holds_alternative<T>(r);
+}
+
+template <typename T>
+inline const T& value(const StoreResult<T>& r) {
+  return std::get<T>(r);
+}
+
+template <typename T>
+inline T&& take(StoreResult<T>&& r) {
+  return std::get<T>(std::move(r));
+}
+
+template <typename T>
+inline const StoreError& error(const StoreResult<T>& r) {
+  return std::get<StoreError>(r);
+}
+
+// ---------------------------------------------------------------- Tags
+
+struct Tag {
+  std::string key;
+  std::string value;
+
+  bool operator==(const Tag& o) const = default;
+};
+
+namespace detail {
+inline std::optional<std::string> name_from_tags(const std::vector<Tag>& tags) {
+  for (const auto& t : tags) {
+    if (t.key == "Name") {
+      return t.value;
+    }
+  }
+  return std::nullopt;
+}
+}  // namespace detail
+
+// ---------------------------------------------------------------- POSIX
+
+struct PosixUser {
+  std::int64_t uid = 0;
+  std::int64_t gid = 0;
+  std::vector<std::int64_t> secondary_gids;
+
+  bool operator==(const PosixUser& o) const = default;
+};
+
+struct CreationPermissions {
+  std::int64_t owner_uid = 0;
+  std::int64_t owner_gid = 0;
+  std::string permissions;  // e.g. "0755"
+
+  bool operator==(const CreationPermissions& o) const = default;
+};
+
+struct RootDirectory {
+  std::string path;
+  std::optional<CreationPermissions> creation_permissions;
+
+  bool operator==(const RootDirectory& o) const = default;
+};
+
+// ---------------------------------------------------------------- FileSystem
+
+struct FileSystemSpec {
+  std::string id;                 // server-assigned, e.g. "fs-<17-hex>"
+  std::string arn;                // server-assigned
+  std::string owner_account_id;
+  std::string bucket_arn;
+  std::string prefix;             // captured at create
+  std::string role_arn;
+  std::string kms_key_id;
+  std::string placement;          // captured Files-placement name
+  std::string client_token;
+  bool accept_bucket_warning = false;
+  std::vector<Tag> tags;
+  std::int64_t creation_time_unix_seconds = 0;
+};
+
+struct FileSystemStatus {
+  LifecycleState state = LifecycleState::Creating;
+  std::string status_message;
+};
+
+struct FileSystemView {
+  FileSystemSpec spec;
+  FileSystemStatus status;
+
+  // Convenience: the value of the `Name` tag if present
+  // (mirrors the AWS response field of the same name).
+  std::optional<std::string> name() const {
+    return detail::name_from_tags(spec.tags);
+  }
+};
+
+struct CreateFileSystemRequest {
+  std::string owner_account_id;
+  std::string bucket_arn;
+  std::string prefix;
+  std::string role_arn;
+  std::string kms_key_id;
+  std::string client_token;
+  std::string placement;          // optional; resolved from default if empty
+  std::vector<Tag> tags;
+  bool accept_bucket_warning = false;
+};
+
+// ---------------------------------------------------------------- AccessPoint
+
+struct AccessPointSpec {
+  std::string id;                 // server-assigned, e.g. "fsap-<17-hex>"
+  std::string arn;
+  std::string parent_filesystem_id;
+  std::string owner_account_id;
+  std::string client_token;
+  std::optional<PosixUser> posix_user;
+  std::optional<RootDirectory> root_directory;
+  std::vector<Tag> tags;
+};
+
+struct AccessPointStatus {
+  LifecycleState state = LifecycleState::Creating;
+  std::string status_message;
+};
+
+struct AccessPointView {
+  AccessPointSpec spec;
+  AccessPointStatus status;
+
+  std::optional<std::string> name() const {
+    return detail::name_from_tags(spec.tags);
+  }
+};
+
+struct CreateAccessPointRequest {
+  std::string owner_account_id;
+  std::string filesystem_id;
+  std::string client_token;
+  std::optional<PosixUser> posix_user;
+  std::optional<RootDirectory> root_directory;
+  std::vector<Tag> tags;
+};
+
+// ---------------------------------------------------------------- MountTarget
+
+struct MountTargetSpec {
+  std::string id;                 // server-assigned, e.g. "fsmt-<17-hex>"
+  std::string parent_filesystem_id;
+  std::string owner_account_id;
+  std::string zone_id;            // decoded from subnetId at the API layer
+  std::string ip_address_type;    // IPV4_ONLY etc.
+  std::vector<std::string> security_groups;
+};
+
+struct MountTargetStatus {
+  LifecycleState state = LifecycleState::Creating;
+  std::string status_message;
+  std::string ipv4_address;       // resolved by reconciler from placement
+  std::string ipv6_address;
+  std::string network_interface_id;
+  std::string vpc_id;
+};
+
+struct MountTargetView {
+  MountTargetSpec spec;
+  MountTargetStatus status;
+};
+
+struct CreateMountTargetRequest {
+  std::string owner_account_id;
+  std::string filesystem_id;
+  std::string zone_id;            // already decoded from subnetId
+  std::string ip_address_type;
+  std::vector<std::string> security_groups;
+};
+
+struct UpdateMountTargetRequest {
+  std::string id;
+  std::vector<std::string> security_groups;
+};
+
+// ---------------------------------------------------------------- Sync config
+
+struct ImportDataRule {
+  std::string prefix;
+  std::string trigger;            // ON_FILE_ACCESS or ON_DIRECTORY_FIRST_ACCESS
+  std::int64_t size_less_than = 0;
+
+  bool operator==(const ImportDataRule& o) const = default;
+};
+
+struct ExpirationDataRule {
+  std::int32_t days_after_last_access = 0;
+
+  bool operator==(const ExpirationDataRule& o) const = default;
+};
+
+struct SyncConfig {
+  std::vector<ImportDataRule> import_rules;
+  std::vector<ExpirationDataRule> expiration_rules;
+  std::int64_t latest_version_number = 0;
+};
+
+// ---------------------------------------------------------------- Listing
+
+struct ListOptions {
+  std::int32_t max_results = 100;
+  std::string next_token;
+};
+
+template <typename T>
+struct PagedResult {
+  std::vector<T> items;
+  std::string next_token;        // empty if no more pages
+};
+
+// ---------------------------------------------------------------- Store
+
+class Store {
+ public:
+  virtual ~Store() = default;
+
+  // FileSystem CRUD ------------------------------------------------
+
+  virtual StoreResult<FileSystemView> create_file_system(
+      const CreateFileSystemRequest& req) = 0;
+
+  virtual StoreResult<FileSystemView> get_file_system(
+      std::string_view account_id,
+      std::string_view filesystem_id) = 0;
+
+  virtual StoreResult<PagedResult<FileSystemView>> list_file_systems(
+      std::string_view account_id,
+      const ListOptions& opts) = 0;
+
+  virtual StoreResult<Unit> delete_file_system(
+      std::string_view account_id,
+      std::string_view filesystem_id) = 0;
+
+  // FileSystem resource policy --------------------------------------
+
+  virtual StoreResult<Unit> put_file_system_policy(
+      std::string_view account_id,
+      std::string_view filesystem_id,
+      std::string_view policy_json) = 0;
+
+  virtual StoreResult<std::string> get_file_system_policy(
+      std::string_view account_id,
+      std::string_view filesystem_id) = 0;
+
+  virtual StoreResult<Unit> delete_file_system_policy(
+      std::string_view account_id,
+      std::string_view filesystem_id) = 0;
+
+  // FileSystem synchronization configuration ------------------------
+
+  virtual StoreResult<Unit> put_synchronization_configuration(
+      std::string_view account_id,
+      std::string_view filesystem_id,
+      const SyncConfig& cfg,
+      std::optional<std::int64_t> expected_version) = 0;
+
+  virtual StoreResult<SyncConfig> get_synchronization_configuration(
+      std::string_view account_id,
+      std::string_view filesystem_id) = 0;
+
+  // AccessPoint CRUD -----------------------------------------------
+
+  virtual StoreResult<AccessPointView> create_access_point(
+      const CreateAccessPointRequest& req) = 0;
+
+  virtual StoreResult<AccessPointView> get_access_point(
+      std::string_view account_id,
+      std::string_view access_point_id) = 0;
+
+  virtual StoreResult<PagedResult<AccessPointView>> list_access_points(
+      std::string_view account_id,
+      std::string_view filesystem_id,
+      const ListOptions& opts) = 0;
+
+  virtual StoreResult<Unit> delete_access_point(
+      std::string_view account_id,
+      std::string_view access_point_id) = 0;
+
+  // MountTarget CRUD + Update ---------------------------------------
+
+  virtual StoreResult<MountTargetView> create_mount_target(
+      const CreateMountTargetRequest& req) = 0;
+
+  virtual StoreResult<MountTargetView> get_mount_target(
+      std::string_view account_id,
+      std::string_view mount_target_id) = 0;
+
+  virtual StoreResult<PagedResult<MountTargetView>> list_mount_targets(
+      std::string_view account_id,
+      std::optional<std::string_view> filesystem_id,
+      std::optional<std::string_view> access_point_id,
+      const ListOptions& opts) = 0;
+
+  virtual StoreResult<MountTargetView> update_mount_target(
+      std::string_view account_id,
+      const UpdateMountTargetRequest& req) = 0;
+
+  virtual StoreResult<Unit> delete_mount_target(
+      std::string_view account_id,
+      std::string_view mount_target_id) = 0;
+
+  // Tagging — FileSystem and AccessPoint only (per AWS ResourceId pattern)
+
+  virtual StoreResult<PagedResult<Tag>> list_tags_for_resource(
+      std::string_view account_id,
+      std::string_view resource_id,
+      const ListOptions& opts) = 0;
+
+  virtual StoreResult<Unit> tag_resource(
+      std::string_view account_id,
+      std::string_view resource_id,
+      const std::vector<Tag>& tags) = 0;
+
+  virtual StoreResult<Unit> untag_resource(
+      std::string_view account_id,
+      std::string_view resource_id,
+      const std::vector<std::string>& tag_keys) = 0;
+
+  // ---- admin / reconciler scan ------------------------------
+  //
+  // Read every record in the store, regardless of owner. These
+  // methods exist for the reconciler — which composes the
+  // desired Ganesha export set across all accounts known to
+  // the store — and should NOT be invoked from request-scoped
+  // handler code (which is always account-scoped).
+  //
+  // Implementations are expected to return a consistent
+  // snapshot: each scan_* method completes against state as it
+  // existed at some point during the call. There is no
+  // cross-method snapshot guarantee — the reconciler always
+  // runs the three scans back to back and must tolerate
+  // momentary inconsistencies (a FS that's about to gain an AP
+  // shows up before the AP does). The safety-net timer + post-
+  // mutation change-feed signal converge any lag.
+
+  virtual std::vector<FileSystemView> scan_file_systems() = 0;
+  virtual std::vector<AccessPointView> scan_access_points() = 0;
+  virtual std::vector<MountTargetView> scan_mount_targets() = 0;
+
+  // Register a callback to fire after every successful mutation
+  // — used by in-process change-feed wiring (typically with
+  // MemoryStore + InProcessChangeFeed, where the reconciler
+  // lives in the same process). Backends that have native
+  // change-feed mechanisms (RADOS watch/notify, FDB watches)
+  // ignore this hook; it's an opt-in extension for stores that
+  // don't carry their own out-of-band notification path.
+  //
+  // Default: no-op. MemoryStore overrides.
+  virtual void set_on_change(std::function<void()> /*cb*/) {}
+};
+
+}  // namespace rgw::file_state

--- a/src/rgw/rgw_s3files_errors.h
+++ b/src/rgw/rgw_s3files_errors.h
@@ -1,0 +1,70 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+//
+// Canonical errorCode string values returned in S3 Files API error
+// responses.
+//
+// Smithy declares the six exception types (ValidationException,
+// ConflictException, ResourceNotFoundException, ThrottlingException,
+// ServiceQuotaExceededException, InternalServerException) and their
+// HTTP status codes, but the inner `errorCode` member of each
+// exception is typed only as a non-empty string. AWS does not publish
+// its canonical errorCode values. This header is the single source of
+// truth for the values RGW returns; the Python mirror at
+// src/test/rgw/s3files/errors.py must be kept in sync.
+
+#pragma once
+
+#include <string_view>
+
+namespace rgw::s3files {
+
+// Validation (HTTP 400, ValidationException)
+inline constexpr std::string_view ERR_INVALID_BUCKET_ARN              = "INVALID_BUCKET_ARN";
+inline constexpr std::string_view ERR_INVALID_BUCKET_REGION           = "INVALID_BUCKET_REGION";
+inline constexpr std::string_view ERR_INVALID_ROLE_ARN                = "INVALID_ROLE_ARN";
+inline constexpr std::string_view ERR_INVALID_PREFIX                  = "INVALID_PREFIX";
+inline constexpr std::string_view ERR_INVALID_KMS_KEY                 = "INVALID_KMS_KEY";
+inline constexpr std::string_view ERR_INVALID_ROOT_DIRECTORY          = "INVALID_ROOT_DIRECTORY";
+inline constexpr std::string_view ERR_INVALID_POSIX_USER              = "INVALID_POSIX_USER";
+inline constexpr std::string_view ERR_INVALID_ZONE_ID                 = "INVALID_ZONE_ID";
+inline constexpr std::string_view ERR_ZONE_NOT_IN_ZONEGROUP           = "ZONE_NOT_IN_ZONEGROUP";
+inline constexpr std::string_view ERR_INVALID_POLICY_DOCUMENT         = "INVALID_POLICY_DOCUMENT";
+inline constexpr std::string_view ERR_INVALID_TAG_KEY                 = "INVALID_TAG_KEY";
+inline constexpr std::string_view ERR_INVALID_TAG_VALUE               = "INVALID_TAG_VALUE";
+inline constexpr std::string_view ERR_BUCKET_CONFIGURATION_WARNING    = "BUCKET_CONFIGURATION_WARNING";
+inline constexpr std::string_view ERR_INVALID_MAX_RESULTS             = "INVALID_MAX_RESULTS";
+inline constexpr std::string_view ERR_INVALID_SYNC_RULES              = "INVALID_SYNC_RULES";
+
+// Not-found (HTTP 404, ResourceNotFoundException)
+inline constexpr std::string_view ERR_BUCKET_NOT_FOUND                = "BUCKET_NOT_FOUND";
+inline constexpr std::string_view ERR_ROLE_NOT_FOUND                  = "ROLE_NOT_FOUND";
+inline constexpr std::string_view ERR_FILE_SYSTEM_NOT_FOUND           = "FILE_SYSTEM_NOT_FOUND";
+inline constexpr std::string_view ERR_ACCESS_POINT_NOT_FOUND          = "ACCESS_POINT_NOT_FOUND";
+inline constexpr std::string_view ERR_MOUNT_TARGET_NOT_FOUND          = "MOUNT_TARGET_NOT_FOUND";
+inline constexpr std::string_view ERR_POLICY_NOT_FOUND                = "POLICY_NOT_FOUND";
+
+// Conflict (HTTP 409, ConflictException)
+inline constexpr std::string_view ERR_FILE_SYSTEM_ALREADY_EXISTS      = "FILE_SYSTEM_ALREADY_EXISTS";
+inline constexpr std::string_view ERR_BUCKET_ALREADY_IN_USE           = "BUCKET_ALREADY_IN_USE";
+inline constexpr std::string_view ERR_FILE_SYSTEM_HAS_CHILDREN        = "FILE_SYSTEM_HAS_CHILDREN";
+inline constexpr std::string_view ERR_FILE_SYSTEM_IN_INVALID_STATE    = "FILE_SYSTEM_IN_INVALID_STATE";
+inline constexpr std::string_view ERR_MOUNT_TARGET_ALREADY_IN_ZONE    = "MOUNT_TARGET_ALREADY_EXISTS_IN_ZONE";
+inline constexpr std::string_view ERR_PLACEMENT_NOT_BOUND_IN_ZONE     = "PLACEMENT_NOT_BOUND_IN_ZONE";
+inline constexpr std::string_view ERR_UNRESOLVED_NFS_SERVICE          = "UNRESOLVED_NFS_SERVICE";
+
+// Quota (HTTP 402, ServiceQuotaExceededException)
+inline constexpr std::string_view ERR_TOO_MANY_FILE_SYSTEMS           = "TOO_MANY_FILE_SYSTEMS";
+inline constexpr std::string_view ERR_TOO_MANY_ACCESS_POINTS          = "TOO_MANY_ACCESS_POINTS";
+inline constexpr std::string_view ERR_TOO_MANY_MOUNT_TARGETS          = "TOO_MANY_MOUNT_TARGETS";
+inline constexpr std::string_view ERR_TOO_MANY_TAGS                   = "TOO_MANY_TAGS";
+inline constexpr std::string_view ERR_POLICY_TOO_LARGE                = "POLICY_TOO_LARGE";
+
+// Throttling (HTTP 429, ThrottlingException)
+inline constexpr std::string_view ERR_THROTTLED                       = "THROTTLED";
+
+// Server-side (HTTP 500, InternalServerException)
+inline constexpr std::string_view ERR_INTERNAL                        = "INTERNAL";
+inline constexpr std::string_view ERR_BACKEND_UNAVAILABLE             = "BACKEND_UNAVAILABLE";
+
+}  // namespace rgw::s3files

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -308,6 +308,21 @@ target_include_directories(unittest_rgw_arn
   SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
 target_link_libraries(unittest_rgw_arn ${rgw_libs})
 
+# unittest_rgw_file_state_memory_store
+# Substrate only: Store / MemoryStore / ChangeFeed. Self-contained --
+# compiles the sources directly into the test binary rather than
+# depending on rgw_libs, so the substrate can be reviewed and tested
+# without the REST surface or reconciler. The reconciler / GaneshaSink
+# layer lands in a later PR with its own test binary.
+add_executable(unittest_rgw_file_state_memory_store
+  test_file_state_memory_store.cc
+  ${CMAKE_SOURCE_DIR}/src/rgw/file_state/change_feed.cc
+  ${CMAKE_SOURCE_DIR}/src/rgw/file_state/memory_store.cc)
+add_ceph_unittest(unittest_rgw_file_state_memory_store)
+target_include_directories(unittest_rgw_file_state_memory_store
+  SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw"
+                 "${CMAKE_SOURCE_DIR}/src/rgw/file_state")
+
 # unittest_rgw_kms
 add_executable(unittest_rgw_kms test_rgw_kms.cc)
 add_ceph_unittest(unittest_rgw_kms)

--- a/src/test/rgw/test_file_state_memory_store.cc
+++ b/src/test/rgw/test_file_state_memory_store.cc
@@ -1,0 +1,603 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#include "file_state/change_feed.h"
+#include "file_state/memory_store.h"
+#include "rgw_s3files_errors.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <thread>
+#include <unordered_map>
+
+#include <gtest/gtest.h>
+
+using namespace rgw::file_state;
+using rgw::s3files::ERR_INVALID_BUCKET_ARN;
+using rgw::s3files::ERR_INVALID_ROLE_ARN;
+using rgw::s3files::ERR_INVALID_POLICY_DOCUMENT;
+using rgw::s3files::ERR_INVALID_POSIX_USER;
+using rgw::s3files::ERR_BUCKET_ALREADY_IN_USE;
+using rgw::s3files::ERR_FILE_SYSTEM_NOT_FOUND;
+using rgw::s3files::ERR_FILE_SYSTEM_HAS_CHILDREN;
+using rgw::s3files::ERR_FILE_SYSTEM_IN_INVALID_STATE;
+using rgw::s3files::ERR_ACCESS_POINT_NOT_FOUND;
+using rgw::s3files::ERR_MOUNT_TARGET_NOT_FOUND;
+using rgw::s3files::ERR_MOUNT_TARGET_ALREADY_IN_ZONE;
+using rgw::s3files::ERR_POLICY_NOT_FOUND;
+using rgw::s3files::ERR_INVALID_ZONE_ID;
+
+namespace {
+
+constexpr std::string_view kAccount = "1234567890";
+constexpr std::string_view kBucket  = "arn:aws:s3:::test-bucket";
+constexpr std::string_view kRole    = "arn:aws:iam::1234567890:role/test-role";
+constexpr std::string_view kZone    = "00000000000000000000000000000001";
+
+CreateFileSystemRequest minimum_fs_req() {
+  CreateFileSystemRequest req;
+  req.owner_account_id = kAccount;
+  req.bucket_arn = kBucket;
+  req.role_arn = kRole;
+  return req;
+}
+
+}  // namespace
+
+// =================================================================
+// FileSystem
+// =================================================================
+
+TEST(MemoryStore, CreateFileSystem_Minimum) {
+  MemoryStore s;
+  auto r = s.create_file_system(minimum_fs_req());
+  ASSERT_TRUE(ok(r)) << error(r).error_code;
+  const auto& fs = value(r);
+  EXPECT_FALSE(fs.spec.id.empty());
+  EXPECT_EQ(fs.spec.bucket_arn, kBucket);
+  EXPECT_EQ(fs.status.state, LifecycleState::Available);
+  EXPECT_TRUE(fs.spec.arn.find(fs.spec.id) != std::string::npos);
+}
+
+TEST(MemoryStore, CreateFileSystem_MissingBucket) {
+  MemoryStore s;
+  auto req = minimum_fs_req();
+  req.bucket_arn.clear();
+  auto r = s.create_file_system(req);
+  ASSERT_FALSE(ok(r));
+  EXPECT_EQ(error(r).kind, StoreError::Kind::InvalidArgument);
+  EXPECT_EQ(error(r).error_code, ERR_INVALID_BUCKET_ARN);
+}
+
+TEST(MemoryStore, CreateFileSystem_MissingRoleArn) {
+  MemoryStore s;
+  auto req = minimum_fs_req();
+  req.role_arn.clear();
+  auto r = s.create_file_system(req);
+  ASSERT_FALSE(ok(r));
+  EXPECT_EQ(error(r).error_code, ERR_INVALID_ROLE_ARN);
+}
+
+TEST(MemoryStore, CreateFileSystem_BucketAlreadyInUse) {
+  MemoryStore s;
+  ASSERT_TRUE(ok(s.create_file_system(minimum_fs_req())));
+  auto r = s.create_file_system(minimum_fs_req());
+  ASSERT_FALSE(ok(r));
+  EXPECT_EQ(error(r).kind, StoreError::Kind::Conflict);
+  EXPECT_EQ(error(r).error_code, ERR_BUCKET_ALREADY_IN_USE);
+}
+
+TEST(MemoryStore, CreateFileSystem_IdempotentClientToken) {
+  MemoryStore s;
+  auto req = minimum_fs_req();
+  req.client_token = "tok-1";
+  auto a = s.create_file_system(req);
+  ASSERT_TRUE(ok(a));
+  auto b = s.create_file_system(req);
+  ASSERT_TRUE(ok(b));
+  EXPECT_EQ(value(a).spec.id, value(b).spec.id);
+}
+
+TEST(MemoryStore, GetFileSystem_NotFound) {
+  MemoryStore s;
+  auto r = s.get_file_system(kAccount, "fs-doesnotexist");
+  ASSERT_FALSE(ok(r));
+  EXPECT_EQ(error(r).kind, StoreError::Kind::NotFound);
+  EXPECT_EQ(error(r).error_code, ERR_FILE_SYSTEM_NOT_FOUND);
+}
+
+TEST(MemoryStore, GetFileSystem_WrongAccount) {
+  MemoryStore s;
+  auto created = s.create_file_system(minimum_fs_req());
+  ASSERT_TRUE(ok(created));
+  auto r = s.get_file_system("9999999999", value(created).spec.id);
+  ASSERT_FALSE(ok(r));
+  EXPECT_EQ(error(r).error_code, ERR_FILE_SYSTEM_NOT_FOUND);
+}
+
+TEST(MemoryStore, ListFileSystems_FiltersByAccount) {
+  MemoryStore s;
+  auto a = s.create_file_system(minimum_fs_req());
+  ASSERT_TRUE(ok(a));
+
+  auto req2 = minimum_fs_req();
+  req2.owner_account_id = "9999999999";
+  req2.bucket_arn = "arn:aws:s3:::other-bucket";
+  ASSERT_TRUE(ok(s.create_file_system(req2)));
+
+  auto r = s.list_file_systems(kAccount, ListOptions{});
+  ASSERT_TRUE(ok(r));
+  EXPECT_EQ(value(r).items.size(), 1u);
+  EXPECT_EQ(value(r).items.front().spec.id, value(a).spec.id);
+}
+
+TEST(MemoryStore, DeleteFileSystem_RoundTrip) {
+  MemoryStore s;
+  auto fs = s.create_file_system(minimum_fs_req());
+  ASSERT_TRUE(ok(fs));
+  ASSERT_TRUE(ok(s.delete_file_system(kAccount, value(fs).spec.id)));
+  auto r = s.get_file_system(kAccount, value(fs).spec.id);
+  ASSERT_FALSE(ok(r));
+  EXPECT_EQ(error(r).error_code, ERR_FILE_SYSTEM_NOT_FOUND);
+}
+
+TEST(MemoryStore, DeleteFileSystem_NotFound) {
+  MemoryStore s;
+  auto r = s.delete_file_system(kAccount, "fs-doesnotexist");
+  ASSERT_FALSE(ok(r));
+  EXPECT_EQ(error(r).error_code, ERR_FILE_SYSTEM_NOT_FOUND);
+}
+
+// =================================================================
+// FileSystem policy
+// =================================================================
+
+TEST(MemoryStore, FileSystemPolicy_PutGetDelete) {
+  MemoryStore s;
+  auto fs = s.create_file_system(minimum_fs_req());
+  ASSERT_TRUE(ok(fs));
+  const auto& fs_id = value(fs).spec.id;
+
+  // No policy initially.
+  auto r1 = s.get_file_system_policy(kAccount, fs_id);
+  ASSERT_FALSE(ok(r1));
+  EXPECT_EQ(error(r1).error_code, ERR_POLICY_NOT_FOUND);
+
+  // Put.
+  std::string policy = R"({"Version":"2012-10-17"})";
+  ASSERT_TRUE(ok(s.put_file_system_policy(kAccount, fs_id, policy)));
+
+  // Get returns the same.
+  auto r2 = s.get_file_system_policy(kAccount, fs_id);
+  ASSERT_TRUE(ok(r2));
+  EXPECT_EQ(value(r2), policy);
+
+  // Delete.
+  ASSERT_TRUE(ok(s.delete_file_system_policy(kAccount, fs_id)));
+
+  // Now NotFound again.
+  auto r3 = s.get_file_system_policy(kAccount, fs_id);
+  ASSERT_FALSE(ok(r3));
+  EXPECT_EQ(error(r3).error_code, ERR_POLICY_NOT_FOUND);
+}
+
+TEST(MemoryStore, FileSystemPolicy_InvalidJson) {
+  MemoryStore s;
+  auto fs = s.create_file_system(minimum_fs_req());
+  ASSERT_TRUE(ok(fs));
+  auto r = s.put_file_system_policy(kAccount, value(fs).spec.id, "not-json{");
+  ASSERT_FALSE(ok(r));
+  EXPECT_EQ(error(r).error_code, ERR_INVALID_POLICY_DOCUMENT);
+}
+
+// =================================================================
+// SynchronizationConfiguration
+// =================================================================
+
+TEST(MemoryStore, SyncConfig_PutGet_VersionIncrements) {
+  MemoryStore s;
+  auto fs = s.create_file_system(minimum_fs_req());
+  ASSERT_TRUE(ok(fs));
+  const auto& fs_id = value(fs).spec.id;
+
+  SyncConfig cfg;
+  cfg.import_rules.push_back({"", "ON_FILE_ACCESS", 1024});
+  cfg.expiration_rules.push_back({30});
+
+  ASSERT_TRUE(ok(s.put_synchronization_configuration(
+      kAccount, fs_id, cfg, std::nullopt)));
+
+  auto r1 = s.get_synchronization_configuration(kAccount, fs_id);
+  ASSERT_TRUE(ok(r1));
+  EXPECT_EQ(value(r1).latest_version_number, 1);
+
+  // Subsequent put with matching expected_version succeeds and
+  // increments the version.
+  ASSERT_TRUE(ok(s.put_synchronization_configuration(
+      kAccount, fs_id, cfg, /*expected_version=*/1)));
+  auto r2 = s.get_synchronization_configuration(kAccount, fs_id);
+  ASSERT_TRUE(ok(r2));
+  EXPECT_EQ(value(r2).latest_version_number, 2);
+}
+
+TEST(MemoryStore, SyncConfig_VersionMismatch) {
+  MemoryStore s;
+  auto fs = s.create_file_system(minimum_fs_req());
+  ASSERT_TRUE(ok(fs));
+  SyncConfig cfg;
+  cfg.import_rules.push_back({"", "ON_FILE_ACCESS", 1024});
+  cfg.expiration_rules.push_back({30});
+  ASSERT_TRUE(ok(s.put_synchronization_configuration(
+      kAccount, value(fs).spec.id, cfg, std::nullopt)));
+
+  auto r = s.put_synchronization_configuration(
+      kAccount, value(fs).spec.id, cfg, /*expected_version=*/999);
+  ASSERT_FALSE(ok(r));
+  EXPECT_EQ(error(r).kind, StoreError::Kind::Conflict);
+}
+
+// =================================================================
+// AccessPoint
+// =================================================================
+
+TEST(MemoryStore, CreateAccessPoint_Minimum) {
+  MemoryStore s;
+  auto fs = s.create_file_system(minimum_fs_req());
+  ASSERT_TRUE(ok(fs));
+
+  CreateAccessPointRequest req;
+  req.owner_account_id = kAccount;
+  req.filesystem_id = value(fs).spec.id;
+
+  auto r = s.create_access_point(req);
+  ASSERT_TRUE(ok(r));
+  EXPECT_FALSE(value(r).spec.id.empty());
+  EXPECT_EQ(value(r).spec.parent_filesystem_id, value(fs).spec.id);
+  EXPECT_EQ(value(r).status.state, LifecycleState::Available);
+}
+
+TEST(MemoryStore, CreateAccessPoint_NonexistentFs) {
+  MemoryStore s;
+  CreateAccessPointRequest req;
+  req.owner_account_id = kAccount;
+  req.filesystem_id = "fs-doesnotexist";
+  auto r = s.create_access_point(req);
+  ASSERT_FALSE(ok(r));
+  EXPECT_EQ(error(r).error_code, ERR_FILE_SYSTEM_NOT_FOUND);
+}
+
+TEST(MemoryStore, CreateAccessPoint_InvalidPosixUser) {
+  MemoryStore s;
+  auto fs = s.create_file_system(minimum_fs_req());
+  ASSERT_TRUE(ok(fs));
+
+  CreateAccessPointRequest req;
+  req.owner_account_id = kAccount;
+  req.filesystem_id = value(fs).spec.id;
+  PosixUser pu;
+  pu.uid = -1;  // invalid
+  pu.gid = 0;
+  req.posix_user = pu;
+
+  auto r = s.create_access_point(req);
+  ASSERT_FALSE(ok(r));
+  EXPECT_EQ(error(r).error_code, ERR_INVALID_POSIX_USER);
+}
+
+TEST(MemoryStore, ListAccessPoints_FiltersByParentFs) {
+  MemoryStore s;
+  auto fs = s.create_file_system(minimum_fs_req());
+  ASSERT_TRUE(ok(fs));
+
+  CreateAccessPointRequest req;
+  req.owner_account_id = kAccount;
+  req.filesystem_id = value(fs).spec.id;
+  ASSERT_TRUE(ok(s.create_access_point(req)));
+  ASSERT_TRUE(ok(s.create_access_point(req)));
+
+  auto r = s.list_access_points(kAccount, value(fs).spec.id, ListOptions{});
+  ASSERT_TRUE(ok(r));
+  EXPECT_EQ(value(r).items.size(), 2u);
+}
+
+// =================================================================
+// MountTarget
+// =================================================================
+
+TEST(MemoryStore, CreateMountTarget_Minimum) {
+  MemoryStore s;
+  auto fs = s.create_file_system(minimum_fs_req());
+  ASSERT_TRUE(ok(fs));
+
+  CreateMountTargetRequest req;
+  req.owner_account_id = kAccount;
+  req.filesystem_id = value(fs).spec.id;
+  req.zone_id = std::string(kZone);
+
+  auto r = s.create_mount_target(req);
+  ASSERT_TRUE(ok(r));
+  EXPECT_EQ(value(r).spec.zone_id, kZone);
+  EXPECT_EQ(value(r).spec.ip_address_type, "IPV4_ONLY");
+}
+
+TEST(MemoryStore, CreateMountTarget_OnePerZone) {
+  MemoryStore s;
+  auto fs = s.create_file_system(minimum_fs_req());
+  ASSERT_TRUE(ok(fs));
+
+  CreateMountTargetRequest req;
+  req.owner_account_id = kAccount;
+  req.filesystem_id = value(fs).spec.id;
+  req.zone_id = std::string(kZone);
+  ASSERT_TRUE(ok(s.create_mount_target(req)));
+
+  auto r = s.create_mount_target(req);
+  ASSERT_FALSE(ok(r));
+  EXPECT_EQ(error(r).kind, StoreError::Kind::Conflict);
+  EXPECT_EQ(error(r).error_code, ERR_MOUNT_TARGET_ALREADY_IN_ZONE);
+}
+
+TEST(MemoryStore, CreateMountTarget_MissingZone) {
+  MemoryStore s;
+  auto fs = s.create_file_system(minimum_fs_req());
+  ASSERT_TRUE(ok(fs));
+
+  CreateMountTargetRequest req;
+  req.owner_account_id = kAccount;
+  req.filesystem_id = value(fs).spec.id;
+
+  auto r = s.create_mount_target(req);
+  ASSERT_FALSE(ok(r));
+  EXPECT_EQ(error(r).error_code, ERR_INVALID_ZONE_ID);
+}
+
+TEST(MemoryStore, UpdateMountTarget_SecurityGroups) {
+  MemoryStore s;
+  auto fs = s.create_file_system(minimum_fs_req());
+  ASSERT_TRUE(ok(fs));
+  CreateMountTargetRequest mreq;
+  mreq.owner_account_id = kAccount;
+  mreq.filesystem_id = value(fs).spec.id;
+  mreq.zone_id = std::string(kZone);
+  auto mt = s.create_mount_target(mreq);
+  ASSERT_TRUE(ok(mt));
+
+  UpdateMountTargetRequest ureq;
+  ureq.id = value(mt).spec.id;
+  ureq.security_groups = {"sg-1", "sg-2"};
+  auto upd = s.update_mount_target(kAccount, ureq);
+  ASSERT_TRUE(ok(upd));
+  EXPECT_EQ(value(upd).spec.security_groups,
+            (std::vector<std::string>{"sg-1", "sg-2"}));
+
+  auto got = s.get_mount_target(kAccount, value(mt).spec.id);
+  ASSERT_TRUE(ok(got));
+  EXPECT_EQ(value(got).spec.security_groups,
+            (std::vector<std::string>{"sg-1", "sg-2"}));
+}
+
+TEST(MemoryStore, ListMountTargets_FilteredByFs) {
+  MemoryStore s;
+  auto fs1 = s.create_file_system(minimum_fs_req());
+  ASSERT_TRUE(ok(fs1));
+
+  auto fs2_req = minimum_fs_req();
+  fs2_req.bucket_arn = "arn:aws:s3:::other-bucket";
+  auto fs2 = s.create_file_system(fs2_req);
+  ASSERT_TRUE(ok(fs2));
+
+  CreateMountTargetRequest mt1;
+  mt1.owner_account_id = kAccount;
+  mt1.filesystem_id = value(fs1).spec.id;
+  mt1.zone_id = std::string(kZone);
+  ASSERT_TRUE(ok(s.create_mount_target(mt1)));
+
+  CreateMountTargetRequest mt2;
+  mt2.owner_account_id = kAccount;
+  mt2.filesystem_id = value(fs2).spec.id;
+  mt2.zone_id = std::string(kZone);
+  ASSERT_TRUE(ok(s.create_mount_target(mt2)));
+
+  auto r = s.list_mount_targets(
+      kAccount, std::optional<std::string_view>{value(fs1).spec.id},
+      std::nullopt, ListOptions{});
+  ASSERT_TRUE(ok(r));
+  EXPECT_EQ(value(r).items.size(), 1u);
+  EXPECT_EQ(value(r).items.front().spec.parent_filesystem_id,
+            value(fs1).spec.id);
+}
+
+// =================================================================
+// Cascade
+// =================================================================
+
+TEST(MemoryStore, DeleteFileSystem_RejectsWithChildren) {
+  MemoryStore s;
+  auto fs = s.create_file_system(minimum_fs_req());
+  ASSERT_TRUE(ok(fs));
+  CreateAccessPointRequest req;
+  req.owner_account_id = kAccount;
+  req.filesystem_id = value(fs).spec.id;
+  auto ap = s.create_access_point(req);
+  ASSERT_TRUE(ok(ap));
+
+  auto r = s.delete_file_system(kAccount, value(fs).spec.id);
+  ASSERT_FALSE(ok(r));
+  EXPECT_EQ(error(r).kind, StoreError::Kind::Conflict);
+  EXPECT_EQ(error(r).error_code, ERR_FILE_SYSTEM_HAS_CHILDREN);
+
+  // Cleaning up the AP allows the FS delete to succeed.
+  ASSERT_TRUE(ok(s.delete_access_point(kAccount, value(ap).spec.id)));
+  ASSERT_TRUE(ok(s.delete_file_system(kAccount, value(fs).spec.id)));
+}
+
+// =================================================================
+// Tagging
+// =================================================================
+
+TEST(MemoryStore, Tagging_RoundTrip) {
+  MemoryStore s;
+  auto fs = s.create_file_system(minimum_fs_req());
+  ASSERT_TRUE(ok(fs));
+  const auto& fs_id = value(fs).spec.id;
+
+  std::vector<Tag> tags = {{"env", "ci"}, {"Name", "test"}};
+  ASSERT_TRUE(ok(s.tag_resource(kAccount, fs_id, tags)));
+
+  auto listed = s.list_tags_for_resource(kAccount, fs_id, ListOptions{});
+  ASSERT_TRUE(ok(listed));
+  EXPECT_EQ(value(listed).items.size(), 2u);
+
+  // A second tag_resource with the same key replaces the value.
+  ASSERT_TRUE(ok(s.tag_resource(kAccount, fs_id, {{"env", "prod"}})));
+  auto listed2 = s.list_tags_for_resource(kAccount, fs_id, ListOptions{});
+  ASSERT_TRUE(ok(listed2));
+  bool found = false;
+  for (const auto& t : value(listed2).items) {
+    if (t.key == "env") {
+      EXPECT_EQ(t.value, "prod");
+      found = true;
+    }
+  }
+  EXPECT_TRUE(found);
+
+  // Untag removes by key.
+  ASSERT_TRUE(ok(s.untag_resource(kAccount, fs_id, {"env"})));
+  auto listed3 = s.list_tags_for_resource(kAccount, fs_id, ListOptions{});
+  ASSERT_TRUE(ok(listed3));
+  for (const auto& t : value(listed3).items) {
+    EXPECT_NE(t.key, "env");
+  }
+}
+
+TEST(MemoryStore, Tagging_NameTagDrivesView) {
+  MemoryStore s;
+  auto req = minimum_fs_req();
+  req.tags = {{"Name", "the-name"}};
+  auto r = s.create_file_system(req);
+  ASSERT_TRUE(ok(r));
+  EXPECT_EQ(value(r).name(), "the-name");
+}
+
+TEST(MemoryStore, Tagging_NotFound) {
+  MemoryStore s;
+  auto r = s.tag_resource(kAccount, "fs-doesnotexist", {{"k", "v"}});
+  ASSERT_FALSE(ok(r));
+  EXPECT_EQ(error(r).kind, StoreError::Kind::NotFound);
+}
+
+// =================================================================
+// ChangeFeed
+// =================================================================
+
+TEST(ChangeFeed, InProcess_FiresAllSubscribers) {
+  InProcessChangeFeed feed;
+  std::atomic<int> a{0}, b{0};
+  feed.subscribe([&]{ a++; });
+  feed.subscribe([&]{ b++; });
+  feed.fire();
+  feed.fire();
+  EXPECT_EQ(a.load(), 2);
+  EXPECT_EQ(b.load(), 2);
+}
+
+TEST(ChangeFeed, InProcess_UnsubscribeStopsCallback) {
+  InProcessChangeFeed feed;
+  std::atomic<int> a{0}, b{0};
+  auto h_a = feed.subscribe([&]{ a++; });
+  feed.subscribe([&]{ b++; });
+  feed.fire();
+  feed.unsubscribe(h_a);
+  feed.fire();
+  EXPECT_EQ(a.load(), 1);
+  EXPECT_EQ(b.load(), 2);
+}
+
+TEST(ChangeFeed, Noop_NeverFires) {
+  NoopChangeFeed feed;
+  std::atomic<int> n{0};
+  feed.subscribe([&]{ n++; });  // accepted but never invoked
+  // No fire() — interface has none. The reconciler relies on the
+  // safety-net timer when paired with NoopChangeFeed.
+  EXPECT_EQ(n.load(), 0);
+}
+
+// =================================================================
+// MemoryStore + ChangeFeed wiring
+// =================================================================
+
+TEST(MemoryStore, OnChange_FiresAfterMutation) {
+  MemoryStore s;
+  std::atomic<int> n{0};
+  s.set_on_change([&]{ n++; });
+
+  // Mutations fire.
+  auto r = s.create_file_system(minimum_fs_req());
+  ASSERT_TRUE(ok(r));
+  EXPECT_EQ(n.load(), 1);
+
+  s.tag_resource(kAccount, value(r).spec.id, {{"k", "v"}});
+  EXPECT_EQ(n.load(), 2);
+
+  s.delete_file_system(kAccount, value(r).spec.id);
+  EXPECT_EQ(n.load(), 3);
+}
+
+TEST(MemoryStore, OnChange_DoesNotFireOnReads) {
+  MemoryStore s;
+  auto r = s.create_file_system(minimum_fs_req());
+  ASSERT_TRUE(ok(r));
+
+  // Wire the callback only AFTER the create so we can count
+  // reads in isolation.
+  std::atomic<int> n{0};
+  s.set_on_change([&]{ n++; });
+
+  s.get_file_system(kAccount, value(r).spec.id);
+  ListOptions opts;
+  s.list_file_systems(kAccount, opts);
+  EXPECT_EQ(n.load(), 0);
+
+  s.delete_file_system(kAccount, value(r).spec.id);  // mutation
+  EXPECT_EQ(n.load(), 1);
+}
+
+TEST(MemoryStore, OnChange_DoesNotFireOnFailedMutation) {
+  MemoryStore s;
+  std::atomic<int> n{0};
+  s.set_on_change([&]{ n++; });
+
+  // Invalid request: missing required field. Should not fire.
+  CreateFileSystemRequest bad;
+  bad.owner_account_id = kAccount;
+  // bucket_arn intentionally empty
+  bad.role_arn = kRole;
+  auto r = s.create_file_system(bad);
+  ASSERT_FALSE(ok(r));
+  EXPECT_EQ(n.load(), 0);
+}
+
+TEST(MemoryStore, OnChange_FiresThroughInProcessFeed) {
+  // The classic wiring: a feed subscribes, MemoryStore fires
+  // through it, downstream observer wakes.
+  MemoryStore s;
+  InProcessChangeFeed feed;
+  s.set_on_change([&feed]{ feed.fire(); });
+
+  std::atomic<int> reconciler_wakeups{0};
+  feed.subscribe([&]{ reconciler_wakeups++; });
+
+  auto r1 = s.create_file_system(minimum_fs_req());
+  ASSERT_TRUE(ok(r1));
+  CreateAccessPointRequest apreq;
+  apreq.owner_account_id = kAccount;
+  apreq.filesystem_id = value(r1).spec.id;
+  auto r2 = s.create_access_point(apreq);
+  ASSERT_TRUE(ok(r2));
+  s.delete_access_point(kAccount, value(r2).spec.id);
+
+  EXPECT_EQ(reconciler_wakeups.load(), 3);
+}


### PR DESCRIPTION
Part of the decomposition of #68852 (S3 Files API). The **inert state-layer substrate** the S3 Files REST surface and reconciler are built on. No REST handlers, no radosgw wiring, no behavior change — nothing in librgw references these sources yet (`src/rgw/CMakeLists.txt` is intentionally untouched); they are exercised solely by a self-contained unit test. Independent of the other day-one PRs.

- `src/rgw/file_state/store.h` — the `Store` interface (FileSystem / AccessPoint / MountTarget / tag / policy / sync-config records, typed error space, `ChangeFeed` handle).
- `src/rgw/file_state/memory_store.{cc,h}` — `MemoryStore`, the in-process reference Store used today (FoundationDB-backed Store is design-only, #65535).
- `src/rgw/file_state/change_feed.{cc,h}` — `ChangeFeed` interface + Noop / in-process implementations.
- `src/rgw/rgw_s3files_errors.h` — the shared `errorCode` catalog.
- `src/test/rgw/test_file_state_memory_store.cc` + a self-contained `unittest_rgw_file_state_memory_store` target (compiled directly, no `rgw_libs` dependency).

The reconciler / GaneshaSink half lands in a later PR with its own test binary.

**Validation:** `unittest_rgw_file_state_memory_store` built standalone on the decomposition base and **34/34 tests pass**.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
