### PR TITLE
osd: handle BackfillTooFull in state ReplicaActive

### DIFF
--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -6137,6 +6137,15 @@ void PeeringState::RepWaitBackfillReserved::exit()
 }
 
 boost::statechart::result
+PeeringState::RepWaitBackfillReserved::react(const BackfillTooFull &)
+{
+  DECLARE_LOCALS;
+  ps->reject_reservation();
+  post_event(RemoteReservationRejectedTooFull());
+  return discard_event();
+}
+
+boost::statechart::result
 PeeringState::RepWaitBackfillReserved::react(const RemoteBackfillReserved &evt)
 {
   DECLARE_LOCALS;

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -1061,6 +1061,7 @@ public:
       boost::statechart::custom_reaction< RemoteBackfillPreempted >,
       boost::statechart::custom_reaction< RemoteRecoveryPreempted >,
       boost::statechart::custom_reaction< RecoveryDone >,
+      boost::statechart::custom_reaction< BackfillTooFull >,
       boost::statechart::transition<DeleteStart, ToDelete>,
       boost::statechart::custom_reaction< MLease >
       > reactions;
@@ -1095,6 +1096,9 @@ public:
     boost::statechart::result react(const RemoteRecoveryPreempted& evt) {
       return discard_event();
     }
+    boost::statechart::result react(const BackfillTooFull& evt) {
+      return discard_event();
+    }
   };
 
   struct RepRecovering : boost::statechart::state< RepRecovering, ReplicaActive >, NamedState {
@@ -1116,6 +1120,7 @@ public:
 
   struct RepWaitBackfillReserved : boost::statechart::state< RepWaitBackfillReserved, ReplicaActive >, NamedState {
     typedef boost::mpl::list<
+      boost::statechart::custom_reaction< BackfillTooFull >,
       boost::statechart::custom_reaction< RemoteBackfillReserved >,
       boost::statechart::custom_reaction< RejectTooFullRemoteReservation >,
       boost::statechart::custom_reaction< RemoteReservationRejectedTooFull >,
@@ -1123,6 +1128,7 @@ public:
       > reactions;
     explicit RepWaitBackfillReserved(my_context ctx);
     void exit();
+    boost::statechart::result react(const BackfillTooFull &evt);
     boost::statechart::result react(const RemoteBackfillReserved &evt);
     boost::statechart::result react(const RejectTooFullRemoteReservation &evt);
     boost::statechart::result react(const RemoteReservationRejectedTooFull &evt);

--- a/src/test/osd/TestPeeringState.cc
+++ b/src/test/osd/TestPeeringState.cc
@@ -2005,6 +2005,119 @@ TEST_F(PeeringStateTest, PoolMigrationPrempt) {
 }
 #endif
 
+// Test that BackfillTooFull event won't crash the OSD when received
+// in RepNotRecovering state.
+// This is to test the fix for https://tracker.ceph.com/issues/76751
+TEST_F(PeeringStateTest, BackfillTooFullInRepNotRecovering) {
+  dout(0) << "== BackfillTooFullInRepNotRecovering ==" << dendl;
+  // Init
+  test_create_peering_state();
+  test_init();
+  test_event_initialize();
+  // Append 3 log entries to all shards - trim the log so that
+  // backfill occurs later on
+  test_append_log_entry();
+  eversion_t expected_tail = test_append_log_entry();
+  eversion_t expected = test_append_log_entry(shard_id_set(), shard_id_set(), false, true);
+  // Full peering cycle
+  test_peering();
+  // Verify that we got to active+clean and that log entries were kept
+  verify_all_active_clean(expected, expected_tail);
+
+  // Swap out OSD 1 for OSD 9
+  modify_up_acting(1, 9);
+  test_create_peering_state(9, 1);
+  test_init(9);
+  test_event_initialize(9);
+  // Full peering cycle
+  test_peering();
+
+  // Verify OSD 9 is in RepNotRecovering
+  EXPECT_EQ(get_listener(acting[1])->last_state_entered,
+            "Started/ReplicaActive/RepNotRecovering");
+
+  // Inject BackfillTooFull event on OSD 9 while in RepNotRecovering
+  // This should NOT crash
+  auto evt = std::make_shared<PGPeeringEvent>(
+    osdmap->get_epoch(),
+    osdmap->get_epoch(),
+    PeeringState::BackfillTooFull());
+  get_ps(acting[1])->handle_event(evt, get_ctx(acting[1]));
+  dispatch_all();
+
+  // Verify the OSD state machine didn't enter Crashed
+  // If the bug is present, the process_event above would have aborted
+  EXPECT_NE(get_listener(acting[1])->last_state_entered,
+            "Crashed");
+  // The event should have been discarded, replica stays in RepNotRecovering
+  EXPECT_EQ(get_listener(acting[1])->last_state_entered,
+            "Started/ReplicaActive/RepNotRecovering");
+}
+
+// Test that BackfillTooFull event in RepWaitBackfillReserved state causes
+// the replica to reject the reservation and transition to RepNotRecovering
+TEST_F(PeeringStateTest, BackfillTooFullInRepWaitBackfillReserved) {
+  dout(0) << "== BackfillTooFullInRepWaitBackfillReserved ==" << dendl;
+  // Init
+  test_create_peering_state();
+  test_init();
+  test_event_initialize();
+  // Append 3 log entries to all shards - trim the log so that
+  // backfill occurs later on
+  test_append_log_entry();
+  eversion_t expected_tail = test_append_log_entry();
+  eversion_t expected = test_append_log_entry(shard_id_set(), shard_id_set(), false, true);
+  // Full peering cycle
+  test_peering();
+  // Verify that we got to active+clean and that log entries were kept
+  verify_all_active_clean(expected, expected_tail);
+
+  // Swap out OSD 1 for OSD 9
+  modify_up_acting(1, 9);
+  test_create_peering_state(9, 1);
+  test_init(9);
+  test_event_initialize(9);
+  test_peering();
+
+  // Verify OSD 9 is in RepNotRecovering
+  EXPECT_EQ(get_listener(acting[1])->last_state_entered,
+            "Started/ReplicaActive/RepNotRecovering");
+
+  // Inject event RequestBackfillPrio to move the state to RepWaitBackfillReserved
+  // Don't dispatch_all() so the RemoteBackfillReserved stays unprocessed
+  // and the replica remains in RepWaitBackfillReserved
+  auto evt1 = std::make_shared<PGPeeringEvent>(
+    osdmap->get_epoch(),
+    osdmap->get_epoch(),
+    RequestBackfillPrio(OSD_BACKFILL_PRIORITY_BASE, 0, 0));
+  get_ps(acting[1])->handle_event(evt1, get_ctx(acting[1]));
+
+  // Verify OSD 9 is in RepWaitBackfillReserved
+  EXPECT_EQ(get_listener(acting[1])->last_state_entered,
+            "Started/ReplicaActive/RepWaitBackfillReserved");
+
+  // Inject BackfillTooFull event on OSD 9 while in RepWaitBackfillReserved
+  // This should NOT crash
+  auto evt2 = std::make_shared<PGPeeringEvent>(
+    osdmap->get_epoch(),
+    osdmap->get_epoch(),
+    PeeringState::BackfillTooFull());
+  get_ps(acting[1])->handle_event(evt2, get_ctx(acting[1]));
+  dispatch_all();
+
+  // Verify the OSD state machine didn't enter Crashed
+  // If the bug is present, the process_event above would have aborted
+  EXPECT_NE(get_listener(acting[1])->last_state_entered,
+            "Crashed");
+
+  // The reservation should have been rejected and the state goes to RepNotRecovering
+  EXPECT_EQ(get_listener(acting[1])->last_state_entered,
+            "Started/ReplicaActive/RepNotRecovering");
+  // Verify reservation was rejected (unreserve called)
+  EXPECT_TRUE(get_listener(acting[1])->recovery_space_unreserved);
+}
+
+
 // ============================================================================
 // Tests for bug fixes
 // ============================================================================


### PR DESCRIPTION

Fixes: https://tracker.ceph.com/issues/76751
Signed-off-by: Jane Zhu [jzhu116@bloomberg.net](mailto:jzhu116@bloomberg.net)


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
