### PR TITLE
tentacle: rgw: stop crashing when an admin tries to assume a nonexistent role

### DIFF
--- a/src/rgw/rgw_sts.cc
+++ b/src/rgw/rgw_sts.cc
@@ -399,16 +399,16 @@ AssumeRoleResponse STSService::assumeRole(const DoutPrefixProvider *dpp,
   AssumeRoleResponse response;
   response.packedPolicySize = 0;
 
-  //Get the role info which is being assumed
-  boost::optional<rgw::ARN> r_arn = rgw::ARN::parse(req.getRoleARN());
-  if (r_arn == boost::none) {
-    ldpp_dout(dpp, 0) << "Error in parsing role arn: " << req.getRoleARN() << dendl;
-    response.retCode = -EINVAL;
+  auto [ret, r] = getRoleInfo(dpp, req.getRoleARN(), y);
+  if (ret < 0) {
+    response.retCode = ret;
     return response;
   }
 
-  string roleId = role->get_id();
-  uint64_t roleMaxSessionDuration = role->get_max_session_duration();
+  boost::optional<rgw::ARN> r_arn = rgw::ARN::parse(req.getRoleARN());
+
+  string roleId = r->get_id();
+  uint64_t roleMaxSessionDuration = r->get_max_session_duration();
   req.setMaxDuration(roleMaxSessionDuration);
 
   //Validate input


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76130

---

backport of https://github.com/ceph/ceph/pull/67863
parent tracker: https://tracker.ceph.com/issues/75569

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh