### PR TITLE
Feature/per storage class quota

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -90,6 +90,7 @@ set(librgw_common_srcs
   rgw_public_access.cc
   rgw_putobj.cc
   rgw_quota.cc
+  rgw_sc_quota_checker.cc
   rgw_resolve.cc
   rgw_rest.cc
   rgw_rest_account.cc

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -55,6 +55,7 @@ extern "C" {
 #include "rgw_user.h"
 #include "rgw_otp.h"
 #include "rgw_rados.h"
+#include "rgw_sc_quota_types.h"
 #include "rgw_acl.h"
 #include "rgw_acl_s3.h"
 #include "rgw_datalog.h"
@@ -439,7 +440,10 @@ void usage()
   cout << "   --read-only                       set zone as read-only (when adding to zonegroup)\n";
   cout << "   --redirect-zone                   specify zone id to redirect when response is 404 (not found)\n";
   cout << "   --placement-id                    placement id for zonegroup placement commands\n";
-  cout << "   --storage-class                   storage class for zonegroup placement commands\n";
+  cout << "   --placement-target                alias for --placement-id; for 'quota set' this scopes\n";
+  cout << "                                       the quota to a per-storage-class slot\n";
+  cout << "   --storage-class                   storage class for zonegroup placement commands; for\n";
+  cout << "                                       'quota set' this scopes the quota to a per-SC slot\n";
   cout << "   --tags=<list>                     list of tags for zonegroup placement add and modify commands\n";
   cout << "   --tags-add=<list>                 list of tags to add for zonegroup placement modify command\n";
   cout << "   --tags-rm=<list>                  list of tags to remove for zonegroup placement modify command\n";
@@ -1536,6 +1540,141 @@ void set_quota_info(RGWQuotaInfo& quota, OPT opt_cmd, int64_t max_size, int64_t 
     default:
       break;
   }
+}
+
+/*
+ * Per-storage-class quota setter.
+ *
+ * Writes into RGWQuotaInfo.storage_class_quotas at key
+ *   rgw_sc_quota_key(placement_id, storage_class)
+ * and bumps enforcement_mode to HYBRID if it is currently LEGACY -- so
+ * that the existing global quota fields keep being enforced AND the new
+ * per-SC field is enforced too.  Admins that want SC-only enforcement
+ * can explicitly downgrade to STORAGE_CLASS via the JSON admin API
+ * after setting up the per-SC entries.
+ *
+ * Returns true if any change was applied (so callers know whether to
+ * actually persist the RGWQuotaInfo back to the store).
+ */
+static bool set_sc_quota_info(RGWQuotaInfo& quota, OPT opt_cmd,
+                              const std::string& placement_id,
+                              const std::string& storage_class,
+                              int64_t max_size, int64_t max_objects,
+                              bool have_max_size, bool have_max_objects)
+{
+  const std::string key = rgw_sc_quota_key(placement_id, storage_class);
+
+  switch (opt_cmd) {
+    case OPT::QUOTA_SET:
+    case OPT::QUOTA_ENABLE: {
+      auto& sc = quota.storage_class_quotas[key];
+      if (have_max_objects) {
+        sc.max_objects = (max_objects < 0) ? -1 : max_objects;
+      }
+      if (have_max_size) {
+        /* Match the kB-rounding semantics of the global quota path so
+         * that radosgw-admin's --max-size value behaves identically
+         * whether or not a storage class is supplied. */
+        sc.max_size = (max_size < 0) ? -1 : rgw_rounded_kb(max_size) * 1024;
+      }
+      if (opt_cmd == OPT::QUOTA_ENABLE) {
+        sc.enabled = true;
+      } else if (sc.max_size >= 0 || sc.max_objects >= 0) {
+        /* `quota set` with at least one limit specified -- mark this
+         * entry "enabled" automatically so the admin doesn't need a
+         * separate `quota enable` step.  This matches the practical
+         * UX expectation that "set a limit" implies "enforce it". */
+        sc.enabled = true;
+      }
+      /* If the bucket/user was running in LEGACY mode, upgrade to
+       * HYBRID so the new SC entry actually takes effect.  We never
+       * silently downgrade enforcement_mode -- if the admin chose
+       * STORAGE_CLASS explicitly we honour that. */
+      if (quota.enforcement_mode == RGWQuotaEnforcementMode::LEGACY ||
+          quota.enforcement_mode == RGWQuotaEnforcementMode::GLOBAL_ONLY) {
+        quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+      }
+      return true;
+    }
+    case OPT::QUOTA_DISABLE: {
+      auto it = quota.storage_class_quotas.find(key);
+      if (it == quota.storage_class_quotas.end()) {
+        cerr << "WARNING: no per-storage-class quota configured for key="
+             << key << "; nothing to disable" << std::endl;
+        return false;
+      }
+      it->second.enabled = false;
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+
+int set_bucket_sc_quota(rgw::sal::Driver* driver, OPT opt_cmd,
+                        const string& tenant_name, const string& bucket_name,
+                        const string& placement_id,
+                        const string& storage_class,
+                        int64_t max_size, int64_t max_objects,
+                        bool have_max_size, bool have_max_objects)
+{
+  std::unique_ptr<rgw::sal::Bucket> bucket;
+  int r = driver->load_bucket(dpp(), rgw_bucket(tenant_name, bucket_name),
+                              &bucket, null_yield);
+  if (r < 0) {
+    cerr << "could not get bucket info for bucket=" << bucket_name
+         << ": " << cpp_strerror(-r) << std::endl;
+    return -r;
+  }
+  if (!set_sc_quota_info(bucket->get_info().quota, opt_cmd,
+                         placement_id, storage_class,
+                         max_size, max_objects,
+                         have_max_size, have_max_objects)) {
+    return 0;  // nothing to write
+  }
+  r = bucket->put_info(dpp(), false, real_time(), null_yield);
+  if (r < 0) {
+    cerr << "ERROR: failed writing bucket instance info: "
+         << cpp_strerror(-r) << std::endl;
+    return -r;
+  }
+  return 0;
+}
+
+int set_user_sc_quota(OPT opt_cmd, RGWUser& user, RGWUserAdminOpState& op_state,
+                      const string& quota_scope,
+                      const string& placement_id,
+                      const string& storage_class,
+                      int64_t max_size, int64_t max_objects,
+                      bool have_max_size, bool have_max_objects)
+{
+  RGWUserInfo& user_info = op_state.get_user_info();
+  /* For users the per-SC limits live under user.quota.user_quota or
+   * user.quota.bucket_quota depending on --quota-scope, matching the
+   * existing semantics of the global quotas. */
+  RGWQuotaInfo& target = (quota_scope == "bucket")
+                         ? user_info.quota.bucket_quota
+                         : user_info.quota.user_quota;
+  if (!set_sc_quota_info(target, opt_cmd, placement_id, storage_class,
+                         max_size, max_objects,
+                         have_max_size, have_max_objects)) {
+    return 0;
+  }
+  /* Mirror the global path: push the updated RGWQuotaInfo through
+   * RGWUserAdminOpState so user metadata replication picks it up. */
+  if (quota_scope == "bucket") {
+    op_state.set_bucket_quota(user_info.quota.bucket_quota);
+  } else {
+    op_state.set_user_quota(user_info.quota.user_quota);
+  }
+  string err;
+  int r = user.modify(dpp(), op_state, null_yield, &err);
+  if (r < 0) {
+    cerr << "ERROR: failed updating user info: "
+         << cpp_strerror(-r) << ": " << err << std::endl;
+    return -r;
+  }
+  return 0;
 }
 
 int set_bucket_quota(rgw::sal::Driver* driver, OPT opt_cmd,
@@ -4309,6 +4448,12 @@ int main(int argc, const char **argv)
     } else if (ceph_argparse_witharg(args, i, &val, "--zonegroup-new-name", (char*)NULL)) {
       zonegroup_new_name = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--placement-id", (char*)NULL)) {
+      placement_id = val;
+    } else if (ceph_argparse_witharg(args, i, &val, "--placement-target", (char*)NULL)) {
+      /* --placement-target is the user-facing alias used in the
+       * per-storage-class quota documentation.  It writes into the same
+       * `placement_id` slot so all downstream code (including the
+       * zonegroup placement commands) treats them identically. */
       placement_id = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--storage-class", (char*)NULL)) {
       opt_storage_class = val;
@@ -11429,6 +11574,52 @@ next:
   bool quota_op = (opt_cmd == OPT::QUOTA_SET || opt_cmd == OPT::QUOTA_ENABLE || opt_cmd == OPT::QUOTA_DISABLE);
 
   if (quota_op) {
+    /*
+     * Per-storage-class quotas activate when BOTH --placement-target
+     * (a.k.a. --placement-id) and --storage-class are provided.
+     * Providing only one is rejected -- it would be ambiguous about
+     * which slot in storage_class_quotas the limit lives in.
+     */
+    const bool sc_quota_op =
+        !placement_id.empty() && opt_storage_class && !opt_storage_class->empty();
+    if (sc_quota_op) {
+      if (!bucket_name.empty()) {
+        if (!quota_scope.empty() && quota_scope != "bucket") {
+          cerr << "ERROR: invalid quota scope specification." << std::endl;
+          return EINVAL;
+        }
+        return set_bucket_sc_quota(driver, opt_cmd, tenant, bucket_name,
+                                   placement_id, *opt_storage_class,
+                                   max_size, max_objects,
+                                   have_max_size, have_max_objects);
+      } else if (!rgw::sal::User::empty(user)) {
+        if (quota_scope != "bucket" && quota_scope != "user") {
+          cerr << "ERROR: invalid quota scope specification. Please specify "
+                  "either --quota-scope=bucket or --quota-scope=user"
+               << std::endl;
+          return EINVAL;
+        }
+        return set_user_sc_quota(opt_cmd, ruser, user_op, quota_scope,
+                                 placement_id, *opt_storage_class,
+                                 max_size, max_objects,
+                                 have_max_size, have_max_objects);
+      } else {
+        cerr << "ERROR: --placement-target and --storage-class require "
+                "a --bucket or --uid scope" << std::endl;
+        return EINVAL;
+      }
+    }
+
+    /* Reject the ambiguous "only one of placement-target / storage-class"
+     * case BEFORE falling into the global path, so admins get a clear
+     * error rather than silently configuring the wrong quota. */
+    if (!placement_id.empty() ||
+        (opt_storage_class && !opt_storage_class->empty())) {
+      cerr << "ERROR: per-storage-class quota requires BOTH "
+              "--placement-target and --storage-class" << std::endl;
+      return EINVAL;
+    }
+
     if (!bucket_name.empty()) {
       if (!quota_scope.empty() && quota_scope != "bucket") {
         cerr << "ERROR: invalid quota scope specification." << std::endl;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -66,6 +66,7 @@
 #include "rgw_cksum_pipe.h"
 #include "rgw_lua_data_filter.h"
 #include "rgw_lua.h"
+#include "rgw_sc_quota_checker.h"
 #include "rgw_iam_managed_policy.h"
 #include "rgw_bucket_sync.h"
 #include "rgw_bucket_logging.h"
@@ -4629,6 +4630,16 @@ void RGWPutObj::execute(optional_yield y)
       ldpp_dout(this, 20) << "check_quota() returned ret=" << op_ret << dendl;
       return;
     }
+    /* Per-storage-class pre-check.  We only run this for non-chunked
+     * uploads because (a) content_length is meaningful here, and (b) the
+     * post-upload check below will catch chunked uploads anyway. */
+    op_ret = rgw::quota::rgw_check_storage_class_quota(
+        this, quota, s->bucket->get_key(), s->dest_placement,
+        s->content_length, /*new_objects=*/1, y);
+    if (op_ret < 0) {
+      ldpp_dout(this, 20) << "sc-quota pre-check returned ret=" << op_ret << dendl;
+      return;
+    }
   }
 
   if (supplied_etag) {
@@ -4898,6 +4909,17 @@ void RGWPutObj::execute(optional_yield y)
     ldpp_dout(this, 20) << "second check_quota() returned op_ret=" << op_ret << dendl;
     return;
   }
+  /* Authoritative per-SC check using the real streamed size.  Even when
+   * the pre-check above passed (or was skipped for chunked uploads),
+   * this is the call that prevents a measurement-late overshoot from
+   * being persisted. */
+  op_ret = rgw::quota::rgw_check_storage_class_quota(
+      this, quota, s->bucket->get_key(), s->dest_placement,
+      s->obj_size, /*new_objects=*/1, y);
+  if (op_ret < 0) {
+    ldpp_dout(this, 20) << "sc-quota final check returned ret=" << op_ret << dendl;
+    return;
+  }
 
   hash.Final(m);
 
@@ -5151,6 +5173,12 @@ void RGWPostObj::execute(optional_yield y)
     if (op_ret < 0) {
       return;
     }
+    op_ret = rgw::quota::rgw_check_storage_class_quota(
+        this, quota, s->bucket->get_key(), s->dest_placement,
+        s->content_length, /*new_objects=*/1, y);
+    if (op_ret < 0) {
+      return;
+    }
 
     if (supplied_md5_b64) {
       char supplied_md5_bin[CEPH_CRYPTO_MD5_DIGESTSIZE + 1];
@@ -5272,6 +5300,12 @@ void RGWPostObj::execute(optional_yield y)
 
 
     op_ret = s->bucket->check_quota(this, quota, s->obj_size, y);
+    if (op_ret < 0) {
+      return;
+    }
+    op_ret = rgw::quota::rgw_check_storage_class_quota(
+        this, quota, s->bucket->get_key(), s->dest_placement,
+        s->obj_size, /*new_objects=*/1, y);
     if (op_ret < 0) {
       return;
     }
@@ -6387,6 +6421,15 @@ void RGWCopyObj::execute(optional_yield y)
       }
       // enforce quota against the destination bucket owner
       op_ret = s->bucket->check_quota(this, quota, s->src_object->get_accounted_size(), y);
+      if (op_ret < 0) {
+        return;
+      }
+      /* For a copy, the destination's storage class is what determines
+       * which SC quota applies -- not the source's.  s->dest_placement
+       * has already been set up by the placement-resolution code above. */
+      op_ret = rgw::quota::rgw_check_storage_class_quota(
+          this, quota, s->bucket->get_key(), s->dest_placement,
+          s->src_object->get_accounted_size(), /*new_objects=*/1, y);
       if (op_ret < 0) {
         return;
       }
@@ -7576,6 +7619,49 @@ void RGWCompleteMultipart::execute(optional_yield y)
     return;
   }
 
+  /*
+   * Per-storage-class final check for multipart completes.
+   *
+   * The per-part PutObj operations already went through the SC checker.
+   * This pass is the safety net that catches the case where many parts
+   * each individually fit under the limit but the *aggregate* size of
+   * the to-be-committed object pushes the storage class over.  This is
+   * a realistic scenario: a multi-GB multipart upload may sustain
+   * dozens of parallel part PUTs, all of which pre-checked against the
+   * same (stale) cached usage number.
+   *
+   * We require that the destination placement was successfully fetched
+   * by upload->get_info() above.  If it wasn't, we silently skip the
+   * check rather than block the commit -- the per-part PutObj checks
+   * already made a reasonable enforcement effort.
+   */
+  if (dest_placement) {
+    uint64_t mp_total_size = 0;
+    int lp_ret = upload->list_parts(this, s->cct,
+                                    /*max_parts=*/1000,
+                                    /*marker=*/0,
+                                    /*next_marker=*/nullptr,
+                                    /*truncated=*/nullptr,
+                                    y);
+    if (lp_ret >= 0) {
+      for (auto& [_, mp_part] : upload->get_parts()) {
+        mp_total_size += mp_part->get_size();
+      }
+      int q_ret = rgw::quota::rgw_check_storage_class_quota(
+          this, quota, s->bucket->get_key(), *dest_placement,
+          mp_total_size, /*new_objects=*/1, y);
+      if (q_ret < 0) {
+        op_ret = q_ret;
+        ldpp_dout(this, 20) << "sc-quota multipart complete check returned ret="
+                            << op_ret << " total_size=" << mp_total_size << dendl;
+        return;
+      }
+    } else {
+      ldpp_dout(this, 10) << "WARNING: list_parts for sc-quota sum failed ret="
+                          << lp_ret << "; skipping multipart sc-quota check" << dendl;
+    }
+  }
+
   op_ret =
     upload->complete(this, y, s->cct, parts->parts, remove_objs, accounted_size,
                      compressed, cs_info, ofs, s->req_id, s->owner, olh_epoch,
@@ -8645,6 +8731,13 @@ int RGWBulkUploadOp::handle_file(const std::string_view path,
   rgw_placement_rule dest_placement = s->dest_placement;
   dest_placement.inherit_from(bucket->get_placement_rule());
 
+  op_ret = rgw::quota::rgw_check_storage_class_quota(
+      this, quota, bucket->get_key(), dest_placement,
+      size, /*new_objects=*/1, y);
+  if (op_ret < 0) {
+    return op_ret;
+  }
+
   std::unique_ptr<rgw::sal::Writer> processor;
   processor = driver->get_atomic_writer(this, s->yield, obj.get(), bowner,
 				       &s->dest_placement, 0, s->req_id);
@@ -8713,6 +8806,13 @@ int RGWBulkUploadOp::handle_file(const std::string_view path,
   op_ret = bucket->check_quota(this, quota, size, y);
   if (op_ret < 0) {
     ldpp_dout(this, 20) << "quota exceeded for path=" << path << dendl;
+    return op_ret;
+  }
+  op_ret = rgw::quota::rgw_check_storage_class_quota(
+      this, quota, bucket->get_key(), dest_placement,
+      size, /*new_objects=*/1, y);
+  if (op_ret < 0) {
+    ldpp_dout(this, 20) << "sc-quota exceeded for path=" << path << dendl;
     return op_ret;
   }
 

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -1031,6 +1031,29 @@ void rgw_apply_default_account_quota(RGWQuotaInfo& quota, const ConfigProxy& con
   }
 }
 
+/* ---- RGWStorageClassQuota JSON/Formatter ------------------------------- */
+
+void RGWStorageClassQuota::dump(Formatter *f) const
+{
+  f->dump_bool("enabled", enabled);
+  f->dump_int("max_size", max_size);
+  f->dump_int("max_size_kb", rgw_rounded_kb(max_size));
+  f->dump_int("max_objects", max_objects);
+}
+
+void RGWStorageClassQuota::decode_json(JSONObj *obj)
+{
+  if (!JSONDecoder::decode_json("max_size", max_size, obj)) {
+    int64_t max_size_kb = 0;
+    JSONDecoder::decode_json("max_size_kb", max_size_kb, obj);
+    max_size = max_size_kb * 1024;
+  }
+  JSONDecoder::decode_json("max_objects", max_objects, obj);
+  JSONDecoder::decode_json("enabled", enabled, obj);
+}
+
+/* ---- RGWQuotaInfo JSON/Formatter --------------------------------------- */
+
 void RGWQuotaInfo::dump(Formatter *f) const
 {
   f->dump_bool("enabled", enabled);
@@ -1039,6 +1062,21 @@ void RGWQuotaInfo::dump(Formatter *f) const
   f->dump_int("max_size", max_size);
   f->dump_int("max_size_kb", rgw_rounded_kb(max_size));
   f->dump_int("max_objects", max_objects);
+
+  /* v4 additions.  Emitted unconditionally so that downstream tooling
+   * (radosgw-admin output, REST admin API consumers, dashboards) can
+   * detect that an SC-quota-aware RGW is running even when the map is
+   * empty -- the presence of these fields tells operators the feature
+   * is available and just not configured. */
+  f->dump_string("enforcement_mode", to_string(enforcement_mode));
+  f->open_array_section("storage_class_quotas");
+  for (const auto& [key, q] : storage_class_quotas) {
+    f->open_object_section("entry");
+    f->dump_string("key", key);
+    q.dump(f);
+    f->close_section();
+  }
+  f->close_section();
 }
 
 std::list<RGWQuotaInfo> RGWQuotaInfo::generate_test_instances()
@@ -1050,6 +1088,18 @@ std::list<RGWQuotaInfo> RGWQuotaInfo::generate_test_instances()
   o.back().check_on_raw = true;
   o.back().max_size = 1024;
   o.back().max_objects = 1;
+
+  /* A v4 instance with non-empty SC quotas, so encode/decode round-trip
+   * coverage exercises the new fields. */
+  o.emplace_back();
+  o.back().enabled = true;
+  o.back().max_size = 10ULL << 30;          // 10 GiB global
+  o.back().max_objects = 1'000'000;
+  o.back().enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  o.back().storage_class_quotas[rgw_sc_quota_key("default-placement", "SSD")] =
+    RGWStorageClassQuota{ 1LL << 30, 100'000, true };
+  o.back().storage_class_quotas[rgw_sc_quota_key("default-placement", "GLACIER")] =
+    RGWStorageClassQuota{ 100LL << 30, -1, true };
   return o;
 }
 
@@ -1066,5 +1116,34 @@ void RGWQuotaInfo::decode_json(JSONObj *obj)
 
   JSONDecoder::decode_json("check_on_raw", check_on_raw, obj);
   JSONDecoder::decode_json("enabled", enabled, obj);
+
+  /* v4 fields.  All optional so that JSON input from older clients
+   * (e.g. dashboard versions that predate this PR) still parses. */
+  std::string mode_str;
+  if (JSONDecoder::decode_json("enforcement_mode", mode_str, obj)) {
+    RGWQuotaEnforcementMode parsed;
+    if (parse_quota_enforcement_mode(mode_str, parsed)) {
+      enforcement_mode = parsed;
+    }
+  }
+
+  /* storage_class_quotas is emitted as an array of {key,...} objects to
+   * preserve JSON ordering and avoid restricting keys to JSON-compatible
+   * names (":" is valid in our composite key but some JSON readers
+   * dislike colons in object keys). */
+  JSONObj *sc_arr = obj->find_obj("storage_class_quotas");
+  if (sc_arr) {
+    storage_class_quotas.clear();
+    auto iter = sc_arr->find_first();
+    for (; !iter.end(); ++iter) {
+      JSONObj *entry = *iter;
+      std::string key;
+      JSONDecoder::decode_json("key", key, entry);
+      if (key.empty()) continue;
+      RGWStorageClassQuota q;
+      q.decode_json(entry);
+      storage_class_quotas.emplace(std::move(key), std::move(q));
+    }
+  }
 }
 

--- a/src/rgw/rgw_quota_types.h
+++ b/src/rgw/rgw_quota_types.h
@@ -80,8 +80,20 @@ struct RGWQuotaInfo {
     /* v4 additions.  Appended AFTER all v3 fields so that an old (v3)
      * decoder running against a v4 blob will simply stop at the
      * DECODE_FINISH() boundary and silently ignore them.  This is the
-     * standard Ceph "additive" forward-compat pattern. */
-    encode(storage_class_quotas, bl);
+     * standard Ceph "additive" forward-compat pattern.
+     *
+     * The map is encoded manually (count + key/value pairs) rather than
+     * via the std::map template so that nested RGWStorageClassQuota
+     * blobs always use the member encode/decode path regardless of how
+     * denc/feature traits evolve for std::map in encoding.h. */
+    {
+      const __u32 n = static_cast<__u32>(storage_class_quotas.size());
+      encode(n, bl);
+      for (const auto& [key, q] : storage_class_quotas) {
+        encode(key, bl);
+        q.encode(bl);
+      }
+    }
     encode(static_cast<uint8_t>(enforcement_mode), bl);
     ENCODE_FINISH(bl);
   }
@@ -100,7 +112,16 @@ struct RGWQuotaInfo {
       decode(check_on_raw, bl);
     }
     if (struct_v >= 4) {
-      decode(storage_class_quotas, bl);
+      __u32 n = 0;
+      decode(n, bl);
+      storage_class_quotas.clear();
+      while (n--) {
+        std::string key;
+        RGWStorageClassQuota q;
+        decode(key, bl);
+        q.decode(bl);
+        storage_class_quotas.emplace(std::move(key), std::move(q));
+      }
       uint8_t mode_byte = 0;
       decode(mode_byte, bl);
       enforcement_mode = static_cast<RGWQuotaEnforcementMode>(mode_byte);

--- a/src/rgw/rgw_quota_types.h
+++ b/src/rgw/rgw_quota_types.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "rgw_sc_quota_types.h"
+
 static inline int64_t rgw_rounded_kb(int64_t bytes)
 {
   return (bytes + 1023) / 1024;
@@ -35,6 +37,28 @@ struct RGWQuotaInfo {
    * or maybe rounded-to-4KiB RGWStorageStats::size_rounded (false)? */
   bool check_on_raw;
 
+  /*
+   * Per-storage-class quotas (added in encode v4).
+   *
+   * Keyed by rgw_sc_quota_key("<placement>", "<storage_class>"); each value
+   * holds an independent (max_size, max_objects, enabled) tuple.  An empty
+   * map means "no per-SC quotas configured" which is the equivalent of the
+   * pre-feature behaviour and is exactly what a v3 blob decodes to.
+   */
+  RGWStorageClassQuotaMap storage_class_quotas;
+
+  /*
+   * Which quota dimensions to evaluate on the write path (added in v4).
+   * Defaults to LEGACY so that:
+   *   1. A freshly-constructed RGWQuotaInfo (no admin action yet) preserves
+   *      legacy semantics.
+   *   2. An RGWQuotaInfo decoded from a v3 blob -- which has no on-disk
+   *      enforcement_mode field -- also reads back as LEGACY.
+   * In both cases the existing global-only enforcement behaviour is
+   * bit-for-bit preserved.
+   */
+  RGWQuotaEnforcementMode enforcement_mode = RGWQuotaEnforcementMode::LEGACY;
+
   RGWQuotaInfo()
     : max_size(-1),
       max_objects(-1),
@@ -43,7 +67,7 @@ struct RGWQuotaInfo {
   }
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(3, 1, bl);
+    ENCODE_START(4, 1, bl);
     if (max_size < 0) {
       encode(-rgw_rounded_kb(abs(max_size)), bl);
     } else {
@@ -53,10 +77,16 @@ struct RGWQuotaInfo {
     encode(enabled, bl);
     encode(max_size, bl);
     encode(check_on_raw, bl);
+    /* v4 additions.  Appended AFTER all v3 fields so that an old (v3)
+     * decoder running against a v4 blob will simply stop at the
+     * DECODE_FINISH() boundary and silently ignore them.  This is the
+     * standard Ceph "additive" forward-compat pattern. */
+    encode(storage_class_quotas, bl);
+    encode(static_cast<uint8_t>(enforcement_mode), bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START_LEGACY_COMPAT_LEN(3, 1, 1, bl);
+    DECODE_START_LEGACY_COMPAT_LEN(4, 1, 1, bl);
     int64_t max_size_kb;
     decode(max_size_kb, bl);
     decode(max_objects, bl);
@@ -69,7 +99,42 @@ struct RGWQuotaInfo {
     if (struct_v >= 3) {
       decode(check_on_raw, bl);
     }
+    if (struct_v >= 4) {
+      decode(storage_class_quotas, bl);
+      uint8_t mode_byte = 0;
+      decode(mode_byte, bl);
+      enforcement_mode = static_cast<RGWQuotaEnforcementMode>(mode_byte);
+    } else {
+      /* Explicitly leave defaults: empty SC-quota map and LEGACY mode.
+       * This is what gives us "old buckets keep doing exactly what they
+       * always did, with zero behavioural change". */
+      storage_class_quotas.clear();
+      enforcement_mode = RGWQuotaEnforcementMode::LEGACY;
+    }
     DECODE_FINISH(bl);
+  }
+
+  /*
+   * Lookup helper.  Returns a pointer into storage_class_quotas (so the
+   * caller can also read max_size/max_objects) or nullptr if no per-SC
+   * quota is configured for the given (placement, storage-class) pair.
+   *
+   * Returning a pointer avoids copying RGWStorageClassQuota on the
+   * write-path hot loop -- this is called per-request.
+   */
+  const RGWStorageClassQuota* get_sc_quota(const std::string& sc_key) const {
+    auto it = storage_class_quotas.find(sc_key);
+    return it == storage_class_quotas.end() ? nullptr : &it->second;
+  }
+
+  /* Convenience: true if any per-SC quota in this RGWQuotaInfo is enabled.
+   * Used by the checker to short-circuit out of the per-SC code path on
+   * the (very common) write request that has no SC quotas configured. */
+  bool has_any_sc_quota() const {
+    for (const auto& [_, q] : storage_class_quotas) {
+      if (q.enabled) return true;
+    }
+    return false;
   }
 
   void dump(Formatter *f) const;

--- a/src/rgw/rgw_sc_quota_INTEGRATION.md
+++ b/src/rgw/rgw_sc_quota_INTEGRATION.md
@@ -1,0 +1,95 @@
+# Per-storage-class quota — integration guide
+
+This document is for the developer landing the observability-cache PR
+(#66109) and wiring it into per-storage-class quota enforcement.
+
+## What this PR shipped
+
+1. **Data model**: `RGWQuotaInfo` was extended to v4 with
+   `storage_class_quotas` (a `std::map<key, RGWStorageClassQuota>`) and
+   `enforcement_mode`.  The key format is
+   `rgw_sc_quota_key(placement, storage_class)` -> `"<pl>::<sc>"`.
+
+2. **Enforcement engine**:
+   `rgw::quota::rgw_check_storage_class_quota()` is called from every
+   write-path op in `rgw_op.cc` (PutObj pre+post, PostObj pre+post,
+   CopyObj, CompleteMultipart, BulkUpload).
+
+3. **Admin tool**: `radosgw-admin quota set --bucket=B
+   --placement-target=P --storage-class=C --max-size=N` writes into the
+   new map; `radosgw-admin quota enable` / `quota disable` work the same
+   way when both flags are provided.
+
+4. **Unit tests**: encode/decode roundtrip + checker semantics in
+   `src/test/rgw/test_rgw_sc_quota.cc`.
+
+## What is intentionally pluggable
+
+The checker reads usage stats through a tiny abstract interface
+(`rgw::quota::ScUsageStatsProvider`).  Until a provider is installed,
+the checker always returns 0 (fail-open) — which makes this PR
+behaviour-neutral on any cluster that does not also have the obs-cache
+PR.
+
+## Integration steps for the obs-cache PR
+
+1. **Implement the provider.**  Make your obs-cache singleton subclass
+   `rgw::quota::ScUsageStatsProvider`:
+
+   ```cpp
+   class RGWObsCache final : public rgw::quota::ScUsageStatsProvider {
+     std::optional<rgw::quota::ScUsageStats> lookup(
+         const rgw_bucket& bucket,
+         const std::string& sc_key) const override {
+       // hash-map lookup into your pre-aggregated table
+       ...
+     }
+   };
+   ```
+
+   `lookup()` must be thread-safe and non-blocking.
+
+2. **Register the provider during RGW startup**, after the background
+   refresh thread has at least primed itself once (or accept that
+   first-window writes will fail-open):
+
+   ```cpp
+   rgw::quota::set_sc_stats_provider(&g_obs_cache);
+   ```
+
+3. **Unregister during shutdown** — call
+   `rgw::quota::set_sc_stats_provider(nullptr)` BEFORE the obs-cache
+   object is destroyed.  The pointer is stored in a
+   `std::atomic<>`; in-flight requests already past the load will
+   complete safely because the pointer install/uninstall is on the
+   slow control path, not the request path.
+
+4. **Populate keys from Pedro's bucket-index stats (PR #66501).**
+   The obs cache's background refresh should iterate
+   `rgw_bucket_dir_header::stats_per_storage_class` (or whatever
+   Pedro's PR named the field), summing across shards, and produce a
+   table keyed by `rgw_sc_quota_key(placement, sc_name)`.  Use the
+   exact same key-builder so this PR's lookups match.
+
+## Failure modes (intentional)
+
+| Condition                                | Behaviour | Why                       |
+| ---                                      | ---       | ---                       |
+| No provider registered                   | Allow     | Obs-cache not enabled     |
+| Provider returns `nullopt`               | Allow     | Cold cache, new bucket    |
+| `enforcement_mode == LEGACY`             | Skip      | Backward compat default   |
+| `storage_class_quotas` empty             | Skip      | No SC quota configured    |
+| SC quota present but for a different key | Allow     | Doesn't apply to this op  |
+| SC quota present, size or count exceeded | -EDQUOT   | The whole point           |
+
+Every reach-the-cache failure path falls through to ALLOW the write —
+this is the safety property that lets us merge this PR independently
+of the obs-cache PR without any risk to existing deployments.
+
+## Multi-RGW consistency
+
+Each RGW process has its own ScUsageStatsProvider (its own obs cache),
+so two RGWs may see slightly different cached usage values within one
+refresh interval.  This is documented in the design and is the same
+tradeoff every other distributed object store makes for quota
+enforcement.  No cross-instance coordination is added by this PR.

--- a/src/rgw/rgw_sc_quota_checker.cc
+++ b/src/rgw/rgw_sc_quota_checker.cc
@@ -1,0 +1,246 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Per-storage-class quota enforcement engine.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#include "rgw_sc_quota_checker.h"
+
+#include <atomic>
+#include <cerrno>
+#include <limits>
+
+#include "common/dout.h"
+#include "rgw_common.h"     // rgw_bucket, ldpp_dout
+
+#define dout_subsys ceph_subsys_rgw
+
+namespace rgw::quota {
+
+/*
+ * Global provider slot.
+ *
+ * - We deliberately do NOT use a shared_ptr here.  The obs cache is a
+ *   long-lived singleton that outlives all in-flight requests; reference
+ *   counting on the hot path would just be overhead.
+ * - std::atomic with relaxed ordering on the load is sufficient: stale
+ *   reads are tolerable (they fail open by returning a null provider),
+ *   and there is no causal dependency between the pointer and any other
+ *   memory the consumer reads.  The store side uses release ordering
+ *   so that any provider state initialised before the install is visible.
+ */
+static std::atomic<ScUsageStatsProvider*> g_sc_stats_provider{nullptr};
+
+void set_sc_stats_provider(ScUsageStatsProvider* p) {
+  g_sc_stats_provider.store(p, std::memory_order_release);
+}
+
+ScUsageStatsProvider* get_sc_stats_provider() {
+  return g_sc_stats_provider.load(std::memory_order_acquire);
+}
+
+namespace {
+
+/*
+ * Evaluate a single (limit, current, delta) triple.
+ *
+ * Pulled out into a helper so the size and object-count branches read
+ * identically and so the overflow check lives in exactly one place.
+ *
+ * Returns true iff the resulting value would exceed `limit`.
+ *
+ * NOTE on signed vs unsigned: `limit` is int64_t (matches the on-disk
+ * type and "-1 means unlimited" convention) but `current` and `delta`
+ * are uint64_t (matches the obs-cache and write-path types).  We
+ * already excluded the "unlimited" case before calling this, so a
+ * static_cast<uint64_t> of `limit` is safe.
+ */
+inline bool would_exceed(int64_t limit, uint64_t current, uint64_t delta) {
+  // overflow-safe: current + delta cannot exceed UINT64_MAX in practice
+  // (bucket sizes are bounded by addressable storage), but we guard
+  // anyway because the obs cache could in theory return garbage.
+  if (delta > 0 && current > std::numeric_limits<uint64_t>::max() - delta) {
+    return true;  // overflow -> definitely over quota
+  }
+  return (current + delta) > static_cast<uint64_t>(limit);
+}
+
+/*
+ * Combine the bucket and user SC quotas for a given key into "the
+ * effective limit this op must satisfy".
+ *
+ * The semantics intentionally mirror the existing global-quota path
+ * (bucket->check_quota): if both a bucket-level and user-level limit
+ * apply, the tighter one wins.  When only one side has a quota, that
+ * one is used directly.
+ */
+struct EffectiveScQuota {
+  bool      have_size_limit   = false;
+  bool      have_object_limit = false;
+  int64_t   max_size          = -1;
+  int64_t   max_objects       = -1;
+};
+
+EffectiveScQuota combine(const RGWStorageClassQuota* bq,
+                         const RGWStorageClassQuota* uq) {
+  EffectiveScQuota out;
+  auto fold = [&](const RGWStorageClassQuota* q) {
+    if (!q || !q->enabled) return;
+    if (q->max_size >= 0) {
+      if (!out.have_size_limit || q->max_size < out.max_size) {
+        out.max_size = q->max_size;
+      }
+      out.have_size_limit = true;
+    }
+    if (q->max_objects >= 0) {
+      if (!out.have_object_limit || q->max_objects < out.max_objects) {
+        out.max_objects = q->max_objects;
+      }
+      out.have_object_limit = true;
+    }
+  };
+  fold(bq);
+  fold(uq);
+  return out;
+}
+
+/*
+ * Should the per-SC code path run at all for this op?
+ *
+ * The intent here is to keep the cost of "no SC quotas configured"
+ * down to ONE std::map::find on the empty map -- which is the case
+ * for the overwhelming majority of buckets in any deployment.
+ *
+ * Returns true iff *either* enforcement_mode requests it AND at least
+ * one side has any enabled per-SC entry that could possibly match.
+ *
+ * Note we intentionally check `has_any_sc_quota()` rather than the
+ * specific key: a bucket may have an SC quota for "SSD" but the write
+ * is to "STANDARD".  We let the lookup-by-key step (in the caller)
+ * filter that out -- it's cheaper than two map iterations.
+ */
+inline bool sc_enforcement_active(const RGWQuotaInfo& q) {
+  switch (q.enforcement_mode) {
+    case RGWQuotaEnforcementMode::STORAGE_CLASS:
+    case RGWQuotaEnforcementMode::HYBRID:
+      return q.has_any_sc_quota();
+    case RGWQuotaEnforcementMode::LEGACY:
+    case RGWQuotaEnforcementMode::GLOBAL_ONLY:
+      return false;
+  }
+  return false;
+}
+
+} // anonymous namespace
+
+int rgw_check_storage_class_quota(const DoutPrefixProvider* dpp,
+                                  const RGWQuota& quota,
+                                  const rgw_bucket& bucket,
+                                  const rgw_placement_rule& placement,
+                                  uint64_t new_size,
+                                  uint64_t new_objects,
+                                  optional_yield y) {
+  /* Fast bail-out: neither side has any SC quotas configured. This is
+   * the path taken by ~every write in a typical cluster, so it MUST
+   * be branch-predictable and allocation-free.  Two integer loads and
+   * two `enabled` checks is the entire cost. */
+  const bool bucket_active = sc_enforcement_active(quota.bucket_quota);
+  const bool user_active   = sc_enforcement_active(quota.user_quota);
+  if (!bucket_active && !user_active) {
+    return 0;
+  }
+
+  /* Compose the lookup key.  See rgw_sc_quota_key() for the format
+   * rationale ("placement::storage_class"). */
+  const std::string sc_key = rgw_sc_quota_key(placement);
+
+  /* Find the per-SC limit on each side. */
+  const RGWStorageClassQuota* bq =
+    bucket_active ? quota.bucket_quota.get_sc_quota(sc_key) : nullptr;
+  const RGWStorageClassQuota* uq =
+    user_active   ? quota.user_quota.get_sc_quota(sc_key)   : nullptr;
+
+  /* The bucket/user quota object enabled an SC quota in general but
+   * not for THIS specific (placement, storage_class).  Nothing to do. */
+  if ((!bq || !bq->enabled) && (!uq || !uq->enabled)) {
+    return 0;
+  }
+
+  const EffectiveScQuota lim = combine(bq, uq);
+  if (!lim.have_size_limit && !lim.have_object_limit) {
+    /* Both sides set enabled=true but neither set an actual limit
+     * (max_size=-1 and max_objects=-1).  Treat as "no constraint". */
+    return 0;
+  }
+
+  /* Pull live usage from the obs cache.  No provider installed, or the
+   * cache has no data yet for this key -> fail open.  This is the
+   * single most important safety property of this feature: any failure
+   * to *acquire* a measurement falls through to "allow the write".
+   *
+   * Hard-rejecting writes when the cache is missing would turn a stats
+   * subsystem outage into a data-plane outage, which is exactly the
+   * tradeoff we are explicitly choosing to avoid. */
+  ScUsageStatsProvider* provider = get_sc_stats_provider();
+  if (!provider) {
+    ldpp_dout(dpp, 20)
+      << "sc-quota: no stats provider installed; failing open for sc_key="
+      << sc_key << dendl;
+    return 0;
+  }
+
+  const std::optional<ScUsageStats> usage = provider->lookup(bucket, sc_key);
+  if (!usage) {
+    ldpp_dout(dpp, 20)
+      << "sc-quota: no cached stats for sc_key=" << sc_key
+      << " bucket=" << bucket << "; failing open" << dendl;
+    return 0;
+  }
+
+  /* Enforce.  Order: size check first, then object-count.  Either
+   * dimension being over the limit returns -EDQUOT; we don't bother
+   * computing both -- the order does not affect the externally
+   * observable behaviour and a single message is enough for the log. */
+  if (lim.have_size_limit &&
+      would_exceed(lim.max_size, usage->size, new_size)) {
+    ldpp_dout(dpp, 5)
+      << "sc-quota: size limit exceeded for sc_key=" << sc_key
+      << " bucket=" << bucket
+      << " current=" << usage->size
+      << " delta=" << new_size
+      << " limit=" << lim.max_size
+      << dendl;
+    return -EDQUOT;
+  }
+
+  if (lim.have_object_limit &&
+      would_exceed(lim.max_objects, usage->num_objects, new_objects)) {
+    ldpp_dout(dpp, 5)
+      << "sc-quota: object-count limit exceeded for sc_key=" << sc_key
+      << " bucket=" << bucket
+      << " current=" << usage->num_objects
+      << " delta=" << new_objects
+      << " limit=" << lim.max_objects
+      << dendl;
+    return -EDQUOT;
+  }
+
+  ldpp_dout(dpp, 25)
+    << "sc-quota: ok sc_key=" << sc_key
+    << " size " << usage->size << "+" << new_size
+    << "<=" << (lim.have_size_limit ? lim.max_size : -1)
+    << " objs " << usage->num_objects << "+" << new_objects
+    << "<=" << (lim.have_object_limit ? lim.max_objects : -1)
+    << dendl;
+  return 0;
+}
+
+} // namespace rgw::quota

--- a/src/rgw/rgw_sc_quota_checker.h
+++ b/src/rgw/rgw_sc_quota_checker.h
@@ -1,0 +1,149 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Per-storage-class quota enforcement engine.
+ *
+ * This is the layer that turns the configured RGWStorageClassQuota values
+ * (in RGWQuotaInfo) into accept/reject decisions on the write path.  It is
+ * deliberately separated from rgw_quota.{h,cc} because:
+ *
+ *   1. The legacy quota path (RGWQuotaHandler) is tightly coupled to RADOS;
+ *      our checker must be usable from any SAL backend.
+ *   2. The legacy path owns its own cache.  We do NOT want a second cache
+ *      for SC stats -- we read from the observability cache (PR #66109).
+ *   3. Mixing the two would force PR #66109 and Pedro's per-SC stats PR
+ *      (#66501) into one giant patch series.  Splitting them keeps each
+ *      reviewable on its own merits.
+ *
+ * The checker exposes a single hot-path function -- rgw_check_storage_class_quota
+ * -- plus a tiny stats-provider interface that lets the obs-cache PR plug
+ * itself in without us taking a build-time dependency on it.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include "common/async/yield_context.h"
+#include "common/dout.h"
+
+#include "rgw_quota_types.h"      // RGWQuotaInfo, RGWQuota
+#include "rgw_sc_quota_types.h"   // RGWStorageClassQuota, rgw_sc_quota_key
+#include "rgw_placement_types.h"  // rgw_placement_rule
+
+struct rgw_bucket;
+
+namespace rgw::quota {
+
+/*
+ * Live per-storage-class usage numbers, as observed by the obs cache.
+ *
+ * Why a struct rather than two parallel return values: future extensions
+ * (e.g. per-SC inflight-bytes for in-flight overshoot accounting) want
+ * to add fields without touching every call site.
+ */
+struct ScUsageStats {
+  uint64_t size        = 0;  // total bytes currently stored in this SC
+  uint64_t num_objects = 0;  // total object count in this SC
+};
+
+/*
+ * Storage-class usage stats source.
+ *
+ * Implemented by the observability cache (PR #66109).  Kept here as a pure
+ * abstract interface so:
+ *
+ *   - This PR can be reviewed and merged independently of #66109.  Until
+ *     a provider is installed, the checker fails open -- which is the
+ *     correct behaviour by design (see option 3 in the design doc).
+ *   - Tests can inject deterministic stat values without spinning up the
+ *     full obs-cache subsystem.
+ *
+ * Implementations MUST be thread-safe; lookup() is called from the write
+ * path with no external locking.
+ */
+class ScUsageStatsProvider {
+ public:
+  virtual ~ScUsageStatsProvider() = default;
+
+  /*
+   * Returns the most recent cached usage for (bucket, sc_key), or
+   * std::nullopt if the cache has no data yet (cold start, refresh in
+   * progress, key never observed, etc.).  std::nullopt MUST be treated
+   * as "fail open" by the caller.
+   *
+   * Must not block on RADOS.  This is called per-PUT.
+   */
+  virtual std::optional<ScUsageStats> lookup(
+      const rgw_bucket& bucket,
+      const std::string& sc_key) const = 0;
+};
+
+/*
+ * Process-global provider registration.
+ *
+ * The obs-cache subsystem calls set_sc_stats_provider() during RGW boot
+ * once its background refresh thread is running.  Passing nullptr unsets.
+ *
+ * Lifetime: the caller (the obs cache) owns the object.  RGW's shutdown
+ * sequence will call set_sc_stats_provider(nullptr) before tearing down
+ * the obs cache so we never see a dangling pointer.
+ *
+ * The pointer is stored in a std::atomic<> so the read side
+ * (get_sc_stats_provider, called by the write path) does not need a lock.
+ */
+void set_sc_stats_provider(ScUsageStatsProvider* p);
+ScUsageStatsProvider* get_sc_stats_provider();
+
+/*
+ * The hot-path entry point.
+ *
+ * Called from rgw_op.cc on every write that could touch a quota-managed
+ * storage class.  Returns:
+ *
+ *   0           : write is allowed (either no SC quota applies, or
+ *                 it applies and there is sufficient headroom).
+ *   -EDQUOT     : write would exceed a configured SC quota.  rgw_op.cc
+ *                 already translates -EDQUOT into S3 QuotaExceeded.
+ *   other < 0   : unrecoverable internal error.  In practice we never
+ *                 return such a code: any internal error path falls
+ *                 through to "fail open" and returns 0.
+ *
+ * Arguments:
+ *   dpp         : for ldpp_dout() tracing.
+ *   quota       : the aggregated (bucket + user) RGWQuota for this op,
+ *                 as already built by get_quota_info() in rgw_op.cc.
+ *   bucket      : the destination bucket.  Used as the obs-cache key.
+ *   placement   : the destination placement rule (name + storage_class).
+ *                 Already filled in by rgw_build_object_placement() for
+ *                 every write-path op before we get here.
+ *   new_size    : bytes about to be added by this op.  For RGWPutObj's
+ *                 pre-check this is content_length; for the post-check
+ *                 it is the actual streamed size.  For RGWCopyObj it is
+ *                 the source object's accounted size.  For multipart it
+ *                 is the sum of part sizes.
+ *   new_objects : object count about to be added (almost always 1, but
+ *                 multipart-complete or bulk-upload paths may pass more).
+ *   y           : the request's optional_yield, passed through for
+ *                 future async provider implementations.  Currently the
+ *                 default provider does not block on it.
+ */
+int rgw_check_storage_class_quota(const DoutPrefixProvider* dpp,
+                                  const RGWQuota& quota,
+                                  const rgw_bucket& bucket,
+                                  const rgw_placement_rule& placement,
+                                  uint64_t new_size,
+                                  uint64_t new_objects,
+                                  optional_yield y);
+
+} // namespace rgw::quota

--- a/src/rgw/rgw_sc_quota_types.h
+++ b/src/rgw/rgw_sc_quota_types.h
@@ -59,14 +59,14 @@ struct RGWStorageClassQuota {
   bool has_object_limit()  const { return enabled && max_objects >= 0; }
   bool is_active()         const { return enabled && (max_size >= 0 || max_objects >= 0); }
 
-  void encode(ceph::buffer::list& bl) const {
+  void encode(bufferlist& bl) const {
     ENCODE_START(1, 1, bl);
     encode(max_size,    bl);
     encode(max_objects, bl);
     encode(enabled,     bl);
     ENCODE_FINISH(bl);
   }
-  void decode(ceph::buffer::list::const_iterator& bl) {
+  void decode(bufferlist::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(max_size,    bl);
     decode(max_objects, bl);

--- a/src/rgw/rgw_sc_quota_types.h
+++ b/src/rgw/rgw_sc_quota_types.h
@@ -1,0 +1,172 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Per-storage-class quota types.
+ *
+ * This header defines the fundamental serialized types that extend
+ * RGWQuotaInfo with a per-storage-class breakdown.  It is intentionally
+ * minimal and free of radosgw / OSD-context includes so that it can be
+ * pulled in from headers shared with the OSD-side bucket index code.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <string>
+
+#include "include/encoding.h"
+#include "rgw_placement_types.h"
+
+class JSONObj;
+namespace ceph { class Formatter; }
+
+/*
+ * RGWStorageClassQuota
+ *
+ * Holds a single per-storage-class quota limit.  An instance lives inside
+ * RGWQuotaInfo's storage_class_quotas map, keyed by
+ *   rgw_sc_quota_key(placement, storage_class).
+ *
+ * Field semantics intentionally mirror RGWQuotaInfo so that callers can
+ * reason about them identically:
+ *   max_size    : maximum total bytes allowed in this storage class.
+ *                 A value < 0 means "unlimited".
+ *   max_objects : maximum total object count.  < 0 means "unlimited".
+ *   enabled     : if false, the quota is configured but not enforced.
+ *                 Quotas should be created in the disabled state and
+ *                 explicitly turned on, matching the existing
+ *                 `radosgw-admin quota enable` workflow.
+ */
+struct RGWStorageClassQuota {
+  int64_t max_size    = -1;
+  int64_t max_objects = -1;
+  bool    enabled     = false;
+
+  RGWStorageClassQuota() = default;
+  RGWStorageClassQuota(int64_t sz, int64_t objs, bool en)
+    : max_size(sz), max_objects(objs), enabled(en) {}
+
+  bool has_size_limit()    const { return enabled && max_size    >= 0; }
+  bool has_object_limit()  const { return enabled && max_objects >= 0; }
+  bool is_active()         const { return enabled && (max_size >= 0 || max_objects >= 0); }
+
+  void encode(ceph::buffer::list& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(max_size,    bl);
+    encode(max_objects, bl);
+    encode(enabled,     bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(ceph::buffer::list::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(max_size,    bl);
+    decode(max_objects, bl);
+    decode(enabled,     bl);
+    DECODE_FINISH(bl);
+  }
+
+  void dump(ceph::Formatter *f) const;
+  void decode_json(JSONObj *obj);
+};
+WRITE_CLASS_ENCODER(RGWStorageClassQuota)
+
+/*
+ * RGWQuotaEnforcementMode
+ *
+ * Controls which quota dimensions are evaluated on the write path.
+ *
+ *   LEGACY        : Behaves exactly like pre-feature RGW: only the global
+ *                   bucket/user quotas are checked.  This is the value
+ *                   produced when an old (v3) RGWQuotaInfo blob is decoded,
+ *                   so existing buckets get the legacy semantics by default.
+ *   GLOBAL_ONLY   : Same as LEGACY semantically, but set explicitly by the
+ *                   admin (so the value survives re-encoding without being
+ *                   reinterpreted).
+ *   STORAGE_CLASS : Only per-storage-class quotas are enforced; the global
+ *                   bucket/user quota fields are ignored.  Useful for tier
+ *                   workloads where the global limit would just be the sum
+ *                   of the per-class limits anyway.
+ *   HYBRID        : Both global AND per-storage-class quotas are enforced.
+ *                   A write must satisfy every applicable limit.  This is
+ *                   the mode automatically set by `radosgw-admin quota set`
+ *                   when --placement-target/--storage-class are provided.
+ *
+ * The enum is encoded as uint8_t so its on-wire footprint is one byte.
+ */
+enum class RGWQuotaEnforcementMode : uint8_t {
+  LEGACY        = 0,
+  GLOBAL_ONLY   = 1,
+  STORAGE_CLASS = 2,
+  HYBRID        = 3,
+};
+
+inline const char* to_string(RGWQuotaEnforcementMode m) {
+  switch (m) {
+    case RGWQuotaEnforcementMode::LEGACY:        return "legacy";
+    case RGWQuotaEnforcementMode::GLOBAL_ONLY:   return "global_only";
+    case RGWQuotaEnforcementMode::STORAGE_CLASS: return "storage_class";
+    case RGWQuotaEnforcementMode::HYBRID:        return "hybrid";
+  }
+  return "unknown";
+}
+
+inline bool parse_quota_enforcement_mode(const std::string& s,
+                                         RGWQuotaEnforcementMode& out) {
+  if      (s == "legacy")        { out = RGWQuotaEnforcementMode::LEGACY;        return true; }
+  else if (s == "global_only" ||
+           s == "global")        { out = RGWQuotaEnforcementMode::GLOBAL_ONLY;   return true; }
+  else if (s == "storage_class" ||
+           s == "sc")            { out = RGWQuotaEnforcementMode::STORAGE_CLASS; return true; }
+  else if (s == "hybrid" ||
+           s == "both")          { out = RGWQuotaEnforcementMode::HYBRID;        return true; }
+  return false;
+}
+
+/*
+ * rgw_sc_quota_key
+ *
+ * Composite key used to index both the configured per-storage-class
+ * limits (in RGWQuotaInfo.storage_class_quotas) and the live per-storage-
+ * class usage numbers (in the observability cache and Pedro's per-SC
+ * bucket-index stats map).
+ *
+ * Format: "<placement-id>::<storage-class>"
+ *
+ * The "::" delimiter is chosen deliberately:
+ *   - Neither placement IDs nor S3 storage-class names use "::"
+ *     (S3 uses uppercase letters, digits, and underscores).
+ *   - A single ":" would collide with future RGW use of ":" in
+ *     placement names (it already appears in some tenant:user keys
+ *     elsewhere in RGW).
+ *
+ * The storage class is normalised to its canonical form so that an
+ * empty value is treated as the STANDARD class -- matching the
+ * behaviour of rgw_placement_rule::get_canonical_storage_class().
+ */
+inline std::string rgw_sc_quota_key(const std::string& placement_id,
+                                    const std::string& storage_class) {
+  const std::string& sc =
+    rgw_placement_rule::get_canonical_storage_class(storage_class);
+  return placement_id + "::" + sc;
+}
+
+inline std::string rgw_sc_quota_key(const rgw_placement_rule& rule) {
+  return rgw_sc_quota_key(rule.name, rule.storage_class);
+}
+
+/*
+ * RGWStorageClassQuotaMap
+ *
+ * Typedef so the map type is named consistently across the codebase
+ * (RGWQuotaInfo, the obs cache, and admin RPC payloads).
+ */
+using RGWStorageClassQuotaMap = std::map<std::string, RGWStorageClassQuota>;

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -309,7 +309,7 @@ target_include_directories(unittest_rgw_arn
 target_link_libraries(unittest_rgw_arn ${rgw_libs})
 
 # unittest_rgw_sc_quota -- per-storage-class quota encode/decode and checker
-add_executable(unittest_rgw_sc_quota test_rgw_sc_quota.cc)
+add_executable(unittest_rgw_sc_quota test_rgw_sc_quota.cc $<TARGET_OBJECTS:unit-main>)
 add_ceph_unittest(unittest_rgw_sc_quota)
 target_include_directories(unittest_rgw_sc_quota
   SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -308,6 +308,13 @@ target_include_directories(unittest_rgw_arn
   SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
 target_link_libraries(unittest_rgw_arn ${rgw_libs})
 
+# unittest_rgw_sc_quota -- per-storage-class quota encode/decode and checker
+add_executable(unittest_rgw_sc_quota test_rgw_sc_quota.cc)
+add_ceph_unittest(unittest_rgw_sc_quota)
+target_include_directories(unittest_rgw_sc_quota
+  SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
+target_link_libraries(unittest_rgw_sc_quota ${rgw_libs})
+
 # unittest_rgw_kms
 add_executable(unittest_rgw_kms test_rgw_kms.cc)
 add_ceph_unittest(unittest_rgw_kms)

--- a/src/test/rgw/test_rgw_sc_quota.cc
+++ b/src/test/rgw/test_rgw_sc_quota.cc
@@ -43,12 +43,11 @@
 
 using namespace rgw::quota;
 
+#define dout_subsys ceph_subsys_rgw
+
 namespace {
-/* The test process never starts an RGW frontend so we need our own
- * minimal DoutPrefixProvider; NoDoutPrefix is the standard pattern
- * elsewhere in src/test/rgw. */
 struct TestDpp : NoDoutPrefix {
-  TestDpp() : NoDoutPrefix(g_ceph_context, /*subsys=*/0) {}
+  TestDpp() : NoDoutPrefix(g_ceph_context, dout_subsys) {}
 };
 } // namespace
 
@@ -90,18 +89,33 @@ struct ScopedProvider {
 
 /* ----------------------------- encode/decode ---------------------------- */
 
+TEST(RGWStorageClassQuota, Roundtrip) {
+  RGWStorageClassQuota in{ 1024 * 1024, 100, true };
+
+  bufferlist bl;
+  in.encode(bl);
+
+  RGWStorageClassQuota out;
+  auto iter = bl.cbegin();
+  out.decode(iter);
+
+  EXPECT_EQ(out.max_size, in.max_size);
+  EXPECT_EQ(out.max_objects, in.max_objects);
+  EXPECT_EQ(out.enabled, in.enabled);
+}
+
 TEST(RGWQuotaInfoV4, RoundtripEmptyScMap) {
   RGWQuotaInfo in;
   in.enabled = true;
   in.max_size = 1024;
   in.max_objects = 10;
 
-  ceph::buffer::list bl;
-  encode(in, bl);
+  bufferlist bl;
+  in.encode(bl);
 
   RGWQuotaInfo out;
-  auto p = bl.cbegin();
-  decode(out, p);
+  auto iter = bl.cbegin();
+  out.decode(iter);
 
   EXPECT_TRUE(out.enabled);
   EXPECT_EQ(out.max_size, 1024);
@@ -119,12 +133,12 @@ TEST(RGWQuotaInfoV4, RoundtripPopulatedScMap) {
   in.storage_class_quotas[rgw_sc_quota_key("default", "GLACIER")] =
     RGWStorageClassQuota{ -1, 50, true };
 
-  ceph::buffer::list bl;
-  encode(in, bl);
+  bufferlist bl;
+  in.encode(bl);
 
   RGWQuotaInfo out;
-  auto p = bl.cbegin();
-  decode(out, p);
+  auto iter = bl.cbegin();
+  out.decode(iter);
 
   EXPECT_EQ(out.enforcement_mode, RGWQuotaEnforcementMode::HYBRID);
   ASSERT_EQ(out.storage_class_quotas.size(), 2u);
@@ -149,11 +163,11 @@ TEST(RGWQuotaInfoV4, RoundtripPopulatedScMap) {
  */
 TEST(RGWQuotaInfoV4, RoundtripLegacyDefaultsStable) {
   for (auto& in : RGWQuotaInfo::generate_test_instances()) {
-    ceph::buffer::list bl;
-    encode(in, bl);
+    bufferlist bl;
+    in.encode(bl);
     RGWQuotaInfo out;
-    auto p = bl.cbegin();
-    decode(out, p);
+    auto iter = bl.cbegin();
+    out.decode(iter);
     EXPECT_EQ(in.enabled, out.enabled);
     EXPECT_EQ(in.max_size, out.max_size);
     EXPECT_EQ(in.max_objects, out.max_objects);

--- a/src/test/rgw/test_rgw_sc_quota.cc
+++ b/src/test/rgw/test_rgw_sc_quota.cc
@@ -1,0 +1,338 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+/*
+ * Unit tests for the per-storage-class quota feature.
+ *
+ * We exercise three layers in isolation:
+ *
+ *   1. The on-the-wire encoding of RGWQuotaInfo at v3 <-> v4 boundaries.
+ *      This catches the "did we accidentally break backward compat?" bug,
+ *      which is the single highest-risk failure mode of this PR.
+ *
+ *   2. The composite-key construction (rgw_sc_quota_key).  Tiny but the
+ *      whole feature is keyed on it being stable and reversible.
+ *
+ *   3. rgw_check_storage_class_quota() against a deterministic in-test
+ *      stats provider, covering:
+ *        - no enforcement_mode set => check returns 0 (legacy preservation)
+ *        - HYBRID + under limit    => returns 0
+ *        - HYBRID + over size      => returns -EDQUOT
+ *        - HYBRID + over count     => returns -EDQUOT
+ *        - HYBRID + missing stats  => returns 0 (fail-open)
+ *        - STORAGE_CLASS mode      => global quota fields ignored
+ *        - Different sc_key        => no false positive
+ *
+ * All cases are pure unit tests: no RADOS, no driver, no asio.
+ */
+
+#include <gtest/gtest.h>
+#include <cerrno>
+
+#include "common/ceph_context.h"
+#include "common/dout.h"
+#include "common/async/yield_context.h"
+#include "global/global_context.h"
+
+#include "rgw_quota_types.h"
+#include "rgw_sc_quota_types.h"
+#include "rgw_sc_quota_checker.h"
+#include "rgw_placement_types.h"
+#include "rgw_basic_types.h"        // for rgw_bucket
+#include "include/buffer.h"
+
+using namespace rgw::quota;
+
+namespace {
+/* The test process never starts an RGW frontend so we need our own
+ * minimal DoutPrefixProvider; NoDoutPrefix is the standard pattern
+ * elsewhere in src/test/rgw. */
+struct TestDpp : NoDoutPrefix {
+  TestDpp() : NoDoutPrefix(g_ceph_context, /*subsys=*/0) {}
+};
+} // namespace
+
+/* ----------------------------- helpers ---------------------------------- */
+
+static rgw_bucket make_bucket(const std::string& name = "test-bucket",
+                              const std::string& tenant = "") {
+  rgw_bucket b;
+  b.name = name;
+  b.tenant = tenant;
+  return b;
+}
+
+static rgw_placement_rule make_placement(const std::string& name,
+                                         const std::string& sc) {
+  return rgw_placement_rule(name, sc);
+}
+
+namespace {
+class FakeStatsProvider : public ScUsageStatsProvider {
+ public:
+  std::map<std::string, ScUsageStats> stats;
+  std::optional<ScUsageStats> lookup(const rgw_bucket& /*b*/,
+                                     const std::string& sc_key) const override {
+    auto it = stats.find(sc_key);
+    if (it == stats.end()) return std::nullopt;
+    return it->second;
+  }
+};
+
+// RAII installer for the global provider slot so tests don't leak state.
+struct ScopedProvider {
+  explicit ScopedProvider(ScUsageStatsProvider* p) {
+    set_sc_stats_provider(p);
+  }
+  ~ScopedProvider() { set_sc_stats_provider(nullptr); }
+};
+} // namespace
+
+/* ----------------------------- encode/decode ---------------------------- */
+
+TEST(RGWQuotaInfoV4, RoundtripEmptyScMap) {
+  RGWQuotaInfo in;
+  in.enabled = true;
+  in.max_size = 1024;
+  in.max_objects = 10;
+
+  ceph::buffer::list bl;
+  encode(in, bl);
+
+  RGWQuotaInfo out;
+  auto p = bl.cbegin();
+  decode(out, p);
+
+  EXPECT_TRUE(out.enabled);
+  EXPECT_EQ(out.max_size, 1024);
+  EXPECT_EQ(out.max_objects, 10);
+  EXPECT_TRUE(out.storage_class_quotas.empty());
+  EXPECT_EQ(out.enforcement_mode, RGWQuotaEnforcementMode::LEGACY);
+}
+
+TEST(RGWQuotaInfoV4, RoundtripPopulatedScMap) {
+  RGWQuotaInfo in;
+  in.enabled = true;
+  in.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  in.storage_class_quotas[rgw_sc_quota_key("default", "SSD")] =
+    RGWStorageClassQuota{ 1024 * 1024, 100, true };
+  in.storage_class_quotas[rgw_sc_quota_key("default", "GLACIER")] =
+    RGWStorageClassQuota{ -1, 50, true };
+
+  ceph::buffer::list bl;
+  encode(in, bl);
+
+  RGWQuotaInfo out;
+  auto p = bl.cbegin();
+  decode(out, p);
+
+  EXPECT_EQ(out.enforcement_mode, RGWQuotaEnforcementMode::HYBRID);
+  ASSERT_EQ(out.storage_class_quotas.size(), 2u);
+
+  const auto* ssd = out.get_sc_quota(rgw_sc_quota_key("default", "SSD"));
+  ASSERT_NE(ssd, nullptr);
+  EXPECT_EQ(ssd->max_size, 1024 * 1024);
+  EXPECT_EQ(ssd->max_objects, 100);
+  EXPECT_TRUE(ssd->enabled);
+
+  const auto* gla = out.get_sc_quota(rgw_sc_quota_key("default", "GLACIER"));
+  ASSERT_NE(gla, nullptr);
+  EXPECT_EQ(gla->max_size, -1);
+  EXPECT_EQ(gla->max_objects, 50);
+}
+
+/*
+ * Critical backward-compat test: encode a v4 blob with NO sc quotas and
+ * an explicit LEGACY mode, decode it, then re-encode it.  The behaviour
+ * must be indistinguishable from how a pre-feature RGW would treat the
+ * same RGWQuotaInfo -- empty map, legacy mode preserved.
+ */
+TEST(RGWQuotaInfoV4, RoundtripLegacyDefaultsStable) {
+  for (auto& in : RGWQuotaInfo::generate_test_instances()) {
+    ceph::buffer::list bl;
+    encode(in, bl);
+    RGWQuotaInfo out;
+    auto p = bl.cbegin();
+    decode(out, p);
+    EXPECT_EQ(in.enabled, out.enabled);
+    EXPECT_EQ(in.max_size, out.max_size);
+    EXPECT_EQ(in.max_objects, out.max_objects);
+    EXPECT_EQ(in.check_on_raw, out.check_on_raw);
+    EXPECT_EQ(in.enforcement_mode, out.enforcement_mode);
+    EXPECT_EQ(in.storage_class_quotas.size(), out.storage_class_quotas.size());
+  }
+}
+
+/* ----------------------------- key construction ------------------------- */
+
+TEST(RGWScQuotaKey, BasicComposition) {
+  EXPECT_EQ(rgw_sc_quota_key("default-placement", "SSD"),
+            "default-placement::SSD");
+}
+
+TEST(RGWScQuotaKey, EmptyStorageClassMapsToSTANDARD) {
+  // get_canonical_storage_class("") -> "STANDARD"
+  EXPECT_EQ(rgw_sc_quota_key("default-placement", ""),
+            "default-placement::STANDARD");
+}
+
+TEST(RGWScQuotaKey, FromRule) {
+  EXPECT_EQ(rgw_sc_quota_key(make_placement("p1", "GLACIER")),
+            "p1::GLACIER");
+}
+
+/* ----------------------------- checker semantics ------------------------ */
+
+TEST(RGWScQuotaChecker, LegacyModeReturnsZero) {
+  TestDpp dpp;
+  FakeStatsProvider prov;
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enabled = true;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::LEGACY;
+  // Even with an entry present, LEGACY mode must NOT consult it.
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+    RGWStorageClassQuota{ 1, 1, true };
+
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      1ULL << 30, 100, null_yield);
+  EXPECT_EQ(r, 0);
+}
+
+TEST(RGWScQuotaChecker, NoSCConfiguredFallsThrough) {
+  TestDpp dpp;
+  FakeStatsProvider prov;
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enabled = true;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  // storage_class_quotas is empty -> sc_enforcement_active() returns false.
+
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      1ULL << 40, 1'000'000, null_yield);
+  EXPECT_EQ(r, 0);
+}
+
+TEST(RGWScQuotaChecker, UnderLimitAllows) {
+  TestDpp dpp;
+  FakeStatsProvider prov;
+  prov.stats[rgw_sc_quota_key("p", "SSD")] = ScUsageStats{ 50, 5 };
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+    RGWStorageClassQuota{ /*max_size=*/100, /*max_objects=*/10, /*enabled=*/true };
+
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      /*new_size=*/40, /*new_objects=*/3, null_yield);
+  EXPECT_EQ(r, 0);
+}
+
+TEST(RGWScQuotaChecker, OverSizeReturnsEDQUOT) {
+  TestDpp dpp;
+  FakeStatsProvider prov;
+  prov.stats[rgw_sc_quota_key("p", "SSD")] = ScUsageStats{ 90, 5 };
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+    RGWStorageClassQuota{ 100, -1, true };
+
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      /*new_size=*/15, /*new_objects=*/1, null_yield);
+  EXPECT_EQ(r, -EDQUOT);
+}
+
+TEST(RGWScQuotaChecker, OverObjectCountReturnsEDQUOT) {
+  TestDpp dpp;
+  FakeStatsProvider prov;
+  prov.stats[rgw_sc_quota_key("p", "SSD")] = ScUsageStats{ 10, 9 };
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+    RGWStorageClassQuota{ -1, /*max_objects=*/10, true };
+
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      /*new_size=*/1, /*new_objects=*/2, null_yield);
+  EXPECT_EQ(r, -EDQUOT);
+}
+
+TEST(RGWScQuotaChecker, MissingStatsFailsOpen) {
+  TestDpp dpp;
+  FakeStatsProvider prov;  // empty
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+    RGWStorageClassQuota{ 1, 1, true };
+
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      1'000'000, 1, null_yield);
+  EXPECT_EQ(r, 0);  // fail-open even though we are way over limit
+}
+
+TEST(RGWScQuotaChecker, NoProviderFailsOpen) {
+  TestDpp dpp;
+  // No ScopedProvider -> get_sc_stats_provider() returns nullptr.
+
+  RGWQuota q;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+    RGWStorageClassQuota{ 1, 1, true };
+
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      1'000'000, 1, null_yield);
+  EXPECT_EQ(r, 0);
+}
+
+TEST(RGWScQuotaChecker, DifferentScKeyNoFalsePositive) {
+  TestDpp dpp;
+  FakeStatsProvider prov;
+  prov.stats[rgw_sc_quota_key("p", "GLACIER")] = ScUsageStats{ 9999999, 9999 };
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+    RGWStorageClassQuota{ 1, 1, true };
+  // Writing to GLACIER but only SSD has a quota -> no SC quota applies.
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "GLACIER"),
+      1, 1, null_yield);
+  EXPECT_EQ(r, 0);
+}
+
+TEST(RGWScQuotaChecker, BucketAndUserCombineTighter) {
+  TestDpp dpp;
+  FakeStatsProvider prov;
+  prov.stats[rgw_sc_quota_key("p", "SSD")] = ScUsageStats{ 80, 5 };
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+    RGWStorageClassQuota{ /*max_size=*/200, /*max_objects=*/-1, true };
+  q.user_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  q.user_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+    RGWStorageClassQuota{ /*max_size=*/100, /*max_objects=*/-1, true };
+
+  // 80 + 25 = 105 > 100 (user limit) but < 200 (bucket limit) -> reject.
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      25, 1, null_yield);
+  EXPECT_EQ(r, -EDQUOT);
+}


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
