### PR TITLE
tentacle: librbd/pwl: fix memory leaks in discard operations

### DIFF
--- a/src/librbd/cache/pwl/Request.h
+++ b/src/librbd/cache/pwl/Request.h
@@ -246,7 +246,7 @@ public:
                    PerfCounters *perfcounter, Context *user_req);
 
   ~C_DiscardRequest() override;
-  void finish_req(int r) override {}
+  void finish_req(int r) override;
 
   bool alloc_resources() override;
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75077

---

backport of https://github.com/ceph/ceph/pull/66876
parent tracker: https://tracker.ceph.com/issues/74972

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh