### PR TITLE
doc/dev: refresh vstart.sh options in dev_cluster_deployment

### DIFF
--- a/doc/dev/dev_cluster_deployment.rst
+++ b/doc/dev/dev_cluster_deployment.rst
@@ -16,6 +16,9 @@ To start your development cluster, type the following::
 
 	vstart.sh [OPTIONS]...
 
+On a fresh build, the first run must create the cluster by passing ``-n``;
+later runs can omit it to restart and reuse the existing cluster.
+
 In order to stop the cluster, you can type::
 
 	./stop.sh
@@ -23,9 +26,13 @@ In order to stop the cluster, you can type::
 Options
 =======
 
+The most common options are listed below.  ``vstart.sh`` accepts many more
+(crimson, seastore, msgr versions, bluestore devices, and so on); see the
+``usage`` text near the top of ``src/vstart.sh`` for the complete list.
+
 .. option:: -b, --bluestore
 
-    Use bluestore as the objectstore backend for osds.
+    Use bluestore as the objectstore backend for osds.  This is the default.
 
 .. option:: --cache <pool>
 
@@ -51,10 +58,6 @@ Options
 
     Keep old configuration files instead of overwriting these.
 
-.. option:: -K, --kstore
-
-    Use kstore as the osd objectstore backend.
-
 .. option:: -l, --localhost
 
     Use localhost instead of hostname.
@@ -73,11 +76,8 @@ Options
 
 .. option:: -n, --new
 
-    Create a new cluster.
-
-.. option:: -N, --not-new
-
-    Reuse existing cluster config (default).
+    Create a new cluster, replacing any existing one.  Without this flag,
+    ``vstart.sh`` reuses the existing cluster config; that is the default.
 
 .. option:: --nodaemon
 
@@ -97,7 +97,7 @@ Options
 
 .. option:: --rgw_frontend <frontend>
 
-    Specify the rgw frontend configuration (default is civetweb).
+    Specify the rgw frontend configuration (default is beast).
 
 .. option:: --rgw_compression <compression_type>
 
@@ -137,7 +137,7 @@ These environment variables will contains the number of instances of the desired
 
 Example: ::
 
-	OSD=3 MON=3 RGW=1 vstart.sh
+	OSD=3 MON=3 RGW=1 vstart.sh -n
 
 
 ============================================================


### PR DESCRIPTION
Bring doc/dev/dev_cluster_deployment.rst back in line with the current src/vstart.sh:

* drop the removed `-K`/`--kstore` objectstore backend
* drop -N/--not-new, which was dropped in 8dd2e418; reusing the existing cluster config is simply the default when -n is not given
* correct the `--rgw_frontend` default from civetweb to beast
* note that `-b`/`--bluestore` is the default objectstore backend
* update the example and add a note that a fresh build needs -n on the first run, while later runs can omit it
* note that the option list is not exhaustive and point at `src/vstart.sh`

Fixes: https://tracker.ceph.com/issues/57272





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
