### PR TITLE
qa: fixing failures in TestShellOpts

### DIFF
--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -1109,6 +1109,17 @@ class TestShellOpts(TestCephFSShell):
     Contains tests for shell options from conf file and shell prompt.
     """
 
+    def extract_set_editor_output(self, out):
+        res = None
+        for line in out.splitlines():
+            line_parts = line.split()
+            if len(line_parts) > 4 and line_parts[0] == "editor":
+                res = line_parts
+                break
+
+        self.assertIsNotNone(res, f"didn't find editor output in: {out}")
+        return res[1]
+
     def setUp(self):
         super(type(self), self).setUp()
 
@@ -1119,9 +1130,8 @@ class TestShellOpts(TestCephFSShell):
         # ====================================================================================================
         # editor  ?                               Program used by 'edit'
         self.editor_val = self.get_cephfs_shell_cmd_output(
-            'set editor ?, set editor').split('\n')[4]
-        self.editor_val = self.editor_val.split()[1].strip(). \
-            replace("'", "", 2)
+            'set editor ?, set editor')
+        self.editor_val = self.extract_set_editor_output(self.editor_val)
 
     def write_tempconf(self, confcontents):
         self.tempconfpath = self.mount_a.client_remote.mktemp(
@@ -1139,9 +1149,7 @@ class TestShellOpts(TestCephFSShell):
         # editor  ???                             Program used by 'edit'
         final_editor_val = self.get_cephfs_shell_cmd_output(
             cmd='set editor', shell_conf_path=self.tempconfpath)
-        final_editor_val = final_editor_val.split('\n')[2]
-        final_editor_val = final_editor_val.split()[1].strip(). \
-            replace("'", "", 2)
+        final_editor_val = self.extract_set_editor_output(final_editor_val)
 
         self.assertNotEqual(self.editor_val, final_editor_val)
 
@@ -1159,9 +1167,7 @@ class TestShellOpts(TestCephFSShell):
         # editor  ?                               Program used by 'edit'
         final_editor_val = self.get_cephfs_shell_cmd_output(
             cmd='set editor', shell_conf_path=self.tempconfpath)
-        final_editor_val = final_editor_val.split('\n')[2]
-        final_editor_val = final_editor_val.split()[1].strip(). \
-            replace("'", "", 2)
+        final_editor_val = self.extract_set_editor_output(final_editor_val)
 
         self.assertEqual(self.editor_val, final_editor_val)
 
@@ -1177,8 +1183,6 @@ class TestShellOpts(TestCephFSShell):
         final_editor_val = self.get_cephfs_shell_cmd_output(
             cmd='set editor %s, set editor' % self.editor_val,
             shell_conf_path=self.tempconfpath)
-        final_editor_val = final_editor_val.split('\n')[4]
-        final_editor_val = final_editor_val.split()[1].strip(). \
-            replace("'", "", 2)
+        final_editor_val = self.extract_set_editor_output(final_editor_val)
 
         self.assertEqual(self.editor_val, final_editor_val)


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/71795
Signed-off-by: Neeraj Pratap Singh <Neeraj.Pratap.Singh1@ibm.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
