### PR TITLE
mgr/cephadm: apply OSD spec config at daemon scope for created OSDs

### DIFF
--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -13,7 +13,7 @@ from ceph.utils import datetime_to_str, str_to_datetime
 from datetime import datetime
 import orchestrator
 from cephadm.serve import CephadmServe
-from cephadm.utils import SpecialHostLabels
+from cephadm.utils import SpecialHostLabels, can_apply_post_create
 from ceph.utils import datetime_now
 from orchestrator import OrchestratorError, DaemonDescription
 from mgr_module import MonCommandFailed
@@ -30,6 +30,50 @@ logger = logging.getLogger(__name__)
 @register_cephadm_service
 class OSDService(CephService):
     TYPE = 'osd'
+
+    def _apply_osd_config_to_daemon(
+        self,
+        osd_id: str,
+        cfg: dict[str, str],
+    ) -> None:
+        if not cfg:
+            return
+
+        for key, value in cfg.items():
+            logger.info(
+                "Applying OSD spec config %s=%s to osd.%s",
+                key, value, osd_id,
+            )
+
+            self.mgr.check_mon_command({
+                'prefix': 'config set',
+                'who': f'osd.{osd_id}',
+                'name': key,
+                'value': value,
+            })
+
+    def _get_post_create_osd_config(
+        self,
+        spec: DriveGroupSpec,
+    ) -> dict[str, str]:
+        cfg = getattr(spec, 'config', None) or {}
+        if not cfg:
+            return {}
+
+        meta_cache: dict[str, Optional[dict[str, Any]]] = {}
+        post_create_cfg: dict[str, str] = {}
+
+        for key, value in cfg.items():
+            if not can_apply_post_create(self.mgr, key, meta_cache):
+                logger.debug(
+                    "Skipping OSD spec config key %s in post-create",
+                    key,
+                )
+                continue
+
+            post_create_cfg[key] = str(value)
+
+        return post_create_cfg
 
     def create_from_spec(self, drive_group: DriveGroupSpec, force_apply: bool = False) -> str:
         """
@@ -122,6 +166,7 @@ class OSDService(CephService):
         # daemon (misleading "Created no osd(s)" while the osd exists but is still down).
         # wait_for_latest_osdmap() is synchronous:
         # We need to run it in a thread pool so we do not block the cephadm asyncio event loop.
+        post_create_cfg = self._get_post_create_osd_config(spec)
         ret = await to_thread(self.mgr.rados.wait_for_latest_osdmap)
         if ret < 0:
             raise OrchestratorError(
@@ -176,6 +221,8 @@ class OSDService(CephService):
                     daemon_spec,
                     osd_uuid_map=osd_uuid_map)
 
+                self._apply_osd_config_to_daemon(str(osd_id), post_create_cfg)
+
         # check result: raw
         raw_elems: dict = await CephadmServe(self.mgr)._run_cephadm_json(
             host, 'osd', 'ceph-volume',
@@ -217,6 +264,7 @@ class OSDService(CephService):
             await CephadmServe(self.mgr)._create_daemon(
                 daemon_spec,
                 osd_uuid_map=osd_uuid_map)
+            self._apply_osd_config_to_daemon(osd_id, post_create_cfg)
 
         if created:
             self.mgr.cache.invalidate_host_devices(host)

--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -206,3 +206,38 @@ def get_node_proxy_status_value(data: Any, key: str, lower: bool = False) -> str
     if not isinstance(value, str):
         return ''
     return value.lower() if lower else value
+
+
+def get_config_option_meta(
+    mgr: 'CephadmOrchestrator',
+    key: str,
+    cache: Optional[dict[str, Optional[dict[str, Any]]]] = None,
+) -> Optional[dict[str, Any]]:
+    if cache is not None and key in cache:
+        return cache[key]
+
+    try:
+        ret, out, err = mgr.check_mon_command({
+            'prefix': 'config help',
+            'key': key,
+            'format': 'json',
+        })
+        meta = json.loads(out) if out else None
+    except Exception:
+        logger.exception("Failed to fetch config metadata for key %s", key)
+        meta = None
+
+    if cache is not None:
+        cache[key] = meta
+    return meta
+
+
+def can_apply_post_create(
+    mgr: 'CephadmOrchestrator',
+    key: str,
+    cache: Optional[dict[str, Optional[dict[str, Any]]]] = None,
+) -> bool:
+    meta = get_config_option_meta(mgr, key, cache)
+    if not meta:
+        return False
+    return bool(meta.get('can_update_at_runtime', False))


### PR DESCRIPTION
mgr/cephadm: apply OSD spec config at daemon scope for created OSDs

OSD spec config values are currently stored at the OSD service scope but are not reflected in the created osd.<id> daemon runtime.

For OSDs created from a DriveGroup spec, cephadm already associates the created OSDs with the service via CEPH_VOLUME_OSDSPEC_AFFINITY, but there is no equivalent step that applies spec.config values to the concrete osd.<id> daemons after ceph-volume returns the created OSD IDs.

This change adds a first pass in OSDService to apply spec.config values directly at osd.<id> scope once the daemon IDs are known during deploy_osd_daemons_for_existing_osds().

Ref o/p before the fix:

```
[ceph: root@ceph-7iotq4sf ~]# ceph config dump
WHO              MASK                LEVEL     OPTION                                            VALUE                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 RO
global                               basic     container_image
osd              host:ceph-7iotq4sf  basic     osd_memory_target                                 22198662656
osd                                  advanced  osd_memory_target_autotune                        true
osd.0                                basic     osd_mclock_max_capacity_iops_ssd                  53706.985963
osd.1                                basic     osd_mclock_max_capacity_iops_ssd                  55848.317608
osd.10                               basic     osd_mclock_max_capacity_iops_ssd                  53571.617029
osd.11                               basic     container_image                                   localhost/ceph-patched@sha256:38869c8d2b2003aafbd016b1b7b225f5f87fe990f7ff5c60b77178d114d4854d                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        *
osd.11                               basic     osd_mclock_max_capacity_iops_ssd                  57113.128943
osd.12                               basic     osd_mclock_max_capacity_iops_ssd                  51275.201441
osd.13                               basic     osd_mclock_max_capacity_iops_ssd                  51451.938547
osd.14                               basic     osd_mclock_max_capacity_iops_ssd                  53236.074574
osd.15                               basic     osd_mclock_max_capacity_iops_ssd                  52941.562010
osd.2                                basic     osd_mclock_max_capacity_iops_ssd                  49627.670881
osd.3                                basic     osd_mclock_max_capacity_iops_ssd                  50566.501574
osd.4                                basic     osd_mclock_max_capacity_iops_ssd                  51277.901716
osd.5                                basic     osd_mclock_max_capacity_iops_ssd                  54834.101254
osd.6                                basic     osd_mclock_max_capacity_iops_ssd                  56687.477458
osd.7                                basic     osd_mclock_max_capacity_iops_ssd                  53604.159654
osd.8                                basic     osd_mclock_max_capacity_iops_ssd                  58664.606991
osd.9                                basic     osd_mclock_max_capacity_iops_ssd                  53651.893957
osd.fcm                              dev       bluestore_cache_autotune                          true
osd.fcm                              advanced  bluestore_use_optimal_io_size_for_min_alloc_size  false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 *
osd.fcm                              basic     osd_memory_target                                 8589934592
osd.fcm                              advanced  osd_memory_target_autotune                        false
osd.fcm-test                         advanced  bdev_async_discard_threads                        2
osd.fcm-test                         advanced  bdev_enable_discard                               true
osd.fcm-test                         dev       bluestore_hybrid_alloc_mem_cap                    1024000000
osd.fcm-test                         advanced  bluestore_min_alloc_size                          16384                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 *
osd.fcm-test                         advanced  set_keepcaps                                      true                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  *
osd.fcm_osds                         dev       bluestore_cache_autotune                          true
osd.fcm_osds                         advanced  bluestore_use_optimal_io_size_for_min_alloc_size  false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 *
osd.fcm_osds                         basic     osd_memory_target                                 8589934592
osd.fcm_osds                         advanced  osd_memory_target_autotune                        false
osd.osd_fcm                          advanced  bdev_async_discard_threads                        2
osd.osd_fcm                          advanced  bdev_enable_discard                               true
osd.osd_fcm                          dev       bluestore_hybrid_alloc_mem_cap                    1024000000
osd.osd_fcm                          advanced  bluestore_min_alloc_size                          16384                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 *
osd.osd_fcm                          advanced  set_keepcaps                                      true                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  *
```


After the fix:


```
[ceph: root@ceph-node-0 ~]# cat osd.yaml 
service_type: osd
service_id: osd_fcm_runtime_test
placement:
  hosts:
    - ceph-node-0
spec:
  objectstore: bluestore
  crush_device_class: fcm
  data_devices:
    paths:
      - /dev/vdc
config:
  bdev_enable_discard: "true"
  bdev_async_discard_threads: "2"
  bluestore_hybrid_alloc_mem_cap: "1024M"
```

```
[ceph: root@ceph-node-0 ~]# ceph orch ps
NAME                    HOST         PORTS        STATUS         REFRESHED  AGE  MEM USE  MEM LIM  VERSION               IMAGE ID      CONTAINER ID  
crash.ceph-node-0       ceph-node-0               running (91m)     3s ago  91m    7208k        -  21.3.0-219-g1b51e11d  600ebb7993be  17e987dec6f7  
crash.ceph-node-1       ceph-node-1               running (87m)     6m ago  87m    7215k        -  21.3.0-219-g1b51e11d  600ebb7993be  ef3d57668140  
crash.ceph-node-2       ceph-node-2               running (83m)     6m ago  83m    7215k        -  21.3.0-219-g1b51e11d  600ebb7993be  4fbc9b406271  
mgr.ceph-node-0.zogvfe  ceph-node-0  *:9283,8765  running (92m)     3s ago  92m     199M        -  21.3.0-219-g1b51e11d  600ebb7993be  72405bdc8f0a  
mgr.ceph-node-1.xxbolw  ceph-node-1  *:8443,8765  running (87m)     6m ago  87m     149M        -  21.3.0-219-g1b51e11d  600ebb7993be  df9ef75df81e  
mon.ceph-node-0         ceph-node-0               running (92m)     3s ago  92m    60.7M    2048M  21.3.0-219-g1b51e11d  600ebb7993be  f9fb1b329b0d  
mon.ceph-node-1         ceph-node-1               running (87m)     6m ago  87m    49.0M    2048M  21.3.0-219-g1b51e11d  600ebb7993be  64db3cc8a523  
mon.ceph-node-2         ceph-node-2               running (83m)     6m ago  83m    48.9M    2048M  21.3.0-219-g1b51e11d  600ebb7993be  b761b44f167a  
osd.0                   ceph-node-0               running (87m)     3s ago  87m    57.7M    4096M  21.3.0-219-g1b51e11d  600ebb7993be  f6a3c7a570f7  
osd.1                   ceph-node-1               running (87m)     6m ago  87m    57.3M    4096M  21.3.0-219-g1b51e11d  600ebb7993be  1a420b0d23ac  
osd.2                   ceph-node-2               running (83m)     6m ago  83m    56.6M    2992M  21.3.0-219-g1b51e11d  600ebb7993be  0afb47c33908  
osd.3                   ceph-node-0               running (11s)     3s ago  11s    46.8M    4096M  21.3.0-219-g1b51e11d  600ebb7993be  163667fb9f3d  

[ceph: root@ceph-node-0 ~]# ceph orch ls
NAME                       PORTS  RUNNING  REFRESHED  AGE  PLACEMENT    
crash                                 3/3  7m ago     91m  *            
mgr                                   2/2  7m ago     91m  count:2      
mon                                   3/5  7m ago     91m  count:5      
osd.all-available-devices               3  7m ago     91m  *            
osd.osd_fcm_runtime_test                1  8s ago     34s  ceph-node-0  
```

```
[ceph: root@ceph-node-0 ~]# ceph config dump | grep osd.3
osd.3                                       advanced  bdev_async_discard_threads             2                                                                                            
osd.3                                       advanced  bdev_enable_discard                    true                                                                                         
osd.3                                       dev       bluestore_hybrid_alloc_mem_cap         1024000000   
                                                                                
[ceph: root@ceph-node-0 ~]# ceph config get osd.3 bdev_async_discard_threads
2

[ceph: root@ceph-node-0 ~]# ceph config dump | grep osd  
osd                       host:ceph-node-2  basic     osd_memory_target                      3138345779                                                                                   
osd                                         advanced  osd_memory_target_autotune             true                                                                                         
osd.3                                       advanced  bdev_async_discard_threads             2                                                                                            
osd.3                                       advanced  bdev_enable_discard                    true                                                                                         
osd.3                                       dev       bluestore_hybrid_alloc_mem_cap         1024000000                                                                                   
osd.osd_fcm_runtime_test                    advanced  bdev_async_discard_threads             2                                                                                            
osd.osd_fcm_runtime_test                    advanced  bdev_enable_discard                    true                                                                                         
osd.osd_fcm_runtime_test                    dev       bluestore_hybrid_alloc_mem_cap         1024000000   

```
## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
