### PR TITLE
crimson/os/seastore: fix cleaner stall under IO-block pressure

### DIFF
--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -1433,9 +1433,12 @@ public:
       return false;
     }
     auto aratio = segments.get_available_ratio();
+    auto projected_aratio = get_projected_available_ratio();
     auto rratio = get_reclaim_ratio();
+    // should_block_io_on_clean() uses projected ratio; mirror that here so the
+    // cleaner wakes whenever IO would block, not only when actual space is low.
     return (
-      (aratio < config.available_ratio_hard_limit) ||
+      (projected_aratio < config.available_ratio_hard_limit) ||
       ((aratio < config.available_ratio_gc_max) &&
        (rratio > config.reclaim_ratio_gc_threshold))
     );

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -807,6 +807,11 @@ ExtentPlacementManager::BackgroundProcess::maybe_wake_blocked_io()
     DEBUG("");
     blocking_io->set_value();
     blocking_io = std::nullopt;
+    // Remember that we just woke a blocked IO; run() yields once on
+    // this edge so the woken continuation has a chance to retry the
+    // reservation before the cleaner spins another cycle and consumes
+    // the projected_avail headroom we just freed.
+    pending_user_io_wake = true;
   }
 }
 
@@ -818,6 +823,12 @@ ExtentPlacementManager::BackgroundProcess::run()
     if (background_should_run()) {
       log_state("run(background)");
       co_await do_background_cycle();
+      // Edge-triggered: yield only when a blocked IO was actually woken, so the
+      // resumed continuation retries try_reserve_io() before the next cycle runs.
+      if (pending_user_io_wake) {
+        pending_user_io_wake = false;
+        co_await seastar::yield();
+      }
     } else {
       log_state("run(block)");
       assert(!blocking_background);

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -755,8 +755,14 @@ ExtentPlacementManager::BackgroundProcess::reserve_projected_usage(
     ++stats.io_blocked_count;
     stats.io_blocked_sum += stats.io_blocking_num;
 
-    blocking_io = seastar::promise<>();
     auto begin_time = seastar::lowres_system_clock::now();
+    // IO blocked -> needs cleaner -> cleaner sleeping -> nothing runs -> deadlock.
+    // Kick the background so it can free space and call maybe_wake_blocked_io().
+    auto arm_blocking_io_and_wake = [this] {
+      blocking_io = seastar::promise<>();
+      do_wake_background();
+    };
+    arm_blocking_io_and_wake();
     // we just blocked this IO, now wait until
     // maybe_wake_blocked_io will set value to blocking_io
     do {
@@ -784,7 +790,7 @@ ExtentPlacementManager::BackgroundProcess::reserve_projected_usage(
           if (!res.cleaner_result.is_successful()) {
           ++stats.io_retried_blocked_count_clean;
         }
-        blocking_io = seastar::promise<>();
+        arm_blocking_io_and_wake();
       }
     } while (blocking_io);
   }

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -1124,6 +1124,11 @@ private:
     std::optional<seastar::future<>> process_join;
     std::optional<seastar::promise<>> blocking_background;
     std::optional<seastar::promise<>> blocking_io;
+    // Set by maybe_wake_blocked_io() whenever it actually unblocks a
+    // user IO; consumed by run() to yield exactly once on that edge,
+    // giving the woken continuation a chance to retry the reservation
+    // before the next background cycle.
+    bool pending_user_io_wake = false;
     bool is_running_until_halt = false;
     state_t state = state_t::STOP;
     eviction_state_t eviction_state;


### PR DESCRIPTION
This series fixes two coordination bugs in `SegmentCleaner` that
together caused OSDs to deadlock under sustained write pressure at
moderate cluster fill levels. Observed in the
`qa/standalone/crimson/test_multi_osd.sh` randwrite reproducer at ~70%
full: one OSD froze with the cleaner stopped and 32 slow ops blocked
indefinitely (4000+ seconds), with no `ceph_abort`. The OSD process
stays alive but cannot accept new writes.

## Commit 1: fix IO-block deadlock when cleaner is sleeping

Two coordinated changes that together close a missed-wake-up:

1. `SegmentCleaner::should_clean_space()` used
   `segments.get_available_ratio()` (actual ratio) while
   `should_block_io_on_clean()` used `get_projected_available_ratio()`
   (actual minus in-flight reservations). When the actual ratio sat
   just above `available_ratio_hard_limit` but the projected ratio
   dipped below it, IO would block while the cleaner slept. Now
   `should_clean_space()` also trips on the projected ratio.

2. `BackgroundProcess::reserve_projected_usage()` did not wake the
   background process when an IO blocked. With the cleaner asleep and
   all IO blocked, nothing called `maybe_wake_blocked_io()` (no
   `release_projected_usage` runs without completing IO; no segment
   release runs without the cleaner). Now kicks `do_wake_background()`
   at the point of blocking.

## Commit 2: yield to user IO between cleaner cycles

After commit 1, the cleaner stays awake but its tight
allocate-and-fill loop never gives the woken user-IO continuation a
chance to retry `try_reserve_io()` before the cleaner consumes the
`projected_avail` headroom again. The user IO retries fail and
re-block immediately, starving user IO at high alive_ratio.

Adds a `seastar::yield()` in `BackgroundProcess::run()` between
background cycles when an IO is blocked, so the user-IO continuation
slots in and completes a reservation before the next cycle.

## Reproducer

`qa/standalone/crimson/test_multi_osd.sh` at ~70% full random write:

| | Before | After |
|---|---|---|
| Cleaner state on the affected OSD | frozen at `alive_ratio` ~0.79 | actively reclaiming |
| Slow ops blocked | 32 ops for 4000+ s | none |
| `user_written` before stall | 535 GB | 1,374 GB (target 1,280 GB) |
| Bench duration | 9 min, then dead | 34 min, target reached |

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).
- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.
- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests