### PR TITLE
squid: rgw/gc: mark rgw_gc_max_objs as startup-only

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -1694,10 +1694,13 @@ options:
   level: advanced
   desc: Number of shards for garbage collector data
   long_desc: The number of garbage collector data shards, is the number of RADOS objects
-    that RGW will use to store the garbage collection information on.
+    that RGW will use to store the garbage collection information on. This value is
+    read once at daemon startup.
   fmt_desc: The maximum number of objects that may be handled by
     garbage collection in one garbage collection processing cycle.
-    Please do not change this value after the first deployment.
+    This value can be increased after first deployment, please do
+    not decrease this value without ensuring all data shards are
+    completely empty.
   default: 32
   services:
   - rgw
@@ -1706,6 +1709,8 @@ options:
   - rgw_gc_processor_max_time
   - rgw_gc_processor_period
   - rgw_gc_max_concurrent_io
+  flags:
+  - startup
   with_legacy: true
 # wait time before object may be handled by gc, recommended lower limit is 30 mins
 - name: rgw_gc_obj_min_wait

--- a/src/rgw/driver/rados/rgw_gc.cc
+++ b/src/rgw/driver/rados/rgw_gc.cc
@@ -369,8 +369,9 @@ public:
                                                                                   cct(_cct),
                                                                                   gc(_gc) {
     max_aio = cct->_conf->rgw_gc_max_concurrent_io;
-    remove_tags.resize(min(static_cast<int>(cct->_conf->rgw_gc_max_objs), rgw_shards_max()));
-    tag_io_size.resize(min(static_cast<int>(cct->_conf->rgw_gc_max_objs), rgw_shards_max()));
+    // must match obj_names[] / transitioned_objects_cache sized in initialize()
+    remove_tags.resize(gc->get_max_objs());
+    tag_io_size.resize(gc->get_max_objs());
   }
 
   ~RGWGCIOManager() {

--- a/src/rgw/driver/rados/rgw_gc.h
+++ b/src/rgw/driver/rados/rgw_gc.h
@@ -50,6 +50,7 @@ public:
     finalize();
   }
   std::vector<bool> transitioned_objects_cache;
+  int get_max_objs() const { return max_objs; }
   std::tuple<int, std::optional<cls_rgw_obj_chain>> send_split_chain(const cls_rgw_obj_chain& chain, const std::string& tag, optional_yield y);
 
   // asynchronously defer garbage collection on an object that's still being read


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76696

---

backport of https://github.com/ceph/ceph/pull/68478
parent tracker: https://tracker.ceph.com/issues/75958

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh