### PR TITLE
squid: tools/ceph-kvstore-tool: fix crash on db close.

### DIFF
--- a/src/tools/kvstore_tool.cc
+++ b/src/tools/kvstore_tool.cc
@@ -49,6 +49,8 @@ StoreTool::StoreTool(const string& type,
   }
 }
 
+#ifdef WITH_BLUESTORE
+
 int StoreTool::load_bluestore(const string& path, bool read_only, bool to_repair)
 {
     auto bluestore = new BlueStore(g_ceph_context, path);
@@ -60,6 +62,8 @@ int StoreTool::load_bluestore(const string& path, bool read_only, bool to_repair
     db = decltype(db){db_ptr, Deleter(bluestore)};
     return 0;
 }
+
+#endif // WITH_BLUESTORE
 
 uint32_t StoreTool::traverse(const string& prefix,
                              const bool do_crc,

--- a/src/tools/kvstore_tool.cc
+++ b/src/tools/kvstore_tool.cc
@@ -28,13 +28,8 @@ StoreTool::StoreTool(const string& type,
   }
 
   if (type == "bluestore-kv") {
-#ifdef WITH_BLUESTORE
     if (load_bluestore(path, read_only, to_repair) != 0)
       exit(1);
-#else
-    cerr << "bluestore not compiled in" << std::endl;
-    exit(1);
-#endif
   } else {
     auto db_ptr = KeyValueDB::create(g_ceph_context, type, path);
     if (!to_repair) {
@@ -49,21 +44,24 @@ StoreTool::StoreTool(const string& type,
   }
 }
 
-#ifdef WITH_BLUESTORE
 
 int StoreTool::load_bluestore(const string& path, bool read_only, bool to_repair)
 {
+#ifdef WITH_BLUESTORE
     auto bluestore = new BlueStore(g_ceph_context, path);
     KeyValueDB *db_ptr;
     int r = bluestore->open_db_environment(&db_ptr, read_only, to_repair);
     if (r < 0) {
      return -EINVAL;
     }
-    db = decltype(db){db_ptr, Deleter(bluestore)};
+    db = decltype(db){db_ptr, Deleter((ObjectStore*)bluestore)};
     return 0;
+#else
+    cerr << "bluestore not compiled in" << std::endl;
+    return -1;
+#endif // WITH_BLUESTORE
 }
 
-#endif // WITH_BLUESTORE
 
 uint32_t StoreTool::traverse(const string& prefix,
                              const bool do_crc,

--- a/src/tools/kvstore_tool.h
+++ b/src/tools/kvstore_tool.h
@@ -79,6 +79,8 @@ public:
   int print_stats() const;
   int build_size_histogram(const std::string& prefix) const;
 
+#ifdef WITH_BLUESTORE
 private:
   int load_bluestore(const std::string& path, bool read_only, bool need_open_db);
+#endif // WITH_BLUESTORE
 };

--- a/src/tools/kvstore_tool.h
+++ b/src/tools/kvstore_tool.h
@@ -9,34 +9,28 @@
 
 #include "acconfig.h"
 #include "include/buffer_fwd.h"
-#ifdef WITH_BLUESTORE
-#include "os/bluestore/BlueStore.h"
-#endif
+#include "kv/KeyValueDB.h"
+#include "os/ObjectStore.h"
 
 class KeyValueDB;
 
 class StoreTool
 {
-#ifdef WITH_BLUESTORE
   struct Deleter {
-    BlueStore *bluestore;
-    Deleter()
-      : bluestore(nullptr) {}
-    Deleter(BlueStore *store)
-      : bluestore(store) {}
+    ObjectStore *store = nullptr;
+    Deleter() {}
+    Deleter(ObjectStore *_store)
+      : store(_store) {}
     void operator()(KeyValueDB *db) {
-      if (bluestore) {
-	bluestore->umount();
-	delete bluestore;
+      if (store) {
+	store->umount();
+	delete store;
       } else {
 	delete db;
       }
     }
   };
   std::unique_ptr<KeyValueDB, Deleter> db;
-#else
-  std::unique_ptr<KeyValueDB> db;
-#endif
 
   const std::string store_path;
 
@@ -79,8 +73,6 @@ public:
   int print_stats() const;
   int build_size_histogram(const std::string& prefix) const;
 
-#ifdef WITH_BLUESTORE
 private:
   int load_bluestore(const std::string& path, bool read_only, bool need_open_db);
-#endif // WITH_BLUESTORE
 };

--- a/src/tools/kvstore_tool.h
+++ b/src/tools/kvstore_tool.h
@@ -46,7 +46,6 @@ public:
             bool read_only,
 	    bool need_open_db = true,
 	    bool need_stats = false);
-  int load_bluestore(const std::string& path, bool read_only, bool need_open_db);
   uint32_t traverse(const std::string& prefix,
                     const bool do_crc,
                     const bool do_value_dump,
@@ -79,4 +78,7 @@ public:
 
   int print_stats() const;
   int build_size_histogram(const std::string& prefix) const;
+
+private:
+  int load_bluestore(const std::string& path, bool read_only, bool need_open_db);
 };


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75939

---

backport of https://github.com/ceph/ceph/pull/67069
parent tracker: https://tracker.ceph.com/issues/74332

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh