### PR TITLE
tentacle: nvmeofgw : ignore  beacons and send empty maps to  GWs in DELETING state

### DIFF
--- a/src/mon/NVMeofGwMap.cc
+++ b/src/mon/NVMeofGwMap.cc
@@ -41,10 +41,10 @@ void NVMeofGwMap::to_gmap(
       const auto& gw_id = gw_created_pair.first;
       const auto& gw_created  = gw_created_pair.second;
       gw_availability_t availability = gw_created.availability;
-      // Gateways expect to see UNAVAILABLE, not DELETING
-      // for entries in DELETING state
       if (gw_created.availability == gw_availability_t::GW_DELETING) {
-         availability = gw_availability_t::GW_UNAVAILABLE;
+         dout (4) << gw_id << "Send empty unicast map in Deleting state"
+                  << dendl;
+         continue;
       }
 
       auto gw_state = NvmeGwClientState(

--- a/src/mon/NVMeofGwMon.cc
+++ b/src/mon/NVMeofGwMon.cc
@@ -1097,6 +1097,14 @@ bool NVMeofGwMon::prepare_beacon(MonOpRequestRef op)
 	       << map.created_gws << dendl;
       goto set_propose;
     } else {
+      if (pending_map.created_gws[group_key][gw_id].availability ==
+	  gw_availability_t::GW_DELETING) {
+	  dout(4) << "Beacon from GW in Created while in monitor's"
+	             " map it in DELETING state, ignore it"
+	          << gw_id << dendl;
+	  mon.no_reply(op);
+	  goto false_return; // not sending ack to this beacon
+      }
       pending_map.created_gws[group_key][gw_id].subsystems.clear();
       pending_map.set_gw_beacon_sequence_number(gw_id, header_ver,
             group_key, sequence);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76726

---

backport of https://github.com/ceph/ceph/pull/67331
parent tracker: https://tracker.ceph.com/issues/76724

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh