### PR TITLE
squid: rgw: account presigned POST bytes_received in usage log

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1227,7 +1227,9 @@ int RGWPostObj_ObjStore::read_with_boundary(ceph::bufferlist& bl,
 
     bufferptr bp(need_to_read);
 
+    ACCOUNTING_IO(s)->set_account(true);
     const auto read_len = recv_body(s, bp.c_str(), need_to_read);
+    ACCOUNTING_IO(s)->set_account(false);
     if (read_len < 0) {
       return read_len;
     }
@@ -1259,7 +1261,9 @@ int RGWPostObj_ObjStore::read_with_boundary(ceph::bufferlist& bl,
     if (left < skip + 2) {
       int need = skip + 2 - left;
       bufferptr boundary_bp(need);
+      ACCOUNTING_IO(s)->set_account(true);
       const int r = recv_body(s, boundary_bp.c_str(), need);
+      ACCOUNTING_IO(s)->set_account(false);
       if (r < 0) {
         return r;
       }


### PR DESCRIPTION
Cherry-pick of 7d2484c45b4b7ec0129e701717e83ef20a52b753 to squid.

Presigned POST uploads reported `bytes_received=0` in the usage log, while
equivalent PUT uploads reported the full object size.

The `AccountingFilter` starts disabled, and only the PUT path explicitly
enables it around its body read. POST bodies are consumed via
`RGWPostObj_ObjStore::read_with_boundary`, which did not toggle accounting
around its `recv_body` calls, so every byte pulled off the wire during
multipart parsing was silently dropped by the accounter.

Wrap the two `recv_body` calls in `read_with_boundary` with
`ACCOUNTING_IO(s)->set_account(true/false)`, mirroring the PUT pattern in
`RGWPutObj_ObjStore::get_data`. POST uploads now account correctly; PUT
behavior is unchanged.

Tracker: https://tracker.ceph.com/issues/76625

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [x] No tests