### PR TITLE
osd,crimson/osd: build with -fno-omit-frame-pointer

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -839,6 +839,7 @@ set(ceph_osd_srcs
   ceph_osd.cc)
 
 add_executable(ceph-osd ${ceph_osd_srcs})
+target_compile_options(ceph-osd PRIVATE -fno-omit-frame-pointer)
 add_dependencies(ceph-osd erasure_code_plugins extblkdev_plugins)
 target_link_libraries(ceph-osd osd os global-static common
   ${ALLOC_LIBS}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -668,6 +668,7 @@ if(WITH_BREAKPAD)
 endif()
 
 add_library(common STATIC ${ceph_common_objs})
+target_compile_options(common PRIVATE -fno-omit-frame-pointer)
 target_link_libraries(common
   ${ceph_common_deps}
   legacy-option-headers)

--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -141,6 +141,7 @@ target_compile_definitions(crimson-common PRIVATE
   "CEPH_INSTALL_FULL_PKGLIBDIR=\"${CEPH_INSTALL_FULL_PKGLIBDIR}\""
   "CEPH_INSTALL_DATADIR=\"${CEPH_INSTALL_DATADIR}\"")
 
+target_compile_options(crimson-common PRIVATE -fno-omit-frame-pointer)
 target_link_libraries(crimson-common
   PUBLIC
     $<$<BOOL:${WITH_JAEGER}>:jaeger_base>
@@ -192,7 +193,8 @@ add_library(crimson STATIC
   ${crimson_mon_srcs}
   ${crimson_net_srcs})
 target_compile_options(crimson PUBLIC
-  "-ftemplate-backtrace-limit=0")
+  "-ftemplate-backtrace-limit=0"
+  PRIVATE -fno-omit-frame-pointer)
 set_target_properties(crimson PROPERTIES
   JOB_POOL_COMPILE heavy_compile_job_pool)
 target_link_libraries(crimson

--- a/src/crimson/admin/CMakeLists.txt
+++ b/src/crimson/admin/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(crimson-admin STATIC
   admin_socket.cc
   osd_admin.cc
   pg_commands.cc)
+target_compile_options(crimson-admin PRIVATE -fno-omit-frame-pointer)
 target_link_libraries(crimson-admin
   legacy-option-headers
   crimson::cflags

--- a/src/crimson/os/CMakeLists.txt
+++ b/src/crimson/os/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(crimson-os STATIC
   futurized_store.cc
   ${PROJECT_SOURCE_DIR}/src/os/Transaction.cc)
+target_compile_options(crimson-os PRIVATE -fno-omit-frame-pointer)
 add_subdirectory(cyanstore)
 
 if(WITH_BLUESTORE)

--- a/src/crimson/osd/CMakeLists.txt
+++ b/src/crimson/osd/CMakeLists.txt
@@ -69,6 +69,7 @@ if(HAS_VTA)
   set_source_files_properties(main.cc
     PROPERTIES COMPILE_FLAGS -fno-var-tracking-assignments)
 endif()
+target_compile_options(crimson-osd PRIVATE -fno-omit-frame-pointer)
 target_link_libraries(crimson-osd
   legacy-option-headers
   crimson-admin

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(os STATIC
   ObjectStore.cc
   Transaction.cc)
+target_compile_options(os PRIVATE -fno-omit-frame-pointer)
 
 target_link_libraries(os
   PRIVATE

--- a/src/osd/CMakeLists.txt
+++ b/src/osd/CMakeLists.txt
@@ -62,6 +62,7 @@ if(HAS_VTA)
     PROPERTIES COMPILE_FLAGS -fno-var-tracking-assignments)
 endif()
 add_library(osd STATIC ${osd_srcs})
+target_compile_options(osd PRIVATE -fno-omit-frame-pointer)
 target_link_libraries(osd
   PUBLIC dmclock::dmclock Boost::MPL
   PRIVATE


### PR DESCRIPTION
... to facilitate better stack traces in OSD crashes.

Traceback is not available, unless either the full debug-info files (which are not collected
by Teuthology) are available, or the frame-pointers chain is maintained.
The main C++ compilers made 'omit-frame-pointer' the default a while back, vastly complocating
debugging.

This PR only affects the OSD and the Common library, limiting the (already minimal) performance
effect of this change.

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>