### PR TITLE
.github/workflows/releng-audit: remove override on reopen

### DIFF
--- a/.github/workflows/releng-audit.yaml
+++ b/.github/workflows/releng-audit.yaml
@@ -10,6 +10,11 @@ on:
   issue_comment:
     types: [created]
 
+# Group concurrency by PR/Issue number to serialize executions and prevent race conditions
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: false
+
 jobs:
   audit:
     name: Backport Audit

--- a/.github/workflows/releng-audit.yaml
+++ b/.github/workflows/releng-audit.yaml
@@ -31,6 +31,31 @@ jobs:
             const actor = context.actor;
             const isBot = actor === 'github-actions[bot]' || actor === 'github-actions';
             
+            async function checkAuthorization(username) {
+              let authorized = false;
+              try {
+                const { data: permData } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner: context.repo.owner, repo: context.repo.repo, username: username
+                });
+                authorized = (permData.permission === 'admin' || permData.permission === 'maintain')
+              } catch (e) { 
+                core.info(`[Router] Failed to fetch repo permissions: ${e.message}`); 
+              }
+
+              if (!authorized && context.repo.owner === 'ceph' && process.env.ORG_TOKEN) {
+                try {
+                  const orgOctokit = github.getOctokit(process.env.ORG_TOKEN);
+                  const { data: teamData } = await orgOctokit.rest.teams.getMembershipForUserInOrg({
+                    org: 'ceph', team_slug: 'ceph-release-manager', username: username
+                  });
+                  authorized = (teamData.state === 'active');
+                } catch (e) { 
+                  core.info(`[Router] Failed to fetch org team membership: ${e.message}`); 
+                }
+              }
+              return authorized;
+            }
+
             core.info(`[Router] Evaluating event: ${eventName}, action: ${payload.action || 'N/A'}`);
 
             // ==========================================
@@ -54,27 +79,7 @@ jobs:
               
               if (commentBody.startsWith('/audit override')) {
                 core.info(`[Router] Validating if user @${actor} is authorized to apply override.`);
-                let isAuthorized = false;
-                try {
-                  const { data: permData } = await github.rest.repos.getCollaboratorPermissionLevel({
-                    owner: context.repo.owner, repo: context.repo.repo, username: actor
-                  });
-                  if (permData.permission === 'admin' || permData.permission === 'maintain') isAuthorized = true;
-                } catch (e) { 
-                  core.info(`[Router] Failed to fetch repo permissions: ${e.message}`); 
-                }
-
-                if (!isAuthorized && context.repo.owner === 'ceph' && process.env.ORG_TOKEN) {
-                  try {
-                    const orgOctokit = github.getOctokit(process.env.ORG_TOKEN);
-                    const { data: teamData } = await orgOctokit.rest.teams.getMembershipForUserInOrg({
-                      org: 'ceph', team_slug: 'ceph-release-manager', username: actor
-                    });
-                    isAuthorized = (teamData.state === 'active');
-                  } catch (e) { 
-                    core.info(`[Router] Failed to fetch org team membership: ${e.message}`); 
-                  }
-                }
+                const isAuthorized = await checkAuthorization(actor);
                 
                 if (isAuthorized) {
                   core.info(`[Router] User @${actor} is authorized. Applying override and stripping fail label.`);
@@ -198,23 +203,7 @@ jobs:
               if (labelName === 'releng-audit-override') {
                 if (!isBot) {
                   core.info(`[Router] Validating if user @${actor} is authorized to apply override.`);
-                  let isAuthorized = false;
-                  try {
-                    const { data: permData } = await github.rest.repos.getCollaboratorPermissionLevel({ owner: context.repo.owner, repo: context.repo.repo, username: actor });
-                    if (permData.permission === 'admin' || permData.permission === 'maintain') isAuthorized = true;
-                  } catch (e) {
-                    core.info(`[Router] Failed to fetch repo permissions: ${e.message}`);
-                  }
-
-                  if (!isAuthorized && context.repo.owner === 'ceph' && process.env.ORG_TOKEN) {
-                    try {
-                      const orgOctokit = github.getOctokit(process.env.ORG_TOKEN);
-                      const { data: teamData } = await orgOctokit.rest.teams.getMembershipForUserInOrg({ org: 'ceph', team_slug: 'ceph-release-manager', username: actor });
-                      isAuthorized = (teamData.state === 'active');
-                    } catch (e) {
-                      core.info(`[Router] Failed to fetch org team membership: ${e.message}`);
-                    }
-                  }
+                  const isAuthorized = await checkAuthorization(actor);
 
                   if (!isAuthorized) {
                     core.info(`[Router] User @${actor} NOT authorized. Removing override label.`);

--- a/.github/workflows/releng-audit.yaml
+++ b/.github/workflows/releng-audit.yaml
@@ -227,6 +227,20 @@ jobs:
             // --- OPENED / REOPENED ---
             if (eventName === 'pull_request_target' && (payload.action === 'opened' || payload.action === 'reopened')) {
               core.info(`[Router] PR ${payload.action}. Triggering audit.`);
+              
+              if (payload.action === 'reopened' && hasOverrideLabel) {
+                core.info('[Router] PR had override label. Removing it on reopen.');
+                try {
+                  await github.rest.issues.removeLabel({ owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, name: 'releng-audit-override' });
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number,
+                    body: '⚠️ **Audit Override Removed**\n\nThis PR was reopened, so the previous `releng-audit-override` has been removed.'
+                  });
+                } catch (e) {
+                  core.info(`[Router] Failed to remove override label: ${e.message}`);
+                }
+              }
+
               core.setOutput('run_audit', 'true');
               return;
             }


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
