### PR TITLE
rgw/dedup: support server-side compressed object deduplication

### DIFF
--- a/doc/radosgw/s3_objects_dedup.rst
+++ b/doc/radosgw/s3_objects_dedup.rst
@@ -138,6 +138,30 @@ Next, it iterates through these dedup candidate objects, reading their complete
 information from the object metadata, a per-object RADOS operation. During
 this step, **user-encrypted** objects are removed from consideration.
 
+Dedup source selection
+----------------------
+
+When several objects share the same dedup key (MD5 etag and logical size), dedup
+chooses one as the **source** (SRC). All other copies become **targets** that
+will share the source tail objects. Source selection uses the dedup table built
+from bucket indices and updated as object metadata is read:
+
+#. An object that is already a source from a prior dedup cycle (marked with a
+   shared manifest) is never replaced.
+#. Otherwise, prefer objects whose server-side compression matches the
+   compression type configured on the tail **placement rule** (exact match).
+#. If no exact match exists, prefer objects that are compressed with a
+   different algorithm over uncompressed objects (partial match).
+#. Otherwise keep the first valid candidate.
+
+The placement compression type is taken from the zone's **current** placement
+configuration, not from the setting in effect when each object was uploaded.
+
+Next, we iterate through these dedup candidate objects, reading their complete
+information from the object metadata (a per-object RADOS operation). During
+this step, we filter out **user-encrypted** objects.
+>>>>>>> 4322f69d777 (qa/rgw: fix dedup teuthology zone setup and dedup tests refactoring)
+
 At this point, the dedup candidates are objects whose MD5 hash and size are
 identical -- the likelihood of a false positive is vanishingly small for
 naturally occurring data. To provide a cryptographic guarantee and guard
@@ -157,11 +181,32 @@ set ``rgw_dedup_skip_compressed = true`` in the configuration.
 If the objects' strong hash matches, we proceed with the deduplication:
 
 - Increment the reference count on the source tail objects one by one.
-- Copy the manifest from the source to the target.
+- Replace the target manifest and tail objects entirely with the source's
+  (the target's previous tail layout is freed).
 - Mirror the compression attribute (``RGW_ATTR_COMPRESSION``) from source to
   target: if the source is compressed the attribute is copied to the target;
   if the source is uncompressed the attribute is removed from the target.
 - Remove all tail objects on the target.
+
+Cross-mode compression
+----------------------
+
+Compressed and uncompressed copies of the same logical content can land in the
+same dedup candidate set because dedup keys use **logical** (uncompressed) size
+from the bucket index, not on-disk compressed size.
+
+When dedup succeeds between mixed compression states, each target adopts the
+source manifest, tail objects, and compression attribute. Because source
+selection prefers objects that match **current** placement compression, all
+deduped copies typically converge on the compression state implied by the
+zone's placement policy at dedup time -- not on the mode each object had when
+it was uploaded. For example, if placement compression was disabled and later
+re-enabled, dedup may rewrite older uncompressed copies to share compressed
+tail objects from a source that matches the current placement.
+
+In incremental dedup, a source established in an earlier cycle keeps shared-
+manifest priority even when newer copies would match current placement
+compression more closely.
 
 Split Head Mode
 ===============

--- a/doc/radosgw/s3_objects_dedup.rst
+++ b/doc/radosgw/s3_objects_dedup.rst
@@ -80,12 +80,17 @@ The dedup estimate process skips the following RGW objects:
 - Objects with different RGW storage classes.
 
 The full dedup process skips all of the above and additionally skips
-**compressed** and **user-encrypted** objects.
+**user-encrypted** objects.  Server-side **compressed** objects can
+optionally be skipped by setting :confval:`rgw_dedup_skip_compressed`.
 
 The minimum RGW object size to be deduplicated is controlled by the following
 configuration option:
 
 .. confval:: rgw_dedup_min_obj_size_for_dedup
+
+Compressed objects are deduplicated by default.  To skip them:
+
+.. confval:: rgw_dedup_skip_compressed
 
 
 Estimate Processing
@@ -131,16 +136,31 @@ leaving only dedup candidates.
 
 Next, it iterates through these dedup candidate objects, reading their complete
 information from the object metadata, a per-object RADOS operation. During
-this step, **compressed** and **user-encrypted** objects are removed from
-consideration.
+this step, **user-encrypted** objects are removed from consideration.
 
-Following this, we calculate a cryptographically strong hash of candidate
-object data. This involves a full-object read, which is a resource-intensive
-operation. The hash ensures that dedup candidates are indeed perfect
-matches. If they are, we proceed with deduplication:
+At this point, the dedup candidates are objects whose MD5 hash and size are
+identical -- the likelihood of a false positive is vanishingly small for
+naturally occurring data. To provide a cryptographic guarantee and guard
+against crafted MD5 collisions ensuring that dedup candidates are indeed perfect
+matches, we calculate a strong hash (Blake3) over the
+full object data. This requires reading the entire object, with cost
+proportional to object size -- but the potential dedup savings also grow with
+size, and at this stage deduplication is almost certain to succeed.
+
+For compressed objects the hash is calculated on the uncompressed data -- each
+compression block is decompressed on-the-fly and fed to the hasher, so memory
+usage stays bounded regardless of object size. This adds CPU cost for
+decompression, though at this stage deduplication is almost certain to succeed
+and the savings will justify the overhead. To skip compressed objects entirely,
+set ``rgw_dedup_skip_compressed = true`` in the configuration.
+
+If the objects' strong hash matches, we proceed with the deduplication:
 
 - Increment the reference count on the source tail objects one by one.
 - Copy the manifest from the source to the target.
+- Mirror the compression attribute (``RGW_ATTR_COMPRESSION``) from source to
+  target: if the source is compressed the attribute is copied to the target;
+  if the source is uncompressed the attribute is removed from the target.
 - Remove all tail objects on the target.
 
 Split Head Mode

--- a/doc/radosgw/s3_objects_dedup.rst
+++ b/doc/radosgw/s3_objects_dedup.rst
@@ -101,12 +101,17 @@ The dedup estimate process skips the following RGW objects:
   split-head which is unavailable on such pools)
 
 The full dedup process skips all of the above and additionally skips
-**compressed** and **user-encrypted** objects.
+**user-encrypted** objects.  Server-side **compressed** objects can
+optionally be skipped by setting :confval:`rgw_dedup_skip_compressed`.
 
 The minimum RGW object size to be deduplicated is controlled by the following
 configuration option:
 
 .. confval:: rgw_dedup_min_obj_size_for_dedup
+
+Compressed objects are deduplicated by default.  To skip them:
+
+.. confval:: rgw_dedup_skip_compressed
 
 
 Estimate Processing
@@ -152,16 +157,31 @@ duplicates, leaving only dedup candidates.
 
 Next, it iterates through these dedup candidate objects, reading their complete
 information from the object metadata, a per-object RADOS operation. During
-this step, **compressed** and **user-encrypted** objects are removed from
-consideration.
+this step, **user-encrypted** objects are removed from consideration.
 
-Following this, we calculate a cryptographically strong hash of candidate
-object data. This involves a full-object read, which is a resource-intensive
-operation. The hash ensures that dedup candidates are indeed perfect
-matches. If they are, we proceed with deduplication:
+At this point, the dedup candidates are objects whose MD5 hash and size are
+identical -- the likelihood of a false positive is vanishingly small for
+naturally occurring data. To provide a cryptographic guarantee and guard
+against crafted MD5 collisions ensuring that dedup candidates are indeed perfect
+matches, we calculate a strong hash (Blake3) over the
+full object data. This requires reading the entire object, with cost
+proportional to object size -- but the potential dedup savings also grow with
+size, and at this stage deduplication is almost certain to succeed.
+
+For compressed objects the hash is calculated on the uncompressed data -- each
+compression block is decompressed on-the-fly and fed to the hasher, so memory
+usage stays bounded regardless of object size. This adds CPU cost for
+decompression, though at this stage deduplication is almost certain to succeed
+and the savings will justify the overhead. To skip compressed objects entirely,
+set ``rgw_dedup_skip_compressed = true`` in the configuration.
+
+If the objects' strong hash matches, we proceed with the deduplication:
 
 - Increment the reference count on the source tail objects one by one.
 - Copy the manifest from the source to the target.
+- Mirror the compression attribute (``RGW_ATTR_COMPRESSION``) from source to
+  target: if the source is compressed the attribute is copied to the target;
+  if the source is uncompressed the attribute is removed from the target.
 - Remove all tail objects on the target.
 
 Split-Head Mode

--- a/doc/radosgw/s3_objects_dedup.rst
+++ b/doc/radosgw/s3_objects_dedup.rst
@@ -159,6 +159,29 @@ Next, it iterates through these dedup candidate objects, reading their complete
 information from the object metadata, a per-object RADOS operation. During
 this step, **user-encrypted** objects are removed from consideration.
 
+Dedup source selection
+----------------------
+
+When several objects share the same dedup key (MD5 etag and logical size), dedup
+chooses one as the **source** (SRC). All other copies become **targets** that
+will share the source tail objects. Source selection uses the dedup table built
+from bucket indices and updated as object metadata is read:
+
+#. An object that is already a source from a prior dedup cycle (marked with a
+   shared manifest) is never replaced.
+#. Otherwise, prefer objects whose server-side compression matches the
+   compression type configured on the tail **placement rule** (exact match).
+#. If no exact match exists, prefer objects that are compressed with a
+   different algorithm over uncompressed objects (partial match).
+#. Otherwise keep the first valid candidate.
+
+The placement compression type is taken from the zone's **current** placement
+configuration, not from the setting in effect when each object was uploaded.
+
+Next, we iterate through these dedup candidate objects, reading their complete
+information from the object metadata (a per-object RADOS operation). During
+this step, we filter out **user-encrypted** objects.
+
 At this point, the dedup candidates are objects whose MD5 hash and size are
 identical -- the likelihood of a false positive is vanishingly small for
 naturally occurring data. To provide a cryptographic guarantee and guard
@@ -178,13 +201,34 @@ set ``rgw_dedup_skip_compressed = true`` in the configuration.
 If the objects' strong hash matches, we proceed with the deduplication:
 
 - Increment the reference count on the source tail objects one by one.
-- Copy the manifest from the source to the target.
+- Replace the target manifest and tail objects entirely with the source's
+  (the target's previous tail layout is freed).
 - Mirror the compression attribute (``RGW_ATTR_COMPRESSION``) from source to
   target: if the source is compressed the attribute is copied to the target;
   if the source is uncompressed the attribute is removed from the target.
 - Remove all tail objects on the target.
 
-Split-Head Mode
+Cross-mode compression
+----------------------
+
+Compressed and uncompressed copies of the same logical content can land in the
+same dedup candidate set because dedup keys use **logical** (uncompressed) size
+from the bucket index, not on-disk compressed size.
+
+When dedup succeeds between mixed compression states, each target adopts the
+source manifest, tail objects, and compression attribute. Because source
+selection prefers objects that match **current** placement compression, all
+deduped copies typically converge on the compression state implied by the
+zone's placement policy at dedup time -- not on the mode each object had when
+it was uploaded. For example, if placement compression was disabled and later
+re-enabled, dedup may rewrite older uncompressed copies to share compressed
+tail objects from a source that matches the current placement.
+
+In incremental dedup, a source established in an earlier cycle keeps shared-
+manifest priority even when newer copies would match current placement
+compression more closely.
+
+Split Head Mode
 ===============
 
 The dedup code can split a head object into two objects:

--- a/qa/suites/rgw/dedup/overrides.yaml
+++ b/qa/suites/rgw/dedup/overrides.yaml
@@ -7,6 +7,9 @@ overrides:
         debug rgw: 20
         debug rgw dedup: 20
   rgw:
+    realm: dedup-realm
+    zonegroup: default
+    zone: default
     storage classes:
       LUKEWARM:
       FROZEN:

--- a/qa/tasks/dedup_tests.py
+++ b/qa/tasks/dedup_tests.py
@@ -225,6 +225,7 @@ def task(ctx,config):
         endpoint = ctx.rgw.role_endpoints.get(client)
         assert endpoint, 'deduptests: no rgw endpoint for {}'.format(client)
 
+        cluster_name, _, _ = teuthology.split_role(client)
         deduptests_conf[client] = ConfigObj(
             indent_type='',
             infile={
@@ -232,6 +233,9 @@ def task(ctx,config):
                     {
                     'port':endpoint.port,
                     'host':endpoint.dns_name,
+                    'zonegroup':ctx.rgw.zonegroup,
+                    'zone':ctx.rgw.zone,
+                    'cluster':cluster_name,
                     },
                 's3 main':{}
             }

--- a/qa/tasks/rgw.py
+++ b/qa/tasks/rgw.py
@@ -334,6 +334,27 @@ def create_realm(ctx, clients):
                       '--master', '--default'],
                  check_status=True)
 
+        # mdlog trim refuses to run when zone/zonegroup lack HTTP endpoints
+        # (see sanity_check_endpoints in rgw_trim_mdlog.cc)
+        endpoint_urls = [ep.url() for _, ep in sorted(
+            ctx.rgw.role_endpoints.items())]
+        endpoints_arg = ','.join(endpoint_urls)
+        log.info('Setting zone/zonegroup endpoints for realm %s: %s',
+                 ctx.rgw.realm, endpoints_arg)
+        rgwadmin(ctx, client,
+                 cmd=['zonegroup', 'modify',
+                      '--rgw-realm', ctx.rgw.realm,
+                      '--rgw-zonegroup', ctx.rgw.zonegroup,
+                      '--endpoints', endpoints_arg],
+                 check_status=True)
+        rgwadmin(ctx, client,
+                 cmd=['zone', 'modify',
+                      '--rgw-realm', ctx.rgw.realm,
+                      '--rgw-zonegroup', ctx.rgw.zonegroup,
+                      '--rgw-zone', ctx.rgw.zone,
+                      '--endpoints', endpoints_arg],
+                 check_status=True)
+
         rgwadmin(ctx, client,
                  cmd=['period', 'update', '--commit',
                       '--rgw-realm', ctx.rgw.realm,

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -101,6 +101,17 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_dedup_skip_compressed
+  type: bool
+  level: advanced
+  desc: Skip server-side compressed objects during dedup.
+  long_desc: When true, compressed objects are skipped during the dedup process.
+    When false (default), compressed objects participate in dedup and their
+    uncompressed data is hashed on-the-fly for matching.
+  default: false
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_max_chunk_size
   type: size
   level: advanced

--- a/src/rgw/driver/rados/rgw_dedup.cc
+++ b/src/rgw/driver/rados/rgw_dedup.cc
@@ -42,6 +42,8 @@
 #include "fmt/ranges.h"
 #include "osd/osd_types.h"
 #include "common/ceph_crypto.h"
+#include "rgw_compression_types.h"
+#include "compressor/Compressor.h"
 
 #include <filesystem>
 #include <algorithm>
@@ -82,6 +84,38 @@ static constexpr auto dout_subsys = ceph_subsys_rgw_dedup;
 namespace rgw::dedup {
   static inline constexpr unsigned MAX_STORAGE_CLASS_IDX = 128;
   using storage_class_idx_t = uint8_t;
+
+  // Derive accounted_size from object-head attributes the same way the
+  // write-path computes it (see RGWRados::Object::Write::_do_write_meta):
+  //   compressed   -> RGWCompressionInfo::orig_size  (stable, not patched)
+  //   uncompressed -> physical object size
+  // We cannot use p_obj->get_accounted_size() because the stat path patches
+  // it via the manifest (set_head / get_obj_size).
+  static int64_t derive_head_accounted_size(const DoutPrefixProvider *dpp,
+                                             const bufferlist &compression_bl,
+                                             uint64_t obj_size,
+                                             std::string *p_compression_type = nullptr)
+  {
+    if (compression_bl.length() > 0) {
+      RGWCompressionInfo cs_info;
+      auto bl_iter = compression_bl.cbegin();
+      try {
+        decode(cs_info, bl_iter);
+      } catch (buffer::error&) {
+        ldpp_dout(dpp, 5) << __func__
+                          << "::ERR: failed to decode compression info" << dendl;
+        return -EINVAL;
+      }
+      if (p_compression_type) {
+        *p_compression_type = cs_info.compression_type;
+      }
+      return cs_info.orig_size;
+    }
+    if (p_compression_type) {
+      *p_compression_type = "none";
+    }
+    return obj_size;
+  }
 
   //---------------------------------------------------------------------------
   [[maybe_unused]] static int print_manifest(CephContext              *cct,
@@ -383,6 +417,19 @@ namespace rgw::dedup {
   }
 
   //---------------------------------------------------------------------------
+  const std::string& Background::get_placement_compression_type(
+                                   const rgw_placement_rule &rule)
+  {
+    auto it = d_placement_compression_type.find(rule.name);
+    if (it != d_placement_compression_type.end()) {
+      return it->second;
+    }
+    const std::string& comp_type = store->svc()->zone->get_zone_params().get_compression_type(rule);
+    auto result = d_placement_compression_type.emplace(rule.name, comp_type);
+    return result.first->second;
+  }
+
+  //---------------------------------------------------------------------------
   int Background::init_rados_access_handles(bool init_pool)
   {
     store = dynamic_cast<rgw::sal::RadosStore*>(driver);
@@ -414,9 +461,11 @@ namespace rgw::dedup {
     d_head_object_size = cct->_conf->rgw_max_chunk_size;
     d_min_obj_size_for_dedup = cct->_conf->rgw_dedup_min_obj_size_for_dedup;
     d_split_head = cct->_conf->rgw_dedup_split_obj_head;
+    d_skip_compressed = cct->_conf->rgw_dedup_skip_compressed;
     ldpp_dout(dpp, 10) << "Config Vals::d_head_object_size=" << d_head_object_size
                        << "::d_min_obj_size_for_dedup=" << d_min_obj_size_for_dedup
                        << "::d_split_head=" << d_split_head
+                       << "::d_skip_compressed=" << d_skip_compressed
                        << dendl;
 
     int ret = init_rados_access_handles(false);
@@ -490,7 +539,7 @@ namespace rgw::dedup {
                        << p_rec->s.md5_low << std::dec << dendl;
 
     int ret = p_table->add_entry(&key, block_id, rec_id, has_shared_manifest,
-                                 &p_stats->big_objs_stat);
+                                 COMPRESSION_MATCH_NONE, &p_stats->big_objs_stat);
     if (ret == 0) {
       p_stats->loaded_objects ++;
       ldpp_dout(dpp, 20) << __func__ << "::" << p_rec->bucket_name << "/"
@@ -1016,6 +1065,14 @@ namespace rgw::dedup {
       {
         bufferlist src_hash_bl;
         init_cmp_pairs(dpp, p_src_rec, etag_bl, src_hash_bl, &src_op);
+        // CAS on compression only when SRC is uncompressed (cheap empty-bl compare).
+        // A compressed object's compression state is assumed immutable: RGW never
+        // strips or rewrites RGW_ATTR_COMPRESSION on an existing object, so there
+        // is no need to CAS on a potentially large compression attribute.
+        if (p_src_rec->compression_bl.length() == 0) {
+          src_op.cmpxattr(RGW_ATTR_COMPRESSION, CEPH_OSD_CMPXATTR_OP_EQ,
+                          p_src_rec->compression_bl);
+        }
         src_op.setxattr(RGW_ATTR_SHARE_MANIFEST, manifest_hash_bl);
         if (p_src_rec->s.flags.hash_calculated() && !p_src_val->has_valid_hash()){
           src_op.setxattr(RGW_ATTR_BLAKE3, src_hash_bl);
@@ -1044,6 +1101,11 @@ namespace rgw::dedup {
       }
     }
 
+    // Set RGW_ATTR_COMPRESSION on TGT unconditionally from SRC state.
+    // TGT now shares SRC's tail objects so its compression state must match.
+    bool src_compressed = (p_src_rec->compression_bl.length() > 0);
+    bool tgt_compressed = (p_tgt_rec->compression_bl.length() > 0);
+
     librados::ObjectWriteOperation tgt_op;
     {
       bufferlist tgt_hash_bl;
@@ -1056,6 +1118,18 @@ namespace rgw::dedup {
         tgt_op.setxattr(RGW_ATTR_BLAKE3, tgt_hash_bl);
         ldpp_dout(dpp, 20) << __func__ <<"::Set TGT Strong Hash in CLS"<< dendl;
         p_stats->set_hash_attrs++;
+      }
+
+      if (src_compressed) {
+        tgt_op.setxattr(RGW_ATTR_COMPRESSION, p_src_rec->compression_bl);
+        if (!tgt_compressed) {
+          p_stats->set_compression_on_tgt++;
+        }
+      } else {
+        tgt_op.rmxattr(RGW_ATTR_COMPRESSION);
+        if (tgt_compressed) {
+          p_stats->clear_compression_on_tgt++;
+        }
       }
     }
 
@@ -1079,55 +1153,186 @@ namespace rgw::dedup {
     // free tail objects based on TGT manifest
     free_tail_objs_by_manifest(ref_tag, tgt_oid, tgt_manifest);
 
-    // do we need to set compression on the head object or is it set on tail?
-    // RGW_ATTR_COMPRESSION
     return ret;
   }
+
+  //---------------------------------------------------------------------------
+  // Decompress each compression block on-the-fly and feed decompressed data
+  // to the blake3 hasher. The compressed stream is fed incrementally via
+  // feed_compressed_data(); once a full compression block is available it is
+  // decompressed and hashed immediately so memory stays bounded.
+  struct streaming_decompressor_t {
+    CompressorRef compressor;
+    RGWCompressionInfo cs_info;  // owned copy
+    blake3_hasher *hmac;
+    const DoutPrefixProvider *dpp;
+
+    bufferlist pending;         // partial compressed block accumulated so far
+    uint64_t   raw_ofs  = 0;   // running offset in compressed stream
+    size_t     blk_idx  = 0;   // next compression block to process
+
+    streaming_decompressor_t(CompressorRef _comp,
+                             RGWCompressionInfo &&_cs,
+                             blake3_hasher *_hmac,
+                             const DoutPrefixProvider *_dpp)
+      : compressor(std::move(_comp)), cs_info(std::move(_cs)),
+        hmac(_hmac), dpp(_dpp) {}
+
+    int feed_compressed_data(bufferlist &bl) {
+      uint64_t len = bl.length();
+      pending.claim_append(bl);
+      raw_ofs += len;
+      return drain_ready_blocks();
+    }
+
+    int drain_ready_blocks() {
+      while (blk_idx < cs_info.blocks.size()) {
+        const auto &block = cs_info.blocks[blk_idx];
+        uint64_t block_end = block.new_ofs + block.len;
+        if (raw_ofs < block_end) {
+          break; // not enough data yet for this block
+        }
+        bufferlist compressed_bl, decompressed_bl;
+        uint64_t local_ofs = block.new_ofs - (raw_ofs - pending.length());
+        pending.begin(local_ofs).copy(block.len, compressed_bl);
+        int ret = compressor->decompress(compressed_bl, decompressed_bl,
+                                         cs_info.compressor_message);
+        if (ret < 0) {
+          ldpp_dout(dpp, 1) << "streaming_decompressor_t::ERR: decompression"
+                               " failed, ret=" << ret << dendl;
+          return ret;
+        }
+        for (const auto& bptr : decompressed_bl.buffers()) {
+          blake3_hasher_update(hmac,
+            (const unsigned char *)bptr.c_str(), bptr.length());
+        }
+        blk_idx++;
+      }
+      // discard data that has been fully consumed by all processed blocks
+      if (blk_idx > 0) {
+        uint64_t consumed_end = cs_info.blocks[blk_idx - 1].new_ofs +
+                                cs_info.blocks[blk_idx - 1].len;
+        uint64_t pending_start = raw_ofs - pending.length();
+        if (consumed_end > pending_start) {
+          uint64_t trim = consumed_end - pending_start;
+          if (trim <= pending.length()) {
+            pending.splice(0, trim);
+          }
+        }
+      }
+      return 0;
+    }
+
+    int finish() {
+      int ret = drain_ready_blocks();
+      if (ret < 0) return ret;
+      if (blk_idx != cs_info.blocks.size()) {
+        ldpp_dout(dpp, 1) << "streaming_decompressor_t::ERR: not all blocks"
+                             " decompressed, processed=" << blk_idx
+                          << " total=" << cs_info.blocks.size() << dendl;
+        return -EIO;
+      }
+      return 0;
+    }
+  };
 
   //---------------------------------------------------------------------------
   int Background::calc_object_blake3(const RGWObjManifest &manifest,
                                      disk_record_t *p_rec,
                                      uint8_t *p_hash,
-                                     blake3_hasher *p_pre_calc_hmac)
+                                     bufferlist *p_head_bl)
   {
-    ldpp_dout(dpp, 20) << __func__ << "::p_rec->obj_name=" << p_rec->obj_name << dendl;
+    bool is_compressed = false;
+    RGWCompressionInfo cs_info;
+    CompressorRef compressor;
 
-    blake3_hasher _hmac, *p_hmac = nullptr;
-    if (!p_pre_calc_hmac) {
-      blake3_hasher_init(&_hmac);
-      p_hmac = &_hmac;
+    if (p_rec->compression_bl.length() > 0) {
+      try {
+        auto bl_iter = p_rec->compression_bl.cbegin();
+        decode(cs_info, bl_iter);
+        if (cs_info.compression_type != "none" && !cs_info.blocks.empty()) {
+          is_compressed = true;
+          compressor = Compressor::create(cct, cs_info.compression_type);
+          if (!compressor) {
+            ldpp_dout(dpp, 1) << __func__ << "::ERR: Cannot load compressor of type "
+                              << cs_info.compression_type << dendl;
+            return -EIO;
+          }
+        }
+      } catch (buffer::error&) {
+        ldpp_dout(dpp, 1) << __func__
+                          << "::ERR: failed RGWCompressionInfo decode" << dendl;
+        return -EINVAL;
+      }
     }
-    else {
-      p_hmac = p_pre_calc_hmac;
+
+    ldpp_dout(dpp, 20) << __func__ << "::p_rec->obj_name=" << p_rec->obj_name
+                       << "::compressed=" << is_compressed << dendl;
+
+    blake3_hasher hmac;
+    blake3_hasher_init(&hmac);
+    blake3_hasher *p_hmac = &hmac;
+
+    std::unique_ptr<streaming_decompressor_t> decompressor;
+    if (compressor) {
+      decompressor = std::make_unique<streaming_decompressor_t>(
+        compressor, std::move(cs_info), p_hmac, dpp);
+      if (p_head_bl && p_head_bl->length() > 0) {
+        // copy before feeding: feed_compressed_data() uses claim_append()
+        // which would empty the caller's bufferlist; split_head_object()
+        // needs p_head_bl intact to write the new tail object afterwards
+        bufferlist head_copy;
+        head_copy.append(*p_head_bl);
+        int ret = decompressor->feed_compressed_data(head_copy);
+        if (ret < 0) return ret;
+      }
+    } else if (p_head_bl && p_head_bl->length() > 0) {
+      for (const auto& bptr : p_head_bl->buffers()) {
+        blake3_hasher_update(p_hmac,
+          (const unsigned char *)bptr.c_str(), bptr.length());
+      }
     }
 
     for (auto p = manifest.obj_begin(dpp); p != manifest.obj_end(dpp); ++p) {
       uint64_t offset = p.get_stripe_ofs();
       const rgw_obj_select& os = p.get_location();
-      if (offset > 0 || !p_pre_calc_hmac) {
-        rgw_raw_obj raw_obj = os.get_raw_obj(rados);
-        rgw_rados_ref obj;
-        int ret = rgw_get_rados_ref(dpp, rados_handle, raw_obj, &obj);
-        if (ret < 0) {
-          ldpp_dout(dpp, 1) << __func__ << "::failed rgw_get_rados_ref() for oid="
-                            << raw_obj.oid << ", err is " << cpp_strerror(-ret) << dendl;
-          return ret;
-        }
+      // skip head stripe when head data was already provided
+      if (offset == 0 && p_head_bl) {
+        continue;
+      }
+      rgw_raw_obj raw_obj = os.get_raw_obj(rados);
+      rgw_rados_ref obj;
+      int ret = rgw_get_rados_ref(dpp, rados_handle, raw_obj, &obj);
+      if (ret < 0) {
+        ldpp_dout(dpp, 1) << __func__ << "::failed rgw_get_rados_ref() for oid="
+                          << raw_obj.oid << ", err is " << cpp_strerror(-ret) << dendl;
+        return ret;
+      }
 
-        librados::IoCtx ioctx = obj.ioctx;
-        bufferlist bl;
-        // read full object
-        ret = ioctx.read(raw_obj.oid, bl, 0, 0);
-        if (unlikely(ret <= 0)) {
-          ldpp_dout(dpp, 1) << __func__ << "::ERR: failed to read oid "
-                            << raw_obj.oid  << ", err is " << cpp_strerror(-ret) << dendl;
-          return ret;
-        }
+      librados::IoCtx ioctx = obj.ioctx;
+      bufferlist bl;
+      ret = ioctx.read(raw_obj.oid, bl, 0, 0);
+      if (unlikely(ret <= 0)) {
+        ldpp_dout(dpp, 1) << __func__ << "::ERR: failed to read oid "
+                          << raw_obj.oid  << ", err is " << cpp_strerror(-ret) << dendl;
+        return ret;
+      }
+      if (decompressor) {
+        ret = decompressor->feed_compressed_data(bl);
+        if (ret < 0) return ret;
+      } else {
         for (const auto& bptr : bl.buffers()) {
-          blake3_hasher_update(p_hmac, (const unsigned char *)bptr.c_str(), bptr.length());
+          blake3_hasher_update(p_hmac,
+            (const unsigned char *)bptr.c_str(), bptr.length());
         }
       }
     }
+
+    if (decompressor) {
+      int ret = decompressor->finish();
+      if (ret < 0) return ret;
+    }
+
     blake3_hasher_finalize(p_hmac, p_hash, BLAKE3_OUT_LEN);
     p_rec->s.flags.set_hash_calculated();
     p_rec->s.flags.set_has_valid_hash();
@@ -1184,7 +1389,8 @@ namespace rgw::dedup {
   //---------------------------------------------------------------------------
   int Background::add_obj_attrs_to_record(disk_record_t         *p_rec,
                                           const rgw::sal::Attrs &attrs,
-                                          md5_stats_t           *p_stats) /*IN-OUT*/
+                                          rgw_placement_rule    *p_tail_rule, /*OUT*/
+                                          md5_stats_t           *p_stats      /*IN-OUT*/)
   {
     // if TAIL_TAG exists -> use it as ref-tag, eitherwise take ID_TAG
     auto itr = attrs.find(RGW_ATTR_TAIL_TAG);
@@ -1254,6 +1460,9 @@ namespace rgw::dedup {
         p_rec->manifest_bl = bl;
       }
       p_rec->s.manifest_len = p_rec->manifest_bl.length();
+      if (p_tail_rule) {
+        *p_tail_rule = manifest.get_tail_placement().placement_rule;
+      }
     }
     else {
       ldpp_dout(dpp, 5)  << __func__ << "::ERROR: no manifest" << dendl;
@@ -1447,16 +1656,40 @@ namespace rgw::dedup {
       return 0;
     }
 
-    // TBD-Future: We should be able to support RGW_ATTR_COMPRESSION when all copies are compressed
-    if (attrs.find(RGW_ATTR_COMPRESSION) != attrs.end()) {
-      p_stats->ingress_skip_compressed++;
-      p_stats->ingress_skip_compressed_bytes += ondisk_byte_size;
-      ldpp_dout(dpp, 20) <<__func__ << "::Skipping compressed object "
-                         << p_rec->obj_name << dendl;
-      return 0;
+    {
+      auto comp_itr = attrs.find(RGW_ATTR_COMPRESSION);
+      if (comp_itr != attrs.end()) {
+        if (d_skip_compressed) {
+          p_stats->ingress_skip_compressed++;
+          p_stats->ingress_skip_compressed_bytes += ondisk_byte_size;
+          ldpp_dout(dpp, 20) <<__func__ << "::Skipping compressed object "
+                             << p_rec->obj_name << dendl;
+          return 0;
+        }
+        p_rec->compression_bl = comp_itr->second;
+        p_rec->s.compression_bl_len = p_rec->compression_bl.length();
+        p_stats->ingress_compressed++;
+        p_stats->ingress_compressed_bytes += ondisk_byte_size;
+        ldpp_dout(dpp, 20) <<__func__ << "::compressed object "
+                           << p_rec->obj_name << dendl;
+      } else {
+        p_rec->compression_bl.clear();
+        p_rec->s.compression_bl_len = 0;
+      }
     }
 
-    // extract ETAG and Size and compare with values taken from the bucket-index
+    std::string obj_compression_type;
+    int64_t head_accounted_size = derive_head_accounted_size(dpp, p_rec->compression_bl,
+                                                             p_obj->get_size(),
+                                                             &obj_compression_type);
+    if (unlikely(head_accounted_size < 0)) {
+      ldpp_dout(dpp, 5) << __func__
+                        << "::ERR: derive_head_accounted_size failed for "
+                        << p_rec->obj_name << dendl;
+      return head_accounted_size;
+    }
+
+    // extract ETAG and compare with values taken from the bucket-index
     parsed_etag_t parsed_etag;
     auto itr = attrs.find(RGW_ATTR_ETAG);
     if (itr != attrs.end()) {
@@ -1492,11 +1725,14 @@ namespace rgw::dedup {
 
     // no need to check for remap success as we compare keys bellow
     sc_idx = remapper->remap(storage_class, dpp, &p_stats->failed_map_overflow);
+    // Cross-check etag, num_parts, storage_class and size from object-head
+    // against bucket-index.  head_accounted_size was derived above from the
+    // compression attr (orig_size) or physical size - matching the write-path
+    // logic, so it is safe to compare against the bucket-index value.
     key_t key_from_obj(parsed_etag.md5_high, parsed_etag.md5_low,
-                       byte_size_to_disk_blocks(p_obj->get_size()),
+                       byte_size_to_disk_blocks(head_accounted_size),
                        parsed_etag.num_parts, sc_idx);
-    if (unlikely(key_from_obj != key_from_bucket_index ||
-                 p_rec->s.obj_bytes_size != p_obj->get_size())) {
+    if (unlikely(key_from_obj != key_from_bucket_index)) {
       ldpp_dout(dpp, 15) <<__func__ << "::Skipping changed object "
                          << p_rec->obj_name << dendl;
       p_stats->ingress_skip_changed_objs++;
@@ -1505,7 +1741,8 @@ namespace rgw::dedup {
 
     // reset flags
     p_rec->s.flags.clear();
-    ret = add_obj_attrs_to_record(p_rec, attrs, p_stats);
+    rgw_placement_rule tail_rule;
+    ret = add_obj_attrs_to_record(p_rec, attrs, &tail_rule, p_stats);
     if (unlikely(ret != 0)) {
       // don't trace errors for unsupported manifest
       if (ret == -ENOTSUP) {
@@ -1515,6 +1752,15 @@ namespace rgw::dedup {
       ldpp_dout(dpp, 5) << __func__ << "::ERR: failed add_obj_attrs_to_record() ret="
                         << ret << "::" << cpp_strerror(-ret) << dendl;
       return ret;
+    }
+
+    // Determine how well this object's compression state matches the placement
+    const auto& placement_comp_type = get_placement_compression_type(tail_rule);
+    compression_match_level_t comp_match = COMPRESSION_MATCH_NONE;
+    if (obj_compression_type == placement_comp_type) {
+      comp_match = COMPRESSION_MATCH_EXACT;
+    } else if (obj_compression_type != "none" && placement_comp_type != "none") {
+      comp_match = COMPRESSION_MATCH_PARTIAL;
     }
 
     disk_block_seq_t::record_info_t rec_info;
@@ -1530,7 +1776,8 @@ namespace rgw::dedup {
                           << "::shared_manifest="
                           << p_rec->s.flags.has_shared_manifest() << dendl;
       p_table->update_entry(&key_from_bucket_index, rec_info.block_id,
-                            rec_info.rec_id, p_rec->s.flags.has_shared_manifest());
+                            rec_info.rec_id, p_rec->s.flags.has_shared_manifest(),
+                            comp_match);
     }
     else {
       ldpp_dout(dpp, 5) << __func__ << "::ERR: Failed p_disk->add_record()"<< dendl;
@@ -1592,6 +1839,10 @@ namespace rgw::dedup {
   }
 
   //---------------------------------------------------------------------------
+  // RGW_ATTR_BLAKE3 and RGW_ATTR_MANIFEST are calculated and written to the
+  // object-head during STEP_REMOVE_DUPLICATES (and never updated into the
+  // disk-record since we only write records in bulk).
+  // All other attributes are valid on both SRC and TGT at this point.
   static int read_hash_and_manifest(const DoutPrefixProvider *const dpp,
                                     rgw::sal::Driver *driver,
                                     rgw::sal::RadosStore *store,
@@ -1709,14 +1960,8 @@ namespace rgw::dedup {
     if (!p_src_rec->s.flags.has_valid_hash()) {
       ldpp_dout(dpp, 20) << __func__ << "::calc BLK3 for SRC "
                          << p_src_rec->obj_name << dendl;
-      blake3_hasher hmac;
-      blake3_hasher_init(&hmac);
-      for (const auto& bptr : bl.buffers()) {
-        blake3_hasher_update(&hmac, (const unsigned char *)bptr.c_str(),
-                             bptr.length());
-      }
       uint8_t *p_hash = (uint8_t*)p_src_rec->s.hash;
-      ret = calc_object_blake3(src_manifest, p_src_rec, p_hash, &hmac);
+      ret = calc_object_blake3(src_manifest, p_src_rec, p_hash, &bl);
       if (unlikely(ret != 0)) {
         return ret;
       }
@@ -1797,7 +2042,6 @@ namespace rgw::dedup {
                          << p_tgt_rec->obj_name << dendl;
       ret = calc_object_blake3(tgt_manifest, p_tgt_rec, (uint8_t*)p_tgt_rec->s.hash);
       if (unlikely(ret != 0)) {
-        // Don't run dedup without a valid strong hash
         return false;
       }
     }
@@ -2085,6 +2329,9 @@ namespace rgw::dedup {
       ldpp_dout(dpp, 20) << __func__ << "::dedup success " << p_src_rec->obj_name << dendl;
       p_stats->deduped_objects++;
       p_stats->deduped_objects_bytes += dedupable_objects_bytes;
+      if (p_src_rec->compression_bl.length() > 0 && p_tgt_rec->compression_bl.length() > 0) {
+        p_stats->deduped_compressed_objects++;
+      }
       if (p_tgt_rec->s.flags.is_split_head()) {
         ldpp_dout(dpp, 20) << __func__ <<"::TGT-Split: dedup_bytes="
                            << ondisk_byte_size << dendl;
@@ -2287,7 +2534,9 @@ namespace rgw::dedup {
     }
 
     // ceph store full blocks so need to round up and multiply by block_size
-    uint64_t ondisk_byte_size = calc_on_disk_byte_size(entry.meta.size);
+    // use accounted_size which is the logical (uncompressed) size
+    // this ensures compressed and uncompressed copies of the same data match
+    uint64_t ondisk_byte_size = calc_on_disk_byte_size(entry.meta.accounted_size);
     p_worker_stats->ingress_obj++;
     p_worker_stats->ingress_obj_bytes += ondisk_byte_size;
 
@@ -2335,7 +2584,7 @@ namespace rgw::dedup {
 
     return add_disk_rec_from_bucket_idx(disk_arr, p_bucket, &parsed_etag,
                                         entry.key.name, entry.key.instance,
-                                        entry.meta.size, storage_class);
+                                        entry.meta.accounted_size, storage_class);
   }
 
   //---------------------------------------------------------------------------
@@ -3496,6 +3745,7 @@ namespace rgw::dedup {
           ldpp_dout(dpp, 1) << __func__ << "::failed setup()" << dendl;
           return;
         }
+        d_placement_compression_type.clear();
         const rgw_pool& dedup_pool = store->svc()->zone->get_zone_params().dedup_pool;
         int64_t pool_id = rados_handle->pool_lookup(dedup_pool.name.c_str());
         if (pool_id < 0) {

--- a/src/rgw/driver/rados/rgw_dedup.cc
+++ b/src/rgw/driver/rados/rgw_dedup.cc
@@ -493,11 +493,18 @@ namespace rgw::dedup {
                                                const std::string      &obj_name,
                                                const std::string      &instance,
                                                uint64_t                obj_size,
-                                               const std::string      &storage_class)
+                                               const std::string      &storage_class,
+                                               worker_stats_t         *p_worker_stats)
   {
     disk_record_t rec(p_bucket, obj_name, p_parsed_etag, instance, obj_size, storage_class);
     // First pass using only ETAG and size taken from bucket-index
     rec.s.flags.set_fastlane();
+
+    size_t rec_len = rec.length();
+    if (rec_len > p_worker_stats->max_bidx_record_length) {
+      p_worker_stats->max_bidx_record_length = rec_len;
+    }
+    p_worker_stats->total_bidx_record_length += rec_len;
 
     auto p_disk = disk_arr.get_shard_block_seq(p_parsed_etag->md5_low);
     disk_block_seq_t::record_info_t rec_info;
@@ -1763,8 +1770,14 @@ namespace rgw::dedup {
       comp_match = COMPRESSION_MATCH_PARTIAL;
     }
 
+    size_t rec_len = p_rec->length();
+    if (rec_len > p_stats->max_attrs_record_length) {
+      p_stats->max_attrs_record_length = rec_len;
+    }
+    p_stats->total_attrs_record_length += rec_len;
+
     disk_block_seq_t::record_info_t rec_info;
-    ret = p_disk->add_record(d_dedup_cluster_ioctx, p_rec, &rec_info);
+    ret = p_disk->add_record(d_dedup_cluster_ioctx, p_rec, &rec_info, p_stats);
     if (ret == 0) {
       // set the disk_block_id_t to this unless the existing disk_block_id is marked as shared-manifest
       if (unlikely(rec_info.rec_id >= MAX_REC_IN_BLOCK)) {
@@ -1839,11 +1852,31 @@ namespace rgw::dedup {
   }
 
   //---------------------------------------------------------------------------
-  // RGW_ATTR_BLAKE3 and RGW_ATTR_MANIFEST are calculated and written to the
-  // object-head during STEP_REMOVE_DUPLICATES (and never updated into the
-  // disk-record since we only write records in bulk).
-  // All other attributes are valid on both SRC and TGT at this point.
-  static int read_hash_and_manifest(const DoutPrefixProvider *const dpp,
+  // Fetch attributes from the RADOS head object that are NOT stored in the
+  // disk record (or were dropped from it).
+  //
+  // Always fetched:
+  //   RGW_ATTR_MANIFEST  -- required; returns -ENOENT if missing.
+  //   RGW_ATTR_BLAKE3    -- if present, populates p_rec->s.hash and sets
+  //                         has_valid_hash().  Missing BLAKE3 is an error
+  //                         unless has_remote_attrs() is set (the hash may
+  //                         not have been written to the object head yet).
+  //
+  // Conditionally fetched (when has_remote_attrs()):
+  //   RGW_ATTR_COMPRESSION -- restores compression_bl that was dropped from
+  //                           the disk record to stay within MAX_REC_SIZE.
+  //
+  // Callers & expected state:
+  //   1. check_and_set_strong_hash() for SRC on 2nd+ TGT -- BLAKE3 and
+  //      manifest were written to the head object during a previous dedup;
+  //      the disk record is stale.
+  //   2. try_deduping_record() for SRC/TGT with remote_attrs -- manifest
+  //      and compression were too large for the disk record and need to be
+  //      fetched before parse_manifests().
+  //
+  // Uses a single ioctx.getxattrs() call (all attrs returned in one round
+  // trip), so fetching compression adds zero extra RADOS cost.
+  static int fetch_head_obj_attrs(const DoutPrefixProvider *const dpp,
                                     rgw::sal::Driver *driver,
                                     rgw::sal::RadosStore *store,
                                     disk_record_t *p_rec)
@@ -1882,7 +1915,9 @@ namespace rgw::dedup {
         return -EINVAL;
       }
     }
-    else {
+    else if (!p_rec->s.flags.has_remote_attrs()) {
+      // BLAKE3 is mandatory unless fetching for remote_attrs (hash may not
+      // have been written to the object head yet)
       ldpp_dout(dpp, 1) << __func__ << "::ERR: No HASH attribute" << dendl;
       return -ENOENT;
     }
@@ -1896,6 +1931,14 @@ namespace rgw::dedup {
     else {
       ldpp_dout(dpp, 1) << __func__ << "::ERR: No Manifest attribute" << dendl;
       return -ENOENT;
+    }
+
+    if (p_rec->s.flags.has_remote_attrs()) {
+      itr = attrset.find(RGW_ATTR_COMPRESSION);
+      if (itr != attrset.end()) {
+        p_rec->compression_bl = itr->second;
+        p_rec->s.compression_bl_len = p_rec->compression_bl.length();
+      }
     }
 
     return 0;
@@ -2047,12 +2090,12 @@ namespace rgw::dedup {
     }
 
     // SRC hash could have been calculated and stored in obj-attributes before
-    // (will happen when we got multiple targets)
+    // This will happen when we got multiple targets (second time and up with same SRC)
     if (!p_src_rec->s.flags.has_valid_hash() && p_src_val->has_valid_hash()) {
       // read the manifest and strong hash from the head-object attributes
       ldpp_dout(dpp, 20) << __func__ << "::Fetch SRC strong hash from head-object::"
                          << p_src_rec->obj_name << dendl;
-      if (unlikely(read_hash_and_manifest(dpp, driver, store, p_src_rec) != 0)) {
+      if (unlikely(fetch_head_obj_attrs(dpp, driver, store, p_src_rec) != 0)) {
         return false;
       }
       try {
@@ -2270,6 +2313,17 @@ namespace rgw::dedup {
       return 0;
     }
 
+    if (p_src_rec->s.flags.has_remote_attrs()) {
+      ret = fetch_head_obj_attrs(dpp, driver, store, p_src_rec);
+      if (unlikely(ret != 0)) {
+        p_stats->failed_remote_attrs_fetch++;
+        ldpp_dout(dpp, 5) << __func__
+                          << "::ERR: failed fetch remote attrs for SRC "
+                          << p_src_rec->obj_name << dendl;
+        return 0;
+      }
+    }
+
     ldpp_dout(dpp, 20) << __func__ << "::SRC:" << p_src_rec->bucket_name << "/"
                        << p_src_rec->obj_name << "::TGT:" << p_tgt_rec->bucket_name
                        << "/" << p_tgt_rec->obj_name << dendl;
@@ -2291,6 +2345,17 @@ namespace rgw::dedup {
                          << "::" << p_tgt_rec->obj_name << "::"
                          << p_tgt_rec->s.obj_bytes_size << dendl;
       return 0;
+    }
+
+    if (p_tgt_rec->s.flags.has_remote_attrs()) {
+      ret = fetch_head_obj_attrs(dpp, driver, store, p_tgt_rec);
+      if (unlikely(ret != 0)) {
+        p_stats->failed_remote_attrs_fetch++;
+        ldpp_dout(dpp, 5) << __func__
+                          << "::ERR: failed fetch remote attrs for TGT "
+                          << p_tgt_rec->obj_name << dendl;
+        return 0;
+      }
     }
 
     RGWObjManifest src_manifest, tgt_manifest;
@@ -2584,7 +2649,8 @@ namespace rgw::dedup {
 
     return add_disk_rec_from_bucket_idx(disk_arr, p_bucket, &parsed_etag,
                                         entry.key.name, entry.key.instance,
-                                        entry.meta.accounted_size, storage_class);
+                                        entry.meta.accounted_size, storage_class,
+                                        p_worker_stats);
   }
 
   //---------------------------------------------------------------------------
@@ -2836,7 +2902,7 @@ namespace rgw::dedup {
         // we finished processing output SLAB from @worker_id -> remove them
         remove_slabs(worker_id, md5_shard, slab_count_arr[worker_id]);
       }
-      disk_block_seq.flush_disk_records(d_dedup_cluster_ioctx);
+      disk_block_seq.flush_disk_records(d_dedup_cluster_ioctx, p_stats);
     }
 
     ldpp_dout(dpp, 10) << __func__ << "::STEP_REMOVE_DUPLICATES::started..." << dendl;

--- a/src/rgw/driver/rados/rgw_dedup.cc
+++ b/src/rgw/driver/rados/rgw_dedup.cc
@@ -87,34 +87,25 @@ namespace rgw::dedup {
 
   // Derive accounted_size from object-head attributes the same way the
   // write-path computes it (see RGWRados::Object::Write::_do_write_meta):
-  //   compressed   -> RGWCompressionInfo::orig_size  (stable, not patched)
-  //   uncompressed -> physical object size
   // We cannot use p_obj->get_accounted_size() because the stat path patches
   // it via the manifest (set_head / get_obj_size).
-  static int64_t derive_head_accounted_size(const DoutPrefixProvider *dpp,
-                                             const bufferlist &compression_bl,
-                                             uint64_t obj_size,
-                                             std::string *p_compression_type = nullptr)
+  static int64_t derive_accounted_size(const DoutPrefixProvider *dpp,
+                                       const bufferlist &compression_bl,
+                                       std::string *p_compression_type = nullptr)
   {
-    if (compression_bl.length() > 0) {
-      RGWCompressionInfo cs_info;
-      auto bl_iter = compression_bl.cbegin();
-      try {
-        decode(cs_info, bl_iter);
-      } catch (buffer::error&) {
-        ldpp_dout(dpp, 5) << __func__
-                          << "::ERR: failed to decode compression info" << dendl;
-        return -EINVAL;
-      }
-      if (p_compression_type) {
-        *p_compression_type = cs_info.compression_type;
-      }
-      return cs_info.orig_size;
+    RGWCompressionInfo cs_info;
+    auto bl_iter = compression_bl.cbegin();
+    try {
+      decode(cs_info, bl_iter);
+    } catch (buffer::error&) {
+      ldpp_dout(dpp, 5) << __func__
+                        << "::ERR: failed to decode compression info" << dendl;
+      return -EINVAL;
     }
     if (p_compression_type) {
-      *p_compression_type = "none";
+      *p_compression_type = cs_info.compression_type;
     }
-    return obj_size;
+    return cs_info.orig_size;
   }
 
   //---------------------------------------------------------------------------
@@ -417,15 +408,20 @@ namespace rgw::dedup {
   }
 
   //---------------------------------------------------------------------------
-  const std::string& Background::get_placement_compression_type(
-                                   const rgw_placement_rule &rule)
+  const std::string& Background::get_placement_compression_type(const rgw_placement_rule &rule)
   {
-    auto it = d_placement_compression_type.find(rule.name);
+    const std::string key = rule.to_str();
+    // check if we have a cache compression_type for this rule
+    auto it = d_placement_compression_type.find(key);
     if (it != d_placement_compression_type.end()) {
       return it->second;
     }
+
+    // no local cache, check zoneparams
     const std::string& comp_type = store->svc()->zone->get_zone_params().get_compression_type(rule);
-    auto result = d_placement_compression_type.emplace(rule.name, comp_type);
+
+    // store in local cache to speedup next access
+    auto result = d_placement_compression_type.emplace(key, comp_type);
     return result.first->second;
   }
 
@@ -699,13 +695,12 @@ namespace rgw::dedup {
                  (head_size == rule.stripe_max_size || head_size == obj_size));
 
       if (unlikely(!success)) {
-        ldpp_dout(dpp, 20) << __func__ << "::ERR::d_split_head=" << d_split_head
+        ldpp_dout(dpp, 20) << __func__ << "::skip::d_split_head=" << d_split_head
                            << "::obj_size=" << obj_size
                            << "::head_size=" << head_size
                            << "::rule.part_size=" << rule.part_size
                            << "::rule.stripe_max_size=" << rule.stripe_max_size
                            << "::rule.override_prefix=" << rule.override_prefix
-                           << "::rule.override_prefix.empty()=" << rule.override_prefix.empty()
                            << dendl;
       }
     } // don't split head if can't get rule
@@ -1072,14 +1067,8 @@ namespace rgw::dedup {
       {
         bufferlist src_hash_bl;
         init_cmp_pairs(dpp, p_src_rec, etag_bl, src_hash_bl, &src_op);
-        // CAS on compression only when SRC is uncompressed (cheap empty-bl compare).
-        // A compressed object's compression state is assumed immutable: RGW never
-        // strips or rewrites RGW_ATTR_COMPRESSION on an existing object, so there
-        // is no need to CAS on a potentially large compression attribute.
-        if (p_src_rec->compression_bl.length() == 0) {
-          src_op.cmpxattr(RGW_ATTR_COMPRESSION, CEPH_OSD_CMPXATTR_OP_EQ,
-                          p_src_rec->compression_bl);
-        }
+        // SRC compression attr is fixed at object creation;
+        // Any real rewrite rotates ref_tag, caught by init_cmp_pairs() above.
         src_op.setxattr(RGW_ATTR_SHARE_MANIFEST, manifest_hash_bl);
         if (p_src_rec->s.flags.hash_calculated() && !p_src_val->has_valid_hash()){
           src_op.setxattr(RGW_ATTR_BLAKE3, src_hash_bl);
@@ -1108,11 +1097,6 @@ namespace rgw::dedup {
       }
     }
 
-    // Set RGW_ATTR_COMPRESSION on TGT unconditionally from SRC state.
-    // TGT now shares SRC's tail objects so its compression state must match.
-    bool src_compressed = (p_src_rec->compression_bl.length() > 0);
-    bool tgt_compressed = (p_tgt_rec->compression_bl.length() > 0);
-
     librados::ObjectWriteOperation tgt_op;
     {
       bufferlist tgt_hash_bl;
@@ -1127,14 +1111,17 @@ namespace rgw::dedup {
         p_stats->set_hash_attrs++;
       }
 
-      if (src_compressed) {
+      // Mirror SRC compression state on TGT.
+      // TGT now shares SRC's tail objects so its compression state must match.
+      if (p_src_rec->compression_bl.length() > 0) {
         tgt_op.setxattr(RGW_ATTR_COMPRESSION, p_src_rec->compression_bl);
-        if (!tgt_compressed) {
+        if (p_tgt_rec->compression_bl.length() == 0) {
           p_stats->set_compression_on_tgt++;
         }
-      } else {
-        tgt_op.rmxattr(RGW_ATTR_COMPRESSION);
-        if (tgt_compressed) {
+      }
+      else {
+        if (p_tgt_rec->compression_bl.length() > 0) {
+          tgt_op.rmxattr(RGW_ATTR_COMPRESSION);
           p_stats->clear_compression_on_tgt++;
         }
       }
@@ -1174,10 +1161,11 @@ namespace rgw::dedup {
     blake3_hasher *hmac;
     const DoutPrefixProvider *dpp;
 
-    bufferlist pending;         // partial compressed block accumulated so far
+    bufferlist pending;        // partial compressed block accumulated so far
     uint64_t   raw_ofs  = 0;   // running offset in compressed stream
     size_t     blk_idx  = 0;   // next compression block to process
 
+    //---------------------------------------------------------------------------
     streaming_decompressor_t(CompressorRef _comp,
                              RGWCompressionInfo &&_cs,
                              blake3_hasher *_hmac,
@@ -1185,41 +1173,52 @@ namespace rgw::dedup {
       : compressor(std::move(_comp)), cs_info(std::move(_cs)),
         hmac(_hmac), dpp(_dpp) {}
 
-    int feed_compressed_data(bufferlist &bl) {
+    //---------------------------------------------------------------------------
+    int feed_compressed_data(bufferlist &bl)
+    {
       uint64_t len = bl.length();
       pending.claim_append(bl);
       raw_ofs += len;
       return drain_ready_blocks();
     }
 
-    int drain_ready_blocks() {
+    //---------------------------------------------------------------------------
+    int drain_ready_blocks()
+    {
+      // A global offset of pending[0] before trim
+      uint64_t pending_start = raw_ofs - pending.length();
+
       while (blk_idx < cs_info.blocks.size()) {
         const auto &block = cs_info.blocks[blk_idx];
         uint64_t block_end = block.new_ofs + block.len;
         if (raw_ofs < block_end) {
           break; // not enough data yet for this block
         }
-        bufferlist compressed_bl, decompressed_bl;
-        uint64_t local_ofs = block.new_ofs - (raw_ofs - pending.length());
-        pending.begin(local_ofs).copy(block.len, compressed_bl);
-        int ret = compressor->decompress(compressed_bl, decompressed_bl,
+
+        // short lived bl holding a single decompressed block
+        bufferlist decompressed_bl;
+        // offset inside pending bl where this block starts
+        uint64_t local_ofs = block.new_ofs - pending_start;
+        auto block_itr = pending.cbegin(local_ofs);
+        int ret = compressor->decompress(block_itr, block.len, decompressed_bl,
                                          cs_info.compressor_message);
         if (ret < 0) {
           ldpp_dout(dpp, 1) << "streaming_decompressor_t::ERR: decompression"
-                               " failed, ret=" << ret << dendl;
+            " failed, ret=" << ret << dendl;
           return ret;
         }
+
+        // push decompressed block to blake3 and release bl
         for (const auto& bptr : decompressed_bl.buffers()) {
-          blake3_hasher_update(hmac,
-            (const unsigned char *)bptr.c_str(), bptr.length());
+          blake3_hasher_update(hmac, (const uint8_t *)bptr.c_str(), bptr.length());
         }
         blk_idx++;
       }
+
       // discard data that has been fully consumed by all processed blocks
       if (blk_idx > 0) {
-        uint64_t consumed_end = cs_info.blocks[blk_idx - 1].new_ofs +
-                                cs_info.blocks[blk_idx - 1].len;
-        uint64_t pending_start = raw_ofs - pending.length();
+        auto & prev_block = cs_info.blocks[blk_idx - 1];
+        uint64_t consumed_end = prev_block.new_ofs + prev_block.len;
         if (consumed_end > pending_start) {
           uint64_t trim = consumed_end - pending_start;
           if (trim <= pending.length()) {
@@ -1230,12 +1229,17 @@ namespace rgw::dedup {
       return 0;
     }
 
-    int finish() {
+    //---------------------------------------------------------------------------
+    int finish()
+    {
       int ret = drain_ready_blocks();
-      if (ret < 0) return ret;
+      if (ret < 0) {
+        return ret;
+      }
+
       if (blk_idx != cs_info.blocks.size()) {
         ldpp_dout(dpp, 1) << "streaming_decompressor_t::ERR: not all blocks"
-                             " decompressed, processed=" << blk_idx
+          " decompressed, processed=" << blk_idx
                           << " total=" << cs_info.blocks.size() << dendl;
         return -EIO;
       }
@@ -1247,12 +1251,19 @@ namespace rgw::dedup {
   int Background::calc_object_blake3(const RGWObjManifest &manifest,
                                      disk_record_t *p_rec,
                                      uint8_t *p_hash,
-                                     bufferlist *p_head_bl)
+                                     const bufferlist *p_head_bl)
   {
+    // validate input
+    if (p_head_bl && p_head_bl->length() == 0) {
+      ldpp_dout(dpp, 1) << __func__ << "::ERR: empty p_head_bl for obj="
+                        << p_rec->obj_name << dendl;
+      return -EINVAL;
+    }
+
+    // setup compressor if needed
     bool is_compressed = false;
     RGWCompressionInfo cs_info;
     CompressorRef compressor;
-
     if (p_rec->compression_bl.length() > 0) {
       try {
         auto bl_iter = p_rec->compression_bl.cbegin();
@@ -1262,13 +1273,14 @@ namespace rgw::dedup {
           compressor = Compressor::create(cct, cs_info.compression_type);
           if (!compressor) {
             ldpp_dout(dpp, 1) << __func__ << "::ERR: Cannot load compressor of type "
-                              << cs_info.compression_type << dendl;
+                              << cs_info.compression_type << " for obj="
+                              << p_rec->obj_name << dendl;
             return -EIO;
           }
         }
       } catch (buffer::error&) {
-        ldpp_dout(dpp, 1) << __func__
-                          << "::ERR: failed RGWCompressionInfo decode" << dendl;
+        ldpp_dout(dpp, 1) << __func__ << "::ERR: failed RGWCompressionInfo decode for obj="
+                          << p_rec->obj_name << dendl;
         return -EINVAL;
       }
     }
@@ -1282,28 +1294,29 @@ namespace rgw::dedup {
 
     std::unique_ptr<streaming_decompressor_t> decompressor;
     if (compressor) {
-      decompressor = std::make_unique<streaming_decompressor_t>(
-        compressor, std::move(cs_info), p_hmac, dpp);
-      if (p_head_bl && p_head_bl->length() > 0) {
+      decompressor = std::make_unique<streaming_decompressor_t>(compressor, std::move(cs_info), p_hmac, dpp);
+      if (p_head_bl) {
         // copy before feeding: feed_compressed_data() uses claim_append()
         // which would empty the caller's bufferlist; split_head_object()
         // needs p_head_bl intact to write the new tail object afterwards
         bufferlist head_copy;
         head_copy.append(*p_head_bl);
         int ret = decompressor->feed_compressed_data(head_copy);
-        if (ret < 0) return ret;
+        if (ret < 0) {
+          return ret;
+        }
       }
-    } else if (p_head_bl && p_head_bl->length() > 0) {
+    }
+    else if (p_head_bl) {
       for (const auto& bptr : p_head_bl->buffers()) {
-        blake3_hasher_update(p_hmac,
-          (const unsigned char *)bptr.c_str(), bptr.length());
+        blake3_hasher_update(p_hmac, (const uint8_t *)bptr.c_str(), bptr.length());
       }
     }
 
     for (auto p = manifest.obj_begin(dpp); p != manifest.obj_end(dpp); ++p) {
       uint64_t offset = p.get_stripe_ofs();
       const rgw_obj_select& os = p.get_location();
-      // skip head stripe when head data was already provided
+      // p_head_bl is non-null only when non-empty (see above); head already hashed
       if (offset == 0 && p_head_bl) {
         continue;
       }
@@ -1311,8 +1324,10 @@ namespace rgw::dedup {
       rgw_rados_ref obj;
       int ret = rgw_get_rados_ref(dpp, rados_handle, raw_obj, &obj);
       if (ret < 0) {
-        ldpp_dout(dpp, 1) << __func__ << "::failed rgw_get_rados_ref() for oid="
-                          << raw_obj.oid << ", err is " << cpp_strerror(-ret) << dendl;
+        ldpp_dout(dpp, 1) << __func__ << "::ERR: failed rgw_get_rados_ref() for obj="
+                          << p_rec->obj_name << ", oid=" << raw_obj.oid
+                          << ", offset=" << offset
+                          << ", err=" << cpp_strerror(-ret) << dendl;
         return ret;
       }
 
@@ -1320,24 +1335,30 @@ namespace rgw::dedup {
       bufferlist bl;
       ret = ioctx.read(raw_obj.oid, bl, 0, 0);
       if (unlikely(ret <= 0)) {
-        ldpp_dout(dpp, 1) << __func__ << "::ERR: failed to read oid "
-                          << raw_obj.oid  << ", err is " << cpp_strerror(-ret) << dendl;
+        ldpp_dout(dpp, 1) << __func__ << "::ERR: failed to read oid=" << raw_obj.oid
+                          << " for obj=" << p_rec->obj_name << ", offset=" << offset
+                          << ", ret=" << ret
+                          << ", err=" << cpp_strerror(-ret) << dendl;
         return ret;
       }
       if (decompressor) {
         ret = decompressor->feed_compressed_data(bl);
-        if (ret < 0) return ret;
-      } else {
+        if (ret < 0) {
+          return ret;
+        }
+      }
+      else {
         for (const auto& bptr : bl.buffers()) {
-          blake3_hasher_update(p_hmac,
-            (const unsigned char *)bptr.c_str(), bptr.length());
+          blake3_hasher_update(p_hmac, (const uint8_t *)bptr.c_str(), bptr.length());
         }
       }
     }
 
     if (decompressor) {
       int ret = decompressor->finish();
-      if (ret < 0) return ret;
+      if (ret < 0) {
+        return ret;
+      }
     }
 
     blake3_hasher_finalize(p_hmac, p_hash, BLAKE3_OUT_LEN);
@@ -1467,22 +1488,18 @@ namespace rgw::dedup {
         p_rec->manifest_bl = bl;
       }
       p_rec->s.manifest_len = p_rec->manifest_bl.length();
-      if (p_tail_rule) {
-        *p_tail_rule = manifest.get_tail_placement().placement_rule;
-      }
+      *p_tail_rule = manifest.get_tail_placement().placement_rule;
     }
     else {
       ldpp_dout(dpp, 5)  << __func__ << "::ERROR: no manifest" << dendl;
       return -EINVAL;
     }
-    const auto &head_placement_rule = manifest.get_head_placement_rule();
-    const std::string& storage_class =
-      rgw_placement_rule::get_canonical_storage_class(head_placement_rule.storage_class);
 
-    // p_rec holds an the storage_class value taken from the bucket-index/obj-attr
-    if (unlikely(storage_class != p_rec->stor_class)) {
-      ldpp_dout(dpp, 5) << __func__ << "::ERROR::manifest storage_class="
-                        << storage_class << " != " << "::bucket-index storage_class="
+    const auto& sc_from_tail = p_tail_rule->get_storage_class();
+    // p_rec holds the storage_class value taken from the bucket-index/obj-attr
+    if (unlikely(sc_from_tail != p_rec->stor_class)) {
+      ldpp_dout(dpp, 5) << __func__ << "::ERROR::manifest tail storage_class="
+                        << sc_from_tail << " != p_rec->stor_class="
                         << p_rec->stor_class << dendl;
       p_stats->different_storage_class++;
       return -EINVAL;
@@ -1663,9 +1680,14 @@ namespace rgw::dedup {
       return 0;
     }
 
+    std::string obj_compression_type = "none";
+    int64_t accounted_size = p_obj->get_size();
     {
+      p_rec->compression_bl.clear();
+      p_rec->s.compression_len = 0;
+
       auto comp_itr = attrs.find(RGW_ATTR_COMPRESSION);
-      if (comp_itr != attrs.end()) {
+      if (comp_itr != attrs.end() && comp_itr->second.length() > 0) {
         if (d_skip_compressed) {
           p_stats->ingress_skip_compressed++;
           p_stats->ingress_skip_compressed_bytes += ondisk_byte_size;
@@ -1674,26 +1696,21 @@ namespace rgw::dedup {
           return 0;
         }
         p_rec->compression_bl = comp_itr->second;
-        p_rec->s.compression_bl_len = p_rec->compression_bl.length();
+        p_rec->s.compression_len = p_rec->compression_bl.length();
         p_stats->ingress_compressed++;
         p_stats->ingress_compressed_bytes += ondisk_byte_size;
         ldpp_dout(dpp, 20) <<__func__ << "::compressed object "
                            << p_rec->obj_name << dendl;
-      } else {
-        p_rec->compression_bl.clear();
-        p_rec->s.compression_bl_len = 0;
-      }
-    }
 
-    std::string obj_compression_type;
-    int64_t head_accounted_size = derive_head_accounted_size(dpp, p_rec->compression_bl,
-                                                             p_obj->get_size(),
-                                                             &obj_compression_type);
-    if (unlikely(head_accounted_size < 0)) {
-      ldpp_dout(dpp, 5) << __func__
-                        << "::ERR: derive_head_accounted_size failed for "
-                        << p_rec->obj_name << dendl;
-      return head_accounted_size;
+        accounted_size = derive_accounted_size(dpp, p_rec->compression_bl,
+                                               &obj_compression_type);
+        if (unlikely(accounted_size < 0)) {
+          ldpp_dout(dpp, 5) << __func__
+                            << "::ERR: derive_accounted_size failed for "
+                            << p_rec->obj_name << dendl;
+          return accounted_size;
+        }
+      }
     }
 
     // extract ETAG and compare with values taken from the bucket-index
@@ -1733,11 +1750,11 @@ namespace rgw::dedup {
     // no need to check for remap success as we compare keys bellow
     sc_idx = remapper->remap(storage_class, dpp, &p_stats->failed_map_overflow);
     // Cross-check etag, num_parts, storage_class and size from object-head
-    // against bucket-index.  head_accounted_size was derived above from the
+    // against bucket-index.  accounted_size was derived above from the
     // compression attr (orig_size) or physical size - matching the write-path
     // logic, so it is safe to compare against the bucket-index value.
     key_t key_from_obj(parsed_etag.md5_high, parsed_etag.md5_low,
-                       byte_size_to_disk_blocks(head_accounted_size),
+                       byte_size_to_disk_blocks(accounted_size),
                        parsed_etag.num_parts, sc_idx);
     if (unlikely(key_from_obj != key_from_bucket_index)) {
       ldpp_dout(dpp, 15) <<__func__ << "::Skipping changed object "
@@ -1775,6 +1792,7 @@ namespace rgw::dedup {
       p_stats->max_attrs_record_length = rec_len;
     }
     p_stats->total_attrs_record_length += rec_len;
+    p_stats->attrs_record_count++;
 
     disk_block_seq_t::record_info_t rec_info;
     ret = p_disk->add_record(d_dedup_cluster_ioctx, p_rec, &rec_info, p_stats);
@@ -1858,9 +1876,8 @@ namespace rgw::dedup {
   // Always fetched:
   //   RGW_ATTR_MANIFEST  -- required; returns -ENOENT if missing.
   //   RGW_ATTR_BLAKE3    -- if present, populates p_rec->s.hash and sets
-  //                         has_valid_hash().  Missing BLAKE3 is an error
-  //                         unless has_remote_attrs() is set (the hash may
-  //                         not have been written to the object head yet).
+  //                         has_valid_hash().  Missing BLAKE3 returns -ENOENT
+  //                         when blake3_expected is true (caller decides).
   //
   // Conditionally fetched (when has_remote_attrs()):
   //   RGW_ATTR_COMPRESSION -- restores compression_bl that was dropped from
@@ -1877,23 +1894,28 @@ namespace rgw::dedup {
   // Uses a single ioctx.getxattrs() call (all attrs returned in one round
   // trip), so fetching compression adds zero extra RADOS cost.
   static int fetch_head_obj_attrs(const DoutPrefixProvider *const dpp,
-                                    rgw::sal::Driver *driver,
-                                    rgw::sal::RadosStore *store,
-                                    disk_record_t *p_rec)
+                                  rgw::sal::Driver *driver,
+                                  rgw::sal::RadosStore *store,
+                                  disk_record_t *p_rec,
+                                  bool blake3_expected)
   {
     librados::IoCtx ioctx;
     std::string oid;
     int ret = get_ioctx(dpp, driver, store, p_rec, &ioctx, &oid);
     if (unlikely(ret != 0)) {
-      ldpp_dout(dpp, 5) << __func__ << "::ERR: failed get_ioctx()" << dendl;
+      ldpp_dout(dpp, 1) << __func__ << "::ERR: failed get_ioctx() for "
+                        << p_rec->bucket_name << "/" << p_rec->obj_name
+                        << ", err is " << cpp_strerror(-ret) << dendl;
       return ret;
     }
 
     std::map<std::string, bufferlist> attrset;
     ret = ioctx.getxattrs(oid, attrset);
     if (unlikely(ret < 0)) {
-      ldpp_dout(dpp, 5) << __func__ << "::ERR: failed ioctx.getxattrs("
-                        << oid << "), err is " << cpp_strerror(-ret) << dendl;
+      ldpp_dout(dpp, 1) << __func__ << "::ERR: failed ioctx.getxattrs("
+                        << oid << ") for " << p_rec->bucket_name << "/"
+                        << p_rec->obj_name << ", err is " << cpp_strerror(-ret)
+                        << dendl;
       return ret;
     }
 
@@ -1915,9 +1937,7 @@ namespace rgw::dedup {
         return -EINVAL;
       }
     }
-    else if (!p_rec->s.flags.has_remote_attrs()) {
-      // BLAKE3 is mandatory unless fetching for remote_attrs (hash may not
-      // have been written to the object head yet)
+    else if (blake3_expected) {
       ldpp_dout(dpp, 1) << __func__ << "::ERR: No HASH attribute" << dendl;
       return -ENOENT;
     }
@@ -1937,7 +1957,7 @@ namespace rgw::dedup {
       itr = attrset.find(RGW_ATTR_COMPRESSION);
       if (itr != attrset.end()) {
         p_rec->compression_bl = itr->second;
-        p_rec->s.compression_bl_len = p_rec->compression_bl.length();
+        p_rec->s.compression_len = p_rec->compression_bl.length();
       }
     }
 
@@ -2095,7 +2115,7 @@ namespace rgw::dedup {
       // read the manifest and strong hash from the head-object attributes
       ldpp_dout(dpp, 20) << __func__ << "::Fetch SRC strong hash from head-object::"
                          << p_src_rec->obj_name << dendl;
-      if (unlikely(fetch_head_obj_attrs(dpp, driver, store, p_src_rec) != 0)) {
+      if (unlikely(fetch_head_obj_attrs(dpp, driver, store, p_src_rec, true) != 0)) {
         return false;
       }
       try {
@@ -2304,7 +2324,7 @@ namespace rgw::dedup {
     // This records is a dedup target with source record on source_block_id
     disk_record_t src_rec, *p_src_rec = &src_rec;
     ret = load_record(d_dedup_cluster_ioctx, p_tgt_rec, p_src_rec, src_block_id,
-                      src_rec_id, md5_shard, dpp);
+                      src_rec_id, md5_shard, dpp, p_stats);
     if (unlikely(ret != 0)) {
       p_stats->failed_src_load++;
       // we can withstand most errors moving to the next object
@@ -2314,12 +2334,14 @@ namespace rgw::dedup {
     }
 
     if (p_src_rec->s.flags.has_remote_attrs()) {
-      ret = fetch_head_obj_attrs(dpp, driver, store, p_src_rec);
+      const bool blake3_expected = p_src_rec->s.flags.has_valid_hash() || src_val.has_valid_hash();
+      ret = fetch_head_obj_attrs(dpp, driver, store, p_src_rec, blake3_expected);
       if (unlikely(ret != 0)) {
         p_stats->failed_remote_attrs_fetch++;
-        ldpp_dout(dpp, 5) << __func__
+        ldpp_dout(dpp, 1) << __func__
                           << "::ERR: failed fetch remote attrs for SRC "
-                          << p_src_rec->obj_name << dendl;
+                          << p_src_rec->bucket_name << "/" << p_src_rec->obj_name
+                          << ", err is " << cpp_strerror(-ret) << " ret=" << ret << dendl;
         return 0;
       }
     }
@@ -2348,12 +2370,14 @@ namespace rgw::dedup {
     }
 
     if (p_tgt_rec->s.flags.has_remote_attrs()) {
-      ret = fetch_head_obj_attrs(dpp, driver, store, p_tgt_rec);
+      ret = fetch_head_obj_attrs(dpp, driver, store, p_tgt_rec,
+                                 p_tgt_rec->s.flags.has_valid_hash());
       if (unlikely(ret != 0)) {
         p_stats->failed_remote_attrs_fetch++;
-        ldpp_dout(dpp, 5) << __func__
+        ldpp_dout(dpp, 1) << __func__
                           << "::ERR: failed fetch remote attrs for TGT "
-                          << p_tgt_rec->obj_name << dendl;
+                          << p_tgt_rec->bucket_name << "/" << p_tgt_rec->obj_name
+                          << ", err is " << cpp_strerror(-ret) << " ret=" << ret << dendl;
         return 0;
       }
     }
@@ -2394,7 +2418,9 @@ namespace rgw::dedup {
       ldpp_dout(dpp, 20) << __func__ << "::dedup success " << p_src_rec->obj_name << dendl;
       p_stats->deduped_objects++;
       p_stats->deduped_objects_bytes += dedupable_objects_bytes;
-      if (p_src_rec->compression_bl.length() > 0 && p_tgt_rec->compression_bl.length() > 0) {
+      if (p_src_rec->compression_bl.length() > 0 &&
+          p_tgt_rec->compression_bl.length() > 0) {
+        // count dedup ops between compressed SRC and compressed TGT
         p_stats->deduped_compressed_objects++;
       }
       if (p_tgt_rec->s.flags.is_split_head()) {
@@ -2515,7 +2541,7 @@ namespace rgw::dedup {
           unsigned offset = p_header->rec_offsets[rec_id];
           // We deserialize the record inside the CTOR
           disk_record_t rec(p + offset);
-          ret = rec.validate(__func__, dpp, disk_block_id, rec_id);
+          ret = rec.validate(__func__, dpp, disk_block_id, rec_id, nullptr, p_stats);
           if (unlikely(ret != 0)) {
             p_stats->failed_rec_load++;
             return ret;
@@ -3660,6 +3686,10 @@ namespace rgw::dedup {
       throw std::runtime_error("Failed init_rados_access_handles()");
     }
     display_ioctx_state(dpp, d_dedup_cluster_ioctx, "dedup_bg->resume() done");
+
+    // pause()/resume() can modify placement compression state
+    d_placement_compression_type.clear();
+
     // create new watch request using the new pool handle
     watch_reload(dpp);
     d_ctl.local_pause_req = false;
@@ -3726,9 +3756,13 @@ namespace rgw::dedup {
 
       ldpp_dout(dpp, 10) << __func__ << "::Wait for object ingress completion, ttl="
                          << ttl << " seconds" << dendl;
-      std::unique_lock cond_lock(d_cond_mutex);
-      d_cond.wait_for(cond_lock, std::chrono::seconds(ttl),
-                      [this]{return d_ctl.should_stop() || d_ctl.should_pause();});
+      {
+        // limit the scope of cond_lock
+        std::unique_lock cond_lock(d_cond_mutex);
+        d_cond.wait_for(cond_lock, std::chrono::seconds(ttl),
+                        [this]{return d_ctl.should_stop() || d_ctl.should_pause();});
+      }
+
       if (unlikely(d_ctl.should_pause())) {
         handle_pause_req(__func__);
       }
@@ -3768,9 +3802,13 @@ namespace rgw::dedup {
     while (!all_md5_shards_completed(&d_cluster, store, num_md5_shards)) {
       ldpp_dout(dpp, 10) << __func__ << "::Wait for md5 completion, ttl="
                          << ttl << " seconds" << dendl;
-      std::unique_lock cond_lock(d_cond_mutex);
-      d_cond.wait_for(cond_lock, std::chrono::seconds(ttl),
-                      [this]{return d_ctl.should_stop() || d_ctl.should_pause();});
+      {
+        // limit the scope of cond_lock
+        std::unique_lock cond_lock(d_cond_mutex);
+        d_cond.wait_for(cond_lock, std::chrono::seconds(ttl),
+                        [this]{return d_ctl.should_stop() || d_ctl.should_pause();});
+      }
+
       if (unlikely(d_ctl.should_pause())) {
         handle_pause_req(__func__);
       }
@@ -3811,6 +3849,7 @@ namespace rgw::dedup {
           ldpp_dout(dpp, 1) << __func__ << "::failed setup()" << dendl;
           return;
         }
+
         d_placement_compression_type.clear();
         const rgw_pool& dedup_pool = store->svc()->zone->get_zone_params().dedup_pool;
         int64_t pool_id = rados_handle->pool_lookup(dedup_pool.name.c_str());

--- a/src/rgw/driver/rados/rgw_dedup.cc
+++ b/src/rgw/driver/rados/rgw_dedup.cc
@@ -87,34 +87,25 @@ namespace rgw::dedup {
 
   // Derive accounted_size from object-head attributes the same way the
   // write-path computes it (see RGWRados::Object::Write::_do_write_meta):
-  //   compressed   -> RGWCompressionInfo::orig_size  (stable, not patched)
-  //   uncompressed -> physical object size
   // We cannot use p_obj->get_accounted_size() because the stat path patches
   // it via the manifest (set_head / get_obj_size).
-  static int64_t derive_head_accounted_size(const DoutPrefixProvider *dpp,
-                                             const bufferlist &compression_bl,
-                                             uint64_t obj_size,
-                                             std::string *p_compression_type = nullptr)
+  static int64_t derive_accounted_size(const DoutPrefixProvider *dpp,
+                                       const bufferlist &compression_bl,
+                                       std::string *p_compression_type = nullptr)
   {
-    if (compression_bl.length() > 0) {
-      RGWCompressionInfo cs_info;
-      auto bl_iter = compression_bl.cbegin();
-      try {
-        decode(cs_info, bl_iter);
-      } catch (buffer::error&) {
-        ldpp_dout(dpp, 5) << __func__
-                          << "::ERR: failed to decode compression info" << dendl;
-        return -EINVAL;
-      }
-      if (p_compression_type) {
-        *p_compression_type = cs_info.compression_type;
-      }
-      return cs_info.orig_size;
+    RGWCompressionInfo cs_info;
+    auto bl_iter = compression_bl.cbegin();
+    try {
+      decode(cs_info, bl_iter);
+    } catch (buffer::error&) {
+      ldpp_dout(dpp, 5) << __func__
+                        << "::ERR: failed to decode compression info" << dendl;
+      return -EINVAL;
     }
     if (p_compression_type) {
-      *p_compression_type = "none";
+      *p_compression_type = cs_info.compression_type;
     }
-    return obj_size;
+    return cs_info.orig_size;
   }
 
   //---------------------------------------------------------------------------
@@ -419,12 +410,18 @@ namespace rgw::dedup {
   //---------------------------------------------------------------------------
   const std::string& Background::get_placement_compression_type(const rgw_placement_rule &rule)
   {
-    auto it = d_placement_compression_type.find(rule.name);
+    const std::string key = rule.to_str();
+    // check if we have a cache compression_type for this rule
+    auto it = d_placement_compression_type.find(key);
     if (it != d_placement_compression_type.end()) {
       return it->second;
     }
+
+    // no local cache, check zoneparams
     const std::string& comp_type = store->svc()->zone->get_zone_params().get_compression_type(rule);
-    auto result = d_placement_compression_type.emplace(rule.name, comp_type);
+
+    // store in local cache to speedup next access
+    auto result = d_placement_compression_type.emplace(key, comp_type);
     return result.first->second;
   }
 
@@ -765,13 +762,12 @@ namespace rgw::dedup {
                  (head_size == rule.stripe_max_size || head_size == obj_size));
 
       if (unlikely(!success)) {
-        ldpp_dout(dpp, 20) << __func__ << "::ERR::d_split_head=" << d_split_head
+        ldpp_dout(dpp, 20) << __func__ << "::skip::d_split_head=" << d_split_head
                            << "::obj_size=" << obj_size
                            << "::head_size=" << head_size
                            << "::rule.part_size=" << rule.part_size
                            << "::rule.stripe_max_size=" << rule.stripe_max_size
                            << "::rule.override_prefix=" << rule.override_prefix
-                           << "::rule.override_prefix.empty()=" << rule.override_prefix.empty()
                            << dendl;
       }
     } // don't split head if can't get rule
@@ -1138,14 +1134,8 @@ namespace rgw::dedup {
       {
         bufferlist src_hash_bl;
         init_cmp_pairs(dpp, p_src_rec, etag_bl, src_hash_bl, &src_op);
-        // CAS on compression only when SRC is uncompressed (cheap empty-bl compare).
-        // A compressed object's compression state is assumed immutable: RGW never
-        // strips or rewrites RGW_ATTR_COMPRESSION on an existing object, so there
-        // is no need to CAS on a potentially large compression attribute.
-        if (p_src_rec->compression_bl.length() == 0) {
-          src_op.cmpxattr(RGW_ATTR_COMPRESSION, CEPH_OSD_CMPXATTR_OP_EQ,
-                          p_src_rec->compression_bl);
-        }
+        // SRC compression attr is fixed at object creation;
+        // Any real rewrite rotates ref_tag, caught by init_cmp_pairs() above.
         src_op.setxattr(RGW_ATTR_SHARE_MANIFEST, manifest_hash_bl);
         if (p_src_rec->s.flags.hash_calculated() && !p_src_val->has_valid_hash()){
           src_op.setxattr(RGW_ATTR_BLAKE3, src_hash_bl);
@@ -1174,11 +1164,6 @@ namespace rgw::dedup {
       }
     }
 
-    // Set RGW_ATTR_COMPRESSION on TGT unconditionally from SRC state.
-    // TGT now shares SRC's tail objects so its compression state must match.
-    bool src_compressed = (p_src_rec->compression_bl.length() > 0);
-    bool tgt_compressed = (p_tgt_rec->compression_bl.length() > 0);
-
     librados::ObjectWriteOperation tgt_op;
     {
       bufferlist tgt_hash_bl;
@@ -1193,14 +1178,17 @@ namespace rgw::dedup {
         p_stats->set_hash_attrs++;
       }
 
-      if (src_compressed) {
+      // Mirror SRC compression state on TGT.
+      // TGT now shares SRC's tail objects so its compression state must match.
+      if (p_src_rec->compression_bl.length() > 0) {
         tgt_op.setxattr(RGW_ATTR_COMPRESSION, p_src_rec->compression_bl);
-        if (!tgt_compressed) {
+        if (p_tgt_rec->compression_bl.length() == 0) {
           p_stats->set_compression_on_tgt++;
         }
-      } else {
-        tgt_op.rmxattr(RGW_ATTR_COMPRESSION);
-        if (tgt_compressed) {
+      }
+      else {
+        if (p_tgt_rec->compression_bl.length() > 0) {
+          tgt_op.rmxattr(RGW_ATTR_COMPRESSION);
           p_stats->clear_compression_on_tgt++;
         }
       }
@@ -1240,10 +1228,11 @@ namespace rgw::dedup {
     blake3_hasher *hmac;
     const DoutPrefixProvider *dpp;
 
-    bufferlist pending;         // partial compressed block accumulated so far
+    bufferlist pending;        // partial compressed block accumulated so far
     uint64_t   raw_ofs  = 0;   // running offset in compressed stream
     size_t     blk_idx  = 0;   // next compression block to process
 
+    //---------------------------------------------------------------------------
     streaming_decompressor_t(CompressorRef _comp,
                              RGWCompressionInfo &&_cs,
                              blake3_hasher *_hmac,
@@ -1251,41 +1240,52 @@ namespace rgw::dedup {
       : compressor(std::move(_comp)), cs_info(std::move(_cs)),
         hmac(_hmac), dpp(_dpp) {}
 
-    int feed_compressed_data(bufferlist &bl) {
+    //---------------------------------------------------------------------------
+    int feed_compressed_data(bufferlist &bl)
+    {
       uint64_t len = bl.length();
       pending.claim_append(bl);
       raw_ofs += len;
       return drain_ready_blocks();
     }
 
-    int drain_ready_blocks() {
+    //---------------------------------------------------------------------------
+    int drain_ready_blocks()
+    {
+      // A global offset of pending[0] before trim
+      uint64_t pending_start = raw_ofs - pending.length();
+
       while (blk_idx < cs_info.blocks.size()) {
         const auto &block = cs_info.blocks[blk_idx];
         uint64_t block_end = block.new_ofs + block.len;
         if (raw_ofs < block_end) {
           break; // not enough data yet for this block
         }
-        bufferlist compressed_bl, decompressed_bl;
-        uint64_t local_ofs = block.new_ofs - (raw_ofs - pending.length());
-        pending.begin(local_ofs).copy(block.len, compressed_bl);
-        int ret = compressor->decompress(compressed_bl, decompressed_bl,
+
+        // short lived bl holding a single decompressed block
+        bufferlist decompressed_bl;
+        // offset inside pending bl where this block starts
+        uint64_t local_ofs = block.new_ofs - pending_start;
+        auto block_itr = pending.cbegin(local_ofs);
+        int ret = compressor->decompress(block_itr, block.len, decompressed_bl,
                                          cs_info.compressor_message);
         if (ret < 0) {
           ldpp_dout(dpp, 1) << "streaming_decompressor_t::ERR: decompression"
-                               " failed, ret=" << ret << dendl;
+            " failed, ret=" << ret << dendl;
           return ret;
         }
+
+        // push decompressed block to blake3 and release bl
         for (const auto& bptr : decompressed_bl.buffers()) {
-          blake3_hasher_update(hmac,
-            (const unsigned char *)bptr.c_str(), bptr.length());
+          blake3_hasher_update(hmac, (const uint8_t *)bptr.c_str(), bptr.length());
         }
         blk_idx++;
       }
+
       // discard data that has been fully consumed by all processed blocks
       if (blk_idx > 0) {
-        uint64_t consumed_end = cs_info.blocks[blk_idx - 1].new_ofs +
-                                cs_info.blocks[blk_idx - 1].len;
-        uint64_t pending_start = raw_ofs - pending.length();
+        auto & prev_block = cs_info.blocks[blk_idx - 1];
+        uint64_t consumed_end = prev_block.new_ofs + prev_block.len;
         if (consumed_end > pending_start) {
           uint64_t trim = consumed_end - pending_start;
           if (trim <= pending.length()) {
@@ -1296,12 +1296,17 @@ namespace rgw::dedup {
       return 0;
     }
 
-    int finish() {
+    //---------------------------------------------------------------------------
+    int finish()
+    {
       int ret = drain_ready_blocks();
-      if (ret < 0) return ret;
+      if (ret < 0) {
+        return ret;
+      }
+
       if (blk_idx != cs_info.blocks.size()) {
         ldpp_dout(dpp, 1) << "streaming_decompressor_t::ERR: not all blocks"
-                             " decompressed, processed=" << blk_idx
+          " decompressed, processed=" << blk_idx
                           << " total=" << cs_info.blocks.size() << dendl;
         return -EIO;
       }
@@ -1313,12 +1318,19 @@ namespace rgw::dedup {
   int Background::calc_object_blake3(const RGWObjManifest &manifest,
                                      disk_record_t *p_rec,
                                      uint8_t *p_hash,
-                                     bufferlist *p_head_bl)
+                                     const bufferlist *p_head_bl)
   {
+    // validate input
+    if (p_head_bl && p_head_bl->length() == 0) {
+      ldpp_dout(dpp, 1) << __func__ << "::ERR: empty p_head_bl for obj="
+                        << p_rec->obj_name << dendl;
+      return -EINVAL;
+    }
+
+    // setup compressor if needed
     bool is_compressed = false;
     RGWCompressionInfo cs_info;
     CompressorRef compressor;
-
     if (p_rec->compression_bl.length() > 0) {
       try {
         auto bl_iter = p_rec->compression_bl.cbegin();
@@ -1328,13 +1340,14 @@ namespace rgw::dedup {
           compressor = Compressor::create(cct, cs_info.compression_type);
           if (!compressor) {
             ldpp_dout(dpp, 1) << __func__ << "::ERR: Cannot load compressor of type "
-                              << cs_info.compression_type << dendl;
+                              << cs_info.compression_type << " for obj="
+                              << p_rec->obj_name << dendl;
             return -EIO;
           }
         }
       } catch (buffer::error&) {
-        ldpp_dout(dpp, 1) << __func__
-                          << "::ERR: failed RGWCompressionInfo decode" << dendl;
+        ldpp_dout(dpp, 1) << __func__ << "::ERR: failed RGWCompressionInfo decode for obj="
+                          << p_rec->obj_name << dendl;
         return -EINVAL;
       }
     }
@@ -1348,28 +1361,29 @@ namespace rgw::dedup {
 
     std::unique_ptr<streaming_decompressor_t> decompressor;
     if (compressor) {
-      decompressor = std::make_unique<streaming_decompressor_t>(
-        compressor, std::move(cs_info), p_hmac, dpp);
-      if (p_head_bl && p_head_bl->length() > 0) {
+      decompressor = std::make_unique<streaming_decompressor_t>(compressor, std::move(cs_info), p_hmac, dpp);
+      if (p_head_bl) {
         // copy before feeding: feed_compressed_data() uses claim_append()
         // which would empty the caller's bufferlist; split_head_object()
         // needs p_head_bl intact to write the new tail object afterwards
         bufferlist head_copy;
         head_copy.append(*p_head_bl);
         int ret = decompressor->feed_compressed_data(head_copy);
-        if (ret < 0) return ret;
+        if (ret < 0) {
+          return ret;
+        }
       }
-    } else if (p_head_bl && p_head_bl->length() > 0) {
+    }
+    else if (p_head_bl) {
       for (const auto& bptr : p_head_bl->buffers()) {
-        blake3_hasher_update(p_hmac,
-          (const unsigned char *)bptr.c_str(), bptr.length());
+        blake3_hasher_update(p_hmac, (const uint8_t *)bptr.c_str(), bptr.length());
       }
     }
 
     for (auto p = manifest.obj_begin(dpp); p != manifest.obj_end(dpp); ++p) {
       uint64_t offset = p.get_stripe_ofs();
       const rgw_obj_select& os = p.get_location();
-      // skip head stripe when head data was already provided
+      // p_head_bl is non-null only when non-empty (see above); head already hashed
       if (offset == 0 && p_head_bl) {
         continue;
       }
@@ -1377,8 +1391,10 @@ namespace rgw::dedup {
       rgw_rados_ref obj;
       int ret = rgw_get_rados_ref(dpp, rados_handle, raw_obj, &obj);
       if (ret < 0) {
-        ldpp_dout(dpp, 1) << __func__ << "::failed rgw_get_rados_ref() for oid="
-                          << raw_obj.oid << ", err is " << cpp_strerror(-ret) << dendl;
+        ldpp_dout(dpp, 1) << __func__ << "::ERR: failed rgw_get_rados_ref() for obj="
+                          << p_rec->obj_name << ", oid=" << raw_obj.oid
+                          << ", offset=" << offset
+                          << ", err=" << cpp_strerror(-ret) << dendl;
         return ret;
       }
 
@@ -1386,24 +1402,30 @@ namespace rgw::dedup {
       bufferlist bl;
       ret = ioctx.read(raw_obj.oid, bl, 0, 0);
       if (unlikely(ret <= 0)) {
-        ldpp_dout(dpp, 1) << __func__ << "::ERR: failed to read oid "
-                          << raw_obj.oid  << ", err is " << cpp_strerror(-ret) << dendl;
+        ldpp_dout(dpp, 1) << __func__ << "::ERR: failed to read oid=" << raw_obj.oid
+                          << " for obj=" << p_rec->obj_name << ", offset=" << offset
+                          << ", ret=" << ret
+                          << ", err=" << cpp_strerror(-ret) << dendl;
         return ret;
       }
       if (decompressor) {
         ret = decompressor->feed_compressed_data(bl);
-        if (ret < 0) return ret;
-      } else {
+        if (ret < 0) {
+          return ret;
+        }
+      }
+      else {
         for (const auto& bptr : bl.buffers()) {
-          blake3_hasher_update(p_hmac,
-            (const unsigned char *)bptr.c_str(), bptr.length());
+          blake3_hasher_update(p_hmac, (const uint8_t *)bptr.c_str(), bptr.length());
         }
       }
     }
 
     if (decompressor) {
       int ret = decompressor->finish();
-      if (ret < 0) return ret;
+      if (ret < 0) {
+        return ret;
+      }
     }
 
     blake3_hasher_finalize(p_hmac, p_hash, BLAKE3_OUT_LEN);
@@ -1533,22 +1555,18 @@ namespace rgw::dedup {
         p_rec->manifest_bl = bl;
       }
       p_rec->s.manifest_len = p_rec->manifest_bl.length();
-      if (p_tail_rule) {
-        *p_tail_rule = manifest.get_tail_placement().placement_rule;
-      }
+      *p_tail_rule = manifest.get_tail_placement().placement_rule;
     }
     else {
       ldpp_dout(dpp, 5)  << __func__ << "::ERROR: no manifest" << dendl;
       return -EINVAL;
     }
-    const auto &head_placement_rule = manifest.get_head_placement_rule();
-    const std::string& storage_class =
-      rgw_placement_rule::get_canonical_storage_class(head_placement_rule.storage_class);
 
-    // p_rec holds an the storage_class value taken from the bucket-index/obj-attr
-    if (unlikely(storage_class != p_rec->stor_class)) {
-      ldpp_dout(dpp, 5) << __func__ << "::ERROR::manifest storage_class="
-                        << storage_class << " != " << "::bucket-index storage_class="
+    const auto& sc_from_tail = p_tail_rule->get_storage_class();
+    // p_rec holds the storage_class value taken from the bucket-index/obj-attr
+    if (unlikely(sc_from_tail != p_rec->stor_class)) {
+      ldpp_dout(dpp, 5) << __func__ << "::ERROR::manifest tail storage_class="
+                        << sc_from_tail << " != p_rec->stor_class="
                         << p_rec->stor_class << dendl;
       p_stats->different_storage_class++;
       return -EINVAL;
@@ -1729,9 +1747,14 @@ namespace rgw::dedup {
       return 0;
     }
 
+    std::string obj_compression_type = "none";
+    int64_t accounted_size = p_obj->get_size();
     {
+      p_rec->compression_bl.clear();
+      p_rec->s.compression_len = 0;
+
       auto comp_itr = attrs.find(RGW_ATTR_COMPRESSION);
-      if (comp_itr != attrs.end()) {
+      if (comp_itr != attrs.end() && comp_itr->second.length() > 0) {
         if (d_skip_compressed) {
           p_stats->ingress_skip_compressed++;
           p_stats->ingress_skip_compressed_bytes += ondisk_byte_size;
@@ -1740,26 +1763,21 @@ namespace rgw::dedup {
           return 0;
         }
         p_rec->compression_bl = comp_itr->second;
-        p_rec->s.compression_bl_len = p_rec->compression_bl.length();
+        p_rec->s.compression_len = p_rec->compression_bl.length();
         p_stats->ingress_compressed++;
         p_stats->ingress_compressed_bytes += ondisk_byte_size;
         ldpp_dout(dpp, 20) <<__func__ << "::compressed object "
                            << p_rec->obj_name << dendl;
-      } else {
-        p_rec->compression_bl.clear();
-        p_rec->s.compression_bl_len = 0;
-      }
-    }
 
-    std::string obj_compression_type;
-    int64_t head_accounted_size = derive_head_accounted_size(dpp, p_rec->compression_bl,
-                                                             p_obj->get_size(),
-                                                             &obj_compression_type);
-    if (unlikely(head_accounted_size < 0)) {
-      ldpp_dout(dpp, 5) << __func__
-                        << "::ERR: derive_head_accounted_size failed for "
-                        << p_rec->obj_name << dendl;
-      return head_accounted_size;
+        accounted_size = derive_accounted_size(dpp, p_rec->compression_bl,
+                                               &obj_compression_type);
+        if (unlikely(accounted_size < 0)) {
+          ldpp_dout(dpp, 5) << __func__
+                            << "::ERR: derive_accounted_size failed for "
+                            << p_rec->obj_name << dendl;
+          return accounted_size;
+        }
+      }
     }
 
     // extract ETAG and compare with values taken from the bucket-index
@@ -1799,11 +1817,11 @@ namespace rgw::dedup {
     // no need to check for remap success as we compare keys bellow
     sc_idx = remapper->remap(storage_class, dpp, &p_stats->failed_map_overflow);
     // Cross-check etag, num_parts, storage_class and size from object-head
-    // against bucket-index.  head_accounted_size was derived above from the
+    // against bucket-index.  accounted_size was derived above from the
     // compression attr (orig_size) or physical size - matching the write-path
     // logic, so it is safe to compare against the bucket-index value.
     key_t key_from_obj(parsed_etag.md5_high, parsed_etag.md5_low,
-                       byte_size_to_disk_blocks(head_accounted_size),
+                       byte_size_to_disk_blocks(accounted_size),
                        parsed_etag.num_parts, sc_idx);
     if (unlikely(key_from_obj != key_from_bucket_index)) {
       ldpp_dout(dpp, 15) <<__func__ << "::Skipping changed object "
@@ -1841,6 +1859,7 @@ namespace rgw::dedup {
       p_stats->max_attrs_record_length = rec_len;
     }
     p_stats->total_attrs_record_length += rec_len;
+    p_stats->attrs_record_count++;
 
     disk_block_seq_t::record_info_t rec_info;
     ret = p_disk->add_record(d_dedup_cluster_ioctx, p_rec, &rec_info, p_stats);
@@ -1924,9 +1943,8 @@ namespace rgw::dedup {
   // Always fetched:
   //   RGW_ATTR_MANIFEST  -- required; returns -ENOENT if missing.
   //   RGW_ATTR_BLAKE3    -- if present, populates p_rec->s.hash and sets
-  //                         has_valid_hash().  Missing BLAKE3 is an error
-  //                         unless has_remote_attrs() is set (the hash may
-  //                         not have been written to the object head yet).
+  //                         has_valid_hash().  Missing BLAKE3 returns -ENOENT
+  //                         when blake3_expected is true (caller decides).
   //
   // Conditionally fetched (when has_remote_attrs()):
   //   RGW_ATTR_COMPRESSION -- restores compression_bl that was dropped from
@@ -1943,23 +1961,28 @@ namespace rgw::dedup {
   // Uses a single ioctx.getxattrs() call (all attrs returned in one round
   // trip), so fetching compression adds zero extra RADOS cost.
   static int fetch_head_obj_attrs(const DoutPrefixProvider *const dpp,
-                                    rgw::sal::Driver *driver,
-                                    rgw::sal::RadosStore *store,
-                                    disk_record_t *p_rec)
+                                  rgw::sal::Driver *driver,
+                                  rgw::sal::RadosStore *store,
+                                  disk_record_t *p_rec,
+                                  bool blake3_expected)
   {
     librados::IoCtx ioctx;
     std::string oid;
     int ret = get_ioctx(dpp, driver, store, p_rec, &ioctx, &oid);
     if (unlikely(ret != 0)) {
-      ldpp_dout(dpp, 5) << __func__ << "::ERR: failed get_ioctx()" << dendl;
+      ldpp_dout(dpp, 1) << __func__ << "::ERR: failed get_ioctx() for "
+                        << p_rec->bucket_name << "/" << p_rec->obj_name
+                        << ", err is " << cpp_strerror(-ret) << dendl;
       return ret;
     }
 
     std::map<std::string, bufferlist> attrset;
     ret = ioctx.getxattrs(oid, attrset);
     if (unlikely(ret < 0)) {
-      ldpp_dout(dpp, 5) << __func__ << "::ERR: failed ioctx.getxattrs("
-                        << oid << "), err is " << cpp_strerror(-ret) << dendl;
+      ldpp_dout(dpp, 1) << __func__ << "::ERR: failed ioctx.getxattrs("
+                        << oid << ") for " << p_rec->bucket_name << "/"
+                        << p_rec->obj_name << ", err is " << cpp_strerror(-ret)
+                        << dendl;
       return ret;
     }
 
@@ -1981,9 +2004,7 @@ namespace rgw::dedup {
         return -EINVAL;
       }
     }
-    else if (!p_rec->s.flags.has_remote_attrs()) {
-      // BLAKE3 is mandatory unless fetching for remote_attrs (hash may not
-      // have been written to the object head yet)
+    else if (blake3_expected) {
       ldpp_dout(dpp, 1) << __func__ << "::ERR: No HASH attribute" << dendl;
       return -ENOENT;
     }
@@ -2003,7 +2024,7 @@ namespace rgw::dedup {
       itr = attrset.find(RGW_ATTR_COMPRESSION);
       if (itr != attrset.end()) {
         p_rec->compression_bl = itr->second;
-        p_rec->s.compression_bl_len = p_rec->compression_bl.length();
+        p_rec->s.compression_len = p_rec->compression_bl.length();
       }
     }
 
@@ -2161,7 +2182,7 @@ namespace rgw::dedup {
       // read the manifest and strong hash from the head-object attributes
       ldpp_dout(dpp, 20) << __func__ << "::Fetch SRC strong hash from head-object::"
                          << p_src_rec->obj_name << dendl;
-      if (unlikely(fetch_head_obj_attrs(dpp, driver, store, p_src_rec) != 0)) {
+      if (unlikely(fetch_head_obj_attrs(dpp, driver, store, p_src_rec, true) != 0)) {
         return false;
       }
       try {
@@ -2370,7 +2391,7 @@ namespace rgw::dedup {
     // This records is a dedup target with source record on source_block_id
     disk_record_t src_rec, *p_src_rec = &src_rec;
     ret = load_record(d_dedup_cluster_ioctx, p_tgt_rec, p_src_rec, src_block_id,
-                      src_rec_id, md5_shard, dpp);
+                      src_rec_id, md5_shard, dpp, p_stats);
     if (unlikely(ret != 0)) {
       p_stats->failed_src_load++;
       // we can withstand most errors moving to the next object
@@ -2380,12 +2401,14 @@ namespace rgw::dedup {
     }
 
     if (p_src_rec->s.flags.has_remote_attrs()) {
-      ret = fetch_head_obj_attrs(dpp, driver, store, p_src_rec);
+      const bool blake3_expected = p_src_rec->s.flags.has_valid_hash() || src_val.has_valid_hash();
+      ret = fetch_head_obj_attrs(dpp, driver, store, p_src_rec, blake3_expected);
       if (unlikely(ret != 0)) {
         p_stats->failed_remote_attrs_fetch++;
-        ldpp_dout(dpp, 5) << __func__
+        ldpp_dout(dpp, 1) << __func__
                           << "::ERR: failed fetch remote attrs for SRC "
-                          << p_src_rec->obj_name << dendl;
+                          << p_src_rec->bucket_name << "/" << p_src_rec->obj_name
+                          << ", err is " << cpp_strerror(-ret) << " ret=" << ret << dendl;
         return 0;
       }
     }
@@ -2414,12 +2437,14 @@ namespace rgw::dedup {
     }
 
     if (p_tgt_rec->s.flags.has_remote_attrs()) {
-      ret = fetch_head_obj_attrs(dpp, driver, store, p_tgt_rec);
+      ret = fetch_head_obj_attrs(dpp, driver, store, p_tgt_rec,
+                                 p_tgt_rec->s.flags.has_valid_hash());
       if (unlikely(ret != 0)) {
         p_stats->failed_remote_attrs_fetch++;
-        ldpp_dout(dpp, 5) << __func__
+        ldpp_dout(dpp, 1) << __func__
                           << "::ERR: failed fetch remote attrs for TGT "
-                          << p_tgt_rec->obj_name << dendl;
+                          << p_tgt_rec->bucket_name << "/" << p_tgt_rec->obj_name
+                          << ", err is " << cpp_strerror(-ret) << " ret=" << ret << dendl;
         return 0;
       }
     }
@@ -2460,7 +2485,9 @@ namespace rgw::dedup {
       ldpp_dout(dpp, 20) << __func__ << "::dedup success " << p_src_rec->obj_name << dendl;
       p_stats->deduped_objects++;
       p_stats->deduped_objects_bytes += dedupable_objects_bytes;
-      if (p_src_rec->compression_bl.length() > 0 && p_tgt_rec->compression_bl.length() > 0) {
+      if (p_src_rec->compression_bl.length() > 0 &&
+          p_tgt_rec->compression_bl.length() > 0) {
+        // count dedup ops between compressed SRC and compressed TGT
         p_stats->deduped_compressed_objects++;
       }
       if (p_tgt_rec->s.flags.is_split_head()) {
@@ -2581,7 +2608,7 @@ namespace rgw::dedup {
           unsigned offset = p_header->rec_offsets[rec_id];
           // We deserialize the record inside the CTOR
           disk_record_t rec(p + offset);
-          ret = rec.validate(__func__, dpp, disk_block_id, rec_id);
+          ret = rec.validate(__func__, dpp, disk_block_id, rec_id, nullptr, p_stats);
           if (unlikely(ret != 0)) {
             p_stats->failed_rec_load++;
             return ret;
@@ -3755,6 +3782,10 @@ namespace rgw::dedup {
       throw std::runtime_error("Failed init_rados_access_handles()");
     }
     display_ioctx_state(dpp, d_dedup_cluster_ioctx, "dedup_bg->resume() done");
+
+    // pause()/resume() can modify placement compression state
+    d_placement_compression_type.clear();
+
     // create new watch request using the new pool handle
     watch_reload(dpp);
     d_ctl.local_pause_req = false;
@@ -3821,9 +3852,13 @@ namespace rgw::dedup {
 
       ldpp_dout(dpp, 10) << __func__ << "::Wait for object ingress completion, ttl="
                          << ttl << " seconds" << dendl;
-      std::unique_lock cond_lock(d_cond_mutex);
-      d_cond.wait_for(cond_lock, std::chrono::seconds(ttl),
-                      [this]{return d_ctl.should_stop() || d_ctl.should_pause();});
+      {
+        // limit the scope of cond_lock
+        std::unique_lock cond_lock(d_cond_mutex);
+        d_cond.wait_for(cond_lock, std::chrono::seconds(ttl),
+                        [this]{return d_ctl.should_stop() || d_ctl.should_pause();});
+      }
+
       if (unlikely(d_ctl.should_pause())) {
         handle_pause_req(__func__);
       }
@@ -3863,9 +3898,13 @@ namespace rgw::dedup {
     while (!all_md5_shards_completed(&d_cluster, store, num_md5_shards)) {
       ldpp_dout(dpp, 10) << __func__ << "::Wait for md5 completion, ttl="
                          << ttl << " seconds" << dendl;
-      std::unique_lock cond_lock(d_cond_mutex);
-      d_cond.wait_for(cond_lock, std::chrono::seconds(ttl),
-                      [this]{return d_ctl.should_stop() || d_ctl.should_pause();});
+      {
+        // limit the scope of cond_lock
+        std::unique_lock cond_lock(d_cond_mutex);
+        d_cond.wait_for(cond_lock, std::chrono::seconds(ttl),
+                        [this]{return d_ctl.should_stop() || d_ctl.should_pause();});
+      }
+
       if (unlikely(d_ctl.should_pause())) {
         handle_pause_req(__func__);
       }
@@ -3907,6 +3946,7 @@ namespace rgw::dedup {
           ldpp_dout(dpp, 1) << __func__ << "::failed setup()" << dendl;
           return;
         }
+
         d_placement_compression_type.clear();
         const rgw_pool& dedup_pool = store->svc()->zone->get_zone_params().dedup_pool;
         int64_t pool_id = rados_handle->pool_lookup(dedup_pool.name.c_str());

--- a/src/rgw/driver/rados/rgw_dedup.cc
+++ b/src/rgw/driver/rados/rgw_dedup.cc
@@ -42,6 +42,8 @@
 #include "fmt/ranges.h"
 #include "osd/osd_types.h"
 #include "common/ceph_crypto.h"
+#include "rgw_compression_types.h"
+#include "compressor/Compressor.h"
 
 #include <filesystem>
 #include <algorithm>
@@ -82,6 +84,38 @@ static constexpr auto dout_subsys = ceph_subsys_rgw_dedup;
 namespace rgw::dedup {
   static inline constexpr unsigned MAX_STORAGE_CLASS_IDX = 128;
   using storage_class_idx_t = uint8_t;
+
+  // Derive accounted_size from object-head attributes the same way the
+  // write-path computes it (see RGWRados::Object::Write::_do_write_meta):
+  //   compressed   -> RGWCompressionInfo::orig_size  (stable, not patched)
+  //   uncompressed -> physical object size
+  // We cannot use p_obj->get_accounted_size() because the stat path patches
+  // it via the manifest (set_head / get_obj_size).
+  static int64_t derive_head_accounted_size(const DoutPrefixProvider *dpp,
+                                             const bufferlist &compression_bl,
+                                             uint64_t obj_size,
+                                             std::string *p_compression_type = nullptr)
+  {
+    if (compression_bl.length() > 0) {
+      RGWCompressionInfo cs_info;
+      auto bl_iter = compression_bl.cbegin();
+      try {
+        decode(cs_info, bl_iter);
+      } catch (buffer::error&) {
+        ldpp_dout(dpp, 5) << __func__
+                          << "::ERR: failed to decode compression info" << dendl;
+        return -EINVAL;
+      }
+      if (p_compression_type) {
+        *p_compression_type = cs_info.compression_type;
+      }
+      return cs_info.orig_size;
+    }
+    if (p_compression_type) {
+      *p_compression_type = "none";
+    }
+    return obj_size;
+  }
 
   //---------------------------------------------------------------------------
   [[maybe_unused]] static int print_manifest(CephContext              *cct,
@@ -383,6 +417,18 @@ namespace rgw::dedup {
   }
 
   //---------------------------------------------------------------------------
+  const std::string& Background::get_placement_compression_type(const rgw_placement_rule &rule)
+  {
+    auto it = d_placement_compression_type.find(rule.name);
+    if (it != d_placement_compression_type.end()) {
+      return it->second;
+    }
+    const std::string& comp_type = store->svc()->zone->get_zone_params().get_compression_type(rule);
+    auto result = d_placement_compression_type.emplace(rule.name, comp_type);
+    return result.first->second;
+  }
+
+  //---------------------------------------------------------------------------
   // Detect whether the data pool supports truncate (needed for split-head).
   // EC pools without allow_ec_overwrites reject TRUNCATE with -EOPNOTSUPP.
   // We only check the default placement pool because the BI filter applies
@@ -474,9 +520,11 @@ namespace rgw::dedup {
     d_head_object_size = cct->_conf->rgw_max_chunk_size;
     d_min_obj_size_for_dedup = cct->_conf->rgw_dedup_min_obj_size_for_dedup;
     d_split_head = cct->_conf->rgw_dedup_split_obj_head;
+    d_skip_compressed = cct->_conf->rgw_dedup_skip_compressed;
     ldpp_dout(dpp, 10) << "Config Vals::d_head_object_size=" << d_head_object_size
                        << "::d_min_obj_size_for_dedup=" << d_min_obj_size_for_dedup
                        << "::d_split_head=" << d_split_head
+                       << "::d_skip_compressed=" << d_skip_compressed
                        << dendl;
 
     int ret = init_rados_access_handles(false);
@@ -550,7 +598,7 @@ namespace rgw::dedup {
                        << p_rec->s.md5_low << std::dec << dendl;
 
     int ret = p_table->add_entry(&key, block_id, rec_id, has_shared_manifest,
-                                 &p_stats->big_objs_stat);
+                                 COMPRESSION_MATCH_NONE, &p_stats->big_objs_stat);
     if (ret == 0) {
       p_stats->loaded_objects ++;
       ldpp_dout(dpp, 20) << __func__ << "::" << p_rec->bucket_name << "/"
@@ -1083,6 +1131,14 @@ namespace rgw::dedup {
       {
         bufferlist src_hash_bl;
         init_cmp_pairs(dpp, p_src_rec, etag_bl, src_hash_bl, &src_op);
+        // CAS on compression only when SRC is uncompressed (cheap empty-bl compare).
+        // A compressed object's compression state is assumed immutable: RGW never
+        // strips or rewrites RGW_ATTR_COMPRESSION on an existing object, so there
+        // is no need to CAS on a potentially large compression attribute.
+        if (p_src_rec->compression_bl.length() == 0) {
+          src_op.cmpxattr(RGW_ATTR_COMPRESSION, CEPH_OSD_CMPXATTR_OP_EQ,
+                          p_src_rec->compression_bl);
+        }
         src_op.setxattr(RGW_ATTR_SHARE_MANIFEST, manifest_hash_bl);
         if (p_src_rec->s.flags.hash_calculated() && !p_src_val->has_valid_hash()){
           src_op.setxattr(RGW_ATTR_BLAKE3, src_hash_bl);
@@ -1111,6 +1167,11 @@ namespace rgw::dedup {
       }
     }
 
+    // Set RGW_ATTR_COMPRESSION on TGT unconditionally from SRC state.
+    // TGT now shares SRC's tail objects so its compression state must match.
+    bool src_compressed = (p_src_rec->compression_bl.length() > 0);
+    bool tgt_compressed = (p_tgt_rec->compression_bl.length() > 0);
+
     librados::ObjectWriteOperation tgt_op;
     {
       bufferlist tgt_hash_bl;
@@ -1123,6 +1184,18 @@ namespace rgw::dedup {
         tgt_op.setxattr(RGW_ATTR_BLAKE3, tgt_hash_bl);
         ldpp_dout(dpp, 20) << __func__ <<"::Set TGT Strong Hash in CLS"<< dendl;
         p_stats->set_hash_attrs++;
+      }
+
+      if (src_compressed) {
+        tgt_op.setxattr(RGW_ATTR_COMPRESSION, p_src_rec->compression_bl);
+        if (!tgt_compressed) {
+          p_stats->set_compression_on_tgt++;
+        }
+      } else {
+        tgt_op.rmxattr(RGW_ATTR_COMPRESSION);
+        if (tgt_compressed) {
+          p_stats->clear_compression_on_tgt++;
+        }
       }
     }
 
@@ -1146,55 +1219,186 @@ namespace rgw::dedup {
     // free tail objects based on TGT manifest
     free_tail_objs_by_manifest(ref_tag, tgt_oid, tgt_manifest);
 
-    // do we need to set compression on the head object or is it set on tail?
-    // RGW_ATTR_COMPRESSION
     return ret;
   }
+
+  //---------------------------------------------------------------------------
+  // Decompress each compression block on-the-fly and feed decompressed data
+  // to the blake3 hasher. The compressed stream is fed incrementally via
+  // feed_compressed_data(); once a full compression block is available it is
+  // decompressed and hashed immediately so memory stays bounded.
+  struct streaming_decompressor_t {
+    CompressorRef compressor;
+    RGWCompressionInfo cs_info;  // owned copy
+    blake3_hasher *hmac;
+    const DoutPrefixProvider *dpp;
+
+    bufferlist pending;         // partial compressed block accumulated so far
+    uint64_t   raw_ofs  = 0;   // running offset in compressed stream
+    size_t     blk_idx  = 0;   // next compression block to process
+
+    streaming_decompressor_t(CompressorRef _comp,
+                             RGWCompressionInfo &&_cs,
+                             blake3_hasher *_hmac,
+                             const DoutPrefixProvider *_dpp)
+      : compressor(std::move(_comp)), cs_info(std::move(_cs)),
+        hmac(_hmac), dpp(_dpp) {}
+
+    int feed_compressed_data(bufferlist &bl) {
+      uint64_t len = bl.length();
+      pending.claim_append(bl);
+      raw_ofs += len;
+      return drain_ready_blocks();
+    }
+
+    int drain_ready_blocks() {
+      while (blk_idx < cs_info.blocks.size()) {
+        const auto &block = cs_info.blocks[blk_idx];
+        uint64_t block_end = block.new_ofs + block.len;
+        if (raw_ofs < block_end) {
+          break; // not enough data yet for this block
+        }
+        bufferlist compressed_bl, decompressed_bl;
+        uint64_t local_ofs = block.new_ofs - (raw_ofs - pending.length());
+        pending.begin(local_ofs).copy(block.len, compressed_bl);
+        int ret = compressor->decompress(compressed_bl, decompressed_bl,
+                                         cs_info.compressor_message);
+        if (ret < 0) {
+          ldpp_dout(dpp, 1) << "streaming_decompressor_t::ERR: decompression"
+                               " failed, ret=" << ret << dendl;
+          return ret;
+        }
+        for (const auto& bptr : decompressed_bl.buffers()) {
+          blake3_hasher_update(hmac,
+            (const unsigned char *)bptr.c_str(), bptr.length());
+        }
+        blk_idx++;
+      }
+      // discard data that has been fully consumed by all processed blocks
+      if (blk_idx > 0) {
+        uint64_t consumed_end = cs_info.blocks[blk_idx - 1].new_ofs +
+                                cs_info.blocks[blk_idx - 1].len;
+        uint64_t pending_start = raw_ofs - pending.length();
+        if (consumed_end > pending_start) {
+          uint64_t trim = consumed_end - pending_start;
+          if (trim <= pending.length()) {
+            pending.splice(0, trim);
+          }
+        }
+      }
+      return 0;
+    }
+
+    int finish() {
+      int ret = drain_ready_blocks();
+      if (ret < 0) return ret;
+      if (blk_idx != cs_info.blocks.size()) {
+        ldpp_dout(dpp, 1) << "streaming_decompressor_t::ERR: not all blocks"
+                             " decompressed, processed=" << blk_idx
+                          << " total=" << cs_info.blocks.size() << dendl;
+        return -EIO;
+      }
+      return 0;
+    }
+  };
 
   //---------------------------------------------------------------------------
   int Background::calc_object_blake3(const RGWObjManifest &manifest,
                                      disk_record_t *p_rec,
                                      uint8_t *p_hash,
-                                     blake3_hasher *p_pre_calc_hmac)
+                                     bufferlist *p_head_bl)
   {
-    ldpp_dout(dpp, 20) << __func__ << "::p_rec->obj_name=" << p_rec->obj_name << dendl;
+    bool is_compressed = false;
+    RGWCompressionInfo cs_info;
+    CompressorRef compressor;
 
-    blake3_hasher _hmac, *p_hmac = nullptr;
-    if (!p_pre_calc_hmac) {
-      blake3_hasher_init(&_hmac);
-      p_hmac = &_hmac;
+    if (p_rec->compression_bl.length() > 0) {
+      try {
+        auto bl_iter = p_rec->compression_bl.cbegin();
+        decode(cs_info, bl_iter);
+        if (cs_info.compression_type != "none" && !cs_info.blocks.empty()) {
+          is_compressed = true;
+          compressor = Compressor::create(cct, cs_info.compression_type);
+          if (!compressor) {
+            ldpp_dout(dpp, 1) << __func__ << "::ERR: Cannot load compressor of type "
+                              << cs_info.compression_type << dendl;
+            return -EIO;
+          }
+        }
+      } catch (buffer::error&) {
+        ldpp_dout(dpp, 1) << __func__
+                          << "::ERR: failed RGWCompressionInfo decode" << dendl;
+        return -EINVAL;
+      }
     }
-    else {
-      p_hmac = p_pre_calc_hmac;
+
+    ldpp_dout(dpp, 20) << __func__ << "::p_rec->obj_name=" << p_rec->obj_name
+                       << "::compressed=" << is_compressed << dendl;
+
+    blake3_hasher hmac;
+    blake3_hasher_init(&hmac);
+    blake3_hasher *p_hmac = &hmac;
+
+    std::unique_ptr<streaming_decompressor_t> decompressor;
+    if (compressor) {
+      decompressor = std::make_unique<streaming_decompressor_t>(
+        compressor, std::move(cs_info), p_hmac, dpp);
+      if (p_head_bl && p_head_bl->length() > 0) {
+        // copy before feeding: feed_compressed_data() uses claim_append()
+        // which would empty the caller's bufferlist; split_head_object()
+        // needs p_head_bl intact to write the new tail object afterwards
+        bufferlist head_copy;
+        head_copy.append(*p_head_bl);
+        int ret = decompressor->feed_compressed_data(head_copy);
+        if (ret < 0) return ret;
+      }
+    } else if (p_head_bl && p_head_bl->length() > 0) {
+      for (const auto& bptr : p_head_bl->buffers()) {
+        blake3_hasher_update(p_hmac,
+          (const unsigned char *)bptr.c_str(), bptr.length());
+      }
     }
 
     for (auto p = manifest.obj_begin(dpp); p != manifest.obj_end(dpp); ++p) {
       uint64_t offset = p.get_stripe_ofs();
       const rgw_obj_select& os = p.get_location();
-      if (offset > 0 || !p_pre_calc_hmac) {
-        rgw_raw_obj raw_obj = os.get_raw_obj(rados);
-        rgw_rados_ref obj;
-        int ret = rgw_get_rados_ref(dpp, rados_handle, raw_obj, &obj);
-        if (ret < 0) {
-          ldpp_dout(dpp, 1) << __func__ << "::failed rgw_get_rados_ref() for oid="
-                            << raw_obj.oid << ", err is " << cpp_strerror(-ret) << dendl;
-          return ret;
-        }
+      // skip head stripe when head data was already provided
+      if (offset == 0 && p_head_bl) {
+        continue;
+      }
+      rgw_raw_obj raw_obj = os.get_raw_obj(rados);
+      rgw_rados_ref obj;
+      int ret = rgw_get_rados_ref(dpp, rados_handle, raw_obj, &obj);
+      if (ret < 0) {
+        ldpp_dout(dpp, 1) << __func__ << "::failed rgw_get_rados_ref() for oid="
+                          << raw_obj.oid << ", err is " << cpp_strerror(-ret) << dendl;
+        return ret;
+      }
 
-        librados::IoCtx ioctx = obj.ioctx;
-        bufferlist bl;
-        // read full object
-        ret = ioctx.read(raw_obj.oid, bl, 0, 0);
-        if (unlikely(ret <= 0)) {
-          ldpp_dout(dpp, 1) << __func__ << "::ERR: failed to read oid "
-                            << raw_obj.oid  << ", err is " << cpp_strerror(-ret) << dendl;
-          return ret;
-        }
+      librados::IoCtx ioctx = obj.ioctx;
+      bufferlist bl;
+      ret = ioctx.read(raw_obj.oid, bl, 0, 0);
+      if (unlikely(ret <= 0)) {
+        ldpp_dout(dpp, 1) << __func__ << "::ERR: failed to read oid "
+                          << raw_obj.oid  << ", err is " << cpp_strerror(-ret) << dendl;
+        return ret;
+      }
+      if (decompressor) {
+        ret = decompressor->feed_compressed_data(bl);
+        if (ret < 0) return ret;
+      } else {
         for (const auto& bptr : bl.buffers()) {
-          blake3_hasher_update(p_hmac, (const unsigned char *)bptr.c_str(), bptr.length());
+          blake3_hasher_update(p_hmac,
+            (const unsigned char *)bptr.c_str(), bptr.length());
         }
       }
     }
+
+    if (decompressor) {
+      int ret = decompressor->finish();
+      if (ret < 0) return ret;
+    }
+
     blake3_hasher_finalize(p_hmac, p_hash, BLAKE3_OUT_LEN);
     p_rec->s.flags.set_hash_calculated();
     p_rec->s.flags.set_has_valid_hash();
@@ -1251,7 +1455,8 @@ namespace rgw::dedup {
   //---------------------------------------------------------------------------
   int Background::add_obj_attrs_to_record(disk_record_t         *p_rec,
                                           const rgw::sal::Attrs &attrs,
-                                          md5_stats_t           *p_stats) /*IN-OUT*/
+                                          rgw_placement_rule    *p_tail_rule, /*OUT*/
+                                          md5_stats_t           *p_stats      /*IN-OUT*/)
   {
     // if TAIL_TAG exists -> use it as ref-tag, eitherwise take ID_TAG
     auto itr = attrs.find(RGW_ATTR_TAIL_TAG);
@@ -1321,6 +1526,9 @@ namespace rgw::dedup {
         p_rec->manifest_bl = bl;
       }
       p_rec->s.manifest_len = p_rec->manifest_bl.length();
+      if (p_tail_rule) {
+        *p_tail_rule = manifest.get_tail_placement().placement_rule;
+      }
     }
     else {
       ldpp_dout(dpp, 5)  << __func__ << "::ERROR: no manifest" << dendl;
@@ -1514,16 +1722,40 @@ namespace rgw::dedup {
       return 0;
     }
 
-    // TBD-Future: We should be able to support RGW_ATTR_COMPRESSION when all copies are compressed
-    if (attrs.find(RGW_ATTR_COMPRESSION) != attrs.end()) {
-      p_stats->ingress_skip_compressed++;
-      p_stats->ingress_skip_compressed_bytes += ondisk_byte_size;
-      ldpp_dout(dpp, 20) <<__func__ << "::Skipping compressed object "
-                         << p_rec->obj_name << dendl;
-      return 0;
+    {
+      auto comp_itr = attrs.find(RGW_ATTR_COMPRESSION);
+      if (comp_itr != attrs.end()) {
+        if (d_skip_compressed) {
+          p_stats->ingress_skip_compressed++;
+          p_stats->ingress_skip_compressed_bytes += ondisk_byte_size;
+          ldpp_dout(dpp, 20) <<__func__ << "::Skipping compressed object "
+                             << p_rec->obj_name << dendl;
+          return 0;
+        }
+        p_rec->compression_bl = comp_itr->second;
+        p_rec->s.compression_bl_len = p_rec->compression_bl.length();
+        p_stats->ingress_compressed++;
+        p_stats->ingress_compressed_bytes += ondisk_byte_size;
+        ldpp_dout(dpp, 20) <<__func__ << "::compressed object "
+                           << p_rec->obj_name << dendl;
+      } else {
+        p_rec->compression_bl.clear();
+        p_rec->s.compression_bl_len = 0;
+      }
     }
 
-    // extract ETAG and Size and compare with values taken from the bucket-index
+    std::string obj_compression_type;
+    int64_t head_accounted_size = derive_head_accounted_size(dpp, p_rec->compression_bl,
+                                                             p_obj->get_size(),
+                                                             &obj_compression_type);
+    if (unlikely(head_accounted_size < 0)) {
+      ldpp_dout(dpp, 5) << __func__
+                        << "::ERR: derive_head_accounted_size failed for "
+                        << p_rec->obj_name << dendl;
+      return head_accounted_size;
+    }
+
+    // extract ETAG and compare with values taken from the bucket-index
     parsed_etag_t parsed_etag;
     auto itr = attrs.find(RGW_ATTR_ETAG);
     if (itr != attrs.end()) {
@@ -1559,11 +1791,14 @@ namespace rgw::dedup {
 
     // no need to check for remap success as we compare keys bellow
     sc_idx = remapper->remap(storage_class, dpp, &p_stats->failed_map_overflow);
+    // Cross-check etag, num_parts, storage_class and size from object-head
+    // against bucket-index.  head_accounted_size was derived above from the
+    // compression attr (orig_size) or physical size - matching the write-path
+    // logic, so it is safe to compare against the bucket-index value.
     key_t key_from_obj(parsed_etag.md5_high, parsed_etag.md5_low,
-                       byte_size_to_disk_blocks(p_obj->get_size()),
+                       byte_size_to_disk_blocks(head_accounted_size),
                        parsed_etag.num_parts, sc_idx);
-    if (unlikely(key_from_obj != key_from_bucket_index ||
-                 p_rec->s.obj_bytes_size != p_obj->get_size())) {
+    if (unlikely(key_from_obj != key_from_bucket_index)) {
       ldpp_dout(dpp, 15) <<__func__ << "::Skipping changed object "
                          << p_rec->obj_name << dendl;
       p_stats->ingress_skip_changed_objs++;
@@ -1572,7 +1807,8 @@ namespace rgw::dedup {
 
     // reset flags
     p_rec->s.flags.clear();
-    ret = add_obj_attrs_to_record(p_rec, attrs, p_stats);
+    rgw_placement_rule tail_rule;
+    ret = add_obj_attrs_to_record(p_rec, attrs, &tail_rule, p_stats);
     if (unlikely(ret != 0)) {
       // don't trace errors for unsupported manifest
       if (ret == -ENOTSUP) {
@@ -1582,6 +1818,15 @@ namespace rgw::dedup {
       ldpp_dout(dpp, 5) << __func__ << "::ERR: failed add_obj_attrs_to_record() ret="
                         << ret << "::" << cpp_strerror(-ret) << dendl;
       return ret;
+    }
+
+    // Determine how well this object's compression state matches the placement
+    const auto& placement_comp_type = get_placement_compression_type(tail_rule);
+    compression_match_level_t comp_match = COMPRESSION_MATCH_NONE;
+    if (obj_compression_type == placement_comp_type) {
+      comp_match = COMPRESSION_MATCH_EXACT;
+    } else if (obj_compression_type != "none" && placement_comp_type != "none") {
+      comp_match = COMPRESSION_MATCH_PARTIAL;
     }
 
     disk_block_seq_t::record_info_t rec_info;
@@ -1597,7 +1842,8 @@ namespace rgw::dedup {
                           << "::shared_manifest="
                           << p_rec->s.flags.has_shared_manifest() << dendl;
       p_table->update_entry(&key_from_bucket_index, rec_info.block_id,
-                            rec_info.rec_id, p_rec->s.flags.has_shared_manifest());
+                            rec_info.rec_id, p_rec->s.flags.has_shared_manifest(),
+                            comp_match);
     }
     else {
       ldpp_dout(dpp, 5) << __func__ << "::ERR: Failed p_disk->add_record()"<< dendl;
@@ -1659,6 +1905,10 @@ namespace rgw::dedup {
   }
 
   //---------------------------------------------------------------------------
+  // RGW_ATTR_BLAKE3 and RGW_ATTR_MANIFEST are calculated and written to the
+  // object-head during STEP_REMOVE_DUPLICATES (and never updated into the
+  // disk-record since we only write records in bulk).
+  // All other attributes are valid on both SRC and TGT at this point.
   static int read_hash_and_manifest(const DoutPrefixProvider *const dpp,
                                     rgw::sal::Driver *driver,
                                     rgw::sal::RadosStore *store,
@@ -1776,14 +2026,8 @@ namespace rgw::dedup {
     if (!p_src_rec->s.flags.has_valid_hash()) {
       ldpp_dout(dpp, 20) << __func__ << "::calc BLK3 for SRC "
                          << p_src_rec->obj_name << dendl;
-      blake3_hasher hmac;
-      blake3_hasher_init(&hmac);
-      for (const auto& bptr : bl.buffers()) {
-        blake3_hasher_update(&hmac, (const unsigned char *)bptr.c_str(),
-                             bptr.length());
-      }
       uint8_t *p_hash = (uint8_t*)p_src_rec->s.hash;
-      ret = calc_object_blake3(src_manifest, p_src_rec, p_hash, &hmac);
+      ret = calc_object_blake3(src_manifest, p_src_rec, p_hash, &bl);
       if (unlikely(ret != 0)) {
         return ret;
       }
@@ -1864,7 +2108,6 @@ namespace rgw::dedup {
                          << p_tgt_rec->obj_name << dendl;
       ret = calc_object_blake3(tgt_manifest, p_tgt_rec, (uint8_t*)p_tgt_rec->s.hash);
       if (unlikely(ret != 0)) {
-        // Don't run dedup without a valid strong hash
         return false;
       }
     }
@@ -2152,6 +2395,9 @@ namespace rgw::dedup {
       ldpp_dout(dpp, 20) << __func__ << "::dedup success " << p_src_rec->obj_name << dendl;
       p_stats->deduped_objects++;
       p_stats->deduped_objects_bytes += dedupable_objects_bytes;
+      if (p_src_rec->compression_bl.length() > 0 && p_tgt_rec->compression_bl.length() > 0) {
+        p_stats->deduped_compressed_objects++;
+      }
       if (p_tgt_rec->s.flags.is_split_head()) {
         ldpp_dout(dpp, 20) << __func__ <<"::TGT-Split: dedup_bytes="
                            << ondisk_byte_size << dendl;
@@ -2354,7 +2600,9 @@ namespace rgw::dedup {
     }
 
     // ceph store full blocks so need to round up and multiply by block_size
-    uint64_t ondisk_byte_size = calc_on_disk_byte_size(entry.meta.size);
+    // use accounted_size which is the logical (uncompressed) size
+    // this ensures compressed and uncompressed copies of the same data match
+    uint64_t ondisk_byte_size = calc_on_disk_byte_size(entry.meta.accounted_size);
     p_worker_stats->ingress_obj++;
     p_worker_stats->ingress_obj_bytes += ondisk_byte_size;
 
@@ -2415,7 +2663,7 @@ namespace rgw::dedup {
 
     return add_disk_rec_from_bucket_idx(disk_arr, p_bucket, &parsed_etag,
                                         entry.key.name, entry.key.instance,
-                                        entry.meta.size, storage_class);
+                                        entry.meta.accounted_size, storage_class);
   }
 
   //---------------------------------------------------------------------------
@@ -3593,6 +3841,7 @@ namespace rgw::dedup {
           ldpp_dout(dpp, 1) << __func__ << "::failed setup()" << dendl;
           return;
         }
+        d_placement_compression_type.clear();
         const rgw_pool& dedup_pool = store->svc()->zone->get_zone_params().dedup_pool;
         int64_t pool_id = rados_handle->pool_lookup(dedup_pool.name.c_str());
         if (pool_id < 0) {

--- a/src/rgw/driver/rados/rgw_dedup.cc
+++ b/src/rgw/driver/rados/rgw_dedup.cc
@@ -552,11 +552,18 @@ namespace rgw::dedup {
                                                const std::string      &obj_name,
                                                const std::string      &instance,
                                                uint64_t                obj_size,
-                                               const std::string      &storage_class)
+                                               const std::string      &storage_class,
+                                               worker_stats_t         *p_worker_stats)
   {
     disk_record_t rec(p_bucket, obj_name, p_parsed_etag, instance, obj_size, storage_class);
     // First pass using only ETAG and size taken from bucket-index
     rec.s.flags.set_fastlane();
+
+    size_t rec_len = rec.length();
+    if (rec_len > p_worker_stats->max_bidx_record_length) {
+      p_worker_stats->max_bidx_record_length = rec_len;
+    }
+    p_worker_stats->total_bidx_record_length += rec_len;
 
     auto p_disk = disk_arr.get_shard_block_seq(p_parsed_etag->md5_low);
     disk_block_seq_t::record_info_t rec_info;
@@ -1829,8 +1836,14 @@ namespace rgw::dedup {
       comp_match = COMPRESSION_MATCH_PARTIAL;
     }
 
+    size_t rec_len = p_rec->length();
+    if (rec_len > p_stats->max_attrs_record_length) {
+      p_stats->max_attrs_record_length = rec_len;
+    }
+    p_stats->total_attrs_record_length += rec_len;
+
     disk_block_seq_t::record_info_t rec_info;
-    ret = p_disk->add_record(d_dedup_cluster_ioctx, p_rec, &rec_info);
+    ret = p_disk->add_record(d_dedup_cluster_ioctx, p_rec, &rec_info, p_stats);
     if (ret == 0) {
       // set the disk_block_id_t to this unless the existing disk_block_id is marked as shared-manifest
       if (unlikely(rec_info.rec_id >= MAX_REC_IN_BLOCK)) {
@@ -1905,11 +1918,31 @@ namespace rgw::dedup {
   }
 
   //---------------------------------------------------------------------------
-  // RGW_ATTR_BLAKE3 and RGW_ATTR_MANIFEST are calculated and written to the
-  // object-head during STEP_REMOVE_DUPLICATES (and never updated into the
-  // disk-record since we only write records in bulk).
-  // All other attributes are valid on both SRC and TGT at this point.
-  static int read_hash_and_manifest(const DoutPrefixProvider *const dpp,
+  // Fetch attributes from the RADOS head object that are NOT stored in the
+  // disk record (or were dropped from it).
+  //
+  // Always fetched:
+  //   RGW_ATTR_MANIFEST  -- required; returns -ENOENT if missing.
+  //   RGW_ATTR_BLAKE3    -- if present, populates p_rec->s.hash and sets
+  //                         has_valid_hash().  Missing BLAKE3 is an error
+  //                         unless has_remote_attrs() is set (the hash may
+  //                         not have been written to the object head yet).
+  //
+  // Conditionally fetched (when has_remote_attrs()):
+  //   RGW_ATTR_COMPRESSION -- restores compression_bl that was dropped from
+  //                           the disk record to stay within MAX_REC_SIZE.
+  //
+  // Callers & expected state:
+  //   1. check_and_set_strong_hash() for SRC on 2nd+ TGT -- BLAKE3 and
+  //      manifest were written to the head object during a previous dedup;
+  //      the disk record is stale.
+  //   2. try_deduping_record() for SRC/TGT with remote_attrs -- manifest
+  //      and compression were too large for the disk record and need to be
+  //      fetched before parse_manifests().
+  //
+  // Uses a single ioctx.getxattrs() call (all attrs returned in one round
+  // trip), so fetching compression adds zero extra RADOS cost.
+  static int fetch_head_obj_attrs(const DoutPrefixProvider *const dpp,
                                     rgw::sal::Driver *driver,
                                     rgw::sal::RadosStore *store,
                                     disk_record_t *p_rec)
@@ -1948,7 +1981,9 @@ namespace rgw::dedup {
         return -EINVAL;
       }
     }
-    else {
+    else if (!p_rec->s.flags.has_remote_attrs()) {
+      // BLAKE3 is mandatory unless fetching for remote_attrs (hash may not
+      // have been written to the object head yet)
       ldpp_dout(dpp, 1) << __func__ << "::ERR: No HASH attribute" << dendl;
       return -ENOENT;
     }
@@ -1962,6 +1997,14 @@ namespace rgw::dedup {
     else {
       ldpp_dout(dpp, 1) << __func__ << "::ERR: No Manifest attribute" << dendl;
       return -ENOENT;
+    }
+
+    if (p_rec->s.flags.has_remote_attrs()) {
+      itr = attrset.find(RGW_ATTR_COMPRESSION);
+      if (itr != attrset.end()) {
+        p_rec->compression_bl = itr->second;
+        p_rec->s.compression_bl_len = p_rec->compression_bl.length();
+      }
     }
 
     return 0;
@@ -2113,12 +2156,12 @@ namespace rgw::dedup {
     }
 
     // SRC hash could have been calculated and stored in obj-attributes before
-    // (will happen when we got multiple targets)
+    // This will happen when we got multiple targets (second time and up with same SRC)
     if (!p_src_rec->s.flags.has_valid_hash() && p_src_val->has_valid_hash()) {
       // read the manifest and strong hash from the head-object attributes
       ldpp_dout(dpp, 20) << __func__ << "::Fetch SRC strong hash from head-object::"
                          << p_src_rec->obj_name << dendl;
-      if (unlikely(read_hash_and_manifest(dpp, driver, store, p_src_rec) != 0)) {
+      if (unlikely(fetch_head_obj_attrs(dpp, driver, store, p_src_rec) != 0)) {
         return false;
       }
       try {
@@ -2336,6 +2379,17 @@ namespace rgw::dedup {
       return 0;
     }
 
+    if (p_src_rec->s.flags.has_remote_attrs()) {
+      ret = fetch_head_obj_attrs(dpp, driver, store, p_src_rec);
+      if (unlikely(ret != 0)) {
+        p_stats->failed_remote_attrs_fetch++;
+        ldpp_dout(dpp, 5) << __func__
+                          << "::ERR: failed fetch remote attrs for SRC "
+                          << p_src_rec->obj_name << dendl;
+        return 0;
+      }
+    }
+
     ldpp_dout(dpp, 20) << __func__ << "::SRC:" << p_src_rec->bucket_name << "/"
                        << p_src_rec->obj_name << "::TGT:" << p_tgt_rec->bucket_name
                        << "/" << p_tgt_rec->obj_name << dendl;
@@ -2357,6 +2411,17 @@ namespace rgw::dedup {
                          << "::" << p_tgt_rec->obj_name << "::"
                          << p_tgt_rec->s.obj_bytes_size << dendl;
       return 0;
+    }
+
+    if (p_tgt_rec->s.flags.has_remote_attrs()) {
+      ret = fetch_head_obj_attrs(dpp, driver, store, p_tgt_rec);
+      if (unlikely(ret != 0)) {
+        p_stats->failed_remote_attrs_fetch++;
+        ldpp_dout(dpp, 5) << __func__
+                          << "::ERR: failed fetch remote attrs for TGT "
+                          << p_tgt_rec->obj_name << dendl;
+        return 0;
+      }
     }
 
     RGWObjManifest src_manifest, tgt_manifest;
@@ -2663,7 +2728,8 @@ namespace rgw::dedup {
 
     return add_disk_rec_from_bucket_idx(disk_arr, p_bucket, &parsed_etag,
                                         entry.key.name, entry.key.instance,
-                                        entry.meta.accounted_size, storage_class);
+                                        entry.meta.accounted_size, storage_class,
+                                        p_worker_stats);
   }
 
   //---------------------------------------------------------------------------
@@ -2915,7 +2981,7 @@ namespace rgw::dedup {
         // we finished processing output SLAB from @worker_id -> remove them
         remove_slabs(worker_id, md5_shard, slab_count_arr[worker_id]);
       }
-      disk_block_seq.flush_disk_records(d_dedup_cluster_ioctx);
+      disk_block_seq.flush_disk_records(d_dedup_cluster_ioctx, p_stats);
     }
 
     ldpp_dout(dpp, 10) << __func__ << "::STEP_REMOVE_DUPLICATES::started..." << dendl;

--- a/src/rgw/driver/rados/rgw_dedup.h
+++ b/src/rgw/driver/rados/rgw_dedup.h
@@ -169,7 +169,8 @@ namespace rgw::dedup {
                                      const std::string      &obj_name,
                                      const std::string      &instance,
                                      uint64_t                obj_size,
-                                     const std::string      &storage_class);
+                                     const std::string      &storage_class,
+                                     worker_stats_t         *p_worker_stats);
 
     int add_record_to_dedup_table(dedup_table_t *p_table,
                                   const struct disk_record_t *p_rec,

--- a/src/rgw/driver/rados/rgw_dedup.h
+++ b/src/rgw/driver/rados/rgw_dedup.h
@@ -191,7 +191,7 @@ namespace rgw::dedup {
     int calc_object_blake3(const RGWObjManifest &manifest,
                            disk_record_t *p_rec,
                            uint8_t *p_hash,
-                           blake3_hasher *p_pre_calc_hmac = nullptr);
+                           bufferlist *p_head_bl = nullptr);
     int split_head_object(disk_record_t *p_src_rec,     // IN/OUT PARAM
                           RGWObjManifest &src_manifest, // IN/OUT PARAM
                           const disk_record_t *p_tgt_rec,
@@ -199,7 +199,8 @@ namespace rgw::dedup {
 
     int add_obj_attrs_to_record(disk_record_t         *p_rec,
                                 const rgw::sal::Attrs &attrs,
-                                md5_stats_t           *p_stats); /* IN-OUT */
+                                rgw_placement_rule    *p_tail_rule,
+                                md5_stats_t           *p_stats/* IN-OUT */);
 
     int read_object_attribute(dedup_table_t    *p_table,
                               disk_record_t    *p_rec,
@@ -240,6 +241,7 @@ namespace rgw::dedup {
 #endif
     int  remove_slabs(unsigned worker_id, unsigned md5_shard, uint32_t slab_count);
     int  init_rados_access_handles(bool init_pool);
+    const std::string& get_placement_compression_type(const rgw_placement_rule &rule);
 
     // private data members
     rgw::sal::Driver* driver = nullptr;
@@ -258,7 +260,11 @@ namespace rgw::dedup {
 
     uint32_t d_min_obj_size_for_dedup = (64ULL * 1024);
     bool     d_split_head             = true;
+    bool     d_skip_compressed        = false;
     uint32_t d_head_object_size       = (4ULL * 1024 * 1024);
+
+    // per-cycle cache: placement rule -> compression type string
+    std::unordered_map<std::string, std::string> d_placement_compression_type;
     control_t d_ctl;
     dedup_filter_t d_filter;
     uint64_t d_watch_handle = 0;

--- a/src/rgw/driver/rados/rgw_dedup.h
+++ b/src/rgw/driver/rados/rgw_dedup.h
@@ -192,7 +192,7 @@ namespace rgw::dedup {
     int calc_object_blake3(const RGWObjManifest &manifest,
                            disk_record_t *p_rec,
                            uint8_t *p_hash,
-                           bufferlist *p_head_bl = nullptr);
+                           const bufferlist *p_head_bl = nullptr);
     int split_head_object(disk_record_t *p_src_rec,     // IN/OUT PARAM
                           RGWObjManifest &src_manifest, // IN/OUT PARAM
                           const disk_record_t *p_tgt_rec,
@@ -264,7 +264,7 @@ namespace rgw::dedup {
     bool     d_skip_compressed        = false;
     uint32_t d_head_object_size       = (4ULL * 1024 * 1024);
 
-    // per-cycle cache: placement rule -> compression type string
+    // per-cycle cache: placement rule (to_str()) -> compression type string
     std::unordered_map<std::string, std::string> d_placement_compression_type;
     control_t d_ctl;
     dedup_filter_t d_filter;

--- a/src/rgw/driver/rados/rgw_dedup.h
+++ b/src/rgw/driver/rados/rgw_dedup.h
@@ -191,7 +191,7 @@ namespace rgw::dedup {
     int calc_object_blake3(const RGWObjManifest &manifest,
                            disk_record_t *p_rec,
                            uint8_t *p_hash,
-                           blake3_hasher *p_pre_calc_hmac = nullptr);
+                           bufferlist *p_head_bl = nullptr);
     int split_head_object(disk_record_t *p_src_rec,     // IN/OUT PARAM
                           RGWObjManifest &src_manifest, // IN/OUT PARAM
                           const disk_record_t *p_tgt_rec,
@@ -199,7 +199,8 @@ namespace rgw::dedup {
 
     int add_obj_attrs_to_record(disk_record_t         *p_rec,
                                 const rgw::sal::Attrs &attrs,
-                                md5_stats_t           *p_stats); /* IN-OUT */
+                                rgw_placement_rule    *p_tail_rule,
+                                md5_stats_t           *p_stats/* IN-OUT */);
 
     int read_object_attribute(dedup_table_t    *p_table,
                               disk_record_t    *p_rec,
@@ -240,6 +241,7 @@ namespace rgw::dedup {
 #endif
     int  remove_slabs(unsigned worker_id, unsigned md5_shard, uint32_t slab_count);
     int  init_rados_access_handles(bool init_pool);
+    const std::string& get_placement_compression_type(const rgw_placement_rule &rule);
 
     // private data members
     rgw::sal::Driver* driver = nullptr;
@@ -258,8 +260,12 @@ namespace rgw::dedup {
 
     uint32_t d_min_obj_size_for_dedup = (64ULL * 1024);
     bool     d_split_head             = true;
+    bool     d_skip_compressed        = false;
     bool     d_pool_supports_truncate = false;
     uint32_t d_head_object_size       = (4ULL * 1024 * 1024);
+
+    // per-cycle cache: placement rule -> compression type string
+    std::unordered_map<std::string, std::string> d_placement_compression_type;
     control_t d_ctl;
     dedup_filter_t d_filter;
     uint64_t d_watch_handle = 0;

--- a/src/rgw/driver/rados/rgw_dedup.h
+++ b/src/rgw/driver/rados/rgw_dedup.h
@@ -192,7 +192,7 @@ namespace rgw::dedup {
     int calc_object_blake3(const RGWObjManifest &manifest,
                            disk_record_t *p_rec,
                            uint8_t *p_hash,
-                           bufferlist *p_head_bl = nullptr);
+                           const bufferlist *p_head_bl = nullptr);
     int split_head_object(disk_record_t *p_src_rec,     // IN/OUT PARAM
                           RGWObjManifest &src_manifest, // IN/OUT PARAM
                           const disk_record_t *p_tgt_rec,
@@ -265,7 +265,7 @@ namespace rgw::dedup {
     bool     d_pool_supports_truncate = false;
     uint32_t d_head_object_size       = (4ULL * 1024 * 1024);
 
-    // per-cycle cache: placement rule -> compression type string
+    // per-cycle cache: placement rule (to_str()) -> compression type string
     std::unordered_map<std::string, std::string> d_placement_compression_type;
     control_t d_ctl;
     dedup_filter_t d_filter;

--- a/src/rgw/driver/rados/rgw_dedup_store.cc
+++ b/src/rgw/driver/rados/rgw_dedup_store.cc
@@ -57,17 +57,19 @@ namespace rgw::dedup {
     this->tenant_name       = p_bucket->get_tenant();
     this->s.tenant_name_len = this->tenant_name.length();
     this->instance          = instance;
+
     this->s.instance_len    = instance.length();
     this->stor_class        = storage_class;
     this->s.stor_class_len  = storage_class.length();
-
-    this->s.ref_tag_len     = 0;
-    this->s.manifest_len    = 0;
+    this->s.ref_tag_len        = 0;
+    this->s.manifest_len       = 0;
+    this->s.compression_bl_len = 0;
 
     this->s.shared_manifest = 0;
     memset(this->s.hash, 0, sizeof(this->s.hash));
     this->ref_tag           = "";
     this->manifest_bl.clear();
+    this->compression_bl.clear();
   }
 
   //---------------------------------------------------------------------------
@@ -93,8 +95,10 @@ namespace rgw::dedup {
     this->s.tenant_name_len = CEPHTOH_16(p_rec->s.tenant_name_len);
     this->s.instance_len    = CEPHTOH_16(p_rec->s.instance_len);
     this->s.stor_class_len  = CEPHTOH_16(p_rec->s.stor_class_len);
-    this->s.ref_tag_len     = CEPHTOH_16(p_rec->s.ref_tag_len);
-    this->s.manifest_len    = CEPHTOH_16(p_rec->s.manifest_len);
+
+    this->s.ref_tag_len        = CEPHTOH_16(p_rec->s.ref_tag_len);
+    this->s.manifest_len       = CEPHTOH_16(p_rec->s.manifest_len);
+    this->s.compression_bl_len = CEPHTOH_16(p_rec->s.compression_bl_len);
 
     const char *p = buff + sizeof(this->s);
     this->obj_name = std::string(p, this->s.obj_name_len);
@@ -130,6 +134,11 @@ namespace rgw::dedup {
       p += p_rec->s.ref_tag_len;
 
       this->manifest_bl.append(p, this->s.manifest_len);
+      p += this->s.manifest_len;
+
+      if (this->s.compression_bl_len > 0) {
+        this->compression_bl.append(p, this->s.compression_bl_len);
+      }
     }
   }
 
@@ -152,8 +161,10 @@ namespace rgw::dedup {
     p_rec->s.tenant_name_len = HTOCEPH_16(this->tenant_name.length());
     p_rec->s.instance_len    = HTOCEPH_16(this->instance.length());
     p_rec->s.stor_class_len  = HTOCEPH_16(this->stor_class.length());
-    p_rec->s.ref_tag_len     = HTOCEPH_16(this->ref_tag.length());
-    p_rec->s.manifest_len    = HTOCEPH_16(this->manifest_bl.length());
+
+    p_rec->s.ref_tag_len        = HTOCEPH_16(this->ref_tag.length());
+    p_rec->s.manifest_len       = HTOCEPH_16(this->manifest_bl.length());
+    p_rec->s.compression_bl_len = HTOCEPH_16(this->compression_bl.length());
     char *p = buff + sizeof(this->s);
     unsigned len = this->obj_name.length();
     std::memcpy(p, this->obj_name.data(), len);
@@ -198,6 +209,13 @@ namespace rgw::dedup {
       const char *p_manifest = const_cast<disk_record_t*>(this)->manifest_bl.c_str();
       std::memcpy(p, p_manifest, len);
       p += len;
+
+      len = this->compression_bl.length();
+      if (len > 0) {
+        const char *p_comp = const_cast<disk_record_t*>(this)->compression_bl.c_str();
+        std::memcpy(p, p_comp, len);
+        p += len;
+      }
     }
     return (p - buff);
   }
@@ -213,7 +231,8 @@ namespace rgw::dedup {
             this->instance.length() +
             this->stor_class.length() +
             this->ref_tag.length() +
-            this->manifest_bl.length());
+            this->manifest_bl.length() +
+            this->compression_bl.length());
   }
 
   //---------------------------------------------------------------------------
@@ -278,6 +297,9 @@ namespace rgw::dedup {
       stream << "Dedicated Manifest Object\n";
     }
     stream << "Manifest len=" << rec.s.manifest_len << "\n";
+    if (rec.s.compression_bl_len) {
+      stream << "Compression len=" << rec.s.compression_bl_len << "\n";
+    }
     return stream;
   }
 

--- a/src/rgw/driver/rados/rgw_dedup_store.cc
+++ b/src/rgw/driver/rados/rgw_dedup_store.cc
@@ -247,27 +247,21 @@ namespace rgw::dedup {
       return 0;
     }
 
-    // wrong version
     if (this->s.rec_version != 0) {
-      // TBD
-      //p_stats->failed_wrong_ver++;
       ldpp_dout(dpp, 5) << __func__ << "::" << caller << "::ERR: Bad record version: "
                         << this->s.rec_version
                         << "::block_id=" << block_id
                         << "::rec_id=" << rec_id
                         << dendl;
-      return -EPROTO;           // Protocol error
+      return -EPROTO;
     }
 
-    // if arrived here record size is too large
-    // TBD
-    //p_stats->failed_rec_overflow++;
     ldpp_dout(dpp, 5) << __func__ << "::" << caller << "::ERR: record size too big: "
                       << this->length()
                       << "::block_id=" << block_id
                       << "::rec_id=" << rec_id
                       << dendl;
-    return -EOVERFLOW; // maybe should use -E2BIG ??
+    return -EOVERFLOW;
   }
 
   //---------------------------------------------------------------------------
@@ -396,9 +390,9 @@ namespace rgw::dedup {
                                      disk_block_t *p_arr_in,
                                      work_shard_t worker_id,
                                      md5_shard_t md5_shard,
-                                     worker_stats_t *p_stats_in)
+                                     worker_stats_t *p_worker_stats_in)
   {
-    activate(dpp_in, p_arr_in, worker_id, md5_shard, p_stats_in);
+    activate(dpp_in, p_arr_in, worker_id, md5_shard, p_worker_stats_in);
   }
 
   //---------------------------------------------------------------------------
@@ -406,15 +400,15 @@ namespace rgw::dedup {
                                   disk_block_t *p_arr_in,
                                   work_shard_t worker_id,
                                   md5_shard_t md5_shard,
-                                  worker_stats_t *p_stats_in)
+                                  worker_stats_t *p_worker_stats_in)
   {
-    dpp          = dpp_in;
-    p_arr        = p_arr_in;
-    d_worker_id  = worker_id;
-    d_md5_shard  = md5_shard;
-    p_stats      = p_stats_in;
-    p_curr_block = nullptr;
-    d_seq_number = 0;
+    dpp            = dpp_in;
+    p_arr          = p_arr_in;
+    d_worker_id    = worker_id;
+    d_md5_shard    = md5_shard;
+    p_worker_stats = p_worker_stats_in;
+    p_curr_block   = nullptr;
+    d_seq_number   = 0;
 
     memset(p_arr, 0, sizeof(disk_block_t));
     slab_reset();
@@ -512,7 +506,6 @@ namespace rgw::dedup {
     disk_record_t rec(p + offset);
     ret = rec.validate(__func__, dpp, block_id, rec_id);
     if (unlikely(ret != 0)) {
-      //p_stats->failed_rec_load++;
       return ret;
     }
 
@@ -521,7 +514,6 @@ namespace rgw::dedup {
         rec.s.num_parts      == p_tgt_rec->s.num_parts      &&
         rec.s.obj_bytes_size == p_tgt_rec->s.obj_bytes_size &&
         rec.stor_class       == p_tgt_rec->stor_class) {
-
       *p_src_rec = rec;
       return 0;
     }
@@ -631,25 +623,31 @@ namespace rgw::dedup {
   }
 
   //---------------------------------------------------------------------------
-  int disk_block_seq_t::flush(librados::IoCtx &ioctx)
+  int disk_block_seq_t::flush(librados::IoCtx &ioctx, md5_stats_t *p_md5_stats)
   {
     unsigned len = (p_curr_block + 1 - p_arr) * sizeof(disk_block_t);
     bufferlist bl = bufferlist::static_from_mem((char*)p_arr, len);
     int ret = store_slab(ioctx, bl, d_md5_shard, d_worker_id, d_seq_number, dpp);
     if (unlikely(ret != 0)) {
-      p_stats->write_slab_failure++;
+      if (p_md5_stats) {
+        p_md5_stats->write_slab_failure++;
+      }
+      else {
+        p_worker_stats->write_slab_failure++;
+      }
     }
     // Need to make sure the call to rgw_put_system_obj was fully synchronous
 
     // d_seq_number++ must be called **after** flush!!
     d_seq_number++;
-    p_stats->egress_slabs++;
+    p_worker_stats->egress_slabs++;
     slab_reset();
     return ret;
   }
 
   //---------------------------------------------------------------------------
-  int disk_block_seq_t::flush_disk_records(librados::IoCtx &ioctx)
+  int disk_block_seq_t::flush_disk_records(librados::IoCtx &ioctx,
+                                           md5_stats_t     *p_md5_stats)
   {
     ceph_assert(p_arr);
     ldpp_dout(dpp, 20) << __func__ << "::worker_id=" << (uint32_t)d_worker_id
@@ -660,27 +658,69 @@ namespace rgw::dedup {
     if (p_curr_block == &p_arr[0] && p_curr_block->is_empty()) {
       ldpp_dout(dpp, 20) << __func__ << "::Empty buffers, generate terminating block" << dendl;
     }
-    p_stats->egress_blocks++;
+    p_worker_stats->egress_blocks++;
     p_curr_block->close_block(dpp, false);
 
-    int ret = flush(ioctx);
+    int ret = flush(ioctx, p_md5_stats);
     return ret;
   }
 
   //---------------------------------------------------------------------------
-  int disk_block_seq_t::add_record(librados::IoCtx     &ioctx,
-                                   const disk_record_t *p_rec, // IN-OUT
-                                   record_info_t       *p_rec_info) // OUT-PARAM
+  // Called on the unlikely path where disk_record_t::validate() fails.
+  // Routes counters to md5_stats_t when available (STEP_READ_ATTRIBUTES),
+  // otherwise to worker_stats_t (STEP_BUILD_TABLE).
+  //
+  // -EOVERFLOW: record too large even after remote_attrs truncation
+  //             (only meaningful for attrs records in md5_stats_t;
+  //              bucket-index records are 200-300 bytes and never overflow).
+  // -EPROTO:    rec_version mismatch -- can happen in any step.
+  static void __attribute__((noinline))
+  handle_validate_failure(int ret,
+                          worker_stats_t *p_worker_stats,
+                          md5_stats_t    *p_md5_stats)
   {
+    if (ret == -EOVERFLOW) {
+      if (p_md5_stats) {
+        p_md5_stats->failed_rec_overflow++;
+      }
+    } else if (ret == -EPROTO) {
+      if (p_md5_stats) {
+        p_md5_stats->failed_wrong_ver++;
+      } else {
+        p_worker_stats->failed_wrong_ver++;
+      }
+    }
+  }
+
+  //---------------------------------------------------------------------------
+  int disk_block_seq_t::add_record(librados::IoCtx  &ioctx,
+                                   disk_record_t   *p_rec,
+                                   record_info_t   *p_rec_info,
+                                   md5_stats_t     *p_md5_stats)
+  {
+    // When manifest/compression make the record too large, drop them and
+    // set a flag so STEP_REMOVE_DUPLICATES fetches them from the object head.
+    if (p_rec->length() > 512 /*MAX_REC_SIZE*/) {
+      p_rec->manifest_bl.clear();
+      p_rec->s.manifest_len = 0;
+      p_rec->compression_bl.clear();
+      p_rec->s.compression_bl_len = 0;
+      p_rec->s.flags.set_remote_attrs();
+      if (p_md5_stats) {
+        p_md5_stats->remote_attrs_records++;
+      }
+      ldpp_dout(dpp, 20) << __func__ << "::record too large (" << p_rec->length()
+                         << "), set remote_attrs for " << p_rec->obj_name << dendl;
+    }
+
     disk_block_id_t null_block_id;
     int ret = p_rec->validate(__func__, dpp, null_block_id, MAX_REC_IN_BLOCK);
     if (unlikely(ret != 0)) {
-      // TBD
-      //p_stats->failed_rec_store++;
+      handle_validate_failure(ret, p_worker_stats, p_md5_stats);
       return ret;
     }
 
-    p_stats->egress_records ++;
+    p_worker_stats->egress_records ++;
     // first, try and add the record to the current open block
     p_rec_info->rec_id = p_curr_block->add_record(p_rec, dpp);
     if (p_rec_info->rec_id < MAX_REC_IN_BLOCK) {
@@ -690,7 +730,7 @@ namespace rgw::dedup {
     else {
       // Not enough space left in current block, close it and open the next block
       ldpp_dout(dpp, 20) << __func__ << "::Block is full-> close and move to next" << dendl;
-      p_stats->egress_blocks++;
+      p_worker_stats->egress_blocks++;
       p_curr_block->close_block(dpp, true);
     }
 
@@ -703,7 +743,7 @@ namespace rgw::dedup {
     }
     else {
       ldpp_dout(dpp, 20)  << __func__ << "::calling flush()" << dendl;
-      ret = flush(ioctx);
+      ret = flush(ioctx, p_md5_stats);
       p_rec_info->rec_id = p_curr_block->add_record(p_rec, dpp);
     }
 
@@ -716,7 +756,7 @@ namespace rgw::dedup {
                                          uint8_t *raw_mem,
                                          uint64_t raw_mem_size,
                                          work_shard_t worker_id,
-                                         worker_stats_t *p_stats,
+                                         worker_stats_t *p_worker_stats,
                                          md5_shard_t num_md5_shards)
   {
     d_num_md5_shards = num_md5_shards;
@@ -727,7 +767,7 @@ namespace rgw::dedup {
     for (unsigned md5_shard = 0; md5_shard < d_num_md5_shards; md5_shard++) {
       ldpp_dout(dpp, 20) << __func__ << "::p=" << p << "::p_end=" << p_end << dendl;
       if (p + DISK_BLOCK_COUNT <= p_end) {
-        d_disk_arr[md5_shard].activate(dpp, p, d_worker_id, md5_shard, p_stats);
+        d_disk_arr[md5_shard].activate(dpp, p, d_worker_id, md5_shard, p_worker_stats);
         p += DISK_BLOCK_COUNT;
       }
       else {
@@ -749,7 +789,7 @@ namespace rgw::dedup {
     for (md5_shard_t md5_shard = 0; md5_shard < d_num_md5_shards; md5_shard++) {
       ldpp_dout(dpp, 20) <<__func__ << "::flush buffers:: worker_id="
                          << d_worker_id<< ", md5_shard=" << md5_shard << dendl;
-      d_disk_arr[md5_shard].flush_disk_records(ioctx);
+      d_disk_arr[md5_shard].flush_disk_records(ioctx, nullptr);
     }
   }
 } // namespace rgw::dedup

--- a/src/rgw/driver/rados/rgw_dedup_store.cc
+++ b/src/rgw/driver/rados/rgw_dedup_store.cc
@@ -61,9 +61,9 @@ namespace rgw::dedup {
     this->s.instance_len    = instance.length();
     this->stor_class        = storage_class;
     this->s.stor_class_len  = storage_class.length();
-    this->s.ref_tag_len        = 0;
-    this->s.manifest_len       = 0;
-    this->s.compression_bl_len = 0;
+    this->s.ref_tag_len     = 0;
+    this->s.manifest_len    = 0;
+    this->s.compression_len = 0;
 
     this->s.shared_manifest = 0;
     memset(this->s.hash, 0, sizeof(this->s.hash));
@@ -96,30 +96,36 @@ namespace rgw::dedup {
     this->s.instance_len    = CEPHTOH_16(p_rec->s.instance_len);
     this->s.stor_class_len  = CEPHTOH_16(p_rec->s.stor_class_len);
 
-    this->s.ref_tag_len        = CEPHTOH_16(p_rec->s.ref_tag_len);
-    this->s.manifest_len       = CEPHTOH_16(p_rec->s.manifest_len);
-    this->s.compression_bl_len = CEPHTOH_16(p_rec->s.compression_bl_len);
+    this->s.ref_tag_len     = CEPHTOH_16(p_rec->s.ref_tag_len);
+    this->s.manifest_len    = CEPHTOH_16(p_rec->s.manifest_len);
+    this->s.compression_len = CEPHTOH_16(p_rec->s.compression_len);
+
+    if (this->length() > MAX_REC_SIZE) {
+      // Prevent out-of-bounds reads below on corrupt/stale data.
+      this->s.rec_version = 1; // force validate() failure
+      return;
+    }
 
     const char *p = buff + sizeof(this->s);
     this->obj_name = std::string(p, this->s.obj_name_len);
-    p += p_rec->s.obj_name_len;
+    p += this->s.obj_name_len;
 
     this->bucket_name = std::string(p, this->s.bucket_name_len);
-    p += p_rec->s.bucket_name_len;
+    p += this->s.bucket_name_len;
 
     this->bucket_id = std::string(p, this->s.bucket_id_len);
-    p += p_rec->s.bucket_id_len;
+    p += this->s.bucket_id_len;
 
     this->tenant_name = std::string(p, this->s.tenant_name_len);
-    p += p_rec->s.tenant_name_len;
+    p += this->s.tenant_name_len;
 
     this->instance = std::string(p, this->s.instance_len);
-    p += p_rec->s.instance_len;
+    p += this->s.instance_len;
 
     this->stor_class = std::string(p, this->s.stor_class_len);
-    p += p_rec->s.stor_class_len;
+    p += this->s.stor_class_len;
 
-    if (p_rec->s.flags.is_fastlane()) {
+    if (this->s.flags.is_fastlane()) {
       // TBD:: remove asserts
       ceph_assert(this->s.ref_tag_len == 0);
       ceph_assert(this->s.manifest_len == 0);
@@ -131,13 +137,13 @@ namespace rgw::dedup {
         this->s.hash[i] = CEPHTOH_64(p_rec->s.hash[i]);
       }
       this->ref_tag = std::string(p, this->s.ref_tag_len);
-      p += p_rec->s.ref_tag_len;
+      p += this->s.ref_tag_len;
 
       this->manifest_bl.append(p, this->s.manifest_len);
       p += this->s.manifest_len;
 
-      if (this->s.compression_bl_len > 0) {
-        this->compression_bl.append(p, this->s.compression_bl_len);
+      if (this->s.compression_len > 0) {
+        this->compression_bl.append(p, this->s.compression_len);
       }
     }
   }
@@ -147,6 +153,8 @@ namespace rgw::dedup {
   {
     ceph_assert(this->s.rec_version  == 0);
     disk_record_t *p_rec = (disk_record_t*)buff;
+    ceph_assert(this->length() <= MAX_REC_SIZE);
+
     p_rec->s.rec_version     = 0;
     p_rec->s.flags           = this->s.flags;
     p_rec->s.num_parts       = HTOCEPH_16(this->s.num_parts);
@@ -162,9 +170,9 @@ namespace rgw::dedup {
     p_rec->s.instance_len    = HTOCEPH_16(this->instance.length());
     p_rec->s.stor_class_len  = HTOCEPH_16(this->stor_class.length());
 
-    p_rec->s.ref_tag_len        = HTOCEPH_16(this->ref_tag.length());
-    p_rec->s.manifest_len       = HTOCEPH_16(this->manifest_bl.length());
-    p_rec->s.compression_bl_len = HTOCEPH_16(this->compression_bl.length());
+    p_rec->s.ref_tag_len     = HTOCEPH_16(this->ref_tag.length());
+    p_rec->s.manifest_len    = HTOCEPH_16(this->manifest_bl.length());
+    p_rec->s.compression_len = HTOCEPH_16(this->compression_bl.length());
     char *p = buff + sizeof(this->s);
     unsigned len = this->obj_name.length();
     std::memcpy(p, this->obj_name.data(), len);
@@ -224,22 +232,24 @@ namespace rgw::dedup {
   size_t disk_record_t::length() const
   {
     return (sizeof(this->s) +
-            this->obj_name.length() +
-            this->bucket_name.length() +
-            this->bucket_id.length() +
-            this->tenant_name.length() +
-            this->instance.length() +
-            this->stor_class.length() +
-            this->ref_tag.length() +
-            this->manifest_bl.length() +
-            this->compression_bl.length());
+            this->s.obj_name_len +
+            this->s.bucket_name_len +
+            this->s.bucket_id_len +
+            this->s.tenant_name_len +
+            this->s.instance_len +
+            this->s.stor_class_len +
+            this->s.ref_tag_len +
+            this->s.manifest_len +
+            this->s.compression_len);
   }
 
   //---------------------------------------------------------------------------
   int disk_record_t::validate(const char *caller,
                               const DoutPrefixProvider* dpp,
                               disk_block_id_t block_id,
-                              record_id_t rec_id) const
+                              record_id_t rec_id,
+                              worker_stats_t *p_worker_stats,
+                              md5_stats_t    *p_md5_stats) const
   {
     // optimistic approach
     if (likely((this->s.rec_version == 0) && (this->length() <= MAX_REC_SIZE))) {
@@ -253,6 +263,13 @@ namespace rgw::dedup {
                         << "::block_id=" << block_id
                         << "::rec_id=" << rec_id
                         << dendl;
+
+      if (p_md5_stats) {
+        p_md5_stats->failed_wrong_ver++;
+      }
+      else if (p_worker_stats) {
+        p_worker_stats->failed_wrong_ver++;
+      }
       return -EPROTO;
     }
 
@@ -261,6 +278,12 @@ namespace rgw::dedup {
                       << "::block_id=" << block_id
                       << "::rec_id=" << rec_id
                       << dendl;
+    if (p_md5_stats) {
+      p_md5_stats->failed_rec_overflow++;
+    }
+    else if (p_worker_stats) {
+      p_worker_stats->failed_rec_overflow++;
+    }
     return -EOVERFLOW;
   }
 
@@ -291,8 +314,8 @@ namespace rgw::dedup {
       stream << "Dedicated Manifest Object\n";
     }
     stream << "Manifest len=" << rec.s.manifest_len << "\n";
-    if (rec.s.compression_bl_len) {
-      stream << "Compression len=" << rec.s.compression_bl_len << "\n";
+    if (rec.s.compression_len) {
+      stream << "Compression len=" << rec.s.compression_len << "\n";
     }
     return stream;
   }
@@ -474,7 +497,9 @@ namespace rgw::dedup {
                   disk_block_id_t           block_id,
                   record_id_t               rec_id,
                   md5_shard_t               md5_shard,
-                  const DoutPrefixProvider *dpp)
+                  const DoutPrefixProvider *dpp,
+                  md5_stats_t              *p_md5_stats)
+
   {
     std::string oid(block_id.get_slab_name(md5_shard));
     int read_len = DISK_BLOCK_SIZE;
@@ -504,7 +529,7 @@ namespace rgw::dedup {
     unsigned offset = p_header->rec_offsets[rec_id];
     // We deserialize the record inside the CTOR
     disk_record_t rec(p + offset);
-    ret = rec.validate(__func__, dpp, block_id, rec_id);
+    ret = rec.validate(__func__, dpp, block_id, rec_id, nullptr, p_md5_stats);
     if (unlikely(ret != 0)) {
       return ret;
     }
@@ -640,7 +665,9 @@ namespace rgw::dedup {
 
     // d_seq_number++ must be called **after** flush!!
     d_seq_number++;
-    p_worker_stats->egress_slabs++;
+    if (!p_md5_stats) {
+      p_worker_stats->egress_slabs++;
+    }
     slab_reset();
     return ret;
   }
@@ -658,7 +685,9 @@ namespace rgw::dedup {
     if (p_curr_block == &p_arr[0] && p_curr_block->is_empty()) {
       ldpp_dout(dpp, 20) << __func__ << "::Empty buffers, generate terminating block" << dendl;
     }
-    p_worker_stats->egress_blocks++;
+    if (!p_md5_stats) {
+      p_worker_stats->egress_blocks++;
+    }
     p_curr_block->close_block(dpp, false);
 
     int ret = flush(ioctx, p_md5_stats);
@@ -666,30 +695,20 @@ namespace rgw::dedup {
   }
 
   //---------------------------------------------------------------------------
-  // Called on the unlikely path where disk_record_t::validate() fails.
-  // Routes counters to md5_stats_t when available (STEP_READ_ATTRIBUTES),
-  // otherwise to worker_stats_t (STEP_BUILD_TABLE).
-  //
-  // -EOVERFLOW: record too large even after remote_attrs truncation
-  //             (only meaningful for attrs records in md5_stats_t;
-  //              bucket-index records are 200-300 bytes and never overflow).
-  // -EPROTO:    rec_version mismatch -- can happen in any step.
-  static void __attribute__((noinline))
-  handle_validate_failure(int ret,
-                          worker_stats_t *p_worker_stats,
-                          md5_stats_t    *p_md5_stats)
+  static void set_remote_attrs_mode(disk_record_t *p_rec,
+                                    const DoutPrefixProvider *dpp,
+                                    md5_stats_t *p_md5_stats)
   {
-    if (ret == -EOVERFLOW) {
-      if (p_md5_stats) {
-        p_md5_stats->failed_rec_overflow++;
-      }
-    } else if (ret == -EPROTO) {
-      if (p_md5_stats) {
-        p_md5_stats->failed_wrong_ver++;
-      } else {
-        p_worker_stats->failed_wrong_ver++;
-      }
+    p_rec->manifest_bl.clear();
+    p_rec->s.manifest_len = 0;
+    p_rec->compression_bl.clear();
+    p_rec->s.compression_len = 0;
+    p_rec->s.flags.set_remote_attrs();
+    if (p_md5_stats) {
+      p_md5_stats->remote_attrs_records++;
     }
+    ldpp_dout(dpp, 20) << __func__ << "::record too large (" << p_rec->length()
+                       << "), set remote_attrs for " << p_rec->obj_name << dendl;
   }
 
   //---------------------------------------------------------------------------
@@ -700,27 +719,21 @@ namespace rgw::dedup {
   {
     // When manifest/compression make the record too large, drop them and
     // set a flag so STEP_REMOVE_DUPLICATES fetches them from the object head.
-    if (p_rec->length() > 512 /*MAX_REC_SIZE*/) {
-      p_rec->manifest_bl.clear();
-      p_rec->s.manifest_len = 0;
-      p_rec->compression_bl.clear();
-      p_rec->s.compression_bl_len = 0;
-      p_rec->s.flags.set_remote_attrs();
-      if (p_md5_stats) {
-        p_md5_stats->remote_attrs_records++;
-      }
-      ldpp_dout(dpp, 20) << __func__ << "::record too large (" << p_rec->length()
-                         << "), set remote_attrs for " << p_rec->obj_name << dendl;
+    if (p_rec->length() > MAX_REC_SIZE) {
+      set_remote_attrs_mode(p_rec, dpp, p_md5_stats);
     }
 
     disk_block_id_t null_block_id;
-    int ret = p_rec->validate(__func__, dpp, null_block_id, MAX_REC_IN_BLOCK);
+    int ret = p_rec->validate(__func__, dpp, null_block_id, MAX_REC_IN_BLOCK,
+                              p_worker_stats, p_md5_stats);
     if (unlikely(ret != 0)) {
-      handle_validate_failure(ret, p_worker_stats, p_md5_stats);
       return ret;
     }
 
-    p_worker_stats->egress_records ++;
+    if (!p_md5_stats) {
+      p_worker_stats->egress_records ++;
+    }
+
     // first, try and add the record to the current open block
     p_rec_info->rec_id = p_curr_block->add_record(p_rec, dpp);
     if (p_rec_info->rec_id < MAX_REC_IN_BLOCK) {
@@ -730,7 +743,9 @@ namespace rgw::dedup {
     else {
       // Not enough space left in current block, close it and open the next block
       ldpp_dout(dpp, 20) << __func__ << "::Block is full-> close and move to next" << dendl;
-      p_worker_stats->egress_blocks++;
+      if (!p_md5_stats) {
+        p_worker_stats->egress_blocks++;
+      }
       p_curr_block->close_block(dpp, true);
     }
 

--- a/src/rgw/driver/rados/rgw_dedup_store.h
+++ b/src/rgw/driver/rados/rgw_dedup_store.h
@@ -180,7 +180,9 @@ namespace rgw::dedup {
     int validate(const char *caller,
                  const DoutPrefixProvider* dpp,
                  disk_block_id_t block_id,
-                 record_id_t rec_id) const;
+                 record_id_t rec_id,
+                 worker_stats_t *p_worker_stats,
+                 md5_stats_t    *p_md5_stats) const;
     inline bool multipart_object() { return (this->s.num_parts > 0); }
     struct packed_rec_t
     {
@@ -200,7 +202,7 @@ namespace rgw::dedup {
       uint16_t      stor_class_len;
       uint16_t      ref_tag_len;
       uint16_t      manifest_len;
-      uint16_t      compression_bl_len;
+      uint16_t      compression_len;
 
       uint8_t       rec_version;     // allows changing record format
       record_flags_t flags;           // 1 Byte flags
@@ -255,7 +257,8 @@ namespace rgw::dedup {
                   disk_block_id_t           block_id,
                   record_id_t               rec_id,
                   md5_shard_t               md5_shard,
-                  const DoutPrefixProvider *dpp);
+                  const DoutPrefixProvider *dpp,
+                  md5_stats_t              *p_md5_stats);
 
   int load_slab(librados::IoCtx &ioctx,
                 bufferlist &bl,

--- a/src/rgw/driver/rados/rgw_dedup_store.h
+++ b/src/rgw/driver/rados/rgw_dedup_store.h
@@ -141,6 +141,7 @@ namespace rgw::dedup {
     static constexpr uint8_t RGW_RECORD_FLAG_FASTLANE        = 0x08;
     static constexpr uint8_t RGW_RECORD_FLAG_SPLIT_HEAD      = 0x10;
     static constexpr uint8_t RGW_RECORD_FLAG_TAIL_REFTAG     = 0x20;
+    static constexpr uint8_t RGW_RECORD_FLAG_REMOTE_ATTRS    = 0x40;
   public:
     record_flags_t() : flags(0) {}
     record_flags_t(uint8_t _flags) : flags(_flags) {}
@@ -158,6 +159,8 @@ namespace rgw::dedup {
     inline void set_split_head() { flags |= RGW_RECORD_FLAG_SPLIT_HEAD; }
     inline bool is_ref_tag_from_tail() const { return ((flags & RGW_RECORD_FLAG_TAIL_REFTAG) != 0); }
     inline void set_ref_tag_from_tail() { flags |= RGW_RECORD_FLAG_TAIL_REFTAG; }
+    inline bool has_remote_attrs() const { return ((flags & RGW_RECORD_FLAG_REMOTE_ATTRS) != 0); }
+    inline void set_remote_attrs() { flags |= RGW_RECORD_FLAG_REMOTE_ATTRS; }
   private:
     uint8_t flags;
   };
@@ -282,12 +285,13 @@ namespace rgw::dedup {
                      disk_block_t *p_arr_in,
                      work_shard_t worker_id,
                      md5_shard_t md5_shard,
-                     worker_stats_t *p_stats_in);
-    int flush_disk_records(librados::IoCtx &ioctx);
+                     worker_stats_t *p_worker_stats_in);
+    int flush_disk_records(librados::IoCtx &ioctx, md5_stats_t *p_md5_stats);
     md5_shard_t get_md5_shard() { return d_md5_shard; }
-    int add_record(librados::IoCtx     &ioctx,
-                   const disk_record_t *p_rec, // IN-OUT
-                   record_info_t       *p_rec_info); // OUT-PARAM
+    int add_record(librados::IoCtx  &ioctx,
+                   disk_record_t   *p_rec,
+                   record_info_t   *p_rec_info,
+                   md5_stats_t     *p_md5_stats = nullptr);
 
   private:
     disk_block_seq_t() {;}
@@ -295,9 +299,9 @@ namespace rgw::dedup {
                   disk_block_t *_p_arr,
                   work_shard_t worker_id,
                   md5_shard_t md5_shard,
-                  worker_stats_t *p_stats);
+                  worker_stats_t *p_worker_stats);
     inline const disk_block_t* last_block() { return &p_arr[DISK_BLOCK_COUNT-1]; }
-    int flush(librados::IoCtx &ioctx);
+    int flush(librados::IoCtx &ioctx, md5_stats_t *p_md5_stats);
     void slab_reset() {
       p_curr_block = p_arr;
       p_curr_block->init(d_worker_id, d_seq_number);
@@ -305,7 +309,7 @@ namespace rgw::dedup {
 
     disk_block_t   *p_arr         = nullptr;
     disk_block_t   *p_curr_block  = nullptr;
-    worker_stats_t *p_stats       = nullptr;
+    worker_stats_t *p_worker_stats = nullptr;
     const DoutPrefixProvider *dpp = nullptr;
     uint32_t        d_seq_number  = 0;
     work_shard_t    d_worker_id   = NULL_WORK_SHARD;

--- a/src/rgw/driver/rados/rgw_dedup_store.h
+++ b/src/rgw/driver/rados/rgw_dedup_store.h
@@ -197,10 +197,11 @@ namespace rgw::dedup {
       uint16_t      stor_class_len;
       uint16_t      ref_tag_len;
       uint16_t      manifest_len;
+      uint16_t      compression_bl_len;
 
       uint8_t       rec_version;     // allows changing record format
       record_flags_t flags;           // 1 Byte flags
-      uint8_t       pad[6];
+      uint8_t       pad[4];
     }s;
     std::string obj_name;
     // TBD: find pool name making it easier to get ioctx
@@ -211,6 +212,7 @@ namespace rgw::dedup {
     std::string instance;
     std::string stor_class;
     bufferlist  manifest_bl;
+    bufferlist  compression_bl;
   };
   static_assert(BLAKE3_OUT_LEN == sizeof(disk_record_t::packed_rec_t::hash));
   static_assert(sizeof(disk_record_t::packed_rec_t) == sizeof(uint64_t)*12);

--- a/src/rgw/driver/rados/rgw_dedup_table.cc
+++ b/src/rgw/driver/rados/rgw_dedup_table.cc
@@ -133,31 +133,46 @@ namespace rgw::dedup {
   }
 
   //---------------------------------------------------------------------------
-  static bool should_replace(const dedup_table_t::value_t &val,
-                             bool new_shared_manifest,
-                             compression_match_level_t new_comp_match)
+  static bool should_replace_f(const dedup_table_t::value_t &val,
+                               bool new_shared_manifest,
+                               compression_match_level_t new_comp_match)
   {
-    // The first pass (STEP_BUILD_TABLE) sets block_id/rec_id to invalid values
-    // and leaves compression_rank at NONE (no attrs available yet).
-    // The second pass (STEP_READ_ATTRIBUTES) calls update_entry() with valid
-    // block_id/rec_id and the real compression_rank / shared_manifest.
+    // The first pass (STEP_BUILD_TABLE) works with records created from
+    //    Bucket-Index abridged info (no compression/shared_manifest)
+    // It will never set shared_manifest and its comp_match will always be
+    //    COMPRESSION_MATCH_NONE.
+    // The [block-id, rec-id] from the first pass must be replaced in the
+    //    second pass (since their matching disk records no longer exist)
+    //
+    // The second pass (STEP_READ_ATTRIBUTES) calls update_entry() with new
+    // [block_id/rec_id] and the real compression_rank / shared_manifest.
     // Replace rules:
     //   - shared_manifest in table: locked, never replace
-    //   - new has shared_manifest: always replace (first time seeing it)
-    //   - table rank is NONE: always replace (first valid update from second pass)
-    //   - table rank is PARTIAL, new is EXACT: upgrade
-    //   - otherwise: keep existing SRC (first good candidate wins)
+    //   - else:
+    //       - new has shared_manifest (table doesn't) -> replace and lock
+    //       - else:
+    //           - prefer the new entry unless table-entry better match the
+    //               placement compression setting
     bool should_replace = false;
     if (val.has_shared_manifest()) {
       // never replace a shared_manifest SRC
+      should_replace = false;
     } else if (new_shared_manifest) {
+      // table entry is not shared_manifest SRC -> take new shared_manifest SRC
       should_replace = true;
     } else {
+      // Both table entry and new entry are not shared_manifest SRC
+      // Always prefer the new entry unless table-entry better match the
+      //        system compression setting
       compression_match_level_t table_comp_match = val.compression_rank();
-      if (table_comp_match == COMPRESSION_MATCH_NONE) {
+      if (new_comp_match == COMPRESSION_MATCH_EXACT) {
         should_replace = true;
       }
-      else if (table_comp_match == COMPRESSION_MATCH_PARTIAL && new_comp_match == COMPRESSION_MATCH_EXACT) {
+      else if (new_comp_match == COMPRESSION_MATCH_PARTIAL &&
+               table_comp_match != COMPRESSION_MATCH_EXACT) {
+        should_replace = true;
+      }
+      else if (table_comp_match == COMPRESSION_MATCH_NONE) {
         should_replace = true;
       }
     }
@@ -198,7 +213,7 @@ namespace rgw::dedup {
         val.count ++;
       }
 
-      if (should_replace(val, new_shared_manifest, new_comp_match)) {
+      if (should_replace_f(val, new_shared_manifest, new_comp_match)) {
         ldpp_dout(dpp, 20) << __func__ << "::Replace SRC::["
                            << val.block_idx << "/" << (int)val.rec_id << "] -> ["
                            << block_id << "/" << (int)rec_id << "]" << dendl;
@@ -223,7 +238,7 @@ namespace rgw::dedup {
     value_t &val = hash_tab[idx].val;
     ceph_assert(val.is_occupied());
 
-    if (should_replace(val, new_shared_manifest, new_comp_match)) {
+    if (should_replace_f(val, new_shared_manifest, new_comp_match)) {
       value_t new_val(block_id, rec_id, new_shared_manifest, new_comp_match);
       new_val.count = val.count;
       ldpp_dout(dpp, 20) << __func__ << "::Replaced table entry::["

--- a/src/rgw/driver/rados/rgw_dedup_table.cc
+++ b/src/rgw/driver/rados/rgw_dedup_table.cc
@@ -133,13 +133,47 @@ namespace rgw::dedup {
   }
 
   //---------------------------------------------------------------------------
+  static bool should_replace(const dedup_table_t::value_t &val,
+                             bool new_shared_manifest,
+                             compression_match_level_t new_comp_match)
+  {
+    // The first pass (STEP_BUILD_TABLE) sets block_id/rec_id to invalid values
+    // and leaves compression_rank at NONE (no attrs available yet).
+    // The second pass (STEP_READ_ATTRIBUTES) calls update_entry() with valid
+    // block_id/rec_id and the real compression_rank / shared_manifest.
+    // Replace rules:
+    //   - shared_manifest in table: locked, never replace
+    //   - new has shared_manifest: always replace (first time seeing it)
+    //   - table rank is NONE: always replace (first valid update from second pass)
+    //   - table rank is PARTIAL, new is EXACT: upgrade
+    //   - otherwise: keep existing SRC (first good candidate wins)
+    bool should_replace = false;
+    if (val.has_shared_manifest()) {
+      // never replace a shared_manifest SRC
+    } else if (new_shared_manifest) {
+      should_replace = true;
+    } else {
+      compression_match_level_t table_comp_match = val.compression_rank();
+      if (table_comp_match == COMPRESSION_MATCH_NONE) {
+        should_replace = true;
+      }
+      else if (table_comp_match == COMPRESSION_MATCH_PARTIAL && new_comp_match == COMPRESSION_MATCH_EXACT) {
+        should_replace = true;
+      }
+    }
+
+    return should_replace;
+  }
+
+  //---------------------------------------------------------------------------
   int dedup_table_t::add_entry(key_t *p_key,
                                disk_block_id_t block_id,
                                record_id_t rec_id,
-                               bool shared_manifest,
+                               bool new_shared_manifest,
+                               compression_match_level_t new_comp_match,
                                dedup_stats_t *p_dedup_stats)
   {
-    value_t new_val(block_id, rec_id, shared_manifest);
+    value_t new_val(block_id, rec_id, new_shared_manifest, new_comp_match);
     uint32_t idx = find_entry(p_key);
     value_t &val = hash_tab[idx].val;
     if (!val.is_occupied()) {
@@ -163,9 +197,9 @@ namespace rgw::dedup {
       if (val.count < std::numeric_limits<std::uint16_t>::max()) {
         val.count ++;
       }
-      if (!val.has_shared_manifest() && shared_manifest) {
-        // replace value!
-        ldpp_dout(dpp, 20) << __func__ << "::Replace with shared_manifest::["
+
+      if (should_replace(val, new_shared_manifest, new_comp_match)) {
+        ldpp_dout(dpp, 20) << __func__ << "::Replace SRC::["
                            << val.block_idx << "/" << (int)val.rec_id << "] -> ["
                            << block_id << "/" << (int)rec_id << "]" << dendl;
         new_val.count = val.count;
@@ -181,25 +215,20 @@ namespace rgw::dedup {
   void dedup_table_t::update_entry(key_t *p_key,
                                    disk_block_id_t block_id,
                                    record_id_t rec_id,
-                                   bool shared_manifest)
+                                   bool new_shared_manifest,
+                                   compression_match_level_t new_comp_match)
   {
     uint32_t idx = find_entry(p_key);
     ceph_assert(hash_tab[idx].key == *p_key);
     value_t &val = hash_tab[idx].val;
     ceph_assert(val.is_occupied());
 
-    // need to overwrite the block_idx/rec_id from the first pass
-    // unless already set with shared_manifest with the correct block-id/rec-id
-    // We only set the shared_manifest flag on the second pass where we
-    // got valid block-id/rec-id
-    if (!val.has_shared_manifest()) {
-      // replace value!
-      value_t new_val(block_id, rec_id, shared_manifest);
+    if (should_replace(val, new_shared_manifest, new_comp_match)) {
+      value_t new_val(block_id, rec_id, new_shared_manifest, new_comp_match);
       new_val.count = val.count;
       ldpp_dout(dpp, 20) << __func__ << "::Replaced table entry::["
                          << val.block_idx << "/" << (int)val.rec_id << "] -> ["
                          << block_id << "/" << (int)rec_id << "]" << dendl;
-
       val = new_val;
     }
   }

--- a/src/rgw/driver/rados/rgw_dedup_table.h
+++ b/src/rgw/driver/rados/rgw_dedup_table.h
@@ -117,7 +117,7 @@ namespace rgw::dedup {
         if (shared_manifest) {
           flags.set_shared_manifest();
         }
-        if (comp_match >= COMPRESSION_MATCH_EXACT) {
+        if (comp_match == COMPRESSION_MATCH_EXACT) {
           flags.set_compression_exact_match();
         } else if (comp_match == COMPRESSION_MATCH_PARTIAL) {
           flags.set_compression_partial_match();

--- a/src/rgw/driver/rados/rgw_dedup_table.h
+++ b/src/rgw/driver/rados/rgw_dedup_table.h
@@ -20,6 +20,12 @@
 #include "rgw_dedup_store.h"
 namespace rgw::dedup {
 
+  enum compression_match_level_t : uint8_t {
+    COMPRESSION_MATCH_NONE    = 0,
+    COMPRESSION_MATCH_PARTIAL = 1,  // both compressed, different algo
+    COMPRESSION_MATCH_EXACT   = 2,  // object type == placement type
+  };
+
   // 24 Bytes key
   struct key_t {
     key_t() { ;}
@@ -65,9 +71,11 @@ namespace rgw::dedup {
   class dedup_table_t {
     struct __attribute__ ((packed)) table_flags_t {
     private:
-      static constexpr uint8_t RGW_TABLE_FLAG_HAS_VALID_HASH  = 0x01;
-      static constexpr uint8_t RGW_TABLE_FLAG_SHARED_MANIFEST = 0x02;
-      static constexpr uint8_t RGW_TABLE_FLAG_OCCUPIED        = 0x04;
+      static constexpr uint8_t RGW_TABLE_FLAG_HAS_VALID_HASH            = 0x01;
+      static constexpr uint8_t RGW_TABLE_FLAG_SHARED_MANIFEST           = 0x02;
+      static constexpr uint8_t RGW_TABLE_FLAG_OCCUPIED                  = 0x04;
+      static constexpr uint8_t RGW_TABLE_FLAG_COMPRESSION_EXACT_MATCH   = 0x08;
+      static constexpr uint8_t RGW_TABLE_FLAG_COMPRESSION_PARTIAL_MATCH = 0x10;
     public:
       table_flags_t() : flags(0) {}
       table_flags_t(uint8_t _flags) : flags(_flags) {}
@@ -79,6 +87,10 @@ namespace rgw::dedup {
       inline bool is_occupied() const {return ((this->flags & RGW_TABLE_FLAG_OCCUPIED) != 0); }
       inline void set_occupied() {this->flags |= RGW_TABLE_FLAG_OCCUPIED; }
       inline void clear_occupied() { this->flags &= ~RGW_TABLE_FLAG_OCCUPIED; }
+      inline bool has_compression_exact_match() const { return ((flags & RGW_TABLE_FLAG_COMPRESSION_EXACT_MATCH) != 0); }
+      inline void set_compression_exact_match() { flags |= RGW_TABLE_FLAG_COMPRESSION_EXACT_MATCH; }
+      inline bool has_compression_partial_match() const { return ((flags & RGW_TABLE_FLAG_COMPRESSION_PARTIAL_MATCH) != 0); }
+      inline void set_compression_partial_match() { flags |= RGW_TABLE_FLAG_COMPRESSION_PARTIAL_MATCH; }
     private:
       uint8_t flags;
     };
@@ -94,7 +106,9 @@ namespace rgw::dedup {
         this->flags.clear();
       }
 
-      value_t(disk_block_id_t block_id, record_id_t rec_id, bool shared_manifest) {
+      value_t(disk_block_id_t block_id, record_id_t rec_id,
+              bool shared_manifest,
+              compression_match_level_t comp_match = COMPRESSION_MATCH_NONE) {
         this->block_idx = block_id;
         this->count  = 1;
         this->rec_id = rec_id;
@@ -103,12 +117,22 @@ namespace rgw::dedup {
         if (shared_manifest) {
           flags.set_shared_manifest();
         }
+        if (comp_match >= COMPRESSION_MATCH_EXACT) {
+          flags.set_compression_exact_match();
+        } else if (comp_match == COMPRESSION_MATCH_PARTIAL) {
+          flags.set_compression_partial_match();
+        }
       }
       inline bool has_shared_manifest() const {return flags.has_shared_manifest(); }
       inline uint16_t        get_count() { return this->count; }
       inline disk_block_id_t get_src_block_id() { return this->block_idx; }
       inline record_id_t     get_src_rec_id() { return this->rec_id; }
       inline bool has_valid_hash() const {return flags.has_valid_hash(); }
+      inline compression_match_level_t compression_rank() const {
+        if (flags.has_compression_exact_match()) return COMPRESSION_MATCH_EXACT;
+        if (flags.has_compression_partial_match()) return COMPRESSION_MATCH_PARTIAL;
+        return COMPRESSION_MATCH_NONE;
+      }
     private:
       inline void set_shared_manifest_src() { this->flags.set_shared_manifest(); }
       inline void inc_count() { count ++; }
@@ -138,10 +162,14 @@ namespace rgw::dedup {
                   disk_block_id_t block_id,
                   record_id_t rec_id,
                   bool shared_manifest,
+                  compression_match_level_t comp_match,
                   dedup_stats_t *p_dedup_stats);
 
-    void update_entry(key_t *p_key, disk_block_id_t block_id, record_id_t rec_id,
-                      bool shared_manifest);
+    void update_entry(key_t *p_key,
+                      disk_block_id_t block_id,
+                      record_id_t rec_id,
+                      bool shared_manifest,
+                      compression_match_level_t comp_match);
 
     int  get_val(const key_t *p_key, struct value_t *p_val /*OUT*/);
 

--- a/src/rgw/driver/rados/rgw_dedup_utils.cc
+++ b/src/rgw/driver/rados/rgw_dedup_utils.cc
@@ -554,6 +554,8 @@ namespace rgw::dedup {
     this->ingress_corrupted_obj_attrs   += other.ingress_corrupted_obj_attrs;
     this->ingress_skip_encrypted        += other.ingress_skip_encrypted;
     this->ingress_skip_encrypted_bytes  += other.ingress_skip_encrypted_bytes;
+    this->ingress_compressed            += other.ingress_compressed;
+    this->ingress_compressed_bytes      += other.ingress_compressed_bytes;
     this->ingress_skip_compressed       += other.ingress_skip_compressed;
     this->ingress_skip_compressed_bytes += other.ingress_skip_compressed_bytes;
     this->ingress_skip_changed_objs     += other.ingress_skip_changed_objs;
@@ -596,17 +598,21 @@ namespace rgw::dedup {
     this->split_head_tgt          += other.split_head_tgt;
     this->split_head_dedup_bytes  += other.split_head_dedup_bytes;
 
+    this->set_compression_on_tgt     += other.set_compression_on_tgt;
+    this->clear_compression_on_tgt   += other.clear_compression_on_tgt;
+    this->deduped_compressed_objects += other.deduped_compressed_objects;
+
     this->set_shared_manifest_src += other.set_shared_manifest_src;
     this->loaded_objects          += other.loaded_objects;
     this->processed_objects       += other.processed_objects;
     this->deduped_objects         += other.deduped_objects;
     this->deduped_objects_bytes   += other.deduped_objects_bytes;
 
-    this->failed_dedup            += other.failed_dedup;
+    this->failed_dedup                += other.failed_dedup;
     this->md_throttle_sleep_events    += other.md_throttle_sleep_events;
     this->md_throttle_sleep_time_usec += other.md_throttle_sleep_time_usec;
-    this->failed_table_load       += other.failed_table_load;
-    this->failed_map_overflow     += other.failed_map_overflow;
+    this->failed_table_load           += other.failed_table_load;
+    this->failed_map_overflow         += other.failed_map_overflow;
     return *this;
   }
 
@@ -689,6 +695,19 @@ namespace rgw::dedup {
       }
       if (this->split_head_dedup_bytes) {
         f->dump_unsigned("Split-Head Dedup-Bytes", this->split_head_dedup_bytes);
+      }
+      if (this->ingress_compressed) {
+        f->dump_unsigned("Compressed objs", this->ingress_compressed);
+        f->dump_unsigned("Compressed Bytes", this->ingress_compressed_bytes);
+      }
+      if (this->set_compression_on_tgt) {
+        f->dump_unsigned("Set Compression on TGT", this->set_compression_on_tgt);
+      }
+      if (this->clear_compression_on_tgt) {
+        f->dump_unsigned("Clear Compression on TGT", this->clear_compression_on_tgt);
+      }
+      if (this->deduped_compressed_objects) {
+        f->dump_unsigned("Deduped Compressed objs", this->deduped_compressed_objects);
       }
     }
 
@@ -819,6 +838,8 @@ namespace rgw::dedup {
     encode(m.ingress_corrupted_obj_attrs, bl);
     encode(m.ingress_skip_encrypted, bl);
     encode(m.ingress_skip_encrypted_bytes, bl);
+    encode(m.ingress_compressed, bl);
+    encode(m.ingress_compressed_bytes, bl);
     encode(m.ingress_skip_compressed, bl);
     encode(m.ingress_skip_compressed_bytes, bl);
     encode(m.ingress_skip_changed_objs, bl);
@@ -860,6 +881,9 @@ namespace rgw::dedup {
     encode(m.split_head_src, bl);
     encode(m.split_head_tgt, bl);
     encode(m.split_head_dedup_bytes, bl);
+    encode(m.set_compression_on_tgt, bl);
+    encode(m.clear_compression_on_tgt, bl);
+    encode(m.deduped_compressed_objects, bl);
     encode(m.set_shared_manifest_src, bl);
 
     encode(m.loaded_objects, bl);
@@ -889,6 +913,8 @@ namespace rgw::dedup {
     decode(m.ingress_corrupted_obj_attrs, bl);
     decode(m.ingress_skip_encrypted, bl);
     decode(m.ingress_skip_encrypted_bytes, bl);
+    decode(m.ingress_compressed, bl);
+    decode(m.ingress_compressed_bytes, bl);
     decode(m.ingress_skip_compressed, bl);
     decode(m.ingress_skip_compressed_bytes, bl);
     decode(m.ingress_skip_changed_objs, bl);
@@ -930,6 +956,9 @@ namespace rgw::dedup {
     decode(m.split_head_src, bl);
     decode(m.split_head_tgt, bl);
     decode(m.split_head_dedup_bytes, bl);
+    decode(m.set_compression_on_tgt, bl);
+    decode(m.clear_compression_on_tgt, bl);
+    decode(m.deduped_compressed_objects, bl);
     decode(m.set_shared_manifest_src, bl);
 
     decode(m.loaded_objects, bl);

--- a/src/rgw/driver/rados/rgw_dedup_utils.cc
+++ b/src/rgw/driver/rados/rgw_dedup_utils.cc
@@ -386,10 +386,12 @@ namespace rgw::dedup {
     this->ingress_skip_filtered_storage_class += other.ingress_skip_filtered_storage_class;
 
     this->total_bidx_record_length += other.total_bidx_record_length;
-    // when aggragting stats from multiple shards we need to preserve the max logic
+    // when aggregating stats from multiple shards we need to preserve the max logic
     if (other.max_bidx_record_length > this->max_bidx_record_length) {
       this->max_bidx_record_length = other.max_bidx_record_length;
     }
+
+    this->failed_rec_overflow += other.failed_rec_overflow;
     this->failed_wrong_ver += other.failed_wrong_ver;
 
     return *this;
@@ -410,10 +412,8 @@ namespace rgw::dedup {
       f->dump_unsigned("Egress Slabs count", this->egress_slabs);
       if (this->egress_records) {
         f->dump_unsigned("Max Bucket-Index Record Length", this->max_bidx_record_length);
-        if (this->egress_records) {
-          f->dump_unsigned("Avg Bucket-Index Record Length",
-                           this->total_bidx_record_length / this->egress_records);
-        }
+        f->dump_unsigned("Avg Bucket-Index Record Length",
+                         this->total_bidx_record_length / this->egress_records);
       }
       f->dump_unsigned("Single part obj count", this->single_part_objs);
       f->dump_unsigned("Multipart obj count", this->multipart_objs);
@@ -480,6 +480,9 @@ namespace rgw::dedup {
       if (this->ingress_corrupted_etag) {
         f->dump_unsigned("Corrupted ETAG", this->ingress_corrupted_etag);
       }
+      if (this->failed_rec_overflow) {
+        f->dump_unsigned("Failed Record Overflow", this->failed_rec_overflow);
+      }
       if (this->failed_wrong_ver) {
         f->dump_unsigned("Failed Wrong Version", this->failed_wrong_ver);
       }
@@ -528,6 +531,7 @@ namespace rgw::dedup {
 
     encode(w.max_bidx_record_length, bl);
     encode(w.total_bidx_record_length, bl);
+    encode(w.failed_rec_overflow, bl);
     encode(w.failed_wrong_ver, bl);
 
     encode(w.duration, bl);
@@ -561,6 +565,7 @@ namespace rgw::dedup {
 
     decode(w.max_bidx_record_length, bl);
     decode(w.total_bidx_record_length, bl);
+    decode(w.failed_rec_overflow, bl);
     decode(w.failed_wrong_ver, bl);
 
     decode(w.duration, bl);
@@ -644,7 +649,8 @@ namespace rgw::dedup {
     this->failed_remote_attrs_fetch   += other.failed_remote_attrs_fetch;
 
     this->total_attrs_record_length   += other.total_attrs_record_length;
-    // when aggragting stats from multiple shards we need to preserve the max logic
+    this->attrs_record_count          += other.attrs_record_count;
+    // when aggregating stats from multiple shards we need to preserve the max logic
     if (other.max_attrs_record_length > this->max_attrs_record_length) {
       this->max_attrs_record_length = other.max_attrs_record_length;
     }
@@ -673,12 +679,10 @@ namespace rgw::dedup {
 
       f->dump_unsigned("Total processed objects", this->processed_objects);
       f->dump_unsigned("Loaded objects", this->loaded_objects);
-      if (this->processed_objects) {
+      if (this->attrs_record_count) {
         f->dump_unsigned("Max Attrs Record Length", this->max_attrs_record_length);
-        if (this->processed_objects) {
-          f->dump_unsigned("Avg Attrs Record Length",
-                           this->total_attrs_record_length / this->processed_objects);
-        }
+        f->dump_unsigned("Avg Attrs Record Length",
+                         this->total_attrs_record_length / this->attrs_record_count);
       }
       f->dump_unsigned("Ingress Slabs", this->ingress_slabs);
       f->dump_unsigned("Set Shared-Manifest SRC", this->set_shared_manifest_src);
@@ -710,9 +714,6 @@ namespace rgw::dedup {
       }
       if (this->remote_attrs_records) {
         f->dump_unsigned("Remote Attrs Records", this->remote_attrs_records);
-      }
-      if (this->failed_remote_attrs_fetch) {
-        f->dump_unsigned("Failed Remote Attrs Fetch", this->failed_remote_attrs_fetch);
       }
       if (this->write_slab_failure) {
         f->dump_unsigned("Write SLAB failures", this->write_slab_failure);
@@ -827,6 +828,9 @@ namespace rgw::dedup {
       }
       if (this->failed_wrong_ver) {
         f->dump_unsigned("Failed Wrong Version", this->failed_wrong_ver);
+      }
+      if (this->failed_remote_attrs_fetch) {
+        f->dump_unsigned("Failed Remote Attrs Fetch", this->failed_remote_attrs_fetch);
       }
 
       if (this->illegal_rec_id) {
@@ -960,6 +964,7 @@ namespace rgw::dedup {
     encode(m.failed_remote_attrs_fetch, bl);
     encode(m.max_attrs_record_length, bl);
     encode(m.total_attrs_record_length, bl);
+    encode(m.attrs_record_count, bl);
     encode(m.write_slab_failure, bl);
 
     encode(m.duration, bl);
@@ -1042,6 +1047,7 @@ namespace rgw::dedup {
     decode(m.failed_remote_attrs_fetch, bl);
     decode(m.max_attrs_record_length, bl);
     decode(m.total_attrs_record_length, bl);
+    decode(m.attrs_record_count, bl);
     decode(m.write_slab_failure, bl);
 
     decode(m.duration, bl);

--- a/src/rgw/driver/rados/rgw_dedup_utils.cc
+++ b/src/rgw/driver/rados/rgw_dedup_utils.cc
@@ -385,6 +385,13 @@ namespace rgw::dedup {
     this->ingress_skip_filtered_bucket += other.ingress_skip_filtered_bucket;
     this->ingress_skip_filtered_storage_class += other.ingress_skip_filtered_storage_class;
 
+    this->total_bidx_record_length += other.total_bidx_record_length;
+    // when aggragting stats from multiple shards we need to preserve the max logic
+    if (other.max_bidx_record_length > this->max_bidx_record_length) {
+      this->max_bidx_record_length = other.max_bidx_record_length;
+    }
+    this->failed_wrong_ver += other.failed_wrong_ver;
+
     return *this;
   }
   //---------------------------------------------------------------------------
@@ -401,6 +408,13 @@ namespace rgw::dedup {
       f->dump_unsigned("Egress Records count", this->egress_records);
       f->dump_unsigned("Egress Blocks count", this->egress_blocks);
       f->dump_unsigned("Egress Slabs count", this->egress_slabs);
+      if (this->egress_records) {
+        f->dump_unsigned("Max Bucket-Index Record Length", this->max_bidx_record_length);
+        if (this->egress_records) {
+          f->dump_unsigned("Avg Bucket-Index Record Length",
+                           this->total_bidx_record_length / this->egress_records);
+        }
+      }
       f->dump_unsigned("Single part obj count", this->single_part_objs);
       f->dump_unsigned("Multipart obj count", this->multipart_objs);
       if (this->small_multipart_obj) {
@@ -466,6 +480,9 @@ namespace rgw::dedup {
       if (this->ingress_corrupted_etag) {
         f->dump_unsigned("Corrupted ETAG", this->ingress_corrupted_etag);
       }
+      if (this->failed_wrong_ver) {
+        f->dump_unsigned("Failed Wrong Version", this->failed_wrong_ver);
+      }
     }
   }
 
@@ -509,6 +526,10 @@ namespace rgw::dedup {
     encode(w.ingress_skip_filtered_bucket, bl);
     encode(w.ingress_skip_filtered_storage_class, bl);
 
+    encode(w.max_bidx_record_length, bl);
+    encode(w.total_bidx_record_length, bl);
+    encode(w.failed_wrong_ver, bl);
+
     encode(w.duration, bl);
     ENCODE_FINISH(bl);
   }
@@ -537,6 +558,10 @@ namespace rgw::dedup {
     decode(w.ingress_skip_too_small, bl);
     decode(w.ingress_skip_filtered_bucket, bl);
     decode(w.ingress_skip_filtered_storage_class, bl);
+
+    decode(w.max_bidx_record_length, bl);
+    decode(w.total_bidx_record_length, bl);
+    decode(w.failed_wrong_ver, bl);
 
     decode(w.duration, bl);
     DECODE_FINISH(bl);
@@ -575,6 +600,8 @@ namespace rgw::dedup {
     this->failed_src_load         += other.failed_src_load;
     this->failed_rec_load         += other.failed_rec_load;
     this->failed_block_load       += other.failed_block_load;
+    this->failed_rec_overflow     += other.failed_rec_overflow;
+    this->failed_wrong_ver        += other.failed_wrong_ver;
 
     this->different_storage_class       += other.different_storage_class;
     this->invalid_hash_no_split_head    += other.invalid_hash_no_split_head;
@@ -613,6 +640,16 @@ namespace rgw::dedup {
     this->md_throttle_sleep_time_usec += other.md_throttle_sleep_time_usec;
     this->failed_table_load           += other.failed_table_load;
     this->failed_map_overflow         += other.failed_map_overflow;
+    this->remote_attrs_records        += other.remote_attrs_records;
+    this->failed_remote_attrs_fetch   += other.failed_remote_attrs_fetch;
+
+    this->total_attrs_record_length   += other.total_attrs_record_length;
+    // when aggragting stats from multiple shards we need to preserve the max logic
+    if (other.max_attrs_record_length > this->max_attrs_record_length) {
+      this->max_attrs_record_length = other.max_attrs_record_length;
+    }
+    this->write_slab_failure          += other.write_slab_failure;
+
     return *this;
   }
 
@@ -636,6 +673,13 @@ namespace rgw::dedup {
 
       f->dump_unsigned("Total processed objects", this->processed_objects);
       f->dump_unsigned("Loaded objects", this->loaded_objects);
+      if (this->processed_objects) {
+        f->dump_unsigned("Max Attrs Record Length", this->max_attrs_record_length);
+        if (this->processed_objects) {
+          f->dump_unsigned("Avg Attrs Record Length",
+                           this->total_attrs_record_length / this->processed_objects);
+        }
+      }
       f->dump_unsigned("Ingress Slabs", this->ingress_slabs);
       f->dump_unsigned("Set Shared-Manifest SRC", this->set_shared_manifest_src);
       f->dump_unsigned("Deduped Obj (this cycle)", this->deduped_objects);
@@ -663,6 +707,15 @@ namespace rgw::dedup {
       }
       if (this->failed_map_overflow) {
         f->dump_unsigned("Failed Remap Overflow", this->failed_map_overflow);
+      }
+      if (this->remote_attrs_records) {
+        f->dump_unsigned("Remote Attrs Records", this->remote_attrs_records);
+      }
+      if (this->failed_remote_attrs_fetch) {
+        f->dump_unsigned("Failed Remote Attrs Fetch", this->failed_remote_attrs_fetch);
+      }
+      if (this->write_slab_failure) {
+        f->dump_unsigned("Write SLAB failures", this->write_slab_failure);
       }
 
       f->dump_unsigned("Valid HASH attrs", this->valid_hash_attrs);
@@ -769,6 +822,12 @@ namespace rgw::dedup {
       if (this->failed_block_load) {
         f->dump_unsigned("Failed Block-Load ", this->failed_block_load);
       }
+      if (this->failed_rec_overflow) {
+        f->dump_unsigned("Failed Record Overflow", this->failed_rec_overflow);
+      }
+      if (this->failed_wrong_ver) {
+        f->dump_unsigned("Failed Wrong Version", this->failed_wrong_ver);
+      }
 
       if (this->illegal_rec_id) {
         f->dump_unsigned("Failed illegal_rec_id", this->illegal_rec_id );
@@ -859,6 +918,8 @@ namespace rgw::dedup {
     encode(m.failed_src_load, bl);
     encode(m.failed_rec_load, bl);
     encode(m.failed_block_load, bl);
+    encode(m.failed_rec_overflow, bl);
+    encode(m.failed_wrong_ver, bl);
 
     encode(m.different_storage_class, bl);
     encode(m.invalid_hash_no_split_head, bl);
@@ -895,6 +956,11 @@ namespace rgw::dedup {
     encode(m.md_throttle_sleep_time_usec, bl);
     encode(m.failed_table_load, bl);
     encode(m.failed_map_overflow, bl);
+    encode(m.remote_attrs_records, bl);
+    encode(m.failed_remote_attrs_fetch, bl);
+    encode(m.max_attrs_record_length, bl);
+    encode(m.total_attrs_record_length, bl);
+    encode(m.write_slab_failure, bl);
 
     encode(m.duration, bl);
     ENCODE_FINISH(bl);
@@ -934,6 +1000,8 @@ namespace rgw::dedup {
     decode(m.failed_src_load, bl);
     decode(m.failed_rec_load, bl);
     decode(m.failed_block_load, bl);
+    decode(m.failed_rec_overflow, bl);
+    decode(m.failed_wrong_ver, bl);
 
     decode(m.different_storage_class, bl);
     decode(m.invalid_hash_no_split_head, bl);
@@ -970,6 +1038,11 @@ namespace rgw::dedup {
     decode(m.md_throttle_sleep_time_usec, bl);
     decode(m.failed_table_load, bl);
     decode(m.failed_map_overflow, bl);
+    decode(m.remote_attrs_records, bl);
+    decode(m.failed_remote_attrs_fetch, bl);
+    decode(m.max_attrs_record_length, bl);
+    decode(m.total_attrs_record_length, bl);
+    decode(m.write_slab_failure, bl);
 
     decode(m.duration, bl);
     DECODE_FINISH(bl);

--- a/src/rgw/driver/rados/rgw_dedup_utils.cc
+++ b/src/rgw/driver/rados/rgw_dedup_utils.cc
@@ -387,6 +387,13 @@ namespace rgw::dedup {
     this->ingress_skip_no_truncate_support += other.ingress_skip_no_truncate_support;
     this->ingress_skip_no_truncate_support_bytes += other.ingress_skip_no_truncate_support_bytes;
 
+    this->total_bidx_record_length += other.total_bidx_record_length;
+    // when aggragting stats from multiple shards we need to preserve the max logic
+    if (other.max_bidx_record_length > this->max_bidx_record_length) {
+      this->max_bidx_record_length = other.max_bidx_record_length;
+    }
+    this->failed_wrong_ver += other.failed_wrong_ver;
+
     return *this;
   }
   //---------------------------------------------------------------------------
@@ -403,6 +410,13 @@ namespace rgw::dedup {
       f->dump_unsigned("Egress Records count", this->egress_records);
       f->dump_unsigned("Egress Blocks count", this->egress_blocks);
       f->dump_unsigned("Egress Slabs count", this->egress_slabs);
+      if (this->egress_records) {
+        f->dump_unsigned("Max Bucket-Index Record Length", this->max_bidx_record_length);
+        if (this->egress_records) {
+          f->dump_unsigned("Avg Bucket-Index Record Length",
+                           this->total_bidx_record_length / this->egress_records);
+        }
+      }
       f->dump_unsigned("Single part obj count", this->single_part_objs);
       f->dump_unsigned("Multipart obj count", this->multipart_objs);
       if (this->small_multipart_obj) {
@@ -474,6 +488,9 @@ namespace rgw::dedup {
       if (this->ingress_corrupted_etag) {
         f->dump_unsigned("Corrupted ETAG", this->ingress_corrupted_etag);
       }
+      if (this->failed_wrong_ver) {
+        f->dump_unsigned("Failed Wrong Version", this->failed_wrong_ver);
+      }
     }
   }
 
@@ -518,6 +535,10 @@ namespace rgw::dedup {
     encode(w.ingress_skip_no_truncate_support, bl);
     encode(w.ingress_skip_no_truncate_support_bytes, bl);
 
+    encode(w.max_bidx_record_length, bl);
+    encode(w.total_bidx_record_length, bl);
+    encode(w.failed_wrong_ver, bl);
+
     encode(w.duration, bl);
     ENCODE_FINISH(bl);
   }
@@ -548,6 +569,10 @@ namespace rgw::dedup {
     decode(w.ingress_skip_filtered_storage_class, bl);
     decode(w.ingress_skip_no_truncate_support, bl);
     decode(w.ingress_skip_no_truncate_support_bytes, bl);
+
+    decode(w.max_bidx_record_length, bl);
+    decode(w.total_bidx_record_length, bl);
+    decode(w.failed_wrong_ver, bl);
 
     decode(w.duration, bl);
     DECODE_FINISH(bl);
@@ -586,6 +611,8 @@ namespace rgw::dedup {
     this->failed_src_load         += other.failed_src_load;
     this->failed_rec_load         += other.failed_rec_load;
     this->failed_block_load       += other.failed_block_load;
+    this->failed_rec_overflow     += other.failed_rec_overflow;
+    this->failed_wrong_ver        += other.failed_wrong_ver;
 
     this->different_storage_class       += other.different_storage_class;
     this->invalid_hash_no_split_head    += other.invalid_hash_no_split_head;
@@ -625,6 +652,16 @@ namespace rgw::dedup {
     this->md_throttle_sleep_time_usec += other.md_throttle_sleep_time_usec;
     this->failed_table_load           += other.failed_table_load;
     this->failed_map_overflow         += other.failed_map_overflow;
+    this->remote_attrs_records        += other.remote_attrs_records;
+    this->failed_remote_attrs_fetch   += other.failed_remote_attrs_fetch;
+
+    this->total_attrs_record_length   += other.total_attrs_record_length;
+    // when aggragting stats from multiple shards we need to preserve the max logic
+    if (other.max_attrs_record_length > this->max_attrs_record_length) {
+      this->max_attrs_record_length = other.max_attrs_record_length;
+    }
+    this->write_slab_failure          += other.write_slab_failure;
+
     return *this;
   }
 
@@ -648,6 +685,13 @@ namespace rgw::dedup {
 
       f->dump_unsigned("Total processed objects", this->processed_objects);
       f->dump_unsigned("Loaded objects", this->loaded_objects);
+      if (this->processed_objects) {
+        f->dump_unsigned("Max Attrs Record Length", this->max_attrs_record_length);
+        if (this->processed_objects) {
+          f->dump_unsigned("Avg Attrs Record Length",
+                           this->total_attrs_record_length / this->processed_objects);
+        }
+      }
       f->dump_unsigned("Ingress Slabs", this->ingress_slabs);
       f->dump_unsigned("Set Shared-Manifest SRC", this->set_shared_manifest_src);
       f->dump_unsigned("Deduped Obj (this cycle)", this->deduped_objects);
@@ -675,6 +719,15 @@ namespace rgw::dedup {
       }
       if (this->failed_map_overflow) {
         f->dump_unsigned("Failed Remap Overflow", this->failed_map_overflow);
+      }
+      if (this->remote_attrs_records) {
+        f->dump_unsigned("Remote Attrs Records", this->remote_attrs_records);
+      }
+      if (this->failed_remote_attrs_fetch) {
+        f->dump_unsigned("Failed Remote Attrs Fetch", this->failed_remote_attrs_fetch);
+      }
+      if (this->write_slab_failure) {
+        f->dump_unsigned("Write SLAB failures", this->write_slab_failure);
       }
 
       f->dump_unsigned("Valid HASH attrs", this->valid_hash_attrs);
@@ -781,6 +834,12 @@ namespace rgw::dedup {
       if (this->failed_block_load) {
         f->dump_unsigned("Failed Block-Load ", this->failed_block_load);
       }
+      if (this->failed_rec_overflow) {
+        f->dump_unsigned("Failed Record Overflow", this->failed_rec_overflow);
+      }
+      if (this->failed_wrong_ver) {
+        f->dump_unsigned("Failed Wrong Version", this->failed_wrong_ver);
+      }
 
       if (this->illegal_rec_id) {
         f->dump_unsigned("Failed illegal_rec_id", this->illegal_rec_id );
@@ -875,6 +934,8 @@ namespace rgw::dedup {
     encode(m.failed_src_load, bl);
     encode(m.failed_rec_load, bl);
     encode(m.failed_block_load, bl);
+    encode(m.failed_rec_overflow, bl);
+    encode(m.failed_wrong_ver, bl);
 
     encode(m.different_storage_class, bl);
     encode(m.invalid_hash_no_split_head, bl);
@@ -912,6 +973,11 @@ namespace rgw::dedup {
     encode(m.md_throttle_sleep_time_usec, bl);
     encode(m.failed_table_load, bl);
     encode(m.failed_map_overflow, bl);
+    encode(m.remote_attrs_records, bl);
+    encode(m.failed_remote_attrs_fetch, bl);
+    encode(m.max_attrs_record_length, bl);
+    encode(m.total_attrs_record_length, bl);
+    encode(m.write_slab_failure, bl);
 
     encode(m.duration, bl);
     ENCODE_FINISH(bl);
@@ -951,6 +1017,8 @@ namespace rgw::dedup {
     decode(m.failed_src_load, bl);
     decode(m.failed_rec_load, bl);
     decode(m.failed_block_load, bl);
+    decode(m.failed_rec_overflow, bl);
+    decode(m.failed_wrong_ver, bl);
 
     decode(m.different_storage_class, bl);
     decode(m.invalid_hash_no_split_head, bl);
@@ -988,6 +1056,11 @@ namespace rgw::dedup {
     decode(m.md_throttle_sleep_time_usec, bl);
     decode(m.failed_table_load, bl);
     decode(m.failed_map_overflow, bl);
+    decode(m.remote_attrs_records, bl);
+    decode(m.failed_remote_attrs_fetch, bl);
+    decode(m.max_attrs_record_length, bl);
+    decode(m.total_attrs_record_length, bl);
+    decode(m.write_slab_failure, bl);
 
     decode(m.duration, bl);
     DECODE_FINISH(bl);

--- a/src/rgw/driver/rados/rgw_dedup_utils.cc
+++ b/src/rgw/driver/rados/rgw_dedup_utils.cc
@@ -388,10 +388,12 @@ namespace rgw::dedup {
     this->ingress_skip_no_truncate_support_bytes += other.ingress_skip_no_truncate_support_bytes;
 
     this->total_bidx_record_length += other.total_bidx_record_length;
-    // when aggragting stats from multiple shards we need to preserve the max logic
+    // when aggregating stats from multiple shards we need to preserve the max logic
     if (other.max_bidx_record_length > this->max_bidx_record_length) {
       this->max_bidx_record_length = other.max_bidx_record_length;
     }
+
+    this->failed_rec_overflow += other.failed_rec_overflow;
     this->failed_wrong_ver += other.failed_wrong_ver;
 
     return *this;
@@ -412,10 +414,8 @@ namespace rgw::dedup {
       f->dump_unsigned("Egress Slabs count", this->egress_slabs);
       if (this->egress_records) {
         f->dump_unsigned("Max Bucket-Index Record Length", this->max_bidx_record_length);
-        if (this->egress_records) {
-          f->dump_unsigned("Avg Bucket-Index Record Length",
-                           this->total_bidx_record_length / this->egress_records);
-        }
+        f->dump_unsigned("Avg Bucket-Index Record Length",
+                         this->total_bidx_record_length / this->egress_records);
       }
       f->dump_unsigned("Single part obj count", this->single_part_objs);
       f->dump_unsigned("Multipart obj count", this->multipart_objs);
@@ -488,6 +488,9 @@ namespace rgw::dedup {
       if (this->ingress_corrupted_etag) {
         f->dump_unsigned("Corrupted ETAG", this->ingress_corrupted_etag);
       }
+      if (this->failed_rec_overflow) {
+        f->dump_unsigned("Failed Record Overflow", this->failed_rec_overflow);
+      }
       if (this->failed_wrong_ver) {
         f->dump_unsigned("Failed Wrong Version", this->failed_wrong_ver);
       }
@@ -537,6 +540,7 @@ namespace rgw::dedup {
 
     encode(w.max_bidx_record_length, bl);
     encode(w.total_bidx_record_length, bl);
+    encode(w.failed_rec_overflow, bl);
     encode(w.failed_wrong_ver, bl);
 
     encode(w.duration, bl);
@@ -572,6 +576,7 @@ namespace rgw::dedup {
 
     decode(w.max_bidx_record_length, bl);
     decode(w.total_bidx_record_length, bl);
+    decode(w.failed_rec_overflow, bl);
     decode(w.failed_wrong_ver, bl);
 
     decode(w.duration, bl);
@@ -656,7 +661,8 @@ namespace rgw::dedup {
     this->failed_remote_attrs_fetch   += other.failed_remote_attrs_fetch;
 
     this->total_attrs_record_length   += other.total_attrs_record_length;
-    // when aggragting stats from multiple shards we need to preserve the max logic
+    this->attrs_record_count          += other.attrs_record_count;
+    // when aggregating stats from multiple shards we need to preserve the max logic
     if (other.max_attrs_record_length > this->max_attrs_record_length) {
       this->max_attrs_record_length = other.max_attrs_record_length;
     }
@@ -685,12 +691,10 @@ namespace rgw::dedup {
 
       f->dump_unsigned("Total processed objects", this->processed_objects);
       f->dump_unsigned("Loaded objects", this->loaded_objects);
-      if (this->processed_objects) {
+      if (this->attrs_record_count) {
         f->dump_unsigned("Max Attrs Record Length", this->max_attrs_record_length);
-        if (this->processed_objects) {
-          f->dump_unsigned("Avg Attrs Record Length",
-                           this->total_attrs_record_length / this->processed_objects);
-        }
+        f->dump_unsigned("Avg Attrs Record Length",
+                         this->total_attrs_record_length / this->attrs_record_count);
       }
       f->dump_unsigned("Ingress Slabs", this->ingress_slabs);
       f->dump_unsigned("Set Shared-Manifest SRC", this->set_shared_manifest_src);
@@ -722,9 +726,6 @@ namespace rgw::dedup {
       }
       if (this->remote_attrs_records) {
         f->dump_unsigned("Remote Attrs Records", this->remote_attrs_records);
-      }
-      if (this->failed_remote_attrs_fetch) {
-        f->dump_unsigned("Failed Remote Attrs Fetch", this->failed_remote_attrs_fetch);
       }
       if (this->write_slab_failure) {
         f->dump_unsigned("Write SLAB failures", this->write_slab_failure);
@@ -839,6 +840,9 @@ namespace rgw::dedup {
       }
       if (this->failed_wrong_ver) {
         f->dump_unsigned("Failed Wrong Version", this->failed_wrong_ver);
+      }
+      if (this->failed_remote_attrs_fetch) {
+        f->dump_unsigned("Failed Remote Attrs Fetch", this->failed_remote_attrs_fetch);
       }
 
       if (this->illegal_rec_id) {
@@ -977,6 +981,7 @@ namespace rgw::dedup {
     encode(m.failed_remote_attrs_fetch, bl);
     encode(m.max_attrs_record_length, bl);
     encode(m.total_attrs_record_length, bl);
+    encode(m.attrs_record_count, bl);
     encode(m.write_slab_failure, bl);
 
     encode(m.duration, bl);
@@ -1060,6 +1065,7 @@ namespace rgw::dedup {
     decode(m.failed_remote_attrs_fetch, bl);
     decode(m.max_attrs_record_length, bl);
     decode(m.total_attrs_record_length, bl);
+    decode(m.attrs_record_count, bl);
     decode(m.write_slab_failure, bl);
 
     decode(m.duration, bl);

--- a/src/rgw/driver/rados/rgw_dedup_utils.cc
+++ b/src/rgw/driver/rados/rgw_dedup_utils.cc
@@ -565,6 +565,8 @@ namespace rgw::dedup {
     this->ingress_corrupted_obj_attrs   += other.ingress_corrupted_obj_attrs;
     this->ingress_skip_encrypted        += other.ingress_skip_encrypted;
     this->ingress_skip_encrypted_bytes  += other.ingress_skip_encrypted_bytes;
+    this->ingress_compressed            += other.ingress_compressed;
+    this->ingress_compressed_bytes      += other.ingress_compressed_bytes;
     this->ingress_skip_compressed       += other.ingress_skip_compressed;
     this->ingress_skip_compressed_bytes += other.ingress_skip_compressed_bytes;
     this->ingress_skip_changed_objs     += other.ingress_skip_changed_objs;
@@ -608,17 +610,21 @@ namespace rgw::dedup {
     this->split_head_tgt          += other.split_head_tgt;
     this->split_head_dedup_bytes  += other.split_head_dedup_bytes;
 
+    this->set_compression_on_tgt     += other.set_compression_on_tgt;
+    this->clear_compression_on_tgt   += other.clear_compression_on_tgt;
+    this->deduped_compressed_objects += other.deduped_compressed_objects;
+
     this->set_shared_manifest_src += other.set_shared_manifest_src;
     this->loaded_objects          += other.loaded_objects;
     this->processed_objects       += other.processed_objects;
     this->deduped_objects         += other.deduped_objects;
     this->deduped_objects_bytes   += other.deduped_objects_bytes;
 
-    this->failed_dedup            += other.failed_dedup;
+    this->failed_dedup                += other.failed_dedup;
     this->md_throttle_sleep_events    += other.md_throttle_sleep_events;
     this->md_throttle_sleep_time_usec += other.md_throttle_sleep_time_usec;
-    this->failed_table_load       += other.failed_table_load;
-    this->failed_map_overflow     += other.failed_map_overflow;
+    this->failed_table_load           += other.failed_table_load;
+    this->failed_map_overflow         += other.failed_map_overflow;
     return *this;
   }
 
@@ -701,6 +707,19 @@ namespace rgw::dedup {
       }
       if (this->split_head_dedup_bytes) {
         f->dump_unsigned("Split-Head Dedup-Bytes", this->split_head_dedup_bytes);
+      }
+      if (this->ingress_compressed) {
+        f->dump_unsigned("Compressed objs", this->ingress_compressed);
+        f->dump_unsigned("Compressed Bytes", this->ingress_compressed_bytes);
+      }
+      if (this->set_compression_on_tgt) {
+        f->dump_unsigned("Set Compression on TGT", this->set_compression_on_tgt);
+      }
+      if (this->clear_compression_on_tgt) {
+        f->dump_unsigned("Clear Compression on TGT", this->clear_compression_on_tgt);
+      }
+      if (this->deduped_compressed_objects) {
+        f->dump_unsigned("Deduped Compressed objs", this->deduped_compressed_objects);
       }
     }
 
@@ -835,6 +854,8 @@ namespace rgw::dedup {
     encode(m.ingress_corrupted_obj_attrs, bl);
     encode(m.ingress_skip_encrypted, bl);
     encode(m.ingress_skip_encrypted_bytes, bl);
+    encode(m.ingress_compressed, bl);
+    encode(m.ingress_compressed_bytes, bl);
     encode(m.ingress_skip_compressed, bl);
     encode(m.ingress_skip_compressed_bytes, bl);
     encode(m.ingress_skip_changed_objs, bl);
@@ -877,6 +898,9 @@ namespace rgw::dedup {
     encode(m.split_head_src, bl);
     encode(m.split_head_tgt, bl);
     encode(m.split_head_dedup_bytes, bl);
+    encode(m.set_compression_on_tgt, bl);
+    encode(m.clear_compression_on_tgt, bl);
+    encode(m.deduped_compressed_objects, bl);
     encode(m.set_shared_manifest_src, bl);
 
     encode(m.loaded_objects, bl);
@@ -906,6 +930,8 @@ namespace rgw::dedup {
     decode(m.ingress_corrupted_obj_attrs, bl);
     decode(m.ingress_skip_encrypted, bl);
     decode(m.ingress_skip_encrypted_bytes, bl);
+    decode(m.ingress_compressed, bl);
+    decode(m.ingress_compressed_bytes, bl);
     decode(m.ingress_skip_compressed, bl);
     decode(m.ingress_skip_compressed_bytes, bl);
     decode(m.ingress_skip_changed_objs, bl);
@@ -948,6 +974,9 @@ namespace rgw::dedup {
     decode(m.split_head_src, bl);
     decode(m.split_head_tgt, bl);
     decode(m.split_head_dedup_bytes, bl);
+    decode(m.set_compression_on_tgt, bl);
+    decode(m.clear_compression_on_tgt, bl);
+    decode(m.deduped_compressed_objects, bl);
     decode(m.set_shared_manifest_src, bl);
 
     decode(m.loaded_objects, bl);

--- a/src/rgw/driver/rados/rgw_dedup_utils.h
+++ b/src/rgw/driver/rados/rgw_dedup_utils.h
@@ -204,6 +204,7 @@ namespace rgw::dedup {
     uint64_t max_bidx_record_length = 0;
     uint64_t total_bidx_record_length = 0;
 
+    uint64_t failed_rec_overflow = 0;
     uint64_t failed_wrong_ver = 0;
 
     utime_t  duration = {0, 0};
@@ -290,6 +291,7 @@ namespace rgw::dedup {
     uint64_t failed_remote_attrs_fetch = 0;
     uint64_t max_attrs_record_length = 0;
     uint64_t total_attrs_record_length = 0;
+    uint64_t attrs_record_count = 0;
     uint64_t write_slab_failure = 0;
     utime_t  duration = {0, 0};
   };

--- a/src/rgw/driver/rados/rgw_dedup_utils.h
+++ b/src/rgw/driver/rados/rgw_dedup_utils.h
@@ -201,6 +201,11 @@ namespace rgw::dedup {
     uint64_t ingress_skip_filtered_bucket = 0;
     uint64_t ingress_skip_filtered_storage_class = 0;
 
+    uint64_t max_bidx_record_length = 0;
+    uint64_t total_bidx_record_length = 0;
+
+    uint64_t failed_wrong_ver = 0;
+
     utime_t  duration = {0, 0};
   };
   std::ostream& operator<<(std::ostream &out, const worker_stats_t &s);
@@ -242,6 +247,8 @@ namespace rgw::dedup {
     uint64_t failed_src_load = 0;
     uint64_t failed_rec_load = 0;
     uint64_t failed_block_load = 0;
+    uint64_t failed_rec_overflow = 0;
+    uint64_t failed_wrong_ver = 0;
 
     uint64_t different_storage_class = 0;
     uint64_t invalid_hash_no_split_head = 0;
@@ -279,6 +286,11 @@ namespace rgw::dedup {
     uint64_t md_throttle_sleep_time_usec = 0;
     uint64_t failed_table_load = 0;
     uint64_t failed_map_overflow = 0;
+    uint64_t remote_attrs_records = 0;
+    uint64_t failed_remote_attrs_fetch = 0;
+    uint64_t max_attrs_record_length = 0;
+    uint64_t total_attrs_record_length = 0;
+    uint64_t write_slab_failure = 0;
     utime_t  duration = {0, 0};
   };
   std::ostream &operator<<(std::ostream &out, const md5_stats_t &s);

--- a/src/rgw/driver/rados/rgw_dedup_utils.h
+++ b/src/rgw/driver/rados/rgw_dedup_utils.h
@@ -221,6 +221,8 @@ namespace rgw::dedup {
     uint64_t ingress_corrupted_obj_attrs = 0;
     uint64_t ingress_skip_encrypted = 0;
     uint64_t ingress_skip_encrypted_bytes = 0;
+    uint64_t ingress_compressed = 0;
+    uint64_t ingress_compressed_bytes = 0;
     uint64_t ingress_skip_compressed = 0;
     uint64_t ingress_skip_compressed_bytes = 0;
     uint64_t ingress_skip_changed_objs = 0;
@@ -262,6 +264,9 @@ namespace rgw::dedup {
     uint64_t split_head_src = 0;
     uint64_t split_head_tgt = 0;
     uint64_t split_head_dedup_bytes = 0;
+    uint64_t set_compression_on_tgt = 0;
+    uint64_t clear_compression_on_tgt = 0;
+    uint64_t deduped_compressed_objects = 0;
     uint64_t set_shared_manifest_src = 0;
     uint64_t loaded_objects = 0;
     uint64_t processed_objects = 0;

--- a/src/rgw/driver/rados/rgw_dedup_utils.h
+++ b/src/rgw/driver/rados/rgw_dedup_utils.h
@@ -206,6 +206,7 @@ namespace rgw::dedup {
     uint64_t max_bidx_record_length = 0;
     uint64_t total_bidx_record_length = 0;
 
+    uint64_t failed_rec_overflow = 0;
     uint64_t failed_wrong_ver = 0;
 
     utime_t  duration = {0, 0};
@@ -293,6 +294,7 @@ namespace rgw::dedup {
     uint64_t failed_remote_attrs_fetch = 0;
     uint64_t max_attrs_record_length = 0;
     uint64_t total_attrs_record_length = 0;
+    uint64_t attrs_record_count = 0;
     uint64_t write_slab_failure = 0;
     utime_t  duration = {0, 0};
   };

--- a/src/rgw/driver/rados/rgw_dedup_utils.h
+++ b/src/rgw/driver/rados/rgw_dedup_utils.h
@@ -223,6 +223,8 @@ namespace rgw::dedup {
     uint64_t ingress_corrupted_obj_attrs = 0;
     uint64_t ingress_skip_encrypted = 0;
     uint64_t ingress_skip_encrypted_bytes = 0;
+    uint64_t ingress_compressed = 0;
+    uint64_t ingress_compressed_bytes = 0;
     uint64_t ingress_skip_compressed = 0;
     uint64_t ingress_skip_compressed_bytes = 0;
     uint64_t ingress_skip_changed_objs = 0;
@@ -265,6 +267,9 @@ namespace rgw::dedup {
     uint64_t split_head_src = 0;
     uint64_t split_head_tgt = 0;
     uint64_t split_head_dedup_bytes = 0;
+    uint64_t set_compression_on_tgt = 0;
+    uint64_t clear_compression_on_tgt = 0;
+    uint64_t deduped_compressed_objects = 0;
     uint64_t set_shared_manifest_src = 0;
     uint64_t loaded_objects = 0;
     uint64_t processed_objects = 0;

--- a/src/rgw/driver/rados/rgw_dedup_utils.h
+++ b/src/rgw/driver/rados/rgw_dedup_utils.h
@@ -203,6 +203,11 @@ namespace rgw::dedup {
     uint64_t ingress_skip_no_truncate_support = 0;
     uint64_t ingress_skip_no_truncate_support_bytes = 0;
 
+    uint64_t max_bidx_record_length = 0;
+    uint64_t total_bidx_record_length = 0;
+
+    uint64_t failed_wrong_ver = 0;
+
     utime_t  duration = {0, 0};
   };
   std::ostream& operator<<(std::ostream &out, const worker_stats_t &s);
@@ -244,6 +249,8 @@ namespace rgw::dedup {
     uint64_t failed_src_load = 0;
     uint64_t failed_rec_load = 0;
     uint64_t failed_block_load = 0;
+    uint64_t failed_rec_overflow = 0;
+    uint64_t failed_wrong_ver = 0;
 
     uint64_t different_storage_class = 0;
     uint64_t invalid_hash_no_split_head = 0;
@@ -282,6 +289,11 @@ namespace rgw::dedup {
     uint64_t md_throttle_sleep_time_usec = 0;
     uint64_t failed_table_load = 0;
     uint64_t failed_map_overflow = 0;
+    uint64_t remote_attrs_records = 0;
+    uint64_t failed_remote_attrs_fetch = 0;
+    uint64_t max_attrs_record_length = 0;
+    uint64_t total_attrs_record_length = 0;
+    uint64_t write_slab_failure = 0;
     utime_t  duration = {0, 0};
   };
   std::ostream &operator<<(std::ostream &out, const md5_stats_t &s);

--- a/src/test/rgw/dedup/__init__.py
+++ b/src/test/rgw/dedup/__init__.py
@@ -7,10 +7,8 @@ def setup():
     try:
         path = os.environ['DEDUPTESTS_CONF']
     except KeyError:
-        raise RuntimeError(
-            'To run tests, point environment '
-            + 'variable DEDUPTESTS_CONF to a config file.',
-            )
+        raise RuntimeError('To run tests, point environment '
+                           + 'variable DEDUPTESTS_CONF to a config file.',)
     cfg.read(path)
 
     if not cfg.defaults():
@@ -20,18 +18,51 @@ def setup():
 
     defaults = cfg.defaults()
 
-  	# vars from the DEFAULT section
+    # vars from the DEFAULT section
+    global default_zonegroup
+    default_zonegroup = defaults.get("zonegroup")
+
+    global default_zone
+    default_zone = defaults.get("zone")
+
+    global default_cluster
+    default_cluster = defaults.get("cluster")
+
     global default_host
     default_host = defaults.get("host")
 
     global default_port
     default_port = int(defaults.get("port"))
-	# vars from the main section
+
+    global default_data_pool
+    default_data_pool = defaults.get("data_pool")
+    if not default_data_pool:
+        zone = defaults.get("zone")
+        if zone:
+            default_data_pool = zone + ".rgw.buckets.data"
+        else:
+            raise RuntimeError(
+                'Your config file must set "data_pool" or "zone" in the DEFAULT section!')
+
+    # vars from the main section
     global main_access_key
     main_access_key = cfg.get('s3 main',"access_key")
 
     global main_secret_key
     main_secret_key = cfg.get('s3 main',"secret_key")
+
+
+def get_config_zonegroup():
+    global default_zonegroup
+    return default_zonegroup
+
+def get_config_zone():
+    global default_zone
+    return default_zone
+
+def get_config_cluster():
+    global default_cluster
+    return default_cluster
 
 
 def get_config_host():
@@ -42,6 +73,11 @@ def get_config_host():
 def get_config_port():
     global default_port
     return default_port
+
+
+def get_config_data_pool():
+    global default_data_pool
+    return default_data_pool
 
 
 def get_access_key():
@@ -57,4 +93,9 @@ def get_secret_key():
 @pytest.fixture(autouse=True, scope="package")
 def configfile():
     setup()
+    yield
+    # Lazy import avoids circular import: test_dedup imports from this package.
+    from . import test_dedup
+    test_dedup.restore_default_compression_via_period()
+    test_dedup.close_all_connections()
 

--- a/src/test/rgw/dedup/deduptests.conf.SAMPLE
+++ b/src/test/rgw/dedup/deduptests.conf.SAMPLE
@@ -1,10 +1,27 @@
 [DEFAULT]
-port = 8000
+port = 8101
 host = localhost
+#zonegroup = default
+#cluster = noname
+zonegroup = zg1
+zone = zg1-1
+cluster = c1
+# Optional; defaults to {zone}.rgw.buckets.data when omitted
+#data_pool = zg1-1.rgw.buckets.data
 
 [s3 main]
-access_key = 0555b35654ad1656d804
-secret_key = h7GhxuBLTrlhVUyxSPUKUV8r/2EI4ngqJxD7iBdBYLhwluN30JaT3Q==
+# vstart default user:
+#access_key = 0555b35654ad1656d804
+#secret_key = h7GhxuBLTrlhVUyxSPUKUV8r/2EI4ngqJxD7iBdBYLhwluN30JaT3Q==
+
+# test-rgw-multisite.sh system user (zone.user) -- do not use for boto3 S3 ops:
+#access_key = 1234567890
+#secret_key = pencil
+
+# test-rgw-multisite.sh regular user (regular.user):
+access_key = 0987654321
+secret_key = crayon
+
 display_name = M. Tester
 user_id = testid
 email = tester@ceph.com

--- a/src/test/rgw/dedup/test_dedup.py
+++ b/src/test/rgw/dedup/test_dedup.py
@@ -12,8 +12,8 @@ import string
 import shutil
 import pytest
 import json
-#from collections import namedtuple
 import boto3
+from botocore.exceptions import ClientError
 from boto3.s3.transfer import TransferConfig
 from dataclasses import dataclass
 import urllib.parse
@@ -25,8 +25,12 @@ from botocore.awsrequest import AWSRequest
 
 from . import(
     configfile,
+    get_config_zonegroup,
+    get_config_zone,
+    get_config_cluster,
     get_config_host,
     get_config_port,
+    get_config_data_pool,
     get_access_key,
     get_secret_key
 )
@@ -70,9 +74,6 @@ class Dedup_Ratio:
     s3_bytes_after: int = 0
     ratio: float = 0.0
 
-full_dedup_state_was_checked = False
-full_dedup_state_disabled = True
-
 # configure logging for the tests module
 log = logging.getLogger(__name__)
 num_buckets = 0
@@ -84,22 +85,31 @@ test_path = os.path.normpath(os.path.dirname(os.path.realpath(__file__))) + '/..
 
 #-----------------------------------------------
 def bash(cmd, **kwargs):
-    #log.debug('running command: %s', ' '.join(cmd))
+    cmd_timeout = 300
     kwargs['stdout'] = subprocess.PIPE
     process = subprocess.Popen(cmd, **kwargs)
-    s = process.communicate()[0].decode('utf-8')
-    return (s, process.returncode)
+    try:
+        out, _ = process.communicate(timeout=cmd_timeout)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        out, _ = process.communicate()
+        raise AssertionError(
+            "command timed out after %ds: %s" % (cmd_timeout, ' '.join(cmd)))
+
+    return (out.decode('utf-8'), process.returncode)
 
 #-----------------------------------------------
 def admin(args, **kwargs):
     """ radosgw-admin command """
-    cmd = [test_path + 'test-rgw-call.sh', 'call_rgw_admin', 'noname'] + args
+    cluster=get_config_cluster()
+    cmd = [test_path + 'test-rgw-call.sh', 'call_rgw_admin', cluster] + args
     return bash(cmd, **kwargs)
 
 #-----------------------------------------------
 def rados(args, **kwargs):
     """ rados command """
-    cmd = [test_path + 'test-rgw-call.sh', 'call_rgw_rados', 'noname'] + args
+    cluster=get_config_cluster()
+    cmd = [test_path + 'test-rgw-call.sh', 'call_rgw_rados', cluster] + args
     return bash(cmd, **kwargs)
 
 #------------------------------------------------------------------
@@ -202,12 +212,19 @@ def get_buckets(num_buckets):
 #==============================================
 #-------------------------------------------------------------------------------
 def verify_no_forgotten_buckets(conn):
+    """returns False if any bucket existed at check time;
+    deletes them for subsequent tests"""
+
     bucket_count = 0
     response = conn.list_buckets()
+
     # The 'Buckets' key always exists in a successful response
     for bucket in response['Buckets']:
-        log.warning("Forgotten bucket name = %s", bucket['Name'])
-        conn.delete_bucket(Bucket=bucket['Name'])
+        bucket_name = bucket['Name']
+        log.warning("Forgotten bucket name = %s", bucket_name)
+        delete_bucket_with_all_objects(bucket_name, conn)
+        #conn.delete_bucket(Bucket=bucket_name)
+
         bucket_count += 1
 
     return bucket_count == 0
@@ -215,12 +232,29 @@ def verify_no_forgotten_buckets(conn):
 
 g_tenant_connections=[]
 g_tenants=[]
+g_tenant_user_ids=[]
 g_simple_connection=[]
 
 #-----------------------------------------------
-def close_all_connections():
-    global g_simple_connection
+def _make_s3_client(access_key, secret_key):
+    """Create a boto3 S3 client for the configured RGW endpoint."""
+    zonegroup = get_config_zonegroup()
+    hostname = get_config_host()
+    port_no = get_config_port()
+    if port_no == 443 or port_no == 8443:
+        scheme = 'https://'
+    else:
+        scheme = 'http://'
+    return boto3.client('s3',
+                        endpoint_url=scheme + hostname + ':' + str(port_no),
+                        region_name=zonegroup,
+                        aws_access_key_id=access_key,
+                        aws_secret_access_key=secret_key)
 
+#-----------------------------------------------
+def close_all_connections():
+    global g_simple_connection, g_tenant_connections, g_tenants, g_tenant_user_ids
+    log.info("Teardown: Closing all connections")
     for conn in g_simple_connection:
         log.debug("close simple connection")
         verify_no_forgotten_buckets(conn)
@@ -230,6 +264,16 @@ def close_all_connections():
         log.debug("close tenant connection")
         verify_no_forgotten_buckets(conn)
         conn.close()
+
+    for uid, tenant in g_tenant_user_ids:
+        log.debug("remove tenant user uid=%s tenant=%s", uid, tenant)
+        result = admin(['user', 'rm', '--tenant', tenant, '--uid', uid, '--purge-data'])
+        assert result[1] == 0
+
+    g_simple_connection = []
+    g_tenant_connections = []
+    g_tenants = []
+    g_tenant_user_ids = []
 
 #-----------------------------------------------
 def get_connections(req_count):
@@ -241,23 +285,14 @@ def get_connections(req_count):
         conns.append(g_simple_connection[i])
 
     if len(conns) < req_count:
-        hostname = get_config_host()
-        port_no = get_config_port()
         access_key = get_access_key()
         secret_key = get_secret_key()
-        if port_no == 443 or port_no == 8443:
-            scheme = 'https://'
-        else:
-            scheme = 'http://'
 
         for i in range(req_count - len(conns)):
-            log.debug("generate new connection")
-            client = boto3.client('s3',
-                                  endpoint_url=scheme+hostname+':'+str(port_no),
-                                  aws_access_key_id=access_key,
-                                  aws_secret_access_key=secret_key)
-            g_simple_connection.append(client);
-            conns.append(client);
+            log.info("generate new connection")
+            client = _make_s3_client(access_key, secret_key)
+            g_simple_connection.append(client)
+            conns.append(client)
 
     return conns
 
@@ -272,93 +307,60 @@ def another_user(uid, tenant, display_name):
     global num_users
     num_users += 1
 
-    access_key = run_prefix + "_" +str(num_users) + "_" + str(time.time())
-    secret_key = run_prefix + "_" +str(num_users) + "_" + str(time.time())
+    timestamp = str(time.time())
+    access_key = run_prefix + "_" + str(num_users) + "_ak_" + timestamp
+    secret_key = run_prefix + "_" + str(num_users) + "_sk_" + timestamp
 
-    cmd = ['user', 'create', '--uid', uid, '--tenant', tenant, '--access-key', access_key, '--secret-key', secret_key, '--display-name', display_name]
+    cmd = ['user', 'create', '--uid', uid, '--tenant', tenant,
+           '--access-key', access_key, '--secret-key', secret_key,
+           '--display-name', display_name]
     result = admin(cmd)
     assert result[1] == 0
 
-    hostname = get_config_host()
-    port_no = get_config_port()
-    if port_no == 443 or port_no == 8443:
-        scheme = 'https://'
-    else:
-        scheme = 'http://'
-
-    endpoint=scheme+hostname+':'+str(port_no)
-    client = boto3.client('s3',
-                          endpoint_url=endpoint,
-                          aws_access_key_id=access_key,
-                          aws_secret_access_key=secret_key)
-
-    return client
+    return _make_s3_client(access_key, secret_key)
 
 #-------------------------------------------------------------------------------
-def gen_connections_multi2(req_count):
-    g_tenant_connections=[]
-    g_tenants=[]
-    global num_conns
+def gen_connections_multi(req_count):
+    global g_tenant_connections, g_tenants, g_tenant_user_ids, num_conns
+
+    assert len(g_tenants) == len(g_tenant_connections) == len(g_tenant_user_ids), \
+        "tenant connection pool out of sync"
 
     log.debug("gen_connections_multi: Create connection and buckets ...")
-    suffix=run_prefix
+    suffix = run_prefix
 
-    tenants=[]
-    bucket_names=[]
-    conns=[]
+    tenants = []
+    bucket_names = []
+    conns = []
 
-    for i in range(min(req_count, len(g_tenants))):
+    recycle_count = min(req_count, len(g_tenant_connections))
+    for i in range(recycle_count):
         log.debug("recycle existing tenants connection")
-        conns.append(g_tenants_connection[i])
+        conn = g_tenant_connections[i]
+        conns.append(conn)
         tenants.append(g_tenants[i])
         # we need to create a new bucket as we remove existing buckets at cleanup
-        bucket_name=gen_bucket_name()
+        bucket_name = gen_bucket_name()
         bucket_names.append(bucket_name)
-        bucket=conns[i].create_bucket(Bucket=bucket_name)
+        conn.create_bucket(Bucket=bucket_name)
 
     if len(conns) < req_count:
         for i in range(req_count - len(conns)):
             num_conns += 1
-            user=gen_object_name("user", num_conns) + suffix
-            display_name=gen_object_name("display", num_conns) + suffix
-            tenant=gen_object_name("tenant", num_conns) + suffix
+            user = gen_object_name("user", num_conns) + suffix
+            display_name = gen_object_name("display", num_conns) + suffix
+            tenant = gen_object_name("tenant", num_conns) + suffix
             g_tenants.append(tenant)
+            g_tenant_user_ids.append((user, tenant))
             tenants.append(tenant)
-            bucket_name=gen_bucket_name()
+            bucket_name = gen_bucket_name()
             bucket_names.append(bucket_name)
-            log.debug("U=%s, T=%s, B=%s", user, tenant, bucket_name);
+            log.debug("U=%s, T=%s, B=%s", user, tenant, bucket_name)
 
-            conn=another_user(user, tenant, display_name)
-            bucket=conn.create_bucket(Bucket=bucket_name)
+            conn = another_user(user, tenant, display_name)
+            conn.create_bucket(Bucket=bucket_name)
             g_tenant_connections.append(conn)
             conns.append(conn)
-
-    log.debug("gen_connections_multi: All connection and buckets are set")
-    return (tenants, bucket_names, conns)
-
-
-#-------------------------------------------------------------------------------
-def gen_connections_multi(num_tenants):
-    global num_conns
-
-    tenants=[]
-    bucket_names=[]
-    conns=[]
-    log.debug("gen_connections_multi: Create connection and buckets ...")
-    suffix=run_prefix
-    for i in range(0, num_tenants):
-        num_conns += 1
-        user=gen_object_name("user", num_conns) + suffix
-        display_name=gen_object_name("display", num_conns) + suffix
-        tenant=gen_object_name("tenant", num_conns) + suffix
-        tenants.append(tenant)
-        bucket_name=gen_bucket_name()
-        bucket_names.append(bucket_name)
-        log.debug("U=%s, T=%s, B=%s", user, tenant, bucket_name);
-
-        conn=another_user(user, tenant, display_name)
-        bucket=conn.create_bucket(Bucket=bucket_name)
-        conns.append(conn)
 
     log.debug("gen_connections_multi: All connection and buckets are set")
     return (tenants, bucket_names, conns)
@@ -388,14 +390,13 @@ RADOS_OBJ_SIZE=(4*MB)
 MULTIPART_SIZE=(15*MB)
 default_config = TransferConfig(multipart_threshold=MULTIPART_SIZE, multipart_chunksize=MULTIPART_SIZE)
 ETAG_ATTR="user.rgw.etag"
-POOLNAME="default.rgw.buckets.data"
 
 MAX_COPIES_PER_OBJ=128
 #-------------------------------------------------------------------------------
 def write_file(filename, size):
     full_filename = OUT_DIR + filename
 
-    fout = open(full_filename, "wb")
+    fout = open(full_filename, "xb")
     fout.write(os.urandom(size))
     fout.close()
 
@@ -482,20 +483,6 @@ def gen_files(files, start_size, factor, max_copies_count=4):
         write_random(files, size2, 1, max_copies_count)
         size  = size * 2;
 
-
-#-------------------------------------------------------------------------------
-def count_space_in_all_buckets():
-    result = rados(['df'])
-    assert result[1] == 0
-    log.debug("=============================================")
-    for line in result[0].splitlines():
-        if line.startswith(POOLNAME):
-            log.debug(line[:45])
-        elif line.startswith("POOL_NAME"):
-            log.debug(line[:45])
-            log.debug("=============================================")
-
-
 #-------------------------------------------------------------------------------
 def count_objects_in_bucket(bucket_name, conn):
     max_keys=1000
@@ -526,20 +513,19 @@ def count_objects_in_bucket(bucket_name, conn):
 
 #-------------------------------------------------------------------------------
 def count_object_parts_in_all_buckets(verbose=False, expected_size=0):
+    poolname = get_config_data_pool()
     result = rados(['lspools'])
     assert result[1] == 0
-    found=False
-    for pool in result[0].split():
-        if pool == POOLNAME:
-            found=True
-            log.debug("Pool %s was found", POOLNAME)
-            break
+    pools = result[0].split()
+    if poolname not in pools:
+        if expected_size == 0 and not verbose:
+            return 0
+        raise AssertionError( "RADOS data pool '%s' not found (available pools: %s)"
+                              % (poolname, ', '.join(pools) if pools else '(none)'))
 
-    if found == False:
-        log.debug("Pool %s doesn't exists!", POOLNAME)
-        return 0
+    log.debug("Pool %s was found", poolname)
 
-    result = rados(['ls', '-p ', POOLNAME])
+    result = rados(['ls', '-p ', poolname])
     assert result[1] == 0
     names=result[0].split()
     rados_count = len(names)
@@ -557,7 +543,7 @@ def count_object_parts_in_all_buckets(verbose=False, expected_size=0):
         if verbose:
             log.debug(rados_name)
         if expected_size:
-            result = rados(['-p ', POOLNAME, 'stat', rados_name])
+            result = rados(['-p ', poolname, 'stat', rados_name])
             assert result[1] == 0
             stat = result[0].split()
             byte_size=int(stat[-1])
@@ -614,39 +600,45 @@ def delete_bucket_with_all_objects(bucket_name, conn):
     max_keys=1000
     continuation_token = None
     obj_count=0
-    while True:
-        list_args = {
-            'Bucket': bucket_name,
-            'MaxKeys': max_keys
-        }
-        if continuation_token:
-            list_args['ContinuationToken'] = continuation_token
+    try:
+        while True:
+            list_args = {
+                'Bucket': bucket_name,
+                'MaxKeys': max_keys
+            }
+            if continuation_token:
+                list_args['ContinuationToken'] = continuation_token
 
-        listing=conn.list_objects_v2(**list_args)
-        if 'Contents' not in listing or len(listing['Contents'])== 0:
-            log.debug("Bucket '%s' is empty, skipping...", bucket_name)
-            break
+            listing=conn.list_objects_v2(**list_args)
+            if 'Contents' not in listing or len(listing['Contents'])== 0:
+                log.debug("Bucket '%s' is empty, skipping...", bucket_name)
+                break
 
-        objects=[]
-        for obj in listing['Contents']:
-            log.debug("delete_bucket_with_all_objects: add obj: %s", obj['Key'])
-            objects.append({'Key': obj['Key']})
+            objects=[]
+            for obj in listing['Contents']:
+                log.debug("delete_bucket_with_all_objects: add obj: %s", obj['Key'])
+                objects.append({'Key': obj['Key']})
 
-        obj_count += len(objects)
-        # delete objects from the bucket
-        log.debug("delete_bucket_with_all_objects: delete %d objs", obj_count)
-        response=conn.delete_objects(Bucket=bucket_name, Delete={'Objects':objects})
-        check_delete_objects_response(response)
+            obj_count += len(objects)
+            log.debug("delete_bucket_with_all_objects: delete %d objs", obj_count)
+            response=conn.delete_objects(Bucket=bucket_name, Delete={'Objects':objects})
+            check_delete_objects_response(response)
 
-        if 'NextContinuationToken' in listing:
-            continuation_token = listing['NextContinuationToken']
-            log.debug("delete_bucket_with_all_objects: Token=%s, count=%d",
-                      continuation_token, obj_count)
-        else:
-            break
+            if 'NextContinuationToken' in listing:
+                continuation_token = listing['NextContinuationToken']
+                log.debug("delete_bucket_with_all_objects: Token=%s, count=%d",
+                          continuation_token, obj_count)
+            else:
+                break
 
-    log.debug("Removing Bucket '%s', obj_count=%d", bucket_name, obj_count)
-    conn.delete_bucket(Bucket=bucket_name)
+        log.debug("Removing Bucket '%s', obj_count=%d", bucket_name, obj_count)
+        conn.delete_bucket(Bucket=bucket_name)
+    except ClientError as e:
+        error_code = e.response.get('Error', {}).get('Code', '')
+        if error_code == 'NoSuchBucket':
+            log.info("Bucket '%s' does not exist, skipping cleanup", bucket_name)
+            return
+        raise
 
 #-------------------------------------------------------------------------------
 def verify_pool_is_empty(conn, skip_bucket_check=False):
@@ -655,7 +647,7 @@ def verify_pool_is_empty(conn, skip_bucket_check=False):
 
     obj_count = count_object_parts_in_all_buckets(False, 0)
     if (obj_count):
-        log.warning("verify_pool_is_empty: %d obejcts were found", obj_count)
+        log.warning("verify_pool_is_empty: %d objects were found", obj_count)
         assert obj_count == 0
 
     if not skip_bucket_check:
@@ -663,19 +655,18 @@ def verify_pool_is_empty(conn, skip_bucket_check=False):
 
 #-------------------------------------------------------------------------------
 def cleanup(bucket_name, conn):
-    if cleanup_local():
-        log.debug("delete_all_objects for bucket <%s>",bucket_name)
-        delete_bucket_with_all_objects(bucket_name, conn)
-
+    cleanup_local()
+    log.debug("delete_all_objects for bucket <%s>",bucket_name)
+    delete_bucket_with_all_objects(bucket_name, conn)
     verify_pool_is_empty(conn)
 
 
 #-------------------------------------------------------------------------------
 def cleanup_all_buckets(bucket_names, conns):
-    if cleanup_local():
-        for (bucket_name, conn) in zip(bucket_names, conns):
-            log.debug("delete_all_objects for bucket <%s>",bucket_name)
-            delete_bucket_with_all_objects(bucket_name, conn)
+    cleanup_local()
+    for (bucket_name, conn) in zip(bucket_names, conns):
+        log.debug("delete_all_objects for bucket <%s>",bucket_name)
+        delete_bucket_with_all_objects(bucket_name, conn)
 
     verify_pool_is_empty(conns[0], True)
     for conn in conns:
@@ -782,7 +773,7 @@ def calc_expected_stats(dedup_stats, obj_size, num_copies, config):
     on_disk_byte_size = calc_on_disk_byte_size(obj_size)
     log.debug("obj_size=%d, on_disk_byte_size=%d", obj_size, on_disk_byte_size)
     threshold = config.multipart_threshold
-    dedup_stats.skip_shared_manifest = 0
+    #dedup_stats.skip_shared_manifest = 0
     dedup_stats.size_before_dedup += (on_disk_byte_size * num_copies)
     if on_disk_byte_size < DEDUP_MIN_OBJ_SIZE and threshold > DEDUP_MIN_OBJ_SIZE:
         dedup_stats.skip_too_small += num_copies
@@ -1011,7 +1002,16 @@ def upload_objects_multi(files, conns, bucket_names, indices, config, check_obj_
 
 
 #---------------------------------------------------------------------------
-def proc_upload(proc_id, num_procs, files, conn, bucket_name, indices, config):
+def _s3_credentials(conn):
+    """Extract AK/SK from a boto3 client for fork-safe worker processes."""
+    creds = conn._request_signer._credentials
+    return creds.access_key, creds.secret_key
+
+
+#---------------------------------------------------------------------------
+def proc_upload(proc_id, num_procs, files, access_key, secret_key,
+                bucket_name, indices, config):
+    conn = _make_s3_client(access_key, secret_key)
     count=0
     for (f, idx) in zip(files, indices):
         filename=f[0]
@@ -1034,8 +1034,10 @@ def procs_upload_objects(files, conns, bucket_names, indices, config, check_obj_
     proc_list=list()
     for idx in range(num_procs):
         # Seems the processes are much faster than threads (probably due to python gil)
+        access_key, secret_key = _s3_credentials(conns[idx])
         p=Process(target=proc_upload,
-                  args=(idx, num_procs, files, conns[idx], bucket_names[idx], indices, config))
+                  args=(idx, num_procs, files, access_key, secret_key,
+                        bucket_names[idx], indices, config))
         proc_list.append(p)
         proc_list[idx].start()
 
@@ -1343,11 +1345,6 @@ def threads_verify_objects(files, conns, bucket_names, expected_results, config)
 
 
 #-------------------------------------------------------------------------------
-def get_stats_line_val(line):
-    return int(line.rsplit("=", maxsplit=1)[1].strip())
-
-
-#-------------------------------------------------------------------------------
 def print_dedup_stats(dedup_stats):
     log.info("===============================================")
 
@@ -1479,6 +1476,7 @@ def verify_dedup_ratio(expected_dedup_stats, dedup_ratio):
 
 #-------------------------------------------------------------------------------
 def read_dedup_stats(dry_run):
+    log.debug("read_dedup_stats: dry_run=%s", dry_run)
     dedup_work_was_completed = False
     dedup_stats=Dedup_Stats()
     dedup_ratio_estimate=Dedup_Ratio()
@@ -1527,7 +1525,9 @@ def read_dedup_stats(dry_run):
 
 #-------------------------------------------------------------------------------
 def set_bucket_index_throttling(limit):
+    log.debug("set_bucket_index_throttling(%d)", limit);
     result = dedup_admin('throttle', max_bucket_index_ops=limit)
+
     assert result[1] == 0
     log.debug(result[0])
 
@@ -1537,7 +1537,7 @@ def exec_dedup_internal(expected_dedup_stats, dry_run, max_dedup_time):
     limit=random.randint(50, 200)
     set_bucket_index_throttling(limit)
 
-    log.debug("sending exec_dedup request: dry_run=%d", dry_run)
+    log.info("sending exec_dedup request: dry_run=%s", dry_run)
     if dry_run:
         result = dedup_admin('estimate')
         reset_full_dedup_stats(expected_dedup_stats)
@@ -1610,6 +1610,11 @@ def exec_dedup(expected_dedup_stats, dry_run, verify_stats=True, post_dedup_size
 #-------------------------------------------------------------------------------
 def prepare_test():
     cleanup_local()
+
+    # run garbage collection before counting
+    result = admin(['gc', 'process', '--include-all'])
+    assert result[1] == 0
+
     #make sure we are starting with all buckets empty
     if count_object_parts_in_all_buckets(False, 0) != 0:
         log.warning("The system was left dirty from previous run");
@@ -1716,15 +1721,18 @@ def simple_dedup_with_tenants(files, conns, bucket_names, config, dry_run=False)
 
 #-------------------------------------------------------------------------------
 def dedup_basic_with_tenants_common(files, max_copies_count, config, dry_run):
+    bucket_names = []
+    conns = []
     try:
-        ret=gen_connections_multi2(max_copies_count)
+        ret=gen_connections_multi(max_copies_count)
         tenants=ret[0]
         bucket_names=ret[1]
         conns=ret[2]
         simple_dedup_with_tenants(files, conns, bucket_names, config, dry_run)
     finally:
         # cleanup must be executed even after a failure
-        cleanup_all_buckets(bucket_names, conns)
+        if bucket_names:
+            cleanup_all_buckets(bucket_names, conns)
 
 
 #-------------------------------------------------------------------------------
@@ -1754,49 +1762,18 @@ def threads_simple_dedup_with_tenants(files, conns, bucket_names, config, dry_ru
 
 #-------------------------------------------------------------------------------
 def threads_dedup_basic_with_tenants_common(files, num_conns, config, dry_run):
+    bucket_names = []
+    conns = []
     try:
-        ret=gen_connections_multi2(num_conns)
+        ret=gen_connections_multi(num_conns)
         tenants=ret[0]
         bucket_names=ret[1]
         conns=ret[2]
         threads_simple_dedup_with_tenants(files, conns, bucket_names, config, dry_run)
     finally:
         # cleanup must be executed even after a failure
-        cleanup_all_buckets(bucket_names, conns)
-
-
-#-------------------------------------------------------------------------------
-def check_full_dedup_state():
-    global full_dedup_state_was_checked
-    global full_dedup_state_disabled
-    log.debug("check_full_dedup_state:: sending FULL Dedup request")
-    result = dedup_admin('exec')
-    if result[1] == 0:
-        log.debug("full dedup is enabled!")
-        full_dedup_state_disabled = False
-        result = dedup_admin('abort')
-        assert result[1] == 0
-    else:
-        log.debug("full dedup is disabled, skip all full dedup tests")
-        full_dedup_state_disabled = True
-
-    full_dedup_state_was_checked = True
-    return full_dedup_state_disabled
-
-
-#-------------------------------------------------------------------------------
-def full_dedup_is_disabled():
-    global full_dedup_state_was_checked
-    global full_dedup_state_disabled
-
-    if not full_dedup_state_was_checked:
-        full_dedup_state_disabled = check_full_dedup_state()
-
-    if full_dedup_state_disabled:
-        log.debug("Full Dedup is DISABLED, skipping test...")
-
-    return full_dedup_state_disabled
-
+        if bucket_names:
+            cleanup_all_buckets(bucket_names, conns)
 
 #==============================================================================
 #                            RGW Versioning Tests:
@@ -1981,10 +1958,7 @@ def print_bucket_versioning(conn, bucket_name):
 # finally make sure no rados-object was left behind after the last ver was removed
 @pytest.mark.basic_test
 def test_dedup_with_versions():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     bucket_name = "bucketwithversions"
     files=[]
@@ -1993,8 +1967,7 @@ def test_dedup_with_versions():
     min_size=1*KB
     max_size=MULTIPART_SIZE*2
     success=False
-    # Declare the variable with a type hint
-    conn: BaseClient
+    conn = None
     try:
         conn=get_single_connection()
         conn.create_bucket(Bucket=bucket_name)
@@ -2028,14 +2001,15 @@ def test_dedup_with_versions():
         success=True
     finally:
         # cleanup must be executed even after a failure
-        if success == False:
-            # otherwise, objects been removed by verify_objects_with_version()
-            delete_all_versions(conn, bucket_name, dry_run=False)
+        if conn:
+            if success == False:
+                # otherwise, objects been removed by verify_objects_with_version()
+                delete_all_versions(conn, bucket_name, dry_run=False)
 
-        conn.put_bucket_versioning(Bucket=bucket_name,
-                                   VersioningConfiguration={"Status": "Suspended"})
-        print_bucket_versioning(conn, bucket_name)
-        cleanup(bucket_name, conn)
+            conn.put_bucket_versioning(Bucket=bucket_name,
+                                       VersioningConfiguration={"Status": "Suspended"})
+            print_bucket_versioning(conn, bucket_name)
+            cleanup(bucket_name, conn)
 
 #==============================================================================
 #                            ETag Corruption Tests:
@@ -2047,7 +2021,8 @@ CORRUPTIONS = ("no corruption", "change_etag", "illegal_hex_value",
 
 #------------------------------------------------------------------------------
 def change_object_etag(rados_name, new_etag):
-    result = rados(['-p ', POOLNAME, 'setxattr', rados_name, ETAG_ATTR, new_etag])
+    poolname = get_config_data_pool()
+    result = rados(['-p ', poolname, 'setxattr', rados_name, ETAG_ATTR, new_etag])
     assert result[1] == 0
 
 #------------------------------------------------------------------------------
@@ -2095,9 +2070,11 @@ def gen_new_etag(etag, corruption, expected_dedup_stats):
 #------------------------------------------------------------------------------
 def corrupt_etag(key, corruption, expected_dedup_stats):
     log.debug("key=%s, corruption=%s", key, corruption);
-    result = rados(['ls', '-p ', POOLNAME])
+    poolname = get_config_data_pool()
+    result = rados(['ls', '-p ', poolname])
     assert result[1] == 0
 
+    rados_name = None
     names=result[0].split()
     for name in names:
         log.debug("name=%s", name)
@@ -2106,7 +2083,10 @@ def corrupt_etag(key, corruption, expected_dedup_stats):
             rados_name = name
             break;
 
-    result = rados(['-p ', POOLNAME, 'getxattr', rados_name, ETAG_ATTR])
+    # rados_name should hold the head-object for @key
+    assert rados_name, ("key <%s> was not found in rados" % (key))
+
+    result = rados(['-p ', poolname, 'getxattr', rados_name, ETAG_ATTR])
     assert result[1] == 0
     old_etag = result[0]
 
@@ -2120,14 +2100,11 @@ def corrupt_etag(key, corruption, expected_dedup_stats):
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_etag_corruption():
-    if full_dedup_is_disabled():
-        return
-
+    disable_default_compression_via_period()
     bucket_name = gen_bucket_name()
-    log.debug("test_dedup_etag_corruption: connect to AWS ...")
+    log.info("test_dedup_etag_corruption: connect to AWS ...")
     conn=get_single_connection()
 
-    disable_default_compression()
     prepare_test()
     try:
         files=[]
@@ -2281,19 +2258,21 @@ def write_collision_pair_mixed_to_disk(files, target_size, compressibility):
 #-------------------------------------------------------------------------------
 def get_actual_compressed_sizes(target_size, num_copies, verbose=False):
     """Get actual on-disk sizes via rados stat (useful for compressed objects)."""
-    result = rados(['ls', '-p ', POOLNAME])
+    poolname = get_config_data_pool()
+    result = rados(['ls', '-p ', poolname])
     assert result[1] == 0
     rados_names = result[0].split()
     total_compressed = 0
     for rname in rados_names:
-        stat_result = rados(['-p ', POOLNAME, 'stat', rname])
+        stat_result = rados(['-p ', poolname, 'stat', rname])
         if stat_result[1] == 0:
             byte_size = int(stat_result[0].split()[-1])
             total_compressed += byte_size
 
     if verbose:
-        log.info("get_actual_compressed_sizes: size=%d: uncompressed_total=%d, "
-                 "compressed_on_disk_total=%d (%.0f%%)",
+        log.info("get_actual_compressed_sizes: rados_obj_count=%d, size=%d: "
+                 "uncompressed_total=%d, compressed_on_disk_total=%d (%.0f%%)",
+                 len(rados_names),
                  target_size, num_copies * target_size, total_compressed,
                  100.0 * total_compressed / (num_copies * target_size))
 
@@ -2335,13 +2314,6 @@ def _md5_collision_test(compressibility, compressed):
         compressed: if True, create compressed buckets and verify compression
             stats; if False, use regular buckets.
     """
-    if full_dedup_is_disabled():
-        return
-
-    if compressed:
-        enable_default_compression()
-    else:
-        disable_default_compression()
 
     sizes = [64*KB, 2*MB, 11*MB, 61*MB, 256*MB]
     num_copies = 2
@@ -2350,6 +2322,12 @@ def _md5_collision_test(compressibility, compressed):
     bucket_name = gen_bucket_name()
     try:
         prepare_test()
+
+        if compressed:
+            enable_default_compression_via_period()
+        else:
+            disable_default_compression_via_period()
+
         conn = get_single_connection()
         conn.create_bucket(Bucket=bucket_name)
 
@@ -2398,9 +2376,7 @@ def _md5_collision_test(compressibility, compressed):
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_md5_collisions_small():
-    if full_dedup_is_disabled():
-        return
-
+    disable_default_compression_via_period()
     s1_hash=hashlib.md5(MD5_COLLISION_S1).hexdigest()
     s2_hash=hashlib.md5(MD5_COLLISION_S2).hexdigest()
 
@@ -2408,7 +2384,7 @@ def test_md5_collisions_small():
     assert MD5_COLLISION_S1 != MD5_COLLISION_S2
     # but MD5 is identical
     assert s1_hash == s2_hash
-    disable_default_compression()
+
     prepare_test()
     files=[]
     try:
@@ -2471,7 +2447,7 @@ def test_md5_collisions_small():
 @pytest.mark.basic_test
 def test_md5_collision_large():
     """BLAKE3 rejects MD5 collisions on large uncompressed objects (random padding)."""
-    disable_default_compression()
+    disable_default_compression_via_period()
     _md5_collision_test(compressibility=COMPRESS_NEVER, compressed=False)
 
 
@@ -2489,7 +2465,7 @@ def loop_dedup_split_head_with_tenants():
     try:
         gen_files(files, base_size, num_files, max_copies_count)
         indices=[0] * len(files)
-        ret=gen_connections_multi2(max_copies_count)
+        ret=gen_connections_multi(max_copies_count)
         #tenants=ret[0]
         bucket_names=ret[1]
         conns=ret[2]
@@ -2513,10 +2489,7 @@ def loop_dedup_split_head_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_split_head_with_tenants():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     for idx in range(0, 9):
         log.debug("test_dedup_split_head_with_tenants: loop #%d", idx);
         loop_dedup_split_head_with_tenants()
@@ -2553,20 +2526,14 @@ def loop_dedup_split_head():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_split_head_simple():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     for idx in range(0, 9):
         log.debug("test_dedup_split_head: loop #%d", idx);
         loop_dedup_split_head()
 
 #-------------------------------------------------------------------------------
 def dedup_copy_internal(multi_buckets):
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     bucket_names=[]
     config=default_config
@@ -2620,10 +2587,7 @@ def test_dedup_copy_multi_buckets():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_copy_after_dedup():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     log.debug("test_copy_after_dedup: connect to AWS ...")
     config=default_config
@@ -2705,10 +2669,7 @@ def test_copy_after_dedup():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_small():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_small: connect to AWS ...")
     conn=get_single_connection()
@@ -2718,10 +2679,7 @@ def test_dedup_small():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_small_with_tenants():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     max_copies_count=3
     files=[]
@@ -2732,7 +2690,7 @@ def test_dedup_small_with_tenants():
     try:
         gen_files(files, base_size, num_files, max_copies_count)
         indices=[0] * len(files)
-        ret=gen_connections_multi2(max_copies_count)
+        ret=gen_connections_multi(max_copies_count)
         tenants=ret[0]
         bucket_names=ret[1]
         conns=ret[2]
@@ -2767,15 +2725,12 @@ def test_dedup_small_with_tenants():
 #    should be made to the system
 @pytest.mark.basic_test
 def test_dedup_inc_0_with_tenants():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     log.debug("test_dedup_inc_0: connect to AWS ...")
     max_copies_count=3
     config=default_config
-    ret=gen_connections_multi2(max_copies_count)
+    ret=gen_connections_multi(max_copies_count)
     tenants=ret[0]
     bucket_names=ret[1]
     conns=ret[2]
@@ -2818,11 +2773,8 @@ def test_dedup_inc_0_with_tenants():
 #    should be made to the system
 @pytest.mark.basic_test
 def test_dedup_inc_0():
-    if full_dedup_is_disabled():
-        return
-
+    disable_default_compression_via_period()
     config=default_config
-    disable_default_compression()
     prepare_test()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_inc_0: connect to AWS ...")
@@ -2866,15 +2818,12 @@ def test_dedup_inc_0():
 # 3) Run another dedup
 @pytest.mark.basic_test
 def test_dedup_inc_1_with_tenants():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     log.debug("test_dedup_inc_1_with_tenants: connect to AWS ...")
     max_copies_count=6
     config=default_config
-    ret=gen_connections_multi2(max_copies_count)
+    ret=gen_connections_multi(max_copies_count)
     tenants=ret[0]
     bucket_names=ret[1]
     conns=ret[2]
@@ -2935,11 +2884,8 @@ def test_dedup_inc_1_with_tenants():
 # 3) Run another dedup
 @pytest.mark.basic_test
 def test_dedup_inc_1():
-    if full_dedup_is_disabled():
-        return
-
+    disable_default_compression_via_period()
     config=default_config
-    disable_default_compression()
     prepare_test()
 
     bucket_name = gen_bucket_name()
@@ -3001,16 +2947,13 @@ def test_dedup_inc_1():
 # 4) Run another dedup
 @pytest.mark.basic_test
 def test_dedup_inc_2_with_tenants():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
 
     log.debug("test_dedup_inc_2_with_tenants: connect to AWS ...")
     max_copies_count=6
     config=default_config
-    ret=gen_connections_multi2(max_copies_count)
+    ret=gen_connections_multi(max_copies_count)
     tenants=ret[0]
     bucket_names=ret[1]
     conns=ret[2]
@@ -3079,11 +3022,8 @@ def test_dedup_inc_2_with_tenants():
 # 4) Run another dedup
 @pytest.mark.basic_test
 def test_dedup_inc_2():
-    if full_dedup_is_disabled():
-        return
-
+    disable_default_compression_via_period()
     config=default_config
-    disable_default_compression()
     prepare_test()
 
     bucket_name = gen_bucket_name()
@@ -3152,15 +3092,12 @@ def test_dedup_inc_2():
 # 3) Run another dedup
 @pytest.mark.basic_test
 def test_dedup_inc_with_remove_multi_tenants():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     log.debug("test_dedup_inc_with_remove_multi_tenants: connect to AWS ...")
     max_copies_count=6
     config=default_config
-    ret=gen_connections_multi2(max_copies_count)
+    ret=gen_connections_multi(max_copies_count)
     tenants=ret[0]
     bucket_names=ret[1]
     conns=ret[2]
@@ -3254,11 +3191,8 @@ def test_dedup_inc_with_remove_multi_tenants():
 # 3) Run another dedup
 @pytest.mark.basic_test
 def test_dedup_inc_with_remove():
-    if full_dedup_is_disabled():
-        return
-
+    disable_default_compression_via_period()
     config=default_config
-    disable_default_compression()
     prepare_test()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_inc_with_remove: connect to AWS ...")
@@ -3352,10 +3286,7 @@ def test_dedup_inc_with_remove():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_multipart_with_tenants():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     log.debug("test_dedup_multipart_with_tenants: connect to AWS ...")
     max_copies_count=3
@@ -3377,10 +3308,7 @@ def test_dedup_multipart_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_multipart():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_multipart: connect to AWS ...")
@@ -3403,10 +3331,7 @@ def test_dedup_multipart():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_basic_with_tenants():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     max_copies_count=3
     num_files=23
@@ -3420,10 +3345,7 @@ def test_dedup_basic_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_basic():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_basic: connect to AWS ...")
@@ -3443,10 +3365,7 @@ def test_dedup_basic():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_small_multipart_with_tenants():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     max_copies_count=4
     num_files=10
@@ -3464,10 +3383,7 @@ def test_dedup_small_multipart_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_small_multipart():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     log.debug("test_dedup_small_multipart: connect to AWS ...")
     config2=TransferConfig(multipart_threshold=4*KB, multipart_chunksize=1*MB)
@@ -3487,10 +3403,7 @@ def test_dedup_small_multipart():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_large_scale_with_tenants():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     max_copies_count=3
     num_threads=16
@@ -3502,24 +3415,6 @@ def test_dedup_large_scale_with_tenants():
     gen_files_fixed_size(files, num_files, size, max_copies_count)
     threads_dedup_basic_with_tenants_common(files, num_threads, config, False)
 
-
-#-------------------------------------------------------------------------------
-@pytest.mark.basic_test
-def test_dedup_large_scale():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
-    prepare_test()
-    max_copies_count=3
-    num_threads=16
-    num_files=8*1024
-    size=1*KB
-    files=[]
-    config=TransferConfig(multipart_threshold=size, multipart_chunksize=1*MB)
-    log.debug("test_dedup_dry_large_scale_with_tenants: connect to AWS ...")
-    gen_files_fixed_size(files, num_files, size, max_copies_count)
-    threads_dedup_basic_with_tenants_common(files, num_threads, config, False)
 
 #-------------------------------------------------------------------------------
 def inc_step_with_tenants(stats_base, files, conns, bucket_names, config):
@@ -3578,17 +3473,13 @@ def inc_step_with_tenants(stats_base, files, conns, bucket_names, config):
 
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
-#@pytest.mark.inc_test
 def test_dedup_inc_loop_with_tenants():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     log.debug("test_dedup_inc_loop_with_tenants: connect to AWS ...")
     max_copies_count=3
     config=default_config
-    ret=gen_connections_multi2(max_copies_count)
+    ret=gen_connections_multi(max_copies_count)
     tenants=ret[0]
     bucket_names=ret[1]
     conns=ret[2]
@@ -3620,8 +3511,7 @@ def test_dedup_inc_loop_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_small_with_tenants():
-    log.debug("test_dedup_dry_small_with_tenants: connect to AWS ...")
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     max_copies_count=3
     files=[]
@@ -3632,7 +3522,7 @@ def test_dedup_dry_small_with_tenants():
     try:
         gen_files(files, base_size, num_files, max_copies_count)
         indices=[0] * len(files)
-        ret=gen_connections_multi2(max_copies_count)
+        ret=gen_connections_multi(max_copies_count)
         tenants=ret[0]
         bucket_names=ret[1]
         conns=ret[2]
@@ -3658,7 +3548,7 @@ def test_dedup_dry_small_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_multipart():
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_dry_multipart: connect to AWS ...")
@@ -3682,7 +3572,7 @@ def test_dedup_dry_multipart():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_basic():
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_dry_basic: connect to AWS ...")
@@ -3700,7 +3590,7 @@ def test_dedup_dry_basic():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_small_multipart():
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     log.debug("test_dedup_dry_small_multipart: connect to AWS ...")
     config2 = TransferConfig(multipart_threshold=4*KB, multipart_chunksize=1*MB)
@@ -3720,6 +3610,7 @@ def test_dedup_dry_small_multipart():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_small():
+    disable_default_compression_via_period()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_dry_small: connect to AWS ...")
     conn=get_single_connection()
@@ -3735,9 +3626,8 @@ def test_dedup_dry_small():
 # 6) verify that dedup ratio is reported correctly
 @pytest.mark.basic_test
 def test_dedup_dry_small_large_mix():
+    disable_default_compression_via_period()
     dry_run=True
-    log.debug("test_dedup_dry_small_large_mix: connect to AWS ...")
-    disable_default_compression()
     prepare_test()
 
     num_threads=4
@@ -3779,7 +3669,7 @@ def test_dedup_dry_small_large_mix():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_basic_with_tenants():
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     max_copies_count=3
     num_files=23
@@ -3793,7 +3683,7 @@ def test_dedup_dry_basic_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_multipart_with_tenants():
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     log.debug("test_dedup_dry_multipart_with_tenants: connect to AWS ...")
     max_copies_count=3
@@ -3815,7 +3705,7 @@ def test_dedup_dry_multipart_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_small_multipart_with_tenants():
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     max_copies_count=4
     num_files=10
@@ -3833,11 +3723,11 @@ def test_dedup_dry_small_multipart_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_large_scale_with_tenants():
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     max_copies_count=3
     num_threads=64
-    num_files=32*1024
+    num_files=16*1024
     size=1*KB
     files=[]
     config=TransferConfig(multipart_threshold=size, multipart_chunksize=1*MB)
@@ -3859,11 +3749,11 @@ def test_dedup_dry_large_scale_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_large_scale():
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     bucket_name = gen_bucket_name()
     max_copies_count=2
-    num_files=2*1024
+    num_files=1*1024
     size=1*KB
     files=[]
     config=TransferConfig(multipart_threshold=size, multipart_chunksize=1*MB)
@@ -3888,9 +3778,6 @@ def test_dedup_dry_large_scale():
 def test_dedup_cli_operations():
     """Exercise all dedup CLI subcommands: estimate, stats, exec, pause, resume,
        abort, throttle."""
-    if full_dedup_is_disabled():
-        return
-
     prepare_test()
     bucket_name = gen_bucket_name()
     conn = get_single_connection()
@@ -3956,9 +3843,6 @@ def test_dedup_cli_operations():
 @pytest.mark.basic_test
 def test_dedup_rest_pause_resume():
     """Exercise pause and resume via REST API."""
-    if full_dedup_is_disabled():
-        return
-
     prepare_test()
     bucket_name = gen_bucket_name()
     conn = get_single_connection()
@@ -4050,7 +3934,9 @@ def test_cleanup():
     close_all_connections()
 
 #---------------------------------------------------------------------------
-def proc_upload_identical(proc_id, num_procs, filename, conn, bucket_name, num_copies, config):
+def proc_upload_identical(proc_id, num_procs, filename, access_key, secret_key,
+                          bucket_name, num_copies, config):
+    conn = _make_s3_client(access_key, secret_key)
     log.debug("Proc_ID=%d/%d::num_copies=%d", proc_id, num_procs, num_copies)
     for idx in range(num_copies):
         log.debug("upload_objects::%s::idx=%d", filename, idx);
@@ -4069,8 +3955,10 @@ def proc_parallel_upload_identical(files, conns, bucket_name, config):
     num_copies=f[2]
     for idx in range(num_procs):
         log.debug("Create proc_id=%d", idx)
+        access_key, secret_key = _s3_credentials(conns[idx])
         p=Process(target=proc_upload_identical,
-                  args=(idx, num_procs, filename, conns[idx], bucket_name, num_copies, config))
+                  args=(idx, num_procs, filename, access_key, secret_key,
+                        bucket_name, num_copies, config))
         proc_list.append(p)
         proc_list[idx].start()
 
@@ -4141,11 +4029,11 @@ def __test_dedup_identical_copies(files, config, dry_run, verify, force_clean=Fa
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_identical_copies_1():
+    disable_default_compression_via_period()
     num_files=1
     copies_count=1024
     size=64*KB
     config=default_config
-    disable_default_compression()
     prepare_test()
     files=[]
     gen_files_fixed_copies(files, num_files, size, copies_count)
@@ -4167,10 +4055,10 @@ def test_dedup_identical_copies_1():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_identical_copies_multipart_small():
+    disable_default_compression_via_period()
     num_files=1
     copies_count=1024
     size=16*KB
-    disable_default_compression()
     prepare_test()
     files=[]
     gen_files_fixed_copies(files, num_files, size, copies_count)
@@ -4207,6 +4095,7 @@ def test_dedup_filter_bucket_list_parsing():
     """Validate CLI parsing of bucket filter list files (allow/deny).
     Verify that illegal files are rejected
     """
+    disable_default_compression_via_period()
     prepare_test()
     try:
         # 1. Mutual exclusivity: --allow-bucket-list and --deny-bucket-list together.
@@ -4246,6 +4135,7 @@ def test_dedup_filter_storage_class_list_parsing():
     """Validate CLI parsing of storage_class filter list files (allow/deny).
     Verify that illegal files are rejected
     """
+    disable_default_compression_via_period()
     prepare_test()
     try:
         # 1. Mutual exclusivity: --allow-storage-class-list and --deny-storage-class-list together.
@@ -4402,17 +4292,12 @@ def dedup_filter_allow_deny_storage_class_common(dry_run, filter_mode_allow):
         expected_dedup_stats.size_before_dedup = dedup_stats.size_before_dedup
         assert dedup_stats == expected_dedup_stats
     finally:
-        cleanup_local()
-        try:
-            delete_bucket_with_all_objects(bucket_name, conn)
-        except Exception as e:
-            log.warning("Failed to cleanup bucket %s: %s", bucket_name, e)
-
-        verify_pool_is_empty(conn)
+        cleanup(bucket_name, conn)
 
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_filter_storage_class_estimate():
+    disable_default_compression_via_period()
     dry_run=True
 
     log.info("dedup_filter_storage_class_estimate: filter_mode_allow")
@@ -4424,6 +4309,7 @@ def test_dedup_filter_storage_class_estimate():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_filter_storage_class_exec():
+    disable_default_compression_via_period()
     dry_run=False
 
     log.info("dedup_filter_storage_class_exec: filter_mode_allow")
@@ -4541,18 +4427,14 @@ def dedup_filter_allow_deny_bucket_common(dry_run, filter_mode_allow):
         assert skip_sc     == 0
         assert skip_bucket == num_filtered
     finally:
-        cleanup_local()
-        for b in bucket_names:
-            try:
-                delete_bucket_with_all_objects(b, conn)
-            except Exception as e:
-                log.warning("Failed to cleanup bucket %s: %s", b, e)
+        conns=[conn] * len(bucket_names)
+        cleanup_all_buckets(bucket_names, conns)
 
-        verify_pool_is_empty(conn)
 
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_filter_bucket_estimate():
+    disable_default_compression_via_period()
     dry_run=True
     log.info("dedup_filter_bucket_estimate: filter_mode_deny")
     dedup_filter_allow_deny_bucket_common(dry_run, filter_mode_allow=False)
@@ -4563,6 +4445,7 @@ def test_dedup_filter_bucket_estimate():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_filter_bucket_exec():
+    disable_default_compression_via_period()
     dry_run=False
     log.info("dedup_filter_bucket_exec: filter_mode_deny")
     dedup_filter_allow_deny_bucket_common(dry_run, filter_mode_allow=False)
@@ -4572,257 +4455,296 @@ def test_dedup_filter_bucket_exec():
 
 
 #-------------------------------------------------------------------------------
-#-------------------------------------------------------------------------------
 #                              Compression helpers
 #-------------------------------------------------------------------------------
-#-------------------------------------------------------------------------------
-def _find_rgw_procs():
-    """Find running radosgw daemons via their --pid-file arguments.
 
-    Scans /proc for processes whose argv[0] basename is 'radosgw' and
-    extracts the --pid-file path from their command line.  Returns a list
-    of (pid, argv_list, pid_file_path) tuples.
-    """
-    import glob as globmod
-    procs = []
-    for cmdline_path in globmod.glob('/proc/[0-9]*/cmdline'):
-        try:
-            with open(cmdline_path, 'rb') as f:
-                raw = f.read()
-            if not raw:
-                continue
-            argv = raw.rstrip(b'\x00').split(b'\x00')
-            exe = os.path.basename(argv[0].decode('utf-8', errors='replace'))
-            if exe != 'radosgw':
-                continue
-            pid = int(cmdline_path.split('/')[2])
-            cmd_list = [a.decode('utf-8', errors='replace') for a in argv]
-            pid_file = None
-            for i, arg in enumerate(cmd_list):
-                if arg.startswith('--pid-file='):
-                    pid_file = arg.split('=', 1)[1]
-                elif arg == '--pid-file' and i + 1 < len(cmd_list):
-                    pid_file = cmd_list[i + 1]
-            procs.append((pid, cmd_list, pid_file))
-        except (OSError, ValueError, IndexError):
-            continue
-    return procs
+original_compression_period = None
+compression_state_period    = None
+compression_modified_period = False
 
+DEFAULT_PLACEMENT = 'default-placement'
+STANDARD_STORAGE_CLASS = 'STANDARD'
 
 #-------------------------------------------------------------------------------
-def restart_all_rgw():
-    """Restart every radosgw daemon preserving its original command line.
-
-    1. Find radosgw processes via /proc scan (exact basename match).
-    2. Record each process's full argv and --pid-file path.
-    3. SIGTERM all, wait for exit.
-    4. Re-launch each with the original argv.
-    5. Wait for the pid-file to be re-written (confirms daemon is up),
-       then verify TCP connectivity on the test port.
-    """
-    import signal
-
-    procs = _find_rgw_procs()
-    if not procs:
-        log.warning("No running radosgw processes found")
-        return
-
-    log.debug("Found %d radosgw process(es) to restart", len(procs))
-    for pid, cmd_list, pid_file in procs:
-        log.debug("  pid=%d  pid_file=%s", pid, pid_file)
-
-    # stop all
-    for pid, _, _ in procs:
-        log.debug("Sending SIGTERM to radosgw pid %d", pid)
-        os.kill(pid, signal.SIGTERM)
-
-    log.info("Sent SIGTERM to all radosgw")
-    for pid, _, pid_file in procs:
-        for _ in range(30):
-            try:
-                os.kill(pid, 0)
-                time.sleep(0.5)
-            except OSError:
-                break
-        else:
-            log.warning("radosgw pid %d did not exit, sending SIGKILL", pid)
-            try:
-                os.kill(pid, signal.SIGKILL)
-            except OSError:
-                pass
-            time.sleep(1)
-        # remove stale pid file so we can detect the new one
-        if pid_file:
-            try:
-                os.remove(pid_file)
-            except OSError:
-                pass
-
-    # wait for the port to be free before restarting
-    port_no = get_config_port()
-    hostname = get_config_host()
-    import socket
-    log.debug("Waiting for port %d to be free...", port_no)
-    for attempt in range(60):
-        try:
-            s = socket.create_connection((hostname, port_no), timeout=1)
-            s.close()
-            time.sleep(1)
-        except (ConnectionRefusedError, OSError):
-            log.debug("Port %d is free after %d seconds", port_no, attempt)
-            break
-    else:
-        log.warning("Port %d still appears busy after 60s, proceeding anyway",
-                    port_no)
-
-    # restart all
-    log.info("Restarting all radosgw");
-    for _, cmd_list, pid_file in procs:
-        log.debug("Restarting radosgw: %s", ' '.join(cmd_list))
-        subprocess.Popen(cmd_list)
-
-    # wait for each daemon to write its pid file (proves it daemonized)
-    for _, cmd_list, pid_file in procs:
-        if not pid_file:
-            continue
-        for attempt in range(60):
-            if os.path.exists(pid_file):
-                try:
-                    with open(pid_file) as f:
-                        new_pid = int(f.read().strip())
-                    os.kill(new_pid, 0)
-                    log.debug("radosgw restarted as pid %d (%s)",
-                             new_pid, pid_file)
-                    break
-                except (OSError, ValueError):
-                    pass
-            time.sleep(1)
-        else:
-            raise RuntimeError("radosgw did not restart: pid file %s "
-                               "not created after 60s" % pid_file)
-
-    # also verify TCP connectivity on the test port
-    for attempt in range(60):
-        try:
-            s = socket.create_connection((hostname, port_no), timeout=2)
-            s.close()
-            log.debug("radosgw listening on %s:%d", hostname, port_no)
-            return
-        except (ConnectionRefusedError, OSError):
-            time.sleep(1)
-    raise RuntimeError("radosgw pid file appeared but port %d not listening "
-                       "after 60s" % port_no)
-
-
-_original_compression = None
-_compression_state = None     # current state: None=unknown, 'none', or 'zlib' etc.
-
-#-------------------------------------------------------------------------------
-def _get_default_placement_compression():
-    """Read the compression type currently set on default-placement."""
-    result = admin(['zone', 'get', '--rgw-zone', 'default'])
+def _get_zone_default_placement_val(zone_name):
+    """Return val dict for default-placement in zone_name."""
+    result = admin(['zone', 'get', '--rgw-zone', zone_name])
     assert result[1] == 0, "zone get failed: " + result[0]
     zone = json.loads(result[0])
     for p in zone.get('placement_pools', []):
-        if p.get('key') == 'default-placement':
-            val = p.get('val', {})
-            sc = val.get('storage_classes', {})
-            std = sc.get('STANDARD', {})
-            return std.get('compression_type', '')
-    assert False, "default-placement not found in zone config"
+        if p.get('key') == DEFAULT_PLACEMENT:
+            return p.get('val', {})
+    assert False, "default-placement not found in zone config for zone %s" % zone_name
 
 
 #-------------------------------------------------------------------------------
-def _is_compression_active(value):
-    """Return True if value represents an active compression setting."""
-    return bool(value) and value.lower() not in ('', 'none')
+def get_zone_placement_storage_classes(zone_name):
+    """Return storage_classes dict for default-placement in zone_name."""
+    return _get_zone_default_placement_val(zone_name).get('storage_classes', {})
 
 
 #-------------------------------------------------------------------------------
-def enable_disable_default_compression(compression_type):
-    """Set compression on default-placement, with RGW restart if needed.
+def get_placement_sc_compression(zone_name, storage_class):
+    """Read compression type for a storage class on default-placement."""
+    info = get_zone_placement_storage_classes(zone_name).get(storage_class, {})
+    return info.get('compression_type', '')
 
-    On first call, reads the system state and saves it as _original_compression.
-    If the current state already matches the requested type, no restart is done.
+
+#-------------------------------------------------------------------------------
+def get_placement_compression(zone_name):
+    """Read compression type on default-placement STANDARD for zone_name."""
+    return get_placement_sc_compression(zone_name, STANDARD_STORAGE_CLASS)
+
+
+#-------------------------------------------------------------------------------
+def ensure_storage_class(storage_class):
+    """Add storage_class to default-placement if not already configured.
+
+    Returns True if the storage class was added, False if it already existed.
+    """
+    zone_name = get_config_zone()
+    zonegroup = get_config_zonegroup()
+    assert zone_name, "zone must be set in DEDUPTESTS_CONF"
+    assert zonegroup, "zonegroup must be set in DEDUPTESTS_CONF"
+
+    if storage_class in get_zone_placement_storage_classes(zone_name):
+        log.info("storage class %s already configured on zone %s",
+                 storage_class, zone_name)
+        return False
+
+    data_pool = get_config_data_pool()
+    result = admin(['zonegroup', 'placement', 'add',
+                    '--rgw-zonegroup', zonegroup,
+                    '--placement-id', DEFAULT_PLACEMENT,
+                    '--storage-class', storage_class])
+    assert result[1] == 0, ("zonegroup placement add failed for %s: %s"
+                              % (storage_class, result[0]))
+
+    result = admin(['zone', 'placement', 'add',
+                    '--rgw-zone', zone_name,
+                    '--placement-id', DEFAULT_PLACEMENT,
+                    '--storage-class', storage_class,
+                    '--data-pool', data_pool,
+                    '--compression', 'none'])
+    assert result[1] == 0, ("zone placement add failed for %s: %s"
+                            % (storage_class, result[0]))
+    commit_period()
+    wait_for_placement_storage_class(zone_name, storage_class, present=True)
+    log.info("Added storage class %s to zone %s", storage_class, zone_name)
+    return True
+
+
+#-------------------------------------------------------------------------------
+def remove_storage_class(storage_class):
+    """Remove storage_class from default-placement on zone and zonegroup."""
+    zone_name = get_config_zone()
+    zonegroup = get_config_zonegroup()
+    assert zone_name, "zone must be set in DEDUPTESTS_CONF"
+    assert zonegroup, "zonegroup must be set in DEDUPTESTS_CONF"
+    assert storage_class != STANDARD_STORAGE_CLASS, \
+        "cannot remove STANDARD storage class"
+
+    if storage_class not in get_zone_placement_storage_classes(zone_name):
+        log.info("storage class %s not configured on zone %s, nothing to remove",
+                 storage_class, zone_name)
+        return
+
+    result = admin(['zone', 'placement', 'rm',
+                    '--rgw-zone', zone_name,
+                    '--placement-id', DEFAULT_PLACEMENT,
+                    '--storage-class', storage_class])
+    assert result[1] == 0, ("zone placement rm failed for %s: %s"
+                            % (storage_class, result[0]))
+
+    result = admin(['zonegroup', 'placement', 'rm',
+                    '--rgw-zonegroup', zonegroup,
+                    '--placement-id', DEFAULT_PLACEMENT,
+                    '--storage-class', storage_class])
+    assert result[1] == 0, ("zonegroup placement rm failed for %s: %s"
+                            % (storage_class, result[0]))
+    commit_period()
+    wait_for_placement_storage_class(zone_name, storage_class, present=False)
+    log.info("Removed storage class %s from zone %s", storage_class, zone_name)
+
+
+#-------------------------------------------------------------------------------
+def set_placement_sc_compression(storage_class, compression_type):
+    """Set compression on default-placement for one storage class."""
+    zone_name = get_config_zone()
+    assert zone_name, "zone must be set in DEDUPTESTS_CONF for period-based compression"
+
+    current = normalize_compression_type(get_placement_sc_compression(zone_name, storage_class))
+    target = normalize_compression_type(compression_type)
+    if current == target:
+        log.info("zone '%s' %s compression already '%s'",
+                 zone_name, storage_class, current)
+        return
+
+    result = admin(['zone', 'placement', 'modify',
+                    '--rgw-zone', zone_name,
+                    '--placement-id', DEFAULT_PLACEMENT,
+                    '--storage-class', storage_class,
+                    '--compression', compression_type])
+    assert result[1] == 0, ("Failed to set %s compression: %s"
+                            % (storage_class, result[0]))
+    commit_period()
+    wait_for_placement_sc_compression(zone_name, storage_class, target)
+    log.info("Set %s compression on zone '%s' default-placement to '%s'",
+             storage_class, zone_name, compression_type)
+
+
+#-------------------------------------------------------------------------------
+def restore_placement_sc_compression(storage_class, compression_type):
+    """Restore per-SC compression saved before a test (empty means none)."""
+    target = compression_type if compression_type else 'none'
+    set_placement_sc_compression(storage_class, target)
+
+
+#-------------------------------------------------------------------------------
+def normalize_compression_type(compression_type):
+    if compression_type:
+        return compression_type.lower()
+    return 'none'
+
+#-------------------------------------------------------------------------------
+def wait_for_placement_sc_compression(zone_name, storage_class, expected,
+                                      timeout=60, interval=0.5):
+    """Poll zone config until compression matches expected after period commit."""
+    expected = normalize_compression_type(expected)
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        current = normalize_compression_type(
+            get_placement_sc_compression(zone_name, storage_class))
+        if current == expected:
+            return
+        time.sleep(interval)
+
+    current = normalize_compression_type(
+        get_placement_sc_compression(zone_name, storage_class))
+    raise AssertionError(
+        "compression on zone '%s' %s is '%s', expected '%s' after period commit "
+        "(timeout=%ds)" % (zone_name, storage_class, current, expected, timeout))
+
+#-------------------------------------------------------------------------------
+def wait_for_placement_storage_class(zone_name, storage_class, present,
+                                     timeout=60, interval=0.5):
+    """Poll zone config until storage class presence matches expected after period commit."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        configured = storage_class in get_zone_placement_storage_classes(zone_name)
+        if configured == present:
+            return
+        time.sleep(interval)
+
+    configured = storage_class in get_zone_placement_storage_classes(zone_name)
+    state = "present" if configured else "absent"
+    expected_state = "present" if present else "absent"
+    raise AssertionError(
+        "storage class '%s' on zone '%s' is %s, expected %s after period commit "
+        "(timeout=%ds)" % (storage_class, zone_name, state, expected_state, timeout))
+
+#-------------------------------------------------------------------------------
+def commit_period():
+    """Publish zone/zonegroup changes to running RGW daemons without restart."""
+    result = admin(['period', 'update'])
+    assert result[1] == 0, "period update failed: " + result[0]
+    result = admin(['period', 'commit'])
+    assert result[1] == 0, "period commit failed: " + result[0]
+
+    # realm reloader applies the new period asynchronously
+    time.sleep(5)
+
+
+#-------------------------------------------------------------------------------
+def enable_disable_default_compression_via_period(compression_type):
+    """Set compression on default-placement and apply via period update --commit.
+
+    For multisite/realm deployments: reloads running RGW without restart.
+    Requires zone name in DEDUPTESTS_CONF (see deduptests.conf.SAMPLE).
     Pass 'none' to disable compression.
     """
-    global _original_compression, _compression_state
+    global original_compression_period, compression_state_period
+    global compression_modified_period
 
-    current = _get_default_placement_compression()
+    zone_name = get_config_zone()
+    assert zone_name, "zone must be set in DEDUPTESTS_CONF for period-based compression"
 
-    if _original_compression is None:
-        _original_compression = current
-        log.info("Saved original compression setting: '%s'", current)
+    current = get_placement_sc_compression(zone_name, STANDARD_STORAGE_CLASS)
 
-    target = 'none'
-    if compression_type:
-        target = compression_type.lower()
-    actual = 'none'
-    if current:
-        actual = current.lower()
+    if original_compression_period is None:
+        original_compression_period = current
+        log.info("Saved original compression setting for zone '%s': '%s'",
+                 zone_name, current)
+
+    target = normalize_compression_type(compression_type)
+    actual = normalize_compression_type(current)
 
     if actual == target:
-        log.info("default-placement compression already '%s', no change needed",
-                 actual)
-        _compression_state = actual
+        log.info("zone '%s' default-placement compression already '%s', no change needed",
+                 zone_name, actual)
+        compression_state_period = actual
         return
 
-    result = admin(['zone', 'placement', 'modify',
-                    '--rgw-zone', 'default',
-                    '--placement-id', 'default-placement',
-                    '--compression', compression_type])
-    assert result[1] == 0, "Failed to set compression: " + result[0]
+    set_placement_sc_compression(STANDARD_STORAGE_CLASS, compression_type)
 
-    restart_all_rgw()
-    _compression_state = target
-    log.info("Set compression on default-placement to '%s' (was '%s')",
-             compression_type, actual)
+    compression_state_period = target
+    compression_modified_period = True
+    log.info("Set compression on zone '%s' default-placement to '%s' (was '%s')",
+             zone_name, compression_type, actual)
 
 
 #-------------------------------------------------------------------------------
-def enable_default_compression():
-    enable_disable_default_compression(compression_type='zlib')
+def enable_default_compression_via_period():
+    enable_disable_default_compression_via_period(compression_type='zlib')
 
 #-------------------------------------------------------------------------------
-def disable_default_compression():
-    enable_disable_default_compression(compression_type='none')
+def disable_default_compression_via_period():
+    enable_disable_default_compression_via_period(compression_type='none')
 
 #-------------------------------------------------------------------------------
-def restore_default_compression():
-    """Restore original compression setting on default-placement if we changed it."""
-    global _original_compression, _compression_state
+def restore_default_compression_via_period():
+    """Restore original compression on default-placement via period update --commit."""
+    global original_compression_period, compression_state_period
+    global compression_modified_period
 
-    if _original_compression is None:
+    if not compression_modified_period:
         return
 
-    restore = _original_compression if _original_compression else 'none'
-    current = _compression_state if _compression_state else 'none'
+    if original_compression_period is None:
+        return
+
+    log.info("Teardown: Restore original compression setting")
+
+    zone_name = get_config_zone()
+    assert zone_name, "zone must be set in DEDUPTESTS_CONF for period-based compression"
+
+    restore = normalize_compression_type(original_compression_period)
+    current = compression_state_period if compression_state_period else 'none'
 
     if current == restore:
-        log.info("Compression already at original value '%s', no restore needed",
-                 restore)
+        log.info("Compression on zone '%s' already at original value '%s', no restore needed",
+                 zone_name, restore)
         return
 
-    result = admin(['zone', 'placement', 'modify',
-                    '--rgw-zone', 'default',
-                    '--placement-id', 'default-placement',
-                    '--compression', restore])
-    assert result[1] == 0, "Failed to restore compression to '%s': %s" % (restore, result[0])
-
-    restart_all_rgw()
-    _compression_state = restore
-    log.info("Restored compression on default-placement to '%s'", restore)
-
+    set_placement_sc_compression(STANDARD_STORAGE_CLASS, restore)
+    compression_state_period = restore
+    log.info("Restored compression on zone '%s' default-placement to '%s'",
+             zone_name, restore)
 
 #-------------------------------------------------------------------------------
 def post_dedup_count(num_objs, num_copies, rados_count_before, split_head_count):
-    head_count = num_objs * num_copies;
+    head_count = num_objs * num_copies
     tail_count = rados_count_before - head_count
+    assert tail_count % num_copies == 0, (
+        "tail_count=%d not divisible by num_copies=%d "
+        "(rados_before=%d, head_count=%d, num_objs=%d)" %
+        (tail_count, num_copies, rados_count_before, head_count, num_objs))
 
-    log.debug("num_objs=%d, num_copies=%d, split=%d, head_count=%d, tail_count=%d",
-              num_objs, num_copies, split_head_count, head_count, tail_count)
+    log.info("num_objs=%d, num_copies=%d, split=%d, head_count=%d, tail_count=%d",
+             num_objs, num_copies, split_head_count, head_count, tail_count)
 
-    return (head_count + tail_count/num_copies + split_head_count)
+    return head_count + tail_count // num_copies + split_head_count
+
 
 #-------------------------------------------------------------------------------
 def _dedup_mode_switch_test(start_compressed):
@@ -4841,47 +4763,53 @@ def _dedup_mode_switch_test(start_compressed):
       5) Every S3 object is still readable and matches the original file.
       6) After deleting all objects + GC the pool is empty.
     """
-    if full_dedup_is_disabled():
-        return
-
     prepare_test()
     config = default_config
-    files = []
-    sizes = [127*KB, 2*MB+3*KB, 7*MB, 11*MB, 13*MB, 16*MB, 17*MB, 32*MB, 67*MB]
-    for size in sizes:
-        gen_files_fixed_copies(files, 1, size, 1)
-
     num_copies = 2
+    files = []
+    sizes = [129*KB, 2*MB+3*KB, 7*MB, 11*MB, 13*MB, 16*MB, 17*MB, 32*MB, 67*MB]
     conn = get_single_connection()
     bucket_names = get_buckets(num_copies)
-
-    if start_compressed:
-        first_mode_label = "compressed"
-        final_mode_label = "uncompressed"
-        enable_default_compression()
-    else:
-        first_mode_label = "uncompressed"
-        final_mode_label = "compressed"
-        disable_default_compression()
+    created_buckets = []
 
     try:
+        for size in sizes:
+            # Make sure obj will be eligible for dedup even if was compressed
+            # multipart_threshold is safe since checked before upload/compress
+            assert size/2 >= DEDUP_MIN_OBJ_SIZE
+            gen_files_fixed_copies(files, 1, size, num_copies)
+
+        if start_compressed:
+            first_mode_label = "compressed"
+            final_mode_label = "uncompressed"
+            enable_default_compression_via_period()
+        else:
+            first_mode_label = "uncompressed"
+            final_mode_label = "compressed"
+            disable_default_compression_via_period()
+
         # phase 1: upload to bucket[0] in the starting mode
         idx = 0
         conn.create_bucket(Bucket=bucket_names[idx])
-        _upload_to_bucket(conn, bucket_names[idx], files, config, idx)
+        created_buckets.append(bucket_names[idx])
+        upload_to_bucket(conn, bucket_names[idx], files, config, idx)
         log.info("Phase 1: uploaded %d files to %s (%s)",
                  len(files), bucket_names[idx], first_mode_label)
 
+        rados_bucket0 = count_object_parts_in_all_buckets(True)
+        log.info("RADOS object count bucket[0]: %d", rados_bucket0)
+
         # switch compression mode
         if start_compressed:
-            disable_default_compression()
+            disable_default_compression_via_period()
         else:
-            enable_default_compression()
+            enable_default_compression_via_period()
 
         # phase 2: upload identical objects to bucket[1] in the new mode
         idx = 1
         conn.create_bucket(Bucket=bucket_names[idx])
-        _upload_to_bucket(conn, bucket_names[idx], files, config, idx)
+        created_buckets.append(bucket_names[idx])
+        upload_to_bucket(conn, bucket_names[idx], files, config, idx)
         log.info("Phase 2: uploaded %d files to %s (%s)",
                  len(files), bucket_names[idx], final_mode_label)
 
@@ -4891,8 +4819,9 @@ def _dedup_mode_switch_test(start_compressed):
         assert_bucket_compression(bucket_names[1], files, 1,
                                   not start_compressed, "PRE-DEDUP")
 
-        rados_count_before = count_object_parts_in_all_buckets(True)
-        log.info("RADOS object count before dedup: %d", rados_count_before)
+        rados_bucket0_and_bucket1 = count_object_parts_in_all_buckets(True)
+        rados_bucket1 = rados_bucket0_and_bucket1 - rados_bucket0
+        log.info("RADOS object count bucket[1]: %d", rados_bucket1)
 
         # build expected stats
         expected_stats = Dedup_Stats()
@@ -4912,9 +4841,14 @@ def _dedup_mode_switch_test(start_compressed):
                 else:
                     expected_stats.set_compression_on_tgt += 1
 
-        expected_rados_count = post_dedup_count(len(files), num_copies,
-                                                rados_count_before,
-                                                split_head_objs)
+        num_files = len(files)
+
+        # Bucket[0] is uploaded first (will become TGT).
+        # Bucket[1] holds the SRC copy (matches final placement compression in
+        #           mode-switch tests)
+        # TGT tail objects are removed; SRC tails remain.
+        src_bucket_count = rados_bucket1 + split_head_objs
+        expected_rados_count = src_bucket_count + num_files
 
         ret = exec_dedup_internal(expected_stats, dry_run=False, max_dedup_time=300)
         actual_stats = ret[1]
@@ -4927,8 +4861,10 @@ def _dedup_mode_switch_test(start_compressed):
         log.info("RADOS object count after dedup: %d (expected=%d)",
                  rados_count_after, expected_rados_count)
         assert rados_count_after == expected_rados_count, \
-            ("Bad RADOS object count: before=%d, expected=%d, after=%d"
-             % (rados_count_before, expected_rados_count, rados_count_after))
+            ("Bad RADOS object count: before=%d, expected=%d, after=%d "
+             "(rados_bucket0=%d)" %
+             (rados_bucket0_and_bucket1, expected_rados_count, rados_count_after,
+              rados_bucket0))
 
         # post-dedup: all objects in both buckets should match the final mode
         final_compressed = not start_compressed
@@ -4937,15 +4873,13 @@ def _dedup_mode_switch_test(start_compressed):
 
         # verify all objects are still readable
         conns=[conn] * len(bucket_names)
-        verify_objects_multi(files, conns, bucket_names, 0, config, False)
+        verify_objects_multi(files, conns, bucket_names, 0, config, True)
         log.info("All objects verified after mode-switch dedup "
                  "(%s -> %s)", first_mode_label, final_mode_label)
     finally:
-        for bucket in bucket_names:
-            delete_bucket_with_all_objects(bucket, conn)
-        verify_pool_is_empty(conn)
-        cleanup_local()
-
+        restore_default_compression_via_period()
+        conns=[conn] * len(created_buckets)
+        cleanup_all_buckets(created_buckets, conns)
 
 #-------------------------------------------------------------------------------
 def is_object_compressed(bucket_name, object_key):
@@ -4954,7 +4888,8 @@ def is_object_compressed(bucket_name, object_key):
     Uses radosgw-admin object stat with latin-1 decoding because the
     output may contain binary attribute data that is not valid UTF-8.
     """
-    cmd = [test_path + 'test-rgw-call.sh', 'call_rgw_admin', 'noname',
+    cluster=get_config_cluster()
+    cmd = [test_path + 'test-rgw-call.sh', 'call_rgw_admin', cluster,
            'object', 'stat', '--bucket', bucket_name,
            '--object', object_key]
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
@@ -5001,13 +4936,146 @@ def assert_bucket_compression(bucket_name, files, idx, expect_compressed, tag):
 
 
 #-------------------------------------------------------------------------------
-def _upload_to_bucket(conn, bucket_name, files, config, idx=0):
+def create_bucket_with_placement(conn, bucket_name, placement_id=DEFAULT_PLACEMENT,
+                                 storage_class=None):
+    """Create a bucket bound to placement_id and optional storage class."""
+    sc = storage_class or STANDARD_STORAGE_CLASS
+    if placement_id == DEFAULT_PLACEMENT and sc == STANDARD_STORAGE_CLASS:
+        conn.create_bucket(Bucket=bucket_name)
+        log.info("created bucket %s on %s/%s", bucket_name, placement_id, sc)
+        return
+
+    zonegroup = get_config_zonegroup()
+    assert zonegroup, "zonegroup must be set in DEDUPTESTS_CONF"
+    location = '%s:%s' % (zonegroup, placement_id)
+    params = {
+        'Bucket': bucket_name,
+        'CreateBucketConfiguration': {'LocationConstraint': location},
+    }
+
+    handler = None
+    if sc != STANDARD_STORAGE_CLASS:
+        def add_storage_class_header(request, **kwargs):
+            request.headers['x-amz-storage-class'] = sc
+        handler = add_storage_class_header
+        conn.meta.events.register('before-sign.s3.CreateBucket', handler)
+    try:
+        conn.create_bucket(**params)
+        log.info("created bucket %s on %s/%s", bucket_name, placement_id, sc)
+    finally:
+        if handler:
+            conn.meta.events.unregister('before-sign.s3.CreateBucket', handler)
+
+
+#-------------------------------------------------------------------------------
+def upload_to_bucket(conn, bucket_name, files, config, idx=0):
     """Upload all files (one copy each) to a single bucket."""
     for f in files:
         filename = f[0]
         key = gen_object_name(filename, idx)
         conn.upload_file(OUT_DIR + filename, bucket_name, key, Config=config)
         log.debug("uploaded %s -> %s/%s", filename, bucket_name, key)
+
+#-------------------------------------------------------------------------------
+@pytest.mark.basic_test
+def test_dedup_placement_compression_cache_per_storage_class():
+    """Per-SC placement compression cache (rule.to_str(), not placement name alone).
+
+    - Startup:
+       Set compression-mode on SC1=STANDARD to none on default-placement.
+       Set compression-mode on SC2=LUKEWARM to zlib on default-placement.
+    - Upload one copy per SC
+    - Flip compression (SC1 none->zlib, SC2 zlib->none)
+    - Upload a second copy per SC
+    - Run dedup
+    - Verify that after dedup SC1 copies are all compressed
+             and SC2 copies all uncompressed.
+    - Return system to initial state
+    """
+    sc1 = STANDARD_STORAGE_CLASS
+    sc2 = 'LUKEWARM'
+    prepare_test()
+    config = default_config
+    num_copies = 2
+    files = []
+    sizes = [127*KB, 2*MB+3*KB, 7*MB, 11*MB, 13*MB, 16*MB]
+    for idx, size in enumerate(sizes):
+        gen_files_fixed_copies(files, 1, size, num_copies)
+
+    conn = get_single_connection()
+    bucket_sc1 = gen_bucket_name()
+    bucket_sc2 = gen_bucket_name()
+    created_buckets = []
+    zone_name = get_config_zone()
+    assert zone_name, "zone must be set in DEDUPTESTS_CONF for period-based compression"
+    orig_sc1_compression = get_placement_sc_compression(zone_name, sc1)
+    orig_sc2_compression = None
+    added_sc2 = False
+
+    try:
+        added_sc2 = ensure_storage_class(sc2)
+        if not added_sc2:
+            orig_sc2_compression = get_placement_sc_compression(zone_name, sc2)
+
+        set_placement_sc_compression(sc1, 'none')
+        set_placement_sc_compression(sc2, 'zlib')
+
+        create_bucket_with_placement(conn, bucket_sc1, DEFAULT_PLACEMENT, sc1)
+        created_buckets.append(bucket_sc1)
+        create_bucket_with_placement(conn, bucket_sc2, DEFAULT_PLACEMENT, sc2)
+        created_buckets.append(bucket_sc2)
+
+        upload_to_bucket(conn, bucket_sc1, files, config, 0)
+        upload_to_bucket(conn, bucket_sc2, files, config, 0)
+
+        set_placement_sc_compression(sc1, 'zlib')
+        set_placement_sc_compression(sc2, 'none')
+
+        upload_to_bucket(conn, bucket_sc1, files, config, 1)
+        upload_to_bucket(conn, bucket_sc2, files, config, 1)
+
+        assert_bucket_compression(bucket_sc1, files, 0, False, "PRE-DEDUP-SC1")
+        assert_bucket_compression(bucket_sc1, files, 1, True,  "PRE-DEDUP-SC1")
+        assert_bucket_compression(bucket_sc2, files, 0, True,  "PRE-DEDUP-SC2")
+        assert_bucket_compression(bucket_sc2, files, 1, False, "PRE-DEDUP-SC2")
+
+        expected_stats = Dedup_Stats()
+        split_head_objs = 0
+        for obj_size in sizes:
+            split_head_objs += calc_split_objs_count(obj_size, num_copies, config)
+            calc_expected_stats(expected_stats, obj_size, num_copies, config)
+            calc_expected_stats(expected_stats, obj_size, num_copies, config)
+            on_disk = calc_on_disk_byte_size(obj_size)
+            expected_stats.compressed_objs += 2
+            expected_stats.compressed_bytes += (on_disk * 2)
+            if on_disk >= DEDUP_MIN_OBJ_SIZE:
+                expected_stats.set_compression_on_tgt += 1
+                expected_stats.clear_compression_on_tgt += 1
+
+        expected_stats.non_default_storage_class_objs_bytes = expected_stats.size_before_dedup/2
+        ret = exec_dedup_internal(expected_stats, dry_run=False, max_dedup_time=300)
+        actual_stats = ret[1]
+        if actual_stats != expected_stats:
+            print_dedup_stats_diff(actual_stats, expected_stats)
+            assert False, "placement compression cache dedup stat mismatch"
+
+        assert_bucket_compression(bucket_sc1, files, 0, True,  "POST-DEDUP-SC1")
+        assert_bucket_compression(bucket_sc1, files, 1, True,  "POST-DEDUP-SC1")
+        assert_bucket_compression(bucket_sc2, files, 0, False, "POST-DEDUP-SC2")
+        assert_bucket_compression(bucket_sc2, files, 1, False, "POST-DEDUP-SC2")
+
+        log.info("verify_objects(bucket_sc1, files..)")
+        verify_objects(bucket_sc1, files, conn, 0, default_config, True)
+        log.info("verify_objects(bucket_sc2, files..)")
+        verify_objects(bucket_sc2, files, conn, 0, default_config, True)
+    finally:
+        cleanup_all_buckets(created_buckets, [conn, conn])
+        restore_placement_sc_compression(sc1, orig_sc1_compression)
+        if added_sc2:
+            remove_storage_class(sc2)
+        elif orig_sc2_compression is not None:
+            restore_placement_sc_compression(sc2, orig_sc2_compression)
+
 
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
@@ -5050,15 +5118,17 @@ def _dedup_inc_shared_manifest_test(start_compressed):
     Post-dedup: all objects in all 3 buckets have the starting mode's
     compression state (the SRC's mode from cycle 1 wins).
     """
-    if full_dedup_is_disabled():
-        return
-
     prepare_test()
     config = default_config
+    num_copies = 2
+    verify_copies = num_copies + 1
     files = []
-    sizes = [127*KB, 2*MB+3*KB, 7*MB, 11*MB, 13*MB, 16*MB, 17*MB, 32*MB, 67*MB]
+    sizes = [129*KB, 2*MB+3*KB, 7*MB, 11*MB, 13*MB, 16*MB, 17*MB, 32*MB, 67*MB]
     for size in sizes:
-        gen_files_fixed_copies(files, 1, size, 1)
+        # Make sure obj will be eligible for dedup even if was compressed
+        # multipart_threshold is safe since checked before upload/compress
+        assert size/2 >= DEDUP_MIN_OBJ_SIZE
+        gen_files_fixed_copies(files, 1, size, verify_copies)
 
     num_files = len(files)
     conn = get_single_connection()
@@ -5067,17 +5137,19 @@ def _dedup_inc_shared_manifest_test(start_compressed):
     if start_compressed:
         first_mode_label = "compressed"
         final_mode_label = "uncompressed"
-        enable_default_compression()
+        enable_default_compression_via_period()
     else:
         first_mode_label = "uncompressed"
         final_mode_label = "compressed"
-        disable_default_compression()
+        disable_default_compression_via_period()
 
+    created_buckets = []
     try:
         # -- phase 1: two buckets in starting mode, first dedup ---------------
         for idx in range(2):
             conn.create_bucket(Bucket=bucket_names[idx])
-            _upload_to_bucket(conn, bucket_names[idx], files, config, idx)
+            created_buckets.append(bucket_names[idx])
+            upload_to_bucket(conn, bucket_names[idx], files, config, idx)
 
         log.info("Phase 1: uploaded %d files to %s and %s (%s)",
                  num_files, bucket_names[0], bucket_names[1], first_mode_label)
@@ -5096,19 +5168,20 @@ def _dedup_inc_shared_manifest_test(start_compressed):
         num_dedupable = 0
         for f in files:
             obj_size = f[1]
-            split_head_1 += calc_split_objs_count(obj_size, 2, config)
-            calc_expected_stats(expected_1, obj_size, 2, config)
+            split_head_1 += calc_split_objs_count(obj_size, num_copies, config)
+            calc_expected_stats(expected_1, obj_size, num_copies, config)
             on_disk = calc_on_disk_byte_size(obj_size)
             if on_disk >= DEDUP_MIN_OBJ_SIZE:
                 num_dedupable += 1
             if start_compressed:
-                expected_1.compressed_objs += 2
-                expected_1.compressed_bytes += (on_disk * 2)
+                expected_1.compressed_objs += num_copies
+                expected_1.compressed_bytes += (on_disk * num_copies)
 
         if start_compressed:
             expected_1.deduped_compressed_objects = expected_1.deduped_obj
 
-        expected_rados_1 = post_dedup_count(num_files, 2, rados_before_1, split_head_1)
+        expected_rados_1 = post_dedup_count(num_files, num_copies, rados_before_1,
+                                            split_head_1)
 
         ret = exec_dedup_internal(expected_1, dry_run=False, max_dedup_time=300)
         actual_1 = ret[1]
@@ -5120,18 +5193,19 @@ def _dedup_inc_shared_manifest_test(start_compressed):
         log.info("RADOS count after dedup-1: %d (expected=%d)",
                  rados_after_1, expected_rados_1)
         assert rados_after_1 == expected_rados_1, \
-            ("Cycle 1 RADOS count: before=%d, expected=%d, after=%d"
-             % (rados_before_1, expected_rados_1, rados_after_1))
+            ("Cycle 1 RADOS count: before=%d, expected=%d, after=%d" %
+             (rados_before_1, expected_rados_1, rados_after_1))
 
         # -- phase 2: switch mode, add bucket[2], second dedup ----------------
         if start_compressed:
-            disable_default_compression()
+            disable_default_compression_via_period()
         else:
-            enable_default_compression()
+            enable_default_compression_via_period()
 
         idx = 2
         conn.create_bucket(Bucket=bucket_names[idx])
-        _upload_to_bucket(conn, bucket_names[idx], files, config, idx)
+        created_buckets.append(bucket_names[idx])
+        upload_to_bucket(conn, bucket_names[idx], files, config, idx)
         log.info("Phase 2: uploaded %d files to %s (%s)",
                  num_files, bucket_names[idx], final_mode_label)
 
@@ -5210,7 +5284,7 @@ def _dedup_inc_shared_manifest_test(start_compressed):
         rados_after_2 = count_object_parts_in_all_buckets(True)
         log.info("RADOS count after dedup-2: %d (expected=%d)",
                  rados_after_2, expected_rados_2)
-        assert rados_after_2 == expected_rados_2 or 1, \
+        assert rados_after_2 == expected_rados_2, \
             ("Cycle 2 RADOS count: before=%d, expected=%d, after=%d"
              % (rados_before_2, expected_rados_2, rados_after_2))
 
@@ -5221,14 +5295,13 @@ def _dedup_inc_shared_manifest_test(start_compressed):
 
         # verify all objects readable
         conns=[conn] * len(bucket_names)
-        verify_objects_multi(files, conns, bucket_names, 0, config, False)
+        verify_objects_multi(files, conns, bucket_names, 0, config, True)
         log.info("All objects verified after incremental shared_manifest test "
                  "(start=%s)", first_mode_label)
     finally:
-        for bucket in bucket_names:
-            delete_bucket_with_all_objects(bucket, conn)
-        verify_pool_is_empty(conn)
-        cleanup_local()
+        restore_default_compression_via_period()
+        conns=[conn] * len(created_buckets)
+        cleanup_all_buckets(created_buckets, conns)
 
 
 #-------------------------------------------------------------------------------
@@ -5260,10 +5333,64 @@ def test_dedup_compressed_to_uncompressed():
 
 
 #-------------------------------------------------------------------------------
+NUM_PERIOD_COMMIT_CYCLES = 12
+
 @pytest.mark.basic_test
-def test_compression_teardown():
-    """Restore original compression setting if we changed it."""
-    restore_default_compression()
+def test_period_commit_cycling_s3_ops():
+    """Repeated period commit with S3 only (no dedup admin).
+
+    Each cycle toggles default-placement compression (zone placement modify +
+    period update/commit), then create_bucket, upload, download, delete.
+    Use this to see whether realm-reloader / notify-110 / frontend-paused
+    issues are general RGW period-commit behavior vs dedup-specific.
+
+    After a failure, check radosgw logs, e.g.:
+      grep -a 'frontend pause\\|frontend unpaused' .../radosgw.8101.log | tail -20
+    """
+
+    # Debug-only test; enable by removing the skip.
+    #pytest.skip("debug-only test; enable manually when needed")
+
+    prepare_test()
+    conn = get_single_connection()
+    config = default_config
+
+    files = []
+    sizes = [127*KB, 2*MB+3*KB, 7*MB, 11*MB, 13*MB, 16*MB, 17*MB, 32*MB, 67*MB]
+    for size in sizes:
+        gen_files_fixed_copies(files, 1, size, 1)
+
+    filename = files[0][0]
+    src_path = OUT_DIR + filename
+
+    disable_default_compression_via_period()
+    created_buckets = []
+
+    try:
+        for cycle in range(NUM_PERIOD_COMMIT_CYCLES):
+            log.info("=== period commit cycle %d/%d ===",
+                     cycle + 1, NUM_PERIOD_COMMIT_CYCLES)
+
+            if cycle % 2 == 0:
+                enable_default_compression_via_period()
+            else:
+                disable_default_compression_via_period()
+
+            bucket_name = gen_bucket_name()
+            conn.create_bucket(Bucket=bucket_name)
+            created_buckets.append(bucket_name)
+            upload_to_bucket(conn, bucket_name, files, config)
+            dedup_stats = Dedup_Stats()
+            exec_dedup_internal(dedup_stats, dry_run=True, max_dedup_time=300)
+
+        log.info("completed %d period commit + S3 cycles (no dedup)",
+                 NUM_PERIOD_COMMIT_CYCLES)
+    finally:
+        if created_buckets:
+            cleanup_all_buckets(created_buckets, [conn] * len(created_buckets))
+        else:
+            cleanup_local()
+
 
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
@@ -5271,10 +5398,11 @@ def test_compression_sanity():
     """Sanity: upload one object with compression enabled, stop.
     Manually verify RGW_ATTR_COMPRESSION is set on the object head."""
 
-    ### Keep this test for debug purpose only
-    return
+    # Debug-only test; enable by removing the skip.
+    pytest.skip("debug-only test; enable manually when needed")
+
     prepare_test()
-    enable_default_compression()
+    enable_default_compression_via_period()
     bucket_name = "compression-sanity"
     obj_key = "compression_sanity_obj"
     filename="compression_sanity_file"
@@ -5292,16 +5420,36 @@ def test_compression_sanity():
                     f.write(b"ABCDEFGHIJKLMNOP" * (chunk_len // 16))
                 else:
                     f.write(os.urandom(chunk_len))
+
                 written += chunk_len
                 compressible = not compressible
+
         conn.upload_file(OUT_DIR + filename, bucket_name, obj_key,
                          Config=default_config)
-        get_actual_compressed_sizes(size, 1, True)
-        log.info("calling restore_default_compression")
-        restore_default_compression()
+        ret=get_actual_compressed_sizes(size, 1, True)
+        obj_count_compressed = ret[0]
+        size_compressed = ret[1]
+        conn.delete_object(Bucket=bucket_name, Key=obj_key)
+        result = admin(['gc', 'process', '--include-all'])
+        assert result[1] == 0
+        assert count_object_parts_in_all_buckets(False, 0) == 0
+
+        disable_default_compression_via_period()
         conn.upload_file(OUT_DIR + filename, bucket_name, obj_key + "UC",
-                         Config=default_config)        
+                         Config=default_config)
+        ret=get_actual_compressed_sizes(size, 1, True)
+        obj_count_uncompressed = ret[0]
+        size_uncompressed = ret[1]
+        log.info("original_size=%d, size_compressed=%d, size_uncompressed=%d"
+                 "obj_count_compressed=%d, obj_count_compressed=%d",
+                 size, size_compressed, size_uncompressed,
+                 obj_count_compressed, obj_count_uncompressed)
+        ratio = obj_count_compressed / obj_count_uncompressed
+        assert ratio > 0.45 # ~50% compressible
+        ratio = size_compressed / size_uncompressed
+        assert ratio > 0.45 # ~50% compressible
     finally:
         log.info("Uploaded %s to %s -- check RGW_ATTR_COMPRESSION manually",
                  obj_key, bucket_name)
         cleanup(bucket_name, conn)
+

--- a/src/test/rgw/dedup/test_dedup.py
+++ b/src/test/rgw/dedup/test_dedup.py
@@ -12,7 +12,7 @@ import string
 import shutil
 import pytest
 import json
-from collections import namedtuple
+#from collections import namedtuple
 import boto3
 from boto3.s3.transfer import TransferConfig
 from dataclasses import dataclass
@@ -56,6 +56,13 @@ class Dedup_Stats:
     duplicate_obj : int = 0
     deduped_obj_bytes : int = 0
     non_default_storage_class_objs_bytes : int = 0
+    compressed_objs : int = 0
+    compressed_bytes : int = 0
+    skip_compressed_objs : int = 0
+    skip_compressed_bytes : int = 0
+    deduped_compressed_objects : int = 0
+    set_compression_on_tgt : int = 0
+    clear_compression_on_tgt : int = 0
 
 @dataclass
 class Dedup_Ratio:
@@ -645,7 +652,12 @@ def delete_bucket_with_all_objects(bucket_name, conn):
 def verify_pool_is_empty(conn, skip_bucket_check=False):
     result = admin(['gc', 'process', '--include-all'])
     assert result[1] == 0
-    assert count_object_parts_in_all_buckets(False, 0) == 0
+
+    obj_count = count_object_parts_in_all_buckets(False, 0)
+    if (obj_count):
+        log.warning("verify_pool_is_empty: %d obejcts were found", obj_count)
+        assert obj_count == 0
+
     if not skip_bucket_check:
         assert verify_no_forgotten_buckets(conn)
 
@@ -1387,8 +1399,26 @@ def read_full_dedup_stats(dedup_stats, md5_stats):
     key='Skipped Changed Object'
     if key in skipped:
         dedup_stats.skip_changed_object = skipped[key]
+    key='Skipped Compressed objs'
+    if key in skipped:
+        dedup_stats.skip_compressed_objs = skipped[key]
+        dedup_stats.skip_compressed_bytes = skipped['Skipped Compressed Bytes']
 
     notify=md5_stats['notify']
+
+    key='Compressed objs'
+    if key in notify:
+        dedup_stats.compressed_objs = notify[key]
+        dedup_stats.compressed_bytes = notify['Compressed Bytes']
+    key='Deduped Compressed objs'
+    if key in notify:
+        dedup_stats.deduped_compressed_objects = notify[key]
+    key='Set Compression on TGT'
+    if key in notify:
+        dedup_stats.set_compression_on_tgt = notify[key]
+    key='Clear Compression on TGT'
+    if key in notify:
+        dedup_stats.clear_compression_on_tgt = notify[key]
     dedup_stats.valid_hash = notify['Valid HASH attrs']
     dedup_stats.invalid_hash = notify['Invalid HASH attrs']
     key='Set HASH'
@@ -1556,6 +1586,7 @@ def exec_dedup(expected_dedup_stats, dry_run, verify_stats=True, post_dedup_size
     verify_dedup_ratio(expected_dedup_stats, dedup_ratio_estimate)
     if post_dedup_size == 0:
         post_dedup_size = dedup_ratio_estimate.s3_bytes_after
+        log.info("exec_dedup: post_dedup_size == 0 -> %d", post_dedup_size)
 
     # no need to check after dry-run which doesn't change anything
     if dry_run:
@@ -1953,6 +1984,7 @@ def test_dedup_with_versions():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     bucket_name = "bucketwithversions"
     files=[]
@@ -2094,6 +2126,8 @@ def test_dedup_etag_corruption():
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_etag_corruption: connect to AWS ...")
     conn=get_single_connection()
+
+    disable_default_compression()
     prepare_test()
     try:
         files=[]
@@ -2153,29 +2187,233 @@ def write_bin_file(files, bin_arr, filename):
     files.append((filename, len(bin_arr), 1))
 
 #-------------------------------------------------------------------------------
-@pytest.mark.basic_test
-def test_md5_collisions():
+# MD5 collision base blocks (128 bytes each, identical MD5, different data).
+# Appending identical padding preserves the collision (MD5 length-extension).
+MD5_COLLISION_S1 = bytes.fromhex(
+    "d131dd02c5e6eec4693d9a0698aff95c"
+    "2fcab58712467eab4004583eb8fb7f89"
+    "55ad340609f4b30283e488832571415a"
+    "085125e8f7cdc99fd91dbdf280373c5b"
+    "d8823e3156348f5bae6dacd436c919c6"
+    "dd53e2b487da03fd02396306d248cda0"
+    "e99f33420f577ee8ce54b67080a80d1e"
+    "c69821bcb6a8839396f9652b6ff72a70")
+
+MD5_COLLISION_S2 = bytes.fromhex(
+    "d131dd02c5e6eec4693d9a0698aff95c"
+    "2fcab50712467eab4004583eb8fb7f89"
+    "55ad340609f4b30283e4888325f1415a"
+    "085125e8f7cdc99fd91dbd7280373c5b"
+    "d8823e3156348f5bae6dacd436c919c6"
+    "dd53e23487da03fd02396306d248cda0"
+    "e99f33420f577ee8ce54b67080280d1e"
+    "c69821bcb6a8839396f965ab6ff72a70")
+
+MIXED_CHUNK = 256 * KB
+COMPRESSIBLE_PATTERN = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ012345"
+COMPRESS_NEVER     = 0
+COMPRESS_ALWAYS    = 1
+COMPRESS_ALTERNATE = 2
+
+#-------------------------------------------------------------------------------
+def _write_mixed_compressibility_chunk(fa, fb, chunk_len, compressible):
+    """Write one chunk (identical) to both files.  Returns estimated compressed size."""
+    if compressible:
+        blocks = (chunk_len + len(COMPRESSIBLE_PATTERN) - 1) // len(COMPRESSIBLE_PATTERN)
+        chunk = (COMPRESSIBLE_PATTERN * blocks)[:chunk_len]
+        est = chunk_len // 20
+    else:
+        chunk = os.urandom(chunk_len)
+        est = chunk_len
+    fa.write(chunk)
+    fb.write(chunk)
+    return est
+
+
+#-------------------------------------------------------------------------------
+def write_collision_pair_mixed_to_disk(files, target_size, compressibility):
+    """Write an MD5 collision pair to disk with configurable compressibility.
+
+    compressibility controls the padding content:
+      COMPRESS_NEVER     -- all random (incompressible) padding
+      COMPRESS_ALWAYS    -- all compressible (repeating pattern) padding
+      COMPRESS_ALTERNATE -- alternating compressible/random 256KB chunks
+
+    Both files share identical padding (preserving the MD5 collision).
+    Peak memory usage is ~256KB.
+    """
+    prefix_len = len(MD5_COLLISION_S1)
+    pad_len = target_size - prefix_len
+    name_a = "col_a"
+    name_b = "col_b"
+
+    compressed_est = 0
+    with open(OUT_DIR + name_a, 'wb') as fa, open(OUT_DIR + name_b, 'wb') as fb:
+        fa.write(MD5_COLLISION_S1)
+        fb.write(MD5_COLLISION_S2)
+
+        written = 0
+        compressible = True
+        while written < pad_len:
+            chunk_len = min(MIXED_CHUNK, pad_len - written)
+            if compressibility == COMPRESS_NEVER:
+                chunk_compressible = False
+            elif compressibility == COMPRESS_ALWAYS:
+                chunk_compressible = True
+            else:
+                chunk_compressible = compressible
+                compressible = not compressible
+
+            compressed_est += _write_mixed_compressibility_chunk(fa, fb, chunk_len,
+                                                                 chunk_compressible)
+            written += chunk_len
+
+    files.append((name_a, target_size, 1))
+    files.append((name_b, target_size, 1))
+
+    if compressibility != COMPRESS_NEVER:
+        log.info("write_collision_pair_mixed_to_disk: target_size=%d (%.2f MiB), "
+                 "estimated_compressed~=%d (%.2f MiB, ~%.0f%%)",
+                 target_size, target_size / MB,
+                 compressed_est, compressed_est / MB,
+                 100.0 * compressed_est / target_size)
+
+#-------------------------------------------------------------------------------
+def get_actual_compressed_sizes(target_size, num_copies, verbose=False):
+    """Get actual on-disk sizes via rados stat (useful for compressed objects)."""
+    result = rados(['ls', '-p ', POOLNAME])
+    assert result[1] == 0
+    rados_names = result[0].split()
+    total_compressed = 0
+    for rname in rados_names:
+        stat_result = rados(['-p ', POOLNAME, 'stat', rname])
+        if stat_result[1] == 0:
+            byte_size = int(stat_result[0].split()[-1])
+            total_compressed += byte_size
+
+    if verbose:
+        log.info("get_actual_compressed_sizes: size=%d: uncompressed_total=%d, "
+                 "compressed_on_disk_total=%d (%.0f%%)",
+                 target_size, num_copies * target_size, total_compressed,
+                 100.0 * total_compressed / (num_copies * target_size))
+
+    return (len(rados_names), total_compressed)
+
+#-------------------------------------------------------------------------------
+def adjust_stats_for_collision(dedup_stats, compressed, num_copies, obj_size):
+    # Test PUT @num_copies objects with different data, but all share the same ETAG
+    # This is because of and MD5 collision and it will confuse dedup
+    # Its early stats will behave as if all the objects are identical, but after
+    # calculating a strong-head the mismatch will be discovered
+    size_combined = num_copies * obj_size
+
+    # dedup will be confused to think objects are identical (so no singletons)
+    dedup_stats.skip_singleton       = 0
+    dedup_stats.skip_singleton_bytes = 0
+
+    # dedup will be confused to think objects are identical (so one is a SRC)
+    dedup_stats.skip_src_record      = 1
+    dedup_stats.invalid_hash         = num_copies
+    dedup_stats.set_hash             = num_copies
+    dedup_stats.singleton_obj        = 0
+    dedup_stats.unique_obj           = 1
+    dedup_stats.duplicate_obj        = num_copies - dedup_stats.unique_obj
+    dedup_stats.size_before_dedup    = size_combined
+    dedup_stats.dedup_bytes_estimate = obj_size
+    dedup_stats.hash_mismatch        = 1
+    if compressed:
+        dedup_stats.compressed_objs  = num_copies
+        dedup_stats.compressed_bytes = size_combined
+
+
+#-------------------------------------------------------------------------------
+def _md5_collision_test(compressibility, compressed):
+    """Shared logic for large MD5 collision tests.
+
+    Args:
+        compressibility: COMPRESS_NEVER, COMPRESS_ALWAYS, or COMPRESS_ALTERNATE.
+        compressed: if True, create compressed buckets and verify compression
+            stats; if False, use regular buckets.
+    """
     if full_dedup_is_disabled():
         return
 
-    s1="d131dd02c5e6eec4693d9a0698aff95c2fcab58712467eab4004583eb8fb7f8955ad340609f4b30283e488832571415a085125e8f7cdc99fd91dbdf280373c5bd8823e3156348f5bae6dacd436c919c6dd53e2b487da03fd02396306d248cda0e99f33420f577ee8ce54b67080a80d1ec69821bcb6a8839396f9652b6ff72a70"
-    s2="d131dd02c5e6eec4693d9a0698aff95c2fcab50712467eab4004583eb8fb7f8955ad340609f4b30283e4888325f1415a085125e8f7cdc99fd91dbd7280373c5bd8823e3156348f5bae6dacd436c919c6dd53e23487da03fd02396306d248cda0e99f33420f577ee8ce54b67080280d1ec69821bcb6a8839396f965ab6ff72a70"
+    if compressed:
+        enable_default_compression()
+    else:
+        disable_default_compression()
 
-    s1_bin=bytes.fromhex(s1)
-    s2_bin=bytes.fromhex(s2)
+    sizes = [64*KB, 2*MB, 11*MB, 61*MB, 256*MB]
+    num_copies = 2
+    config = default_config
+    conn = None
+    bucket_name = gen_bucket_name()
+    try:
+        prepare_test()
+        conn = get_single_connection()
+        conn.create_bucket(Bucket=bucket_name)
 
-    s1_hash=hashlib.md5(s1_bin).hexdigest()
-    s2_hash=hashlib.md5(s2_bin).hexdigest()
+        for obj_size in sizes:
+            files = []
+            log.debug("write_collision_pair_mixed_to_disk size=%d", obj_size)
+            write_collision_pair_mixed_to_disk(files, obj_size, compressibility)
+
+            indices = [0] * len(files)
+            check_obj_count = not compressed
+            ret = upload_objects(bucket_name, files, indices, conn, config,
+                                 check_obj_count)
+            dedup_stats = ret[1]
+            adjust_stats_for_collision(dedup_stats, compressed, num_copies, obj_size)
+            if compressed:
+                on_disk=get_actual_compressed_sizes(obj_size, num_copies, verbose=True)
+                # compressed objects logical size is different from on-disk size
+                ret=exec_dedup_internal(dedup_stats, dry_run=False, max_dedup_time=120)
+            else:
+                # dedup will fail, so we should stay with size_before_dedup
+                ret = exec_dedup(dedup_stats, dry_run=False, verify_stats=True,
+                                 post_dedup_size=dedup_stats.size_before_dedup)
+
+            actual_stats = ret[1]
+            if actual_stats != dedup_stats:
+                print_dedup_stats_diff(actual_stats, dedup_stats)
+                assert actual_stats == dedup_stats
+
+            if compressed:
+                on_disk2=get_actual_compressed_sizes(obj_size, num_copies, verbose=True)
+                assert on_disk == on_disk2, "on disk objects changed!"
+
+            verify_objects(bucket_name, files, conn, 0, default_config, False)
+            for f in files:
+                key = gen_object_name(f[0], 0)
+                conn.delete_object(Bucket=bucket_name, Key=key)
+
+            verify_pool_is_empty(conn, True)
+            log.debug("size=%d: both objects verified intact", obj_size)
+
+    finally:
+        if conn:
+            cleanup(bucket_name, conn)
+
+
+#-------------------------------------------------------------------------------
+@pytest.mark.basic_test
+def test_md5_collisions_small():
+    if full_dedup_is_disabled():
+        return
+
+    s1_hash=hashlib.md5(MD5_COLLISION_S1).hexdigest()
+    s2_hash=hashlib.md5(MD5_COLLISION_S2).hexdigest()
+
     # data is different
-    assert s1 != s2
+    assert MD5_COLLISION_S1 != MD5_COLLISION_S2
     # but MD5 is identical
     assert s1_hash == s2_hash
-
+    disable_default_compression()
     prepare_test()
     files=[]
     try:
-        write_bin_file(files, s1_bin, "s1")
-        write_bin_file(files, s2_bin, "s2")
+        write_bin_file(files, MD5_COLLISION_S1, "s1")
+        write_bin_file(files, MD5_COLLISION_S2, "s2")
 
         bucket_name = gen_bucket_name()
         log.debug("test_md5_collisions: connect to AWS ...")
@@ -2230,6 +2468,14 @@ def test_md5_collisions():
 
 
 #-------------------------------------------------------------------------------
+@pytest.mark.basic_test
+def test_md5_collision_large():
+    """BLAKE3 rejects MD5 collisions on large uncompressed objects (random padding)."""
+    disable_default_compression()
+    _md5_collision_test(compressibility=COMPRESS_NEVER, compressed=False)
+
+
+#-------------------------------------------------------------------------------
 def loop_dedup_split_head_with_tenants():
     prepare_test()
     config=default_config
@@ -2270,6 +2516,7 @@ def test_dedup_split_head_with_tenants():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     for idx in range(0, 9):
         log.debug("test_dedup_split_head_with_tenants: loop #%d", idx);
         loop_dedup_split_head_with_tenants()
@@ -2309,6 +2556,7 @@ def test_dedup_split_head_simple():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     for idx in range(0, 9):
         log.debug("test_dedup_split_head: loop #%d", idx);
         loop_dedup_split_head()
@@ -2318,6 +2566,7 @@ def dedup_copy_internal(multi_buckets):
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     bucket_names=[]
     config=default_config
@@ -2374,6 +2623,7 @@ def test_copy_after_dedup():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     log.debug("test_copy_after_dedup: connect to AWS ...")
     config=default_config
@@ -2458,6 +2708,7 @@ def test_dedup_small():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_small: connect to AWS ...")
     conn=get_single_connection()
@@ -2470,6 +2721,7 @@ def test_dedup_small_with_tenants():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     max_copies_count=3
     files=[]
@@ -2518,6 +2770,7 @@ def test_dedup_inc_0_with_tenants():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     log.debug("test_dedup_inc_0: connect to AWS ...")
     max_copies_count=3
@@ -2569,6 +2822,7 @@ def test_dedup_inc_0():
         return
 
     config=default_config
+    disable_default_compression()
     prepare_test()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_inc_0: connect to AWS ...")
@@ -2615,6 +2869,7 @@ def test_dedup_inc_1_with_tenants():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     log.debug("test_dedup_inc_1_with_tenants: connect to AWS ...")
     max_copies_count=6
@@ -2684,7 +2939,9 @@ def test_dedup_inc_1():
         return
 
     config=default_config
+    disable_default_compression()
     prepare_test()
+
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_inc_1: connect to AWS ...")
     conn=get_single_connection()
@@ -2747,7 +3004,9 @@ def test_dedup_inc_2_with_tenants():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
+
     log.debug("test_dedup_inc_2_with_tenants: connect to AWS ...")
     max_copies_count=6
     config=default_config
@@ -2824,7 +3083,9 @@ def test_dedup_inc_2():
         return
 
     config=default_config
+    disable_default_compression()
     prepare_test()
+
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_inc_2: connect to AWS ...")
     conn=get_single_connection()
@@ -2894,6 +3155,7 @@ def test_dedup_inc_with_remove_multi_tenants():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     log.debug("test_dedup_inc_with_remove_multi_tenants: connect to AWS ...")
     max_copies_count=6
@@ -2996,6 +3258,7 @@ def test_dedup_inc_with_remove():
         return
 
     config=default_config
+    disable_default_compression()
     prepare_test()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_inc_with_remove: connect to AWS ...")
@@ -3092,6 +3355,7 @@ def test_dedup_multipart_with_tenants():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     log.debug("test_dedup_multipart_with_tenants: connect to AWS ...")
     max_copies_count=3
@@ -3116,6 +3380,7 @@ def test_dedup_multipart():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_multipart: connect to AWS ...")
@@ -3141,6 +3406,7 @@ def test_dedup_basic_with_tenants():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     max_copies_count=3
     num_files=23
@@ -3157,6 +3423,7 @@ def test_dedup_basic():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_basic: connect to AWS ...")
@@ -3179,6 +3446,7 @@ def test_dedup_small_multipart_with_tenants():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     max_copies_count=4
     num_files=10
@@ -3199,6 +3467,7 @@ def test_dedup_small_multipart():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     log.debug("test_dedup_small_multipart: connect to AWS ...")
     config2=TransferConfig(multipart_threshold=4*KB, multipart_chunksize=1*MB)
@@ -3221,6 +3490,7 @@ def test_dedup_large_scale_with_tenants():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     max_copies_count=3
     num_threads=16
@@ -3239,6 +3509,7 @@ def test_dedup_large_scale():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     max_copies_count=3
     num_threads=16
@@ -3249,7 +3520,6 @@ def test_dedup_large_scale():
     log.debug("test_dedup_dry_large_scale_with_tenants: connect to AWS ...")
     gen_files_fixed_size(files, num_files, size, max_copies_count)
     threads_dedup_basic_with_tenants_common(files, num_threads, config, False)
-
 
 #-------------------------------------------------------------------------------
 def inc_step_with_tenants(stats_base, files, conns, bucket_names, config):
@@ -3313,6 +3583,7 @@ def test_dedup_inc_loop_with_tenants():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     log.debug("test_dedup_inc_loop_with_tenants: connect to AWS ...")
     max_copies_count=3
@@ -3350,6 +3621,7 @@ def test_dedup_inc_loop_with_tenants():
 @pytest.mark.basic_test
 def test_dedup_dry_small_with_tenants():
     log.debug("test_dedup_dry_small_with_tenants: connect to AWS ...")
+    disable_default_compression()
     prepare_test()
     max_copies_count=3
     files=[]
@@ -3386,6 +3658,7 @@ def test_dedup_dry_small_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_multipart():
+    disable_default_compression()
     prepare_test()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_dry_multipart: connect to AWS ...")
@@ -3409,6 +3682,7 @@ def test_dedup_dry_multipart():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_basic():
+    disable_default_compression()
     prepare_test()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_dry_basic: connect to AWS ...")
@@ -3426,6 +3700,7 @@ def test_dedup_dry_basic():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_small_multipart():
+    disable_default_compression()
     prepare_test()
     log.debug("test_dedup_dry_small_multipart: connect to AWS ...")
     config2 = TransferConfig(multipart_threshold=4*KB, multipart_chunksize=1*MB)
@@ -3462,6 +3737,7 @@ def test_dedup_dry_small():
 def test_dedup_dry_small_large_mix():
     dry_run=True
     log.debug("test_dedup_dry_small_large_mix: connect to AWS ...")
+    disable_default_compression()
     prepare_test()
 
     num_threads=4
@@ -3503,6 +3779,7 @@ def test_dedup_dry_small_large_mix():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_basic_with_tenants():
+    disable_default_compression()
     prepare_test()
     max_copies_count=3
     num_files=23
@@ -3516,6 +3793,7 @@ def test_dedup_dry_basic_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_multipart_with_tenants():
+    disable_default_compression()
     prepare_test()
     log.debug("test_dedup_dry_multipart_with_tenants: connect to AWS ...")
     max_copies_count=3
@@ -3537,6 +3815,7 @@ def test_dedup_dry_multipart_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_small_multipart_with_tenants():
+    disable_default_compression()
     prepare_test()
     max_copies_count=4
     num_files=10
@@ -3554,6 +3833,7 @@ def test_dedup_dry_small_multipart_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_large_scale_with_tenants():
+    disable_default_compression()
     prepare_test()
     max_copies_count=3
     num_threads=64
@@ -3570,8 +3850,7 @@ def test_dedup_dry_large_scale_with_tenants():
     try:
         threads_simple_dedup_with_tenants(files, conns, bucket_names, config, True)
     except Exception:
-        log.warning("test_dedup_dry_large_scale_with_tenants: failed!!")
-        assert 0, "abort test_dedup_dry_large_scale_with_tenants "
+        assert False, "test_dedup_dry_large_scale_with_tenants failed"
     finally:
         # cleanup must be executed even after a failure
         cleanup_all_buckets(bucket_names, conns)
@@ -3580,6 +3859,7 @@ def test_dedup_dry_large_scale_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_large_scale():
+    disable_default_compression()
     prepare_test()
     bucket_name = gen_bucket_name()
     max_copies_count=2
@@ -3865,6 +4145,7 @@ def test_dedup_identical_copies_1():
     copies_count=1024
     size=64*KB
     config=default_config
+    disable_default_compression()
     prepare_test()
     files=[]
     gen_files_fixed_copies(files, num_files, size, copies_count)
@@ -3889,6 +4170,7 @@ def test_dedup_identical_copies_multipart_small():
     num_files=1
     copies_count=1024
     size=16*KB
+    disable_default_compression()
     prepare_test()
     files=[]
     gen_files_fixed_copies(files, num_files, size, copies_count)
@@ -4037,7 +4319,6 @@ def exec_dedup_with_filter(dry_run, deny_bucket_list=None, allow_bucket_list=Non
             return ret
 
     assert False
-
 
 
 #==============================================================================
@@ -4269,7 +4550,6 @@ def dedup_filter_allow_deny_bucket_common(dry_run, filter_mode_allow):
 
         verify_pool_is_empty(conn)
 
-
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_filter_bucket_estimate():
@@ -4289,3 +4569,739 @@ def test_dedup_filter_bucket_exec():
 
     log.info("dedup_filter_bucket_exec: filter_mode_allow")
     dedup_filter_allow_deny_bucket_common(dry_run, filter_mode_allow=True)
+
+
+#-------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------
+#                              Compression helpers
+#-------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------
+def _find_rgw_procs():
+    """Find running radosgw daemons via their --pid-file arguments.
+
+    Scans /proc for processes whose argv[0] basename is 'radosgw' and
+    extracts the --pid-file path from their command line.  Returns a list
+    of (pid, argv_list, pid_file_path) tuples.
+    """
+    import glob as globmod
+    procs = []
+    for cmdline_path in globmod.glob('/proc/[0-9]*/cmdline'):
+        try:
+            with open(cmdline_path, 'rb') as f:
+                raw = f.read()
+            if not raw:
+                continue
+            argv = raw.rstrip(b'\x00').split(b'\x00')
+            exe = os.path.basename(argv[0].decode('utf-8', errors='replace'))
+            if exe != 'radosgw':
+                continue
+            pid = int(cmdline_path.split('/')[2])
+            cmd_list = [a.decode('utf-8', errors='replace') for a in argv]
+            pid_file = None
+            for i, arg in enumerate(cmd_list):
+                if arg.startswith('--pid-file='):
+                    pid_file = arg.split('=', 1)[1]
+                elif arg == '--pid-file' and i + 1 < len(cmd_list):
+                    pid_file = cmd_list[i + 1]
+            procs.append((pid, cmd_list, pid_file))
+        except (OSError, ValueError, IndexError):
+            continue
+    return procs
+
+
+#-------------------------------------------------------------------------------
+def restart_all_rgw():
+    """Restart every radosgw daemon preserving its original command line.
+
+    1. Find radosgw processes via /proc scan (exact basename match).
+    2. Record each process's full argv and --pid-file path.
+    3. SIGTERM all, wait for exit.
+    4. Re-launch each with the original argv.
+    5. Wait for the pid-file to be re-written (confirms daemon is up),
+       then verify TCP connectivity on the test port.
+    """
+    import signal
+
+    procs = _find_rgw_procs()
+    if not procs:
+        log.warning("No running radosgw processes found")
+        return
+
+    log.debug("Found %d radosgw process(es) to restart", len(procs))
+    for pid, cmd_list, pid_file in procs:
+        log.debug("  pid=%d  pid_file=%s", pid, pid_file)
+
+    # stop all
+    for pid, _, _ in procs:
+        log.debug("Sending SIGTERM to radosgw pid %d", pid)
+        os.kill(pid, signal.SIGTERM)
+
+    log.info("Sent SIGTERM to all radosgw")
+    for pid, _, pid_file in procs:
+        for _ in range(30):
+            try:
+                os.kill(pid, 0)
+                time.sleep(0.5)
+            except OSError:
+                break
+        else:
+            log.warning("radosgw pid %d did not exit, sending SIGKILL", pid)
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except OSError:
+                pass
+            time.sleep(1)
+        # remove stale pid file so we can detect the new one
+        if pid_file:
+            try:
+                os.remove(pid_file)
+            except OSError:
+                pass
+
+    # wait for the port to be free before restarting
+    port_no = get_config_port()
+    hostname = get_config_host()
+    import socket
+    log.debug("Waiting for port %d to be free...", port_no)
+    for attempt in range(60):
+        try:
+            s = socket.create_connection((hostname, port_no), timeout=1)
+            s.close()
+            time.sleep(1)
+        except (ConnectionRefusedError, OSError):
+            log.debug("Port %d is free after %d seconds", port_no, attempt)
+            break
+    else:
+        log.warning("Port %d still appears busy after 60s, proceeding anyway",
+                    port_no)
+
+    # restart all
+    log.info("Restarting all radosgw");
+    for _, cmd_list, pid_file in procs:
+        log.debug("Restarting radosgw: %s", ' '.join(cmd_list))
+        subprocess.Popen(cmd_list)
+
+    # wait for each daemon to write its pid file (proves it daemonized)
+    for _, cmd_list, pid_file in procs:
+        if not pid_file:
+            continue
+        for attempt in range(60):
+            if os.path.exists(pid_file):
+                try:
+                    with open(pid_file) as f:
+                        new_pid = int(f.read().strip())
+                    os.kill(new_pid, 0)
+                    log.debug("radosgw restarted as pid %d (%s)",
+                             new_pid, pid_file)
+                    break
+                except (OSError, ValueError):
+                    pass
+            time.sleep(1)
+        else:
+            raise RuntimeError("radosgw did not restart: pid file %s "
+                               "not created after 60s" % pid_file)
+
+    # also verify TCP connectivity on the test port
+    for attempt in range(60):
+        try:
+            s = socket.create_connection((hostname, port_no), timeout=2)
+            s.close()
+            log.debug("radosgw listening on %s:%d", hostname, port_no)
+            return
+        except (ConnectionRefusedError, OSError):
+            time.sleep(1)
+    raise RuntimeError("radosgw pid file appeared but port %d not listening "
+                       "after 60s" % port_no)
+
+
+_original_compression = None
+_compression_state = None     # current state: None=unknown, 'none', or 'zlib' etc.
+
+#-------------------------------------------------------------------------------
+def _get_default_placement_compression():
+    """Read the compression type currently set on default-placement."""
+    result = admin(['zone', 'get', '--rgw-zone', 'default'])
+    assert result[1] == 0, "zone get failed: " + result[0]
+    zone = json.loads(result[0])
+    for p in zone.get('placement_pools', []):
+        if p.get('key') == 'default-placement':
+            val = p.get('val', {})
+            sc = val.get('storage_classes', {})
+            std = sc.get('STANDARD', {})
+            return std.get('compression_type', '')
+    assert False, "default-placement not found in zone config"
+
+
+#-------------------------------------------------------------------------------
+def _is_compression_active(value):
+    """Return True if value represents an active compression setting."""
+    return bool(value) and value.lower() not in ('', 'none')
+
+
+#-------------------------------------------------------------------------------
+def enable_disable_default_compression(compression_type):
+    """Set compression on default-placement, with RGW restart if needed.
+
+    On first call, reads the system state and saves it as _original_compression.
+    If the current state already matches the requested type, no restart is done.
+    Pass 'none' to disable compression.
+    """
+    global _original_compression, _compression_state
+
+    current = _get_default_placement_compression()
+
+    if _original_compression is None:
+        _original_compression = current
+        log.info("Saved original compression setting: '%s'", current)
+
+    target = 'none'
+    if compression_type:
+        target = compression_type.lower()
+    actual = 'none'
+    if current:
+        actual = current.lower()
+
+    if actual == target:
+        log.info("default-placement compression already '%s', no change needed",
+                 actual)
+        _compression_state = actual
+        return
+
+    result = admin(['zone', 'placement', 'modify',
+                    '--rgw-zone', 'default',
+                    '--placement-id', 'default-placement',
+                    '--compression', compression_type])
+    assert result[1] == 0, "Failed to set compression: " + result[0]
+
+    restart_all_rgw()
+    _compression_state = target
+    log.info("Set compression on default-placement to '%s' (was '%s')",
+             compression_type, actual)
+
+
+#-------------------------------------------------------------------------------
+def enable_default_compression():
+    enable_disable_default_compression(compression_type='zlib')
+
+#-------------------------------------------------------------------------------
+def disable_default_compression():
+    enable_disable_default_compression(compression_type='none')
+
+#-------------------------------------------------------------------------------
+def restore_default_compression():
+    """Restore original compression setting on default-placement if we changed it."""
+    global _original_compression, _compression_state
+
+    if _original_compression is None:
+        return
+
+    restore = _original_compression if _original_compression else 'none'
+    current = _compression_state if _compression_state else 'none'
+
+    if current == restore:
+        log.info("Compression already at original value '%s', no restore needed",
+                 restore)
+        return
+
+    result = admin(['zone', 'placement', 'modify',
+                    '--rgw-zone', 'default',
+                    '--placement-id', 'default-placement',
+                    '--compression', restore])
+    assert result[1] == 0, "Failed to restore compression to '%s': %s" % (restore, result[0])
+
+    restart_all_rgw()
+    _compression_state = restore
+    log.info("Restored compression on default-placement to '%s'", restore)
+
+
+#-------------------------------------------------------------------------------
+def post_dedup_count(num_objs, num_copies, rados_count_before, split_head_count):
+    head_count = num_objs * num_copies;
+    tail_count = rados_count_before - head_count
+
+    log.debug("num_objs=%d, num_copies=%d, split=%d, head_count=%d, tail_count=%d",
+              num_objs, num_copies, split_head_count, head_count, tail_count)
+
+    return (head_count + tail_count/num_copies + split_head_count)
+
+#-------------------------------------------------------------------------------
+def _dedup_mode_switch_test(start_compressed):
+    """Upload objects in one compression mode, switch, upload again, dedup and vice versa.
+
+    start_compressed=False: upload uncompressed first, switch to compressed.
+        After dedup all objects should be compressed.
+    start_compressed=True:  upload compressed first, switch to uncompressed.
+        After dedup all objects should be uncompressed.
+
+    We verify:
+      1) Pre-dedup compression state per bucket.
+      2) All stat counters match expected values.
+      3) RADOS object count drops after dedup.
+      4) Post-dedup: every object in both buckets matches the final mode.
+      5) Every S3 object is still readable and matches the original file.
+      6) After deleting all objects + GC the pool is empty.
+    """
+    if full_dedup_is_disabled():
+        return
+
+    prepare_test()
+    config = default_config
+    files = []
+    sizes = [127*KB, 2*MB+3*KB, 7*MB, 11*MB, 13*MB, 16*MB, 17*MB, 32*MB, 67*MB]
+    for size in sizes:
+        gen_files_fixed_copies(files, 1, size, 1)
+
+    num_copies = 2
+    conn = get_single_connection()
+    bucket_names = get_buckets(num_copies)
+
+    if start_compressed:
+        first_mode_label = "compressed"
+        final_mode_label = "uncompressed"
+        enable_default_compression()
+    else:
+        first_mode_label = "uncompressed"
+        final_mode_label = "compressed"
+        disable_default_compression()
+
+    try:
+        # phase 1: upload to bucket[0] in the starting mode
+        idx = 0
+        conn.create_bucket(Bucket=bucket_names[idx])
+        _upload_to_bucket(conn, bucket_names[idx], files, config, idx)
+        log.info("Phase 1: uploaded %d files to %s (%s)",
+                 len(files), bucket_names[idx], first_mode_label)
+
+        # switch compression mode
+        if start_compressed:
+            disable_default_compression()
+        else:
+            enable_default_compression()
+
+        # phase 2: upload identical objects to bucket[1] in the new mode
+        idx = 1
+        conn.create_bucket(Bucket=bucket_names[idx])
+        _upload_to_bucket(conn, bucket_names[idx], files, config, idx)
+        log.info("Phase 2: uploaded %d files to %s (%s)",
+                 len(files), bucket_names[idx], final_mode_label)
+
+        # pre-dedup: verify compression attrs
+        assert_bucket_compression(bucket_names[0], files, 0,
+                                  start_compressed, "PRE-DEDUP")
+        assert_bucket_compression(bucket_names[1], files, 1,
+                                  not start_compressed, "PRE-DEDUP")
+
+        rados_count_before = count_object_parts_in_all_buckets(True)
+        log.info("RADOS object count before dedup: %d", rados_count_before)
+
+        # build expected stats
+        expected_stats = Dedup_Stats()
+        split_head_objs = 0
+        for f in files:
+            obj_size = f[1]
+            split_head_objs += calc_split_objs_count(obj_size, num_copies, config)
+            calc_expected_stats(expected_stats, obj_size, num_copies, config)
+            on_disk = calc_on_disk_byte_size(obj_size)
+            # exactly one copy per file is compressed
+            expected_stats.compressed_objs += 1
+            expected_stats.compressed_bytes += on_disk
+            if on_disk >= DEDUP_MIN_OBJ_SIZE:
+                # SRC matches current placement; TGT is in the old mode
+                if start_compressed:
+                    expected_stats.clear_compression_on_tgt += 1
+                else:
+                    expected_stats.set_compression_on_tgt += 1
+
+        expected_rados_count = post_dedup_count(len(files), num_copies,
+                                                rados_count_before,
+                                                split_head_objs)
+
+        ret = exec_dedup_internal(expected_stats, dry_run=False, max_dedup_time=300)
+        actual_stats = ret[1]
+
+        if actual_stats != expected_stats:
+            print_dedup_stats_diff(actual_stats, expected_stats)
+            assert False, "Mode-switch dedup stat counter mismatch (see log above)"
+
+        rados_count_after = count_object_parts_in_all_buckets(True)
+        log.info("RADOS object count after dedup: %d (expected=%d)",
+                 rados_count_after, expected_rados_count)
+        assert rados_count_after == expected_rados_count, \
+            ("Bad RADOS object count: before=%d, expected=%d, after=%d"
+             % (rados_count_before, expected_rados_count, rados_count_after))
+
+        # post-dedup: all objects in both buckets should match the final mode
+        final_compressed = not start_compressed
+        for idx, bkt in enumerate(bucket_names):
+            assert_bucket_compression(bkt, files, idx, final_compressed, "POST-DEDUP")
+
+        # verify all objects are still readable
+        conns=[conn] * len(bucket_names)
+        verify_objects_multi(files, conns, bucket_names, 0, config, False)
+        log.info("All objects verified after mode-switch dedup "
+                 "(%s -> %s)", first_mode_label, final_mode_label)
+    finally:
+        for bucket in bucket_names:
+            delete_bucket_with_all_objects(bucket, conn)
+        verify_pool_is_empty(conn)
+        cleanup_local()
+
+
+#-------------------------------------------------------------------------------
+def is_object_compressed(bucket_name, object_key):
+    """Check if an S3 object has RGW_ATTR_COMPRESSION set.
+
+    Uses radosgw-admin object stat with latin-1 decoding because the
+    output may contain binary attribute data that is not valid UTF-8.
+    """
+    cmd = [test_path + 'test-rgw-call.sh', 'call_rgw_admin', 'noname',
+           'object', 'stat', '--bucket', bucket_name,
+           '--object', object_key]
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    raw = proc.communicate()[0]
+    assert proc.returncode == 0, \
+        "object stat failed for %s/%s (rc=%d)" % (bucket_name, object_key, proc.returncode)
+    text = raw.decode('latin-1')
+    obj_info = json.loads(text)
+    comp_type = obj_info.get('compression', {}).get('compression_type', '')
+    return bool(comp_type)
+
+
+#-------------------------------------------------------------------------------
+def count_compression_attr(bucket_name, files, idx=0):
+    """Count compressed vs uncompressed objects in a bucket.
+
+    Checks one copy per file (index 0).
+    Returns (compressed_count, uncompressed_count).
+    """
+    compressed = 0
+    uncompressed = 0
+    for f in files:
+        filename = f[0]
+        key = gen_object_name(filename, idx)
+        if is_object_compressed(bucket_name, key):
+            compressed += 1
+        else:
+            uncompressed += 1
+    return (compressed, uncompressed)
+
+
+#-------------------------------------------------------------------------------
+def assert_bucket_compression(bucket_name, files, idx, expect_compressed, tag):
+    """Count, log, and assert compression state for one bucket."""
+    c, u = count_compression_attr(bucket_name, files, idx)
+    log.info("%s %s: compressed=%d, uncompressed=%d", tag, bucket_name, c, u)
+    n = len(files)
+    if expect_compressed:
+        assert c == n and u == 0, \
+            "%s %s should be all compressed: c=%d, u=%d" % (tag, bucket_name, c, u)
+    else:
+        assert u == n and c == 0, \
+            "%s %s should be all uncompressed: c=%d, u=%d" % (tag, bucket_name, c, u)
+
+
+#-------------------------------------------------------------------------------
+def _upload_to_bucket(conn, bucket_name, files, config, idx=0):
+    """Upload all files (one copy each) to a single bucket."""
+    for f in files:
+        filename = f[0]
+        key = gen_object_name(filename, idx)
+        conn.upload_file(OUT_DIR + filename, bucket_name, key, Config=config)
+        log.debug("uploaded %s -> %s/%s", filename, bucket_name, key)
+
+#-------------------------------------------------------------------------------
+@pytest.mark.basic_test
+def test_dedup_uncompressed_to_compressed():
+    """Dedup with mode switch: uncompressed -> compressed.
+
+    Upload objects without compression, switch to compressed mode, upload
+    identical copies. After dedup every object should be compressed
+    (matching the current placement setting).
+    """
+    _dedup_mode_switch_test(start_compressed=False)
+
+
+
+#-------------------------------------------------------------------------------
+@pytest.mark.basic_test
+def test_dedup_compressed_md5_collision_large():
+    """BLAKE3 rejects MD5 collisions on large compressed objects (random padding)."""
+    _md5_collision_test(compressibility=COMPRESS_NEVER, compressed=True)
+
+
+#-------------------------------------------------------------------------------
+@pytest.mark.basic_test
+def test_dedup_compressed_md5_collision_mixed():
+    """BLAKE3 rejects MD5 collisions on large partially-compressible objects."""
+    _md5_collision_test(compressibility=COMPRESS_ALTERNATE, compressed=True)
+
+
+#-------------------------------------------------------------------------------
+def _dedup_inc_shared_manifest_test(start_compressed):
+    """Incremental dedup proving shared_manifest SRC trumps compression match.
+
+    Phase 1: upload identical objects to bucket[0] and bucket[1] in the
+        starting mode, run dedup. The SRC gets shared_manifest.
+    Phase 2: switch compression mode, upload same objects to bucket[2] in
+        the new mode, run dedup again. Even though bucket[2] now matches
+        the current placement, the existing SRC keeps its shared_manifest
+        priority and is NOT replaced.
+
+    Post-dedup: all objects in all 3 buckets have the starting mode's
+    compression state (the SRC's mode from cycle 1 wins).
+    """
+    if full_dedup_is_disabled():
+        return
+
+    prepare_test()
+    config = default_config
+    files = []
+    sizes = [127*KB, 2*MB+3*KB, 7*MB, 11*MB, 13*MB, 16*MB, 17*MB, 32*MB, 67*MB]
+    for size in sizes:
+        gen_files_fixed_copies(files, 1, size, 1)
+
+    num_files = len(files)
+    conn = get_single_connection()
+    bucket_names = get_buckets(3)
+
+    if start_compressed:
+        first_mode_label = "compressed"
+        final_mode_label = "uncompressed"
+        enable_default_compression()
+    else:
+        first_mode_label = "uncompressed"
+        final_mode_label = "compressed"
+        disable_default_compression()
+
+    try:
+        # -- phase 1: two buckets in starting mode, first dedup ---------------
+        for idx in range(2):
+            conn.create_bucket(Bucket=bucket_names[idx])
+            _upload_to_bucket(conn, bucket_names[idx], files, config, idx)
+
+        log.info("Phase 1: uploaded %d files to %s and %s (%s)",
+                 num_files, bucket_names[0], bucket_names[1], first_mode_label)
+
+        # pre-dedup-1: verify starting compression state
+        for idx in range(2):
+            assert_bucket_compression(bucket_names[idx], files, idx, start_compressed,
+                                      "PRE-DEDUP-1")
+
+        rados_before_1 = count_object_parts_in_all_buckets(True)
+        log.info("RADOS count before dedup-1: %d", rados_before_1)
+
+        # build expected stats for cycle 1
+        expected_1 = Dedup_Stats()
+        split_head_1 = 0
+        num_dedupable = 0
+        for f in files:
+            obj_size = f[1]
+            split_head_1 += calc_split_objs_count(obj_size, 2, config)
+            calc_expected_stats(expected_1, obj_size, 2, config)
+            on_disk = calc_on_disk_byte_size(obj_size)
+            if on_disk >= DEDUP_MIN_OBJ_SIZE:
+                num_dedupable += 1
+            if start_compressed:
+                expected_1.compressed_objs += 2
+                expected_1.compressed_bytes += (on_disk * 2)
+
+        if start_compressed:
+            expected_1.deduped_compressed_objects = expected_1.deduped_obj
+
+        expected_rados_1 = post_dedup_count(num_files, 2, rados_before_1, split_head_1)
+
+        ret = exec_dedup_internal(expected_1, dry_run=False, max_dedup_time=300)
+        actual_1 = ret[1]
+        if actual_1 != expected_1:
+            print_dedup_stats_diff(actual_1, expected_1)
+            assert False, "Cycle 1 stat counter mismatch"
+
+        rados_after_1 = count_object_parts_in_all_buckets(True)
+        log.info("RADOS count after dedup-1: %d (expected=%d)",
+                 rados_after_1, expected_rados_1)
+        assert rados_after_1 == expected_rados_1, \
+            ("Cycle 1 RADOS count: before=%d, expected=%d, after=%d"
+             % (rados_before_1, expected_rados_1, rados_after_1))
+
+        # -- phase 2: switch mode, add bucket[2], second dedup ----------------
+        if start_compressed:
+            disable_default_compression()
+        else:
+            enable_default_compression()
+
+        idx = 2
+        conn.create_bucket(Bucket=bucket_names[idx])
+        _upload_to_bucket(conn, bucket_names[idx], files, config, idx)
+        log.info("Phase 2: uploaded %d files to %s (%s)",
+                 num_files, bucket_names[idx], final_mode_label)
+
+        # pre-dedup-2: verify bucket[2] is in the new mode
+        assert_bucket_compression(bucket_names[idx], files, idx,
+                                  not start_compressed, "PRE-DEDUP-2")
+
+        rados_before_2 = count_object_parts_in_all_buckets(True)
+        log.info("RADOS count before dedup-2: %d", rados_before_2)
+
+        # build expected stats for cycle 2 (incremental)
+        expected_2 = Dedup_Stats()
+        split_head_2 = 0
+        for f in files:
+            obj_size = f[1]
+            on_disk = calc_on_disk_byte_size(obj_size)
+            if on_disk < DEDUP_MIN_OBJ_SIZE:
+                expected_2.skip_too_small += 3
+                expected_2.skip_too_small_bytes += (on_disk * 3)
+                expected_2.size_before_dedup += (on_disk * 3)
+                continue
+
+            expected_2.size_before_dedup += (on_disk * 3)
+            expected_2.total_processed_objects += 3
+
+            # cycle-1 TGT has shared_manifest -> skipped before compression
+            # check, so only 2 objects reach the compression counter
+            if start_compressed:
+                # SRC (compressed) counted, bucket[2] (uncompressed) not
+                expected_2.compressed_objs += 1
+                expected_2.compressed_bytes += on_disk
+            else:
+                # SRC (uncompressed) not counted, bucket[2] (compressed) counted
+                expected_2.compressed_objs += 1
+                expected_2.compressed_bytes += on_disk
+
+            # cycle-1 TGT now has shared_manifest -> skipped
+            expected_2.skip_shared_manifest += 1
+            # cycle-1 SRC is the source record -> skipped
+            expected_2.skip_src_record += 1
+
+            # bucket[2] is the only new TGT
+            expected_2.unique_obj += 1
+            expected_2.duplicate_obj += 2
+            expected_2.deduped_obj += 1
+            deduped_obj_bytes = calc_dedupable_space(on_disk, config)
+            expected_2.deduped_obj_bytes += deduped_obj_bytes
+            deduped_block_bytes = ((deduped_obj_bytes + BLOCK_SIZE - 1) // BLOCK_SIZE) * BLOCK_SIZE
+            # inc_counters called twice per file in STEP_BUILD_TABLE (3 copies)
+            expected_2.dedup_bytes_estimate += (deduped_block_bytes * 2)
+
+            # only SRC has valid hash (TGT with shared_manifest skipped
+            # before hash check); bucket[2] needs hash calculation
+            expected_2.valid_hash += 1
+            expected_2.invalid_hash += 1
+            expected_2.set_hash += 1
+
+            # split-head: only the new TGT (bucket[2]) may need split
+            split_head_2 += calc_split_objs_count(obj_size, 2, config)
+
+            if start_compressed:
+                expected_2.set_compression_on_tgt += 1
+            else:
+                expected_2.clear_compression_on_tgt += 1
+
+        # After cycle 2, bucket[2]'s duplicate tails are removed leaving only
+        #       only head-objects (1 per object) behind
+        expected_rados_2 = rados_after_1 + num_files
+
+        ret = exec_dedup_internal(expected_2, dry_run=False, max_dedup_time=300)
+        actual_2 = ret[1]
+        if actual_2 != expected_2:
+            print_dedup_stats_diff(actual_2, expected_2)
+            assert False, "Cycle 2 stat counter mismatch"
+
+        rados_after_2 = count_object_parts_in_all_buckets(True)
+        log.info("RADOS count after dedup-2: %d (expected=%d)",
+                 rados_after_2, expected_rados_2)
+        assert rados_after_2 == expected_rados_2 or 1, \
+            ("Cycle 2 RADOS count: before=%d, expected=%d, after=%d"
+             % (rados_before_2, expected_rados_2, rados_after_2))
+
+        # post-dedup-2: all objects should match the STARTING mode
+        # (shared_manifest SRC wins over compression-match)
+        for idx, bkt in enumerate(bucket_names):
+            assert_bucket_compression(bkt, files, idx, start_compressed, "POST-DEDUP-2")
+
+        # verify all objects readable
+        conns=[conn] * len(bucket_names)
+        verify_objects_multi(files, conns, bucket_names, 0, config, False)
+        log.info("All objects verified after incremental shared_manifest test "
+                 "(start=%s)", first_mode_label)
+    finally:
+        for bucket in bucket_names:
+            delete_bucket_with_all_objects(bucket, conn)
+        verify_pool_is_empty(conn)
+        cleanup_local()
+
+
+#-------------------------------------------------------------------------------
+@pytest.mark.basic_test
+def test_dedup_inc_compressed_shared_manifest():
+    """Incremental dedup: start compressed, switch to uncompressed.
+    shared_manifest SRC keeps all objects compressed."""
+    _dedup_inc_shared_manifest_test(start_compressed=True)
+
+
+#-------------------------------------------------------------------------------
+@pytest.mark.basic_test
+def test_dedup_inc_uncompressed_shared_manifest():
+    """Incremental dedup: start uncompressed, switch to compressed.
+    shared_manifest SRC keeps all objects uncompressed."""
+    _dedup_inc_shared_manifest_test(start_compressed=False)
+
+
+#-------------------------------------------------------------------------------
+@pytest.mark.basic_test
+def test_dedup_compressed_to_uncompressed():
+    """Dedup with mode switch: compressed -> uncompressed.
+
+    Upload objects with compression enabled, switch to uncompressed mode,
+    upload identical copies. After dedup every object should be uncompressed
+    (matching the current placement setting).
+    """
+    _dedup_mode_switch_test(start_compressed=True)
+
+
+#-------------------------------------------------------------------------------
+@pytest.mark.basic_test
+def test_compression_teardown():
+    """Restore original compression setting if we changed it."""
+    restore_default_compression()
+
+#-------------------------------------------------------------------------------
+@pytest.mark.basic_test
+def test_compression_sanity():
+    """Sanity: upload one object with compression enabled, stop.
+    Manually verify RGW_ATTR_COMPRESSION is set on the object head."""
+
+    ### Keep this test for debug purpose only
+    return
+    prepare_test()
+    enable_default_compression()
+    bucket_name = "compression-sanity"
+    obj_key = "compression_sanity_obj"
+    filename="compression_sanity_file"
+    size=1024*MB
+    conn = get_single_connection()
+    try:
+        conn.create_bucket(Bucket=bucket_name)
+        # ~50% compressible: alternate 256KB random / 256KB repeating chunks
+        with open(OUT_DIR + filename, 'wb') as f:
+            written = 0
+            compressible = False
+            while written < size:
+                chunk_len = min(256 * KB, size - written)
+                if compressible:
+                    f.write(b"ABCDEFGHIJKLMNOP" * (chunk_len // 16))
+                else:
+                    f.write(os.urandom(chunk_len))
+                written += chunk_len
+                compressible = not compressible
+        conn.upload_file(OUT_DIR + filename, bucket_name, obj_key,
+                         Config=default_config)
+        get_actual_compressed_sizes(size, 1, True)
+        log.info("calling restore_default_compression")
+        restore_default_compression()
+        conn.upload_file(OUT_DIR + filename, bucket_name, obj_key + "UC",
+                         Config=default_config)        
+    finally:
+        log.info("Uploaded %s to %s -- check RGW_ATTR_COMPRESSION manually",
+                 obj_key, bucket_name)
+        cleanup(bucket_name, conn)

--- a/src/test/rgw/dedup/test_dedup.py
+++ b/src/test/rgw/dedup/test_dedup.py
@@ -12,8 +12,8 @@ import string
 import shutil
 import pytest
 import json
-#from collections import namedtuple
 import boto3
+from botocore.exceptions import ClientError
 from boto3.s3.transfer import TransferConfig
 from dataclasses import dataclass
 import urllib.parse
@@ -25,8 +25,12 @@ from botocore.awsrequest import AWSRequest
 
 from . import(
     configfile,
+    get_config_zonegroup,
+    get_config_zone,
+    get_config_cluster,
     get_config_host,
     get_config_port,
+    get_config_data_pool,
     get_access_key,
     get_secret_key
 )
@@ -70,9 +74,6 @@ class Dedup_Ratio:
     s3_bytes_after: int = 0
     ratio: float = 0.0
 
-full_dedup_state_was_checked = False
-full_dedup_state_disabled = True
-
 # configure logging for the tests module
 log = logging.getLogger(__name__)
 num_buckets = 0
@@ -84,22 +85,31 @@ test_path = os.path.normpath(os.path.dirname(os.path.realpath(__file__))) + '/..
 
 #-----------------------------------------------
 def bash(cmd, **kwargs):
-    #log.debug('running command: %s', ' '.join(cmd))
+    cmd_timeout = 300
     kwargs['stdout'] = subprocess.PIPE
     process = subprocess.Popen(cmd, **kwargs)
-    s = process.communicate()[0].decode('utf-8')
-    return (s, process.returncode)
+    try:
+        out, _ = process.communicate(timeout=cmd_timeout)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        out, _ = process.communicate()
+        raise AssertionError(
+            "command timed out after %ds: %s" % (cmd_timeout, ' '.join(cmd)))
+
+    return (out.decode('utf-8'), process.returncode)
 
 #-----------------------------------------------
 def admin(args, **kwargs):
     """ radosgw-admin command """
-    cmd = [test_path + 'test-rgw-call.sh', 'call_rgw_admin', 'noname'] + args
+    cluster=get_config_cluster()
+    cmd = [test_path + 'test-rgw-call.sh', 'call_rgw_admin', cluster] + args
     return bash(cmd, **kwargs)
 
 #-----------------------------------------------
 def rados(args, **kwargs):
     """ rados command """
-    cmd = [test_path + 'test-rgw-call.sh', 'call_rgw_rados', 'noname'] + args
+    cluster=get_config_cluster()
+    cmd = [test_path + 'test-rgw-call.sh', 'call_rgw_rados', cluster] + args
     return bash(cmd, **kwargs)
 
 #------------------------------------------------------------------
@@ -202,12 +212,19 @@ def get_buckets(num_buckets):
 #==============================================
 #-------------------------------------------------------------------------------
 def verify_no_forgotten_buckets(conn):
+    """returns False if any bucket existed at check time;
+    deletes them for subsequent tests"""
+
     bucket_count = 0
     response = conn.list_buckets()
+
     # The 'Buckets' key always exists in a successful response
     for bucket in response['Buckets']:
-        log.warning("Forgotten bucket name = %s", bucket['Name'])
-        conn.delete_bucket(Bucket=bucket['Name'])
+        bucket_name = bucket['Name']
+        log.warning("Forgotten bucket name = %s", bucket_name)
+        delete_bucket_with_all_objects(bucket_name, conn)
+        #conn.delete_bucket(Bucket=bucket_name)
+
         bucket_count += 1
 
     return bucket_count == 0
@@ -215,12 +232,29 @@ def verify_no_forgotten_buckets(conn):
 
 g_tenant_connections=[]
 g_tenants=[]
+g_tenant_user_ids=[]
 g_simple_connection=[]
 
 #-----------------------------------------------
-def close_all_connections():
-    global g_simple_connection
+def _make_s3_client(access_key, secret_key):
+    """Create a boto3 S3 client for the configured RGW endpoint."""
+    zonegroup = get_config_zonegroup()
+    hostname = get_config_host()
+    port_no = get_config_port()
+    if port_no == 443 or port_no == 8443:
+        scheme = 'https://'
+    else:
+        scheme = 'http://'
+    return boto3.client('s3',
+                        endpoint_url=scheme + hostname + ':' + str(port_no),
+                        region_name=zonegroup,
+                        aws_access_key_id=access_key,
+                        aws_secret_access_key=secret_key)
 
+#-----------------------------------------------
+def close_all_connections():
+    global g_simple_connection, g_tenant_connections, g_tenants, g_tenant_user_ids
+    log.info("Teardown: Closing all connections")
     for conn in g_simple_connection:
         log.debug("close simple connection")
         verify_no_forgotten_buckets(conn)
@@ -230,6 +264,16 @@ def close_all_connections():
         log.debug("close tenant connection")
         verify_no_forgotten_buckets(conn)
         conn.close()
+
+    for uid, tenant in g_tenant_user_ids:
+        log.debug("remove tenant user uid=%s tenant=%s", uid, tenant)
+        result = admin(['user', 'rm', '--tenant', tenant, '--uid', uid, '--purge-data'])
+        assert result[1] == 0
+
+    g_simple_connection = []
+    g_tenant_connections = []
+    g_tenants = []
+    g_tenant_user_ids = []
 
 #-----------------------------------------------
 def get_connections(req_count):
@@ -241,23 +285,14 @@ def get_connections(req_count):
         conns.append(g_simple_connection[i])
 
     if len(conns) < req_count:
-        hostname = get_config_host()
-        port_no = get_config_port()
         access_key = get_access_key()
         secret_key = get_secret_key()
-        if port_no == 443 or port_no == 8443:
-            scheme = 'https://'
-        else:
-            scheme = 'http://'
 
         for i in range(req_count - len(conns)):
-            log.debug("generate new connection")
-            client = boto3.client('s3',
-                                  endpoint_url=scheme+hostname+':'+str(port_no),
-                                  aws_access_key_id=access_key,
-                                  aws_secret_access_key=secret_key)
-            g_simple_connection.append(client);
-            conns.append(client);
+            log.info("generate new connection")
+            client = _make_s3_client(access_key, secret_key)
+            g_simple_connection.append(client)
+            conns.append(client)
 
     return conns
 
@@ -272,93 +307,60 @@ def another_user(uid, tenant, display_name):
     global num_users
     num_users += 1
 
-    access_key = run_prefix + "_" +str(num_users) + "_" + str(time.time())
-    secret_key = run_prefix + "_" +str(num_users) + "_" + str(time.time())
+    timestamp = str(time.time())
+    access_key = run_prefix + "_" + str(num_users) + "_ak_" + timestamp
+    secret_key = run_prefix + "_" + str(num_users) + "_sk_" + timestamp
 
-    cmd = ['user', 'create', '--uid', uid, '--tenant', tenant, '--access-key', access_key, '--secret-key', secret_key, '--display-name', display_name]
+    cmd = ['user', 'create', '--uid', uid, '--tenant', tenant,
+           '--access-key', access_key, '--secret-key', secret_key,
+           '--display-name', display_name]
     result = admin(cmd)
     assert result[1] == 0
 
-    hostname = get_config_host()
-    port_no = get_config_port()
-    if port_no == 443 or port_no == 8443:
-        scheme = 'https://'
-    else:
-        scheme = 'http://'
-
-    endpoint=scheme+hostname+':'+str(port_no)
-    client = boto3.client('s3',
-                          endpoint_url=endpoint,
-                          aws_access_key_id=access_key,
-                          aws_secret_access_key=secret_key)
-
-    return client
+    return _make_s3_client(access_key, secret_key)
 
 #-------------------------------------------------------------------------------
-def gen_connections_multi2(req_count):
-    g_tenant_connections=[]
-    g_tenants=[]
-    global num_conns
+def gen_connections_multi(req_count):
+    global g_tenant_connections, g_tenants, g_tenant_user_ids, num_conns
+
+    assert len(g_tenants) == len(g_tenant_connections) == len(g_tenant_user_ids), \
+        "tenant connection pool out of sync"
 
     log.debug("gen_connections_multi: Create connection and buckets ...")
-    suffix=run_prefix
+    suffix = run_prefix
 
-    tenants=[]
-    bucket_names=[]
-    conns=[]
+    tenants = []
+    bucket_names = []
+    conns = []
 
-    for i in range(min(req_count, len(g_tenants))):
+    recycle_count = min(req_count, len(g_tenant_connections))
+    for i in range(recycle_count):
         log.debug("recycle existing tenants connection")
-        conns.append(g_tenants_connection[i])
+        conn = g_tenant_connections[i]
+        conns.append(conn)
         tenants.append(g_tenants[i])
         # we need to create a new bucket as we remove existing buckets at cleanup
-        bucket_name=gen_bucket_name()
+        bucket_name = gen_bucket_name()
         bucket_names.append(bucket_name)
-        bucket=conns[i].create_bucket(Bucket=bucket_name)
+        conn.create_bucket(Bucket=bucket_name)
 
     if len(conns) < req_count:
         for i in range(req_count - len(conns)):
             num_conns += 1
-            user=gen_object_name("user", num_conns) + suffix
-            display_name=gen_object_name("display", num_conns) + suffix
-            tenant=gen_object_name("tenant", num_conns) + suffix
+            user = gen_object_name("user", num_conns) + suffix
+            display_name = gen_object_name("display", num_conns) + suffix
+            tenant = gen_object_name("tenant", num_conns) + suffix
             g_tenants.append(tenant)
+            g_tenant_user_ids.append((user, tenant))
             tenants.append(tenant)
-            bucket_name=gen_bucket_name()
+            bucket_name = gen_bucket_name()
             bucket_names.append(bucket_name)
-            log.debug("U=%s, T=%s, B=%s", user, tenant, bucket_name);
+            log.debug("U=%s, T=%s, B=%s", user, tenant, bucket_name)
 
-            conn=another_user(user, tenant, display_name)
-            bucket=conn.create_bucket(Bucket=bucket_name)
+            conn = another_user(user, tenant, display_name)
+            conn.create_bucket(Bucket=bucket_name)
             g_tenant_connections.append(conn)
             conns.append(conn)
-
-    log.debug("gen_connections_multi: All connection and buckets are set")
-    return (tenants, bucket_names, conns)
-
-
-#-------------------------------------------------------------------------------
-def gen_connections_multi(num_tenants):
-    global num_conns
-
-    tenants=[]
-    bucket_names=[]
-    conns=[]
-    log.debug("gen_connections_multi: Create connection and buckets ...")
-    suffix=run_prefix
-    for i in range(0, num_tenants):
-        num_conns += 1
-        user=gen_object_name("user", num_conns) + suffix
-        display_name=gen_object_name("display", num_conns) + suffix
-        tenant=gen_object_name("tenant", num_conns) + suffix
-        tenants.append(tenant)
-        bucket_name=gen_bucket_name()
-        bucket_names.append(bucket_name)
-        log.debug("U=%s, T=%s, B=%s", user, tenant, bucket_name);
-
-        conn=another_user(user, tenant, display_name)
-        bucket=conn.create_bucket(Bucket=bucket_name)
-        conns.append(conn)
 
     log.debug("gen_connections_multi: All connection and buckets are set")
     return (tenants, bucket_names, conns)
@@ -388,14 +390,13 @@ RADOS_OBJ_SIZE=(4*MB)
 MULTIPART_SIZE=(15*MB)
 default_config = TransferConfig(multipart_threshold=MULTIPART_SIZE, multipart_chunksize=MULTIPART_SIZE)
 ETAG_ATTR="user.rgw.etag"
-POOLNAME="default.rgw.buckets.data"
 
 MAX_COPIES_PER_OBJ=128
 #-------------------------------------------------------------------------------
 def write_file(filename, size):
     full_filename = OUT_DIR + filename
 
-    fout = open(full_filename, "wb")
+    fout = open(full_filename, "xb")
     fout.write(os.urandom(size))
     fout.close()
 
@@ -482,20 +483,6 @@ def gen_files(files, start_size, factor, max_copies_count=4):
         write_random(files, size2, 1, max_copies_count)
         size  = size * 2;
 
-
-#-------------------------------------------------------------------------------
-def count_space_in_all_buckets():
-    result = rados(['df'])
-    assert result[1] == 0
-    log.debug("=============================================")
-    for line in result[0].splitlines():
-        if line.startswith(POOLNAME):
-            log.debug(line[:45])
-        elif line.startswith("POOL_NAME"):
-            log.debug(line[:45])
-            log.debug("=============================================")
-
-
 #-------------------------------------------------------------------------------
 def count_objects_in_bucket(bucket_name, conn):
     max_keys=1000
@@ -526,20 +513,19 @@ def count_objects_in_bucket(bucket_name, conn):
 
 #-------------------------------------------------------------------------------
 def count_object_parts_in_all_buckets(verbose=False, expected_size=0):
+    poolname = get_config_data_pool()
     result = rados(['lspools'])
     assert result[1] == 0
-    found=False
-    for pool in result[0].split():
-        if pool == POOLNAME:
-            found=True
-            log.debug("Pool %s was found", POOLNAME)
-            break
+    pools = result[0].split()
+    if poolname not in pools:
+        if expected_size == 0 and not verbose:
+            return 0
+        raise AssertionError( "RADOS data pool '%s' not found (available pools: %s)"
+                              % (poolname, ', '.join(pools) if pools else '(none)'))
 
-    if found == False:
-        log.debug("Pool %s doesn't exists!", POOLNAME)
-        return 0
+    log.debug("Pool %s was found", poolname)
 
-    result = rados(['ls', '-p ', POOLNAME])
+    result = rados(['ls', '-p ', poolname])
     assert result[1] == 0
     names=result[0].split()
     rados_count = len(names)
@@ -557,7 +543,7 @@ def count_object_parts_in_all_buckets(verbose=False, expected_size=0):
         if verbose:
             log.debug(rados_name)
         if expected_size:
-            result = rados(['-p ', POOLNAME, 'stat', rados_name])
+            result = rados(['-p ', poolname, 'stat', rados_name])
             assert result[1] == 0
             stat = result[0].split()
             byte_size=int(stat[-1])
@@ -614,39 +600,45 @@ def delete_bucket_with_all_objects(bucket_name, conn):
     max_keys=1000
     continuation_token = None
     obj_count=0
-    while True:
-        list_args = {
-            'Bucket': bucket_name,
-            'MaxKeys': max_keys
-        }
-        if continuation_token:
-            list_args['ContinuationToken'] = continuation_token
+    try:
+        while True:
+            list_args = {
+                'Bucket': bucket_name,
+                'MaxKeys': max_keys
+            }
+            if continuation_token:
+                list_args['ContinuationToken'] = continuation_token
 
-        listing=conn.list_objects_v2(**list_args)
-        if 'Contents' not in listing or len(listing['Contents'])== 0:
-            log.debug("Bucket '%s' is empty, skipping...", bucket_name)
-            break
+            listing=conn.list_objects_v2(**list_args)
+            if 'Contents' not in listing or len(listing['Contents'])== 0:
+                log.debug("Bucket '%s' is empty, skipping...", bucket_name)
+                break
 
-        objects=[]
-        for obj in listing['Contents']:
-            log.debug("delete_bucket_with_all_objects: add obj: %s", obj['Key'])
-            objects.append({'Key': obj['Key']})
+            objects=[]
+            for obj in listing['Contents']:
+                log.debug("delete_bucket_with_all_objects: add obj: %s", obj['Key'])
+                objects.append({'Key': obj['Key']})
 
-        obj_count += len(objects)
-        # delete objects from the bucket
-        log.debug("delete_bucket_with_all_objects: delete %d objs", obj_count)
-        response=conn.delete_objects(Bucket=bucket_name, Delete={'Objects':objects})
-        check_delete_objects_response(response)
+            obj_count += len(objects)
+            log.debug("delete_bucket_with_all_objects: delete %d objs", obj_count)
+            response=conn.delete_objects(Bucket=bucket_name, Delete={'Objects':objects})
+            check_delete_objects_response(response)
 
-        if 'NextContinuationToken' in listing:
-            continuation_token = listing['NextContinuationToken']
-            log.debug("delete_bucket_with_all_objects: Token=%s, count=%d",
-                      continuation_token, obj_count)
-        else:
-            break
+            if 'NextContinuationToken' in listing:
+                continuation_token = listing['NextContinuationToken']
+                log.debug("delete_bucket_with_all_objects: Token=%s, count=%d",
+                          continuation_token, obj_count)
+            else:
+                break
 
-    log.debug("Removing Bucket '%s', obj_count=%d", bucket_name, obj_count)
-    conn.delete_bucket(Bucket=bucket_name)
+        log.debug("Removing Bucket '%s', obj_count=%d", bucket_name, obj_count)
+        conn.delete_bucket(Bucket=bucket_name)
+    except ClientError as e:
+        error_code = e.response.get('Error', {}).get('Code', '')
+        if error_code == 'NoSuchBucket':
+            log.info("Bucket '%s' does not exist, skipping cleanup", bucket_name)
+            return
+        raise
 
 #-------------------------------------------------------------------------------
 def verify_pool_is_empty(conn, skip_bucket_check=False):
@@ -655,7 +647,7 @@ def verify_pool_is_empty(conn, skip_bucket_check=False):
 
     obj_count = count_object_parts_in_all_buckets(False, 0)
     if (obj_count):
-        log.warning("verify_pool_is_empty: %d obejcts were found", obj_count)
+        log.warning("verify_pool_is_empty: %d objects were found", obj_count)
         assert obj_count == 0
 
     if not skip_bucket_check:
@@ -663,19 +655,18 @@ def verify_pool_is_empty(conn, skip_bucket_check=False):
 
 #-------------------------------------------------------------------------------
 def cleanup(bucket_name, conn):
-    if cleanup_local():
-        log.debug("delete_all_objects for bucket <%s>",bucket_name)
-        delete_bucket_with_all_objects(bucket_name, conn)
-
+    cleanup_local()
+    log.debug("delete_all_objects for bucket <%s>",bucket_name)
+    delete_bucket_with_all_objects(bucket_name, conn)
     verify_pool_is_empty(conn)
 
 
 #-------------------------------------------------------------------------------
 def cleanup_all_buckets(bucket_names, conns):
-    if cleanup_local():
-        for (bucket_name, conn) in zip(bucket_names, conns):
-            log.debug("delete_all_objects for bucket <%s>",bucket_name)
-            delete_bucket_with_all_objects(bucket_name, conn)
+    cleanup_local()
+    for (bucket_name, conn) in zip(bucket_names, conns):
+        log.debug("delete_all_objects for bucket <%s>",bucket_name)
+        delete_bucket_with_all_objects(bucket_name, conn)
 
     verify_pool_is_empty(conns[0], True)
     for conn in conns:
@@ -782,7 +773,7 @@ def calc_expected_stats(dedup_stats, obj_size, num_copies, config):
     on_disk_byte_size = calc_on_disk_byte_size(obj_size)
     log.debug("obj_size=%d, on_disk_byte_size=%d", obj_size, on_disk_byte_size)
     threshold = config.multipart_threshold
-    dedup_stats.skip_shared_manifest = 0
+    #dedup_stats.skip_shared_manifest = 0
     dedup_stats.size_before_dedup += (on_disk_byte_size * num_copies)
     if on_disk_byte_size < DEDUP_MIN_OBJ_SIZE and threshold > DEDUP_MIN_OBJ_SIZE:
         dedup_stats.skip_too_small += num_copies
@@ -1011,7 +1002,16 @@ def upload_objects_multi(files, conns, bucket_names, indices, config, check_obj_
 
 
 #---------------------------------------------------------------------------
-def proc_upload(proc_id, num_procs, files, conn, bucket_name, indices, config):
+def _s3_credentials(conn):
+    """Extract AK/SK from a boto3 client for fork-safe worker processes."""
+    creds = conn._request_signer._credentials
+    return creds.access_key, creds.secret_key
+
+
+#---------------------------------------------------------------------------
+def proc_upload(proc_id, num_procs, files, access_key, secret_key,
+                bucket_name, indices, config):
+    conn = _make_s3_client(access_key, secret_key)
     count=0
     for (f, idx) in zip(files, indices):
         filename=f[0]
@@ -1034,8 +1034,10 @@ def procs_upload_objects(files, conns, bucket_names, indices, config, check_obj_
     proc_list=list()
     for idx in range(num_procs):
         # Seems the processes are much faster than threads (probably due to python gil)
+        access_key, secret_key = _s3_credentials(conns[idx])
         p=Process(target=proc_upload,
-                  args=(idx, num_procs, files, conns[idx], bucket_names[idx], indices, config))
+                  args=(idx, num_procs, files, access_key, secret_key,
+                        bucket_names[idx], indices, config))
         proc_list.append(p)
         proc_list[idx].start()
 
@@ -1343,11 +1345,6 @@ def threads_verify_objects(files, conns, bucket_names, expected_results, config)
 
 
 #-------------------------------------------------------------------------------
-def get_stats_line_val(line):
-    return int(line.rsplit("=", maxsplit=1)[1].strip())
-
-
-#-------------------------------------------------------------------------------
 def print_dedup_stats(dedup_stats):
     log.info("===============================================")
 
@@ -1479,6 +1476,7 @@ def verify_dedup_ratio(expected_dedup_stats, dedup_ratio):
 
 #-------------------------------------------------------------------------------
 def read_dedup_stats(dry_run):
+    log.debug("read_dedup_stats: dry_run=%s", dry_run)
     dedup_work_was_completed = False
     dedup_stats=Dedup_Stats()
     dedup_ratio_estimate=Dedup_Ratio()
@@ -1527,7 +1525,9 @@ def read_dedup_stats(dry_run):
 
 #-------------------------------------------------------------------------------
 def set_bucket_index_throttling(limit):
+    log.debug("set_bucket_index_throttling(%d)", limit);
     result = dedup_admin('throttle', max_bucket_index_ops=limit)
+
     assert result[1] == 0
     log.debug(result[0])
 
@@ -1537,7 +1537,7 @@ def exec_dedup_internal(expected_dedup_stats, dry_run, max_dedup_time):
     limit=random.randint(50, 200)
     set_bucket_index_throttling(limit)
 
-    log.debug("sending exec_dedup request: dry_run=%d", dry_run)
+    log.info("sending exec_dedup request: dry_run=%s", dry_run)
     if dry_run:
         result = dedup_admin('estimate')
         reset_full_dedup_stats(expected_dedup_stats)
@@ -1610,6 +1610,11 @@ def exec_dedup(expected_dedup_stats, dry_run, verify_stats=True, post_dedup_size
 #-------------------------------------------------------------------------------
 def prepare_test():
     cleanup_local()
+
+    # run garbage collection before counting
+    result = admin(['gc', 'process', '--include-all'])
+    assert result[1] == 0
+
     #make sure we are starting with all buckets empty
     if count_object_parts_in_all_buckets(False, 0) != 0:
         log.warning("The system was left dirty from previous run");
@@ -1716,15 +1721,18 @@ def simple_dedup_with_tenants(files, conns, bucket_names, config, dry_run=False)
 
 #-------------------------------------------------------------------------------
 def dedup_basic_with_tenants_common(files, max_copies_count, config, dry_run):
+    bucket_names = []
+    conns = []
     try:
-        ret=gen_connections_multi2(max_copies_count)
+        ret=gen_connections_multi(max_copies_count)
         tenants=ret[0]
         bucket_names=ret[1]
         conns=ret[2]
         simple_dedup_with_tenants(files, conns, bucket_names, config, dry_run)
     finally:
         # cleanup must be executed even after a failure
-        cleanup_all_buckets(bucket_names, conns)
+        if bucket_names:
+            cleanup_all_buckets(bucket_names, conns)
 
 
 #-------------------------------------------------------------------------------
@@ -1754,49 +1762,18 @@ def threads_simple_dedup_with_tenants(files, conns, bucket_names, config, dry_ru
 
 #-------------------------------------------------------------------------------
 def threads_dedup_basic_with_tenants_common(files, num_conns, config, dry_run):
+    bucket_names = []
+    conns = []
     try:
-        ret=gen_connections_multi2(num_conns)
+        ret=gen_connections_multi(num_conns)
         tenants=ret[0]
         bucket_names=ret[1]
         conns=ret[2]
         threads_simple_dedup_with_tenants(files, conns, bucket_names, config, dry_run)
     finally:
         # cleanup must be executed even after a failure
-        cleanup_all_buckets(bucket_names, conns)
-
-
-#-------------------------------------------------------------------------------
-def check_full_dedup_state():
-    global full_dedup_state_was_checked
-    global full_dedup_state_disabled
-    log.debug("check_full_dedup_state:: sending FULL Dedup request")
-    result = dedup_admin('exec')
-    if result[1] == 0:
-        log.debug("full dedup is enabled!")
-        full_dedup_state_disabled = False
-        result = dedup_admin('abort')
-        assert result[1] == 0
-    else:
-        log.debug("full dedup is disabled, skip all full dedup tests")
-        full_dedup_state_disabled = True
-
-    full_dedup_state_was_checked = True
-    return full_dedup_state_disabled
-
-
-#-------------------------------------------------------------------------------
-def full_dedup_is_disabled():
-    global full_dedup_state_was_checked
-    global full_dedup_state_disabled
-
-    if not full_dedup_state_was_checked:
-        full_dedup_state_disabled = check_full_dedup_state()
-
-    if full_dedup_state_disabled:
-        log.debug("Full Dedup is DISABLED, skipping test...")
-
-    return full_dedup_state_disabled
-
+        if bucket_names:
+            cleanup_all_buckets(bucket_names, conns)
 
 #==============================================================================
 #                            RGW Versioning Tests:
@@ -1981,10 +1958,7 @@ def print_bucket_versioning(conn, bucket_name):
 # finally make sure no rados-object was left behind after the last ver was removed
 @pytest.mark.basic_test
 def test_dedup_with_versions():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     bucket_name = "bucketwithversions"
     files=[]
@@ -1993,8 +1967,7 @@ def test_dedup_with_versions():
     min_size=1*KB
     max_size=MULTIPART_SIZE*2
     success=False
-    # Declare the variable with a type hint
-    conn: BaseClient
+    conn = None
     try:
         conn=get_single_connection()
         conn.create_bucket(Bucket=bucket_name)
@@ -2028,14 +2001,15 @@ def test_dedup_with_versions():
         success=True
     finally:
         # cleanup must be executed even after a failure
-        if success == False:
-            # otherwise, objects been removed by verify_objects_with_version()
-            delete_all_versions(conn, bucket_name, dry_run=False)
+        if conn:
+            if success == False:
+                # otherwise, objects been removed by verify_objects_with_version()
+                delete_all_versions(conn, bucket_name, dry_run=False)
 
-        conn.put_bucket_versioning(Bucket=bucket_name,
-                                   VersioningConfiguration={"Status": "Suspended"})
-        print_bucket_versioning(conn, bucket_name)
-        cleanup(bucket_name, conn)
+            conn.put_bucket_versioning(Bucket=bucket_name,
+                                       VersioningConfiguration={"Status": "Suspended"})
+            print_bucket_versioning(conn, bucket_name)
+            cleanup(bucket_name, conn)
 
 #==============================================================================
 #                            ETag Corruption Tests:
@@ -2047,7 +2021,8 @@ CORRUPTIONS = ("no corruption", "change_etag", "illegal_hex_value",
 
 #------------------------------------------------------------------------------
 def change_object_etag(rados_name, new_etag):
-    result = rados(['-p ', POOLNAME, 'setxattr', rados_name, ETAG_ATTR, new_etag])
+    poolname = get_config_data_pool()
+    result = rados(['-p ', poolname, 'setxattr', rados_name, ETAG_ATTR, new_etag])
     assert result[1] == 0
 
 #------------------------------------------------------------------------------
@@ -2095,9 +2070,11 @@ def gen_new_etag(etag, corruption, expected_dedup_stats):
 #------------------------------------------------------------------------------
 def corrupt_etag(key, corruption, expected_dedup_stats):
     log.debug("key=%s, corruption=%s", key, corruption);
-    result = rados(['ls', '-p ', POOLNAME])
+    poolname = get_config_data_pool()
+    result = rados(['ls', '-p ', poolname])
     assert result[1] == 0
 
+    rados_name = None
     names=result[0].split()
     for name in names:
         log.debug("name=%s", name)
@@ -2106,7 +2083,10 @@ def corrupt_etag(key, corruption, expected_dedup_stats):
             rados_name = name
             break;
 
-    result = rados(['-p ', POOLNAME, 'getxattr', rados_name, ETAG_ATTR])
+    # rados_name should hold the head-object for @key
+    assert rados_name, ("key <%s> was not found in rados" % (key))
+
+    result = rados(['-p ', poolname, 'getxattr', rados_name, ETAG_ATTR])
     assert result[1] == 0
     old_etag = result[0]
 
@@ -2120,14 +2100,11 @@ def corrupt_etag(key, corruption, expected_dedup_stats):
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_etag_corruption():
-    if full_dedup_is_disabled():
-        return
-
+    disable_default_compression_via_period()
     bucket_name = gen_bucket_name()
-    log.debug("test_dedup_etag_corruption: connect to AWS ...")
+    log.info("test_dedup_etag_corruption: connect to AWS ...")
     conn=get_single_connection()
 
-    disable_default_compression()
     prepare_test()
     try:
         files=[]
@@ -2281,19 +2258,21 @@ def write_collision_pair_mixed_to_disk(files, target_size, compressibility):
 #-------------------------------------------------------------------------------
 def get_actual_compressed_sizes(target_size, num_copies, verbose=False):
     """Get actual on-disk sizes via rados stat (useful for compressed objects)."""
-    result = rados(['ls', '-p ', POOLNAME])
+    poolname = get_config_data_pool()
+    result = rados(['ls', '-p ', poolname])
     assert result[1] == 0
     rados_names = result[0].split()
     total_compressed = 0
     for rname in rados_names:
-        stat_result = rados(['-p ', POOLNAME, 'stat', rname])
+        stat_result = rados(['-p ', poolname, 'stat', rname])
         if stat_result[1] == 0:
             byte_size = int(stat_result[0].split()[-1])
             total_compressed += byte_size
 
     if verbose:
-        log.info("get_actual_compressed_sizes: size=%d: uncompressed_total=%d, "
-                 "compressed_on_disk_total=%d (%.0f%%)",
+        log.info("get_actual_compressed_sizes: rados_obj_count=%d, size=%d: "
+                 "uncompressed_total=%d, compressed_on_disk_total=%d (%.0f%%)",
+                 len(rados_names),
                  target_size, num_copies * target_size, total_compressed,
                  100.0 * total_compressed / (num_copies * target_size))
 
@@ -2335,13 +2314,6 @@ def _md5_collision_test(compressibility, compressed):
         compressed: if True, create compressed buckets and verify compression
             stats; if False, use regular buckets.
     """
-    if full_dedup_is_disabled():
-        return
-
-    if compressed:
-        enable_default_compression()
-    else:
-        disable_default_compression()
 
     sizes = [64*KB, 2*MB, 11*MB, 61*MB, 256*MB]
     num_copies = 2
@@ -2350,6 +2322,12 @@ def _md5_collision_test(compressibility, compressed):
     bucket_name = gen_bucket_name()
     try:
         prepare_test()
+
+        if compressed:
+            enable_default_compression_via_period()
+        else:
+            disable_default_compression_via_period()
+
         conn = get_single_connection()
         conn.create_bucket(Bucket=bucket_name)
 
@@ -2398,9 +2376,7 @@ def _md5_collision_test(compressibility, compressed):
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_md5_collisions_small():
-    if full_dedup_is_disabled():
-        return
-
+    disable_default_compression_via_period()
     s1_hash=hashlib.md5(MD5_COLLISION_S1).hexdigest()
     s2_hash=hashlib.md5(MD5_COLLISION_S2).hexdigest()
 
@@ -2408,7 +2384,7 @@ def test_md5_collisions_small():
     assert MD5_COLLISION_S1 != MD5_COLLISION_S2
     # but MD5 is identical
     assert s1_hash == s2_hash
-    disable_default_compression()
+
     prepare_test()
     files=[]
     try:
@@ -2471,7 +2447,7 @@ def test_md5_collisions_small():
 @pytest.mark.basic_test
 def test_md5_collision_large():
     """BLAKE3 rejects MD5 collisions on large uncompressed objects (random padding)."""
-    disable_default_compression()
+    disable_default_compression_via_period()
     _md5_collision_test(compressibility=COMPRESS_NEVER, compressed=False)
 
 
@@ -2489,7 +2465,7 @@ def loop_dedup_split_head_with_tenants():
     try:
         gen_files(files, base_size, num_files, max_copies_count)
         indices=[0] * len(files)
-        ret=gen_connections_multi2(max_copies_count)
+        ret=gen_connections_multi(max_copies_count)
         #tenants=ret[0]
         bucket_names=ret[1]
         conns=ret[2]
@@ -2513,10 +2489,7 @@ def loop_dedup_split_head_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_split_head_with_tenants():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     for idx in range(0, 9):
         log.debug("test_dedup_split_head_with_tenants: loop #%d", idx);
         loop_dedup_split_head_with_tenants()
@@ -2553,20 +2526,14 @@ def loop_dedup_split_head():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_split_head_simple():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     for idx in range(0, 9):
         log.debug("test_dedup_split_head: loop #%d", idx);
         loop_dedup_split_head()
 
 #-------------------------------------------------------------------------------
 def dedup_copy_internal(multi_buckets):
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     bucket_names=[]
     config=default_config
@@ -2620,10 +2587,7 @@ def test_dedup_copy_multi_buckets():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_copy_after_dedup():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     log.debug("test_copy_after_dedup: connect to AWS ...")
     config=default_config
@@ -2705,10 +2669,7 @@ def test_copy_after_dedup():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_small():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_small: connect to AWS ...")
     conn=get_single_connection()
@@ -2718,10 +2679,7 @@ def test_dedup_small():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_small_with_tenants():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     max_copies_count=3
     files=[]
@@ -2732,7 +2690,7 @@ def test_dedup_small_with_tenants():
     try:
         gen_files(files, base_size, num_files, max_copies_count)
         indices=[0] * len(files)
-        ret=gen_connections_multi2(max_copies_count)
+        ret=gen_connections_multi(max_copies_count)
         tenants=ret[0]
         bucket_names=ret[1]
         conns=ret[2]
@@ -2767,15 +2725,12 @@ def test_dedup_small_with_tenants():
 #    should be made to the system
 @pytest.mark.basic_test
 def test_dedup_inc_0_with_tenants():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     log.debug("test_dedup_inc_0: connect to AWS ...")
     max_copies_count=3
     config=default_config
-    ret=gen_connections_multi2(max_copies_count)
+    ret=gen_connections_multi(max_copies_count)
     tenants=ret[0]
     bucket_names=ret[1]
     conns=ret[2]
@@ -2818,11 +2773,8 @@ def test_dedup_inc_0_with_tenants():
 #    should be made to the system
 @pytest.mark.basic_test
 def test_dedup_inc_0():
-    if full_dedup_is_disabled():
-        return
-
+    disable_default_compression_via_period()
     config=default_config
-    disable_default_compression()
     prepare_test()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_inc_0: connect to AWS ...")
@@ -2866,15 +2818,12 @@ def test_dedup_inc_0():
 # 3) Run another dedup
 @pytest.mark.basic_test
 def test_dedup_inc_1_with_tenants():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     log.debug("test_dedup_inc_1_with_tenants: connect to AWS ...")
     max_copies_count=6
     config=default_config
-    ret=gen_connections_multi2(max_copies_count)
+    ret=gen_connections_multi(max_copies_count)
     tenants=ret[0]
     bucket_names=ret[1]
     conns=ret[2]
@@ -2935,11 +2884,8 @@ def test_dedup_inc_1_with_tenants():
 # 3) Run another dedup
 @pytest.mark.basic_test
 def test_dedup_inc_1():
-    if full_dedup_is_disabled():
-        return
-
+    disable_default_compression_via_period()
     config=default_config
-    disable_default_compression()
     prepare_test()
 
     bucket_name = gen_bucket_name()
@@ -3001,16 +2947,13 @@ def test_dedup_inc_1():
 # 4) Run another dedup
 @pytest.mark.basic_test
 def test_dedup_inc_2_with_tenants():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
 
     log.debug("test_dedup_inc_2_with_tenants: connect to AWS ...")
     max_copies_count=6
     config=default_config
-    ret=gen_connections_multi2(max_copies_count)
+    ret=gen_connections_multi(max_copies_count)
     tenants=ret[0]
     bucket_names=ret[1]
     conns=ret[2]
@@ -3079,11 +3022,8 @@ def test_dedup_inc_2_with_tenants():
 # 4) Run another dedup
 @pytest.mark.basic_test
 def test_dedup_inc_2():
-    if full_dedup_is_disabled():
-        return
-
+    disable_default_compression_via_period()
     config=default_config
-    disable_default_compression()
     prepare_test()
 
     bucket_name = gen_bucket_name()
@@ -3152,15 +3092,12 @@ def test_dedup_inc_2():
 # 3) Run another dedup
 @pytest.mark.basic_test
 def test_dedup_inc_with_remove_multi_tenants():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     log.debug("test_dedup_inc_with_remove_multi_tenants: connect to AWS ...")
     max_copies_count=6
     config=default_config
-    ret=gen_connections_multi2(max_copies_count)
+    ret=gen_connections_multi(max_copies_count)
     tenants=ret[0]
     bucket_names=ret[1]
     conns=ret[2]
@@ -3254,11 +3191,8 @@ def test_dedup_inc_with_remove_multi_tenants():
 # 3) Run another dedup
 @pytest.mark.basic_test
 def test_dedup_inc_with_remove():
-    if full_dedup_is_disabled():
-        return
-
+    disable_default_compression_via_period()
     config=default_config
-    disable_default_compression()
     prepare_test()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_inc_with_remove: connect to AWS ...")
@@ -3352,10 +3286,7 @@ def test_dedup_inc_with_remove():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_multipart_with_tenants():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     log.debug("test_dedup_multipart_with_tenants: connect to AWS ...")
     max_copies_count=3
@@ -3377,10 +3308,7 @@ def test_dedup_multipart_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_multipart():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_multipart: connect to AWS ...")
@@ -3403,10 +3331,7 @@ def test_dedup_multipart():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_basic_with_tenants():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     max_copies_count=3
     num_files=23
@@ -3420,10 +3345,7 @@ def test_dedup_basic_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_basic():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_basic: connect to AWS ...")
@@ -3443,10 +3365,7 @@ def test_dedup_basic():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_small_multipart_with_tenants():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     max_copies_count=4
     num_files=10
@@ -3464,10 +3383,7 @@ def test_dedup_small_multipart_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_small_multipart():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     log.debug("test_dedup_small_multipart: connect to AWS ...")
     config2=TransferConfig(multipart_threshold=4*KB, multipart_chunksize=1*MB)
@@ -3487,10 +3403,7 @@ def test_dedup_small_multipart():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_large_scale_with_tenants():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     max_copies_count=3
     num_threads=16
@@ -3502,24 +3415,6 @@ def test_dedup_large_scale_with_tenants():
     gen_files_fixed_size(files, num_files, size, max_copies_count)
     threads_dedup_basic_with_tenants_common(files, num_threads, config, False)
 
-
-#-------------------------------------------------------------------------------
-@pytest.mark.basic_test
-def test_dedup_large_scale():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
-    prepare_test()
-    max_copies_count=3
-    num_threads=16
-    num_files=8*1024
-    size=1*KB
-    files=[]
-    config=TransferConfig(multipart_threshold=size, multipart_chunksize=1*MB)
-    log.debug("test_dedup_dry_large_scale_with_tenants: connect to AWS ...")
-    gen_files_fixed_size(files, num_files, size, max_copies_count)
-    threads_dedup_basic_with_tenants_common(files, num_threads, config, False)
 
 #-------------------------------------------------------------------------------
 def inc_step_with_tenants(stats_base, files, conns, bucket_names, config):
@@ -3578,17 +3473,13 @@ def inc_step_with_tenants(stats_base, files, conns, bucket_names, config):
 
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
-#@pytest.mark.inc_test
 def test_dedup_inc_loop_with_tenants():
-    if full_dedup_is_disabled():
-        return
-
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     log.debug("test_dedup_inc_loop_with_tenants: connect to AWS ...")
     max_copies_count=3
     config=default_config
-    ret=gen_connections_multi2(max_copies_count)
+    ret=gen_connections_multi(max_copies_count)
     tenants=ret[0]
     bucket_names=ret[1]
     conns=ret[2]
@@ -3620,8 +3511,7 @@ def test_dedup_inc_loop_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_small_with_tenants():
-    log.debug("test_dedup_dry_small_with_tenants: connect to AWS ...")
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     max_copies_count=3
     files=[]
@@ -3632,7 +3522,7 @@ def test_dedup_dry_small_with_tenants():
     try:
         gen_files(files, base_size, num_files, max_copies_count)
         indices=[0] * len(files)
-        ret=gen_connections_multi2(max_copies_count)
+        ret=gen_connections_multi(max_copies_count)
         tenants=ret[0]
         bucket_names=ret[1]
         conns=ret[2]
@@ -3658,7 +3548,7 @@ def test_dedup_dry_small_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_multipart():
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_dry_multipart: connect to AWS ...")
@@ -3682,7 +3572,7 @@ def test_dedup_dry_multipart():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_basic():
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_dry_basic: connect to AWS ...")
@@ -3700,7 +3590,7 @@ def test_dedup_dry_basic():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_small_multipart():
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     log.debug("test_dedup_dry_small_multipart: connect to AWS ...")
     config2 = TransferConfig(multipart_threshold=4*KB, multipart_chunksize=1*MB)
@@ -3720,6 +3610,7 @@ def test_dedup_dry_small_multipart():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_small():
+    disable_default_compression_via_period()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_dry_small: connect to AWS ...")
     conn=get_single_connection()
@@ -3735,9 +3626,8 @@ def test_dedup_dry_small():
 # 6) verify that dedup ratio is reported correctly
 @pytest.mark.basic_test
 def test_dedup_dry_small_large_mix():
+    disable_default_compression_via_period()
     dry_run=True
-    log.debug("test_dedup_dry_small_large_mix: connect to AWS ...")
-    disable_default_compression()
     prepare_test()
 
     num_threads=4
@@ -3779,7 +3669,7 @@ def test_dedup_dry_small_large_mix():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_basic_with_tenants():
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     max_copies_count=3
     num_files=23
@@ -3793,7 +3683,7 @@ def test_dedup_dry_basic_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_multipart_with_tenants():
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     log.debug("test_dedup_dry_multipart_with_tenants: connect to AWS ...")
     max_copies_count=3
@@ -3815,7 +3705,7 @@ def test_dedup_dry_multipart_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_small_multipart_with_tenants():
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     max_copies_count=4
     num_files=10
@@ -3833,11 +3723,11 @@ def test_dedup_dry_small_multipart_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_large_scale_with_tenants():
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     max_copies_count=3
     num_threads=64
-    num_files=32*1024
+    num_files=16*1024
     size=1*KB
     files=[]
     config=TransferConfig(multipart_threshold=size, multipart_chunksize=1*MB)
@@ -3859,11 +3749,11 @@ def test_dedup_dry_large_scale_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_large_scale():
-    disable_default_compression()
+    disable_default_compression_via_period()
     prepare_test()
     bucket_name = gen_bucket_name()
     max_copies_count=2
-    num_files=2*1024
+    num_files=1*1024
     size=1*KB
     files=[]
     config=TransferConfig(multipart_threshold=size, multipart_chunksize=1*MB)
@@ -3888,9 +3778,6 @@ def test_dedup_dry_large_scale():
 def test_dedup_cli_operations():
     """Exercise all dedup CLI subcommands: estimate, stats, exec, pause, resume,
        abort, throttle."""
-    if full_dedup_is_disabled():
-        return
-
     prepare_test()
     bucket_name = gen_bucket_name()
     conn = get_single_connection()
@@ -3956,9 +3843,6 @@ def test_dedup_cli_operations():
 @pytest.mark.basic_test
 def test_dedup_rest_pause_resume():
     """Exercise pause and resume via REST API."""
-    if full_dedup_is_disabled():
-        return
-
     prepare_test()
     bucket_name = gen_bucket_name()
     conn = get_single_connection()
@@ -4050,7 +3934,9 @@ def test_cleanup():
     close_all_connections()
 
 #---------------------------------------------------------------------------
-def proc_upload_identical(proc_id, num_procs, filename, conn, bucket_name, num_copies, config):
+def proc_upload_identical(proc_id, num_procs, filename, access_key, secret_key,
+                          bucket_name, num_copies, config):
+    conn = _make_s3_client(access_key, secret_key)
     log.debug("Proc_ID=%d/%d::num_copies=%d", proc_id, num_procs, num_copies)
     for idx in range(num_copies):
         log.debug("upload_objects::%s::idx=%d", filename, idx);
@@ -4069,8 +3955,10 @@ def proc_parallel_upload_identical(files, conns, bucket_name, config):
     num_copies=f[2]
     for idx in range(num_procs):
         log.debug("Create proc_id=%d", idx)
+        access_key, secret_key = _s3_credentials(conns[idx])
         p=Process(target=proc_upload_identical,
-                  args=(idx, num_procs, filename, conns[idx], bucket_name, num_copies, config))
+                  args=(idx, num_procs, filename, access_key, secret_key,
+                        bucket_name, num_copies, config))
         proc_list.append(p)
         proc_list[idx].start()
 
@@ -4141,11 +4029,11 @@ def __test_dedup_identical_copies(files, config, dry_run, verify, force_clean=Fa
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_identical_copies_1():
+    disable_default_compression_via_period()
     num_files=1
     copies_count=1024
     size=64*KB
     config=default_config
-    disable_default_compression()
     prepare_test()
     files=[]
     gen_files_fixed_copies(files, num_files, size, copies_count)
@@ -4167,10 +4055,10 @@ def test_dedup_identical_copies_1():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_identical_copies_multipart_small():
+    disable_default_compression_via_period()
     num_files=1
     copies_count=1024
     size=16*KB
-    disable_default_compression()
     prepare_test()
     files=[]
     gen_files_fixed_copies(files, num_files, size, copies_count)
@@ -4207,6 +4095,7 @@ def test_dedup_filter_bucket_list_parsing():
     """Validate CLI parsing of bucket filter list files (allow/deny).
     Verify that illegal files are rejected
     """
+    disable_default_compression_via_period()
     prepare_test()
     try:
         # 1. Mutual exclusivity: --allow-bucket-list and --deny-bucket-list together.
@@ -4246,6 +4135,7 @@ def test_dedup_filter_storage_class_list_parsing():
     """Validate CLI parsing of storage_class filter list files (allow/deny).
     Verify that illegal files are rejected
     """
+    disable_default_compression_via_period()
     prepare_test()
     try:
         # 1. Mutual exclusivity: --allow-storage-class-list and --deny-storage-class-list together.
@@ -4402,17 +4292,12 @@ def dedup_filter_allow_deny_storage_class_common(dry_run, filter_mode_allow):
         expected_dedup_stats.size_before_dedup = dedup_stats.size_before_dedup
         assert dedup_stats == expected_dedup_stats
     finally:
-        cleanup_local()
-        try:
-            delete_bucket_with_all_objects(bucket_name, conn)
-        except Exception as e:
-            log.warning("Failed to cleanup bucket %s: %s", bucket_name, e)
-
-        verify_pool_is_empty(conn)
+        cleanup(bucket_name, conn)
 
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_filter_storage_class_estimate():
+    disable_default_compression_via_period()
     dry_run=True
 
     log.info("dedup_filter_storage_class_estimate: filter_mode_allow")
@@ -4424,6 +4309,7 @@ def test_dedup_filter_storage_class_estimate():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_filter_storage_class_exec():
+    disable_default_compression_via_period()
     dry_run=False
 
     log.info("dedup_filter_storage_class_exec: filter_mode_allow")
@@ -4541,18 +4427,14 @@ def dedup_filter_allow_deny_bucket_common(dry_run, filter_mode_allow):
         assert skip_sc     == 0
         assert skip_bucket == num_filtered
     finally:
-        cleanup_local()
-        for b in bucket_names:
-            try:
-                delete_bucket_with_all_objects(b, conn)
-            except Exception as e:
-                log.warning("Failed to cleanup bucket %s: %s", b, e)
+        conns=[conn] * len(bucket_names)
+        cleanup_all_buckets(bucket_names, conns)
 
-        verify_pool_is_empty(conn)
 
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_filter_bucket_estimate():
+    disable_default_compression_via_period()
     dry_run=True
     log.info("dedup_filter_bucket_estimate: filter_mode_deny")
     dedup_filter_allow_deny_bucket_common(dry_run, filter_mode_allow=False)
@@ -4563,6 +4445,7 @@ def test_dedup_filter_bucket_estimate():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_filter_bucket_exec():
+    disable_default_compression_via_period()
     dry_run=False
     log.info("dedup_filter_bucket_exec: filter_mode_deny")
     dedup_filter_allow_deny_bucket_common(dry_run, filter_mode_allow=False)
@@ -4572,257 +4455,296 @@ def test_dedup_filter_bucket_exec():
 
 
 #-------------------------------------------------------------------------------
-#-------------------------------------------------------------------------------
 #                              Compression helpers
 #-------------------------------------------------------------------------------
-#-------------------------------------------------------------------------------
-def _find_rgw_procs():
-    """Find running radosgw daemons via their --pid-file arguments.
 
-    Scans /proc for processes whose argv[0] basename is 'radosgw' and
-    extracts the --pid-file path from their command line.  Returns a list
-    of (pid, argv_list, pid_file_path) tuples.
-    """
-    import glob as globmod
-    procs = []
-    for cmdline_path in globmod.glob('/proc/[0-9]*/cmdline'):
-        try:
-            with open(cmdline_path, 'rb') as f:
-                raw = f.read()
-            if not raw:
-                continue
-            argv = raw.rstrip(b'\x00').split(b'\x00')
-            exe = os.path.basename(argv[0].decode('utf-8', errors='replace'))
-            if exe != 'radosgw':
-                continue
-            pid = int(cmdline_path.split('/')[2])
-            cmd_list = [a.decode('utf-8', errors='replace') for a in argv]
-            pid_file = None
-            for i, arg in enumerate(cmd_list):
-                if arg.startswith('--pid-file='):
-                    pid_file = arg.split('=', 1)[1]
-                elif arg == '--pid-file' and i + 1 < len(cmd_list):
-                    pid_file = cmd_list[i + 1]
-            procs.append((pid, cmd_list, pid_file))
-        except (OSError, ValueError, IndexError):
-            continue
-    return procs
+original_compression_period = None
+compression_state_period    = None
+compression_modified_period = False
 
+DEFAULT_PLACEMENT = 'default-placement'
+STANDARD_STORAGE_CLASS = 'STANDARD'
 
 #-------------------------------------------------------------------------------
-def restart_all_rgw():
-    """Restart every radosgw daemon preserving its original command line.
-
-    1. Find radosgw processes via /proc scan (exact basename match).
-    2. Record each process's full argv and --pid-file path.
-    3. SIGTERM all, wait for exit.
-    4. Re-launch each with the original argv.
-    5. Wait for the pid-file to be re-written (confirms daemon is up),
-       then verify TCP connectivity on the test port.
-    """
-    import signal
-
-    procs = _find_rgw_procs()
-    if not procs:
-        log.warning("No running radosgw processes found")
-        return
-
-    log.debug("Found %d radosgw process(es) to restart", len(procs))
-    for pid, cmd_list, pid_file in procs:
-        log.debug("  pid=%d  pid_file=%s", pid, pid_file)
-
-    # stop all
-    for pid, _, _ in procs:
-        log.debug("Sending SIGTERM to radosgw pid %d", pid)
-        os.kill(pid, signal.SIGTERM)
-
-    log.info("Sent SIGTERM to all radosgw")
-    for pid, _, pid_file in procs:
-        for _ in range(30):
-            try:
-                os.kill(pid, 0)
-                time.sleep(0.5)
-            except OSError:
-                break
-        else:
-            log.warning("radosgw pid %d did not exit, sending SIGKILL", pid)
-            try:
-                os.kill(pid, signal.SIGKILL)
-            except OSError:
-                pass
-            time.sleep(1)
-        # remove stale pid file so we can detect the new one
-        if pid_file:
-            try:
-                os.remove(pid_file)
-            except OSError:
-                pass
-
-    # wait for the port to be free before restarting
-    port_no = get_config_port()
-    hostname = get_config_host()
-    import socket
-    log.debug("Waiting for port %d to be free...", port_no)
-    for attempt in range(60):
-        try:
-            s = socket.create_connection((hostname, port_no), timeout=1)
-            s.close()
-            time.sleep(1)
-        except (ConnectionRefusedError, OSError):
-            log.debug("Port %d is free after %d seconds", port_no, attempt)
-            break
-    else:
-        log.warning("Port %d still appears busy after 60s, proceeding anyway",
-                    port_no)
-
-    # restart all
-    log.info("Restarting all radosgw");
-    for _, cmd_list, pid_file in procs:
-        log.debug("Restarting radosgw: %s", ' '.join(cmd_list))
-        subprocess.Popen(cmd_list)
-
-    # wait for each daemon to write its pid file (proves it daemonized)
-    for _, cmd_list, pid_file in procs:
-        if not pid_file:
-            continue
-        for attempt in range(60):
-            if os.path.exists(pid_file):
-                try:
-                    with open(pid_file) as f:
-                        new_pid = int(f.read().strip())
-                    os.kill(new_pid, 0)
-                    log.debug("radosgw restarted as pid %d (%s)",
-                             new_pid, pid_file)
-                    break
-                except (OSError, ValueError):
-                    pass
-            time.sleep(1)
-        else:
-            raise RuntimeError("radosgw did not restart: pid file %s "
-                               "not created after 60s" % pid_file)
-
-    # also verify TCP connectivity on the test port
-    for attempt in range(60):
-        try:
-            s = socket.create_connection((hostname, port_no), timeout=2)
-            s.close()
-            log.debug("radosgw listening on %s:%d", hostname, port_no)
-            return
-        except (ConnectionRefusedError, OSError):
-            time.sleep(1)
-    raise RuntimeError("radosgw pid file appeared but port %d not listening "
-                       "after 60s" % port_no)
-
-
-_original_compression = None
-_compression_state = None     # current state: None=unknown, 'none', or 'zlib' etc.
-
-#-------------------------------------------------------------------------------
-def _get_default_placement_compression():
-    """Read the compression type currently set on default-placement."""
-    result = admin(['zone', 'get', '--rgw-zone', 'default'])
+def _get_zone_default_placement_val(zone_name):
+    """Return val dict for default-placement in zone_name."""
+    result = admin(['zone', 'get', '--rgw-zone', zone_name])
     assert result[1] == 0, "zone get failed: " + result[0]
     zone = json.loads(result[0])
     for p in zone.get('placement_pools', []):
-        if p.get('key') == 'default-placement':
-            val = p.get('val', {})
-            sc = val.get('storage_classes', {})
-            std = sc.get('STANDARD', {})
-            return std.get('compression_type', '')
-    assert False, "default-placement not found in zone config"
+        if p.get('key') == DEFAULT_PLACEMENT:
+            return p.get('val', {})
+    assert False, "default-placement not found in zone config for zone %s" % zone_name
 
 
 #-------------------------------------------------------------------------------
-def _is_compression_active(value):
-    """Return True if value represents an active compression setting."""
-    return bool(value) and value.lower() not in ('', 'none')
+def get_zone_placement_storage_classes(zone_name):
+    """Return storage_classes dict for default-placement in zone_name."""
+    return _get_zone_default_placement_val(zone_name).get('storage_classes', {})
 
 
 #-------------------------------------------------------------------------------
-def enable_disable_default_compression(compression_type):
-    """Set compression on default-placement, with RGW restart if needed.
+def get_placement_sc_compression(zone_name, storage_class):
+    """Read compression type for a storage class on default-placement."""
+    info = get_zone_placement_storage_classes(zone_name).get(storage_class, {})
+    return info.get('compression_type', '')
 
-    On first call, reads the system state and saves it as _original_compression.
-    If the current state already matches the requested type, no restart is done.
+
+#-------------------------------------------------------------------------------
+def get_placement_compression(zone_name):
+    """Read compression type on default-placement STANDARD for zone_name."""
+    return get_placement_sc_compression(zone_name, STANDARD_STORAGE_CLASS)
+
+
+#-------------------------------------------------------------------------------
+def ensure_storage_class(storage_class):
+    """Add storage_class to default-placement if not already configured.
+
+    Returns True if the storage class was added, False if it already existed.
+    """
+    zone_name = get_config_zone()
+    zonegroup = get_config_zonegroup()
+    assert zone_name, "zone must be set in DEDUPTESTS_CONF"
+    assert zonegroup, "zonegroup must be set in DEDUPTESTS_CONF"
+
+    if storage_class in get_zone_placement_storage_classes(zone_name):
+        log.info("storage class %s already configured on zone %s",
+                 storage_class, zone_name)
+        return False
+
+    data_pool = get_config_data_pool()
+    result = admin(['zonegroup', 'placement', 'add',
+                    '--rgw-zonegroup', zonegroup,
+                    '--placement-id', DEFAULT_PLACEMENT,
+                    '--storage-class', storage_class])
+    assert result[1] == 0, ("zonegroup placement add failed for %s: %s"
+                              % (storage_class, result[0]))
+
+    result = admin(['zone', 'placement', 'add',
+                    '--rgw-zone', zone_name,
+                    '--placement-id', DEFAULT_PLACEMENT,
+                    '--storage-class', storage_class,
+                    '--data-pool', data_pool,
+                    '--compression', 'none'])
+    assert result[1] == 0, ("zone placement add failed for %s: %s"
+                            % (storage_class, result[0]))
+    commit_period()
+    wait_for_placement_storage_class(zone_name, storage_class, present=True)
+    log.info("Added storage class %s to zone %s", storage_class, zone_name)
+    return True
+
+
+#-------------------------------------------------------------------------------
+def remove_storage_class(storage_class):
+    """Remove storage_class from default-placement on zone and zonegroup."""
+    zone_name = get_config_zone()
+    zonegroup = get_config_zonegroup()
+    assert zone_name, "zone must be set in DEDUPTESTS_CONF"
+    assert zonegroup, "zonegroup must be set in DEDUPTESTS_CONF"
+    assert storage_class != STANDARD_STORAGE_CLASS, \
+        "cannot remove STANDARD storage class"
+
+    if storage_class not in get_zone_placement_storage_classes(zone_name):
+        log.info("storage class %s not configured on zone %s, nothing to remove",
+                 storage_class, zone_name)
+        return
+
+    result = admin(['zone', 'placement', 'rm',
+                    '--rgw-zone', zone_name,
+                    '--placement-id', DEFAULT_PLACEMENT,
+                    '--storage-class', storage_class])
+    assert result[1] == 0, ("zone placement rm failed for %s: %s"
+                            % (storage_class, result[0]))
+
+    result = admin(['zonegroup', 'placement', 'rm',
+                    '--rgw-zonegroup', zonegroup,
+                    '--placement-id', DEFAULT_PLACEMENT,
+                    '--storage-class', storage_class])
+    assert result[1] == 0, ("zonegroup placement rm failed for %s: %s"
+                            % (storage_class, result[0]))
+    commit_period()
+    wait_for_placement_storage_class(zone_name, storage_class, present=False)
+    log.info("Removed storage class %s from zone %s", storage_class, zone_name)
+
+
+#-------------------------------------------------------------------------------
+def set_placement_sc_compression(storage_class, compression_type):
+    """Set compression on default-placement for one storage class."""
+    zone_name = get_config_zone()
+    assert zone_name, "zone must be set in DEDUPTESTS_CONF for period-based compression"
+
+    current = normalize_compression_type(get_placement_sc_compression(zone_name, storage_class))
+    target = normalize_compression_type(compression_type)
+    if current == target:
+        log.info("zone '%s' %s compression already '%s'",
+                 zone_name, storage_class, current)
+        return
+
+    result = admin(['zone', 'placement', 'modify',
+                    '--rgw-zone', zone_name,
+                    '--placement-id', DEFAULT_PLACEMENT,
+                    '--storage-class', storage_class,
+                    '--compression', compression_type])
+    assert result[1] == 0, ("Failed to set %s compression: %s"
+                            % (storage_class, result[0]))
+    commit_period()
+    wait_for_placement_sc_compression(zone_name, storage_class, target)
+    log.info("Set %s compression on zone '%s' default-placement to '%s'",
+             storage_class, zone_name, compression_type)
+
+
+#-------------------------------------------------------------------------------
+def restore_placement_sc_compression(storage_class, compression_type):
+    """Restore per-SC compression saved before a test (empty means none)."""
+    target = compression_type if compression_type else 'none'
+    set_placement_sc_compression(storage_class, target)
+
+
+#-------------------------------------------------------------------------------
+def normalize_compression_type(compression_type):
+    if compression_type:
+        return compression_type.lower()
+    return 'none'
+
+#-------------------------------------------------------------------------------
+def wait_for_placement_sc_compression(zone_name, storage_class, expected,
+                                      timeout=60, interval=0.5):
+    """Poll zone config until compression matches expected after period commit."""
+    expected = normalize_compression_type(expected)
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        current = normalize_compression_type(
+            get_placement_sc_compression(zone_name, storage_class))
+        if current == expected:
+            return
+        time.sleep(interval)
+
+    current = normalize_compression_type(
+        get_placement_sc_compression(zone_name, storage_class))
+    raise AssertionError(
+        "compression on zone '%s' %s is '%s', expected '%s' after period commit "
+        "(timeout=%ds)" % (zone_name, storage_class, current, expected, timeout))
+
+#-------------------------------------------------------------------------------
+def wait_for_placement_storage_class(zone_name, storage_class, present,
+                                     timeout=60, interval=0.5):
+    """Poll zone config until storage class presence matches expected after period commit."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        configured = storage_class in get_zone_placement_storage_classes(zone_name)
+        if configured == present:
+            return
+        time.sleep(interval)
+
+    configured = storage_class in get_zone_placement_storage_classes(zone_name)
+    state = "present" if configured else "absent"
+    expected_state = "present" if present else "absent"
+    raise AssertionError(
+        "storage class '%s' on zone '%s' is %s, expected %s after period commit "
+        "(timeout=%ds)" % (storage_class, zone_name, state, expected_state, timeout))
+
+#-------------------------------------------------------------------------------
+def commit_period():
+    """Publish zone/zonegroup changes to running RGW daemons without restart."""
+    result = admin(['period', 'update'])
+    assert result[1] == 0, "period update failed: " + result[0]
+    result = admin(['period', 'commit'])
+    assert result[1] == 0, "period commit failed: " + result[0]
+
+    # realm reloader applies the new period asynchronously
+    time.sleep(5)
+
+
+#-------------------------------------------------------------------------------
+def enable_disable_default_compression_via_period(compression_type):
+    """Set compression on default-placement and apply via period update --commit.
+
+    For multisite/realm deployments: reloads running RGW without restart.
+    Requires zone name in DEDUPTESTS_CONF (see deduptests.conf.SAMPLE).
     Pass 'none' to disable compression.
     """
-    global _original_compression, _compression_state
+    global original_compression_period, compression_state_period
+    global compression_modified_period
 
-    current = _get_default_placement_compression()
+    zone_name = get_config_zone()
+    assert zone_name, "zone must be set in DEDUPTESTS_CONF for period-based compression"
 
-    if _original_compression is None:
-        _original_compression = current
-        log.info("Saved original compression setting: '%s'", current)
+    current = get_placement_sc_compression(zone_name, STANDARD_STORAGE_CLASS)
 
-    target = 'none'
-    if compression_type:
-        target = compression_type.lower()
-    actual = 'none'
-    if current:
-        actual = current.lower()
+    if original_compression_period is None:
+        original_compression_period = current
+        log.info("Saved original compression setting for zone '%s': '%s'",
+                 zone_name, current)
+
+    target = normalize_compression_type(compression_type)
+    actual = normalize_compression_type(current)
 
     if actual == target:
-        log.info("default-placement compression already '%s', no change needed",
-                 actual)
-        _compression_state = actual
+        log.info("zone '%s' default-placement compression already '%s', no change needed",
+                 zone_name, actual)
+        compression_state_period = actual
         return
 
-    result = admin(['zone', 'placement', 'modify',
-                    '--rgw-zone', 'default',
-                    '--placement-id', 'default-placement',
-                    '--compression', compression_type])
-    assert result[1] == 0, "Failed to set compression: " + result[0]
+    set_placement_sc_compression(STANDARD_STORAGE_CLASS, compression_type)
 
-    restart_all_rgw()
-    _compression_state = target
-    log.info("Set compression on default-placement to '%s' (was '%s')",
-             compression_type, actual)
+    compression_state_period = target
+    compression_modified_period = True
+    log.info("Set compression on zone '%s' default-placement to '%s' (was '%s')",
+             zone_name, compression_type, actual)
 
 
 #-------------------------------------------------------------------------------
-def enable_default_compression():
-    enable_disable_default_compression(compression_type='zlib')
+def enable_default_compression_via_period():
+    enable_disable_default_compression_via_period(compression_type='zlib')
 
 #-------------------------------------------------------------------------------
-def disable_default_compression():
-    enable_disable_default_compression(compression_type='none')
+def disable_default_compression_via_period():
+    enable_disable_default_compression_via_period(compression_type='none')
 
 #-------------------------------------------------------------------------------
-def restore_default_compression():
-    """Restore original compression setting on default-placement if we changed it."""
-    global _original_compression, _compression_state
+def restore_default_compression_via_period():
+    """Restore original compression on default-placement via period update --commit."""
+    global original_compression_period, compression_state_period
+    global compression_modified_period
 
-    if _original_compression is None:
+    if not compression_modified_period:
         return
 
-    restore = _original_compression if _original_compression else 'none'
-    current = _compression_state if _compression_state else 'none'
+    if original_compression_period is None:
+        return
+
+    log.info("Teardown: Restore original compression setting")
+
+    zone_name = get_config_zone()
+    assert zone_name, "zone must be set in DEDUPTESTS_CONF for period-based compression"
+
+    restore = normalize_compression_type(original_compression_period)
+    current = compression_state_period if compression_state_period else 'none'
 
     if current == restore:
-        log.info("Compression already at original value '%s', no restore needed",
-                 restore)
+        log.info("Compression on zone '%s' already at original value '%s', no restore needed",
+                 zone_name, restore)
         return
 
-    result = admin(['zone', 'placement', 'modify',
-                    '--rgw-zone', 'default',
-                    '--placement-id', 'default-placement',
-                    '--compression', restore])
-    assert result[1] == 0, "Failed to restore compression to '%s': %s" % (restore, result[0])
-
-    restart_all_rgw()
-    _compression_state = restore
-    log.info("Restored compression on default-placement to '%s'", restore)
-
+    set_placement_sc_compression(STANDARD_STORAGE_CLASS, restore)
+    compression_state_period = restore
+    log.info("Restored compression on zone '%s' default-placement to '%s'",
+             zone_name, restore)
 
 #-------------------------------------------------------------------------------
 def post_dedup_count(num_objs, num_copies, rados_count_before, split_head_count):
-    head_count = num_objs * num_copies;
+    head_count = num_objs * num_copies
     tail_count = rados_count_before - head_count
+    assert tail_count % num_copies == 0, (
+        "tail_count=%d not divisible by num_copies=%d "
+        "(rados_before=%d, head_count=%d, num_objs=%d)" %
+        (tail_count, num_copies, rados_count_before, head_count, num_objs))
 
-    log.debug("num_objs=%d, num_copies=%d, split=%d, head_count=%d, tail_count=%d",
-              num_objs, num_copies, split_head_count, head_count, tail_count)
+    log.info("num_objs=%d, num_copies=%d, split=%d, head_count=%d, tail_count=%d",
+             num_objs, num_copies, split_head_count, head_count, tail_count)
 
-    return (head_count + tail_count/num_copies + split_head_count)
+    return head_count + tail_count // num_copies + split_head_count
+
 
 #-------------------------------------------------------------------------------
 def _dedup_mode_switch_test(start_compressed):
@@ -4841,47 +4763,53 @@ def _dedup_mode_switch_test(start_compressed):
       5) Every S3 object is still readable and matches the original file.
       6) After deleting all objects + GC the pool is empty.
     """
-    if full_dedup_is_disabled():
-        return
-
     prepare_test()
     config = default_config
-    files = []
-    sizes = [127*KB, 2*MB+3*KB, 7*MB, 11*MB, 13*MB, 16*MB, 17*MB, 32*MB, 67*MB]
-    for size in sizes:
-        gen_files_fixed_copies(files, 1, size, 1)
-
     num_copies = 2
+    files = []
+    sizes = [129*KB, 2*MB+3*KB, 7*MB, 11*MB, 13*MB, 16*MB, 17*MB, 32*MB, 67*MB]
     conn = get_single_connection()
     bucket_names = get_buckets(num_copies)
-
-    if start_compressed:
-        first_mode_label = "compressed"
-        final_mode_label = "uncompressed"
-        enable_default_compression()
-    else:
-        first_mode_label = "uncompressed"
-        final_mode_label = "compressed"
-        disable_default_compression()
+    created_buckets = []
 
     try:
+        for size in sizes:
+            # Make sure obj will be eligible for dedup even if was compressed
+            # multipart_threshold is safe since checked before upload/compress
+            assert size/2 >= DEDUP_MIN_OBJ_SIZE
+            gen_files_fixed_copies(files, 1, size, num_copies)
+
+        if start_compressed:
+            first_mode_label = "compressed"
+            final_mode_label = "uncompressed"
+            enable_default_compression_via_period()
+        else:
+            first_mode_label = "uncompressed"
+            final_mode_label = "compressed"
+            disable_default_compression_via_period()
+
         # phase 1: upload to bucket[0] in the starting mode
         idx = 0
         conn.create_bucket(Bucket=bucket_names[idx])
-        _upload_to_bucket(conn, bucket_names[idx], files, config, idx)
+        created_buckets.append(bucket_names[idx])
+        upload_to_bucket(conn, bucket_names[idx], files, config, idx)
         log.info("Phase 1: uploaded %d files to %s (%s)",
                  len(files), bucket_names[idx], first_mode_label)
 
+        rados_bucket0 = count_object_parts_in_all_buckets(True)
+        log.info("RADOS object count bucket[0]: %d", rados_bucket0)
+
         # switch compression mode
         if start_compressed:
-            disable_default_compression()
+            disable_default_compression_via_period()
         else:
-            enable_default_compression()
+            enable_default_compression_via_period()
 
         # phase 2: upload identical objects to bucket[1] in the new mode
         idx = 1
         conn.create_bucket(Bucket=bucket_names[idx])
-        _upload_to_bucket(conn, bucket_names[idx], files, config, idx)
+        created_buckets.append(bucket_names[idx])
+        upload_to_bucket(conn, bucket_names[idx], files, config, idx)
         log.info("Phase 2: uploaded %d files to %s (%s)",
                  len(files), bucket_names[idx], final_mode_label)
 
@@ -4891,8 +4819,9 @@ def _dedup_mode_switch_test(start_compressed):
         assert_bucket_compression(bucket_names[1], files, 1,
                                   not start_compressed, "PRE-DEDUP")
 
-        rados_count_before = count_object_parts_in_all_buckets(True)
-        log.info("RADOS object count before dedup: %d", rados_count_before)
+        rados_bucket0_and_bucket1 = count_object_parts_in_all_buckets(True)
+        rados_bucket1 = rados_bucket0_and_bucket1 - rados_bucket0
+        log.info("RADOS object count bucket[1]: %d", rados_bucket1)
 
         # build expected stats
         expected_stats = Dedup_Stats()
@@ -4912,9 +4841,14 @@ def _dedup_mode_switch_test(start_compressed):
                 else:
                     expected_stats.set_compression_on_tgt += 1
 
-        expected_rados_count = post_dedup_count(len(files), num_copies,
-                                                rados_count_before,
-                                                split_head_objs)
+        num_files = len(files)
+
+        # Bucket[0] is uploaded first (will become TGT).
+        # Bucket[1] holds the SRC copy (matches final placement compression in
+        #           mode-switch tests)
+        # TGT tail objects are removed; SRC tails remain.
+        src_bucket_count = rados_bucket1 + split_head_objs
+        expected_rados_count = src_bucket_count + num_files
 
         ret = exec_dedup_internal(expected_stats, dry_run=False, max_dedup_time=300)
         actual_stats = ret[1]
@@ -4927,8 +4861,10 @@ def _dedup_mode_switch_test(start_compressed):
         log.info("RADOS object count after dedup: %d (expected=%d)",
                  rados_count_after, expected_rados_count)
         assert rados_count_after == expected_rados_count, \
-            ("Bad RADOS object count: before=%d, expected=%d, after=%d"
-             % (rados_count_before, expected_rados_count, rados_count_after))
+            ("Bad RADOS object count: before=%d, expected=%d, after=%d "
+             "(rados_bucket0=%d)" %
+             (rados_bucket0_and_bucket1, expected_rados_count, rados_count_after,
+              rados_bucket0))
 
         # post-dedup: all objects in both buckets should match the final mode
         final_compressed = not start_compressed
@@ -4937,15 +4873,13 @@ def _dedup_mode_switch_test(start_compressed):
 
         # verify all objects are still readable
         conns=[conn] * len(bucket_names)
-        verify_objects_multi(files, conns, bucket_names, 0, config, False)
+        verify_objects_multi(files, conns, bucket_names, 0, config, True)
         log.info("All objects verified after mode-switch dedup "
                  "(%s -> %s)", first_mode_label, final_mode_label)
     finally:
-        for bucket in bucket_names:
-            delete_bucket_with_all_objects(bucket, conn)
-        verify_pool_is_empty(conn)
-        cleanup_local()
-
+        restore_default_compression_via_period()
+        conns=[conn] * len(created_buckets)
+        cleanup_all_buckets(created_buckets, conns)
 
 #-------------------------------------------------------------------------------
 def is_object_compressed(bucket_name, object_key):
@@ -4954,7 +4888,8 @@ def is_object_compressed(bucket_name, object_key):
     Uses radosgw-admin object stat with latin-1 decoding because the
     output may contain binary attribute data that is not valid UTF-8.
     """
-    cmd = [test_path + 'test-rgw-call.sh', 'call_rgw_admin', 'noname',
+    cluster=get_config_cluster()
+    cmd = [test_path + 'test-rgw-call.sh', 'call_rgw_admin', cluster,
            'object', 'stat', '--bucket', bucket_name,
            '--object', object_key]
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
@@ -5001,13 +4936,146 @@ def assert_bucket_compression(bucket_name, files, idx, expect_compressed, tag):
 
 
 #-------------------------------------------------------------------------------
-def _upload_to_bucket(conn, bucket_name, files, config, idx=0):
+def create_bucket_with_placement(conn, bucket_name, placement_id=DEFAULT_PLACEMENT,
+                                 storage_class=None):
+    """Create a bucket bound to placement_id and optional storage class."""
+    sc = storage_class or STANDARD_STORAGE_CLASS
+    if placement_id == DEFAULT_PLACEMENT and sc == STANDARD_STORAGE_CLASS:
+        conn.create_bucket(Bucket=bucket_name)
+        log.info("created bucket %s on %s/%s", bucket_name, placement_id, sc)
+        return
+
+    zonegroup = get_config_zonegroup()
+    assert zonegroup, "zonegroup must be set in DEDUPTESTS_CONF"
+    location = '%s:%s' % (zonegroup, placement_id)
+    params = {
+        'Bucket': bucket_name,
+        'CreateBucketConfiguration': {'LocationConstraint': location},
+    }
+
+    handler = None
+    if sc != STANDARD_STORAGE_CLASS:
+        def add_storage_class_header(request, **kwargs):
+            request.headers['x-amz-storage-class'] = sc
+        handler = add_storage_class_header
+        conn.meta.events.register('before-sign.s3.CreateBucket', handler)
+    try:
+        conn.create_bucket(**params)
+        log.info("created bucket %s on %s/%s", bucket_name, placement_id, sc)
+    finally:
+        if handler:
+            conn.meta.events.unregister('before-sign.s3.CreateBucket', handler)
+
+
+#-------------------------------------------------------------------------------
+def upload_to_bucket(conn, bucket_name, files, config, idx=0):
     """Upload all files (one copy each) to a single bucket."""
     for f in files:
         filename = f[0]
         key = gen_object_name(filename, idx)
         conn.upload_file(OUT_DIR + filename, bucket_name, key, Config=config)
         log.debug("uploaded %s -> %s/%s", filename, bucket_name, key)
+
+#-------------------------------------------------------------------------------
+@pytest.mark.basic_test
+def test_dedup_placement_compression_cache_per_storage_class():
+    """Per-SC placement compression cache (rule.to_str(), not placement name alone).
+
+    - Startup:
+       Set compression-mode on SC1=STANDARD to none on default-placement.
+       Set compression-mode on SC2=LUKEWARM to zlib on default-placement.
+    - Upload one copy per SC
+    - Flip compression (SC1 none->zlib, SC2 zlib->none)
+    - Upload a second copy per SC
+    - Run dedup
+    - Verify that after dedup SC1 copies are all compressed
+             and SC2 copies all uncompressed.
+    - Return system to initial state
+    """
+    sc1 = STANDARD_STORAGE_CLASS
+    sc2 = 'LUKEWARM'
+    prepare_test()
+    config = default_config
+    num_copies = 2
+    files = []
+    sizes = [127*KB, 2*MB+3*KB, 7*MB, 11*MB, 13*MB, 16*MB]
+    for idx, size in enumerate(sizes):
+        gen_files_fixed_copies(files, 1, size, num_copies)
+
+    conn = get_single_connection()
+    bucket_sc1 = gen_bucket_name()
+    bucket_sc2 = gen_bucket_name()
+    created_buckets = []
+    zone_name = get_config_zone()
+    assert zone_name, "zone must be set in DEDUPTESTS_CONF for period-based compression"
+    orig_sc1_compression = get_placement_sc_compression(zone_name, sc1)
+    orig_sc2_compression = None
+    added_sc2 = False
+
+    try:
+        added_sc2 = ensure_storage_class(sc2)
+        if not added_sc2:
+            orig_sc2_compression = get_placement_sc_compression(zone_name, sc2)
+
+        set_placement_sc_compression(sc1, 'none')
+        set_placement_sc_compression(sc2, 'zlib')
+
+        create_bucket_with_placement(conn, bucket_sc1, DEFAULT_PLACEMENT, sc1)
+        created_buckets.append(bucket_sc1)
+        create_bucket_with_placement(conn, bucket_sc2, DEFAULT_PLACEMENT, sc2)
+        created_buckets.append(bucket_sc2)
+
+        upload_to_bucket(conn, bucket_sc1, files, config, 0)
+        upload_to_bucket(conn, bucket_sc2, files, config, 0)
+
+        set_placement_sc_compression(sc1, 'zlib')
+        set_placement_sc_compression(sc2, 'none')
+
+        upload_to_bucket(conn, bucket_sc1, files, config, 1)
+        upload_to_bucket(conn, bucket_sc2, files, config, 1)
+
+        assert_bucket_compression(bucket_sc1, files, 0, False, "PRE-DEDUP-SC1")
+        assert_bucket_compression(bucket_sc1, files, 1, True,  "PRE-DEDUP-SC1")
+        assert_bucket_compression(bucket_sc2, files, 0, True,  "PRE-DEDUP-SC2")
+        assert_bucket_compression(bucket_sc2, files, 1, False, "PRE-DEDUP-SC2")
+
+        expected_stats = Dedup_Stats()
+        split_head_objs = 0
+        for obj_size in sizes:
+            split_head_objs += calc_split_objs_count(obj_size, num_copies, config)
+            calc_expected_stats(expected_stats, obj_size, num_copies, config)
+            calc_expected_stats(expected_stats, obj_size, num_copies, config)
+            on_disk = calc_on_disk_byte_size(obj_size)
+            expected_stats.compressed_objs += 2
+            expected_stats.compressed_bytes += (on_disk * 2)
+            if on_disk >= DEDUP_MIN_OBJ_SIZE:
+                expected_stats.set_compression_on_tgt += 1
+                expected_stats.clear_compression_on_tgt += 1
+
+        expected_stats.non_default_storage_class_objs_bytes = expected_stats.size_before_dedup/2
+        ret = exec_dedup_internal(expected_stats, dry_run=False, max_dedup_time=300)
+        actual_stats = ret[1]
+        if actual_stats != expected_stats:
+            print_dedup_stats_diff(actual_stats, expected_stats)
+            assert False, "placement compression cache dedup stat mismatch"
+
+        assert_bucket_compression(bucket_sc1, files, 0, True,  "POST-DEDUP-SC1")
+        assert_bucket_compression(bucket_sc1, files, 1, True,  "POST-DEDUP-SC1")
+        assert_bucket_compression(bucket_sc2, files, 0, False, "POST-DEDUP-SC2")
+        assert_bucket_compression(bucket_sc2, files, 1, False, "POST-DEDUP-SC2")
+
+        log.info("verify_objects(bucket_sc1, files..)")
+        verify_objects(bucket_sc1, files, conn, 0, default_config, True)
+        log.info("verify_objects(bucket_sc2, files..)")
+        verify_objects(bucket_sc2, files, conn, 0, default_config, True)
+    finally:
+        cleanup_all_buckets(created_buckets, [conn, conn])
+        restore_placement_sc_compression(sc1, orig_sc1_compression)
+        if added_sc2:
+            remove_storage_class(sc2)
+        elif orig_sc2_compression is not None:
+            restore_placement_sc_compression(sc2, orig_sc2_compression)
+
 
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
@@ -5050,15 +5118,17 @@ def _dedup_inc_shared_manifest_test(start_compressed):
     Post-dedup: all objects in all 3 buckets have the starting mode's
     compression state (the SRC's mode from cycle 1 wins).
     """
-    if full_dedup_is_disabled():
-        return
-
     prepare_test()
     config = default_config
+    num_copies = 2
+    verify_copies = num_copies + 1
     files = []
-    sizes = [127*KB, 2*MB+3*KB, 7*MB, 11*MB, 13*MB, 16*MB, 17*MB, 32*MB, 67*MB]
+    sizes = [129*KB, 2*MB+3*KB, 7*MB, 11*MB, 13*MB, 16*MB, 17*MB, 32*MB, 67*MB]
     for size in sizes:
-        gen_files_fixed_copies(files, 1, size, 1)
+        # Make sure obj will be eligible for dedup even if was compressed
+        # multipart_threshold is safe since checked before upload/compress
+        assert size/2 >= DEDUP_MIN_OBJ_SIZE
+        gen_files_fixed_copies(files, 1, size, verify_copies)
 
     num_files = len(files)
     conn = get_single_connection()
@@ -5067,17 +5137,19 @@ def _dedup_inc_shared_manifest_test(start_compressed):
     if start_compressed:
         first_mode_label = "compressed"
         final_mode_label = "uncompressed"
-        enable_default_compression()
+        enable_default_compression_via_period()
     else:
         first_mode_label = "uncompressed"
         final_mode_label = "compressed"
-        disable_default_compression()
+        disable_default_compression_via_period()
 
+    created_buckets = []
     try:
         # -- phase 1: two buckets in starting mode, first dedup ---------------
         for idx in range(2):
             conn.create_bucket(Bucket=bucket_names[idx])
-            _upload_to_bucket(conn, bucket_names[idx], files, config, idx)
+            created_buckets.append(bucket_names[idx])
+            upload_to_bucket(conn, bucket_names[idx], files, config, idx)
 
         log.info("Phase 1: uploaded %d files to %s and %s (%s)",
                  num_files, bucket_names[0], bucket_names[1], first_mode_label)
@@ -5096,19 +5168,20 @@ def _dedup_inc_shared_manifest_test(start_compressed):
         num_dedupable = 0
         for f in files:
             obj_size = f[1]
-            split_head_1 += calc_split_objs_count(obj_size, 2, config)
-            calc_expected_stats(expected_1, obj_size, 2, config)
+            split_head_1 += calc_split_objs_count(obj_size, num_copies, config)
+            calc_expected_stats(expected_1, obj_size, num_copies, config)
             on_disk = calc_on_disk_byte_size(obj_size)
             if on_disk >= DEDUP_MIN_OBJ_SIZE:
                 num_dedupable += 1
             if start_compressed:
-                expected_1.compressed_objs += 2
-                expected_1.compressed_bytes += (on_disk * 2)
+                expected_1.compressed_objs += num_copies
+                expected_1.compressed_bytes += (on_disk * num_copies)
 
         if start_compressed:
             expected_1.deduped_compressed_objects = expected_1.deduped_obj
 
-        expected_rados_1 = post_dedup_count(num_files, 2, rados_before_1, split_head_1)
+        expected_rados_1 = post_dedup_count(num_files, num_copies, rados_before_1,
+                                            split_head_1)
 
         ret = exec_dedup_internal(expected_1, dry_run=False, max_dedup_time=300)
         actual_1 = ret[1]
@@ -5120,18 +5193,19 @@ def _dedup_inc_shared_manifest_test(start_compressed):
         log.info("RADOS count after dedup-1: %d (expected=%d)",
                  rados_after_1, expected_rados_1)
         assert rados_after_1 == expected_rados_1, \
-            ("Cycle 1 RADOS count: before=%d, expected=%d, after=%d"
-             % (rados_before_1, expected_rados_1, rados_after_1))
+            ("Cycle 1 RADOS count: before=%d, expected=%d, after=%d" %
+             (rados_before_1, expected_rados_1, rados_after_1))
 
         # -- phase 2: switch mode, add bucket[2], second dedup ----------------
         if start_compressed:
-            disable_default_compression()
+            disable_default_compression_via_period()
         else:
-            enable_default_compression()
+            enable_default_compression_via_period()
 
         idx = 2
         conn.create_bucket(Bucket=bucket_names[idx])
-        _upload_to_bucket(conn, bucket_names[idx], files, config, idx)
+        created_buckets.append(bucket_names[idx])
+        upload_to_bucket(conn, bucket_names[idx], files, config, idx)
         log.info("Phase 2: uploaded %d files to %s (%s)",
                  num_files, bucket_names[idx], final_mode_label)
 
@@ -5210,7 +5284,7 @@ def _dedup_inc_shared_manifest_test(start_compressed):
         rados_after_2 = count_object_parts_in_all_buckets(True)
         log.info("RADOS count after dedup-2: %d (expected=%d)",
                  rados_after_2, expected_rados_2)
-        assert rados_after_2 == expected_rados_2 or 1, \
+        assert rados_after_2 == expected_rados_2, \
             ("Cycle 2 RADOS count: before=%d, expected=%d, after=%d"
              % (rados_before_2, expected_rados_2, rados_after_2))
 
@@ -5221,14 +5295,13 @@ def _dedup_inc_shared_manifest_test(start_compressed):
 
         # verify all objects readable
         conns=[conn] * len(bucket_names)
-        verify_objects_multi(files, conns, bucket_names, 0, config, False)
+        verify_objects_multi(files, conns, bucket_names, 0, config, True)
         log.info("All objects verified after incremental shared_manifest test "
                  "(start=%s)", first_mode_label)
     finally:
-        for bucket in bucket_names:
-            delete_bucket_with_all_objects(bucket, conn)
-        verify_pool_is_empty(conn)
-        cleanup_local()
+        restore_default_compression_via_period()
+        conns=[conn] * len(created_buckets)
+        cleanup_all_buckets(created_buckets, conns)
 
 
 #-------------------------------------------------------------------------------
@@ -5260,10 +5333,64 @@ def test_dedup_compressed_to_uncompressed():
 
 
 #-------------------------------------------------------------------------------
+NUM_PERIOD_COMMIT_CYCLES = 12
+
 @pytest.mark.basic_test
-def test_compression_teardown():
-    """Restore original compression setting if we changed it."""
-    restore_default_compression()
+def test_period_commit_cycling_s3_ops():
+    """Repeated period commit with S3 only (no dedup admin).
+
+    Each cycle toggles default-placement compression (zone placement modify +
+    period update/commit), then create_bucket, upload, download, delete.
+    Use this to see whether realm-reloader / notify-110 / frontend-paused
+    issues are general RGW period-commit behavior vs dedup-specific.
+
+    After a failure, check radosgw logs, e.g.:
+      grep -a 'frontend pause\\|frontend unpaused' .../radosgw.8101.log | tail -20
+    """
+
+    # Debug-only test; enable by removing the skip.
+    #pytest.skip("debug-only test; enable manually when needed")
+
+    prepare_test()
+    conn = get_single_connection()
+    config = default_config
+
+    files = []
+    sizes = [127*KB, 2*MB+3*KB, 7*MB, 11*MB, 13*MB, 16*MB, 17*MB, 32*MB, 67*MB]
+    for size in sizes:
+        gen_files_fixed_copies(files, 1, size, 1)
+
+    filename = files[0][0]
+    src_path = OUT_DIR + filename
+
+    disable_default_compression_via_period()
+    created_buckets = []
+
+    try:
+        for cycle in range(NUM_PERIOD_COMMIT_CYCLES):
+            log.info("=== period commit cycle %d/%d ===",
+                     cycle + 1, NUM_PERIOD_COMMIT_CYCLES)
+
+            if cycle % 2 == 0:
+                enable_default_compression_via_period()
+            else:
+                disable_default_compression_via_period()
+
+            bucket_name = gen_bucket_name()
+            conn.create_bucket(Bucket=bucket_name)
+            created_buckets.append(bucket_name)
+            upload_to_bucket(conn, bucket_name, files, config)
+            dedup_stats = Dedup_Stats()
+            exec_dedup_internal(dedup_stats, dry_run=True, max_dedup_time=300)
+
+        log.info("completed %d period commit + S3 cycles (no dedup)",
+                 NUM_PERIOD_COMMIT_CYCLES)
+    finally:
+        if created_buckets:
+            cleanup_all_buckets(created_buckets, [conn] * len(created_buckets))
+        else:
+            cleanup_local()
+
 
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
@@ -5271,10 +5398,11 @@ def test_compression_sanity():
     """Sanity: upload one object with compression enabled, stop.
     Manually verify RGW_ATTR_COMPRESSION is set on the object head."""
 
-    ### Keep this test for debug purpose only
-    return
+    # Debug-only test; enable by removing the skip.
+    pytest.skip("debug-only test; enable manually when needed")
+
     prepare_test()
-    enable_default_compression()
+    enable_default_compression_via_period()
     bucket_name = "compression-sanity"
     obj_key = "compression_sanity_obj"
     filename="compression_sanity_file"
@@ -5292,15 +5420,34 @@ def test_compression_sanity():
                     f.write(b"ABCDEFGHIJKLMNOP" * (chunk_len // 16))
                 else:
                     f.write(os.urandom(chunk_len))
+
                 written += chunk_len
                 compressible = not compressible
+
         conn.upload_file(OUT_DIR + filename, bucket_name, obj_key,
                          Config=default_config)
-        get_actual_compressed_sizes(size, 1, True)
-        log.info("calling restore_default_compression")
-        restore_default_compression()
+        ret=get_actual_compressed_sizes(size, 1, True)
+        obj_count_compressed = ret[0]
+        size_compressed = ret[1]
+        conn.delete_object(Bucket=bucket_name, Key=obj_key)
+        result = admin(['gc', 'process', '--include-all'])
+        assert result[1] == 0
+        assert count_object_parts_in_all_buckets(False, 0) == 0
+
+        disable_default_compression_via_period()
         conn.upload_file(OUT_DIR + filename, bucket_name, obj_key + "UC",
-                         Config=default_config)        
+                         Config=default_config)
+        ret=get_actual_compressed_sizes(size, 1, True)
+        obj_count_uncompressed = ret[0]
+        size_uncompressed = ret[1]
+        log.info("original_size=%d, size_compressed=%d, size_uncompressed=%d"
+                 "obj_count_compressed=%d, obj_count_compressed=%d",
+                 size, size_compressed, size_uncompressed,
+                 obj_count_compressed, obj_count_uncompressed)
+        ratio = obj_count_compressed / obj_count_uncompressed
+        assert ratio > 0.45 # ~50% compressible
+        ratio = size_compressed / size_uncompressed
+        assert ratio > 0.45 # ~50% compressible
     finally:
         log.info("Uploaded %s to %s -- check RGW_ATTR_COMPRESSION manually",
                  obj_key, bucket_name)
@@ -5389,5 +5536,4 @@ def test_dedup_many_buckets():
         log.info("restore orig_max_buckets=%d", orig_max_buckets)
         admin(['user', 'modify', '--uid', uid,
                '--max-buckets', str(orig_max_buckets)])
-
 

--- a/src/test/rgw/dedup/test_dedup.py
+++ b/src/test/rgw/dedup/test_dedup.py
@@ -12,7 +12,7 @@ import string
 import shutil
 import pytest
 import json
-from collections import namedtuple
+#from collections import namedtuple
 import boto3
 from boto3.s3.transfer import TransferConfig
 from dataclasses import dataclass
@@ -56,6 +56,13 @@ class Dedup_Stats:
     duplicate_obj : int = 0
     deduped_obj_bytes : int = 0
     non_default_storage_class_objs_bytes : int = 0
+    compressed_objs : int = 0
+    compressed_bytes : int = 0
+    skip_compressed_objs : int = 0
+    skip_compressed_bytes : int = 0
+    deduped_compressed_objects : int = 0
+    set_compression_on_tgt : int = 0
+    clear_compression_on_tgt : int = 0
 
 @dataclass
 class Dedup_Ratio:
@@ -645,7 +652,12 @@ def delete_bucket_with_all_objects(bucket_name, conn):
 def verify_pool_is_empty(conn, skip_bucket_check=False):
     result = admin(['gc', 'process', '--include-all'])
     assert result[1] == 0
-    assert count_object_parts_in_all_buckets(False, 0) == 0
+
+    obj_count = count_object_parts_in_all_buckets(False, 0)
+    if (obj_count):
+        log.warning("verify_pool_is_empty: %d obejcts were found", obj_count)
+        assert obj_count == 0
+
     if not skip_bucket_check:
         assert verify_no_forgotten_buckets(conn)
 
@@ -1387,8 +1399,26 @@ def read_full_dedup_stats(dedup_stats, md5_stats):
     key='Skipped Changed Object'
     if key in skipped:
         dedup_stats.skip_changed_object = skipped[key]
+    key='Skipped Compressed objs'
+    if key in skipped:
+        dedup_stats.skip_compressed_objs = skipped[key]
+        dedup_stats.skip_compressed_bytes = skipped['Skipped Compressed Bytes']
 
     notify=md5_stats['notify']
+
+    key='Compressed objs'
+    if key in notify:
+        dedup_stats.compressed_objs = notify[key]
+        dedup_stats.compressed_bytes = notify['Compressed Bytes']
+    key='Deduped Compressed objs'
+    if key in notify:
+        dedup_stats.deduped_compressed_objects = notify[key]
+    key='Set Compression on TGT'
+    if key in notify:
+        dedup_stats.set_compression_on_tgt = notify[key]
+    key='Clear Compression on TGT'
+    if key in notify:
+        dedup_stats.clear_compression_on_tgt = notify[key]
     dedup_stats.valid_hash = notify['Valid HASH attrs']
     dedup_stats.invalid_hash = notify['Invalid HASH attrs']
     key='Set HASH'
@@ -1556,6 +1586,7 @@ def exec_dedup(expected_dedup_stats, dry_run, verify_stats=True, post_dedup_size
     verify_dedup_ratio(expected_dedup_stats, dedup_ratio_estimate)
     if post_dedup_size == 0:
         post_dedup_size = dedup_ratio_estimate.s3_bytes_after
+        log.info("exec_dedup: post_dedup_size == 0 -> %d", post_dedup_size)
 
     # no need to check after dry-run which doesn't change anything
     if dry_run:
@@ -1953,6 +1984,7 @@ def test_dedup_with_versions():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     bucket_name = "bucketwithversions"
     files=[]
@@ -2094,6 +2126,8 @@ def test_dedup_etag_corruption():
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_etag_corruption: connect to AWS ...")
     conn=get_single_connection()
+
+    disable_default_compression()
     prepare_test()
     try:
         files=[]
@@ -2153,29 +2187,233 @@ def write_bin_file(files, bin_arr, filename):
     files.append((filename, len(bin_arr), 1))
 
 #-------------------------------------------------------------------------------
-@pytest.mark.basic_test
-def test_md5_collisions():
+# MD5 collision base blocks (128 bytes each, identical MD5, different data).
+# Appending identical padding preserves the collision (MD5 length-extension).
+MD5_COLLISION_S1 = bytes.fromhex(
+    "d131dd02c5e6eec4693d9a0698aff95c"
+    "2fcab58712467eab4004583eb8fb7f89"
+    "55ad340609f4b30283e488832571415a"
+    "085125e8f7cdc99fd91dbdf280373c5b"
+    "d8823e3156348f5bae6dacd436c919c6"
+    "dd53e2b487da03fd02396306d248cda0"
+    "e99f33420f577ee8ce54b67080a80d1e"
+    "c69821bcb6a8839396f9652b6ff72a70")
+
+MD5_COLLISION_S2 = bytes.fromhex(
+    "d131dd02c5e6eec4693d9a0698aff95c"
+    "2fcab50712467eab4004583eb8fb7f89"
+    "55ad340609f4b30283e4888325f1415a"
+    "085125e8f7cdc99fd91dbd7280373c5b"
+    "d8823e3156348f5bae6dacd436c919c6"
+    "dd53e23487da03fd02396306d248cda0"
+    "e99f33420f577ee8ce54b67080280d1e"
+    "c69821bcb6a8839396f965ab6ff72a70")
+
+MIXED_CHUNK = 256 * KB
+COMPRESSIBLE_PATTERN = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ012345"
+COMPRESS_NEVER     = 0
+COMPRESS_ALWAYS    = 1
+COMPRESS_ALTERNATE = 2
+
+#-------------------------------------------------------------------------------
+def _write_mixed_compressibility_chunk(fa, fb, chunk_len, compressible):
+    """Write one chunk (identical) to both files.  Returns estimated compressed size."""
+    if compressible:
+        blocks = (chunk_len + len(COMPRESSIBLE_PATTERN) - 1) // len(COMPRESSIBLE_PATTERN)
+        chunk = (COMPRESSIBLE_PATTERN * blocks)[:chunk_len]
+        est = chunk_len // 20
+    else:
+        chunk = os.urandom(chunk_len)
+        est = chunk_len
+    fa.write(chunk)
+    fb.write(chunk)
+    return est
+
+
+#-------------------------------------------------------------------------------
+def write_collision_pair_mixed_to_disk(files, target_size, compressibility):
+    """Write an MD5 collision pair to disk with configurable compressibility.
+
+    compressibility controls the padding content:
+      COMPRESS_NEVER     -- all random (incompressible) padding
+      COMPRESS_ALWAYS    -- all compressible (repeating pattern) padding
+      COMPRESS_ALTERNATE -- alternating compressible/random 256KB chunks
+
+    Both files share identical padding (preserving the MD5 collision).
+    Peak memory usage is ~256KB.
+    """
+    prefix_len = len(MD5_COLLISION_S1)
+    pad_len = target_size - prefix_len
+    name_a = "col_a"
+    name_b = "col_b"
+
+    compressed_est = 0
+    with open(OUT_DIR + name_a, 'wb') as fa, open(OUT_DIR + name_b, 'wb') as fb:
+        fa.write(MD5_COLLISION_S1)
+        fb.write(MD5_COLLISION_S2)
+
+        written = 0
+        compressible = True
+        while written < pad_len:
+            chunk_len = min(MIXED_CHUNK, pad_len - written)
+            if compressibility == COMPRESS_NEVER:
+                chunk_compressible = False
+            elif compressibility == COMPRESS_ALWAYS:
+                chunk_compressible = True
+            else:
+                chunk_compressible = compressible
+                compressible = not compressible
+
+            compressed_est += _write_mixed_compressibility_chunk(fa, fb, chunk_len,
+                                                                 chunk_compressible)
+            written += chunk_len
+
+    files.append((name_a, target_size, 1))
+    files.append((name_b, target_size, 1))
+
+    if compressibility != COMPRESS_NEVER:
+        log.info("write_collision_pair_mixed_to_disk: target_size=%d (%.2f MiB), "
+                 "estimated_compressed~=%d (%.2f MiB, ~%.0f%%)",
+                 target_size, target_size / MB,
+                 compressed_est, compressed_est / MB,
+                 100.0 * compressed_est / target_size)
+
+#-------------------------------------------------------------------------------
+def get_actual_compressed_sizes(target_size, num_copies, verbose=False):
+    """Get actual on-disk sizes via rados stat (useful for compressed objects)."""
+    result = rados(['ls', '-p ', POOLNAME])
+    assert result[1] == 0
+    rados_names = result[0].split()
+    total_compressed = 0
+    for rname in rados_names:
+        stat_result = rados(['-p ', POOLNAME, 'stat', rname])
+        if stat_result[1] == 0:
+            byte_size = int(stat_result[0].split()[-1])
+            total_compressed += byte_size
+
+    if verbose:
+        log.info("get_actual_compressed_sizes: size=%d: uncompressed_total=%d, "
+                 "compressed_on_disk_total=%d (%.0f%%)",
+                 target_size, num_copies * target_size, total_compressed,
+                 100.0 * total_compressed / (num_copies * target_size))
+
+    return (len(rados_names), total_compressed)
+
+#-------------------------------------------------------------------------------
+def adjust_stats_for_collision(dedup_stats, compressed, num_copies, obj_size):
+    # Test PUT @num_copies objects with different data, but all share the same ETAG
+    # This is because of and MD5 collision and it will confuse dedup
+    # Its early stats will behave as if all the objects are identical, but after
+    # calculating a strong-head the mismatch will be discovered
+    size_combined = num_copies * obj_size
+
+    # dedup will be confused to think objects are identical (so no singletons)
+    dedup_stats.skip_singleton       = 0
+    dedup_stats.skip_singleton_bytes = 0
+
+    # dedup will be confused to think objects are identical (so one is a SRC)
+    dedup_stats.skip_src_record      = 1
+    dedup_stats.invalid_hash         = num_copies
+    dedup_stats.set_hash             = num_copies
+    dedup_stats.singleton_obj        = 0
+    dedup_stats.unique_obj           = 1
+    dedup_stats.duplicate_obj        = num_copies - dedup_stats.unique_obj
+    dedup_stats.size_before_dedup    = size_combined
+    dedup_stats.dedup_bytes_estimate = obj_size
+    dedup_stats.hash_mismatch        = 1
+    if compressed:
+        dedup_stats.compressed_objs  = num_copies
+        dedup_stats.compressed_bytes = size_combined
+
+
+#-------------------------------------------------------------------------------
+def _md5_collision_test(compressibility, compressed):
+    """Shared logic for large MD5 collision tests.
+
+    Args:
+        compressibility: COMPRESS_NEVER, COMPRESS_ALWAYS, or COMPRESS_ALTERNATE.
+        compressed: if True, create compressed buckets and verify compression
+            stats; if False, use regular buckets.
+    """
     if full_dedup_is_disabled():
         return
 
-    s1="d131dd02c5e6eec4693d9a0698aff95c2fcab58712467eab4004583eb8fb7f8955ad340609f4b30283e488832571415a085125e8f7cdc99fd91dbdf280373c5bd8823e3156348f5bae6dacd436c919c6dd53e2b487da03fd02396306d248cda0e99f33420f577ee8ce54b67080a80d1ec69821bcb6a8839396f9652b6ff72a70"
-    s2="d131dd02c5e6eec4693d9a0698aff95c2fcab50712467eab4004583eb8fb7f8955ad340609f4b30283e4888325f1415a085125e8f7cdc99fd91dbd7280373c5bd8823e3156348f5bae6dacd436c919c6dd53e23487da03fd02396306d248cda0e99f33420f577ee8ce54b67080280d1ec69821bcb6a8839396f965ab6ff72a70"
+    if compressed:
+        enable_default_compression()
+    else:
+        disable_default_compression()
 
-    s1_bin=bytes.fromhex(s1)
-    s2_bin=bytes.fromhex(s2)
+    sizes = [64*KB, 2*MB, 11*MB, 61*MB, 256*MB]
+    num_copies = 2
+    config = default_config
+    conn = None
+    bucket_name = gen_bucket_name()
+    try:
+        prepare_test()
+        conn = get_single_connection()
+        conn.create_bucket(Bucket=bucket_name)
 
-    s1_hash=hashlib.md5(s1_bin).hexdigest()
-    s2_hash=hashlib.md5(s2_bin).hexdigest()
+        for obj_size in sizes:
+            files = []
+            log.debug("write_collision_pair_mixed_to_disk size=%d", obj_size)
+            write_collision_pair_mixed_to_disk(files, obj_size, compressibility)
+
+            indices = [0] * len(files)
+            check_obj_count = not compressed
+            ret = upload_objects(bucket_name, files, indices, conn, config,
+                                 check_obj_count)
+            dedup_stats = ret[1]
+            adjust_stats_for_collision(dedup_stats, compressed, num_copies, obj_size)
+            if compressed:
+                on_disk=get_actual_compressed_sizes(obj_size, num_copies, verbose=True)
+                # compressed objects logical size is different from on-disk size
+                ret=exec_dedup_internal(dedup_stats, dry_run=False, max_dedup_time=120)
+            else:
+                # dedup will fail, so we should stay with size_before_dedup
+                ret = exec_dedup(dedup_stats, dry_run=False, verify_stats=True,
+                                 post_dedup_size=dedup_stats.size_before_dedup)
+
+            actual_stats = ret[1]
+            if actual_stats != dedup_stats:
+                print_dedup_stats_diff(actual_stats, dedup_stats)
+                assert actual_stats == dedup_stats
+
+            if compressed:
+                on_disk2=get_actual_compressed_sizes(obj_size, num_copies, verbose=True)
+                assert on_disk == on_disk2, "on disk objects changed!"
+
+            verify_objects(bucket_name, files, conn, 0, default_config, False)
+            for f in files:
+                key = gen_object_name(f[0], 0)
+                conn.delete_object(Bucket=bucket_name, Key=key)
+
+            verify_pool_is_empty(conn, True)
+            log.debug("size=%d: both objects verified intact", obj_size)
+
+    finally:
+        if conn:
+            cleanup(bucket_name, conn)
+
+
+#-------------------------------------------------------------------------------
+@pytest.mark.basic_test
+def test_md5_collisions_small():
+    if full_dedup_is_disabled():
+        return
+
+    s1_hash=hashlib.md5(MD5_COLLISION_S1).hexdigest()
+    s2_hash=hashlib.md5(MD5_COLLISION_S2).hexdigest()
+
     # data is different
-    assert s1 != s2
+    assert MD5_COLLISION_S1 != MD5_COLLISION_S2
     # but MD5 is identical
     assert s1_hash == s2_hash
-
+    disable_default_compression()
     prepare_test()
     files=[]
     try:
-        write_bin_file(files, s1_bin, "s1")
-        write_bin_file(files, s2_bin, "s2")
+        write_bin_file(files, MD5_COLLISION_S1, "s1")
+        write_bin_file(files, MD5_COLLISION_S2, "s2")
 
         bucket_name = gen_bucket_name()
         log.debug("test_md5_collisions: connect to AWS ...")
@@ -2230,6 +2468,14 @@ def test_md5_collisions():
 
 
 #-------------------------------------------------------------------------------
+@pytest.mark.basic_test
+def test_md5_collision_large():
+    """BLAKE3 rejects MD5 collisions on large uncompressed objects (random padding)."""
+    disable_default_compression()
+    _md5_collision_test(compressibility=COMPRESS_NEVER, compressed=False)
+
+
+#-------------------------------------------------------------------------------
 def loop_dedup_split_head_with_tenants():
     prepare_test()
     config=default_config
@@ -2270,6 +2516,7 @@ def test_dedup_split_head_with_tenants():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     for idx in range(0, 9):
         log.debug("test_dedup_split_head_with_tenants: loop #%d", idx);
         loop_dedup_split_head_with_tenants()
@@ -2309,6 +2556,7 @@ def test_dedup_split_head_simple():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     for idx in range(0, 9):
         log.debug("test_dedup_split_head: loop #%d", idx);
         loop_dedup_split_head()
@@ -2318,6 +2566,7 @@ def dedup_copy_internal(multi_buckets):
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     bucket_names=[]
     config=default_config
@@ -2374,6 +2623,7 @@ def test_copy_after_dedup():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     log.debug("test_copy_after_dedup: connect to AWS ...")
     config=default_config
@@ -2458,6 +2708,7 @@ def test_dedup_small():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_small: connect to AWS ...")
     conn=get_single_connection()
@@ -2470,6 +2721,7 @@ def test_dedup_small_with_tenants():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     max_copies_count=3
     files=[]
@@ -2518,6 +2770,7 @@ def test_dedup_inc_0_with_tenants():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     log.debug("test_dedup_inc_0: connect to AWS ...")
     max_copies_count=3
@@ -2569,6 +2822,7 @@ def test_dedup_inc_0():
         return
 
     config=default_config
+    disable_default_compression()
     prepare_test()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_inc_0: connect to AWS ...")
@@ -2615,6 +2869,7 @@ def test_dedup_inc_1_with_tenants():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     log.debug("test_dedup_inc_1_with_tenants: connect to AWS ...")
     max_copies_count=6
@@ -2684,7 +2939,9 @@ def test_dedup_inc_1():
         return
 
     config=default_config
+    disable_default_compression()
     prepare_test()
+
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_inc_1: connect to AWS ...")
     conn=get_single_connection()
@@ -2747,7 +3004,9 @@ def test_dedup_inc_2_with_tenants():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
+
     log.debug("test_dedup_inc_2_with_tenants: connect to AWS ...")
     max_copies_count=6
     config=default_config
@@ -2824,7 +3083,9 @@ def test_dedup_inc_2():
         return
 
     config=default_config
+    disable_default_compression()
     prepare_test()
+
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_inc_2: connect to AWS ...")
     conn=get_single_connection()
@@ -2894,6 +3155,7 @@ def test_dedup_inc_with_remove_multi_tenants():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     log.debug("test_dedup_inc_with_remove_multi_tenants: connect to AWS ...")
     max_copies_count=6
@@ -2996,6 +3258,7 @@ def test_dedup_inc_with_remove():
         return
 
     config=default_config
+    disable_default_compression()
     prepare_test()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_inc_with_remove: connect to AWS ...")
@@ -3092,6 +3355,7 @@ def test_dedup_multipart_with_tenants():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     log.debug("test_dedup_multipart_with_tenants: connect to AWS ...")
     max_copies_count=3
@@ -3116,6 +3380,7 @@ def test_dedup_multipart():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_multipart: connect to AWS ...")
@@ -3141,6 +3406,7 @@ def test_dedup_basic_with_tenants():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     max_copies_count=3
     num_files=23
@@ -3157,6 +3423,7 @@ def test_dedup_basic():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_basic: connect to AWS ...")
@@ -3179,6 +3446,7 @@ def test_dedup_small_multipart_with_tenants():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     max_copies_count=4
     num_files=10
@@ -3199,6 +3467,7 @@ def test_dedup_small_multipart():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     log.debug("test_dedup_small_multipart: connect to AWS ...")
     config2=TransferConfig(multipart_threshold=4*KB, multipart_chunksize=1*MB)
@@ -3221,6 +3490,7 @@ def test_dedup_large_scale_with_tenants():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     max_copies_count=3
     num_threads=16
@@ -3239,6 +3509,7 @@ def test_dedup_large_scale():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     max_copies_count=3
     num_threads=16
@@ -3249,7 +3520,6 @@ def test_dedup_large_scale():
     log.debug("test_dedup_dry_large_scale_with_tenants: connect to AWS ...")
     gen_files_fixed_size(files, num_files, size, max_copies_count)
     threads_dedup_basic_with_tenants_common(files, num_threads, config, False)
-
 
 #-------------------------------------------------------------------------------
 def inc_step_with_tenants(stats_base, files, conns, bucket_names, config):
@@ -3313,6 +3583,7 @@ def test_dedup_inc_loop_with_tenants():
     if full_dedup_is_disabled():
         return
 
+    disable_default_compression()
     prepare_test()
     log.debug("test_dedup_inc_loop_with_tenants: connect to AWS ...")
     max_copies_count=3
@@ -3350,6 +3621,7 @@ def test_dedup_inc_loop_with_tenants():
 @pytest.mark.basic_test
 def test_dedup_dry_small_with_tenants():
     log.debug("test_dedup_dry_small_with_tenants: connect to AWS ...")
+    disable_default_compression()
     prepare_test()
     max_copies_count=3
     files=[]
@@ -3386,6 +3658,7 @@ def test_dedup_dry_small_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_multipart():
+    disable_default_compression()
     prepare_test()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_dry_multipart: connect to AWS ...")
@@ -3409,6 +3682,7 @@ def test_dedup_dry_multipart():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_basic():
+    disable_default_compression()
     prepare_test()
     bucket_name = gen_bucket_name()
     log.debug("test_dedup_dry_basic: connect to AWS ...")
@@ -3426,6 +3700,7 @@ def test_dedup_dry_basic():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_small_multipart():
+    disable_default_compression()
     prepare_test()
     log.debug("test_dedup_dry_small_multipart: connect to AWS ...")
     config2 = TransferConfig(multipart_threshold=4*KB, multipart_chunksize=1*MB)
@@ -3462,6 +3737,7 @@ def test_dedup_dry_small():
 def test_dedup_dry_small_large_mix():
     dry_run=True
     log.debug("test_dedup_dry_small_large_mix: connect to AWS ...")
+    disable_default_compression()
     prepare_test()
 
     num_threads=4
@@ -3503,6 +3779,7 @@ def test_dedup_dry_small_large_mix():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_basic_with_tenants():
+    disable_default_compression()
     prepare_test()
     max_copies_count=3
     num_files=23
@@ -3516,6 +3793,7 @@ def test_dedup_dry_basic_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_multipart_with_tenants():
+    disable_default_compression()
     prepare_test()
     log.debug("test_dedup_dry_multipart_with_tenants: connect to AWS ...")
     max_copies_count=3
@@ -3537,6 +3815,7 @@ def test_dedup_dry_multipart_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_small_multipart_with_tenants():
+    disable_default_compression()
     prepare_test()
     max_copies_count=4
     num_files=10
@@ -3554,6 +3833,7 @@ def test_dedup_dry_small_multipart_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_large_scale_with_tenants():
+    disable_default_compression()
     prepare_test()
     max_copies_count=3
     num_threads=64
@@ -3570,8 +3850,7 @@ def test_dedup_dry_large_scale_with_tenants():
     try:
         threads_simple_dedup_with_tenants(files, conns, bucket_names, config, True)
     except Exception:
-        log.warning("test_dedup_dry_large_scale_with_tenants: failed!!")
-        assert 0, "abort test_dedup_dry_large_scale_with_tenants "
+        assert False, "test_dedup_dry_large_scale_with_tenants failed"
     finally:
         # cleanup must be executed even after a failure
         cleanup_all_buckets(bucket_names, conns)
@@ -3580,6 +3859,7 @@ def test_dedup_dry_large_scale_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_dry_large_scale():
+    disable_default_compression()
     prepare_test()
     bucket_name = gen_bucket_name()
     max_copies_count=2
@@ -3865,6 +4145,7 @@ def test_dedup_identical_copies_1():
     copies_count=1024
     size=64*KB
     config=default_config
+    disable_default_compression()
     prepare_test()
     files=[]
     gen_files_fixed_copies(files, num_files, size, copies_count)
@@ -3889,6 +4170,7 @@ def test_dedup_identical_copies_multipart_small():
     num_files=1
     copies_count=1024
     size=16*KB
+    disable_default_compression()
     prepare_test()
     files=[]
     gen_files_fixed_copies(files, num_files, size, copies_count)
@@ -4037,7 +4319,6 @@ def exec_dedup_with_filter(dry_run, deny_bucket_list=None, allow_bucket_list=Non
             return ret
 
     assert False
-
 
 
 #==============================================================================
@@ -4269,7 +4550,6 @@ def dedup_filter_allow_deny_bucket_common(dry_run, filter_mode_allow):
 
         verify_pool_is_empty(conn)
 
-
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_filter_bucket_estimate():
@@ -4289,6 +4569,742 @@ def test_dedup_filter_bucket_exec():
 
     log.info("dedup_filter_bucket_exec: filter_mode_allow")
     dedup_filter_allow_deny_bucket_common(dry_run, filter_mode_allow=True)
+
+
+#-------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------
+#                              Compression helpers
+#-------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------
+def _find_rgw_procs():
+    """Find running radosgw daemons via their --pid-file arguments.
+
+    Scans /proc for processes whose argv[0] basename is 'radosgw' and
+    extracts the --pid-file path from their command line.  Returns a list
+    of (pid, argv_list, pid_file_path) tuples.
+    """
+    import glob as globmod
+    procs = []
+    for cmdline_path in globmod.glob('/proc/[0-9]*/cmdline'):
+        try:
+            with open(cmdline_path, 'rb') as f:
+                raw = f.read()
+            if not raw:
+                continue
+            argv = raw.rstrip(b'\x00').split(b'\x00')
+            exe = os.path.basename(argv[0].decode('utf-8', errors='replace'))
+            if exe != 'radosgw':
+                continue
+            pid = int(cmdline_path.split('/')[2])
+            cmd_list = [a.decode('utf-8', errors='replace') for a in argv]
+            pid_file = None
+            for i, arg in enumerate(cmd_list):
+                if arg.startswith('--pid-file='):
+                    pid_file = arg.split('=', 1)[1]
+                elif arg == '--pid-file' and i + 1 < len(cmd_list):
+                    pid_file = cmd_list[i + 1]
+            procs.append((pid, cmd_list, pid_file))
+        except (OSError, ValueError, IndexError):
+            continue
+    return procs
+
+
+#-------------------------------------------------------------------------------
+def restart_all_rgw():
+    """Restart every radosgw daemon preserving its original command line.
+
+    1. Find radosgw processes via /proc scan (exact basename match).
+    2. Record each process's full argv and --pid-file path.
+    3. SIGTERM all, wait for exit.
+    4. Re-launch each with the original argv.
+    5. Wait for the pid-file to be re-written (confirms daemon is up),
+       then verify TCP connectivity on the test port.
+    """
+    import signal
+
+    procs = _find_rgw_procs()
+    if not procs:
+        log.warning("No running radosgw processes found")
+        return
+
+    log.debug("Found %d radosgw process(es) to restart", len(procs))
+    for pid, cmd_list, pid_file in procs:
+        log.debug("  pid=%d  pid_file=%s", pid, pid_file)
+
+    # stop all
+    for pid, _, _ in procs:
+        log.debug("Sending SIGTERM to radosgw pid %d", pid)
+        os.kill(pid, signal.SIGTERM)
+
+    log.info("Sent SIGTERM to all radosgw")
+    for pid, _, pid_file in procs:
+        for _ in range(30):
+            try:
+                os.kill(pid, 0)
+                time.sleep(0.5)
+            except OSError:
+                break
+        else:
+            log.warning("radosgw pid %d did not exit, sending SIGKILL", pid)
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except OSError:
+                pass
+            time.sleep(1)
+        # remove stale pid file so we can detect the new one
+        if pid_file:
+            try:
+                os.remove(pid_file)
+            except OSError:
+                pass
+
+    # wait for the port to be free before restarting
+    port_no = get_config_port()
+    hostname = get_config_host()
+    import socket
+    log.debug("Waiting for port %d to be free...", port_no)
+    for attempt in range(60):
+        try:
+            s = socket.create_connection((hostname, port_no), timeout=1)
+            s.close()
+            time.sleep(1)
+        except (ConnectionRefusedError, OSError):
+            log.debug("Port %d is free after %d seconds", port_no, attempt)
+            break
+    else:
+        log.warning("Port %d still appears busy after 60s, proceeding anyway",
+                    port_no)
+
+    # restart all
+    log.info("Restarting all radosgw");
+    for _, cmd_list, pid_file in procs:
+        log.debug("Restarting radosgw: %s", ' '.join(cmd_list))
+        subprocess.Popen(cmd_list)
+
+    # wait for each daemon to write its pid file (proves it daemonized)
+    for _, cmd_list, pid_file in procs:
+        if not pid_file:
+            continue
+        for attempt in range(60):
+            if os.path.exists(pid_file):
+                try:
+                    with open(pid_file) as f:
+                        new_pid = int(f.read().strip())
+                    os.kill(new_pid, 0)
+                    log.debug("radosgw restarted as pid %d (%s)",
+                             new_pid, pid_file)
+                    break
+                except (OSError, ValueError):
+                    pass
+            time.sleep(1)
+        else:
+            raise RuntimeError("radosgw did not restart: pid file %s "
+                               "not created after 60s" % pid_file)
+
+    # also verify TCP connectivity on the test port
+    for attempt in range(60):
+        try:
+            s = socket.create_connection((hostname, port_no), timeout=2)
+            s.close()
+            log.debug("radosgw listening on %s:%d", hostname, port_no)
+            return
+        except (ConnectionRefusedError, OSError):
+            time.sleep(1)
+    raise RuntimeError("radosgw pid file appeared but port %d not listening "
+                       "after 60s" % port_no)
+
+
+_original_compression = None
+_compression_state = None     # current state: None=unknown, 'none', or 'zlib' etc.
+
+#-------------------------------------------------------------------------------
+def _get_default_placement_compression():
+    """Read the compression type currently set on default-placement."""
+    result = admin(['zone', 'get', '--rgw-zone', 'default'])
+    assert result[1] == 0, "zone get failed: " + result[0]
+    zone = json.loads(result[0])
+    for p in zone.get('placement_pools', []):
+        if p.get('key') == 'default-placement':
+            val = p.get('val', {})
+            sc = val.get('storage_classes', {})
+            std = sc.get('STANDARD', {})
+            return std.get('compression_type', '')
+    assert False, "default-placement not found in zone config"
+
+
+#-------------------------------------------------------------------------------
+def _is_compression_active(value):
+    """Return True if value represents an active compression setting."""
+    return bool(value) and value.lower() not in ('', 'none')
+
+
+#-------------------------------------------------------------------------------
+def enable_disable_default_compression(compression_type):
+    """Set compression on default-placement, with RGW restart if needed.
+
+    On first call, reads the system state and saves it as _original_compression.
+    If the current state already matches the requested type, no restart is done.
+    Pass 'none' to disable compression.
+    """
+    global _original_compression, _compression_state
+
+    current = _get_default_placement_compression()
+
+    if _original_compression is None:
+        _original_compression = current
+        log.info("Saved original compression setting: '%s'", current)
+
+    target = 'none'
+    if compression_type:
+        target = compression_type.lower()
+    actual = 'none'
+    if current:
+        actual = current.lower()
+
+    if actual == target:
+        log.info("default-placement compression already '%s', no change needed",
+                 actual)
+        _compression_state = actual
+        return
+
+    result = admin(['zone', 'placement', 'modify',
+                    '--rgw-zone', 'default',
+                    '--placement-id', 'default-placement',
+                    '--compression', compression_type])
+    assert result[1] == 0, "Failed to set compression: " + result[0]
+
+    restart_all_rgw()
+    _compression_state = target
+    log.info("Set compression on default-placement to '%s' (was '%s')",
+             compression_type, actual)
+
+
+#-------------------------------------------------------------------------------
+def enable_default_compression():
+    enable_disable_default_compression(compression_type='zlib')
+
+#-------------------------------------------------------------------------------
+def disable_default_compression():
+    enable_disable_default_compression(compression_type='none')
+
+#-------------------------------------------------------------------------------
+def restore_default_compression():
+    """Restore original compression setting on default-placement if we changed it."""
+    global _original_compression, _compression_state
+
+    if _original_compression is None:
+        return
+
+    restore = _original_compression if _original_compression else 'none'
+    current = _compression_state if _compression_state else 'none'
+
+    if current == restore:
+        log.info("Compression already at original value '%s', no restore needed",
+                 restore)
+        return
+
+    result = admin(['zone', 'placement', 'modify',
+                    '--rgw-zone', 'default',
+                    '--placement-id', 'default-placement',
+                    '--compression', restore])
+    assert result[1] == 0, "Failed to restore compression to '%s': %s" % (restore, result[0])
+
+    restart_all_rgw()
+    _compression_state = restore
+    log.info("Restored compression on default-placement to '%s'", restore)
+
+
+#-------------------------------------------------------------------------------
+def post_dedup_count(num_objs, num_copies, rados_count_before, split_head_count):
+    head_count = num_objs * num_copies;
+    tail_count = rados_count_before - head_count
+
+    log.debug("num_objs=%d, num_copies=%d, split=%d, head_count=%d, tail_count=%d",
+              num_objs, num_copies, split_head_count, head_count, tail_count)
+
+    return (head_count + tail_count/num_copies + split_head_count)
+
+#-------------------------------------------------------------------------------
+def _dedup_mode_switch_test(start_compressed):
+    """Upload objects in one compression mode, switch, upload again, dedup and vice versa.
+
+    start_compressed=False: upload uncompressed first, switch to compressed.
+        After dedup all objects should be compressed.
+    start_compressed=True:  upload compressed first, switch to uncompressed.
+        After dedup all objects should be uncompressed.
+
+    We verify:
+      1) Pre-dedup compression state per bucket.
+      2) All stat counters match expected values.
+      3) RADOS object count drops after dedup.
+      4) Post-dedup: every object in both buckets matches the final mode.
+      5) Every S3 object is still readable and matches the original file.
+      6) After deleting all objects + GC the pool is empty.
+    """
+    if full_dedup_is_disabled():
+        return
+
+    prepare_test()
+    config = default_config
+    files = []
+    sizes = [127*KB, 2*MB+3*KB, 7*MB, 11*MB, 13*MB, 16*MB, 17*MB, 32*MB, 67*MB]
+    for size in sizes:
+        gen_files_fixed_copies(files, 1, size, 1)
+
+    num_copies = 2
+    conn = get_single_connection()
+    bucket_names = get_buckets(num_copies)
+
+    if start_compressed:
+        first_mode_label = "compressed"
+        final_mode_label = "uncompressed"
+        enable_default_compression()
+    else:
+        first_mode_label = "uncompressed"
+        final_mode_label = "compressed"
+        disable_default_compression()
+
+    try:
+        # phase 1: upload to bucket[0] in the starting mode
+        idx = 0
+        conn.create_bucket(Bucket=bucket_names[idx])
+        _upload_to_bucket(conn, bucket_names[idx], files, config, idx)
+        log.info("Phase 1: uploaded %d files to %s (%s)",
+                 len(files), bucket_names[idx], first_mode_label)
+
+        # switch compression mode
+        if start_compressed:
+            disable_default_compression()
+        else:
+            enable_default_compression()
+
+        # phase 2: upload identical objects to bucket[1] in the new mode
+        idx = 1
+        conn.create_bucket(Bucket=bucket_names[idx])
+        _upload_to_bucket(conn, bucket_names[idx], files, config, idx)
+        log.info("Phase 2: uploaded %d files to %s (%s)",
+                 len(files), bucket_names[idx], final_mode_label)
+
+        # pre-dedup: verify compression attrs
+        assert_bucket_compression(bucket_names[0], files, 0,
+                                  start_compressed, "PRE-DEDUP")
+        assert_bucket_compression(bucket_names[1], files, 1,
+                                  not start_compressed, "PRE-DEDUP")
+
+        rados_count_before = count_object_parts_in_all_buckets(True)
+        log.info("RADOS object count before dedup: %d", rados_count_before)
+
+        # build expected stats
+        expected_stats = Dedup_Stats()
+        split_head_objs = 0
+        for f in files:
+            obj_size = f[1]
+            split_head_objs += calc_split_objs_count(obj_size, num_copies, config)
+            calc_expected_stats(expected_stats, obj_size, num_copies, config)
+            on_disk = calc_on_disk_byte_size(obj_size)
+            # exactly one copy per file is compressed
+            expected_stats.compressed_objs += 1
+            expected_stats.compressed_bytes += on_disk
+            if on_disk >= DEDUP_MIN_OBJ_SIZE:
+                # SRC matches current placement; TGT is in the old mode
+                if start_compressed:
+                    expected_stats.clear_compression_on_tgt += 1
+                else:
+                    expected_stats.set_compression_on_tgt += 1
+
+        expected_rados_count = post_dedup_count(len(files), num_copies,
+                                                rados_count_before,
+                                                split_head_objs)
+
+        ret = exec_dedup_internal(expected_stats, dry_run=False, max_dedup_time=300)
+        actual_stats = ret[1]
+
+        if actual_stats != expected_stats:
+            print_dedup_stats_diff(actual_stats, expected_stats)
+            assert False, "Mode-switch dedup stat counter mismatch (see log above)"
+
+        rados_count_after = count_object_parts_in_all_buckets(True)
+        log.info("RADOS object count after dedup: %d (expected=%d)",
+                 rados_count_after, expected_rados_count)
+        assert rados_count_after == expected_rados_count, \
+            ("Bad RADOS object count: before=%d, expected=%d, after=%d"
+             % (rados_count_before, expected_rados_count, rados_count_after))
+
+        # post-dedup: all objects in both buckets should match the final mode
+        final_compressed = not start_compressed
+        for idx, bkt in enumerate(bucket_names):
+            assert_bucket_compression(bkt, files, idx, final_compressed, "POST-DEDUP")
+
+        # verify all objects are still readable
+        conns=[conn] * len(bucket_names)
+        verify_objects_multi(files, conns, bucket_names, 0, config, False)
+        log.info("All objects verified after mode-switch dedup "
+                 "(%s -> %s)", first_mode_label, final_mode_label)
+    finally:
+        for bucket in bucket_names:
+            delete_bucket_with_all_objects(bucket, conn)
+        verify_pool_is_empty(conn)
+        cleanup_local()
+
+
+#-------------------------------------------------------------------------------
+def is_object_compressed(bucket_name, object_key):
+    """Check if an S3 object has RGW_ATTR_COMPRESSION set.
+
+    Uses radosgw-admin object stat with latin-1 decoding because the
+    output may contain binary attribute data that is not valid UTF-8.
+    """
+    cmd = [test_path + 'test-rgw-call.sh', 'call_rgw_admin', 'noname',
+           'object', 'stat', '--bucket', bucket_name,
+           '--object', object_key]
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    raw = proc.communicate()[0]
+    assert proc.returncode == 0, \
+        "object stat failed for %s/%s (rc=%d)" % (bucket_name, object_key, proc.returncode)
+    text = raw.decode('latin-1')
+    obj_info = json.loads(text)
+    comp_type = obj_info.get('compression', {}).get('compression_type', '')
+    return bool(comp_type)
+
+
+#-------------------------------------------------------------------------------
+def count_compression_attr(bucket_name, files, idx=0):
+    """Count compressed vs uncompressed objects in a bucket.
+
+    Checks one copy per file (index 0).
+    Returns (compressed_count, uncompressed_count).
+    """
+    compressed = 0
+    uncompressed = 0
+    for f in files:
+        filename = f[0]
+        key = gen_object_name(filename, idx)
+        if is_object_compressed(bucket_name, key):
+            compressed += 1
+        else:
+            uncompressed += 1
+    return (compressed, uncompressed)
+
+
+#-------------------------------------------------------------------------------
+def assert_bucket_compression(bucket_name, files, idx, expect_compressed, tag):
+    """Count, log, and assert compression state for one bucket."""
+    c, u = count_compression_attr(bucket_name, files, idx)
+    log.info("%s %s: compressed=%d, uncompressed=%d", tag, bucket_name, c, u)
+    n = len(files)
+    if expect_compressed:
+        assert c == n and u == 0, \
+            "%s %s should be all compressed: c=%d, u=%d" % (tag, bucket_name, c, u)
+    else:
+        assert u == n and c == 0, \
+            "%s %s should be all uncompressed: c=%d, u=%d" % (tag, bucket_name, c, u)
+
+
+#-------------------------------------------------------------------------------
+def _upload_to_bucket(conn, bucket_name, files, config, idx=0):
+    """Upload all files (one copy each) to a single bucket."""
+    for f in files:
+        filename = f[0]
+        key = gen_object_name(filename, idx)
+        conn.upload_file(OUT_DIR + filename, bucket_name, key, Config=config)
+        log.debug("uploaded %s -> %s/%s", filename, bucket_name, key)
+
+#-------------------------------------------------------------------------------
+@pytest.mark.basic_test
+def test_dedup_uncompressed_to_compressed():
+    """Dedup with mode switch: uncompressed -> compressed.
+
+    Upload objects without compression, switch to compressed mode, upload
+    identical copies. After dedup every object should be compressed
+    (matching the current placement setting).
+    """
+    _dedup_mode_switch_test(start_compressed=False)
+
+
+
+#-------------------------------------------------------------------------------
+@pytest.mark.basic_test
+def test_dedup_compressed_md5_collision_large():
+    """BLAKE3 rejects MD5 collisions on large compressed objects (random padding)."""
+    _md5_collision_test(compressibility=COMPRESS_NEVER, compressed=True)
+
+
+#-------------------------------------------------------------------------------
+@pytest.mark.basic_test
+def test_dedup_compressed_md5_collision_mixed():
+    """BLAKE3 rejects MD5 collisions on large partially-compressible objects."""
+    _md5_collision_test(compressibility=COMPRESS_ALTERNATE, compressed=True)
+
+
+#-------------------------------------------------------------------------------
+def _dedup_inc_shared_manifest_test(start_compressed):
+    """Incremental dedup proving shared_manifest SRC trumps compression match.
+
+    Phase 1: upload identical objects to bucket[0] and bucket[1] in the
+        starting mode, run dedup. The SRC gets shared_manifest.
+    Phase 2: switch compression mode, upload same objects to bucket[2] in
+        the new mode, run dedup again. Even though bucket[2] now matches
+        the current placement, the existing SRC keeps its shared_manifest
+        priority and is NOT replaced.
+
+    Post-dedup: all objects in all 3 buckets have the starting mode's
+    compression state (the SRC's mode from cycle 1 wins).
+    """
+    if full_dedup_is_disabled():
+        return
+
+    prepare_test()
+    config = default_config
+    files = []
+    sizes = [127*KB, 2*MB+3*KB, 7*MB, 11*MB, 13*MB, 16*MB, 17*MB, 32*MB, 67*MB]
+    for size in sizes:
+        gen_files_fixed_copies(files, 1, size, 1)
+
+    num_files = len(files)
+    conn = get_single_connection()
+    bucket_names = get_buckets(3)
+
+    if start_compressed:
+        first_mode_label = "compressed"
+        final_mode_label = "uncompressed"
+        enable_default_compression()
+    else:
+        first_mode_label = "uncompressed"
+        final_mode_label = "compressed"
+        disable_default_compression()
+
+    try:
+        # -- phase 1: two buckets in starting mode, first dedup ---------------
+        for idx in range(2):
+            conn.create_bucket(Bucket=bucket_names[idx])
+            _upload_to_bucket(conn, bucket_names[idx], files, config, idx)
+
+        log.info("Phase 1: uploaded %d files to %s and %s (%s)",
+                 num_files, bucket_names[0], bucket_names[1], first_mode_label)
+
+        # pre-dedup-1: verify starting compression state
+        for idx in range(2):
+            assert_bucket_compression(bucket_names[idx], files, idx, start_compressed,
+                                      "PRE-DEDUP-1")
+
+        rados_before_1 = count_object_parts_in_all_buckets(True)
+        log.info("RADOS count before dedup-1: %d", rados_before_1)
+
+        # build expected stats for cycle 1
+        expected_1 = Dedup_Stats()
+        split_head_1 = 0
+        num_dedupable = 0
+        for f in files:
+            obj_size = f[1]
+            split_head_1 += calc_split_objs_count(obj_size, 2, config)
+            calc_expected_stats(expected_1, obj_size, 2, config)
+            on_disk = calc_on_disk_byte_size(obj_size)
+            if on_disk >= DEDUP_MIN_OBJ_SIZE:
+                num_dedupable += 1
+            if start_compressed:
+                expected_1.compressed_objs += 2
+                expected_1.compressed_bytes += (on_disk * 2)
+
+        if start_compressed:
+            expected_1.deduped_compressed_objects = expected_1.deduped_obj
+
+        expected_rados_1 = post_dedup_count(num_files, 2, rados_before_1, split_head_1)
+
+        ret = exec_dedup_internal(expected_1, dry_run=False, max_dedup_time=300)
+        actual_1 = ret[1]
+        if actual_1 != expected_1:
+            print_dedup_stats_diff(actual_1, expected_1)
+            assert False, "Cycle 1 stat counter mismatch"
+
+        rados_after_1 = count_object_parts_in_all_buckets(True)
+        log.info("RADOS count after dedup-1: %d (expected=%d)",
+                 rados_after_1, expected_rados_1)
+        assert rados_after_1 == expected_rados_1, \
+            ("Cycle 1 RADOS count: before=%d, expected=%d, after=%d"
+             % (rados_before_1, expected_rados_1, rados_after_1))
+
+        # -- phase 2: switch mode, add bucket[2], second dedup ----------------
+        if start_compressed:
+            disable_default_compression()
+        else:
+            enable_default_compression()
+
+        idx = 2
+        conn.create_bucket(Bucket=bucket_names[idx])
+        _upload_to_bucket(conn, bucket_names[idx], files, config, idx)
+        log.info("Phase 2: uploaded %d files to %s (%s)",
+                 num_files, bucket_names[idx], final_mode_label)
+
+        # pre-dedup-2: verify bucket[2] is in the new mode
+        assert_bucket_compression(bucket_names[idx], files, idx,
+                                  not start_compressed, "PRE-DEDUP-2")
+
+        rados_before_2 = count_object_parts_in_all_buckets(True)
+        log.info("RADOS count before dedup-2: %d", rados_before_2)
+
+        # build expected stats for cycle 2 (incremental)
+        expected_2 = Dedup_Stats()
+        split_head_2 = 0
+        for f in files:
+            obj_size = f[1]
+            on_disk = calc_on_disk_byte_size(obj_size)
+            if on_disk < DEDUP_MIN_OBJ_SIZE:
+                expected_2.skip_too_small += 3
+                expected_2.skip_too_small_bytes += (on_disk * 3)
+                expected_2.size_before_dedup += (on_disk * 3)
+                continue
+
+            expected_2.size_before_dedup += (on_disk * 3)
+            expected_2.total_processed_objects += 3
+
+            # cycle-1 TGT has shared_manifest -> skipped before compression
+            # check, so only 2 objects reach the compression counter
+            if start_compressed:
+                # SRC (compressed) counted, bucket[2] (uncompressed) not
+                expected_2.compressed_objs += 1
+                expected_2.compressed_bytes += on_disk
+            else:
+                # SRC (uncompressed) not counted, bucket[2] (compressed) counted
+                expected_2.compressed_objs += 1
+                expected_2.compressed_bytes += on_disk
+
+            # cycle-1 TGT now has shared_manifest -> skipped
+            expected_2.skip_shared_manifest += 1
+            # cycle-1 SRC is the source record -> skipped
+            expected_2.skip_src_record += 1
+
+            # bucket[2] is the only new TGT
+            expected_2.unique_obj += 1
+            expected_2.duplicate_obj += 2
+            expected_2.deduped_obj += 1
+            deduped_obj_bytes = calc_dedupable_space(on_disk, config)
+            expected_2.deduped_obj_bytes += deduped_obj_bytes
+            deduped_block_bytes = ((deduped_obj_bytes + BLOCK_SIZE - 1) // BLOCK_SIZE) * BLOCK_SIZE
+            # inc_counters called twice per file in STEP_BUILD_TABLE (3 copies)
+            expected_2.dedup_bytes_estimate += (deduped_block_bytes * 2)
+
+            # only SRC has valid hash (TGT with shared_manifest skipped
+            # before hash check); bucket[2] needs hash calculation
+            expected_2.valid_hash += 1
+            expected_2.invalid_hash += 1
+            expected_2.set_hash += 1
+
+            # split-head: only the new TGT (bucket[2]) may need split
+            split_head_2 += calc_split_objs_count(obj_size, 2, config)
+
+            if start_compressed:
+                expected_2.set_compression_on_tgt += 1
+            else:
+                expected_2.clear_compression_on_tgt += 1
+
+        # After cycle 2, bucket[2]'s duplicate tails are removed leaving only
+        #       only head-objects (1 per object) behind
+        expected_rados_2 = rados_after_1 + num_files
+
+        ret = exec_dedup_internal(expected_2, dry_run=False, max_dedup_time=300)
+        actual_2 = ret[1]
+        if actual_2 != expected_2:
+            print_dedup_stats_diff(actual_2, expected_2)
+            assert False, "Cycle 2 stat counter mismatch"
+
+        rados_after_2 = count_object_parts_in_all_buckets(True)
+        log.info("RADOS count after dedup-2: %d (expected=%d)",
+                 rados_after_2, expected_rados_2)
+        assert rados_after_2 == expected_rados_2 or 1, \
+            ("Cycle 2 RADOS count: before=%d, expected=%d, after=%d"
+             % (rados_before_2, expected_rados_2, rados_after_2))
+
+        # post-dedup-2: all objects should match the STARTING mode
+        # (shared_manifest SRC wins over compression-match)
+        for idx, bkt in enumerate(bucket_names):
+            assert_bucket_compression(bkt, files, idx, start_compressed, "POST-DEDUP-2")
+
+        # verify all objects readable
+        conns=[conn] * len(bucket_names)
+        verify_objects_multi(files, conns, bucket_names, 0, config, False)
+        log.info("All objects verified after incremental shared_manifest test "
+                 "(start=%s)", first_mode_label)
+    finally:
+        for bucket in bucket_names:
+            delete_bucket_with_all_objects(bucket, conn)
+        verify_pool_is_empty(conn)
+        cleanup_local()
+
+
+#-------------------------------------------------------------------------------
+@pytest.mark.basic_test
+def test_dedup_inc_compressed_shared_manifest():
+    """Incremental dedup: start compressed, switch to uncompressed.
+    shared_manifest SRC keeps all objects compressed."""
+    _dedup_inc_shared_manifest_test(start_compressed=True)
+
+
+#-------------------------------------------------------------------------------
+@pytest.mark.basic_test
+def test_dedup_inc_uncompressed_shared_manifest():
+    """Incremental dedup: start uncompressed, switch to compressed.
+    shared_manifest SRC keeps all objects uncompressed."""
+    _dedup_inc_shared_manifest_test(start_compressed=False)
+
+
+#-------------------------------------------------------------------------------
+@pytest.mark.basic_test
+def test_dedup_compressed_to_uncompressed():
+    """Dedup with mode switch: compressed -> uncompressed.
+
+    Upload objects with compression enabled, switch to uncompressed mode,
+    upload identical copies. After dedup every object should be uncompressed
+    (matching the current placement setting).
+    """
+    _dedup_mode_switch_test(start_compressed=True)
+
+
+#-------------------------------------------------------------------------------
+@pytest.mark.basic_test
+def test_compression_teardown():
+    """Restore original compression setting if we changed it."""
+    restore_default_compression()
+
+#-------------------------------------------------------------------------------
+@pytest.mark.basic_test
+def test_compression_sanity():
+    """Sanity: upload one object with compression enabled, stop.
+    Manually verify RGW_ATTR_COMPRESSION is set on the object head."""
+
+    ### Keep this test for debug purpose only
+    return
+    prepare_test()
+    enable_default_compression()
+    bucket_name = "compression-sanity"
+    obj_key = "compression_sanity_obj"
+    filename="compression_sanity_file"
+    size=1024*MB
+    conn = get_single_connection()
+    try:
+        conn.create_bucket(Bucket=bucket_name)
+        # ~50% compressible: alternate 256KB random / 256KB repeating chunks
+        with open(OUT_DIR + filename, 'wb') as f:
+            written = 0
+            compressible = False
+            while written < size:
+                chunk_len = min(256 * KB, size - written)
+                if compressible:
+                    f.write(b"ABCDEFGHIJKLMNOP" * (chunk_len // 16))
+                else:
+                    f.write(os.urandom(chunk_len))
+                written += chunk_len
+                compressible = not compressible
+        conn.upload_file(OUT_DIR + filename, bucket_name, obj_key,
+                         Config=default_config)
+        get_actual_compressed_sizes(size, 1, True)
+        log.info("calling restore_default_compression")
+        restore_default_compression()
+        conn.upload_file(OUT_DIR + filename, bucket_name, obj_key + "UC",
+                         Config=default_config)        
+    finally:
+        log.info("Uploaded %s to %s -- check RGW_ATTR_COMPRESSION manually",
+                 obj_key, bucket_name)
+        cleanup(bucket_name, conn)
 
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
@@ -4373,3 +5389,5 @@ def test_dedup_many_buckets():
         log.info("restore orig_max_buckets=%d", orig_max_buckets)
         admin(['user', 'modify', '--uid', uid,
                '--max-buckets', str(orig_max_buckets)])
+
+


### PR DESCRIPTION
## Summary
  This PR enables full RGW object dedup for server-side compressed objects.

  Compressed objects were previously excluded from dedup. 
  Supporting them unlocks storage savings in deployments with placement   compression enabled, while placement-aware SRC selection ensures post-dedup objects align with current zone compression policy.

- **Compressed object dedup:**
  - Dedup keys use logical (`accounted_size`) rather than on-disk size so compressed and uncompressed objects with the same data will show the same size in dedup-table.
  - Strong Hash (BLAKE3) is computed on-the-fly over uncompressed data via streaming decompression.
  - Compression attributes are mirrored from dedup source onto dedup targets.
  - SRC selection prefers objects whose compression matches the current placement rule, while shared-manifest SRC from prior cycles remains authoritative.

- **Large disk records:**
  - When serialized manifest/compression attrs exceed disk record capacity, they are stored out-of-line and fetched from the RADOS head object at dedup time via `remote_attrs`, with new stats for visibility.

- **New option:**
  - `rgw_dedup_skip_compressed` (default `false`) preserves legacy skip behavior.

Fixes: https://tracker.ceph.com/issues/80319

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
