### PR TITLE
squid: rgw/auth: fix internal server error for presigned urls

### DIFF
--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -498,12 +498,12 @@ rgw::auth::Strategy::apply(const DoutPrefixProvider *dpp, const rgw::auth::Strat
       ldpp_dout(dpp, 5) << "Failed the auth strategy, reason="
                        << result.get_reason() << dendl;
       // Special handling for expired pre-signed URL
-      if (result.get_reason() == ERR_PRESIGNED_URL_EXPIRED) {
+      if (result.get_reason() == -ERR_PRESIGNED_URL_EXPIRED) {
         result = result_t::deny(-EPERM);
         set_req_state_err(s, -EPERM, "The pre-signed URL has expired");
       }
       // Special handling for disabled presigned URL
-      if (result.get_reason() == ERR_PRESIGNED_URL_DISABLED) {
+      if (result.get_reason() == -ERR_PRESIGNED_URL_DISABLED) {
         result = result_t::deny(-EPERM);
         set_req_state_err(s, -EPERM, "Presigned URLs are disabled by admin");
       }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68423

---

backport of https://github.com/ceph/ceph/pull/59983
parent tracker: https://tracker.ceph.com/issues/68300

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh