### PR TITLE
os/bluestore,kv/rocksdbstore: more information about slow KV ops

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -5870,6 +5870,12 @@ options:
   desc: Log a collection list operation if it is slower than this age (seconds)
   default: 1_min
   with_legacy: true
+- name: bluestore_log_op_verbose
+  type: bool
+  level: advanced
+  desc: Enable verbose dump of slow transaction(s)
+  default: false
+  with_legacy: true
 - name: bluestore_debug_enforce_settings
   type: str
   level: dev

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -5870,10 +5870,10 @@ options:
   desc: Log a collection list operation if it is slower than this age (seconds)
   default: 1_min
   with_legacy: true
-- name: bluestore_log_op_verbose
+- name: bluestore_log_op_verbose_kv_txc
   type: bool
   level: advanced
-  desc: Enable verbose dump of slow transaction(s)
+  desc: Enable verbose dump of slow KV transaction(s)
   default: false
   with_legacy: true
 - name: bluestore_debug_enforce_settings

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -52,6 +52,10 @@ public:
     // total encoded data size
     virtual size_t get_size_bytes() const = 0;
 
+    // returns list of ops within txc,
+    //  depending on the param it could be either short(false) or verbose(true)
+    virtual std::string get_summary_string(bool) const {return std::string();}
+
     /// Set Keys
     void set(
       const std::string &prefix,                      ///< [in] Prefix for keys, or CF name

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -1549,20 +1549,19 @@ void RocksDBStore::get_statistics(Formatter *f)
 }
 
 struct RocksDBStore::RocksWBHandler: public rocksdb::WriteBatch::Handler {
-  RocksWBHandler(const RocksDBStore& db) : db(db) {}
+  RocksWBHandler(const RocksDBStore& db, bool verbose)
+   : db(db), verbose(verbose) {}
   const RocksDBStore& db;
   std::stringstream seen;
   int num_seen = 0;
+  bool verbose = true;
 
-  void dump(const char* op_name,
+  void dump(const char* op_name, const char* op_short,
 	    uint32_t column_family_id,
 	    const rocksdb::Slice& key_in,
 	    const rocksdb::Slice* value = nullptr) {
     string prefix;
     string key;
-    ssize_t size = value ? value->size() : -1;
-    seen << std::endl << op_name << "(";
-
     if (column_family_id == 0) {
       db.split_key(key_in, &prefix, &key);
     } else {
@@ -1571,46 +1570,64 @@ struct RocksDBStore::RocksWBHandler: public rocksdb::WriteBatch::Handler {
       prefix = it->second;
       key = key_in.ToString();
     }
-    seen << " prefix = " << prefix;
-    seen << " key = " << pretty_binary_string(key);
-    if (size != -1)
-      seen << " value size = " << std::to_string(size);
-    seen << ")";
+    if (verbose) {
+      ssize_t size = value ? value->size() : -1;
+      seen << std::endl << op_name << "(";
+
+      seen << " prefix = " << prefix;
+      seen << " key = " << pretty_binary_string(key);
+      if (size != -1)
+        seen << " value size = " << std::to_string(size);
+      seen << ")";
+    } else {
+      if (num_seen)
+        seen << ",";
+      seen << op_short << ":" << prefix;
+    }
     num_seen++;
   }
   void Put(const rocksdb::Slice& key,
 	   const rocksdb::Slice& value) override {
-    dump("Put", 0, key, &value);
+    dump("Put", " P", 0, key, &value);
   }
   rocksdb::Status PutCF(uint32_t column_family_id, const rocksdb::Slice& key,
 			const rocksdb::Slice& value) override {
-    dump("PutCF", column_family_id, key, &value);
+    dump("PutCF", " p", column_family_id, key, &value);
     return rocksdb::Status::OK();
   }
   void SingleDelete(const rocksdb::Slice& key) override {
-    dump("SingleDelete", 0, key);
+    dump("SingleDelete", "ds", 0, key);
   }
   rocksdb::Status SingleDeleteCF(uint32_t column_family_id, const rocksdb::Slice& key) override {
-    dump("SingleDeleteCF", column_family_id, key);
+    dump("SingleDeleteCF", "DS", column_family_id, key);
     return rocksdb::Status::OK();
   }
   void Delete(const rocksdb::Slice& key) override {
-    dump("Delete", 0, key);
+    dump("Delete", " D", 0, key);
   }
   rocksdb::Status DeleteCF(uint32_t column_family_id, const rocksdb::Slice& key) override {
-    dump("DeleteCF", column_family_id, key);
+    dump("DeleteCF", " d", column_family_id, key);
     return rocksdb::Status::OK();
   }
   void Merge(const rocksdb::Slice& key,
 	     const rocksdb::Slice& value) override {
-    dump("Merge", 0, key, &value);
+    dump("Merge", " M", 0, key, &value);
   }
   rocksdb::Status MergeCF(uint32_t column_family_id, const rocksdb::Slice& key,
 			  const rocksdb::Slice& value) override {
-    dump("MergeCF", column_family_id, key, &value);
+    dump("MergeCF", " m", column_family_id, key, &value);
     return rocksdb::Status::OK();
   }
-  bool Continue() override { return num_seen < 50; }
+  bool Continue() override {
+    bool r = verbose ? num_seen < 128 : num_seen < 50;
+    if (!r) {
+      if (verbose) {
+        seen << std::endl;
+      }
+      seen << " <skipped>";
+    }
+    return r;
+  }
 };
 
 int RocksDBStore::submit_common(rocksdb::WriteOptions& woptions, KeyValueDB::Transaction t) 
@@ -1626,13 +1643,13 @@ int RocksDBStore::submit_common(rocksdb::WriteOptions& woptions, KeyValueDB::Tra
     static_cast<RocksDBTransactionImpl *>(t.get());
   woptions.disableWAL = disableWAL;
   lgeneric_subdout(cct, rocksdb, 30) << __func__;
-  RocksWBHandler bat_txc(*this);
+  RocksWBHandler bat_txc(*this, true);
   _t->bat.Iterate(&bat_txc);
   *_dout << " Rocksdb transaction: " << bat_txc.seen.str() << dendl;
   
   rocksdb::Status s = db->Write(woptions, &_t->bat);
   if (!s.ok()) {
-    RocksWBHandler rocks_txc(*this);
+    RocksWBHandler rocks_txc(*this, true);
     _t->bat.Iterate(&rocks_txc);
     derr << __func__ << " error: " << s.ToString() << " code = " << s.code()
          << " Rocksdb transaction: " << rocks_txc.seen.str() << dendl;
@@ -1713,6 +1730,15 @@ void RocksDBStore::RocksDBTransactionImpl::put_bat(
 	    rocksdb::SliceParts(&key_slice, 1),
             prepare_sliceparts(to_set_bl, &value_slices));
   }
+}
+
+string RocksDBStore::RocksDBTransactionImpl::get_summary_string(
+  bool verbose) const
+{
+  ceph_assert(db);
+  RocksWBHandler bat_txc(*db, verbose);
+  bat.Iterate(&bat_txc);
+  return bat_txc.seen.str();
 }
 
 void RocksDBStore::RocksDBTransactionImpl::set(

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -8,6 +8,7 @@
 #include <string>
 #include <string_view>
 #include <tuple>
+#include <unordered_map>
 #include <errno.h>
 #include <unistd.h>
 #include <sys/types.h>
@@ -1548,88 +1549,6 @@ void RocksDBStore::get_statistics(Formatter *f)
   }
 }
 
-struct RocksDBStore::RocksWBHandler: public rocksdb::WriteBatch::Handler {
-  RocksWBHandler(const RocksDBStore& db, bool verbose)
-   : db(db), verbose(verbose) {}
-  const RocksDBStore& db;
-  std::stringstream seen;
-  int num_seen = 0;
-  bool verbose = true;
-
-  void dump(const char* op_name, const char* op_short,
-	    uint32_t column_family_id,
-	    const rocksdb::Slice& key_in,
-	    const rocksdb::Slice* value = nullptr) {
-    string prefix;
-    string key;
-    if (column_family_id == 0) {
-      db.split_key(key_in, &prefix, &key);
-    } else {
-      auto it = db.cf_ids_to_prefix.find(column_family_id);
-      ceph_assert(it != db.cf_ids_to_prefix.end());
-      prefix = it->second;
-      key = key_in.ToString();
-    }
-    if (verbose) {
-      ssize_t size = value ? value->size() : -1;
-      seen << std::endl << op_name << "(";
-
-      seen << " prefix = " << prefix;
-      seen << " key = " << pretty_binary_string(key);
-      if (size != -1)
-        seen << " value size = " << std::to_string(size);
-      seen << ")";
-    } else {
-      if (num_seen)
-        seen << ",";
-      seen << op_short << ":" << prefix;
-    }
-    num_seen++;
-  }
-  void Put(const rocksdb::Slice& key,
-	   const rocksdb::Slice& value) override {
-    dump("Put", " P", 0, key, &value);
-  }
-  rocksdb::Status PutCF(uint32_t column_family_id, const rocksdb::Slice& key,
-			const rocksdb::Slice& value) override {
-    dump("PutCF", " p", column_family_id, key, &value);
-    return rocksdb::Status::OK();
-  }
-  void SingleDelete(const rocksdb::Slice& key) override {
-    dump("SingleDelete", "ds", 0, key);
-  }
-  rocksdb::Status SingleDeleteCF(uint32_t column_family_id, const rocksdb::Slice& key) override {
-    dump("SingleDeleteCF", "DS", column_family_id, key);
-    return rocksdb::Status::OK();
-  }
-  void Delete(const rocksdb::Slice& key) override {
-    dump("Delete", " D", 0, key);
-  }
-  rocksdb::Status DeleteCF(uint32_t column_family_id, const rocksdb::Slice& key) override {
-    dump("DeleteCF", " d", column_family_id, key);
-    return rocksdb::Status::OK();
-  }
-  void Merge(const rocksdb::Slice& key,
-	     const rocksdb::Slice& value) override {
-    dump("Merge", " M", 0, key, &value);
-  }
-  rocksdb::Status MergeCF(uint32_t column_family_id, const rocksdb::Slice& key,
-			  const rocksdb::Slice& value) override {
-    dump("MergeCF", " m", column_family_id, key, &value);
-    return rocksdb::Status::OK();
-  }
-  bool Continue() override {
-    bool r = verbose ? num_seen < 128 : num_seen < 50;
-    if (!r) {
-      if (verbose) {
-        seen << std::endl;
-      }
-      seen << " <skipped>";
-    }
-    return r;
-  }
-};
-
 int RocksDBStore::submit_common(rocksdb::WriteOptions& woptions, KeyValueDB::Transaction t) 
 {
   // enable rocksdb breakdown
@@ -1645,14 +1564,14 @@ int RocksDBStore::submit_common(rocksdb::WriteOptions& woptions, KeyValueDB::Tra
   lgeneric_subdout(cct, rocksdb, 30) << __func__;
   RocksWBHandler bat_txc(*this, true);
   _t->bat.Iterate(&bat_txc);
-  *_dout << " Rocksdb transaction: " << bat_txc.seen.str() << dendl;
+  *_dout << " Rocksdb transaction: " << bat_txc.get_seen() << dendl;
   
   rocksdb::Status s = db->Write(woptions, &_t->bat);
   if (!s.ok()) {
     RocksWBHandler rocks_txc(*this, true);
     _t->bat.Iterate(&rocks_txc);
     derr << __func__ << " error: " << s.ToString() << " code = " << s.code()
-         << " Rocksdb transaction: " << rocks_txc.seen.str() << dendl;
+         << " Rocksdb transaction: " << rocks_txc.get_seen() << dendl;
   }
 
   if (cct->_conf->rocksdb_perf) {
@@ -1738,7 +1657,7 @@ string RocksDBStore::RocksDBTransactionImpl::get_summary_string(
   ceph_assert(db);
   RocksWBHandler bat_txc(*db, verbose);
   bat.Iterate(&bat_txc);
-  return bat_txc.seen.str();
+  return bat_txc.get_seen();
 }
 
 void RocksDBStore::RocksDBTransactionImpl::set(
@@ -4143,4 +4062,84 @@ void RocksDBStore::util_divide_key_range(
   chunks.emplace_back(base->key, key_to);
   dout(10) << "produced chunk size=" << full_size - base->size << " "
     << pretty_binary_string(base->key) << " " << pretty_binary_string(key_to) << dendl;
+}
+
+void RocksWBHandler::_finalize_seen(bool sorted)
+{
+  if (verbose) {
+    if (num_skipped) {
+      seen << std::endl << "<...>*" << num_skipped;
+    }
+  } else {
+    seen.clear();
+    bool first = true;
+    auto _add = [&](const std::string& k, size_t c) {
+      if (!first) {
+	seen << ",";
+      } else {
+	first = false;
+      }
+      seen << k;
+      if (c > 1) {
+	seen << "*" << c;
+      }
+    };
+    if (sorted) {
+      std::map<std::string, size_t> sorted_seen_counts;
+      for (auto& [k, c] : seen_counts) {
+	sorted_seen_counts.emplace(k, c);
+      }
+      for (auto& [k, c] : sorted_seen_counts) {
+	_add(k, c);
+      }
+    } else {
+      for(auto& [k, c] : seen_counts) {
+        _add(k,c);
+      }
+    }
+    if (num_skipped) {
+      if (!first) {
+	seen << ",";
+      }
+      seen << "...*" << num_skipped;
+    }
+  }
+}
+
+void RocksWBHandler::_dump(const char* op_name, const char* op_short,
+	    uint32_t column_family_id,
+	    const rocksdb::Slice& key_in,
+	    const rocksdb::Slice* value)
+{
+  if (num_seen >= max) {
+    num_skipped++;
+    return;
+  }
+  string prefix;
+  string key;
+  if (column_family_id == 0) {
+    db.split_key(key_in, &prefix, &key);
+  } else {
+    auto it = db.cf_ids_to_prefix.find(column_family_id);
+    ceph_assert(it != db.cf_ids_to_prefix.end());
+    prefix = it->second;
+    key = key_in.ToString();
+  }
+  if (verbose) {
+    ssize_t size = value ? value->size() : -1;
+    seen << std::endl << op_name << "(";
+
+    seen << "prefix = " << prefix;
+    seen << ", key = " << pretty_binary_string(key);
+    if (size != -1)
+      seen << ", val len = " << std::to_string(size);
+    seen << ")";
+  } else {
+    string k = op_short;
+    k += ":";
+    k += prefix;
+    auto [it, found] = seen_counts.emplace(k, 0);
+    it->second++;
+  }
+  num_seen++;
 }

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -1668,10 +1668,10 @@ int RocksDBStore::submit_common(rocksdb::WriteOptions& woptions, KeyValueDB::Tra
 	static_cast<double>(rocksdb::get_perf_context()->write_delay_time)/1000000000);
     write_pre_and_post_process_time.set_from_double(
 	static_cast<double>(rocksdb::get_perf_context()->write_pre_and_post_process_time)/1000000000);
-    logger->tinc(l_rocksdb_write_memtable_time, write_memtable_time);
-    logger->tinc(l_rocksdb_write_delay_time, write_delay_time);
-    logger->tinc(l_rocksdb_write_wal_time, write_wal_time);
-    logger->tinc(l_rocksdb_write_pre_and_post_process_time, write_pre_and_post_process_time);
+    logger->tinc_with_max(l_rocksdb_write_memtable_time, write_memtable_time);
+    logger->tinc_with_max(l_rocksdb_write_delay_time, write_delay_time);
+    logger->tinc_with_max(l_rocksdb_write_wal_time, write_wal_time);
+    logger->tinc_with_max(l_rocksdb_write_pre_and_post_process_time, write_pre_and_post_process_time);
   }
 
   return s.ok() ? 0 : -1;
@@ -1686,7 +1686,7 @@ int RocksDBStore::submit_transaction(KeyValueDB::Transaction t)
   int result = submit_common(woptions, t);
 
   utime_t lat = ceph_clock_now() - start;
-  logger->tinc(l_rocksdb_submit_latency, lat);
+  logger->tinc_with_max(l_rocksdb_submit_latency, lat);
   
   return result;
 }
@@ -1701,7 +1701,7 @@ int RocksDBStore::submit_transaction_sync(KeyValueDB::Transaction t)
   int result = submit_common(woptions, t);
   
   utime_t lat = ceph_clock_now() - start;
-  logger->tinc(l_rocksdb_submit_sync_latency, lat);
+  logger->tinc_with_max(l_rocksdb_submit_sync_latency, lat);
 
   return result;
 }
@@ -1994,7 +1994,7 @@ int RocksDBStore::get(
     }
   }
   utime_t lat = ceph_clock_now() - start;
-  logger->tinc(l_rocksdb_get_latency, lat);
+  logger->tinc_with_max(l_rocksdb_get_latency, lat);
   return 0;
 }
 
@@ -2029,7 +2029,7 @@ int RocksDBStore::get(
     ceph_abort_msg(s.getState());
   }
   utime_t lat = ceph_clock_now() - start;
-  logger->tinc(l_rocksdb_get_latency, lat);
+  logger->tinc_with_max(l_rocksdb_get_latency, lat);
   return r;
 }
 
@@ -2066,7 +2066,7 @@ int RocksDBStore::get(
     ceph_abort_msg(s.getState());
   }
   utime_t lat = ceph_clock_now() - start;
-  logger->tinc(l_rocksdb_get_latency, lat);
+  logger->tinc_with_max(l_rocksdb_get_latency, lat);
   return r;
 }
 

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -328,6 +328,7 @@ public:
       rocksdb::ColumnFamilyHandle *cf,
       const std::string &k,
       const ceph::bufferlist &to_set_bl);
+
   public:
     size_t get_count() const override {
       return bat.Count();
@@ -335,6 +336,7 @@ public:
     size_t get_size_bytes() const override {
       return bat.GetDataSize();
     }
+    std::string get_summary_string(bool verbose) const override;
     void set(
       const std::string &prefix,
       const std::string &k,

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -82,6 +82,7 @@ inline rocksdb::Slice make_slice(const std::optional<std::string>& bound) {
 /**
  * Uses RocksDB to implement the KeyValueDB interface
  */
+struct RocksWBHandler;
 class RocksDBStore : public KeyValueDB {
   CephContext *cct;
   PerfCounters *logger;
@@ -100,6 +101,7 @@ class RocksDBStore : public KeyValueDB {
   friend class ShardMergeIteratorImpl;
   friend class CFIteratorImpl;
   friend class WholeMergeIteratorImpl;
+  friend struct RocksWBHandler;
   /*
    *  See RocksDB's definition of a column family(CF) and how to use it.
    *  The interfaces of KeyValueDB is extended, when a column family is created.
@@ -315,7 +317,6 @@ public:
   int64_t estimate_range_size(const std::string& prefix,
                               const std::string& key_from,
                               const std::string& key_to) override;
-  struct RocksWBHandler;
   class RocksDBTransactionImpl : public KeyValueDB::TransactionImpl {
   public:
     rocksdb::WriteBatch bat;
@@ -598,6 +599,70 @@ public:
     float accepted_variance,          // +/- fluctuation of produced chunk size,
                                       // there is a limit to prediction quality, recommended 0.05.
     std::vector<keyrange_t>& chunks) override;
+};
+
+class RocksWBHandler : public rocksdb::WriteBatch::Handler
+{
+  const RocksDBStore& db;
+  std::stringstream seen;
+  size_t num_seen = 0;
+  size_t num_skipped = 0;
+  bool verbose = true;
+  size_t max = 0;
+  std::unordered_map<std::string, size_t> seen_counts;
+
+  void _finalize_seen(bool sorted);
+  void _dump(const char* op_name, const char* op_short,
+	     uint32_t column_family_id,
+	     const rocksdb::Slice& key_in,
+	     const rocksdb::Slice* value = nullptr);
+public:
+  RocksWBHandler(const RocksDBStore& db, bool verbose, size_t _max = 0)
+   : db(db), verbose(verbose), max(_max) {
+     if (max == 0) {
+       max = verbose ? 128 : 64;
+     }
+   }
+
+  std::string get_seen(bool sorted = false) {
+    _finalize_seen(sorted);
+    return seen.str();
+  }
+  void Put(const rocksdb::Slice& key,
+	   const rocksdb::Slice& value) override {
+    _dump("Put", "P", 0, key, &value);
+  }
+  rocksdb::Status PutCF(uint32_t column_family_id, const rocksdb::Slice& key,
+			const rocksdb::Slice& value) override {
+    _dump("PutCF", "PF", column_family_id, key, &value);
+    return rocksdb::Status::OK();
+  }
+  void SingleDelete(const rocksdb::Slice& key) override {
+    _dump("SingleDelete", "d", 0, key);
+  }
+  rocksdb::Status SingleDeleteCF(uint32_t column_family_id, const rocksdb::Slice& key) override {
+    _dump("SingleDeleteCF", "df", column_family_id, key);
+    return rocksdb::Status::OK();
+  }
+  void Delete(const rocksdb::Slice& key) override {
+    _dump("Delete", "D", 0, key);
+  }
+  rocksdb::Status DeleteCF(uint32_t column_family_id, const rocksdb::Slice& key) override {
+    _dump("DeleteCF", "DF", column_family_id, key);
+    return rocksdb::Status::OK();
+  }
+  void Merge(const rocksdb::Slice& key,
+	     const rocksdb::Slice& value) override {
+    _dump("Merge", "M", 0, key, &value);
+  }
+  rocksdb::Status MergeCF(uint32_t column_family_id, const rocksdb::Slice& key,
+			  const rocksdb::Slice& value) override {
+    _dump("MergeCF", "MF", column_family_id, key, &value);
+    return rocksdb::Status::OK();
+  }
+  bool Continue() override {
+    return true;
+  }
 };
 
 #endif

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -15014,7 +15014,7 @@ void BlueStore::_txc_committed_kv(TransContext *txc)
     mono_clock::now() - txc->start,
     cct->_conf->bluestore_log_op_age,
     [&](auto lat) {
-      bool v = cct->_conf->bluestore_log_op_verbose;
+      bool v = cct->_conf->bluestore_log_op_verbose_kv_txc;
       return ", txc = " + stringify(txc) +
              ", txc bytes = " + stringify(txc->bytes) +
              ", txc ios = " + stringify(txc->ios) +

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -15014,11 +15014,13 @@ void BlueStore::_txc_committed_kv(TransContext *txc)
     mono_clock::now() - txc->start,
     cct->_conf->bluestore_log_op_age,
     [&](auto lat) {
+      bool v = cct->_conf->bluestore_log_op_verbose;
       return ", txc = " + stringify(txc) +
              ", txc bytes = " + stringify(txc->bytes) +
              ", txc ios = " + stringify(txc->ios) +
              ", txc cost = " + stringify(txc->cost) +
              ", txc onodes = " + stringify(txc->onodes.size()) +
+             ", DB ops = '" + stringify(txc->t->get_summary_string(v)) + "'"
              ", DB updates = " + stringify(txc->t->get_count()) +
              ", DB bytes = " + stringify(txc->t->get_size_bytes()) +
              ", cost max = " + stringify(throttle.bytes_observed_max) +

--- a/src/test/objectstore/test_kv.cc
+++ b/src/test/objectstore/test_kv.cc
@@ -135,6 +135,61 @@ TEST_P(KVTest, OpenWriteRead) {
   fini();
 }
 
+TEST_P(KVTest, RocksDBDumpTransaction) {
+  RocksDBStore* rdb = dynamic_cast<RocksDBStore*>(db.get());
+  if (!rdb) {
+    return;
+  }
+
+  ASSERT_EQ(0, db->create_and_open(cout));
+  {
+    KeyValueDB::Transaction t = db->get_transaction();
+    bufferlist value;
+    value.append("value");
+    t->set("O", "key", value);
+    value.clear();
+    value.append("value2");
+    t->set("P", "key2", value);
+    value.clear();
+    value.append("value3");
+    t->set("O", "key3", value);
+
+    t->rmkey("O", "A1");
+    t->rmkey("D", "A1");
+    t->rmkey("D", "A2");
+    t->rmkey("D", "A3");
+    t->merge("A", "A5", value);
+    // following txcs to be skipped
+    t->merge("B", "A5", value);
+    t->merge("B", "A5", value);
+
+    auto* _t = dynamic_cast<RocksDBStore::RocksDBTransactionImpl*>(t.get());
+    ASSERT_TRUE(_t != nullptr);
+    RocksWBHandler bat_txc_short(*rdb, false, 8);
+    _t->bat.Iterate(&bat_txc_short);
+    auto seen = bat_txc_short.get_seen(true); // using 'sorted' result to ensure
+                                              // fixed ordering in the result
+    std::cout << "Seen short = " << seen << std::endl;
+    ASSERT_EQ(seen, "DF:D*3,DF:O,MF:A,PF:O*2,PF:P,...*2");
+
+    RocksWBHandler bat_txc_verbose(*rdb, true, 8);
+    _t->bat.Iterate(&bat_txc_verbose);
+    seen = bat_txc_verbose.get_seen();
+    std::cout << "Seen verbose:" << seen << std::endl;
+    ASSERT_EQ(seen,
+      "\nPutCF(prefix = O, key = 'key', val len = 5)"
+      "\nPutCF(prefix = P, key = 'key2', val len = 6)"
+      "\nPutCF(prefix = O, key = 'key3', val len = 6)"
+      "\nDeleteCF(prefix = O, key = 'A1')"
+      "\nDeleteCF(prefix = D, key = 'A1')"
+      "\nDeleteCF(prefix = D, key = 'A2')"
+      "\nDeleteCF(prefix = D, key = 'A3')"
+      "\nMergeCF(prefix = A, key = 'A5', val len = 6)"
+      "\n<...>*2");
+  }
+  fini();
+}
+
 TEST_P(KVTest, PutReopen) {
   ASSERT_EQ(0, db->create_and_open(cout));
   {


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
