### PR TITLE
Add health warning for deprecated EC plugins and techniques

### DIFF
--- a/doc/rados/operations/erasure-code-clay.rst
+++ b/doc/rados/operations/erasure-code-clay.rst
@@ -2,6 +2,11 @@
 CLAY code plugin
 ================
 
+.. deprecated:: Umbrella
+   
+The CLAY plugin is deprecated. Support for this plugin will be removed in
+the Vampire release.
+
 CLAY (short for coupled-layer) codes are erasure codes designed to bring about significant savings 
 in terms of network bandwidth and disk IO when a failed node/OSD/rack is being repaired. Let:
 

--- a/doc/rados/operations/erasure-code-jerasure.rst
+++ b/doc/rados/operations/erasure-code-jerasure.rst
@@ -2,6 +2,9 @@
 Jerasure erasure code plugin
 ============================
 
+Note: Techniques other than ``reed_sol_van`` are deprecated. Support for deprecated techniques will be removed in
+the Vampire release.
+
 The *jerasure* plugin is a generic and flexible plugin. However,
 the *jerasure* library is no longer maintained and has not been
 updated to support modern CPU instructions that can improve

--- a/doc/rados/operations/erasure-code-profile.rst
+++ b/doc/rados/operations/erasure-code-profile.rst
@@ -25,6 +25,11 @@ same size as the data chunk, i.e. 1MB). The raw space overhead is only
 40% and the object will not be lost even if four OSDs break at the
 same time.
 
+.. warning:: In the Umbrella release, the SHEC and CLAY plugins are deprecated.
+   All Jerasure techniques, other than the default ``reed_sol_van`` technique,
+   are also deprecated. Support for these deprecated plugins and techniques
+   will be removed in the Vampire release.
+
 .. _list of available plugins:
 
 .. toctree::

--- a/doc/rados/operations/erasure-code-shec.rst
+++ b/doc/rados/operations/erasure-code-shec.rst
@@ -2,6 +2,11 @@
 SHEC erasure code plugin
 ========================
 
+.. deprecated:: Umbrella
+   
+The SHEC plugin is deprecated. Support for this plugin will be removed in
+the Vampire release.
+
 The *shec* plugin encapsulates the `multiple SHEC
 <http://tracker.ceph.com/projects/ceph/wiki/Shingled_Erasure_Code_(SHEC)>`_
 library. It allows Ceph to recover data more efficiently than Reed-Solomon codes.

--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -2043,3 +2043,16 @@ Then, to check the ``w`` value for a particular profile, run a command of the fo
 
 The intended solution is to create a new pool with a correct ``w`` value and copy all the objects.
 Then delete the old pool before the data corruption can happen.
+
+DEPRECATED_EC_PLUGIN
+____________________
+
+One or more erasure code profiles are using deprecated plugins or techniques.
+The SHEC and CLAY plugins, as well as Jerasure techniques other than
+``reed_sol_van``, are deprecated as of the Umbrella release and will be
+removed in the Vampire release.
+
+To resolve this warning, migrate data from pools using deprecated erasure code
+configurations to new pools that use supported configurations. See
+:ref:`erasure-code-profiles` for details on supported erasure code plugins
+and techniques.

--- a/qa/standalone/erasure-code/test-erasure-code-plugins.sh
+++ b/qa/standalone/erasure-code/test-erasure-code-plugins.sh
@@ -142,4 +142,44 @@ function TEST_ec_profile_blaum_roth_warning() {
     return 0
 }
 
+function TEST_ec_profile_deprecated_plugin_warning() {
+    local dir=$1
+
+    setup $dir || return 1
+    run_mon $dir a || return 1
+    run_mgr $dir x || return 1
+    for id in $(seq 0 2) ; do
+        run_osd $dir $id || return 1
+    done
+    create_rbd_pool || return 1
+    wait_for_clean || return 1
+
+    echo "Starting test for deprecated EC plugin health warning"
+
+    # Create a clay profile (deprecated)
+    ceph osd erasure-code-profile set clay plugin=clay k=3 m=2 || return 1
+
+    # Create a shec profile (deprecated)
+    ceph osd erasure-code-profile set shec plugin=shec k=4 m=2 c=2 || return 1
+
+    # Create a non-reed_sol_van jerasure profile (deprecated)
+    ceph osd erasure-code-profile set jerasure-cauchy plugin=jerasure k=3 m=2 technique=cauchy_good || return 1
+
+    # Create a reed_sol_van jerasure profile (not deprecated)
+    ceph osd erasure-code-profile set jerasure-rsv plugin=jerasure k=3 m=2 technique=reed_sol_van || return 1
+
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path mon.a) log flush || return 1
+    sleep 10
+    grep -F "1 or more EC profiles are using a plugin and/or technique that are deprecated" $dir/mon.a.log || return 1
+    grep "clay.*deprecated plugin 'clay'" $dir/mon.a.log || return 1
+    grep "shec.*deprecated plugin 'shec'" $dir/mon.a.log || return 1
+    grep "jerasure-cauchy.*deprecated jerasure technique 'cauchy_good'" $dir/mon.a.log || return 1
+
+    ! grep "jerasure-rsv.*deprecated" $dir/mon.a.log || return 1
+
+    teardown $dir || return 1
+    return 0
+}
+
+
 main test-erasure-code-plugins "$@"

--- a/qa/suites/rados/thrash-erasure-code-big/thrashers/careful.yaml
+++ b/qa/suites/rados/thrash-erasure-code-big/thrashers/careful.yaml
@@ -5,6 +5,7 @@ overrides:
     - objects unfound and apparently lost
     - slow request
     - \(POOL_APP_NOT_ENABLED\)
+    - \(DEPRECATED_EC_PLUGIN\)
     conf:
       osd:
         osd debug reject backfill probability: .3

--- a/qa/suites/rados/thrash-erasure-code-big/thrashers/default.yaml
+++ b/qa/suites/rados/thrash-erasure-code-big/thrashers/default.yaml
@@ -5,6 +5,7 @@ overrides:
     - objects unfound and apparently lost
     - slow request
     - \(POOL_APP_NOT_ENABLED\)
+    - \(DEPRECATED_EC_PLUGIN\)
     conf:
       osd:
         osd debug reject backfill probability: .1

--- a/qa/suites/rados/thrash-erasure-code-big/thrashers/fastread.yaml
+++ b/qa/suites/rados/thrash-erasure-code-big/thrashers/fastread.yaml
@@ -4,6 +4,7 @@ overrides:
     - but it is still running
     - objects unfound and apparently lost
     - \(POOL_APP_NOT_ENABLED\)
+    - \(DEPRECATED_EC_PLUGIN\)
     conf:
       mon:
         osd pool default ec fast read: true

--- a/qa/suites/rados/thrash-erasure-code-big/thrashers/mapgap.yaml
+++ b/qa/suites/rados/thrash-erasure-code-big/thrashers/mapgap.yaml
@@ -5,6 +5,7 @@ overrides:
     - objects unfound and apparently lost
     - osd_map_cache_size
     - \(POOL_APP_NOT_ENABLED\)
+    - \(DEPRECATED_EC_PLUGIN\)
     conf:
       mon:
         mon min osdmap epochs: 2

--- a/qa/suites/rados/thrash-erasure-code-big/thrashers/morepggrow.yaml
+++ b/qa/suites/rados/thrash-erasure-code-big/thrashers/morepggrow.yaml
@@ -9,6 +9,7 @@ overrides:
     - but it is still running
     - objects unfound and apparently lost
     - \(POOL_APP_NOT_ENABLED\)
+    - \(DEPRECATED_EC_PLUGIN\)
 tasks:
 - thrashosds:
     timeout: 1200

--- a/qa/suites/rados/thrash-erasure-code-big/thrashers/pggrow.yaml
+++ b/qa/suites/rados/thrash-erasure-code-big/thrashers/pggrow.yaml
@@ -4,6 +4,7 @@ overrides:
     - but it is still running
     - objects unfound and apparently lost
     - \(POOL_APP_NOT_ENABLED\)
+    - \(DEPRECATED_EC_PLUGIN\)
     conf:
       osd:
         osd scrub min interval: 60

--- a/qa/suites/rados/thrash-erasure-code-shec/thrashers/careful.yaml
+++ b/qa/suites/rados/thrash-erasure-code-shec/thrashers/careful.yaml
@@ -5,6 +5,7 @@ overrides:
     - objects unfound and apparently lost
     - slow request
     - \(POOL_APP_NOT_ENABLED\)
+    - \(DEPRECATED_EC_PLUGIN\)
     conf:
       osd:
         osd debug reject backfill probability: .3

--- a/qa/suites/rados/thrash-erasure-code-shec/thrashers/default.yaml
+++ b/qa/suites/rados/thrash-erasure-code-shec/thrashers/default.yaml
@@ -5,6 +5,7 @@ overrides:
     - objects unfound and apparently lost
     - slow request
     - \(POOL_APP_NOT_ENABLED\)
+    - \(DEPRECATED_EC_PLUGIN\)
     conf:
       osd:
         osd debug reject backfill probability: .1

--- a/qa/suites/rados/thrash-erasure-code/thrashers/careful.yaml
+++ b/qa/suites/rados/thrash-erasure-code/thrashers/careful.yaml
@@ -4,6 +4,7 @@ overrides:
     - but it is still running
     - objects unfound and apparently lost
     - \(POOL_APP_NOT_ENABLED\)
+    - \(DEPRECATED_EC_PLUGIN\)
     conf:
       osd:
         osd debug reject backfill probability: .3

--- a/qa/suites/rados/thrash-erasure-code/thrashers/default.yaml
+++ b/qa/suites/rados/thrash-erasure-code/thrashers/default.yaml
@@ -4,6 +4,7 @@ overrides:
     - but it is still running
     - objects unfound and apparently lost
     - \(POOL_APP_NOT_ENABLED\)
+    - \(DEPRECATED_EC_PLUGIN\)
     conf:
       osd:
         osd debug reject backfill probability: .1

--- a/qa/suites/rados/thrash-erasure-code/thrashers/fastread.yaml
+++ b/qa/suites/rados/thrash-erasure-code/thrashers/fastread.yaml
@@ -4,6 +4,7 @@ overrides:
     - but it is still running
     - objects unfound and apparently lost
     - \(POOL_APP_NOT_ENABLED\)
+    - \(DEPRECATED_EC_PLUGIN\)
     conf:
       mon:
         osd pool default ec fast read: true

--- a/qa/suites/rados/thrash-erasure-code/thrashers/minsize_recovery.yaml
+++ b/qa/suites/rados/thrash-erasure-code/thrashers/minsize_recovery.yaml
@@ -4,6 +4,7 @@ overrides:
     - but it is still running
     - objects unfound and apparently lost
     - \(POOL_APP_NOT_ENABLED\)
+    - \(DEPRECATED_EC_PLUGIN\)
     create_rbd_pool: False
     pre-mgr-commands:
       - sudo ceph config set mgr mgr_pool false --force

--- a/qa/suites/rados/thrash-erasure-code/thrashers/morepggrow.yaml
+++ b/qa/suites/rados/thrash-erasure-code/thrashers/morepggrow.yaml
@@ -9,6 +9,7 @@ overrides:
     - but it is still running
     - objects unfound and apparently lost
     - \(POOL_APP_NOT_ENABLED\)
+    - \(DEPRECATED_EC_PLUGIN\)
 tasks:
 - thrashosds:
     timeout: 1200

--- a/qa/suites/rados/thrash-erasure-code/thrashers/pggrow.yaml
+++ b/qa/suites/rados/thrash-erasure-code/thrashers/pggrow.yaml
@@ -4,6 +4,7 @@ overrides:
     - but it is still running
     - objects unfound and apparently lost
     - \(POOL_APP_NOT_ENABLED\)
+    - \(DEPRECATED_EC_PLUGIN\)
     conf:
       osd:
         osd scrub min interval: 60

--- a/src/mon/HealthMonitor.cc
+++ b/src/mon/HealthMonitor.cc
@@ -1369,7 +1369,8 @@ void HealthMonitor::check_netsplit(health_check_map_t *checks, std::set<std::str
 
 void HealthMonitor::check_erasure_code_profiles(health_check_map_t *checks)
 {
-  list<string> details;
+  list<string> blaum_roth_details;
+  list<string> deprecated_details;
   
   //This is a loop that will go through all the erasure code profiles 
   for (auto& erasure_code_profile : mon.osdmon()->osdmap.get_erasure_code_profiles()) {
@@ -1386,22 +1387,68 @@ void HealthMonitor::check_erasure_code_profiles(health_check_map_t *checks)
         if ((w <= 2) || (w >= 256)) {
           ostringstream ds;
           ds << "The value of w must be greater than 2 and less than 256";
-          details.push_back(ds.str());
+          blaum_roth_details.push_back(ds.str());
         }
         if (!is_prime(w + 1)) {
           ostringstream ds;
           ds << "w+1="<< w+1 << " for the EC profile " << erasure_code_profile.first 
             << " is not prime and could lead to data corruption";
-          details.push_back(ds.str());
+          blaum_roth_details.push_back(ds.str());
+        }
+      }
+    }
+
+    // Check for plugins and techniques that are deprecated in Umbrella
+    auto plugin = erasure_code_profile.second.find("plugin");
+    if (plugin != erasure_code_profile.second.end()) {
+      const string& plugin_name = erasure_code_profile.second.at("plugin");
+
+      // Check if plugin is clay, shec (including legacy variants) or legacy jerasure
+      if (plugin_name == "clay" ||
+          plugin_name == "shec" ||
+          plugin_name == "shec_generic" ||
+          plugin_name == "shec_sse3" ||
+          plugin_name == "shec_sse4" ||
+          plugin_name == "shec_neon" ||
+          plugin_name == "jerasure_generic" ||
+          plugin_name == "jerasure_sse3" ||
+          plugin_name == "jerasure_sse4" ||
+          plugin_name == "jerasure_neon") {
+        ostringstream ds;
+        ds << "EC profile '" << erasure_code_profile.first
+           << "' uses deprecated plugin '" << plugin_name << "'";
+        deprecated_details.push_back(ds.str());
+      }
+      // Check if plugin is jerasure with non-reed_sol_van technique
+      else if (plugin_name == "jerasure") {
+        auto technique_it = erasure_code_profile.second.find("technique");
+        if (technique_it != erasure_code_profile.second.end()) {
+          const string& technique_name = erasure_code_profile.second.at("technique");
+          if (technique_name != "reed_sol_van") {
+            ostringstream ds;
+            ds << "EC profile '" << erasure_code_profile.first
+               << "' uses deprecated jerasure technique '" << technique_name << "'";
+            deprecated_details.push_back(ds.str());
+          }
         }
       }
     }
   }
-  if (!details.empty()) {
+
+  if (!blaum_roth_details.empty()) {
     ostringstream ss;
     ss << "1 or more EC profiles have a w value such that w+1 is not prime."
       << " This can result in data corruption";
-    auto &d = checks->add("BLAUM_ROTH_W_IS_NOT_PRIME", HEALTH_WARN, ss.str(), details.size());
-    d.detail.swap(details);
+    auto &d = checks->add("BLAUM_ROTH_W_IS_NOT_PRIME", HEALTH_WARN, ss.str(), blaum_roth_details.size());
+    d.detail.swap(blaum_roth_details);
+  }
+
+  if (!deprecated_details.empty()) {
+    ostringstream ss;
+    ss << "1 or more EC profiles are using a plugin and/or technique that are "
+       << "deprecated in the Umbrella release. This will be unsupported in the V release. "
+       << "Migrate objects to a new pool that uses a supported plugin and technique. ";
+    auto &d = checks->add("DEPRECATED_EC_PLUGIN", HEALTH_WARN, ss.str(), deprecated_details.size());
+    d.detail.swap(deprecated_details);
   }
 }


### PR DESCRIPTION
We want to reduce the number of EC plugins and techniques we support in order to focus dev and test effort on the ones that are most useful.

We are deprecating the following plugins and techniques in Umbrella, and dropping support for them in the V release:
* shec
* clay
* all non-reed_sol_van jerasure techniques






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
