### PR TITLE
mgr/dashboard: Combining Quorum tables data on Monitors page

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/monitors.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/monitors.e2e-spec.ts
@@ -16,13 +16,10 @@ describe('Monitors page', () => {
 
   describe('fields check', () => {
     it('should check status table is present', () => {
-      // check for table header 'Status'
-      monitors.getLegends().its(0).should('have.text', 'Status');
-
-      // check for fields in table
       monitors
-        .getStatusTables()
-        .should('contain.text', 'Cluster ID')
+        .getStatusTable()
+        .should('be.visible')
+        .and('contain.text', 'Cluster ID')
         .and('contain.text', 'monmap modified')
         .and('contain.text', 'monmap epoch')
         .and('contain.text', 'quorum con')
@@ -31,30 +28,21 @@ describe('Monitors page', () => {
         .and('contain.text', 'required mon');
     });
 
-    it('should check In Quorum and Not In Quorum tables are present', () => {
-      // check for there to be two tables
-      monitors.getDataTables().should('have.length', 2);
+    it('should check monitors table is present', () => {
+      monitors.getMonitorTable().should('be.visible');
+      monitors.getDataTables().should('have.length', 1);
 
-      // check for table header 'In Quorum'
-      monitors.getLegends().its(1).should('have.text', 'In Quorum');
+      monitors.getMonitorTable().find('h4').should('contain.text', 'Monitors');
+      monitors
+        .getMonitorTable()
+        .find('p')
+        .should('contain.text', 'Maintains the master copy of the cluster state');
 
-      // check for table header 'Not In Quorum'
-      monitors.getLegends().its(2).should('have.text', 'Not In Quorum');
-
-      // verify correct columns on In Quorum table
-      monitors.getDataTableHeaders().contains('Name');
-
-      monitors.getDataTableHeaders().contains('Rank');
-
-      monitors.getDataTableHeaders().contains('Public Address');
-
-      monitors.getDataTableHeaders().contains('Open Sessions');
-      // verify correct columns on Not In Quorum table
-      monitors.getDataTableHeaders().contains('Name');
-
-      monitors.getDataTableHeaders().contains('Rank');
-
-      monitors.getDataTableHeaders().contains('Public Address');
+      monitors.getMonitorTableHeaders().should('contain.text', 'Name');
+      monitors.getMonitorTableHeaders().should('contain.text', 'Rank');
+      monitors.getMonitorTableHeaders().should('contain.text', 'Public address');
+      monitors.getMonitorTableHeaders().should('contain.text', 'In Quorum');
+      monitors.getMonitorTableHeaders().should('contain.text', 'Open sessions');
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/monitors.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/monitors.po.ts
@@ -4,4 +4,18 @@ export class MonitorsPageHelper extends PageHelper {
   pages = {
     index: { url: '#/monitor', id: 'cd-monitor' }
   };
+
+  getStatusTable() {
+    cy.get('cd-monitor cd-table table[cdstable] tbody').should('exist');
+    cy.contains('Loading').should('not.exist');
+    return cy.get('cd-monitor fieldset table');
+  }
+
+  getMonitorTable() {
+    return cy.get('cd-monitor cd-table');
+  }
+
+  getMonitorTableHeaders() {
+    return this.getMonitorTable().find('th');
+  }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/monitor/monitor.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/monitor/monitor.component.html
@@ -1,65 +1,45 @@
-<div class="row">
-  <div class="col-lg-4">
-    <fieldset>
-      <legend class="cd-header"
-              i18n>Status</legend>
-      <table class="cds--data-table--sort cds--data-table--no-border cds--data-table cds--data-table--md"
-             *ngIf="mon_status">
+<fieldset>
+    @if(mon_status) {
+    <table class="cds--data-table--sort cds--data-table--no-border cds--data-table cds--data-table--md">
         <tbody>
           <tr>
-            <td i18n
-                class="bold">Cluster ID</td>
+            <td i18n><B>Cluster ID</B></td>
             <td>{{ mon_status.monmap.fsid }}</td>
           </tr>
           <tr>
-            <td i18n
-                class="bold">monmap modified</td>
+            <td i18n><B>monmap modified</B></td>
             <td>{{ mon_status.monmap.modified | relativeDate }}</td>
           </tr>
           <tr>
-            <td i18n
-                class="bold">monmap epoch</td>
+            <td i18n><B>monmap epoch</B></td>
             <td>{{ mon_status.monmap.epoch }}</td>
           </tr>
           <tr>
-            <td i18n
-                class="bold">quorum con</td>
+            <td i18n><B>quorum con</B></td>
             <td>{{ mon_status.features.quorum_con }}</td>
           </tr>
           <tr>
-            <td i18n
-                class="bold">quorum mon</td>
+            <td i18n><B>quorum mon</B></td>
             <td>{{ mon_status.features.quorum_mon }}</td>
           </tr>
           <tr>
-            <td i18n
-                class="bold">required con</td>
+            <td i18n><B>required con</B></td>
             <td>{{ mon_status.features.required_con }}</td>
           </tr>
           <tr>
-            <td i18n
-                class="bold">required mon</td>
+            <td i18n><B>required mon</B></td>
             <td>{{ mon_status.features.required_mon }}</td>
           </tr>
         </tbody>
-      </table>
-    </fieldset>
-  </div>
+    </table>
+    }
+</fieldset>
 
-  <div class="col-lg-8">
-    <legend i18n
-            class="in-quorum cd-header">In Quorum</legend>
-    <div>
-    <cd-table [data]="inQuorum.data"
-              [columns]="inQuorum.columns">
-    </cd-table></div>
-
-    <legend i18n
-            class="in-quorum cd-header">Not In Quorum</legend>
-    <div>
-    <cd-table [data]="notInQuorum.data"
-              (fetchData)="refresh()"
-              [columns]="notInQuorum.columns">
-    </cd-table></div>
-  </div>
+<div class="cds-mt-4">
+    <cd-table [data]="quorum.data"
+            [columns]="quorum.columns"
+            [headerTitle]="title"
+            [headerDescription]="description"
+            (fetchData)="refresh()">
+    </cd-table>
 </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/monitor/monitor.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/monitor/monitor.component.spec.ts
@@ -74,31 +74,31 @@ describe('MonitorComponent', () => {
 
     expect(getMonitorSpy).toHaveBeenCalled();
 
-    expect(component.inQuorum.columns[3].comparator(undefined, undefined)).toBe(0);
-    expect(component.inQuorum.columns[3].comparator(null, null)).toBe(0);
-    expect(component.inQuorum.columns[3].comparator([], [])).toBe(0);
+    expect(component.quorum.columns[4].comparator(undefined, undefined)).toBe(0);
+    expect(component.quorum.columns[4].comparator(null, null)).toBe(0);
+    expect(component.quorum.columns[4].comparator([], [])).toBe(0);
     expect(
-      component.inQuorum.columns[3].comparator(
-        component.inQuorum.data[0].cdOpenSessions,
-        component.inQuorum.data[3].cdOpenSessions
+      component.quorum.columns[4].comparator(
+        component.quorum.data[0].cdOpenSessions,
+        component.quorum.data[3].cdOpenSessions
       )
     ).toBe(0);
     expect(
-      component.inQuorum.columns[3].comparator(
-        component.inQuorum.data[0].cdOpenSessions,
-        component.inQuorum.data[1].cdOpenSessions
+      component.quorum.columns[4].comparator(
+        component.quorum.data[0].cdOpenSessions,
+        component.quorum.data[1].cdOpenSessions
       )
     ).toBe(1);
     expect(
-      component.inQuorum.columns[3].comparator(
-        component.inQuorum.data[1].cdOpenSessions,
-        component.inQuorum.data[0].cdOpenSessions
+      component.quorum.columns[4].comparator(
+        component.quorum.data[1].cdOpenSessions,
+        component.quorum.data[0].cdOpenSessions
       )
     ).toBe(-1);
     expect(
-      component.inQuorum.columns[3].comparator(
-        component.inQuorum.data[2].cdOpenSessions,
-        component.inQuorum.data[1].cdOpenSessions
+      component.quorum.columns[4].comparator(
+        component.quorum.data[2].cdOpenSessions,
+        component.quorum.data[1].cdOpenSessions
       )
     ).toBe(1);
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/monitor/monitor.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/monitor/monitor.component.ts
@@ -5,6 +5,11 @@ import _ from 'lodash';
 import { MonitorService } from '~/app/shared/api/monitor.service';
 import { CellTemplate } from '~/app/shared/enum/cell-template.enum';
 
+const enum QuorumPresent {
+  Yes = 'Yes',
+  No = 'No'
+}
+
 @Component({
   selector: 'cd-monitor',
   templateUrl: './monitor.component.html',
@@ -13,20 +18,31 @@ import { CellTemplate } from '~/app/shared/enum/cell-template.enum';
 })
 export class MonitorComponent {
   mon_status: any;
-  inQuorum: any;
-  notInQuorum: any;
-
+  quorum: any;
   interval: any;
+  title: string = $localize`Monitors`;
+  description: string = $localize`Maintains the master copy of the cluster state, including the monitor map, OSD map, and CRUSH map`;
 
   constructor(private monitorService: MonitorService) {
-    this.inQuorum = {
+    this.quorum = {
       columns: [
         { prop: 'name', name: $localize`Name`, cellTransformation: CellTemplate.routerLink },
         { prop: 'rank', name: $localize`Rank` },
-        { prop: 'public_addr', name: $localize`Public Address` },
+        { prop: 'public_addr', name: $localize`Public address` },
+        {
+          prop: 'status',
+          name: $localize`In Quorum`,
+          cellTransformation: CellTemplate.tag,
+          customTemplateConfig: {
+            map: {
+              Yes: { value: $localize`Yes`, class: 'tag-success' },
+              No: { value: $localize`No`, class: 'tag-danger' }
+            }
+          }
+        },
         {
           prop: 'cdOpenSessions',
-          name: $localize`Open Sessions`,
+          name: $localize`Open sessions`,
           cellTransformation: CellTemplate.sparkline,
           comparator: (dataA: any, dataB: any) => {
             // We get the last value of time series to compare:
@@ -42,14 +58,6 @@ export class MonitorComponent {
         }
       ]
     };
-
-    this.notInQuorum = {
-      columns: [
-        { prop: 'name', name: $localize`Name`, cellTransformation: CellTemplate.routerLink },
-        { prop: 'rank', name: $localize`Rank` },
-        { prop: 'public_addr', name: $localize`Public Address` }
-      ]
-    };
   }
 
   refresh() {
@@ -58,17 +66,19 @@ export class MonitorComponent {
         row.cdOpenSessions = row.stats.num_sessions.map((i: string) => i[1]);
         row.cdLink = '/perf_counters/mon/' + row.name;
         row.cdParams = { fromLink: '/monitor' };
+        row.status = QuorumPresent.Yes;
         return row;
       });
 
       data.out_quorum.map((row: any) => {
         row.cdLink = '/perf_counters/mon/' + row.name;
         row.cdParams = { fromLink: '/monitor' };
+        row.status = QuorumPresent.No;
+        row.cdOpenSessions = [];
         return row;
       });
 
-      this.inQuorum.data = [...data.in_quorum];
-      this.notInQuorum.data = [...data.out_quorum];
+      this.quorum.data = [...data.in_quorum, ...data.out_quorum];
       this.mon_status = data.mon_status;
     });
   }


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/76746
Signed-off-by: Devika Babrekar <devika.babrekar@ibm.com>

Before Changes:
<img width="3840" height="1976" alt="image" src="https://github.com/user-attachments/assets/31557f64-be44-49c4-bde3-4673463cdf76" />


After Changes:
<img width="3833" height="1967" alt="image" src="https://github.com/user-attachments/assets/060dbd2f-6b85-4173-9e63-e81536a876c2" />



Description: 
1. Previously two tables were present on Monitors page namely, In Quorum and Not in Quorum. This change combines the data from both tables in single Quorum table
2. Status column is added to indicate if the data belongs to In Quorum or Not in Quorum
3. Alignment has been changes from horizontal placing to vertical placing of two tables.
4. Status table showcasing details is removed.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
