### PR TITLE
rgw: add per-storage-class quota enforcement

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -146,7 +146,8 @@ set(librgw_common_srcs
   rgw_bucket_logging.cc
   rgw_rest_bucket_logging.cc
   rgw_bucket_sync.cc
-  rgw_rest_restore.cc)
+  rgw_rest_restore.cc
+  rgw_sc_quota_checker.cc)
 
 list(APPEND librgw_common_srcs
   driver/immutable_config/store.cc

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -88,6 +88,7 @@ extern "C" {
 #include "services/svc_mdlog.h"
 #include "services/svc_user.h"
 #include "services/svc_zone.h"
+#include "rgw_sc_quota_types.h"
 
 #include "driver/rados/rgw_bucket.h"
 #include "driver/rados/rgw_sal_rados.h"
@@ -439,7 +440,8 @@ void usage()
   cout << "   --read-only                       set zone as read-only (when adding to zonegroup)\n";
   cout << "   --redirect-zone                   specify zone id to redirect when response is 404 (not found)\n";
   cout << "   --placement-id                    placement id for zonegroup placement commands\n";
-  cout << "   --storage-class                   storage class for zonegroup placement commands\n";
+  cout << "   --placement-target                alias for --placement-id; for 'quota set' this scopes the quota to a per-storage-class slot\n";
+  cout << "   --storage-class                   storage class for zonegroup placement commands; for 'quota set' this scopes the quota to a per-SC slot\n";
   cout << "   --tags=<list>                     list of tags for zonegroup placement add and modify commands\n";
   cout << "   --tags-add=<list>                 list of tags to add for zonegroup placement modify command\n";
   cout << "   --tags-rm=<list>                  list of tags to remove for zonegroup placement modify command\n";
@@ -1536,6 +1538,141 @@ void set_quota_info(RGWQuotaInfo& quota, OPT opt_cmd, int64_t max_size, int64_t 
     default:
       break;
   }
+}
+
+/*
+ * Per-storage-class quota setter.
+ *
+ * Writes into RGWQuotaInfo.storage_class_quotas at key
+ *   rgw_sc_quota_key(placement_id, storage_class)
+ * and bumps enforcement_mode to HYBRID if it is currently LEGACY -- so
+ * that the existing global quota fields keep being enforced AND the new
+ * per-SC field is enforced too.  Admins that want SC-only enforcement
+ * can explicitly downgrade to STORAGE_CLASS via the JSON admin API
+ * after setting up the per-SC entries.
+ *
+ * Returns true if any change was applied (so callers know whether to
+ * actually persist the RGWQuotaInfo back to the store).
+ */
+static bool set_sc_quota_info(RGWQuotaInfo& quota, OPT opt_cmd,
+                              const std::string& placement_id,
+                              const std::string& storage_class,
+                              int64_t max_size, int64_t max_objects,
+                              bool have_max_size, bool have_max_objects)
+{
+  const std::string key = rgw_sc_quota_key(placement_id, storage_class);
+
+  switch (opt_cmd) {
+    case OPT::QUOTA_SET:
+    case OPT::QUOTA_ENABLE: {
+      auto& sc = quota.storage_class_quotas[key];
+      if (have_max_objects) {
+        sc.max_objects = (max_objects < 0) ? -1 : max_objects;
+      }
+      if (have_max_size) {
+        /* Match the kB-rounding semantics of the global quota path so
+         * that radosgw-admin's --max-size value behaves identically
+         * whether or not a storage class is supplied. */
+        sc.max_size = (max_size < 0) ? -1 : rgw_rounded_kb(max_size) * 1024;
+      }
+      if (opt_cmd == OPT::QUOTA_ENABLE) {
+        sc.enabled = true;
+      } else if (sc.max_size >= 0 || sc.max_objects >= 0) {
+        /* `quota set` with at least one limit specified -- mark this
+         * entry "enabled" automatically so the admin doesn't need a
+         * separate `quota enable` step.  This matches the practical
+         * UX expectation that "set a limit" implies "enforce it". */
+        sc.enabled = true;
+      }
+      /* If the bucket/user was running in LEGACY mode, upgrade to
+       * HYBRID so the new SC entry actually takes effect.  We never
+       * silently downgrade enforcement_mode -- if the admin chose
+       * STORAGE_CLASS explicitly we honour that. */
+      if (quota.enforcement_mode == RGWQuotaEnforcementMode::LEGACY ||
+          quota.enforcement_mode == RGWQuotaEnforcementMode::GLOBAL_ONLY) {
+        quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+      }
+      return true;
+    }
+    case OPT::QUOTA_DISABLE: {
+      auto it = quota.storage_class_quotas.find(key);
+      if (it == quota.storage_class_quotas.end()) {
+        cerr << "WARNING: no per-storage-class quota configured for key="
+             << key << "; nothing to disable" << std::endl;
+        return false;
+      }
+      it->second.enabled = false;
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+
+int set_bucket_sc_quota(rgw::sal::Driver* driver, OPT opt_cmd,
+                        const string& tenant_name, const string& bucket_name,
+                        const string& placement_id,
+                        const string& storage_class,
+                        int64_t max_size, int64_t max_objects,
+                        bool have_max_size, bool have_max_objects)
+{
+  std::unique_ptr<rgw::sal::Bucket> bucket;
+  int r = driver->load_bucket(dpp(), rgw_bucket(tenant_name, bucket_name),
+                              &bucket, null_yield);
+  if (r < 0) {
+    cerr << "could not get bucket info for bucket=" << bucket_name
+         << ": " << cpp_strerror(-r) << std::endl;
+    return -r;
+  }
+  if (!set_sc_quota_info(bucket->get_info().quota, opt_cmd,
+                         placement_id, storage_class,
+                         max_size, max_objects,
+                         have_max_size, have_max_objects)) {
+    return 0;  // nothing to write
+  }
+  r = bucket->put_info(dpp(), false, real_time(), null_yield);
+  if (r < 0) {
+    cerr << "ERROR: failed writing bucket instance info: "
+         << cpp_strerror(-r) << std::endl;
+    return -r;
+  }
+  return 0;
+}
+
+int set_user_sc_quota(OPT opt_cmd, RGWUser& user, RGWUserAdminOpState& op_state,
+                      const string& quota_scope,
+                      const string& placement_id,
+                      const string& storage_class,
+                      int64_t max_size, int64_t max_objects,
+                      bool have_max_size, bool have_max_objects)
+{
+  RGWUserInfo& user_info = op_state.get_user_info();
+  /* For users the per-SC limits live under user.quota.user_quota or
+   * user.quota.bucket_quota depending on --quota-scope, matching the
+   * existing semantics of the global quotas. */
+  RGWQuotaInfo& target = (quota_scope == "bucket")
+                         ? user_info.quota.bucket_quota
+                         : user_info.quota.user_quota;
+  if (!set_sc_quota_info(target, opt_cmd, placement_id, storage_class,
+                         max_size, max_objects,
+                         have_max_size, have_max_objects)) {
+    return 0;
+  }
+  /* Mirror the global path: push the updated RGWQuotaInfo through
+   * RGWUserAdminOpState so user metadata replication picks it up. */
+  if (quota_scope == "bucket") {
+    op_state.set_bucket_quota(user_info.quota.bucket_quota);
+  } else {
+    op_state.set_user_quota(user_info.quota.user_quota);
+  }
+  string err;
+  int r = user.modify(dpp(), op_state, null_yield, &err);
+  if (r < 0) {
+    cerr << "ERROR: failed updating user info: "
+         << cpp_strerror(-r) << ": " << err << std::endl;
+    return -r;
+  }
+  return 0;
 }
 
 int set_bucket_quota(rgw::sal::Driver* driver, OPT opt_cmd,
@@ -4309,6 +4446,8 @@ int main(int argc, const char **argv)
     } else if (ceph_argparse_witharg(args, i, &val, "--zonegroup-new-name", (char*)NULL)) {
       zonegroup_new_name = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--placement-id", (char*)NULL)) {
+      placement_id = val;
+    } else if (ceph_argparse_witharg(args, i, &val, "--placement-target", (char*)NULL)) {
       placement_id = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--storage-class", (char*)NULL)) {
       opt_storage_class = val;
@@ -11429,6 +11568,42 @@ next:
   bool quota_op = (opt_cmd == OPT::QUOTA_SET || opt_cmd == OPT::QUOTA_ENABLE || opt_cmd == OPT::QUOTA_DISABLE);
 
   if (quota_op) {
+    const bool sc_quota_op =
+        !placement_id.empty() && opt_storage_class && !opt_storage_class->empty();
+    if (sc_quota_op) {
+      if (!bucket_name.empty()) {
+        if (!quota_scope.empty() && quota_scope != "bucket") {
+          cerr << "ERROR: invalid quota scope specification." << std::endl;
+          return EINVAL;
+        }
+        return set_bucket_sc_quota(driver, opt_cmd, tenant, bucket_name,
+                                   placement_id, *opt_storage_class,
+                                   max_size, max_objects,
+                                   have_max_size, have_max_objects);
+      } else if (!rgw::sal::User::empty(user)) {
+        if (quota_scope != "bucket" && quota_scope != "user") {
+          cerr << "ERROR: invalid quota scope specification. Please specify "
+                  "either --quota-scope=bucket or --quota-scope=user"
+               << std::endl;
+          return EINVAL;
+        }
+        return set_user_sc_quota(opt_cmd, ruser, user_op, quota_scope,
+                                 placement_id, *opt_storage_class,
+                                 max_size, max_objects,
+                                 have_max_size, have_max_objects);
+      } else {
+        cerr << "ERROR: --placement-target and --storage-class require "
+                "a --bucket or --uid scope" << std::endl;
+        return EINVAL;
+      }
+    }
+    if (!placement_id.empty() ||
+        (opt_storage_class && !opt_storage_class->empty())) {
+      cerr << "ERROR: per-storage-class quota requires BOTH "
+              "--placement-target and --storage-class" << std::endl;
+      return EINVAL;
+    }
+
     if (!bucket_name.empty()) {
       if (!quota_scope.empty() && quota_scope != "bucket") {
         cerr << "ERROR: invalid quota scope specification." << std::endl;

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -7067,11 +7067,20 @@ int main(int argc, const char **argv)
     rgw_placement_rule target_rule;
     target_rule.name = placement_id;
     target_rule.storage_class = opt_storage_class.value_or("");
-    if (!driver->valid_placement(target_rule)) {
-      cerr << "NOTICE: invalid dest placement: " << target_rule.to_str() << std::endl;
+
+    // Skip placement validation for quota commands , as the SC quota is just a string identifier and not a live placement target
+    const bool is_quota_cmd = (opt_cmd == OPT::QUOTA_SET   ||
+                               opt_cmd == OPT::QUOTA_ENABLE ||
+                               opt_cmd == OPT::QUOTA_DISABLE);
+    if (!is_quota_cmd && !driver->valid_placement(target_rule)) {
+      cerr << "NOTICE: invalid dest placement: "
+           << target_rule.to_str() << std::endl;
       return EINVAL;
     }
-    user_op.set_default_placement(target_rule);
+    if (!is_quota_cmd) {
+      user_op.set_default_placement(target_rule);
+    }
+
   }
 
   if (!tags.empty()) {

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -71,7 +71,7 @@
 #include "rgw_bucket_logging.h"
 #include "rgw_restore.h"
 #include "rgw_restore_waiter.h"
-
+#include "rgw_sc_quota_checker.h"
 #include "services/svc_zone.h"
 #include "services/svc_quota.h"
 #include "services/svc_sys_obj.h"
@@ -4629,6 +4629,13 @@ void RGWPutObj::execute(optional_yield y)
       ldpp_dout(this, 20) << "check_quota() returned ret=" << op_ret << dendl;
       return;
     }
+    op_ret = rgw::quota::rgw_check_storage_class_quota(
+        this, quota, s->bucket->get_key(), s->dest_placement,
+        s->content_length, /*new_objects=*/1, y);
+    if (op_ret < 0) {
+      ldpp_dout(this, 20) << "sc-quota pre-check returned ret=" << op_ret << dendl;
+      return;
+    }
   }
 
   if (supplied_etag) {
@@ -4898,6 +4905,14 @@ void RGWPutObj::execute(optional_yield y)
     ldpp_dout(this, 20) << "second check_quota() returned op_ret=" << op_ret << dendl;
     return;
   }
+  
+  op_ret = rgw::quota::rgw_check_storage_class_quota(
+      this, quota, s->bucket->get_key(), s->dest_placement,
+      s->obj_size, /*new_objects=*/1, y);
+  if (op_ret < 0) {
+    ldpp_dout(this, 20) << "sc-quota final check returned ret=" << op_ret << dendl;
+    return;
+  }
 
   hash.Final(m);
 
@@ -5151,7 +5166,12 @@ void RGWPostObj::execute(optional_yield y)
     if (op_ret < 0) {
       return;
     }
-
+    op_ret = rgw::quota::rgw_check_storage_class_quota(
+        this, quota, s->bucket->get_key(), s->dest_placement,
+        s->content_length, /*new_objects=*/1, y);
+    if (op_ret < 0) {
+      return;
+    }
     if (supplied_md5_b64) {
       char supplied_md5_bin[CEPH_CRYPTO_MD5_DIGESTSIZE + 1];
       ldpp_dout(this, 15) << "supplied_md5_b64=" << supplied_md5_b64 << dendl;
@@ -5275,7 +5295,12 @@ void RGWPostObj::execute(optional_yield y)
     if (op_ret < 0) {
       return;
     }
-
+    op_ret = rgw::quota::rgw_check_storage_class_quota(
+        this, quota, s->bucket->get_key(), s->dest_placement,
+        s->obj_size, /*new_objects=*/1, y);
+    if (op_ret < 0) {
+      return;
+    }
     hash.Final(m);
     etag.clear();
     etag.reserve(CEPH_CRYPTO_MD5_DIGESTSIZE * 2);
@@ -6387,6 +6412,12 @@ void RGWCopyObj::execute(optional_yield y)
       }
       // enforce quota against the destination bucket owner
       op_ret = s->bucket->check_quota(this, quota, s->src_object->get_accounted_size(), y);
+      if (op_ret < 0) {
+        return;
+      }
+      op_ret = rgw::quota::rgw_check_storage_class_quota(
+          this, quota, s->bucket->get_key(), s->dest_placement,
+          s->src_object->get_accounted_size(), /*new_objects=*/1, y);
       if (op_ret < 0) {
         return;
       }
@@ -7576,6 +7607,33 @@ void RGWCompleteMultipart::execute(optional_yield y)
     return;
   }
 
+  if (dest_placement) {
+    uint64_t mp_total_size = 0;
+    int lp_ret = upload->list_parts(this, s->cct,
+                                    /*max_parts=*/1000,
+                                    /*marker=*/0,
+                                    /*next_marker=*/nullptr,
+                                    /*truncated=*/nullptr,
+                                    y);
+    if (lp_ret >= 0) {
+      for (auto& [_, mp_part] : upload->get_parts()) {
+        mp_total_size += mp_part->get_size();
+      }
+      int q_ret = rgw::quota::rgw_check_storage_class_quota(
+          this, quota, s->bucket->get_key(), *dest_placement,
+          mp_total_size, /*new_objects=*/1, y);
+      if (q_ret < 0) {
+        op_ret = q_ret;
+        ldpp_dout(this, 20) << "sc-quota multipart complete check returned ret="
+                            << op_ret << " total_size=" << mp_total_size << dendl;
+        return;
+      }
+    } else {
+      ldpp_dout(this, 10) << "WARNING: list_parts for sc-quota sum failed ret="
+                          << lp_ret << "; skipping multipart sc-quota check" << dendl;
+    }
+  }
+
   op_ret =
     upload->complete(this, y, s->cct, parts->parts, remove_objs, accounted_size,
                      compressed, cs_info, ofs, s->req_id, s->owner, olh_epoch,
@@ -8645,6 +8703,13 @@ int RGWBulkUploadOp::handle_file(const std::string_view path,
   rgw_placement_rule dest_placement = s->dest_placement;
   dest_placement.inherit_from(bucket->get_placement_rule());
 
+  op_ret = rgw::quota::rgw_check_storage_class_quota(
+      this, quota, bucket->get_key(), dest_placement,
+      size, /*new_objects=*/1, y);
+  if (op_ret < 0) {
+    return op_ret;
+  }
+
   std::unique_ptr<rgw::sal::Writer> processor;
   processor = driver->get_atomic_writer(this, s->yield, obj.get(), bowner,
 				       &s->dest_placement, 0, s->req_id);
@@ -8713,6 +8778,14 @@ int RGWBulkUploadOp::handle_file(const std::string_view path,
   op_ret = bucket->check_quota(this, quota, size, y);
   if (op_ret < 0) {
     ldpp_dout(this, 20) << "quota exceeded for path=" << path << dendl;
+    return op_ret;
+  }
+  
+  op_ret = rgw::quota::rgw_check_storage_class_quota(
+      this, quota, bucket->get_key(), dest_placement,
+      size, /*new_objects=*/1, y);
+  if (op_ret < 0) {
+    ldpp_dout(this, 20) << "sc-quota exceeded for path=" << path << dendl;
     return op_ret;
   }
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -7610,7 +7610,7 @@ void RGWCompleteMultipart::execute(optional_yield y)
   if (dest_placement) {
     uint64_t mp_total_size = 0;
     int lp_ret = upload->list_parts(this, s->cct,
-                                    /*max_parts=*/1000,
+                                    /*max_parts=*/10000,
                                     /*marker=*/0,
                                     /*next_marker=*/nullptr,
                                     /*truncated=*/nullptr,

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -1031,6 +1031,25 @@ void rgw_apply_default_account_quota(RGWQuotaInfo& quota, const ConfigProxy& con
   }
 }
 
+void RGWStorageClassQuota::dump(Formatter *f) const
+{
+  f->dump_bool("enabled", enabled);
+  f->dump_int("max_size", max_size);
+  f->dump_int("max_size_kb", rgw_rounded_kb(max_size));
+  f->dump_int("max_objects", max_objects);
+}
+
+void RGWStorageClassQuota::decode_json(JSONObj *obj)
+{
+  if (!JSONDecoder::decode_json("max_size", max_size, obj)) {
+    int64_t max_size_kb = 0;
+    JSONDecoder::decode_json("max_size_kb", max_size_kb, obj);
+    max_size = max_size_kb * 1024;
+  }
+  JSONDecoder::decode_json("max_objects", max_objects, obj);
+  JSONDecoder::decode_json("enabled", enabled, obj);
+}
+
 void RGWQuotaInfo::dump(Formatter *f) const
 {
   f->dump_bool("enabled", enabled);
@@ -1039,6 +1058,16 @@ void RGWQuotaInfo::dump(Formatter *f) const
   f->dump_int("max_size", max_size);
   f->dump_int("max_size_kb", rgw_rounded_kb(max_size));
   f->dump_int("max_objects", max_objects);
+  
+  f->dump_string("enforcement_mode", to_string(enforcement_mode));
+  f->open_array_section("storage_class_quotas");
+  for (const auto& [key, q] : storage_class_quotas) {
+    f->open_object_section("entry");
+    f->dump_string("key", key);
+    q.dump(f);
+    f->close_section();
+  }
+  f->close_section();
 }
 
 std::list<RGWQuotaInfo> RGWQuotaInfo::generate_test_instances()
@@ -1050,6 +1079,15 @@ std::list<RGWQuotaInfo> RGWQuotaInfo::generate_test_instances()
   o.back().check_on_raw = true;
   o.back().max_size = 1024;
   o.back().max_objects = 1;
+  o.emplace_back();
+  o.back().enabled = true;
+  o.back().max_size = 10ULL << 30;          // 10 GiB global
+  o.back().max_objects = 1'000'000;
+  o.back().enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  o.back().storage_class_quotas[rgw_sc_quota_key("default-placement", "SSD")] =
+    RGWStorageClassQuota{ 1LL << 30, 100'000, true };
+  o.back().storage_class_quotas[rgw_sc_quota_key("default-placement", "GLACIER")] =
+    RGWStorageClassQuota{ 100LL << 30, -1, true };
   return o;
 }
 
@@ -1066,5 +1104,28 @@ void RGWQuotaInfo::decode_json(JSONObj *obj)
 
   JSONDecoder::decode_json("check_on_raw", check_on_raw, obj);
   JSONDecoder::decode_json("enabled", enabled, obj);
+  
+  std::string mode_str;
+  if (JSONDecoder::decode_json("enforcement_mode", mode_str, obj)) {
+    RGWQuotaEnforcementMode parsed;
+    if (parse_quota_enforcement_mode(mode_str, parsed)) {
+      enforcement_mode = parsed;
+    }
+  }
+
+  JSONObj *sc_arr = obj->find_obj("storage_class_quotas");
+  if (sc_arr) {
+    storage_class_quotas.clear();
+    auto iter = sc_arr->find_first();
+    for (; !iter.end(); ++iter) {
+      JSONObj *entry = *iter;
+      std::string key;
+      JSONDecoder::decode_json("key", key, entry);
+      if (key.empty()) continue;
+      RGWStorageClassQuota q;
+      q.decode_json(entry);
+      storage_class_quotas.emplace(std::move(key), std::move(q));
+    }
+  }
 }
 

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -1059,15 +1059,18 @@ void RGWQuotaInfo::dump(Formatter *f) const
   f->dump_int("max_size_kb", rgw_rounded_kb(max_size));
   f->dump_int("max_objects", max_objects);
   
-  f->dump_string("enforcement_mode", to_string(enforcement_mode));
-  f->open_array_section("storage_class_quotas");
-  for (const auto& [key, q] : storage_class_quotas) {
-    f->open_object_section("entry");
-    f->dump_string("key", key);
-    q.dump(f);
+  if (!storage_class_quotas.empty() ||
+      enforcement_mode != RGWQuotaEnforcementMode::LEGACY) {
+    f->dump_string("enforcement_mode", to_string(enforcement_mode));
+    f->open_array_section("storage_class_quotas");
+    for (const auto& [key, q] : storage_class_quotas) {
+      f->open_object_section("entry");
+      f->dump_string("key", key);
+      q.dump(f);
+      f->close_section();
+    }
     f->close_section();
   }
-  f->close_section();
 }
 
 std::list<RGWQuotaInfo> RGWQuotaInfo::generate_test_instances()

--- a/src/rgw/rgw_quota_types.h
+++ b/src/rgw/rgw_quota_types.h
@@ -19,6 +19,7 @@
  */
 
 #pragma once
+#include "rgw_sc_quota_types.h"
 
 static inline int64_t rgw_rounded_kb(int64_t bytes)
 {
@@ -35,6 +36,9 @@ struct RGWQuotaInfo {
    * or maybe rounded-to-4KiB RGWStorageStats::size_rounded (false)? */
   bool check_on_raw;
 
+  RGWStorageClassQuotaMap storage_class_quotas;
+  RGWQuotaEnforcementMode enforcement_mode = RGWQuotaEnforcementMode::LEGACY;
+
   RGWQuotaInfo()
     : max_size(-1),
       max_objects(-1),
@@ -43,7 +47,7 @@ struct RGWQuotaInfo {
   }
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(3, 1, bl);
+    ENCODE_START(4, 1, bl);
     if (max_size < 0) {
       encode(-rgw_rounded_kb(abs(max_size)), bl);
     } else {
@@ -53,10 +57,12 @@ struct RGWQuotaInfo {
     encode(enabled, bl);
     encode(max_size, bl);
     encode(check_on_raw, bl);
+    encode(storage_class_quotas, bl);
+    encode(static_cast<uint8_t>(enforcement_mode), bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START_LEGACY_COMPAT_LEN(3, 1, 1, bl);
+    DECODE_START_LEGACY_COMPAT_LEN(4, 1, 1, bl);
     int64_t max_size_kb;
     decode(max_size_kb, bl);
     decode(max_objects, bl);
@@ -70,6 +76,27 @@ struct RGWQuotaInfo {
       decode(check_on_raw, bl);
     }
     DECODE_FINISH(bl);
+    if (struct_v >= 4) {
+      decode(storage_class_quotas, bl);
+      uint8_t mode_byte = 0;
+      decode(mode_byte, bl);
+      enforcement_mode = static_cast<RGWQuotaEnforcementMode>(mode_byte);
+    } else {
+      storage_class_quotas.clear();
+      enforcement_mode = RGWQuotaEnforcementMode::LEGACY;
+    }
+  }
+
+  const RGWStorageClassQuota* get_sc_quota(const std::string& sc_key) const {
+    auto it = storage_class_quotas.find(sc_key);
+    return it == storage_class_quotas.end() ? nullptr : &it->second;
+  }
+
+  bool has_any_sc_quota() const {
+    for (const auto& [_, q] : storage_class_quotas) {
+      if (q.enabled) return true;
+    }
+    return false;
   }
 
   void dump(Formatter *f) const;

--- a/src/rgw/rgw_quota_types.h
+++ b/src/rgw/rgw_quota_types.h
@@ -75,7 +75,6 @@ struct RGWQuotaInfo {
     if (struct_v >= 3) {
       decode(check_on_raw, bl);
     }
-    DECODE_FINISH(bl);
     if (struct_v >= 4) {
       decode(storage_class_quotas, bl);
       uint8_t mode_byte = 0;
@@ -85,6 +84,8 @@ struct RGWQuotaInfo {
       storage_class_quotas.clear();
       enforcement_mode = RGWQuotaEnforcementMode::LEGACY;
     }
+
+    DECODE_FINISH(bl);
   }
 
   const RGWStorageClassQuota* get_sc_quota(const std::string& sc_key) const {

--- a/src/rgw/rgw_sc_quota_checker.cc
+++ b/src/rgw/rgw_sc_quota_checker.cc
@@ -1,0 +1,186 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Per-storage-class quota enforcement engine.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#include "rgw_sc_quota_checker.h"
+
+#include <atomic>
+#include <cerrno>
+#include <limits>
+
+#include "common/dout.h"
+#include "rgw_common.h"     // rgw_bucket, ldpp_dout
+
+#define dout_subsys ceph_subsys_rgw
+
+namespace rgw::quota {
+
+static std::atomic<ScUsageStatsProvider*> g_sc_stats_provider{nullptr};
+
+void set_sc_stats_provider(ScUsageStatsProvider* p) {
+  g_sc_stats_provider.store(p, std::memory_order_release);
+}
+
+ScUsageStatsProvider* get_sc_stats_provider() {
+  return g_sc_stats_provider.load(std::memory_order_acquire);
+}
+
+namespace {
+
+inline bool would_exceed(int64_t limit, uint64_t current, uint64_t delta) {
+  
+  if (delta > 0 && current > std::numeric_limits<uint64_t>::max() - delta) {
+    return true;  // overflow -> definitely over quota
+  }
+  return (current + delta) > static_cast<uint64_t>(limit);
+}
+
+/*
+ * Combine the bucket and user SC quotas for a given key into "the
+ * effective limit this op must satisfy".
+ *
+ * The semantics intentionally mirror the existing global-quota path
+ * (bucket->check_quota): if both a bucket-level and user-level limit
+ * apply, the tighter one wins.  When only one side has a quota, that
+ * one is used directly.
+ */
+struct EffectiveScQuota {
+  bool      have_size_limit   = false;
+  bool      have_object_limit = false;
+  int64_t   max_size          = -1;
+  int64_t   max_objects       = -1;
+};
+
+EffectiveScQuota combine(const RGWStorageClassQuota* bq,
+                         const RGWStorageClassQuota* uq) {
+  EffectiveScQuota out;
+  auto fold = [&](const RGWStorageClassQuota* q) {
+    if (!q || !q->enabled) return;
+    if (q->max_size >= 0) {
+      if (!out.have_size_limit || q->max_size < out.max_size) {
+        out.max_size = q->max_size;
+      }
+      out.have_size_limit = true;
+    }
+    if (q->max_objects >= 0) {
+      if (!out.have_object_limit || q->max_objects < out.max_objects) {
+        out.max_objects = q->max_objects;
+      }
+      out.have_object_limit = true;
+    }
+  };
+  fold(bq);
+  fold(uq);
+  return out;
+}
+
+inline bool sc_enforcement_active(const RGWQuotaInfo& q) {
+  switch (q.enforcement_mode) {
+    case RGWQuotaEnforcementMode::STORAGE_CLASS:
+    case RGWQuotaEnforcementMode::HYBRID:
+      return q.has_any_sc_quota();
+    case RGWQuotaEnforcementMode::LEGACY:
+    case RGWQuotaEnforcementMode::GLOBAL_ONLY:
+      return false;
+  }
+  return false;
+}
+
+} // anonymous namespace
+
+int rgw_check_storage_class_quota(const DoutPrefixProvider* dpp,
+                                  const RGWQuota& quota,
+                                  const rgw_bucket& bucket,
+                                  const rgw_placement_rule& placement,
+                                  uint64_t new_size,
+                                  uint64_t new_objects,
+                                  optional_yield y) {
+
+  const bool bucket_active = sc_enforcement_active(quota.bucket_quota);
+  const bool user_active   = sc_enforcement_active(quota.user_quota);
+  if (!bucket_active && !user_active) {
+    return 0;
+  }
+
+  /* Compose the lookup key.  See rgw_sc_quota_key() for the format
+   * rationale ("placement::storage_class"). */
+  const std::string sc_key = rgw_sc_quota_key(placement);
+
+  /* Find the per-SC limit on each side. */
+  const RGWStorageClassQuota* bq =
+    bucket_active ? quota.bucket_quota.get_sc_quota(sc_key) : nullptr;
+  const RGWStorageClassQuota* uq =
+    user_active   ? quota.user_quota.get_sc_quota(sc_key)   : nullptr;
+
+  if ((!bq || !bq->enabled) && (!uq || !uq->enabled)) {
+    return 0;
+  }
+
+  const EffectiveScQuota lim = combine(bq, uq);
+  if (!lim.have_size_limit && !lim.have_object_limit) {
+    /* Both sides set enabled=true but neither set an actual limit
+     * (max_size=-1 and max_objects=-1).  Treat as "no constraint". */
+    return 0;
+  }
+
+  ScUsageStatsProvider* provider = get_sc_stats_provider();
+  if (!provider) {
+    ldpp_dout(dpp, 20)
+      << "sc-quota: no stats provider installed; failing open for sc_key="
+      << sc_key << dendl;
+    return 0;
+  }
+
+  const std::optional<ScUsageStats> usage = provider->lookup(bucket, sc_key);
+  if (!usage) {
+    ldpp_dout(dpp, 20)
+      << "sc-quota: no cached stats for sc_key=" << sc_key
+      << " bucket=" << bucket << "; failing open" << dendl;
+    return 0;
+  }
+
+  if (lim.have_size_limit &&
+      would_exceed(lim.max_size, usage->size, new_size)) {
+    ldpp_dout(dpp, 5)
+      << "sc-quota: size limit exceeded for sc_key=" << sc_key
+      << " bucket=" << bucket
+      << " current=" << usage->size
+      << " delta=" << new_size
+      << " limit=" << lim.max_size
+      << dendl;
+    return -EDQUOT;
+  }
+
+  if (lim.have_object_limit &&
+      would_exceed(lim.max_objects, usage->num_objects, new_objects)) {
+    ldpp_dout(dpp, 5)
+      << "sc-quota: object-count limit exceeded for sc_key=" << sc_key
+      << " bucket=" << bucket
+      << " current=" << usage->num_objects
+      << " delta=" << new_objects
+      << " limit=" << lim.max_objects
+      << dendl;
+    return -EDQUOT;
+  }
+
+  ldpp_dout(dpp, 25)
+    << "sc-quota: ok sc_key=" << sc_key
+    << " size " << usage->size << "+" << new_size
+    << "<=" << (lim.have_size_limit ? lim.max_size : -1)
+    << " objs " << usage->num_objects << "+" << new_objects
+    << "<=" << (lim.have_object_limit ? lim.max_objects : -1)
+    << dendl;
+  return 0;
+}
+
+} // namespace rgw::quota

--- a/src/rgw/rgw_sc_quota_checker.h
+++ b/src/rgw/rgw_sc_quota_checker.h
@@ -1,0 +1,100 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Per-storage-class quota enforcement engine.
+ *
+ * This is the layer that turns the configured RGWStorageClassQuota values
+ * (in RGWQuotaInfo) into accept/reject decisions on the write path.  It is
+ * deliberately separated from rgw_quota.{h,cc} because:
+ *
+ *   1. The legacy quota path (RGWQuotaHandler) is tightly coupled to RADOS;
+ *      our checker must be usable from any SAL backend.
+ *   2. The legacy path owns its own cache.  We do NOT want a second cache
+ *      for SC stats -- we read from the observability cache (PR #66109).
+ *   3. Mixing the two would force PR #66109 and Pedro's per-SC stats PR
+ *      (#66501) into one giant patch series.  Splitting them keeps each
+ *      reviewable on its own merits.
+ *
+ * The checker exposes a single hot-path function -- rgw_check_storage_class_quota
+ * -- plus a tiny stats-provider interface that lets the obs-cache PR plug
+ * itself in without us taking a build-time dependency on it.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include "common/async/yield_context.h"
+#include "common/dout.h"
+
+#include "rgw_quota_types.h"      // RGWQuotaInfo, RGWQuota
+#include "rgw_sc_quota_types.h"   // RGWStorageClassQuota, rgw_sc_quota_key
+#include "rgw_placement_types.h"  // rgw_placement_rule
+
+struct rgw_bucket;
+
+namespace rgw::quota {
+
+
+struct ScUsageStats {
+  uint64_t size        = 0;  // total bytes currently stored in this SC
+  uint64_t num_objects = 0;  // total object count in this SC
+};
+
+class ScUsageStatsProvider {
+ public:
+  virtual ~ScUsageStatsProvider() = default;
+
+ 
+  virtual std::optional<ScUsageStats> lookup(
+      const rgw_bucket& bucket,
+      const std::string& sc_key) const = 0;
+};
+
+void set_sc_stats_provider(ScUsageStatsProvider* p);
+ScUsageStatsProvider* get_sc_stats_provider();
+
+/*
+ * The hot-path entry point.
+ *
+ * Called from rgw_op.cc on every write that could touch a quota-managed
+ * storage class.  Returns:
+ *
+ *   0           : write is allowed (either no SC quota applies, or
+ *                 it applies and there is sufficient headroom).
+ *   -EDQUOT     : write would exceed a configured SC quota.  rgw_op.cc
+ *                 already translates -EDQUOT into S3 QuotaExceeded.
+ *   other < 0   : unrecoverable internal error.  In practice we never
+ *                 return such a code: any internal error path falls
+ *                 through to "fail open" and returns 0.
+ *
+ * Arguments:
+ *   quota       : the aggregated (bucket + user) RGWQuota for this op,
+ *                 as already built by get_quota_info() in rgw_op.cc.
+ *   bucket      : the destination bucket.  
+ *   placement   : the destination placement rule (name + storage_class).
+ *                 Already filled in by rgw_build_object_placement() for
+ *                 every write-path op before we get here.
+ *   new_size    : bytes about to be added by this op.  For multipart it
+ *                 is the sum of part sizes.
+ *   new_objects : object count about to be added (almost always 1).           
+ */
+int rgw_check_storage_class_quota(const DoutPrefixProvider* dpp,
+                                  const RGWQuota& quota,
+                                  const rgw_bucket& bucket,
+                                  const rgw_placement_rule& placement,
+                                  uint64_t new_size,
+                                  uint64_t new_objects,
+                                  optional_yield y);
+
+} // namespace rgw::quota

--- a/src/rgw/rgw_sc_quota_types.h
+++ b/src/rgw/rgw_sc_quota_types.h
@@ -1,0 +1,156 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Per-storage-class quota types.
+ *
+ * This header defines the fundamental serialized types that extend
+ * RGWQuotaInfo with a per-storage-class breakdown.  It is intentionally
+ * minimal and free of radosgw / OSD-context includes so that it can be
+ * pulled in from headers shared with the OSD-side bucket index code.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <string>
+
+#include "include/encoding.h"
+#include "rgw_placement_types.h"
+
+class JSONObj;
+namespace ceph { class Formatter; }
+
+/*
+ * RGWStorageClassQuota
+ *
+ * Holds a single per-storage-class quota limit.  An instance lives inside
+ * RGWQuotaInfo's storage_class_quotas map, keyed by
+ *   rgw_sc_quota_key(placement, storage_class).
+ *
+ * Field semantics intentionally mirror RGWQuotaInfo so that callers can
+ * reason about them identically:
+ *   max_size    : maximum total bytes allowed in this storage class.
+ *                 A value < 0 means "unlimited".
+ *   max_objects : maximum total object count.  < 0 means "unlimited".
+ *   enabled     : if false, the quota is configured but not enforced.
+ *                
+ */
+struct RGWStorageClassQuota {
+  int64_t max_size    = -1;
+  int64_t max_objects = -1;
+  bool    enabled     = false;
+
+  RGWStorageClassQuota() = default;
+  RGWStorageClassQuota(int64_t sz, int64_t objs, bool en)
+    : max_size(sz), max_objects(objs), enabled(en) {}
+
+  bool has_size_limit()    const { return enabled && max_size    >= 0; }
+  bool has_object_limit()  const { return enabled && max_objects >= 0; }
+  bool is_active()         const { return enabled && (max_size >= 0 || max_objects >= 0); }
+
+  void encode(ceph::buffer::list& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(max_size,    bl);
+    encode(max_objects, bl);
+    encode(enabled,     bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(ceph::buffer::list::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(max_size,    bl);
+    decode(max_objects, bl);
+    decode(enabled,     bl);
+    DECODE_FINISH(bl);
+  }
+
+  void dump(ceph::Formatter *f) const;
+  void decode_json(JSONObj *obj);
+};
+WRITE_CLASS_ENCODER(RGWStorageClassQuota)
+
+/*
+ * RGWQuotaEnforcementMode
+ *
+ * Controls which quota dimensions are evaluated on the write path.
+ *
+ *   LEGACY        : Behaves exactly like pre-feature RGW: only the global
+ *                   bucket/user quotas are checked.  This is the value
+ *                   produced when an old (v3) RGWQuotaInfo blob is decoded,
+ *                   so existing buckets get the legacy semantics by default.
+ *   GLOBAL_ONLY   : Same as LEGACY semantically, but set explicitly by the
+ *                   admin (so the value survives re-encoding without being
+ *                   reinterpreted).
+ *   STORAGE_CLASS : Only per-storage-class quotas are enforced; the global
+ *                   bucket/user quota fields are ignored.  Useful for tier
+ *                   workloads where the global limit would just be the sum
+ *                   of the per-class limits anyway.
+ *   HYBRID        : Both global AND per-storage-class quotas are enforced.
+ *                   A write must satisfy every applicable limit.  This is
+ *                   the mode automatically set by `radosgw-admin quota set`
+ *                   when --placement-target/--storage-class are provided.
+ *
+ * The enum is encoded as uint8_t so its on-wire footprint is one byte.
+ */
+enum class RGWQuotaEnforcementMode : uint8_t {
+  LEGACY        = 0,
+  GLOBAL_ONLY   = 1,
+  STORAGE_CLASS = 2,
+  HYBRID        = 3,
+};
+
+inline const char* to_string(RGWQuotaEnforcementMode m) {
+  switch (m) {
+    case RGWQuotaEnforcementMode::LEGACY:        return "legacy";
+    case RGWQuotaEnforcementMode::GLOBAL_ONLY:   return "global_only";
+    case RGWQuotaEnforcementMode::STORAGE_CLASS: return "storage_class";
+    case RGWQuotaEnforcementMode::HYBRID:        return "hybrid";
+  }
+  return "unknown";
+}
+
+inline bool parse_quota_enforcement_mode(const std::string& s,
+                                         RGWQuotaEnforcementMode& out) {
+  if      (s == "legacy")        { out = RGWQuotaEnforcementMode::LEGACY;        return true; }
+  else if (s == "global_only" ||
+           s == "global")        { out = RGWQuotaEnforcementMode::GLOBAL_ONLY;   return true; }
+  else if (s == "storage_class" ||
+           s == "sc")            { out = RGWQuotaEnforcementMode::STORAGE_CLASS; return true; }
+  else if (s == "hybrid" ||
+           s == "both")          { out = RGWQuotaEnforcementMode::HYBRID;        return true; }
+  return false;
+}
+
+/*
+ * rgw_sc_quota_key
+ *
+ * Composite key used to index both the configured per-storage-class
+ *
+ * Format: "<placement-id>::<storage-class>"
+ *
+ * The "::" delimiter is chosen deliberately:
+ *   - Neither placement IDs nor S3 storage-class names use "::"
+ */
+inline std::string rgw_sc_quota_key(const std::string& placement_id,
+                                    const std::string& storage_class) {
+  const std::string& sc =
+    rgw_placement_rule::get_canonical_storage_class(storage_class);
+  return placement_id + "::" + sc;
+}
+
+inline std::string rgw_sc_quota_key(const rgw_placement_rule& rule) {
+  return rgw_sc_quota_key(rule.name, rule.storage_class);
+}
+
+/*
+ * RGWStorageClassQuotaMap
+ */
+using RGWStorageClassQuotaMap = std::map<std::string, RGWStorageClassQuota>;

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -308,6 +308,13 @@ target_include_directories(unittest_rgw_arn
   SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
 target_link_libraries(unittest_rgw_arn ${rgw_libs})
 
+# unittest_rgw_sc_quota per-storage-class quota encode/decode and checker
+add_executable(unittest_rgw_sc_quota test_rgw_sc_quota.cc)
+add_ceph_unittest(unittest_rgw_sc_quota)
+target_include_directories(unittest_rgw_sc_quota
+  SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
+target_link_libraries(unittest_rgw_sc_quota ${rgw_libs})
+
 # unittest_rgw_kms
 add_executable(unittest_rgw_kms test_rgw_kms.cc)
 add_ceph_unittest(unittest_rgw_kms)

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -308,12 +308,16 @@ target_include_directories(unittest_rgw_arn
   SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
 target_link_libraries(unittest_rgw_arn ${rgw_libs})
 
-# unittest_rgw_sc_quota per-storage-class quota encode/decode and checker
 add_executable(unittest_rgw_sc_quota test_rgw_sc_quota.cc)
-add_ceph_unittest(unittest_rgw_sc_quota)
 target_include_directories(unittest_rgw_sc_quota
   SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
-target_link_libraries(unittest_rgw_sc_quota ${rgw_libs})
+target_link_libraries(unittest_rgw_sc_quota
+  ${rgw_libs}
+  GTest::GTest      # not GTest::Main — we supply main()
+  global)
+add_test(NAME unittest_rgw_sc_quota
+         COMMAND unittest_rgw_sc_quota
+         WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 
 # unittest_rgw_kms
 add_executable(unittest_rgw_kms test_rgw_kms.cc)

--- a/src/test/rgw/test_rgw_sc_quota.cc
+++ b/src/test/rgw/test_rgw_sc_quota.cc
@@ -1,0 +1,326 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+/*
+ * Unit tests for the per-storage-class quota feature.
+ *
+ * We exercise three layers in isolation:
+ *
+ *   1. The on-the-wire encoding of RGWQuotaInfo at v3 <-> v4 boundaries.
+ *
+ *   2. The composite-key construction (rgw_sc_quota_key).
+ *
+ *   3. rgw_check_storage_class_quota() against a deterministic in-test
+ *      stats provider, covering:
+ *        - no enforcement_mode set => check returns 0 (legacy preservation)
+ *        - HYBRID + under limit    => returns 0
+ *        - HYBRID + over size      => returns -EDQUOT
+ *        - HYBRID + over count     => returns -EDQUOT
+ *        - HYBRID + missing stats  => returns 0 (fail-open)
+ *        - STORAGE_CLASS mode      => global quota fields ignored
+ *        - Different sc_key        => no false positive
+ *
+ * All cases are pure unit tests: no RADOS, no driver, no asio.
+ */
+
+#include <gtest/gtest.h>
+#include <cerrno>
+
+#include "common/ceph_context.h"
+#include "common/dout.h"
+#include "common/async/yield_context.h"
+#include "global/global_context.h"
+
+#include "rgw_quota_types.h"
+#include "rgw_sc_quota_types.h"
+#include "rgw_sc_quota_checker.h"
+#include "rgw_placement_types.h"
+#include "rgw_basic_types.h"        // for rgw_bucket
+#include "include/buffer.h"
+
+using namespace rgw::quota;
+
+namespace {
+struct TestDpp : NoDoutPrefix {
+  TestDpp() : NoDoutPrefix(g_ceph_context, /*subsys=*/0) {}
+};
+} // namespace
+
+
+static rgw_bucket make_bucket(const std::string& name = "test-bucket",
+                              const std::string& tenant = "") {
+  rgw_bucket b;
+  b.name = name;
+  b.tenant = tenant;
+  return b;
+}
+
+static rgw_placement_rule make_placement(const std::string& name,
+                                         const std::string& sc) {
+  return rgw_placement_rule(name, sc);
+}
+
+namespace {
+class FakeStatsProvider : public ScUsageStatsProvider {
+ public:
+  std::map<std::string, ScUsageStats> stats;
+  std::optional<ScUsageStats> lookup(const rgw_bucket& /*b*/,
+                                     const std::string& sc_key) const override {
+    auto it = stats.find(sc_key);
+    if (it == stats.end()) return std::nullopt;
+    return it->second;
+  }
+};
+
+// RAII installer for the global provider slot so tests don't leak state.
+struct ScopedProvider {
+  explicit ScopedProvider(ScUsageStatsProvider* p) {
+    set_sc_stats_provider(p);
+  }
+  ~ScopedProvider() { set_sc_stats_provider(nullptr); }
+};
+} // namespace
+
+TEST(RGWQuotaInfoV4, RoundtripEmptyScMap) {
+  RGWQuotaInfo in;
+  in.enabled = true;
+  in.max_size = 1024;
+  in.max_objects = 10;
+
+  ceph::buffer::list bl;
+  encode(in, bl);
+
+  RGWQuotaInfo out;
+  auto p = bl.cbegin();
+  decode(out, p);
+
+  EXPECT_TRUE(out.enabled);
+  EXPECT_EQ(out.max_size, 1024);
+  EXPECT_EQ(out.max_objects, 10);
+  EXPECT_TRUE(out.storage_class_quotas.empty());
+  EXPECT_EQ(out.enforcement_mode, RGWQuotaEnforcementMode::LEGACY);
+}
+
+TEST(RGWQuotaInfoV4, RoundtripPopulatedScMap) {
+  RGWQuotaInfo in;
+  in.enabled = true;
+  in.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  in.storage_class_quotas[rgw_sc_quota_key("default", "SSD")] =
+    RGWStorageClassQuota{ 1024 * 1024, 100, true };
+  in.storage_class_quotas[rgw_sc_quota_key("default", "GLACIER")] =
+    RGWStorageClassQuota{ -1, 50, true };
+
+  ceph::buffer::list bl;
+  encode(in, bl);
+
+  RGWQuotaInfo out;
+  auto p = bl.cbegin();
+  decode(out, p);
+
+  EXPECT_EQ(out.enforcement_mode, RGWQuotaEnforcementMode::HYBRID);
+  ASSERT_EQ(out.storage_class_quotas.size(), 2u);
+
+  const auto* ssd = out.get_sc_quota(rgw_sc_quota_key("default", "SSD"));
+  ASSERT_NE(ssd, nullptr);
+  EXPECT_EQ(ssd->max_size, 1024 * 1024);
+  EXPECT_EQ(ssd->max_objects, 100);
+  EXPECT_TRUE(ssd->enabled);
+
+  const auto* gla = out.get_sc_quota(rgw_sc_quota_key("default", "GLACIER"));
+  ASSERT_NE(gla, nullptr);
+  EXPECT_EQ(gla->max_size, -1);
+  EXPECT_EQ(gla->max_objects, 50);
+}
+
+/*
+ * Critical backward-compat test: encode a v4 blob with NO sc quotas and
+ * an explicit LEGACY mode, decode it, then re-encode it.  The behaviour
+ * must be indistinguishable from how a pre-feature RGW would treat the
+ * same RGWQuotaInfo -- empty map, legacy mode preserved.
+ */
+TEST(RGWQuotaInfoV4, RoundtripLegacyDefaultsStable) {
+  for (auto& in : RGWQuotaInfo::generate_test_instances()) {
+    ceph::buffer::list bl;
+    encode(in, bl);
+    RGWQuotaInfo out;
+    auto p = bl.cbegin();
+    decode(out, p);
+    EXPECT_EQ(in.enabled, out.enabled);
+    EXPECT_EQ(in.max_size, out.max_size);
+    EXPECT_EQ(in.max_objects, out.max_objects);
+    EXPECT_EQ(in.check_on_raw, out.check_on_raw);
+    EXPECT_EQ(in.enforcement_mode, out.enforcement_mode);
+    EXPECT_EQ(in.storage_class_quotas.size(), out.storage_class_quotas.size());
+  }
+}
+
+TEST(RGWScQuotaKey, BasicComposition) {
+  EXPECT_EQ(rgw_sc_quota_key("default-placement", "SSD"),
+            "default-placement::SSD");
+}
+
+TEST(RGWScQuotaKey, EmptyStorageClassMapsToSTANDARD) {
+  // get_canonical_storage_class("") -> "STANDARD"
+  EXPECT_EQ(rgw_sc_quota_key("default-placement", ""),
+            "default-placement::STANDARD");
+}
+
+TEST(RGWScQuotaKey, FromRule) {
+  EXPECT_EQ(rgw_sc_quota_key(make_placement("p1", "GLACIER")),
+            "p1::GLACIER");
+}
+
+
+TEST(RGWScQuotaChecker, LegacyModeReturnsZero) {
+  TestDpp dpp;
+  FakeStatsProvider prov;
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enabled = true;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::LEGACY;
+  // Even with an entry present, LEGACY mode must NOT consult it.
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+    RGWStorageClassQuota{ 1, 1, true };
+
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      1ULL << 30, 100, null_yield);
+  EXPECT_EQ(r, 0);
+}
+
+TEST(RGWScQuotaChecker, NoSCConfiguredFallsThrough) {
+  TestDpp dpp;
+  FakeStatsProvider prov;
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enabled = true;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  // storage_class_quotas is empty -> sc_enforcement_active() returns false.
+
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      1ULL << 40, 1'000'000, null_yield);
+  EXPECT_EQ(r, 0);
+}
+
+TEST(RGWScQuotaChecker, UnderLimitAllows) {
+  TestDpp dpp;
+  FakeStatsProvider prov;
+  prov.stats[rgw_sc_quota_key("p", "SSD")] = ScUsageStats{ 50, 5 };
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+    RGWStorageClassQuota{ /*max_size=*/100, /*max_objects=*/10, /*enabled=*/true };
+
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      /*new_size=*/40, /*new_objects=*/3, null_yield);
+  EXPECT_EQ(r, 0);
+}
+
+TEST(RGWScQuotaChecker, OverSizeReturnsEDQUOT) {
+  TestDpp dpp;
+  FakeStatsProvider prov;
+  prov.stats[rgw_sc_quota_key("p", "SSD")] = ScUsageStats{ 90, 5 };
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+    RGWStorageClassQuota{ 100, -1, true };
+
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      /*new_size=*/15, /*new_objects=*/1, null_yield);
+  EXPECT_EQ(r, -EDQUOT);
+}
+
+TEST(RGWScQuotaChecker, OverObjectCountReturnsEDQUOT) {
+  TestDpp dpp;
+  FakeStatsProvider prov;
+  prov.stats[rgw_sc_quota_key("p", "SSD")] = ScUsageStats{ 10, 9 };
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+    RGWStorageClassQuota{ -1, /*max_objects=*/10, true };
+
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      /*new_size=*/1, /*new_objects=*/2, null_yield);
+  EXPECT_EQ(r, -EDQUOT);
+}
+
+TEST(RGWScQuotaChecker, MissingStatsFailsOpen) {
+  TestDpp dpp;
+  FakeStatsProvider prov;  // empty
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+    RGWStorageClassQuota{ 1, 1, true };
+
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      1'000'000, 1, null_yield);
+  EXPECT_EQ(r, 0);  // fail-open even though we are way over limit
+}
+
+TEST(RGWScQuotaChecker, NoProviderFailsOpen) {
+  TestDpp dpp;
+  // No ScopedProvider -> get_sc_stats_provider() returns nullptr.
+
+  RGWQuota q;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+    RGWStorageClassQuota{ 1, 1, true };
+
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      1'000'000, 1, null_yield);
+  EXPECT_EQ(r, 0);
+}
+
+TEST(RGWScQuotaChecker, DifferentScKeyNoFalsePositive) {
+  TestDpp dpp;
+  FakeStatsProvider prov;
+  prov.stats[rgw_sc_quota_key("p", "GLACIER")] = ScUsageStats{ 9999999, 9999 };
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+    RGWStorageClassQuota{ 1, 1, true };
+  // Writing to GLACIER but only SSD has a quota -> no SC quota applies.
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "GLACIER"),
+      1, 1, null_yield);
+  EXPECT_EQ(r, 0);
+}
+
+TEST(RGWScQuotaChecker, BucketAndUserCombineTighter) {
+  TestDpp dpp;
+  FakeStatsProvider prov;
+  prov.stats[rgw_sc_quota_key("p", "SSD")] = ScUsageStats{ 80, 5 };
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+    RGWStorageClassQuota{ /*max_size=*/200, /*max_objects=*/-1, true };
+  q.user_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  q.user_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+    RGWStorageClassQuota{ /*max_size=*/100, /*max_objects=*/-1, true };
+
+  // 80 + 25 = 105 > 100 (user limit) but < 200 (bucket limit) -> reject.
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      25, 1, null_yield);
+  EXPECT_EQ(r, -EDQUOT);
+}

--- a/src/test/rgw/test_rgw_sc_quota.cc
+++ b/src/test/rgw/test_rgw_sc_quota.cc
@@ -29,8 +29,9 @@
 #include "common/ceph_context.h"
 #include "common/dout.h"
 #include "common/async/yield_context.h"
-#include "global/global_context.h"
 
+#include "global/global_init.h"
+#include "common/ceph_argparse.h"
 #include "rgw_quota_types.h"
 #include "rgw_sc_quota_types.h"
 #include "rgw_sc_quota_checker.h"
@@ -41,8 +42,10 @@
 using namespace rgw::quota;
 
 namespace {
-struct TestDpp : NoDoutPrefix {
-  TestDpp() : NoDoutPrefix(g_ceph_context, /*subsys=*/0) {}
+struct TestDpp : public DoutPrefixProvider {
+  CephContext* get_cct() const override { return g_ceph_context; }
+  unsigned get_subsys() const override { return ceph_subsys_rgw; }
+  std::ostream& gen_prefix(std::ostream& out) const override { return out; }
 };
 } // namespace
 
@@ -323,4 +326,17 @@ TEST(RGWScQuotaChecker, BucketAndUserCombineTighter) {
       &dpp, q, make_bucket(), make_placement("p", "SSD"),
       25, 1, null_yield);
   EXPECT_EQ(r, -EDQUOT);
+}
+
+int main(int argc, char** argv)
+{
+  auto args = argv_to_vec(argc, argv);
+  auto cct = global_init(nullptr, args,
+                         CEPH_ENTITY_TYPE_CLIENT,
+                         CODE_ENVIRONMENT_UTILITY,
+                         CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+  common_init_finish(g_ceph_context);
+
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }

--- a/src/test/rgw/test_rgw_sc_quota.cc
+++ b/src/test/rgw/test_rgw_sc_quota.cc
@@ -340,3 +340,109 @@ int main(int argc, char** argv)
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
+
+TEST(RGWScQuotaChecker, StorageClassOnlyModeIgnoresGlobalQuota) {
+  TestDpp dpp;
+  FakeStatsProvider prov;
+  prov.stats[rgw_sc_quota_key("p", "SSD")] = ScUsageStats{50, 5};
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  // Global quota would fail (max_size=10, current=50+10=60 > 10)
+  q.bucket_quota.max_size    = 10;
+  q.bucket_quota.max_objects = 10;
+  q.bucket_quota.enabled     = true;
+  // But mode is STORAGE_CLASS — global quota is ignored
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::STORAGE_CLASS;
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+      RGWStorageClassQuota{200, 100, true};  // generous SC limit
+
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      10, 1, null_yield);
+  // SC check passes (50+10 < 200), global check not run
+  EXPECT_EQ(r, 0);
+}
+
+TEST(RGWScQuotaChecker, DisabledEntryNotEnforced) {
+  TestDpp dpp;
+  FakeStatsProvider prov;
+  prov.stats[rgw_sc_quota_key("p", "SSD")] = ScUsageStats{999, 999};
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+      RGWStorageClassQuota{1, 1, /*enabled=*/false};  // tiny limit but disabled
+
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      1000, 100, null_yield);
+  EXPECT_EQ(r, 0);  // disabled entry = no enforcement
+}
+
+TEST(RGWScQuotaChecker, ExactLimitBoundaryAllows) {
+  TestDpp dpp;
+  FakeStatsProvider prov;
+  prov.stats[rgw_sc_quota_key("p", "SSD")] = ScUsageStats{90, 9};
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+      RGWStorageClassQuota{100, 10, true};
+
+  // 90 + 10 == 100 exactly — should PASS (not exceed)
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      10, 1, null_yield);
+  EXPECT_EQ(r, 0);
+}
+
+TEST(RGWQuotaInfoV4, JSONRoundtrip) {
+  RGWQuotaInfo in;
+  in.enabled          = true;
+  in.max_size         = 1024 * 1024;
+  in.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  in.storage_class_quotas[rgw_sc_quota_key("default", "SSD")] =
+      RGWStorageClassQuota{512 * 1024, 50, true};
+
+  // Dump to JSON
+  JSONFormatter f;
+  f.open_object_section("quota");
+  in.dump(&f);
+  f.close_section();
+  std::stringstream ss;
+  f.flush(ss);
+
+  // Parse back
+  JSONParser p;
+  ASSERT_TRUE(p.parse(ss.str().c_str(), ss.str().size()));
+  RGWQuotaInfo out;
+  out.decode_json(&p);
+
+  EXPECT_EQ(out.enforcement_mode, RGWQuotaEnforcementMode::HYBRID);
+  ASSERT_EQ(out.storage_class_quotas.size(), 1u);
+  const auto* ssd = out.get_sc_quota(rgw_sc_quota_key("default", "SSD"));
+  ASSERT_NE(ssd, nullptr);
+  EXPECT_EQ(ssd->max_size, 512 * 1024);
+  EXPECT_EQ(ssd->max_objects, 50);
+  EXPECT_TRUE(ssd->enabled);
+}
+
+TEST(RGWScQuotaChecker, GlobalOnlyModeReturnsZero) {
+  TestDpp dpp;
+  FakeStatsProvider prov;
+  prov.stats[rgw_sc_quota_key("p", "SSD")] = ScUsageStats{1, 1};
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::GLOBAL_ONLY;
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+      RGWStorageClassQuota{1, 1, true};  // tiny limit
+
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      1000, 100, null_yield);
+  EXPECT_EQ(r, 0);  // GLOBAL_ONLY = no SC enforcement
+}


### PR DESCRIPTION

## Summary

This PR adds the ability to configure and enforce storage quotas at the per-storage-class (SC) granularity, independently of the existing global bucket and user quotas.

The existing RGW quota system enforces limits at the bucket or user level across all storage classes combined. Operators running tiered storage deployments (e.g. STANDARD + SSD + GLACIER) have no way to cap usage per tier. A tenant uploading entirely to SSD can exhaust an expensive storage class while the global bucket quota still shows headroom.

## What This PR Does

Extends RGWQuotaInfo with a per-SC quota map and an enforcement mode field, wires quota checks into every write-path op, and exposes the new limits via radosgw-admin.

RGWStorageClassQuota — per-SC limit: max_size, max_objects, enabled.

RGWQuotaEnforcementMode — controls which quota dimensions are checked:
  LEGACY                    (0) — existing behaviour, only global quota enforced.Assigned automatically to buckets that predate
                                                this feature. Zero overhead on the write path.
  GLOBAL_ONLY        (1) — same as LEGACY but set explicitly by the admin.
  STORAGE_CLASS   (2) — only per-SC quotas enforced; global ignored.
  HYBRID                     (3) — both global AND per-SC quotas enforced. Set automatically by `quota set --storage-class`.

rgw_sc_quota_key(placement, storage_class)
  Composite key format: "default-placement::STANDARD"
  Empty storage class is normalised to STANDARD
                      

### RGWQuotaInfo Changes 

Bumped to encoding version v4. New fields:
  storage_class_quotas : std::map<string, RGWStorageClassQuota>
  enforcement_mode     : RGWQuotaEnforcementMode (uint8_t on wire)

Old v1-v3 blobs decode with enforcement_mode=LEGACY and an empty map, preserving exact pre-feature behaviour for all existing buckets.

### Enforcement Engine 

rgw_check_storage_class_quota() — hot-path entry point called from rgw_op.cc. Takes the RGWStorageStats already fetched by the global quota check (see Stats Source below), performs a pure in-memory map lookup, and returns 0 or -EDQUOT.

Fast-path: if enforcement_mode is LEGACY or GLOBAL_ONLY, or if storage_class_quotas is empty, the function returns 0 immediately without touching stats. Legacy buckets pay zero overhead.

Fail-open: if per-SC stats are unavailable (bucket predates PR #66501, or stats not yet populated) the function returns 0 and logs a warning rather than incorrectly blocking writes.)


### Write Path Integration (rgw_op.cc)

SC quota checks are inserted after the existing global quota check in

RGWPutObj::execute()
RGWPostObj::execute()
RGWCopyObj::execute()
RGWCompleteMultipart::execute()
RGWBulkUploadOp::handle_file()
The RGWStorageStats struct returned by the existing global quota pathalready contains Pedro's per-SC numbers after PR #66501 . The SC check reuses those stats at zero additional RADOS reads on the write path.

### Admin CLI 

New flags for quota set/enable/disable:
  --placement-target=<id>   placement rule name
  --storage-class=<name>    storage class name
  
  Both flags must be supplied together; supplying only one returns EINVAL with a clear error message.

`quota set --storage-class` auto-enables the entry (sets enabled=true) so a separate `quota enable` step is not required.

Placement validation is skipped for quota commands. SC quota keys are plain string identifiers; the storage class does not need to exist as a live placement target. This allows pre-configuring quotas before a storage class is deployed.


# STEPS TO TEST

cd ~/ceph/build

../src/stop.sh

MON=1 OSD=3 MGR=1 RGW=1 ../src/vstart.sh -n -d --rgw_port 8000

bin/radosgw-admin user create \
  --uid=testuser \
  --display-name="Test User" \
  --access-key=testkey \
  --secret-key=testsecret
  
  
aws configure set aws_access_key_id testkey
aws configure set aws_secret_access_key testsecret
aws configure set default.region us-east-1

EP="--endpoint-url http://localhost:8000 --no-verify-ssl"

// Create test files
dd if=/dev/urandom bs=1M count=3  of=/tmp/3mb.bin  2>/dev/null
dd if=/dev/urandom bs=1M count=7  of=/tmp/7mb.bin  2>/dev/null
dd if=/dev/urandom bs=1M count=12 of=/tmp/12mb.bin 2>/dev/null


ninja -j$(nproc) unittest_rgw_sc_quota

bin/unittest_rgw_sc_quota

// Test : Quota being stored correctly

aws $EP s3 mb s3://quota-test

bin/radosgw-admin quota set \
  --quota-scope=bucket \
  --bucket=quota-test \
  --placement-target=default-placement \
  --storage-class=STANDARD \
  --max-size=10M
  
bin/radosgw-admin bucket stats --bucket=quota-test | python3 -c "
import sys, json
data = json.load(sys.stdin)
q = data.get('bucket_quota', {})
print('enforcement_mode :', q.get('enforcement_mode'))
for s in q.get('storage_class_quotas', []):
    print('key            :', s['key'])
    print('enabled        :', s['enabled'])
    print('max_size_mb    :', s['max_size'] // (1024*1024))



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [X] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [X] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [X] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
