### PR TITLE
osdc: Block balanced or localized reads if pools use tiering or direct reads.

### DIFF
--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1864,6 +1864,10 @@ public:
     return has_flag(FLAG_EC_OPTIMIZATIONS);
   }
 
+  bool allows_nonprimary_reads() const {
+    return !is_tier() && !has_tiers() && (get_dedup_tier() <= 0);
+  }
+
   bool is_crimson() const {
     return has_flag(FLAG_CRIMSON);
   }

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1238,7 +1238,7 @@ void Objecter::handle_osd_map(MOSDMap *m)
 
   if (m->fsid != monc->get_fsid()) {
     ldout(cct, 0) << "handle_osd_map fsid " << m->fsid
-		  << " != " << monc->get_fsid() << dendl;
+                  << " != " << monc->get_fsid() << dendl;
     return;
   }
 
@@ -1247,10 +1247,19 @@ void Objecter::handle_osd_map(MOSDMap *m)
   bool was_pausewr = osdmap->test_flag(CEPH_OSDMAP_PAUSEWR) || cluster_full ||
     _osdmap_has_pool_full();
   map<int64_t, bool> pool_full_map;
+  
+  // Block flags. This is used to block balanced reads when any pool supports
+  // legacy dedupe or tiering (unsupported) features. 
+  int new_blocked_flags = 0;
   for (auto it = osdmap->get_pools().begin();
-       it != osdmap->get_pools().end(); ++it)
+       it != osdmap->get_pools().end(); ++it) {
     pool_full_map[it->first] = _osdmap_pool_full(it->second);
-
+    const pg_pool_t& pool = it->second;
+    if (pool.is_tier() || pool.has_tiers() || pool.get_dedup_tier() > 0) {
+      new_blocked_flags = CEPH_OSD_FLAG_BALANCE_READS | CEPH_OSD_FLAG_LOCALIZE_READS;
+    }
+  }
+  blocked_read_flags = new_blocked_flags;
 
   list<LingerOp*> need_resend_linger;
   map<ceph_tid_t, Op*> need_resend;

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -3148,6 +3148,13 @@ int Objecter::_calc_target(op_target_t *t, bool any_change)
     }
   }
 
+  // Strip balanced and localized read flags if the target pool does not support non-primary reads.
+  // This ensures that even when flags are added via global configuration (e.g. rados_replica_read_policy),
+  // ops targeting a tiered or deduped pool will not attempt replica/balanced reads.
+  if (!pi->allows_nonprimary_reads()) {
+    t->flags &= ~(CEPH_OSD_FLAG_BALANCE_READS | CEPH_OSD_FLAG_LOCALIZE_READS);
+  }
+
   pg_t pgid;
   if (t->precalc_pgid) {
     ceph_assert(t->flags & CEPH_OSD_FLAG_IGNORE_OVERLAY);

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1741,7 +1741,8 @@ private:
   bool keep_balanced_budget = false;
   bool honor_pool_full = true;
 
-  std::atomic<int> extra_read_flags{0};
+  std::atomic<int> extra_read_flags{0}; 
+  int blocked_read_flags = 0;
 
   // If this is true, accumulate a set of blocklisted entities
   // to be drained by consume_blocklist_events.
@@ -2996,6 +2997,8 @@ private:
     int ret = flags | global_op_flags |
               extra_read_flags.load(std::memory_order_relaxed) |
               CEPH_OSD_FLAG_READ;
+    
+    ret &= ~blocked_read_flags;
 
     // If the op is rwordered, strip out the balanced and localized flags.
     if (flags & CEPH_OSD_FLAG_RWORDERED) {

--- a/src/osdc/SplitOp.cc
+++ b/src/osdc/SplitOp.cc
@@ -977,6 +977,12 @@ bool SplitOp::create(Objecter::Op *op, Objecter &objecter,
     return false;
   }
 
+  // Reject if pool does not support non-primary reads.
+  if (!pi->allows_nonprimary_reads()) {
+    ldout(cct, DBG_LVL) << __func__ <<" REJECT: non-primary reads not supported for split ops" << dendl;
+    return false;
+  }
+
   auto [validated, single_op] = validate(op, objecter, pi, cct);
 
   if (!validated) {


### PR DESCRIPTION
Previously, there was no mechanism to block balanced or direct reads in Objecter.   Equally, there are known bugs when tiering or dedupe are used on the pool, which can cause OSDs to panic.

We do not plan on supporting these features, although there are some teuthology tests which we do not yet want to throw away.

As such, this commit adds a "blocked_read_flags" which is set when we update the osd pools to prevent any op
being processed with balanced or localised reads.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
