### PR TITLE
kv/KeyValueDB: New utility function util_divide_key_range

### DIFF
--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -410,6 +410,13 @@ public:
 				       const std::string& key_prefix) {
     return 0;
   }
+  /// estimate space utilization for a specified range (in bytes)
+  virtual int64_t estimate_range_size(
+    const std::string& prefix,
+    const std::string& key_from,
+    const std::string& key_to) {
+      return 0;
+  };
 
   /// compact the underlying store
   virtual void compact() {}

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -485,7 +485,25 @@ protected:
   /// List of matching prefixes/ColumnFamilies and merge operators
   std::vector<std::pair<std::string,
 			std::shared_ptr<MergeOperator> > > merge_ops;
-
+public:
+  struct keyrange_t {
+    std::string first_key;    // is in the range if exists
+    std::string upper_bound;  // is not in the range even if exists
+  };
+  /// splits a key range into multiple chunks of more or less equal size
+  virtual void util_divide_key_range(
+    const std::string& prefix,        // table to operate on
+    const std::string& starting_key,  // included if exists
+    const std::string& guardrail_key, // excluded if exists
+    uint64_t chunk_count,             // desired chunk count, but fewer can happen
+    uint64_t min_chunk_size,          // do not produce chunk smaller than this
+    float accepted_variance,          // +/- fluctuation of produced chunk size,
+                                      // smaller value requires more work, use 0.1 ?
+    std::vector<keyrange_t>& chunks){ // out: chunks
+      chunks.clear();
+      chunks.emplace_back(starting_key, guardrail_key);
+      return;
+    }
 };
 
 #endif

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -3648,3 +3648,184 @@ bool RocksDBStore::get_sharding(std::string& sharding) {
   }
   return result;
 }
+
+// Find a key that is lexicographically between low and high.
+// Try to select "midpoint".
+// If high is a direct successor to low, return "".
+static string key_between(const string& low, const string& high)
+{
+  string result;
+  ceph_assert(low.compare(high) < 0);
+  size_t same = 0;
+  while (same < std::min(low.length(), high.length()) &&
+         low[same] == high[same]) {
+    same++;
+  }
+  if (same == low.length()) {
+    //
+    size_t i = same;
+    while (i < high.length() && high[i] == '\0') {
+      i++;
+    }
+    if (i == high.length()) {
+      // special case that "high"="len00..000"; halfway formula does not work
+      if (i == same + 1) {
+        // just "high" = "len0", no key in-between
+        return string();
+      } else {
+        // add half zeros
+        result = low;
+        result.append(string((same + 1 - i) / 2, '\0'));
+        return result;
+      }
+    }
+  }
+  const std::string &shorter = low.length() < high.length() ? low : high;
+  const std::string &longer = low.length() < high.length() ? high : low;
+
+  result = shorter;
+  result.resize(longer.length() + 1);
+  uint16_t carry = 0;
+  // "+"
+  for (size_t i = longer.length() - 1; i + 1 > same; i--) {
+    uint8_t a = i < shorter.length() ? shorter[i] : 0;
+    uint8_t b = longer[i];
+    uint16_t v = ((uint16_t)a + (uint16_t)b + carry);
+    carry = v >> 8;
+    result[i + 1] = v;
+  }
+  result[same] = carry;
+  //  ">>1"
+  for (size_t i = same; i < longer.length(); i++) {
+    uint16_t v =
+        ((uint16_t)(uint8_t)result[i] << 8) | (uint16_t)(uint8_t)result[i + 1];
+    result[i] = v >> 1;
+  }
+  result[longer.length()] = (uint8_t)result[longer.length()] >> 7;
+  return result;
+};
+
+void RocksDBStore::util_divide_key_range(
+  const string& prefix,
+  const string& starting_key,   //included if exists
+  const string& guardrail_key,  //excluded if exists
+  uint64_t chunk_count,
+  uint64_t min_chunk_size,
+  float accepted_variance,
+  vector<keyrange_t>& chunks)
+{
+  dout(10) << __func__ << " chunks=" << chunk_count
+    << " start=" << pretty_binary_string(starting_key)
+    << " end=" << pretty_binary_string(guardrail_key) << dendl;
+  chunks.clear();
+  map<uint64_t, string> cs_map;
+  string key_from, key_to;
+  auto db_it = get_iterator(prefix);
+  db_it->lower_bound(starting_key);
+  if (!db_it) return; //empty range
+  key_from = db_it->key();
+  db_it->lower_bound(guardrail_key);
+  if (!db_it->valid()) {
+    db_it->seek_to_last();
+    ceph_assert(db_it->valid());
+    key_to = db_it->key();
+    key_to.push_back('\0');
+  } else {
+    key_to = db_it->key();
+    if (key_to <= key_from) return;
+  }
+  uint64_t full_size = estimate_range_size(prefix, key_from, key_to);
+  cs_map[0] = key_from;
+  cs_map[full_size] = key_to;
+  uint64_t target_chunk_size = full_size / chunk_count;
+  uint64_t chunk_min = target_chunk_size * (1 - accepted_variance);
+  uint64_t chunk_max = target_chunk_size * (1 + accepted_variance);
+  if (full_size <= chunk_max) {
+    chunks.emplace_back(key_from, key_to);
+    return;
+  }
+  if (target_chunk_size < chunk_min) {
+    chunk_count = std::min<uint64_t>(chunk_count, full_size / chunk_min + 1);
+    target_chunk_size = full_size / chunk_count;
+    chunk_min = target_chunk_size * (1 - accepted_variance);
+    chunk_max = target_chunk_size * (1 + accepted_variance);
+  }
+  dout(10) << __func__ << " chunks=" << chunk_count
+    << " key_from=" << pretty_binary_string(key_from)
+    << " key_to=" << pretty_binary_string(key_to) << dendl;
+
+  ceph_assert(chunk_count >= 2);
+  dout(20) << "target_chunk_size=" << target_chunk_size
+    << " chunk_min=" << chunk_min << " chunk_max=" << chunk_max << dendl;
+  // Algorithm idea:
+  // Have a mapping MAP with elements: estimated_db_size[key_from .. x] -> x.
+  // Keep bisecting [key_from .. key_to].
+  // When MAP[last] - MAP[current_candidate] is in acceptable range for chunk size
+  //   emit the range and move forward.
+  auto it = cs_map.begin();
+  uint64_t cs_anchor = it->first;
+  string cs_key = it->second;
+  uint32_t bisect_actions = 0;
+  while(true) {
+    ceph_assert(it != cs_map.end());
+    it++;
+    ceph_assert(cs_map.end() != it);
+    dout(20) << "trying   " << it->first << " " << pretty_binary_string(it->second) << dendl;
+    if (it->first - cs_anchor > chunk_max) {
+      if (bisect_actions == 100) {
+        chunks.clear();
+        chunks.emplace_back(key_from, key_to);
+        return;
+      }
+      bisect_actions++;
+      // it is too far, need to roll back and divide
+      auto key_e = it->second;
+      it--;
+      auto key_b = it->second;
+      auto imagined_key = key_between(key_b, key_e);
+      dout(20) << pretty_binary_string(key_b) << "..." << pretty_binary_string(key_e)
+        << "-> midpoint=" << pretty_binary_string(imagined_key) << dendl;
+      ceph_assert( key_b < imagined_key);
+      ceph_assert(imagined_key < key_e);
+      db_it->upper_bound(imagined_key);
+      ceph_assert(db_it->valid());
+      auto real_key = db_it->key();
+      if (real_key == key_e) {
+        db_it->prev();
+        real_key = db_it->key();
+      }
+      uint64_t cs_size = estimate_range_size(prefix, key_from, real_key);
+      if (cs_size > it->first) {
+        cs_map[cs_size] = real_key;
+        dout(20) << "newpoint " << cs_size << " " << pretty_binary_string(real_key) << dendl;
+        ceph_assert(key_b < real_key);
+        ceph_assert(real_key <= key_e);
+        continue;
+      } else {
+        // this seems to be limit for precision, no reason to attempt biseciton further
+        // fell out and emit region
+      }
+    } else if (it->first - cs_anchor < chunk_min) {
+      continue;
+    }
+
+    bisect_actions = 0;
+    // we are satisfied enough
+    chunks.emplace_back(cs_key, it->second);
+    dout(10) << "produced chunk size=" << it->first - cs_anchor << " "
+      << pretty_binary_string(cs_key) << " " << pretty_binary_string(it->second) << dendl;
+    if (chunks.size() == chunk_count - 1) {
+      chunks.emplace_back(it->second, key_to);
+      dout(10) << "produced chunk size=" << full_size - it->first << " "
+        << pretty_binary_string(it->second) << " " << pretty_binary_string(key_to) << dendl;
+      break;
+    }
+    cs_anchor = it->first;
+    cs_key = it->second;
+    target_chunk_size = (full_size - cs_anchor) / (chunk_count - chunks.size());
+    chunk_min = target_chunk_size * (1 - accepted_variance);
+    chunk_max = target_chunk_size * (1 + accepted_variance);
+    dout(20) << "target_chunk_size=" << target_chunk_size
+      << " chunk_min=" << chunk_min << " chunk_max=" << chunk_max << dendl;
+  }
+}

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -1433,6 +1433,36 @@ int64_t RocksDBStore::estimate_prefix_size(const string& prefix,
   return size;
 }
 
+int64_t RocksDBStore::estimate_range_size(
+  const string& prefix,
+  const string& key_from,
+  const string& key_to)
+{
+  // The default mode is to derive estimates based on
+  // sst files alone (INCLUDE_FILES).
+  // This gives an irritating result when a batch of keys is
+  // just commited but estimate keeps showing 0.
+  rocksdb::DB::SizeApproximationFlags flags(
+    rocksdb::DB::SizeApproximationFlags::INCLUDE_FILES |
+    rocksdb::DB::SizeApproximationFlags::INCLUDE_MEMTABLES);
+  uint64_t size = 0;
+  auto p_iter = cf_handles.find(prefix);
+  if (p_iter != cf_handles.end()) {
+    for (const auto cf : p_iter->second.handles) {
+      uint64_t s = 0;
+      rocksdb::Range r(key_from, key_to);
+      db->GetApproximateSizes(cf, &r, 1, &s, flags);
+      size += s;
+    }
+  } else {
+    string start = combine_strings(prefix , key_from);
+    string limit = combine_strings(prefix , key_to);
+    rocksdb::Range r(start, limit);
+    db->GetApproximateSizes(default_cf, &r, 1, &size, flags);
+  }
+  return size;
+}
+
 void RocksDBStore::get_statistics(Formatter *f)
 {
   if (!cct->_conf->rocksdb_perf)  {

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -3654,36 +3654,32 @@ bool RocksDBStore::get_sharding(std::string& sharding) {
 // If high is a direct successor to low, return "".
 static string key_between(const string& low, const string& high)
 {
-  string result;
   ceph_assert(low.compare(high) < 0);
-  size_t same = 0;
-  while (same < std::min(low.length(), high.length()) &&
-         low[same] == high[same]) {
-    same++;
-  }
-  if (same == low.length()) {
-    //
-    size_t i = same;
-    while (i < high.length() && high[i] == '\0') {
-      i++;
-    }
-    if (i == high.length()) {
+
+  const auto [divergent_low_it, divergent_high_it] =
+    std::mismatch(low.begin(), low.end(), high.begin(), high.end());
+  if (divergent_low_it == low.end()) {
+    const auto non_zero_it = std::find_if(divergent_high_it, high.end(), [](char c) {
+      return c != '\0';
+    });
+    if (non_zero_it == high.end()) {
       // special case that "high"="len00..000"; halfway formula does not work
-      if (i == same + 1) {
+      size_t zero_count = std::distance(divergent_high_it, non_zero_it);
+      if (zero_count == 1) {
         // just "high" = "len0", no key in-between
         return string();
-      } else {
-        // add half zeros
-        result = low;
-        result.append(string((same + 1 - i) / 2, '\0'));
-        return result;
       }
+      // Add roughly half the trailing zeros.
+      return low + string((zero_count + 1) / 2, '\0');
     }
   }
-  const std::string &shorter = low.length() < high.length() ? low : high;
-  const std::string &longer = low.length() < high.length() ? high : low;
 
-  result = shorter;
+  size_t same = std::distance(low.begin(), divergent_low_it);
+  const bool low_is_shorter = low.length() < high.length();
+  const std::string& shorter = low_is_shorter ? low : high;
+  const std::string& longer = low_is_shorter ? high : low;
+
+  string result = shorter;
   result.resize(longer.length() + 1);
   uint16_t carry = 0;
   // "+"
@@ -3695,15 +3691,15 @@ static string key_between(const string& low, const string& high)
     result[i + 1] = v;
   }
   result[same] = carry;
-  //  ">>1"
+  // ">>1"
   for (size_t i = same; i < longer.length(); i++) {
-    uint16_t v =
-        ((uint16_t)(uint8_t)result[i] << 8) | (uint16_t)(uint8_t)result[i + 1];
+    uint16_t v = ((uint16_t)(uint8_t)result[i] << 8) |
+                 (uint16_t)(uint8_t)result[i + 1];
     result[i] = v >> 1;
   }
   result[longer.length()] = (uint8_t)result[longer.length()] >> 7;
   return result;
-};
+}
 
 void RocksDBStore::util_divide_key_range(
   const string& prefix,
@@ -3714,18 +3710,20 @@ void RocksDBStore::util_divide_key_range(
   float accepted_variance,
   vector<keyrange_t>& chunks)
 {
+  ceph_assert(chunk_count > 0);
+  ceph_assert(min_chunk_size > 0);
+  ceph_assert(accepted_variance >= 0.0f);
   dout(10) << __func__ << " chunks=" << chunk_count
     << " start=" << pretty_binary_string(starting_key)
     << " end=" << pretty_binary_string(guardrail_key) << dendl;
   chunks.clear();
-  map<uint64_t, string> cs_map;
   string key_from, key_to;
   auto db_it = get_iterator(prefix);
   db_it->lower_bound(starting_key);
-  if (!db_it) return; //empty range
+  if (!db_it->valid()) return; //empty range
   key_from = db_it->key();
   db_it->lower_bound(guardrail_key);
-  if (!db_it->valid()) {
+  if (!db_it->valid() || guardrail_key.empty()) {
     db_it->seek_to_last();
     ceph_assert(db_it->valid());
     key_to = db_it->key();
@@ -3734,98 +3732,108 @@ void RocksDBStore::util_divide_key_range(
     key_to = db_it->key();
     if (key_to <= key_from) return;
   }
-  uint64_t full_size = estimate_range_size(prefix, key_from, key_to);
-  cs_map[0] = key_from;
-  cs_map[full_size] = key_to;
-  uint64_t target_chunk_size = full_size / chunk_count;
-  uint64_t chunk_min = target_chunk_size * (1 - accepted_variance);
-  uint64_t chunk_max = target_chunk_size * (1 + accepted_variance);
-  if (full_size <= chunk_max) {
-    chunks.emplace_back(key_from, key_to);
-    return;
-  }
-  if (target_chunk_size < chunk_min) {
-    chunk_count = std::min<uint64_t>(chunk_count, full_size / chunk_min + 1);
-    target_chunk_size = full_size / chunk_count;
-    chunk_min = target_chunk_size * (1 - accepted_variance);
-    chunk_max = target_chunk_size * (1 + accepted_variance);
+  // Using set as map; allows for named "first"="key" and "second"="size".
+  struct probe_t {
+    string key;
+    int64_t size;
+    struct compare {
+      bool operator()(const probe_t& l, const probe_t& r) const {
+        return l.key < r.key;
+      }
+    };
+  };
+  set<probe_t, probe_t::compare> db_samples;
+  int64_t full_size = estimate_range_size(prefix, key_from, key_to);
+  db_samples.emplace(key_from, 0);
+  db_samples.emplace(key_to, full_size);
+
+  if (full_size / chunk_count < min_chunk_size) {
+    chunk_count = full_size / min_chunk_size + 1;
   }
   dout(10) << __func__ << " chunks=" << chunk_count
     << " key_from=" << pretty_binary_string(key_from)
     << " key_to=" << pretty_binary_string(key_to) << dendl;
 
-  ceph_assert(chunk_count >= 2);
-  dout(20) << "target_chunk_size=" << target_chunk_size
-    << " chunk_min=" << chunk_min << " chunk_max=" << chunk_max << dendl;
   // Algorithm idea:
-  // Have a mapping MAP with elements: estimated_db_size[key_from .. x] -> x.
-  // Keep bisecting [key_from .. key_to].
-  // When MAP[last] - MAP[current_candidate] is in acceptable range for chunk size
-  //   emit the range and move forward.
-  auto it = cs_map.begin();
-  uint64_t cs_anchor = it->first;
-  string cs_key = it->second;
+  // Have a scan over database with keys mapping to value of
+  //   estimate_range_size between key_from and respective key.
+  // The initial range will be successively scanned by bisecting key ranges.
+  // When scanned point is smaller than desired chunk incorporate it;
+  //   when it is larger attempt to bisect and reevaluate.
+  // Once chunk is large enough, emit it and start with next one.
+  // Extra care is taken to protect against RocksDB providing non-monotonic size estimate.
+  auto base = db_samples.begin();
   uint32_t bisect_actions = 0;
-  while(true) {
-    ceph_assert(it != cs_map.end());
-    it++;
-    ceph_assert(cs_map.end() != it);
-    dout(20) << "trying   " << it->first << " " << pretty_binary_string(it->second) << dendl;
-    if (it->first - cs_anchor > chunk_max) {
-      if (bisect_actions == 100) {
-        chunks.clear();
-        chunks.emplace_back(key_from, key_to);
-        return;
-      }
-      bisect_actions++;
-      // it is too far, need to roll back and divide
-      auto key_e = it->second;
-      it--;
-      auto key_b = it->second;
-      auto imagined_key = key_between(key_b, key_e);
-      dout(20) << pretty_binary_string(key_b) << "..." << pretty_binary_string(key_e)
-        << "-> midpoint=" << pretty_binary_string(imagined_key) << dendl;
-      ceph_assert( key_b < imagined_key);
-      ceph_assert(imagined_key < key_e);
-      db_it->upper_bound(imagined_key);
-      ceph_assert(db_it->valid());
-      auto real_key = db_it->key();
-      if (real_key == key_e) {
-        db_it->prev();
-        real_key = db_it->key();
-      }
-      uint64_t cs_size = estimate_range_size(prefix, key_from, real_key);
-      if (cs_size > it->first) {
-        cs_map[cs_size] = real_key;
-        dout(20) << "newpoint " << cs_size << " " << pretty_binary_string(real_key) << dendl;
-        ceph_assert(key_b < real_key);
-        ceph_assert(real_key <= key_e);
-        continue;
-      } else {
-        // this seems to be limit for precision, no reason to attempt biseciton further
-        // fell out and emit region
-      }
-    } else if (it->first - cs_anchor < chunk_min) {
-      continue;
-    }
-
-    bisect_actions = 0;
-    // we are satisfied enough
-    chunks.emplace_back(cs_key, it->second);
-    dout(10) << "produced chunk size=" << it->first - cs_anchor << " "
-      << pretty_binary_string(cs_key) << " " << pretty_binary_string(it->second) << dendl;
-    if (chunks.size() == chunk_count - 1) {
-      chunks.emplace_back(it->second, key_to);
-      dout(10) << "produced chunk size=" << full_size - it->first << " "
-        << pretty_binary_string(it->second) << " " << pretty_binary_string(key_to) << dendl;
-      break;
-    }
-    cs_anchor = it->first;
-    cs_key = it->second;
-    target_chunk_size = (full_size - cs_anchor) / (chunk_count - chunks.size());
-    chunk_min = target_chunk_size * (1 - accepted_variance);
-    chunk_max = target_chunk_size * (1 + accepted_variance);
+  while(chunks.size() < chunk_count - 1 && // Loop until we get enough chunks, except last.
+        base != db_samples.end() &&        // Extra stop if we just incorporated end() into last range.
+        full_size > base->size)            // And protection against non-monotonic RocksDB size estimation.
+  {
+    // Calculate targets
+    int64_t target_chunk_size = (full_size - base->size) / (chunk_count - chunks.size());
+    int64_t chunk_min = target_chunk_size * (1 - accepted_variance);
+    int64_t chunk_max = target_chunk_size * (1 + accepted_variance);
     dout(20) << "target_chunk_size=" << target_chunk_size
       << " chunk_min=" << chunk_min << " chunk_max=" << chunk_max << dendl;
+    auto curr = base;
+    while(curr->size - base->size < chunk_min) {
+      auto next = curr; next++;
+      if (next == db_samples.end()) {
+        // This should not happen: end()->size == full_size and base->size were
+        // used to calculate chunk_target, chunk_min and chunk_max.
+        // But if it happens, just abruptly finish.
+        goto emit_and_exit;
+      }
+      dout(20) << "trying   " << next->size << " " << pretty_binary_string(next->key) << dendl;
+      if (next->size - base->size < chunk_max) {
+        curr++; //just take it
+      } else {
+        // split
+        if (bisect_actions == 100) {
+          goto emit_and_exit;
+        }
+        bisect_actions++;
+        // it is too far, need to roll back and divide
+        auto key_b = curr->key;
+        auto key_e = next->key;
+        auto imagined_key = key_between(key_b, key_e);
+        dout(20) << pretty_binary_string(key_b) << "..." << pretty_binary_string(key_e)
+          << "-> midpoint=" << pretty_binary_string(imagined_key) << dendl;
+        if (imagined_key.empty()) {
+          // Very very unlikely: key_e is direct successor of key_b.
+          curr++;
+          continue;
+        }
+        ceph_assert(key_b < imagined_key && imagined_key < key_e);
+        db_it->upper_bound(imagined_key);
+        ceph_assert(db_it->valid());
+        auto real_key = db_it->key();
+        if (real_key == key_e) {
+          // It means there is nothing between imagined_key and key_e.
+          // Go back one key so next bisect can be better.
+          db_it->prev();
+          real_key = db_it->key();
+          if (key_b == real_key) {
+            // It means we cannot hope to narrow the gap between key_b and key_e.
+            // Take the range.
+            curr++;
+            continue;
+          }
+        }
+        ceph_assert(key_b < real_key && real_key < key_e);
+        uint64_t cs_size = estimate_range_size(prefix, key_from, real_key);
+        dout(20) << "newpoint " << cs_size << " " << pretty_binary_string(real_key) << dendl;
+        db_samples.emplace(real_key, cs_size);
+      }
+    }
+    //emit chunk
+    bisect_actions = 0;
+    chunks.emplace_back(base->key, curr->key);
+    dout(10) << "produced chunk size=" << curr->size - base->size << " "
+      << pretty_binary_string(base->key) << " " << pretty_binary_string(curr->key) << dendl;
+    base = curr;
   }
+  emit_and_exit:
+  chunks.emplace_back(base->key, key_to);
+  dout(10) << "produced chunk size=" << full_size - base->size << " "
+    << pretty_binary_string(base->key) << " " << pretty_binary_string(key_to) << dendl;
 }

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -291,6 +291,9 @@ public:
 
   int64_t estimate_prefix_size(const std::string& prefix,
 			       const std::string& key_prefix) override;
+  int64_t estimate_range_size(const std::string& prefix,
+                              const std::string& key_from,
+                              const std::string& key_to) override;
   struct RocksWBHandler;
   class RocksDBTransactionImpl : public KeyValueDB::TransactionImpl {
   public:

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -566,7 +566,15 @@ public:
   };
   int reshard(const std::string& new_sharding, const resharding_ctrl* ctrl = nullptr);
   bool get_sharding(std::string& sharding);
-
+  void util_divide_key_range(
+    const std::string& prefix,        // table to operate on
+    const std::string& starting_key,  // included if exists
+    const std::string& guardrail_key, // excluded if exists
+    uint64_t chunk_count,             // desired chunk count, but fewer can happen
+    uint64_t min_chunk_size,          // do not produce chunk smaller than this
+    float accepted_variance,          // +/- fluctuation of produced chunk size,
+                                      // smaller value requires more work, use 0.1 ?
+    std::vector<keyrange_t>& chunks) override;
 };
 
 #endif

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -567,13 +567,13 @@ public:
   int reshard(const std::string& new_sharding, const resharding_ctrl* ctrl = nullptr);
   bool get_sharding(std::string& sharding);
   void util_divide_key_range(
-    const std::string& prefix,        // table to operate on
-    const std::string& starting_key,  // included if exists
-    const std::string& guardrail_key, // excluded if exists
-    uint64_t chunk_count,             // desired chunk count, but fewer can happen
-    uint64_t min_chunk_size,          // do not produce chunk smaller than this
+    const std::string& prefix,        // Table to operate on.
+    const std::string& starting_key,  // Included if exists.
+    const std::string& guardrail_key, // Excluded if exists; but "" means up until table end
+    uint64_t chunk_count,             // Desired chunk count, can produce fewer when not enough data.
+    uint64_t min_chunk_size,          // Do not produce chunk smaller than this bytes.
     float accepted_variance,          // +/- fluctuation of produced chunk size,
-                                      // smaller value requires more work, use 0.1 ?
+                                      // there is a limit to prediction quality, recommended 0.05.
     std::vector<keyrange_t>& chunks) override;
 };
 

--- a/src/test/objectstore/test_kv.cc
+++ b/src/test/objectstore/test_kv.cc
@@ -13,9 +13,12 @@
  *
  */
 
+#include <common/pretty_binary.h>
 #include <stdio.h>
 #include <string.h>
 #include <iostream>
+#include <string>
+#include <random>
 #include <time.h>
 #include <sys/mount.h>
 #include "kv/KeyValueDB.h"
@@ -28,6 +31,7 @@
 #include "common/errno.h"
 #include "include/stringify.h"
 #include <gtest/gtest.h>
+#include <fmt/format.h>
 
 using namespace std;
 
@@ -1284,6 +1288,425 @@ TEST_F(RocksDBResharding, change_reshard) {
     check_db();
     db->close();
   }
+}
+
+typedef std::mt19937 gen_type;
+
+class RocksDBSplitRange : public ::testing::Test {
+public:
+  boost::scoped_ptr<RocksDBStore> db;
+  gen_type rng = gen_type(0);
+  RocksDBSplitRange() : db(0) {}
+
+  string _bl_to_str(bufferlist val) {
+    string str(val.c_str(), val.length());
+    return str;
+  }
+
+  void rm_r(string path) {
+    string cmd = string("rm -r ") + path;
+    if (verbose)
+      cout << "==> " << cmd << std::endl;
+    int r = ::system(cmd.c_str());
+    if (r) {
+      cerr << "failed with exit code " << r
+        << ", continuing anyway" << std::endl;
+    }
+  }
+
+  void SetUp() override {
+    verbose = getenv("VERBOSE") && strcmp(getenv("VERBOSE"), "1") == 0;
+
+    int r = ::mkdir("kv_test_temp_dir", 0777);
+    if (r < 0 && errno != EEXIST) {
+      r = -errno;
+      cerr << __func__ << ": unable to create kv_test_temp_dir: "
+        << cpp_strerror(r) << std::endl;
+      return;
+    }
+
+    KeyValueDB* db_kv = KeyValueDB::create(g_ceph_context, "rocksdb", "kv_test_temp_dir");
+    RocksDBStore* db_rocks = dynamic_cast<RocksDBStore*>(db_kv);
+    ceph_assert(db_rocks);
+    db.reset(db_rocks);
+    ASSERT_EQ(0, db->init(g_conf()->bluestore_rocksdb_options));
+  }
+
+  void TearDown() override {
+    db.reset(nullptr);
+    rm_r("kv_test_temp_dir");
+  }
+
+  bool is_jenkins() {
+    return (getenv("JENKINS_HOME") != nullptr);
+  }
+
+  bool verbose;
+  std::vector<std::string> random_words = {
+    "found", "brain", "fully", "pen", "worth", "race",
+    "stand", "nodded", "whenever", "surrounded", "industrial", "skin",
+    "this", "direction", "family", "beginning", "whenever", "held",
+    "metal", "year", "like", "valuable", "softly", "whistle",
+    "perfectly", "broken", "idea", "also", "coffee", "branch",
+    "tongue", "immediately", "bent", "partly", "burn", "include",
+    "certain", "burst", "final", "smoke", "positive", "perfectly"
+  };
+  uniform_int_distribution<> uniform_random_words =
+    uniform_int_distribution<>(0, random_words.size() - 1);
+  uniform_int_distribution<> random_byte =
+    uniform_int_distribution<>('!', '~');
+  std::map<std::string, std::string> data;
+
+  std::string random_string(uint32_t msg_size, uint32_t compress_target)
+  {
+    std::string result;
+    uint32_t s = 0; // accumulated message
+    uint32_t c = 0; // estimated compressed size
+    // pick words
+    while (s < msg_size && (msg_size - s) > (compress_target - c)) {
+      uint32_t idx = uniform_random_words(rng);
+      result += random_words[idx];
+      s += random_words[idx].length();
+      c += 2; //~1 = random byte, ~2 = ref message
+    }
+    // fillup with full random bytes
+    while (s < msg_size) {
+      result.push_back(random_byte(rng));
+      s++;
+    }
+    return result;
+  }
+
+  struct DataToDB {
+    KeyValueDB* db;
+    std::string prefix;
+    KeyValueDB::Transaction t;
+    uint32_t cnt = 0;
+    DataToDB(KeyValueDB* db, const std::string& prefix)
+    : db(db), prefix(prefix)
+    {
+      t = db->get_transaction();
+    }
+    void add(const std::string& key, const std::string& value)
+    {
+      bufferlist v;
+      v.append(value);
+      t->set(prefix, key, v);
+      cnt++;
+      if ((cnt % 1000) == 0) {
+        ASSERT_EQ(db->submit_transaction_sync(t), 0);
+        t.reset();
+        t = db->get_transaction();
+      }
+    }
+    void rm(const std::string& key)
+    {
+      t->rmkey(prefix, key);
+      cnt++;
+      if ((cnt % 1000) == 0) {
+        ASSERT_EQ(db->submit_transaction_sync(t), 0);
+        t.reset();
+        t = db->get_transaction();
+      }
+    }
+    void flush()
+    {
+      ASSERT_EQ(db->submit_transaction_sync(t), 0);
+      t.reset();
+      t = db->get_transaction();
+    }
+  };
+
+  struct TreeGen {
+    uint32_t left_w;
+    uint32_t right_w;
+    std::string left_name;
+    std::string right_name;
+    bool sub_tree_branch(int& n) const
+    {
+      uint32_t count_left = (n * left_w) / (left_w + right_w);
+      uint32_t rem = (n * left_w) % (left_w + right_w);
+      uint32_t count_right = n - count_left;
+      if (rem >= right_w) {
+        n = count_left;
+        return false; //left
+      } else {
+        n = count_right - 1; //right
+        return true;
+      }
+    }
+    std::string get_branch_name(int n) const
+    {
+      std::string result;
+      while (n > 0) {
+        bool do_right = sub_tree_branch(n);
+        if (do_right)
+          result.append(right_name);
+        else
+          result.append(left_name);
+      }
+      return result;
+    }
+    TreeGen(
+      uint32_t left_weight,
+      uint32_t right_weight,
+      const std::string& left_name,
+      const std::string& right_name)
+      : left_w(left_weight)
+      , right_w(right_weight)
+      , left_name(left_name)
+      , right_name(right_name)
+    {
+      if (left_weight < right_weight) {
+        std::swap(this->left_name, this->right_name);
+        std::swap(left_weight, right_weight);
+      }
+    }
+  };
+
+  void grow_tree(
+    const TreeGen& t, DataToDB& data_to_db,
+    uint32_t key_from, uint32_t key_to,
+    const std::string& key_tail,
+    uint32_t value_size, uint32_t value_comp_size)
+  {
+    for(uint32_t i = key_from; i < key_to; i++) {
+      std::string key = t.get_branch_name(i) + key_tail;
+      std::string value = random_string(value_size, value_comp_size);
+      data_to_db.add(key, value);
+    }
+    data_to_db.flush();
+  }
+
+  void prune_tree(
+    const TreeGen& t, DataToDB& data_to_db,
+    uint32_t key_from, uint32_t key_to,
+    const std::string& key_tail)
+  {
+    for(uint32_t i = key_from; i < key_to; i++) {
+      std::string key = t.get_branch_name(i) + key_tail;
+      data_to_db.rm(key);
+    }
+    data_to_db.flush();
+  }
+
+  std::pair<uint64_t, uint64_t> get_split_quality(
+    const std::string& prefix,
+    const std::vector<KeyValueDB::keyrange_t>& chunks)
+  {
+    uint64_t all_keys = 0;
+    uint64_t max_keys = 0;
+    KeyValueDB::Iterator it;
+    it = db->get_iterator(prefix);
+    if (verbose) std::cout << "keys_in_shards: ";
+    for (const auto& c : chunks) {
+      uint64_t keys = 0;
+      it->lower_bound(c.first_key);
+      while(it->valid() && it->key() < c.upper_bound) {
+        keys++;
+        all_keys++;
+        it->next();
+      }
+      if (verbose) std::cout << keys << " " << std::flush;
+      if (max_keys < keys) {
+        max_keys = keys;
+      }
+    }
+    if (verbose) std::cout << std::endl;
+    return make_pair(all_keys, max_keys);
+  }
+
+  void scan_split_quality(
+    const std::string& prefix)
+  {
+    if (!verbose) return;
+    std::vector<KeyValueDB::keyrange_t> chunks;
+    auto c_set = {1, 3, 5, 10, 20, 30};
+    auto p_set = {0.2, 0.1, 0.05, 0.02, 0.01};
+    std::cout << fmt::format("{:6}","");
+    for (uint32_t c: c_set) {
+      std::cout << fmt::format("{:10}",c);
+    }
+    std::cout << std::endl;
+    for (double prec: p_set) {
+      std::cout << fmt::format("{:5.2f} ",prec);
+      for (uint32_t c: c_set) {
+        utime_t start = ceph_clock_now();
+        db->util_divide_key_range(
+          prefix, "", std::string(20, '\377'),
+          c, 1000000, prec, chunks);
+        utime_t end = ceph_clock_now();
+        std::cout << fmt::format("{:7.3f}/{:2}", double(end - start) * 1000, chunks.size());
+      }
+      std::cout << std::endl;
+    }
+  }
+};
+
+TEST_F(RocksDBSplitRange, grow_tree) {
+  ASSERT_EQ(0, db->create_and_open(cout, "O"));
+
+  TreeGen t(70, 30, "l", "r");
+  DataToDB to_db(db.get(), "O");
+  vector<uint32_t> keys_to_test = {0, 1000, 10000, 100000, 1'000'000, 2'000'000, 5'000'000, 10'000'000};
+  if (is_jenkins()) keys_to_test = {1'000'000};
+  uint64_t keys = 0;
+  for (auto keys_end : keys_to_test) {
+    if (verbose) std::cout << "grow " << keys << "->" << keys_end << std::endl;
+    grow_tree(t, to_db, keys, keys_end, "a", 1000, 300);
+    keys = keys_end;
+    keys_end = keys_end * 2;
+
+    std::vector<KeyValueDB::keyrange_t> chunks;
+    utime_t start = ceph_clock_now();
+    db->util_divide_key_range(
+      "O", "", "",
+      10, 10000000, 0.1, chunks);
+    utime_t end = ceph_clock_now();
+    if (verbose) std::cout << "time=" << end - start << std::endl;
+    auto [all_keys, max_keys] = get_split_quality("O", chunks);
+    double speedup = double(all_keys) / max_keys;
+    if (verbose) std::cout << "quality=" << double(all_keys) / max_keys / chunks.size()
+      << " speedup=" << speedup << std::endl;
+    EXPECT_EQ(all_keys, keys);
+    if (all_keys > 1000000) {
+      EXPECT_GT(speedup, 8);
+    }
+    scan_split_quality("O");
+  }
+  db->close();
+}
+
+TEST_F(RocksDBSplitRange, grow_tree_high_quality) {
+  ASSERT_EQ(0, db->create_and_open(cout, "O"));
+
+  TreeGen t(70, 30, "l", "r");
+  DataToDB to_db(db.get(), "O");
+  vector<uint32_t> keys_to_test = {0, 1000, 10000, 100000, 1'000'000, 2'000'000, 5'000'000, 10'000'000};
+  if (is_jenkins()) keys_to_test = {1'000'000};
+  uint64_t keys = 0;
+  for (auto keys_end : keys_to_test) {
+    if (verbose) std::cout << "grow " << keys << "->" << keys_end << std::endl;
+    grow_tree(t, to_db, keys, keys_end, "a", 1000, 300);
+    keys = keys_end;
+    keys_end = keys_end * 2;
+
+    std::vector<KeyValueDB::keyrange_t> chunks;
+    db->util_divide_key_range(
+      "O", "", "",
+      10, 10000000, 0.02, chunks);
+    auto [all_keys, max_keys] = get_split_quality("O", chunks);
+    double speedup = double(all_keys) / max_keys;
+    if (verbose) std::cout << "quality=" << double(all_keys) / max_keys / chunks.size()
+      << " speedup=" << speedup << std::endl;
+    EXPECT_EQ(all_keys, keys);
+    if (all_keys > 1000000) {
+      EXPECT_GT(speedup, 8);
+    }
+    scan_split_quality("O");
+  }
+  db->close();
+}
+
+TEST_F(RocksDBSplitRange, grow_two_trees) {
+  ASSERT_EQ(0, db->create_and_open(cout, "O"));
+
+  TreeGen t1(70, 30, "left", "right");
+  TreeGen t2(60, 40, "left", "right");
+  DataToDB to_db(db.get(), "O");
+  vector<uint32_t> keys_to_test = {0, 1000, 10000, 100000, 1'000'000, 2'000'000, 5'000'000, 10'000'000};
+  if (is_jenkins()) keys_to_test = {1'000'000};
+  uint64_t keys = 0;
+  for (auto keys_end : keys_to_test) {
+    if (verbose) std::cout << "grow " << keys << "->" << keys_end << std::endl;
+    grow_tree(t1, to_db, keys, keys_end, "a", 1000, 300);
+    grow_tree(t2, to_db, keys, keys_end, "b", 500, 150);
+    keys = keys_end;
+    keys_end = keys_end * 2;
+
+    std::vector<KeyValueDB::keyrange_t> chunks;
+    db->util_divide_key_range(
+      "O", "", "",
+      10, 10000000, 0.1, chunks);
+    auto [all_keys, max_keys] = get_split_quality("O", chunks);
+    double speedup = double(all_keys) / max_keys;
+    if (verbose) std::cout << "quality=" << double(all_keys) / max_keys / chunks.size()
+      << " speedup=" << speedup << std::endl;
+    EXPECT_EQ(all_keys, keys * 2);
+    if (all_keys > 1000000) {
+      EXPECT_GT(speedup, 5);
+    }
+    scan_split_quality("O");
+  }
+  db->close();
+}
+
+TEST_F(RocksDBSplitRange, grow_prune_tree) {
+  ASSERT_EQ(0, db->create_and_open(cout, "O"));
+
+  TreeGen t(70, 30, "l", "r");
+  DataToDB to_db(db.get(), "O");
+  vector<uint32_t> keys_to_test = {0, 1000, 10000, 100000, 1'000'000, 2'000'000, 5'000'000, 10'000'000};
+  if (is_jenkins()) keys_to_test = {1'000'000};
+  uint64_t keys = 0;
+  uint64_t pruned_keys = 0;
+  for (auto keys_end : keys_to_test) {
+    if (verbose) std::cout << "grow  " << keys << "->" << keys_end << std::endl;
+    grow_tree(t, to_db, keys, keys_end, "a", 1000, 300);
+    if (verbose) std::cout << "prune " << pruned_keys << "->" << keys / 2 << std::endl;
+    prune_tree(t, to_db, pruned_keys, keys / 2, "a");
+    pruned_keys = keys / 2;
+    keys = keys_end;
+    keys_end = keys_end * 2;
+
+    std::vector<KeyValueDB::keyrange_t> chunks;
+    db->util_divide_key_range(
+      "O", "", "",
+      10, 10000000, 0.1, chunks);
+    auto [all_keys, max_keys] = get_split_quality("O", chunks);
+    double speedup = double(all_keys) / max_keys;
+    if (verbose) std::cout << "quality=" << double(all_keys) / max_keys / chunks.size()
+      << " speedup=" << speedup << std::endl;
+    EXPECT_EQ(all_keys, keys - pruned_keys);
+    if (all_keys > 1000000) {
+      EXPECT_GT(speedup, 5);
+    }
+    scan_split_quality("O");
+  }
+  db->close();
+}
+
+TEST_F(RocksDBSplitRange, grow_tree_small_leaves) {
+  ASSERT_EQ(0, db->create_and_open(cout, "O"));
+
+  TreeGen t(7, 3, "0", "1");
+  DataToDB to_db(db.get(), "O");
+  vector<uint32_t> keys_to_test = {
+    0, 1000, 10000, 100000, 1'000'000, 2'000'000, 5'000'000, 10'000'000, 20'000'000, 50'000'000};
+  if (is_jenkins()) keys_to_test = {2'500'000};
+
+  uint64_t keys = 0;
+  for (auto keys_end : keys_to_test) {
+    if (verbose) std::cout << "grow " << keys << "->" << keys_end << std::endl;
+    grow_tree(t, to_db, keys, keys_end, "aaaa", 100, 30);
+    keys = keys_end;
+    keys_end = keys_end * 2;
+
+    std::vector<KeyValueDB::keyrange_t> chunks;
+    db->util_divide_key_range(
+      "O", "", "",
+      10, 10000000, 0.05, chunks);
+    auto [all_keys, max_keys] = get_split_quality("O", chunks);
+    double speedup = double(all_keys) / max_keys;
+    if (verbose) std::cout << "quality=" << double(all_keys) / max_keys / chunks.size()
+      << " speedup=" << speedup << std::endl;
+    EXPECT_EQ(all_keys, keys);
+    if (all_keys > 2000000) {
+      EXPECT_GT(speedup, 6);
+    }
+    scan_split_quality("O");
+  }
+  db->close();
 }
 
 


### PR DESCRIPTION
This PR is a groundwork for #64369
For convenience it is now in separate PR. 

KeyValueDB::util_divide_key_range splits given key range in N disjointed regions.
It allows to multiple threads to process data independently.
Useful when data retrieval from db is much faster than processing the retrieved data.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
