### PR TITLE
mgr/dashboard: NFS enhancements - terminology alignment 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-details/nfs-cluster-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-details/nfs-cluster-details.component.html
@@ -4,7 +4,7 @@
   >
   {{title | titlecase}}
   <cd-help-text>
-    Lists exports for a cluster
+    Lists shares for a cluster
   </cd-help-text>
   </legend>
   <cd-nfs-list [clusterId]="selection.name"></cd-nfs-list>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-details/nfs-cluster-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-details/nfs-cluster-details.component.ts
@@ -8,7 +8,7 @@ import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
   standalone: false
 })
 export class NfsClusterDetailsComponent {
-  title = $localize`Export`;
+  title = $localize`Share`;
   @Input()
   selection: CdTableSelection;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
@@ -48,7 +48,7 @@
         </ng-template>
       </div>
 
-      <!-- RGW Export Type -->
+      <!-- RGW Share Type -->
       <div *ngIf="storageBackend === 'RGW' && !isEdit"
            class="form-item">
         <cds-select formControlName="rgw_export_type"
@@ -230,7 +230,7 @@
                 i18n>This field is required.</span>
           <span class="invalid-feedback"
                 *ngIf="nfsForm.get('path').hasError('isIsolatedSlash') && nfsForm.get('path').touched"
-                i18n>Export on CephFS volume "<code>/</code>" not allowed.</span>
+                i18n>Share on CephFS volume "<code>/</code>" not allowed.</span>
           <span class="invalid-feedback"
                 *ngIf="nfsForm.showError('path', formDir, 'pattern')"
                 i18n>Path need to start with a '/' and can be followed by a word</span>
@@ -315,8 +315,8 @@
                  [invalid]="nfsForm.controls.pseudo.invalid && (nfsForm.controls.pseudo.dirty)">
         </cds-text-label>
         <ng-template #pseudoHelper>
-          <span i18n>The position this export occupies in the Pseudo FS. It must be unique.</span><br/>
-          <span i18n>By using different Pseudo options, the same Path may be exported multiple times.</span>
+          <span i18n>The position this share occupies in the Pseudo FS. It must be unique.</span><br/>
+          <span i18n>By using different Pseudo options, the same Path may be shared multiple times.</span>
         </ng-template>
         <ng-template #pseudoError>
           <span class="invalid-feedback"
@@ -324,7 +324,7 @@
                 i18n>This field is required.</span>
           <span class="invalid-feedback"
                 *ngIf="nfsForm.showError('pseudo', formDir, 'pseudoAlreadyExists')"
-                i18n>The pseudo is already in use by another export.</span>
+                i18n>The pseudo is already in use by another share.</span>
           <span class="invalid-feedback"
                 *ngIf="nfsForm.showError('pseudo', formDir, 'pattern')"
                 i18n>Pseudo needs to start with a '/' and can't contain any of the following: &gt;, &lt;, |, &, ( or ).</span>
@@ -397,13 +397,13 @@
         </cds-select>
         <ng-template #squashHelper>
           <span *ngIf="nfsForm.getValue('squash') === 'root_squash'"
-                i18n>Maps the root user on the NFS client to an anonymous user/group with limited privileges. This prevents a root client user from having total control over the NFS export.</span>
+                i18n>Maps the root user on the NFS client to an anonymous user/group with limited privileges. This prevents a root client user from having total control over the NFS share.</span>
 
           <span *ngIf="nfsForm.getValue('squash') === 'root_id_squash'"
                 i18n>Maps the root user on the NFS client to an anonymous user/group with limited privileges, preventing root access but retaining non-root group privileges.</span>
 
           <span *ngIf="nfsForm.getValue('squash') === 'all_squash'"
-                i18n>Maps all users on the NFS client to an anonymous user/group with limited privileges, ensuring that no user has special privileges on the NFS export.</span>
+                i18n>Maps all users on the NFS client to an anonymous user/group with limited privileges, ensuring that no user has special privileges on the NFS share.</span>
 
           <span *ngIf="nfsForm.getValue('squash') === 'no_root_squash'"
                 i18n>Allows the root user on the NFS client to retain full root privileges on the NFS server, which may pose security risks.</span>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
@@ -112,7 +112,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
   ) {
     super();
     this.permission = this.authStorageService.getPermissions().pool;
-    this.resource = $localize`NFS export`;
+    this.resource = $localize`NFS share`;
     this.storageBackend = getFsalFromRoute(this.router.url);
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.ts
@@ -237,7 +237,7 @@ export class NfsListComponent extends ListWithDetails implements OnInit, OnDestr
 
     this.modalRef = this.modalService.show(DeleteConfirmationModalComponent, {
       impact: DeletionImpact.high,
-      itemDescription: $localize`NFS export`,
+      itemDescription: $localize`NFS share`,
       itemNames: [`${cluster_id}:${export_id}`],
       submitActionObservable: () =>
         this.taskWrapper.wrapTaskAroundCall({

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/app.constants.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/app.constants.ts
@@ -255,7 +255,7 @@ export class ActionLabelsI18n {
     this.RECONNECT = $localize`Reconnect`;
     this.ADD_STORAGE = $localize`Add Storage`;
 
-    this.NFS_EXPORT = $localize`Create NFS Export`;
+    this.NFS_EXPORT = $localize`Create NFS Share`;
     this.VIEW = $localize`View`;
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/icons.enum.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/icons.enum.ts
@@ -79,7 +79,7 @@ export enum Icons {
   eye = 'fa fa-eye', // Observability
   calendar = 'fa fa-calendar',
   externalUrl = 'fa fa-external-link', // links to external page
-  nfsExport = 'fa fa-server', // NFS export
+  nfsExport = 'fa fa-server', // NFS share
   launch = 'launch',
   parentChild = 'parent-child',
   dataTable = 'data-table',


### PR DESCRIPTION

Fixes: https://tracker.ceph.com/issues/76655



https://github.com/user-attachments/assets/644535e4-91ca-4138-a4cf-859e32160f7e



**Should the API endpoints also be updated to reflect this terminology change? For example: changing 
nfs/export to nfs/share and similar API paths?**


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
