### PR TITLE
rgw: Teach CompleteMultipartUpload to adhere to S3 while completing an upload.

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -7804,7 +7804,6 @@ void RGWCompleteMultipart::execute(optional_yield y)
     // Spawn upload->complete() and send keepalive whitespace from the main
     // coroutine while it runs. Socket writes must happen on the main coroutine
     // because beast's ClientIO::send_body() suspends using its yield context.
-    std::atomic<bool> complete_done{false};
     int complete_ret = 0;
 
     auto executor = y.get_yield_context().get_executor();
@@ -7813,11 +7812,10 @@ void RGWCompleteMultipart::execute(optional_yield y)
     boost::asio::spawn(executor,
       [&](boost::asio::yield_context yield) {
         complete_ret =
-          upload->complete(this, optional_yield{yield}, s->cct, parts->parts,
+          upload->complete(this, yield, s->cct, parts->parts,
                            remove_objs, accounted_size, compressed, cs_info, ofs,
                            s->req_id, s->owner, olh_epoch, s->object.get(),
                            processed_prefixes, if_match, if_nomatch);
-        complete_done.store(true, std::memory_order_release);
         keepalive_timer.cancel();
       },
       [](std::exception_ptr eptr) {
@@ -7826,16 +7824,15 @@ void RGWCompleteMultipart::execute(optional_yield y)
 
     // Send keepalives from the main coroutine (which owns the socket).
     // The spawned coroutine cancels the timer when done, so we wake immediately.
-    {
+    for (;;) {
       constexpr auto keepalive_interval = std::chrono::seconds(5);
-      while (!complete_done.load(std::memory_order_acquire)) {
-        keepalive_timer.expires_after(keepalive_interval);
-        boost::system::error_code ec;
-        keepalive_timer.async_wait(y.get_yield_context()[ec]);
-        if (!complete_done.load(std::memory_order_acquire)) {
-          send_keepalive();
-        }
+      keepalive_timer.expires_after(keepalive_interval);
+      boost::system::error_code ec;
+      keepalive_timer.async_wait(y.get_yield_context()[ec]);
+      if (ec) {
+        break;
       }
+      send_keepalive();
     }
 
     op_ret = complete_ret;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -7790,11 +7790,6 @@ void RGWCompleteMultipart::execute(optional_yield y)
     return;
   }
 
-  // Send 200 OK headers now. We're committed to running the expensive
-  // upload->complete() call. This matches AWS S3's behaviour of sending the
-  // response header immediately and then streaming whitespace keepalives.
-  send_response_begin();
-
   // no coroutine (no beast), no whitespace keepalives.
   if (!y) {
     op_ret = upload->complete(this, y, s->cct, parts->parts,
@@ -7802,6 +7797,10 @@ void RGWCompleteMultipart::execute(optional_yield y)
                      s->req_id, s->owner, olh_epoch, s->object.get(),
                      processed_prefixes, if_match, if_nomatch);
   } else {
+    // Send 200 OK headers now. We're committed to running the expensive
+    // upload->complete() call. This matches AWS S3's behaviour of sending the
+    // response header immediately and then streaming whitespace keepalives.
+    send_response_begin();
     // Spawn upload->complete() and send keepalive whitespace from the main
     // coroutine while it runs. Socket writes must happen on the main coroutine
     // because beast's ClientIO::send_body() suspends using its yield context.

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -12,6 +12,7 @@
 #include <unistd.h>
 
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/asio/steady_timer.hpp>
 #include <boost/optional.hpp>
 #include <boost/utility/in_place_factory.hpp>
 #include <fmt/format.h>
@@ -7789,10 +7790,58 @@ void RGWCompleteMultipart::execute(optional_yield y)
     return;
   }
 
-  op_ret =
-    upload->complete(this, y, s->cct, parts->parts, remove_objs, accounted_size,
-                     compressed, cs_info, ofs, s->req_id, s->owner, olh_epoch,
-                     s->object.get(), processed_prefixes, if_match, if_nomatch);
+  // Send 200 OK headers now. We're committed to running the expensive
+  // upload->complete() call. This matches AWS S3's behaviour of sending the
+  // response header immediately and then streaming whitespace keepalives.
+  send_response_begin();
+
+  // no coroutine (no beast), no whitespace keepalives.
+  if (!y) {
+    op_ret = upload->complete(this, y, s->cct, parts->parts,
+                     remove_objs, accounted_size, compressed, cs_info, ofs,
+                     s->req_id, s->owner, olh_epoch, s->object.get(),
+                     processed_prefixes, if_match, if_nomatch);
+  } else {
+    // Spawn upload->complete() and send keepalive whitespace from the main
+    // coroutine while it runs. Socket writes must happen on the main coroutine
+    // because beast's ClientIO::send_body() suspends using its yield context.
+    std::atomic<bool> complete_done{false};
+    int complete_ret = 0;
+
+    auto executor = y.get_yield_context().get_executor();
+    boost::asio::steady_timer keepalive_timer(executor);
+
+    boost::asio::spawn(executor,
+      [&](boost::asio::yield_context yield) {
+        complete_ret =
+          upload->complete(this, optional_yield{yield}, s->cct, parts->parts,
+                           remove_objs, accounted_size, compressed, cs_info, ofs,
+                           s->req_id, s->owner, olh_epoch, s->object.get(),
+                           processed_prefixes, if_match, if_nomatch);
+        complete_done.store(true, std::memory_order_release);
+        keepalive_timer.cancel();
+      },
+      [](std::exception_ptr eptr) {
+        if (eptr) std::rethrow_exception(eptr);
+      });
+
+    // Send keepalives from the main coroutine (which owns the socket).
+    // The spawned coroutine cancels the timer when done, so we wake immediately.
+    {
+      constexpr auto keepalive_interval = std::chrono::seconds(5);
+      while (!complete_done.load(std::memory_order_acquire)) {
+        keepalive_timer.expires_after(keepalive_interval);
+        boost::system::error_code ec;
+        keepalive_timer.async_wait(y.get_yield_context()[ec]);
+        if (!complete_done.load(std::memory_order_acquire)) {
+          send_keepalive();
+        }
+      }
+    }
+
+    op_ret = complete_ret;
+  }
+
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "ERROR: upload complete failed ret=" << op_ret << dendl;
     return;

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -2123,6 +2123,13 @@ public:
   void complete() override;
 
   virtual int get_params(optional_yield y) = 0;
+  // Called once just before the expensive upload->complete() work begins.
+  // Protocol-specific subclasses should send the 200 OK response headers here
+  // so the client knows the request was accepted, matching AWS S3 behaviour.
+  virtual void send_response_begin() {}
+  // Called periodically while upload->complete() runs to keep the connection
+  // alive. Protocol-specific subclasses should write whitespace or similar.
+  virtual void send_keepalive() {}
   void send_response() override = 0;
   const char* name() const override { return "complete_multipart"; }
   std::string canonical_name() const override { return fmt::format("REST.{}.UPLOAD", s->info.method); }

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -4820,17 +4820,50 @@ int RGWCompleteMultipart_ObjStore_S3::get_params(optional_yield y)
   return do_aws4_auth_completion();
 }
 
-void RGWCompleteMultipart_ObjStore_S3::send_response()
+void RGWCompleteMultipart_ObjStore_S3::send_response_begin()
 {
-  if (op_ret)
-    set_req_state_err(s, op_ret);
+  // Called before upload->complete() runs: send 200 OK headers immediately so
+  // the client knows the request was accepted, matching AWS S3 behaviour.
   dump_errno(s);
   dump_header_if_nonempty(s, "x-amz-version-id", version_id);
   for (auto &it : crypt_http_responses)
     dump_header(s, it.first, it.second);
-  end_header(s, this, to_mime_type(s->format));
+  // Use chunked transfer encoding: we don't know the final body length yet,
+  // and we need to be able to flush whitespace bytes before the body is ready.
+  end_header(s, this, to_mime_type(s->format), CHUNKED_TRANSFER_ENCODING);
+  // Emit the XML declaration before any keepalive whitespace so the full
+  // reassembled body is valid XML (<?xml ...> must be at byte 0).
+  dump_start(s);
+  rgw_flush_formatter_and_reset(s, s->formatter);
+  sent_header = true;
+}
+
+void RGWCompleteMultipart_ObjStore_S3::send_keepalive()
+{
+  // Send a raw whitespace byte to keep the connection alive while
+  // upload->complete() runs. This matches AWS S3's behaviour.
+  ldpp_dout(this, 20) << "CompleteMultipart: sending keepalive whitespace" << dendl;
+  dump_body(s, " ");
+}
+
+void RGWCompleteMultipart_ObjStore_S3::send_response()
+{
+  if (!sent_header) {
+    // Normal error path: headers not yet sent because an error occurred before
+    // we started the expensive upload->complete() work.
+    if (op_ret)
+      set_req_state_err(s, op_ret);
+    dump_errno(s);
+    dump_header_if_nonempty(s, "x-amz-version-id", version_id);
+    for (auto &it : crypt_http_responses)
+      dump_header(s, it.first, it.second);
+    end_header(s, this, to_mime_type(s->format));
+  }
+
   if (op_ret == 0) {
-    dump_start(s);
+    if (!sent_header) {
+      dump_start(s);
+    }
     s->formatter->open_object_section_in_ns("CompleteMultipartUploadResult", XMLNS_AWS_S3);
     std::string base_uri = compute_domain_uri(s);
     if (!s->bucket_tenant.empty()) {
@@ -4857,6 +4890,19 @@ void RGWCompleteMultipart_ObjStore_S3::send_response()
       s->formatter->dump_string(cksum->element_name(), *armored_cksum);
       s->formatter->dump_string("ChecksumType", std::get<1>(cksum_type));
     }
+    s->formatter->close_section();
+    rgw_flush_formatter_and_reset(s, s->formatter);
+  } else if (sent_header) {
+    // 200 OK was already sent but upload->complete() failed. Embed an error in
+    // the response body — this matches AWS S3 behaviour where the response
+    // header has already been committed.
+    // dump_start() was already called in send_response_begin().
+    s->formatter->open_object_section("Error");
+    s->formatter->dump_string("Code", s->err.err_code);
+    s->formatter->dump_string("Message",
+                              s->err.message.empty() ? cpp_strerror(-op_ret)
+                                                     : s->err.message);
+    s->formatter->dump_string("RequestId", s->req_id);
     s->formatter->close_section();
     rgw_flush_formatter_and_reset(s, s->formatter);
   }

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -4902,7 +4902,7 @@ void RGWCompleteMultipart_ObjStore_S3::send_response()
     s->formatter->dump_string("Message",
                               s->err.message.empty() ? cpp_strerror(-op_ret)
                                                      : s->err.message);
-    s->formatter->dump_string("RequestId", s->req_id);
+    s->formatter->dump_string("RequestId", s->trans_id);
     s->formatter->close_section();
     rgw_flush_formatter_and_reset(s, s->formatter);
   }

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -4897,6 +4897,7 @@ void RGWCompleteMultipart_ObjStore_S3::send_response()
     // the response body — this matches AWS S3 behaviour where the response
     // header has already been committed.
     // dump_start() was already called in send_response_begin().
+    set_req_state_err(s, op_ret);
     s->formatter->open_object_section("Error");
     s->formatter->dump_string("Code", s->err.err_code);
     s->formatter->dump_string("Message",

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -513,11 +513,14 @@ public:
 class RGWCompleteMultipart_ObjStore_S3 : public RGWCompleteMultipart_ObjStore {
 private:
   std::map<std::string, std::string> crypt_http_responses;
+  bool sent_header{false};
 public:
   RGWCompleteMultipart_ObjStore_S3() {}
   ~RGWCompleteMultipart_ObjStore_S3() override {}
 
   int get_params(optional_yield y) override;
+  void send_response_begin() override;
+  void send_keepalive() override;
   void send_response() override;
 };
 


### PR DESCRIPTION
Multipart uploads can sometimes take a long time to complete in S3. According to the S3 docs, to cover this S3 periodically sends whitespace characters to prevent connection timeout. This PR implements that behavior in the RGW.

It works by using a coroutine to complete the upload, while the main coroutine sends whitespace every 5 seconds.

Tracker: https://tracker.ceph.com/issues/76260

I have tested this by intentionally delaying the upload coroutine like so:
```diff
diff --git a/src/rgw/rgw_op.cc b/src/rgw/rgw_op.cc
index 28dd0a55960..0eb95ffd954 100644
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -7598,6 +7598,11 @@ void RGWCompleteMultipart::execute(optional_yield y)
 
     boost::asio::spawn(executor,
       [&](boost::asio::yield_context yield) {
+        if (getenv("GO_SLOW")) {
+          boost::asio::steady_timer hack_timer(yield.get_executor());
+          hack_timer.expires_after(std::chrono::seconds(20));
+          hack_timer.async_wait(yield);
+        }
         complete_ret =
           upload->complete(this, optional_yield{yield}, s->cct, parts->parts,
                            remove_objs, accounted_size, compressed, cs_info, ofs,

```
And then using this to perform a multipart upload:

```shell
set -ex

AWS="aws --endpoint-url $ENDPOINT_URL s3api"

$AWS create-bucket --bucket testbucket

# start the upload
upload_id=$($AWS create-multipart-upload --bucket testbucket --key testobj | tee /dev/stderr | jq .UploadId -r)

# upload one part
dd if=/dev/zero bs=1M count=10 of=/tmp/testpart
etag=$($AWS upload-part --bucket testbucket --key testobj --part-number 1 --upload-id $upload_id --body /tmp/testpart | tee /dev/stderr | jq .ETag -r)

# complete the upload, check strace to see the whitespace
date
strace -s 10000 -e trace=recvfrom -tt -o complete-multipart-upload.strace $AWS --debug complete-multipart-upload --bucket testbucket --key testobj --upload-id $upload_id --multipart-upload "{\"Parts\":[{\"PartNumber\":1,\"ETag\":$etag}]}"
date
```
We can then look at the strace output to confirm this is working:

```
14:57:55.063970 recvfrom(3, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nx-amz-request-id: tx00000ca904259dfaa9c48-006a076cb2-4325-default\r\nContent-Type: application/xml\r\nServer: Ceph Object Gateway (umbrella)\r\nDate: Fri, 15 May 2026 18:57:54 GMT\r\nConnection: Keep-Alive\r\n\r\n26\r\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n", 8192, 0, NULL, NULL) = 290
14:58:00.062978 recvfrom(3, "1\r\n \r\n", 8192, 0, NULL, NULL) = 6
14:58:05.064269 recvfrom(3, "1\r\n \r\n", 8192, 0, NULL, NULL) = 6
14:58:10.074829 recvfrom(3, "1\r\n \r\n", 8192, 0, NULL, NULL) = 6
14:58:15.066631 recvfrom(3, "1\r\n \r\n", 8192, 0, NULL, NULL) = 6
14:58:15.078386 recvfrom(3, "118\r\n<CompleteMultipartUploadResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Location>http://localhost:8000/testbucket/testobj</Location><Bucket>testbucket</Bucket><Key>testobj</Key><ETag>&quot;9fbaeee0ccc66f9a8e3d3641dca37281-1&quot;</ETag></CompleteMultipartUploadResult>\r\n0\r\n\r\n", 8192, 0, NULL, NULL) = 292
```


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
