### PR TITLE
tentacle: rgw: avoid doubled ARN in GetBucketReplication for pre-existing data

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1470,7 +1470,17 @@ struct ReplicationConfiguration {
       }
 
       if (pipe.dest.bucket) {
-        destination.bucket = ARN(*pipe.dest.bucket).to_string();
+        // The bucket name may already contain the full ARN from data
+        // written before commit b8f89327e1a ("rgw: handle destination
+        // bucket as an ARN in ReplicationConfiguration").  Detect this
+        // to avoid producing a doubled ARN like
+        // "arn:aws:s3:::arn:aws:s3:::bucket".
+        auto existing = ARN::parse(pipe.dest.bucket->name);
+        if (existing && existing->service == rgw::Service::s3) {
+          destination.bucket = existing->to_string();
+        } else {
+          destination.bucket = ARN(*pipe.dest.bucket).to_string();
+        }
       }
 
       filter.emplace();


### PR DESCRIPTION
Cherry-pick of f7e82e9f8a9e522ff5e8a05bff72069c004054d8 to tentacle.

Before commit b8f89327e1a ("rgw: handle destination bucket as an ARN
in ReplicationConfiguration"), the PutBucketReplication handler stored
the full ARN string (e.g. "arn:aws:s3:::bucket") as the bucket name in
the sync policy. After that commit, the GetBucketReplication handler
wraps the stored bucket name in a new ARN via ARN(rgw_bucket).to_string(),
which produces a doubled prefix like "arn:aws:s3:::arn:aws:s3:::bucket"
for buckets whose replication was configured before the fix.

Detect whether the stored bucket name is already a valid S3 ARN and use
it directly instead of wrapping it again. New data written after
b8f89327e1a stores only the bare bucket name, so the else branch handles
that case unchanged.

Tracker: https://tracker.ceph.com/issues/76702

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [x] No tests