### PR TITLE
test/libcephfs/fscrypt: use ceph_statx() instead of ceph_stat()

### DIFF
--- a/src/test/libcephfs/fscrypt.cc
+++ b/src/test/libcephfs/fscrypt.cc
@@ -590,10 +590,10 @@ TEST(FSCrypt, LockedListDir) {
       file_path.append(result->d_name);
 
       //check that we can get stat info
-      struct stat st;
-      ceph_stat(cmount, file_path.c_str(), &st);
+      struct ceph_statx stx;
+      ceph_statx(cmount, file_path.c_str(), &stx, CEPH_SETATTR_SIZE, 0);
 
-      ASSERT_EQ(sizeof(fscrypt_key), st.st_size);
+      ASSERT_EQ(sizeof(fscrypt_key), stx.stx_size);
       goto done;
     }
   }


### PR DESCRIPTION
ceph_stat() was deprecated by commit 9f44ca31c532b

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
