### PR TITLE
os/bluestore: implement get_free_extents

### DIFF
--- a/src/os/bluestore/Allocator.cc
+++ b/src/os/bluestore/Allocator.cc
@@ -140,3 +140,22 @@ double Allocator::get_fragmentation_score()
   double terrible = (sum / block_size) * get_score(block_size);
   return (ideal - score_sum) / (ideal - terrible);
 }
+
+void Allocator::foreach_interruptible(
+  std::function<void(uint64_t offset, uint64_t length)> notify)
+{
+  // Number of free extents fetched per get_free_extents() call. The allocator
+  // lock is held only for the duration of one batch, so this bounds the
+  // per-batch lock hold
+  static constexpr size_t batch_size = 1024;
+  const uint64_t end = get_capacity();
+  uint64_t cursor = 0;
+  free_extent_vector_t batch;
+  while (cursor < end) {
+    batch.clear();
+    cursor = get_free_extents(cursor, end, batch_size, &batch);
+    for (const auto& [offset, length] : batch) {
+      notify(offset, length);
+    }
+  }
+}

--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -83,6 +83,19 @@ public:
     size_t max_count,
     free_extent_vector_t* out) = 0;
 
+  /*
+   * Weakly-consistent counterpart to foreach()
+   * 
+   * visit every free extent by driving get_free_extents() in bounded 
+   * batches over [0, device_size), so the allocator lock is only held 
+   * for one batch at a time instead of the whole walk. 
+   * 
+   * See get_free_extents() for the weak-consistency contract;
+   * use foreach() when an exact, consistent snapshot is required.
+   */
+  void foreach_interruptible(
+    std::function<void(uint64_t offset, uint64_t length)> notify);
+
   virtual void init_add_free(uint64_t offset, uint64_t length) = 0;
   virtual void init_rm_free(uint64_t offset, uint64_t length) = 0;
 

--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -16,12 +16,19 @@
 #include <atomic>
 #include <functional>
 #include <ostream>
+#include <utility>
+#include <vector>
 #include "include/ceph_assert.h"
 #include "bluestore_types.h"
 #include "common/ceph_mutex.h"
 
 typedef interval_set<uint64_t> release_set_t;
 typedef release_set_t::value_type release_set_entry_t;
+
+// A batch of free extents as (offset, length) pairs, matching the
+// (offset, length) convention used by foreach()/notify throughout the
+// allocators. Returned via the out-param of Allocator::get_free_extents().
+typedef std::vector<bluestore_interval_t<uint64_t, uint64_t>> free_extent_vector_t;
 
 class Allocator {
 public:
@@ -61,6 +68,20 @@ public:
   virtual void dump() = 0;
   virtual void foreach(
     std::function<void(uint64_t offset, uint64_t length)> notify) = 0;
+
+  /*
+   * Returns a resume cursor:
+   *   - if the cursor is >= range_end, the window has been fully enumerated;
+   *   - otherwise the caller should call again with range_begin set to the
+   *     returned cursor to fetch the next batch.
+   *
+   * Preconditions: range_begin <= range_end and max_count > 0..
+   */
+  virtual uint64_t get_free_extents(
+    uint64_t range_begin,
+    uint64_t range_end,
+    size_t max_count,
+    free_extent_vector_t* out) = 0;
 
   virtual void init_add_free(uint64_t offset, uint64_t length) = 0;
   virtual void init_rm_free(uint64_t offset, uint64_t length) = 0;

--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -70,12 +70,52 @@ public:
     std::function<void(uint64_t offset, uint64_t length)> notify) = 0;
 
   /*
-   * Returns a resume cursor:
-   *   - if the cursor is >= range_end, the window has been fully enumerated;
-   *   - otherwise the caller should call again with range_begin set to the
-   *     returned cursor to fetch the next batch.
+   * Retrieves free extents from [range_begin, range_end) window. Up to max_count
+   * extents are to be retrieved. 
+   * 
+   * Returned value is a cursor to pass as range_begin to the next call:
+   *   - cursor >= range_end: the window is fully enumerated, stop.
+   *   - cursor < range_end: pass it as range_begin to resume. The cursor is a
+   *     valid resume point but is NOT guaranteed to land on a free extent; it
+   *     may point into allocated space. An extra call that returns zero extents
+   *     and advances cursor to range_end is possible when max_count is reached
+   *     exactly at the last free extent in the window.
    *
-   * Preconditions: range_begin <= range_end and max_count > 0..
+   * Unlike foreach(), which holds the allocator lock for the entire walk, this
+   * call takes the lock only for the duration of a single batch. The extents
+   * might not be gloablly consistent between each lock. 
+   *
+   * Note, when allocator is idle the batches received via foreach() and
+   * get_free_extents()  will give the same result.
+   *
+   * Consistency contract (read carefully):
+   *   - The result is NOT a point-in-time snapshot of all the extents present
+   *     on the disk. It's only a snapshot of the extents present in the range
+   *     given to the function. Each batch observes the allocator state as of
+   *     its own lock acquisition;
+   *   - Extents within a single batch are mutually consistent and returned in
+   *     ascending offset order, clipped to [range_begin, range_end).
+   *
+   * Therefore the union of all batches is an APPROXIMATION of the free space:
+   * off by at most the extents concurrently allocated/released during
+   * enumeration. 
+   *
+   * This is intended for statistical/best-effort consumers (e.g. fragmentation
+   * scoring, defrag planning, emergency discard). For an exact, consistent
+   * enumeration use foreach() instead.
+   *
+   * Caveats:
+   *   - *out is appended to, not cleared. The caller owns
+   *     preallocating/clearing/reusing. 
+  *   - max_count bounds extents per batch, not bytes; passing 0 means
+  *     unbounded for this call. A single returned extent may be arbitrarily
+  *     large (it is the clipped span of one free extent).
+   *   - The cursor is an opaque offset; do not assume it lands on a free
+   *     extent or even on a block boundary. Only the >= range_end termination
+   *     test is meaningful.
+   *
+   * Preconditions: 
+  *    - range_begin <= range_end.
    */
   virtual uint64_t get_free_extents(
     uint64_t range_begin,

--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -70,12 +70,50 @@ public:
     std::function<void(uint64_t offset, uint64_t length)> notify) = 0;
 
   /*
-   * Returns a resume cursor:
-   *   - if the cursor is >= range_end, the window has been fully enumerated;
-   *   - otherwise the caller should call again with range_begin set to the
-   *     returned cursor to fetch the next batch.
+   * Retrieves free extents from [range_begin, range_end) window. Up to max_count
+   * extents are to be retrieved. 
+   * 
+   * Returned value is a cursor to pass as range_begin to the next call:
+   *   - cursor >= range_end: the window is fully enumerated, stop.
+   *   - cursor < range_end: pass it as range_begin to resume. The cursor is a
+   *     valid resume point but is NOT guaranteed there are any free extents in
+   *     the range  [cursor, range_end)
    *
-   * Preconditions: range_begin <= range_end and max_count > 0..
+   * Unlike foreach(), which holds the allocator lock for the entire walk, this
+   * call takes the lock only for the duration of a single batch. The extents
+   * might not be gloablly consistent between each lock. 
+   *
+   * Note, when allocator is idle the batches received via foreach() and
+   * get_free_extents()  will give the same result.
+   *
+   * Consistency guarantees::
+   *   - The result is NOT a point-in-time snapshot of all the extents present
+   *     on the disk. It's only a snapshot of the extents present in the range
+   *     given to the function. Each batch observes the allocator state as of
+   *     its own lock acquisition;
+   *   - Extents within a single batch are mutually consistent and returned in
+   *     ascending offset order, clipped to [range_begin, range_end).
+   *
+   * Therefore the union of all batches is an APPROXIMATION of the free space:
+   * off by at most the extents concurrently allocated/released during
+   * enumeration. 
+   *
+   * This is intended for statistical/best-effort consumers (e.g. fragmentation
+   * scoring, defrag planning, emergency discard). For an exact, consistent
+   * enumeration use foreach() instead.
+   *
+   * Caveats:
+   *   - *out is appended to, not cleared. The caller owns
+   *     preallocating/clearing/reusing. 
+  *   - max_count bounds extents per batch, not bytes; passing 0 means
+  *     unbounded for this call. A single returned extent may be arbitrarily
+  *     large (it is the clipped span of one free extent).
+   *   - The cursor is an opaque offset; do not assume it lands on a free
+   *     extent or even on a block boundary. Only the >= range_end termination
+   *     test is meaningful.
+   *
+   * Preconditions: 
+  *    - range_begin <= range_end.
    */
   virtual uint64_t get_free_extents(
     uint64_t range_begin,

--- a/src/os/bluestore/AvlAllocator.cc
+++ b/src/os/bluestore/AvlAllocator.cc
@@ -508,7 +508,6 @@ uint64_t AvlAllocator::get_free_extents(
     return range_end;
   }
 
-  // TODO: Naveen: Do we need a lock here ?
   std::lock_guard l(lock);
   auto it = range_tree.lower_bound(range_t{range_begin, range_begin},
 				   range_tree.key_comp());

--- a/src/os/bluestore/AvlAllocator.cc
+++ b/src/os/bluestore/AvlAllocator.cc
@@ -496,6 +496,40 @@ void AvlAllocator::_foreach(
   }
 }
 
+uint64_t AvlAllocator::get_free_extents(
+  uint64_t range_begin,
+  uint64_t range_end,
+  size_t max_count,
+  free_extent_vector_t* out)
+{
+  ceph_assert(range_begin <= range_end);
+  // Empty window: nothing to enumerate, already fully covered.
+  if (range_begin == range_end) {
+    return range_end;
+  }
+
+  // TODO: Naveen: Do we need a lock here ?
+  std::lock_guard l(lock);
+  auto it = range_tree.lower_bound(range_t{range_begin, range_begin},
+				   range_tree.key_comp());
+  size_t n = 0;
+  const bool unbounded = (max_count == 0);
+  while (it != range_tree.end() && it->start < range_end &&
+         (unbounded || n < max_count)) {
+    uint64_t lo = std::max(it->start, range_begin);
+    uint64_t hi = std::min(it->end, range_end);
+    out->emplace_back(lo, hi - lo);
+    ++it;
+    ++n;
+  }
+  if (it == range_tree.end() || it->start >= range_end) {
+    // Window fully enumerated.
+    return range_end;
+  }
+  // Stopped on the count cap: resume from the next, not-yet-emitted extent.
+  return it->start;
+}
+
 void AvlAllocator::init_add_free(uint64_t offset, uint64_t length)
 {
   ldout(cct, 10) << __func__ << std::hex

--- a/src/os/bluestore/AvlAllocator.cc
+++ b/src/os/bluestore/AvlAllocator.cc
@@ -511,6 +511,14 @@ uint64_t AvlAllocator::get_free_extents(
   std::lock_guard l(lock);
   auto it = range_tree.lower_bound(range_t{range_begin, range_begin},
 				   range_tree.key_comp());
+  // An extent starting before range_begin may still straddle it; step back
+  // one to include it so its left edge can be clipped by the lo= max() below.
+  if (it != range_tree.begin()) {
+    auto prev = std::prev(it);
+    if (prev->end > range_begin) {
+      it = prev;
+    }
+  }
   size_t n = 0;
   const bool unbounded = (max_count == 0);
   while (it != range_tree.end() && it->start < range_end &&

--- a/src/os/bluestore/AvlAllocator.cc
+++ b/src/os/bluestore/AvlAllocator.cc
@@ -496,6 +496,40 @@ void AvlAllocator::_foreach(
   }
 }
 
+uint64_t AvlAllocator::get_free_extents(
+  uint64_t range_begin,
+  uint64_t range_end,
+  size_t max_count,
+  free_extent_vector_t* out)
+{
+  ceph_assert(range_begin <= range_end);
+  // Empty window: nothing to enumerate, already fully covered.
+  if (range_begin == range_end) {
+    return range_end;
+  }
+
+  // TODO: Naveen: Do we need a lock here ?
+  std::lock_guard l(lock);
+  auto it = range_tree.lower_bound(range_t{range_begin, range_begin},
+				   range_tree.key_comp());
+  size_t n = 0;
+  max_count--;  // if 0, wraps to SIZE_MAX so n <= max_count is always true (unbounded)
+  while (it != range_tree.end() && it->start < range_end &&
+         (n <= max_count)) {
+    uint64_t lo = std::max(it->start, range_begin);
+    uint64_t hi = std::min(it->end, range_end);
+    out->emplace_back(lo, hi - lo);
+    ++it;
+    ++n;
+  }
+  if (it == range_tree.end() || it->start >= range_end) {
+    // Window fully enumerated.
+    return range_end;
+  }
+  // Stopped on the count cap: resume from the next, not-yet-emitted extent.
+  return it->start;
+}
+
 void AvlAllocator::init_add_free(uint64_t offset, uint64_t length)
 {
   ldout(cct, 10) << __func__ << std::hex

--- a/src/os/bluestore/AvlAllocator.cc
+++ b/src/os/bluestore/AvlAllocator.cc
@@ -511,6 +511,14 @@ uint64_t AvlAllocator::get_free_extents(
   std::lock_guard l(lock);
   auto it = range_tree.lower_bound(range_t{range_begin, range_begin},
 				   range_tree.key_comp());
+  // An extent starting before range_begin may still straddle it; step back
+  // one to include it so its left edge can be clipped by the lo= max() below.
+  if (it != range_tree.begin()) {
+    auto prev = std::prev(it);
+    if (prev->end > range_begin) {
+      it = prev;
+    }
+  }
   size_t n = 0;
   max_count--;  // if 0, wraps to SIZE_MAX so n <= max_count is always true (unbounded)
   while (it != range_tree.end() && it->start < range_end &&

--- a/src/os/bluestore/AvlAllocator.h
+++ b/src/os/bluestore/AvlAllocator.h
@@ -89,6 +89,11 @@ public:
   void dump() override;
   void foreach(
     std::function<void(uint64_t offset, uint64_t length)> notify) override;
+  uint64_t get_free_extents(
+    uint64_t range_begin,
+    uint64_t range_end,
+    size_t max_count,
+    free_extent_vector_t* out) override;
   void init_add_free(uint64_t offset, uint64_t length) override;
   void init_rm_free(uint64_t offset, uint64_t length) override;
   void shutdown() override;

--- a/src/os/bluestore/BitmapAllocator.cc
+++ b/src/os/bluestore/BitmapAllocator.cc
@@ -66,6 +66,19 @@ void BitmapAllocator::release(
 }
 
 
+uint64_t BitmapAllocator::get_free_extents(
+  uint64_t range_begin,
+  uint64_t range_end,
+  size_t max_count,
+  free_extent_vector_t* out)
+{
+  return get_free_extents_internal(
+    range_begin, range_end, max_count,
+    [out](uint64_t offset, uint64_t length) {
+      out->emplace_back(offset, length);
+    });
+}
+
 void BitmapAllocator::init_add_free(uint64_t offset, uint64_t length)
 {
   ldout(cct, 10) << __func__ << " 0x" << std::hex << offset << "~" << length

--- a/src/os/bluestore/BitmapAllocator.h
+++ b/src/os/bluestore/BitmapAllocator.h
@@ -53,10 +53,7 @@ public:
     uint64_t range_begin,
     uint64_t range_end,
     size_t max_count,
-    free_extent_vector_t* out) override
-  {
-    ceph_abort_msg("BitmapAllocator::get_free_extents not implemented");
-  }
+    free_extent_vector_t* out) override;
   double get_fragmentation() override
   {
     return get_fragmentation_internal();

--- a/src/os/bluestore/BitmapAllocator.h
+++ b/src/os/bluestore/BitmapAllocator.h
@@ -49,6 +49,14 @@ public:
   {
     foreach_internal(notify);
   }
+  uint64_t get_free_extents(
+    uint64_t range_begin,
+    uint64_t range_end,
+    size_t max_count,
+    free_extent_vector_t* out) override
+  {
+    ceph_abort_msg("BitmapAllocator::get_free_extents not implemented");
+  }
   double get_fragmentation() override
   {
     return get_fragmentation_internal();

--- a/src/os/bluestore/Btree2Allocator.cc
+++ b/src/os/bluestore/Btree2Allocator.cc
@@ -137,6 +137,77 @@ void Btree2Allocator::release(const release_set_t& release_set)
   }
 }
 
+uint64_t Btree2Allocator::get_free_extents(
+  uint64_t range_begin,
+  uint64_t range_end,
+  size_t max_count,
+  free_extent_vector_t* out)
+{
+  ceph_assert(range_begin <= range_end);
+  if (range_begin == range_end) {
+    return range_end;
+  }
+  std::lock_guard l(lock);
+
+  // Extents released via the fast path (see release()) sit in 'cache'
+  // rather than range_tree until they're reused or evicted. They must be
+  // folded in here too, same as _foreach() already does via cache->foreach,
+  // otherwise a foreach_interruptible() walk driven by get_free_extents()
+  // would silently skip whatever free space currently lives in the cache.
+  // The cache is small and bounded (<= 256 entries), so collecting it
+  // wholesale on every call is cheap; entries are non-overlapping, so a
+  // simple offset-sorted merge with the range_tree scan below is safe.
+  std::vector<std::pair<uint64_t, uint64_t>> cached;
+  if (cache) {
+    cache->foreach([&](uint64_t offset, uint64_t length) {
+      if (offset < range_end && offset + length > range_begin) {
+        cached.emplace_back(offset, length);
+      }
+    });
+    std::sort(cached.begin(), cached.end());
+  }
+
+  auto it = range_tree.lower_bound(range_begin);
+  // An extent whose start < range_begin may still span into the window.
+  if (it != range_tree.begin()) {
+    auto prev = std::prev(it);
+    if (prev->second > range_begin) {
+      it = prev;
+    }
+  }
+  size_t n = 0;
+  size_t ci = 0;
+  const bool unbounded = (max_count == 0);
+  while (((it != range_tree.end() && it->first < range_end) || ci < cached.size()) &&
+         (unbounded || n < max_count)) {
+    bool take_tree = (it != range_tree.end() && it->first < range_end) &&
+      (ci >= cached.size() || it->first <= cached[ci].first);
+    uint64_t start, end;
+    if (take_tree) {
+      start = it->first;
+      end = it->second;
+      ++it;
+    } else {
+      start = cached[ci].first;
+      end = cached[ci].first + cached[ci].second;
+      ++ci;
+    }
+    uint64_t lo = std::max(start, range_begin);
+    uint64_t hi = std::min(end, range_end);
+    out->emplace_back(lo, hi - lo);
+    ++n;
+  }
+
+  uint64_t cursor = range_end;
+  if (it != range_tree.end() && it->first < range_end) {
+    cursor = std::min(cursor, it->first);
+  }
+  if (ci < cached.size()) {
+    cursor = std::min(cursor, cached[ci].first);
+  }
+  return cursor;
+}
+
 void Btree2Allocator::_shutdown()
 {
   if (cache) {

--- a/src/os/bluestore/Btree2Allocator.cc
+++ b/src/os/bluestore/Btree2Allocator.cc
@@ -137,6 +137,80 @@ void Btree2Allocator::release(const release_set_t& release_set)
   }
 }
 
+uint64_t Btree2Allocator::get_free_extents(
+  uint64_t range_begin,
+  uint64_t range_end,
+  size_t max_count,
+  free_extent_vector_t* out)
+{
+  ceph_assert(range_begin <= range_end);
+  if (range_begin == range_end) {
+    return range_end;
+  }
+  std::lock_guard l(lock);
+
+  // Extents released via the fast path (see release()) sit in 'cache'
+  // rather than range_tree until they're reused or evicted. They must be
+  // folded in here too, same as _foreach() already does via cache->foreach,
+  // otherwise a foreach_interruptible() walk driven by get_free_extents()
+  // would silently skip whatever free space currently lives in the cache.
+  // The cache is small and bounded (<= 256 entries), so collecting it
+  // wholesale on every call is cheap; entries are non-overlapping, so a
+  // simple offset-sorted merge with the range_tree scan below is safe.
+  std::vector<std::pair<uint64_t, uint64_t>> cached;
+  if (cache) {
+    // Bounded at 256 (BUCKET_COUNT * EXTENTS_PER_BUCKET, see
+    // AllocatorBase::OpportunisticExtentCache)
+    cached.reserve(256);
+    cache->foreach([&](uint64_t offset, uint64_t length) {
+      if (offset < range_end && offset + length > range_begin) {
+        cached.emplace_back(offset, length);
+      }
+    });
+    std::sort(cached.begin(), cached.end());
+  }
+
+  auto it = range_tree.lower_bound(range_begin);
+  // An extent whose start < range_begin may still span into the window.
+  if (it != range_tree.begin()) {
+    auto prev = std::prev(it);
+    if (prev->second > range_begin) {
+      it = prev;
+    }
+  }
+  size_t n = 0;
+  size_t ci = 0;
+  max_count--; // if 0, wraps to SIZE_MAX so n <= max_count is always true (unbounded)
+  while (((it != range_tree.end() && it->first < range_end) || ci < cached.size()) &&
+         (n <= max_count)) {
+    bool take_tree = (it != range_tree.end() && it->first < range_end) &&
+      (ci >= cached.size() || it->first <= cached[ci].first);
+    uint64_t start, end;
+    if (take_tree) {
+      start = it->first;
+      end = it->second;
+      ++it;
+    } else {
+      start = cached[ci].first;
+      end = cached[ci].first + cached[ci].second;
+      ++ci;
+    }
+    uint64_t lo = std::max(start, range_begin);
+    uint64_t hi = std::min(end, range_end);
+    out->emplace_back(lo, hi - lo);
+    ++n;
+  }
+
+  uint64_t cursor = range_end;
+  if (it != range_tree.end() && it->first < range_end) {
+    cursor = std::min(cursor, it->first);
+  }
+  if (ci < cached.size()) {
+    cursor = std::min(cursor, cached[ci].first);
+  }
+  return cursor;
+}
+
 void Btree2Allocator::_shutdown()
 {
   if (cache) {

--- a/src/os/bluestore/Btree2Allocator.h
+++ b/src/os/bluestore/Btree2Allocator.h
@@ -123,6 +123,14 @@ public:
     std::lock_guard l(lock);
     _foreach(notify);
   }
+  uint64_t get_free_extents(
+    uint64_t range_begin,
+    uint64_t range_end,
+    size_t max_count,
+    free_extent_vector_t* out) override
+  {
+    ceph_abort_msg("Btree2Allocator::get_free_extents not implemented");
+  }
   void shutdown() override {
     std::lock_guard l(lock);
     _shutdown();

--- a/src/os/bluestore/Btree2Allocator.h
+++ b/src/os/bluestore/Btree2Allocator.h
@@ -127,10 +127,7 @@ public:
     uint64_t range_begin,
     uint64_t range_end,
     size_t max_count,
-    free_extent_vector_t* out) override
-  {
-    ceph_abort_msg("Btree2Allocator::get_free_extents not implemented");
-  }
+    free_extent_vector_t* out) override;
   void shutdown() override {
     std::lock_guard l(lock);
     _shutdown();

--- a/src/os/bluestore/BtreeAllocator.cc
+++ b/src/os/bluestore/BtreeAllocator.cc
@@ -466,6 +466,44 @@ void BtreeAllocator::foreach(std::function<void(uint64_t offset, uint64_t length
   }
 }
 
+uint64_t BtreeAllocator::get_free_extents(
+  uint64_t range_begin,
+  uint64_t range_end,
+  size_t max_count,
+  free_extent_vector_t* out)
+{
+  ceph_assert(range_begin <= range_end);
+  if (range_begin == range_end) {
+    return range_end;
+  }
+
+  std::lock_guard l(lock);
+  // lower_bound gives first segment with start >= range_begin.
+  // The previous segment may start before range_begin but extend into the range.
+  auto it = range_tree.lower_bound(range_begin);
+  if (it != range_tree.begin()) {
+    auto prev = std::prev(it);
+    if (prev->second > range_begin) {
+      it = prev;
+    }
+  }
+  size_t n = 0;
+  const bool unbounded = (max_count == 0);
+  while (it != range_tree.end() && it->first < range_end &&
+         (unbounded || n < max_count)) {
+    uint64_t lo = std::max(it->first, range_begin);
+    uint64_t hi = std::min(it->second, range_end);
+    out->emplace_back(lo, hi - lo);
+    ++it;
+    ++n;
+  }
+  if (it == range_tree.end() || it->first >= range_end) {
+    return range_end;
+  }
+  // Stopped on the count cap: resume from the next, not-yet-emitted extent.
+  return it->first;
+}
+
 void BtreeAllocator::init_add_free(uint64_t offset, uint64_t length)
 {
   if (!length)

--- a/src/os/bluestore/BtreeAllocator.cc
+++ b/src/os/bluestore/BtreeAllocator.cc
@@ -466,6 +466,44 @@ void BtreeAllocator::foreach(std::function<void(uint64_t offset, uint64_t length
   }
 }
 
+uint64_t BtreeAllocator::get_free_extents(
+  uint64_t range_begin,
+  uint64_t range_end,
+  size_t max_count,
+  free_extent_vector_t* out)
+{
+  ceph_assert(range_begin <= range_end);
+  if (range_begin == range_end) {
+    return range_end;
+  }
+
+  std::lock_guard l(lock);
+  // lower_bound gives first segment with start >= range_begin.
+  // The previous segment may start before range_begin but extend into the range.
+  auto it = range_tree.lower_bound(range_begin);
+  if (it != range_tree.begin()) {
+    auto prev = std::prev(it);
+    if (prev->second > range_begin) {
+      it = prev;
+    }
+  }
+  size_t n = 0;
+  max_count--;  // if 0, wraps to SIZE_MAX so n <= max_count is always true (unbounded)
+  while (it != range_tree.end() && it->first < range_end &&
+         (n <= max_count)) {
+    uint64_t lo = std::max(it->first, range_begin);
+    uint64_t hi = std::min(it->second, range_end);
+    out->emplace_back(lo, hi - lo);
+    ++it;
+    ++n;
+  }
+  if (it == range_tree.end() || it->first >= range_end) {
+    return range_end;
+  }
+  // Stopped on the count cap: resume from the next, not-yet-emitted extent.
+  return it->first;
+}
+
 void BtreeAllocator::init_add_free(uint64_t offset, uint64_t length)
 {
   if (!length)

--- a/src/os/bluestore/BtreeAllocator.h
+++ b/src/os/bluestore/BtreeAllocator.h
@@ -86,6 +86,14 @@ public:
   void dump() override;
   void foreach(
     std::function<void(uint64_t offset, uint64_t length)> notify) override;
+  uint64_t get_free_extents(
+    uint64_t range_begin,
+    uint64_t range_end,
+    size_t max_count,
+    free_extent_vector_t* out) override
+  {
+    ceph_abort_msg("BtreeAllocator::get_free_extents not implemented");
+  }
   void init_add_free(uint64_t offset, uint64_t length) override;
   void init_rm_free(uint64_t offset, uint64_t length) override;
   void shutdown() override;

--- a/src/os/bluestore/BtreeAllocator.h
+++ b/src/os/bluestore/BtreeAllocator.h
@@ -90,10 +90,7 @@ public:
     uint64_t range_begin,
     uint64_t range_end,
     size_t max_count,
-    free_extent_vector_t* out) override
-  {
-    ceph_abort_msg("BtreeAllocator::get_free_extents not implemented");
-  }
+    free_extent_vector_t* out) override;
   void init_add_free(uint64_t offset, uint64_t length) override;
   void init_rm_free(uint64_t offset, uint64_t length) override;
   void shutdown() override;

--- a/src/os/bluestore/HybridAllocator.h
+++ b/src/os/bluestore/HybridAllocator.h
@@ -72,6 +72,11 @@ public:
     }
   }
 
+  uint64_t get_free_extents(
+    uint64_t range_begin,
+    uint64_t range_end,
+    size_t max_count,
+    free_extent_vector_t* out) override;
   void shutdown() override {
     std::lock_guard l(PrimaryAllocator::get_lock());
     PrimaryAllocator::_shutdown();

--- a/src/os/bluestore/HybridAllocator_impl.h
+++ b/src/os/bluestore/HybridAllocator_impl.h
@@ -153,6 +153,61 @@ uint64_t HybridAllocatorBase<T>::_spillover_allocate(uint64_t want,
     extents);
 }
 
+template <typename T>
+uint64_t HybridAllocatorBase<T>::get_free_extents(
+  uint64_t range_begin,
+  uint64_t range_end,
+  size_t max_count,
+  free_extent_vector_t* out)
+{
+  if (!bmap_alloc) {
+    return T::get_free_extents(range_begin, range_end, max_count, out);
+  }
+
+  // Fetch up to max_count from each sub-allocator independently.
+  // Both return extents sorted by offset; we merge them in O(n+m).
+  free_extent_vector_t primary_out, bmap_out;
+  uint64_t primary_cursor = T::get_free_extents(
+    range_begin, range_end, max_count, &primary_out);
+  uint64_t bmap_cursor = bmap_alloc->get_free_extents(
+    range_begin, range_end, max_count, &bmap_out);
+
+  auto pi = primary_out.begin();
+  auto bi = bmap_out.begin();
+  const bool unbounded = (max_count == 0);
+  size_t n = 0;
+
+  while ((pi != primary_out.end() || bi != bmap_out.end()) &&
+         (unbounded || n < max_count)) {
+    bool take_primary;
+    if (pi == primary_out.end()) {
+      take_primary = false;
+    } else if (bi == bmap_out.end()) {
+      take_primary = true;
+    } else {
+      take_primary = (pi->offset <= bi->offset);
+    }
+    out->push_back(take_primary ? *pi++ : *bi++);
+    ++n;
+  }
+
+  // Resume cursor: the minimum next-unprocessed offset from either stream.
+  // Prefer batch leftovers (exact extent offsets) over sub-cursors (used only
+  // when a batch was exhausted but the sub-allocator signalled more remains).
+  uint64_t cursor = range_end;
+  if (pi != primary_out.end()) {
+    cursor = std::min(cursor, pi->offset);
+  } else if (primary_cursor < range_end) {
+    cursor = std::min(cursor, primary_cursor);
+  }
+  if (bi != bmap_out.end()) {
+    cursor = std::min(cursor, bi->offset);
+  } else if (bmap_cursor < range_end) {
+    cursor = std::min(cursor, bmap_cursor);
+  }
+  return cursor;
+}
+
 template <typename PrimaryAllocator>
 uint64_t HybridAllocatorBase<PrimaryAllocator>::_allocate_or_rollback(
   bool primary,

--- a/src/os/bluestore/HybridAllocator_impl.h
+++ b/src/os/bluestore/HybridAllocator_impl.h
@@ -153,6 +153,57 @@ uint64_t HybridAllocatorBase<T>::_spillover_allocate(uint64_t want,
     extents);
 }
 
+template <typename T>
+uint64_t HybridAllocatorBase<T>::get_free_extents(
+  uint64_t range_begin,
+  uint64_t range_end,
+  size_t max_count,
+  free_extent_vector_t* out)
+{
+  if (!bmap_alloc) {
+    return T::get_free_extents(range_begin, range_end, max_count, out);
+  }
+
+  free_extent_vector_t primary_out;
+  T::get_free_extents(range_begin, range_end, max_count, &primary_out);
+
+  if (primary_out.empty()) {
+    return bmap_alloc->get_free_extents(range_begin, range_end, max_count, out);
+  }
+
+  const bool unbounded = (max_count == 0);
+  size_t n = 0;
+  uint64_t prev_end = range_begin;
+  free_extent_vector_t bmap_out;
+
+  for (size_t i = 0; i <= primary_out.size(); ++i) {
+    uint64_t gap_end = (i < primary_out.size()) ? primary_out[i].offset : range_end;
+
+    bmap_out.clear();
+    uint64_t bmap_cursor = bmap_alloc->get_free_extents(
+      prev_end, gap_end, unbounded ? 0 : (max_count - n), &bmap_out);
+    out->insert(out->end(), bmap_out.begin(), bmap_out.end());
+    n += bmap_out.size();
+
+    if (!unbounded && n >= max_count) {
+      return bmap_cursor;
+    }
+    if (i == primary_out.size()) {
+      return bmap_cursor;  // tail edge done, nothing left to interleave
+    }
+
+    out->push_back(primary_out[i]);
+    n++;
+    prev_end = primary_out[i].offset + primary_out[i].length;
+
+    if (!unbounded && n >= max_count) {
+      return prev_end;
+    }
+  }
+  return range_end;
+}
+
+
 template <typename PrimaryAllocator>
 uint64_t HybridAllocatorBase<PrimaryAllocator>::_allocate_or_rollback(
   bool primary,

--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -306,6 +306,47 @@ void StupidAllocator::foreach(std::function<void(uint64_t offset, uint64_t lengt
   }
 }
 
+// TODO: Naveen: A better alternative approach is min-heap merge
+uint64_t StupidAllocator::get_free_extents(
+  uint64_t range_begin,
+  uint64_t range_end,
+  size_t max_count,
+  free_extent_vector_t *out)
+{
+  ceph_assert(range_begin <= range_end);
+  if (range_begin == range_end) {
+    return range_end;
+  }
+
+  // Offsets interleave across bins (bins are bucketed by size, not offset),
+  // so collect all extents in the window first, then sort by offset.
+  std::vector<std::pair<uint64_t, uint64_t>> tmp;
+
+  std::lock_guard l(lock);
+  for (unsigned bin = 0; bin < free.size(); ++bin) {
+    auto it = free[bin].lower_bound(range_begin);
+    while (it != free[bin].end() && it.get_start() < range_end) {
+      tmp.emplace_back(it.get_start(), it.get_end());
+      ++it;
+    }
+  }
+
+  std::sort(tmp.begin(), tmp.end());
+
+  const bool unbounded = (max_count == 0);
+  size_t emit = unbounded ? tmp.size() : std::min(max_count, tmp.size());
+
+  for (size_t i = 0; i < emit; ++i) {
+    uint64_t lo = std::max(tmp[i].first, range_begin);
+    out->emplace_back(lo, std::min(tmp[i].second, range_end) - lo);
+  }
+
+  if (emit < tmp.size()) {
+    return tmp[emit].first;
+  }
+  return range_end;
+}
+
 void StupidAllocator::init_add_free(uint64_t offset, uint64_t length)
 {
   if (!length)

--- a/src/os/bluestore/StupidAllocator.h
+++ b/src/os/bluestore/StupidAllocator.h
@@ -59,6 +59,14 @@ public:
 
   void dump() override;
   void foreach(std::function<void(uint64_t offset, uint64_t length)> notify) override;
+  uint64_t get_free_extents(
+    uint64_t range_begin,
+    uint64_t range_end,
+    size_t max_count,
+    free_extent_vector_t* out) override
+  {
+    ceph_abort_msg("StupidAllocator::get_free_extents not implemented");
+  }
 
   void init_add_free(uint64_t offset, uint64_t length) override;
   void init_rm_free(uint64_t offset, uint64_t length) override;

--- a/src/os/bluestore/StupidAllocator.h
+++ b/src/os/bluestore/StupidAllocator.h
@@ -63,10 +63,7 @@ public:
     uint64_t range_begin,
     uint64_t range_end,
     size_t max_count,
-    free_extent_vector_t* out) override
-  {
-    ceph_abort_msg("StupidAllocator::get_free_extents not implemented");
-  }
+    free_extent_vector_t* out) override;
 
   void init_add_free(uint64_t offset, uint64_t length) override;
   void init_rm_free(uint64_t offset, uint64_t length) override;

--- a/src/os/bluestore/fastbmap_allocator_impl.cc
+++ b/src/os/bluestore/fastbmap_allocator_impl.cc
@@ -634,91 +634,89 @@ uint64_t AllocatorLevel01Loose::get_free_extents_internal(
     return l0_pos_end;
   }
 
-  uint64_t off = 0;     // start of the open free run, in L0 units (bits)
-  uint64_t len = 0;     // length of the open free run; 0 == no run open
-  size_t   count = 0;   // extents emitted so far
-
-  // Emit the open run, remember where to resume, reset it. Returns true when
-  // the per-batch cap is reached and the walk must stop.
+  FreeRun  run;
+  size_t   count  = 0;   // extents emitted so far
   uint64_t resume = 0;
-  auto close_run = [&]() -> bool {
+
+  // Close the open run (if any), emit it, and check the per-batch cap.
+  // Returns true when the walk must stop now.
+  auto flush = [&]() -> bool {
+    if (!run.is_open()) {
+      return false;
+    }
+    auto [off, len] = run.close();
     resume = off + len;
     notify(off, len);
-    len = 0;
     return !unbounded && (++count == max_count);
   };
 
-  const uint64_t l1_idx_start = l0_pos_start / bits_per_slotset;
-  const uint64_t l1_idx_end =
-    (scan_end + bits_per_slotset - 1) / bits_per_slotset;   // ceil, exclusive
+  const uint64_t l1_idx_start = l0_bit_to_l1_idx(l0_pos_start);
+  const uint64_t l1_idx_end =  // ceil, exclusive
+    l0_bit_to_l1_idx(p2roundup(scan_end, uint64_t(bits_per_slotset)));
 
   for (uint64_t l1_idx = l1_idx_start; l1_idx < l1_idx_end; ++l1_idx) {
-    const uint64_t ss_begin = l1_idx * bits_per_slotset;
-    const uint64_t win_lo = std::max(ss_begin, l0_pos_start);
-    const uint64_t win_hi = std::min(ss_begin + bits_per_slotset, scan_end);
+    auto [ss_lo, ss_hi] = slotset_l0_range(l1_idx);
+    auto [win_lo, win_hi] = intersect(ss_lo, ss_hi, l0_pos_start, scan_end);
 
-    // Decode this slotset's 2-bit L1 entry.
-    const size_t l1_word  = l1_idx / L1_ENTRIES_PER_SLOT;
-    const size_t l1_shift = (l1_idx % L1_ENTRIES_PER_SLOT) * L1_ENTRY_WIDTH;
-    const slot_t w = (l1[l1_word] >> l1_shift) & L1_ENTRY_MASK;
+    switch (l1_entry_at(l1_idx)) {
 
-    if (w == L1_ENTRY_FULL) {
+    case L1_ENTRY_FULL:
       // Whole slotset allocated: a run, if any, ends here.
-      if (len && close_run()) {
+      if (flush()) {
         return resume;
       }
-    } else if (w == L1_ENTRY_FREE) {
+      break;
+
+    case L1_ENTRY_FREE:
       // Whole slotset free: start or extend the run over the window slice.
-      if (len == 0) {
-        off = win_lo;
-      }
-      len += win_hi - win_lo;
-    } else {
-      // L1_ENTRY_PARTIAL: scan the L0 bitmap, restricted to [win_lo, win_hi).
-      const uint64_t slot0 = l1_idx * slots_per_slotset;   // first L0 word
+      run.extend(win_lo, win_hi - win_lo);
+      break;
+
+    case L1_ENTRY_NOT_USED:
+      // Never actually stored in l1 (see ceph_assert in the L1 summary
+      // update code); nothing to do if we ever see it.
+      break;
+
+    case L1_ENTRY_PARTIAL: {
+      // The summary can't tell us where the free bits are, so scan the
+      // slotset's L0 words, restricted to the window.
       for (uint64_t t = 0; t < slots_per_slotset; ++t) {
-        const uint64_t word_base = (slot0 + t) * bits_per_slot;
-        const uint64_t lo = std::max(win_lo, word_base);
-        const uint64_t hi = std::min(win_hi, word_base + bits_per_slot);
+        auto [word_lo, word_hi] = slot_l0_range(l1_idx, t);
+        auto [lo, hi] = intersect(word_lo, word_hi, win_lo, win_hi);
         if (lo >= hi) {
           continue;                     // this L0 word is outside the window
         }
-        size_t p     = lo - word_base;  // first in-window bit of this word
-        size_t p_end = hi - word_base;  // one past the last in-window bit
-        const slot_t pattern = l0[slot0 + t];
+        size_t p     = lo - word_lo;    // first in-window bit of this word
+        size_t p_end = hi - word_lo;    // one past the last in-window bit
+        const slot_t pattern = l0[slotset_first_slot(l1_idx) + t];
 
         while (p < p_end) {
-          if (len == 0) {
-            // Skip allocated (0) bits, then open a run on the free (1) bits.
+          if (!run.is_open()){
+            // Skip allocated (0) bits, before opening a new run
             p += count_0s(pattern, p);
             if (p >= p_end) {
               break;
             }
-            size_t free_count =
-              std::min<size_t>(count_1s(pattern, p), p_end - p);
-            off = word_base + p;
-            len = free_count;
+          }
+
+          size_t free_count =
+            std::min<size_t>(count_1s(pattern, p), p_end - p);
+          if (free_count > 0) {
+            // Free bits, open or extend the run
+            run.extend(word_lo + p, free_count);
             p += free_count;
-          } else if (count_1s(pattern, p) == 0) {
-            // Allocated bit ends the open run.
-            if (close_run()) {
-              return resume;
-            }
-          } else {
-            size_t free_count =
-              std::min<size_t>(count_1s(pattern, p), p_end - p);
-            len += free_count;
-            p += free_count;
+          } else if (flush()) {
+            return resume;
           }
         }
       }
+      break;
+    }
     }
   }
 
   // Window fully enumerated; flush a still-open run.
-  if (len) {
-    notify(off, len);
-  }
+  flush();
   return l0_pos_end;
 }
 

--- a/src/os/bluestore/fastbmap_allocator_impl.cc
+++ b/src/os/bluestore/fastbmap_allocator_impl.cc
@@ -620,6 +620,108 @@ void AllocatorLevel01Loose::foreach_internal(
     notify(off, len);
 }
 
+uint64_t AllocatorLevel01Loose::get_free_extents_internal(
+    uint64_t l0_pos_start,
+    uint64_t l0_pos_end,
+    size_t max_count,
+    std::function<void(uint64_t offset, uint64_t length)> notify)
+{
+  const bool unbounded = (max_count == 0);
+  // Never scan past the physical bitmap.
+  const uint64_t scan_end =
+    std::min<uint64_t>(l0_pos_end, (uint64_t)l0.size() * bits_per_slot);
+  if (l0_pos_start >= scan_end) {
+    return l0_pos_end;
+  }
+
+  uint64_t off = 0;     // start of the open free run, in L0 units (bits)
+  uint64_t len = 0;     // length of the open free run; 0 == no run open
+  size_t   count = 0;   // extents emitted so far
+
+  // Emit the open run, remember where to resume, reset it. Returns true when
+  // the per-batch cap is reached and the walk must stop.
+  uint64_t resume = 0;
+  auto close_run = [&]() -> bool {
+    resume = off + len;
+    notify(off, len);
+    len = 0;
+    return !unbounded && (++count == max_count);
+  };
+
+  const uint64_t l1_idx_start = l0_pos_start / bits_per_slotset;
+  const uint64_t l1_idx_end =
+    (scan_end + bits_per_slotset - 1) / bits_per_slotset;   // ceil, exclusive
+
+  for (uint64_t l1_idx = l1_idx_start; l1_idx < l1_idx_end; ++l1_idx) {
+    const uint64_t ss_begin = l1_idx * bits_per_slotset;
+    const uint64_t win_lo = std::max(ss_begin, l0_pos_start);
+    const uint64_t win_hi = std::min(ss_begin + bits_per_slotset, scan_end);
+
+    // Decode this slotset's 2-bit L1 entry.
+    const size_t l1_word  = l1_idx / L1_ENTRIES_PER_SLOT;
+    const size_t l1_shift = (l1_idx % L1_ENTRIES_PER_SLOT) * L1_ENTRY_WIDTH;
+    const slot_t w = (l1[l1_word] >> l1_shift) & L1_ENTRY_MASK;
+
+    if (w == L1_ENTRY_FULL) {
+      // Whole slotset allocated: a run, if any, ends here.
+      if (len && close_run()) {
+        return resume;
+      }
+    } else if (w == L1_ENTRY_FREE) {
+      // Whole slotset free: start or extend the run over the window slice.
+      if (len == 0) {
+        off = win_lo;
+      }
+      len += win_hi - win_lo;
+    } else {
+      // L1_ENTRY_PARTIAL: scan the L0 bitmap, restricted to [win_lo, win_hi).
+      const uint64_t slot0 = l1_idx * slots_per_slotset;   // first L0 word
+      for (uint64_t t = 0; t < slots_per_slotset; ++t) {
+        const uint64_t word_base = (slot0 + t) * bits_per_slot;
+        const uint64_t lo = std::max(win_lo, word_base);
+        const uint64_t hi = std::min(win_hi, word_base + bits_per_slot);
+        if (lo >= hi) {
+          continue;                     // this L0 word is outside the window
+        }
+        size_t p     = lo - word_base;  // first in-window bit of this word
+        size_t p_end = hi - word_base;  // one past the last in-window bit
+        const slot_t pattern = l0[slot0 + t];
+
+        while (p < p_end) {
+          if (len == 0) {
+            // Skip allocated (0) bits, then open a run on the free (1) bits.
+            p += count_0s(pattern, p);
+            if (p >= p_end) {
+              break;
+            }
+            size_t free_count =
+              std::min<size_t>(count_1s(pattern, p), p_end - p);
+            off = word_base + p;
+            len = free_count;
+            p += free_count;
+          } else if (count_1s(pattern, p) == 0) {
+            // Allocated bit ends the open run.
+            if (close_run()) {
+              return resume;
+            }
+          } else {
+            size_t free_count =
+              std::min<size_t>(count_1s(pattern, p), p_end - p);
+            len += free_count;
+            p += free_count;
+          }
+        }
+      }
+    }
+  }
+
+  // Window fully enumerated; flush a still-open run.
+  if (len) {
+    notify(off, len);
+  }
+  return l0_pos_end;
+}
+
 uint64_t AllocatorLevel01Loose::_claim_free_to_left_l0(int64_t l0_pos_start)
 {
   int64_t d0 = L0_ENTRIES_PER_SLOT;

--- a/src/os/bluestore/fastbmap_allocator_impl.cc
+++ b/src/os/bluestore/fastbmap_allocator_impl.cc
@@ -634,91 +634,89 @@ uint64_t AllocatorLevel01Loose::get_free_extents_internal(
     return l0_pos_end;
   }
 
-  uint64_t off = 0;     // start of the open free run, in L0 units (bits)
-  uint64_t len = 0;     // length of the open free run; 0 == no run open
-  size_t   count = 0;   // extents emitted so far
-
-  // Emit the open run, remember where to resume, reset it. Returns true when
-  // the per-batch cap is reached and the walk must stop.
+  FreeRun  run;
+  size_t   count  = 0;   // extents emitted so far
   uint64_t resume = 0;
-  auto close_run = [&]() -> bool {
+
+  // Close the open run (if any), emit it, and check the per-batch cap.
+  // Returns true when the walk must stop now.
+  auto maybe_flush = [&]() -> bool {
+    if (!run.is_open()) {
+      return false;
+    }
+    auto [off, len] = run.close();
     resume = off + len;
     notify(off, len);
-    len = 0;
     return !unbounded && (++count == max_count);
   };
 
-  const uint64_t l1_idx_start = l0_pos_start / bits_per_slotset;
-  const uint64_t l1_idx_end =
-    (scan_end + bits_per_slotset - 1) / bits_per_slotset;   // ceil, exclusive
+  const uint64_t l1_idx_start = l0_bit_to_l1_idx(l0_pos_start);
+  const uint64_t l1_idx_end =  // ceil, exclusive
+    l0_bit_to_l1_idx(p2roundup(scan_end, uint64_t(bits_per_slotset)));
 
   for (uint64_t l1_idx = l1_idx_start; l1_idx < l1_idx_end; ++l1_idx) {
-    const uint64_t ss_begin = l1_idx * bits_per_slotset;
-    const uint64_t win_lo = std::max(ss_begin, l0_pos_start);
-    const uint64_t win_hi = std::min(ss_begin + bits_per_slotset, scan_end);
+    auto [ss_lo, ss_hi] = slotset_l0_range(l1_idx);
+    auto [win_lo, win_hi] = intersect(ss_lo, ss_hi, l0_pos_start, scan_end);
 
-    // Decode this slotset's 2-bit L1 entry.
-    const size_t l1_word  = l1_idx / L1_ENTRIES_PER_SLOT;
-    const size_t l1_shift = (l1_idx % L1_ENTRIES_PER_SLOT) * L1_ENTRY_WIDTH;
-    const slot_t w = (l1[l1_word] >> l1_shift) & L1_ENTRY_MASK;
+    switch (l1_entry_at(l1_idx)) {
 
-    if (w == L1_ENTRY_FULL) {
+    case L1_ENTRY_FULL:
       // Whole slotset allocated: a run, if any, ends here.
-      if (len && close_run()) {
+      if (maybe_flush()) {
         return resume;
       }
-    } else if (w == L1_ENTRY_FREE) {
+      break;
+
+    case L1_ENTRY_FREE:
       // Whole slotset free: start or extend the run over the window slice.
-      if (len == 0) {
-        off = win_lo;
-      }
-      len += win_hi - win_lo;
-    } else {
-      // L1_ENTRY_PARTIAL: scan the L0 bitmap, restricted to [win_lo, win_hi).
-      const uint64_t slot0 = l1_idx * slots_per_slotset;   // first L0 word
+      run.extend(win_lo, win_hi - win_lo);
+      break;
+
+    case L1_ENTRY_NOT_USED:
+      // Never actually stored in l1 (see ceph_assert in the L1 summary
+      // update code); nothing to do if we ever see it.
+      break;
+
+    case L1_ENTRY_PARTIAL: {
+      // The summary can't tell us where the free bits are, so scan the
+      // slotset's L0 words, restricted to the window.
       for (uint64_t t = 0; t < slots_per_slotset; ++t) {
-        const uint64_t word_base = (slot0 + t) * bits_per_slot;
-        const uint64_t lo = std::max(win_lo, word_base);
-        const uint64_t hi = std::min(win_hi, word_base + bits_per_slot);
+        auto [word_lo, word_hi] = slot_l0_range(l1_idx, t);
+        auto [lo, hi] = intersect(word_lo, word_hi, win_lo, win_hi);
         if (lo >= hi) {
           continue;                     // this L0 word is outside the window
         }
-        size_t p     = lo - word_base;  // first in-window bit of this word
-        size_t p_end = hi - word_base;  // one past the last in-window bit
-        const slot_t pattern = l0[slot0 + t];
+        size_t p     = lo - word_lo;    // first in-window bit of this word
+        size_t p_end = hi - word_lo;    // one past the last in-window bit
+        const slot_t pattern = l0[slotset_first_slot(l1_idx) + t];
 
         while (p < p_end) {
-          if (len == 0) {
-            // Skip allocated (0) bits, then open a run on the free (1) bits.
+          if (!run.is_open()){
+            // Skip allocated (0) bits, before opening a new run
             p += count_0s(pattern, p);
             if (p >= p_end) {
               break;
             }
-            size_t free_count =
-              std::min<size_t>(count_1s(pattern, p), p_end - p);
-            off = word_base + p;
-            len = free_count;
+          }
+
+          size_t free_count =
+            std::min<size_t>(count_1s(pattern, p), p_end - p);
+          if (free_count > 0) {
+            // Free bits, open or extend the run
+            run.extend(word_lo + p, free_count);
             p += free_count;
-          } else if (count_1s(pattern, p) == 0) {
-            // Allocated bit ends the open run.
-            if (close_run()) {
-              return resume;
-            }
-          } else {
-            size_t free_count =
-              std::min<size_t>(count_1s(pattern, p), p_end - p);
-            len += free_count;
-            p += free_count;
+          } else if (maybe_flush()) {
+            return resume;
           }
         }
       }
+      break;
+    }
     }
   }
 
   // Window fully enumerated; flush a still-open run.
-  if (len) {
-    notify(off, len);
-  }
+  maybe_flush();
   return l0_pos_end;
 }
 

--- a/src/os/bluestore/fastbmap_allocator_impl.h
+++ b/src/os/bluestore/fastbmap_allocator_impl.h
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <mutex>
 #include <string_view>
+#include <utility>
 
 typedef uint64_t slot_t;
 
@@ -72,6 +73,76 @@ inline size_t find_next_set_bit(slot_t slot_val, size_t start_pos)
   return start_pos;
 }
 
+// -----------------------------------------------------------------------
+// L0 bit-range primitives, shared by the free-extent walk (see
+// AllocatorLevel01Loose::get_free_extents_internal) and by any level of
+// the allocator doing the same "index -> range of children" arithmetic
+// (e.g. AllocatorLevel02's L2 -> L1 indexing).
+// -----------------------------------------------------------------------
+
+// Intersection of [lo, hi) with [bound_lo, bound_hi).
+inline std::pair<uint64_t, uint64_t> intersect(
+  uint64_t lo, uint64_t hi, uint64_t bound_lo, uint64_t bound_hi)
+{
+  return { std::max(lo, bound_lo), std::min(hi, bound_hi) };
+}
+
+// L0 bit position where L0 word (slot) 'word_idx' begins.
+inline uint64_t l0_word_start(uint64_t word_idx)
+{
+  return word_idx * bits_per_slot;
+}
+
+// [start, end) of L0 bits covered by slotset 'l1_idx'.
+inline std::pair<uint64_t, uint64_t> slotset_l0_range(uint64_t l1_idx)
+{
+  uint64_t start = l1_idx * bits_per_slotset;
+  return { start, start + bits_per_slotset };
+}
+
+// L1 slotset index containing L0 bit position 'pos'. Inverse of
+// slotset_l0_range()'s start.
+inline uint64_t l0_bit_to_l1_idx(uint64_t pos)
+{
+  return pos / bits_per_slotset;
+}
+
+// Index of the first L0 word (slot) belonging to slotset 'l1_idx'.
+inline uint64_t slotset_first_slot(uint64_t l1_idx)
+{
+  return l1_idx * slots_per_slotset;
+}
+
+// [start, end) of L0 bits covered by word 'slot_num' within slotset 'l1_idx'.
+inline std::pair<uint64_t, uint64_t> slot_l0_range(
+  uint64_t l1_idx, uint64_t slot_num)
+{
+  uint64_t start = l0_word_start(slotset_first_slot(l1_idx) + slot_num);
+  return { start, start + bits_per_slot };
+}
+
+// Tracks a free run being accumulated while walking a bitmap. extend()
+// covers both "open" (run was empty) and "extend" (run was already open) --
+// callers never need to open without possibly extending.
+struct FreeRun {
+  uint64_t off = 0;
+  uint64_t len = 0;
+
+  bool is_open() const { return len > 0; }
+
+  void extend(uint64_t pos, uint64_t add_len) {
+    if (!is_open()) {
+      off = pos;
+    }
+    len += add_len;
+  }
+
+  std::pair<uint64_t, uint64_t> close() {
+    std::pair<uint64_t, uint64_t> run{off, len};
+    len = 0;
+    return run;
+  }
+};
 
 class AllocatorLevel
 {
@@ -549,6 +620,22 @@ public:
 
   static inline ssize_t count_0s(slot_t slot_val, size_t start_pos);
   static inline ssize_t count_1s(slot_t slot_val, size_t start_pos);
+
+  // Which l1[] word holds the packed 2-bit entry for slotset 'l1_idx', and
+  // its bit shift within that word.
+  static inline std::pair<size_t, size_t> l1_split(uint64_t l1_idx)
+  {
+    return { l1_idx / L1_ENTRIES_PER_SLOT,
+             (l1_idx % L1_ENTRIES_PER_SLOT) * L1_ENTRY_WIDTH };
+  }
+
+  // Decoded L1 summary for slotset 'l1_idx': one of L1_ENTRY_FULL /
+  // L1_ENTRY_PARTIAL / L1_ENTRY_NOT_USED / L1_ENTRY_FREE.
+  inline slot_t l1_entry_at(uint64_t l1_idx) const
+  {
+    auto [word, shift] = l1_split(l1_idx);
+    return (l1[word] >> shift) & L1_ENTRY_MASK;
+  }
   void foreach_internal(std::function<void(uint64_t offset, uint64_t length)> notify);
 
   // Range- and count-bounded counterpart to foreach_internal(). Enumerates free

--- a/src/os/bluestore/fastbmap_allocator_impl.h
+++ b/src/os/bluestore/fastbmap_allocator_impl.h
@@ -550,6 +550,18 @@ public:
   static inline ssize_t count_0s(slot_t slot_val, size_t start_pos);
   static inline ssize_t count_1s(slot_t slot_val, size_t start_pos);
   void foreach_internal(std::function<void(uint64_t offset, uint64_t length)> notify);
+
+  // Range- and count-bounded counterpart to foreach_internal(). Enumerates free
+  // extents whose offsets (in L0 units, one bit per min_alloc_size) intersect
+  // [l0_pos_start, l0_pos_end), emitting at most max_count of them (0 ==
+  // unbounded). Each run is clipped to the window. Returns an L0 resume cursor:
+  // >= l0_pos_end once the window is exhausted, otherwise the first unit past
+  // the last emitted run (which may land in allocated space).
+  uint64_t get_free_extents_internal(
+    uint64_t l0_pos_start,
+    uint64_t l0_pos_end,
+    size_t max_count,
+    std::function<void(uint64_t offset, uint64_t length)> notify);
 };
 
 
@@ -639,6 +651,36 @@ public:
     std::lock_guard l(lock);
     l1.foreach_internal(multiply_by_alloc_size);
   }
+
+  uint64_t get_free_extents_internal(
+    uint64_t range_begin,
+    uint64_t range_end,
+    size_t max_count,
+    std::function<void(uint64_t offset, uint64_t length)> notify)
+  {
+    ceph_assert(range_begin <= range_end);
+    if (range_begin == range_end) {
+      return range_end;
+    }
+    const uint64_t alloc_size = get_min_alloc_size();
+    // Window expressed in L0 units (one bit per min_alloc_size).
+    const uint64_t l0_pos_start = range_begin / alloc_size;
+    const uint64_t l0_pos_end   = p2roundup(range_end, alloc_size) / alloc_size;
+
+    // Scale unit runs back to bytes, clipped to the exact byte window
+    // (free extents are alloc-unit aligned, so only the boundary units clip).
+    auto emit = [&](uint64_t off, uint64_t len) {
+      uint64_t lo = std::max(off * alloc_size, range_begin);
+      uint64_t hi = std::min((off + len) * alloc_size, range_end);
+      notify(lo, hi - lo);
+    };
+
+    std::lock_guard l(lock);
+    uint64_t cursor =
+      l1.get_free_extents_internal(l0_pos_start, l0_pos_end, max_count, emit);
+    return cursor >= l0_pos_end ? range_end : cursor * alloc_size;
+  }
+
   double get_fragmentation_internal() {
     std::lock_guard l(lock);
     return l1.get_fragmentation();

--- a/src/test/objectstore/Allocator_test.cc
+++ b/src/test/objectstore/Allocator_test.cc
@@ -795,6 +795,338 @@ TEST_P(AllocTest, test_alloc_spatial_locality)
 }
 
 
+// ====================================================================
+// get_free_extents tests
+// ====================================================================
+
+TEST_P(AllocTest, test_get_free_extents_empty)
+{
+  int64_t block_size = 4096;
+  int64_t capacity = 16 * block_size;
+  init_alloc(capacity, block_size);
+
+  free_extent_vector_t out;
+  uint64_t cursor = alloc->get_free_extents(0, capacity, 0, &out);
+  EXPECT_GE(cursor, (uint64_t)capacity);
+  EXPECT_TRUE(out.empty());
+  alloc->shutdown();
+}
+
+TEST_P(AllocTest, test_get_free_extents_fully_free)
+{
+  int64_t block_size = 4096;
+  int64_t capacity = 16 * block_size;
+  init_alloc(capacity, block_size);
+  alloc->init_add_free(0, capacity);
+
+  free_extent_vector_t out;
+  uint64_t cursor = alloc->get_free_extents(0, capacity, 0, &out);
+  EXPECT_GE(cursor, (uint64_t)capacity);
+  uint64_t total = 0;
+  for (auto& e : out) {
+    total += e.length;
+  }
+  EXPECT_EQ((uint64_t)capacity, total);
+  alloc->shutdown();
+}
+
+// A free extent straddling range_end must be clipped to the range boundary.
+TEST_P(AllocTest, test_get_free_extents_clipping_range_end)
+{
+  int64_t block_size = 4096;
+  int64_t capacity = 8 * block_size;
+  init_alloc(capacity, block_size);
+  // free [4*block, 6*block), query only [0, 5*block)
+  alloc->init_add_free(4 * block_size, 2 * block_size);
+
+  uint64_t range_end = 5 * block_size;
+  free_extent_vector_t out;
+  uint64_t cursor = alloc->get_free_extents(0, range_end, 0, &out);
+  EXPECT_GE(cursor, range_end);
+  for (auto& e : out) {
+    EXPECT_LE(e.offset + e.length, range_end);
+  }
+  uint64_t total = 0;
+  for (auto& e : out) total += e.length;
+  EXPECT_EQ((uint64_t)block_size, total);
+  alloc->shutdown();
+}
+
+// A free extent entirely outside the query range must not be returned.
+TEST_P(AllocTest, test_get_free_extents_outside_range)
+{
+  int64_t block_size = 4096;
+  int64_t capacity = 8 * block_size;
+  init_alloc(capacity, block_size);
+  alloc->init_add_free(6 * block_size, block_size);
+
+  uint64_t range_end = 4 * block_size;
+  free_extent_vector_t out;
+  uint64_t cursor = alloc->get_free_extents(0, range_end, 0, &out);
+  EXPECT_GE(cursor, range_end);
+  EXPECT_TRUE(out.empty());
+  alloc->shutdown();
+}
+
+// range_begin == range_end must return immediately with no extents emitted.
+TEST_P(AllocTest, test_get_free_extents_empty_range)
+{
+  int64_t block_size = 4096;
+  int64_t capacity = 8 * block_size;
+  init_alloc(capacity, block_size);
+  alloc->init_add_free(0, capacity);
+
+  free_extent_vector_t out;
+  uint64_t point = 4 * block_size;
+  uint64_t cursor = alloc->get_free_extents(point, point, 0, &out);
+  EXPECT_EQ(point, cursor);
+  EXPECT_TRUE(out.empty());
+  alloc->shutdown();
+}
+
+// get_free_extents must append to out, not clear it — a pre-existing sentinel
+// must survive at index 0.
+TEST_P(AllocTest, test_get_free_extents_appends_to_out)
+{
+  int64_t block_size = 4096;
+  int64_t capacity = 8 * block_size;
+  init_alloc(capacity, block_size);
+  alloc->init_add_free(0, block_size);
+
+  free_extent_vector_t out;
+  out.emplace_back(999u, 1u); // sentinel
+  alloc->get_free_extents(0, capacity, 0, &out);
+  ASSERT_EQ(out.size(), 2u);
+  EXPECT_EQ(999u, out[0].offset);
+  EXPECT_EQ(1u, out[0].length);
+  EXPECT_EQ(0u, out[1].offset);
+  EXPECT_EQ(4096u, out[1].length);
+  alloc->shutdown();
+}
+
+// Returned extents must be in strictly ascending offset order.
+TEST_P(AllocTest, test_get_free_extents_ascending_order)
+{
+  int64_t block_size = 4096;
+  int64_t capacity = 16 * block_size;
+  init_alloc(capacity, block_size);
+  alloc->init_add_free(0 * block_size, block_size);
+  alloc->init_add_free(4 * block_size, block_size);
+  alloc->init_add_free(8 * block_size, block_size);
+  alloc->init_add_free(12 * block_size, block_size);
+
+  free_extent_vector_t out;
+  alloc->get_free_extents(0, capacity, 0, &out);
+  ASSERT_EQ(out.size(), 4u);
+  for (size_t i = 1; i < out.size(); ++i) {
+    EXPECT_LT(out[i-1].offset, out[i].offset);
+  }
+  alloc->shutdown();
+}
+
+// max_count limits extents per call; the returned cursor is a valid resume
+// point so driving it in a loop with max_count=2 covers all 4 extents.
+TEST_P(AllocTest, test_get_free_extents_max_count_batching)
+{
+  int64_t block_size = 4096;
+  int64_t capacity = 8 * block_size;
+  init_alloc(capacity, block_size);
+  alloc->init_add_free(0 * block_size, block_size);
+  alloc->init_add_free(2 * block_size, block_size);
+  alloc->init_add_free(4 * block_size, block_size);
+  alloc->init_add_free(6 * block_size, block_size);
+
+  free_extent_vector_t out;
+
+  // First batch must respect max_count and must not exhaust all extents.
+  uint64_t cursor = alloc->get_free_extents(0, capacity, 2, &out);
+  EXPECT_EQ(2u, out.size());
+  EXPECT_LT(cursor, (uint64_t)capacity);
+
+  // Resume from cursor until done; each batch must respect max_count.
+  int calls = 0;
+  while (cursor < (uint64_t)capacity) {
+    size_t before = out.size();
+    cursor = alloc->get_free_extents(cursor, capacity, 2, &out);
+    EXPECT_LE(out.size(), before + 2);
+    if (out.size() == before) break;  // no new extents: enumeration complete
+    ASSERT_LE(++calls, 10) << "cursor walk did not terminate";
+  }
+  EXPECT_EQ(4u, out.size());
+
+  // All four offsets must be distinct (no duplicates across batches).
+  for (size_t i = 1; i < out.size(); ++i) {
+    EXPECT_NE(out[i-1].offset, out[i].offset);
+  }
+  alloc->shutdown();
+}
+
+// Driving get_free_extents in a cursor loop must cover every free byte exactly
+// once.
+TEST_P(AllocTest, test_get_free_extents_cursor_walk)
+{
+  int64_t block_size = 4096;
+  int64_t capacity = 200 * block_size;
+  init_alloc(capacity, block_size);
+  for (int i = 0; i < 100; ++i) {
+    alloc->init_add_free(2 * i * block_size, block_size);
+  }
+  uint64_t expected_free = alloc->get_free();
+
+  free_extent_vector_t out;
+  uint64_t cursor = 0;
+  while (cursor < (uint64_t)capacity) {
+    cursor = alloc->get_free_extents(cursor, capacity, 32, &out);
+  }
+  uint64_t total = 0;
+  for (auto& e : out) total += e.length;
+  EXPECT_EQ(expected_free, total);
+  alloc->shutdown();
+}
+
+// max_count=1 walks one extent per call; the walk terminates and yields all
+// extents with no skips.
+TEST_P(AllocTest, test_get_free_extents_max_count_one)
+{
+  int64_t block_size = 4096;
+  int64_t capacity = 8 * block_size;
+  init_alloc(capacity, block_size);
+  alloc->init_add_free(0 * block_size, block_size);
+  alloc->init_add_free(2 * block_size, block_size);
+  alloc->init_add_free(4 * block_size, block_size);
+  alloc->init_add_free(6 * block_size, block_size);
+
+  free_extent_vector_t out;
+  uint64_t cursor = 0;
+  int iterations = 0;
+  while (cursor < (uint64_t)capacity) {
+    size_t prev = out.size();
+    cursor = alloc->get_free_extents(cursor, capacity, 1, &out);
+    EXPECT_LE(out.size(), prev + 1);
+    ASSERT_LE(++iterations, 1000) << "cursor walk did not terminate";
+  }
+  EXPECT_EQ(4u, out.size());
+  alloc->shutdown();
+}
+
+// ====================================================================
+// foreach_interruptible tests
+// ====================================================================
+
+TEST_P(AllocTest, test_foreach_interruptible_empty)
+{
+  int64_t block_size = 4096;
+  int64_t capacity = 16 * block_size;
+  init_alloc(capacity, block_size);
+
+  int calls = 0;
+  alloc->foreach_interruptible([&](uint64_t, uint64_t) { ++calls; });
+  EXPECT_EQ(0, calls);
+  alloc->shutdown();
+}
+
+TEST_P(AllocTest, test_foreach_interruptible_fully_free)
+{
+  int64_t block_size = 4096;
+  int64_t capacity = 16 * block_size;
+  init_alloc(capacity, block_size);
+  alloc->init_add_free(0, capacity);
+
+  uint64_t total = 0;
+  alloc->foreach_interruptible([&](uint64_t, uint64_t len) { total += len; });
+  EXPECT_EQ(alloc->get_free(), total);
+  alloc->shutdown();
+}
+
+// 50 disjoint free extents: foreach_interruptible must report the correct total.
+TEST_P(AllocTest, test_foreach_interruptible_disjoint_extents)
+{
+  int64_t block_size = 4096;
+  int64_t capacity = 100 * block_size;
+  init_alloc(capacity, block_size);
+  for (int i = 0; i < 50; ++i) {
+    alloc->init_add_free(2 * i * block_size, block_size);
+  }
+  uint64_t expected_free = alloc->get_free();
+
+  uint64_t total = 0;
+  alloc->foreach_interruptible([&](uint64_t, uint64_t len) { total += len; });
+  EXPECT_EQ(expected_free, total);
+  alloc->shutdown();
+}
+
+// With no concurrent mutation, foreach_interruptible and foreach must visit the
+// exact same (offset, length) pairs in the same order.
+TEST_P(AllocTest, test_foreach_interruptible_matches_foreach)
+{
+  int64_t block_size = 4096;
+  int64_t capacity = 100 * block_size;
+  init_alloc(capacity, block_size);
+  for (int i = 0; i < 50; ++i) {
+    alloc->init_add_free(2 * i * block_size, block_size);
+  }
+
+  std::vector<std::pair<uint64_t, uint64_t>> fe_extents, fi_extents;
+  alloc->foreach([&](uint64_t off, uint64_t len) {
+    fe_extents.emplace_back(off, len);
+  });
+  alloc->foreach_interruptible([&](uint64_t off, uint64_t len) {
+    fi_extents.emplace_back(off, len);
+  });
+  EXPECT_EQ(fe_extents, fi_extents);
+  alloc->shutdown();
+}
+
+// 1500 disjoint free extents forces foreach_interruptible to issue multiple
+// get_free_extents batches (internal batch_size is 1024).
+TEST_P(AllocTest, test_foreach_interruptible_many_extents)
+{
+  int64_t block_size = 4096;
+  int64_t capacity = 3000 * block_size;
+  init_alloc(capacity, block_size);
+  for (int i = 0; i < 1500; ++i) {
+    alloc->init_add_free(2 * i * block_size, block_size);
+  }
+  uint64_t expected_free = alloc->get_free();
+
+  uint64_t total = 0;
+  int calls = 0;
+  alloc->foreach_interruptible([&](uint64_t, uint64_t len) {
+    total += len;
+    ++calls;
+  });
+  EXPECT_EQ(expected_free, total);
+  EXPECT_EQ(1500, calls);
+  alloc->shutdown();
+}
+
+// foreach_interruptible must correctly visit a single free block located at the
+// start, middle, and end of the device.
+TEST_P(AllocTest, test_foreach_interruptible_single_block_positions)
+{
+  int64_t block_size = 4096;
+  int64_t capacity = 16 * block_size;
+
+  auto run = [&](uint64_t free_offset) {
+    init_alloc(capacity, block_size);
+    alloc->init_add_free(free_offset, block_size);
+
+    struct Seen { uint64_t offset; uint64_t length; };
+    std::vector<Seen> seen;
+    alloc->foreach_interruptible([&](uint64_t off, uint64_t len) {
+      seen.push_back({off, len});
+    });
+    ASSERT_EQ(1u, seen.size());
+    EXPECT_EQ(free_offset, seen[0].offset);
+    EXPECT_EQ((uint64_t)block_size, seen[0].length);
+    alloc->shutdown();
+  };
+
+  run(0);                    // start of device
+  run(8 * block_size);       // middle of device
+  run(15 * block_size);      // last block
+}
+
 INSTANTIATE_TEST_SUITE_P(
   Allocator,
   AllocTest,

--- a/src/test/objectstore/Allocator_test.cc
+++ b/src/test/objectstore/Allocator_test.cc
@@ -1243,6 +1243,84 @@ TEST_P(AllocTest, test_get_free_extents_fragmented_after_alloc_release)
   alloc->shutdown();
 }
 
+// ====================================================================
+// Nasty / adversarial cases
+// ====================================================================
+
+// A free extent that starts BEFORE range_begin must be clipped on its left
+// edge so the returned extent begins at range_begin, not at the extent's
+// actual start.  This is the symmetric counterpart of clipping_range_end.
+TEST_P(AllocTest, test_get_free_extents_clipping_range_begin)
+{
+  int64_t block_size = 4096;
+  int64_t capacity = 8 * block_size;
+  init_alloc(capacity, block_size);
+  // free [0, 6*block), query only [4*block, capacity)
+  alloc->init_add_free(0, 6 * block_size);
+
+  uint64_t range_begin = 4 * block_size;
+  free_extent_vector_t out;
+  uint64_t cursor = alloc->get_free_extents(range_begin, capacity, 0, &out);
+  EXPECT_GE(cursor, (uint64_t)capacity);
+  ASSERT_EQ(1u, out.size());
+  EXPECT_EQ((uint64_t)range_begin, out[0].offset);
+  EXPECT_EQ((uint64_t)(2 * block_size), out[0].length);
+  alloc->shutdown();
+}
+
+// 5000 alternating free/allocated single blocks — maximum fragmentation at
+// scale.  Stresses cursor arithmetic, tree-walk depth, and termination.
+TEST_P(AllocTest, test_get_free_extents_massive_fragmentation)
+{
+  int64_t block_size = 4096;
+  const int n_extents = 5000;
+  int64_t capacity = 2 * n_extents * block_size;
+  init_alloc(capacity, block_size);
+  for (int i = 0; i < n_extents; ++i) {
+    alloc->init_add_free(2 * i * block_size, block_size);
+  }
+  uint64_t expected_free = alloc->get_free();
+
+  free_extent_vector_t out;
+  uint64_t cursor = 0;
+  int batches = 0;
+  while (cursor < (uint64_t)capacity) {
+    cursor = alloc->get_free_extents(cursor, capacity, 256, &out);
+    ASSERT_LE(++batches, n_extents) << "cursor walk did not terminate";
+  }
+
+  ASSERT_EQ((size_t)n_extents, out.size());
+  uint64_t total = 0;
+  for (size_t i = 0; i < out.size(); ++i) {
+    total += out[i].length;
+    if (i > 0) {
+      EXPECT_LT(out[i-1].offset, out[i].offset)
+        << "offsets not strictly ascending at index " << i;
+    }
+  }
+  EXPECT_EQ(expected_free, total);
+  alloc->shutdown();
+}
+
+// Almost-full device: free space exists only at the very last block.  The
+// cursor must skip the entire allocated region to find it.
+TEST_P(AllocTest, test_get_free_extents_needle_at_end)
+{
+  int64_t block_size = 4096;
+  int64_t capacity = 10000 * block_size;
+  init_alloc(capacity, block_size);
+  uint64_t free_offset = (uint64_t)(capacity - block_size);
+  alloc->init_add_free(free_offset, block_size);
+
+  free_extent_vector_t out;
+  uint64_t cursor = alloc->get_free_extents(0, capacity, 0, &out);
+  EXPECT_GE(cursor, (uint64_t)capacity);
+  ASSERT_EQ(1u, out.size());
+  EXPECT_EQ(free_offset, out[0].offset);
+  EXPECT_EQ((uint64_t)block_size, out[0].length);
+  alloc->shutdown();
+}
+
 INSTANTIATE_TEST_SUITE_P(
   Allocator,
   AllocTest,

--- a/src/test/objectstore/Allocator_test.cc
+++ b/src/test/objectstore/Allocator_test.cc
@@ -1127,6 +1127,122 @@ TEST_P(AllocTest, test_foreach_interruptible_single_block_positions)
   run(15 * block_size);      // last block
 }
 
+// ====================================================================
+// get_free_extents / foreach_interruptible × allocate() / release()
+// ====================================================================
+
+// After allocating space from a full device, get_free_extents must report
+// exactly the remaining free bytes and must not include any allocated region.
+TEST_P(AllocTest, test_get_free_extents_after_allocate)
+{
+  int64_t block_size = 4096;
+  int64_t capacity = 32 * block_size;
+  init_alloc(capacity, block_size);
+  alloc->init_add_free(0, capacity);
+
+  PExtentVector allocated;
+  ASSERT_GT(alloc->allocate(8 * block_size, block_size, 0, (int64_t)-1, &allocated), 0);
+
+  interval_set<uint64_t> alloc_set;
+  for (auto& e : allocated) {
+    alloc_set.insert(e.offset, e.length);
+  }
+
+  free_extent_vector_t out;
+  alloc->get_free_extents(0, capacity, 0, &out);
+
+  uint64_t total = 0;
+  for (auto& e : out) {
+    total += e.length;
+    EXPECT_FALSE(alloc_set.intersects(e.offset, e.length))
+      << "free extent [" << e.offset << ", +" << e.length
+      << ") overlaps an allocated region";
+  }
+  EXPECT_EQ(alloc->get_free(), total);
+  alloc->shutdown();
+}
+
+// After releasing previously allocated extents, get_free_extents must see
+// the released space and return the full device capacity as free.
+TEST_P(AllocTest, test_get_free_extents_after_release)
+{
+  int64_t block_size = 4096;
+  int64_t capacity = 32 * block_size;
+  init_alloc(capacity, block_size);
+  alloc->init_add_free(0, capacity);
+
+  PExtentVector allocated;
+  ASSERT_GT(alloc->allocate(8 * block_size, block_size, 0, (int64_t)-1, &allocated), 0);
+
+  interval_set<uint64_t> release_set;
+  for (auto& e : allocated) {
+    release_set.insert(e.offset, e.length);
+  }
+  alloc->release(release_set);
+  ASSERT_EQ((uint64_t)capacity, alloc->get_free());
+
+  free_extent_vector_t out;
+  alloc->get_free_extents(0, capacity, 0, &out);
+
+  uint64_t total = 0;
+  for (auto& e : out) total += e.length;
+  EXPECT_EQ((uint64_t)capacity, total);
+
+  // every released byte must be covered by some returned free extent
+  interval_set<uint64_t> free_set;
+  for (auto& e : out) free_set.insert(e.offset, e.length);
+  for (auto [start, len] : release_set) {
+    EXPECT_TRUE(free_set.contains(start, len))
+      << "released region [" << start << ", +" << len
+      << ") not found in free extents";
+  }
+  alloc->shutdown();
+}
+
+// Allocate all blocks one at a time, release every other allocation.
+// get_free_extents must account for exactly the released bytes and each
+// returned extent must lie entirely within the released set.
+TEST_P(AllocTest, test_get_free_extents_fragmented_after_alloc_release)
+{
+  int64_t block_size = 4096;
+  int n_blocks = 32;
+  int64_t capacity = n_blocks * block_size;
+  init_alloc(capacity, block_size);
+  alloc->init_add_free(0, capacity);
+
+  std::vector<PExtentVector> per_block(n_blocks);
+  for (int i = 0; i < n_blocks; ++i) {
+    int64_t got = alloc->allocate(block_size, block_size, 0, (int64_t)-1, &per_block[i]);
+    ASSERT_EQ(block_size, got) << "failed to allocate block " << i;
+  }
+  ASSERT_EQ(0u, alloc->get_free());
+
+  interval_set<uint64_t> released;
+  for (int i = 0; i < n_blocks; i += 2) {
+    interval_set<uint64_t> rs;
+    for (auto& e : per_block[i]) {
+      rs.insert(e.offset, e.length);
+      released.insert(e.offset, e.length);
+    }
+    alloc->release(rs);
+  }
+  uint64_t expected_free = (uint64_t)(n_blocks / 2) * block_size;
+  ASSERT_EQ(expected_free, alloc->get_free());
+
+  free_extent_vector_t out;
+  alloc->get_free_extents(0, capacity, 0, &out);
+
+  uint64_t total = 0;
+  for (auto& e : out) {
+    total += e.length;
+    EXPECT_TRUE(released.contains(e.offset, e.length))
+      << "free extent [" << e.offset << ", +" << e.length
+      << ") is not fully within the released set";
+  }
+  EXPECT_EQ(expected_free, total);
+  alloc->shutdown();
+}
+
 INSTANTIATE_TEST_SUITE_P(
   Allocator,
   AllocTest,


### PR DESCRIPTION
Tracker: https://tracker.ceph.com/issues/76420

`Allocator::foreach()` holds the allocator lock for the entire walk over all free extents. On a fragmented OSD this can block for several seconds. `BlueStore::MempoolThread::entry()` calls `Allocator::get_fragmentation_score()`, which internally calls `foreach()` every hour, causing a visible write-latency spike where all OSD writes appear stalled.

This PR introduces two new primitives to break the full-walk lock hold into bounded batches.

1. `get_free_extents(range_begin, range_end, max_count, out) → cursor`, A ranged, batched enumeration primitive added to the `Allocator` interface as a pure-virtual function. Each call:
   - Takes the allocator lock only for the duration of a single batch (up to `max_count` extents).
   - Returns a resume cursor; callers loop until `cursor >= range_end`.
   - Appends results to `*out` in ascending offset order, clipped to `[range_begin, range_end)`.
   - Important points:
       - Each batch observes the allocator state independently. The union of all batches is an approximation, off by at most the extents concurrently allocated or released during enumeration
       - This is acceptable for fragmentation scoring, defrag planning, and emergency discard, but **not** for allocation decisions.
       - Use `foreach()` when an exact, consistent snapshot is required.
       - The contract and all caveats are documented on the declaration in `Allocator.h`.
2. `foreach_interruptible(notify)`
   - A non-virtual convenience wrapper on `Allocator` that drives `get_free_extents()` in 1024-extent batches over `[0, device_size)`. This is the lock-releasing replacement for `foreach()` for best-effort consumers.

## Implementation Status

`get_free_extents` is implemented for:

- `AVLAllocator`
- `BTreeAllocator`
- `BitMapAllocator`
- `StupidAllocator`
- `HybridAllocator`
- `Btree2Allocator`

## TODO (In follow-up PR)
`foreach_interruptible` is **not yet wired** into `MempoolThread` / `get_fragmentation_score()`. That wiring will be done in a follow-up once all allocators are covered or a fallback to `foreach()` for unsupported allocators is in place.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
