### PR TITLE
mon: use structure encoded mechanism for audit logs

### DIFF
--- a/src/common/LogClient.cc
+++ b/src/common/LogClient.cc
@@ -162,14 +162,26 @@ void LogChannel::do_log(clog_type prio, std::stringstream& ss)
   }
 }
 
+void LogChannel::do_log(clog_type prio, LogMsg &&m) {
+  LogEntry e;
+  std::ostringstream oss;
+  oss << m;
+  e.stamp = ceph_clock_now();
+  // seq and who should be set for syslog/graylog/log_to_mon
+  e.addrs = parent->get_myaddrs();
+  e.name = parent->get_myname();
+  e.rank = parent->get_myrank();
+  e.prio = prio;
+  // stash a copy here for backward compatibility
+  e.msg = oss.str();
+  e.channel = get_log_channel();
+  e.logmsg = std::move(m);
+
+  _do_log(std::move(e));
+}
+
 void LogChannel::do_log(clog_type prio, const std::string& s)
 {
-  std::lock_guard l(channel_lock);
-  if (CLOG_ERROR == prio) {
-    ldout(cct,-1) << "log " << prio << " : " << s << dendl;
-  } else {
-    ldout(cct,0) << "log " << prio << " : " << s << dendl;
-  }
   LogEntry e;
   e.stamp = ceph_clock_now();
   // seq and who should be set for syslog/graylog/log_to_mon
@@ -179,6 +191,18 @@ void LogChannel::do_log(clog_type prio, const std::string& s)
   e.prio = prio;
   e.msg = s;
   e.channel = get_log_channel();
+
+  _do_log(std::move(e));
+}
+
+void LogChannel::_do_log(LogEntry &&e) {
+  std::lock_guard l(channel_lock);
+
+  if (!e.has_logmsg()) {
+    ldout(cct, 0) << "log " << e.prio << " : " << e.msg << dendl;
+  } else {
+    ldout(cct, 0) << "log " << e.prio << " : " << e.logmsg << dendl;
+  }
 
   // log to monitor?
   if (log_to_monitors) {

--- a/src/common/LogClient.h
+++ b/src/common/LogClient.h
@@ -82,6 +82,9 @@ public:
   void debug(std::stringstream &s) final {
     do_log(CLOG_DEBUG, s);
   }
+  void debug(LogMsg &&m) final {
+    do_log(CLOG_DEBUG, std::move(m));
+  }
   /**
    * Convenience function mapping health status to
    * the appropriate cluster log severity.
@@ -105,11 +108,17 @@ public:
   void info(std::stringstream &s) final {
     do_log(CLOG_INFO, s);
   }
+  void info(LogMsg &&m) final {
+    do_log(CLOG_INFO, std::move(m));
+  }
   OstreamTemp warn() final {
     return OstreamTemp(CLOG_WARN, this);
   }
   void warn(std::stringstream &s) final {
     do_log(CLOG_WARN, s);
+  }
+  void warn(LogMsg &&m) final {
+    do_log(CLOG_WARN, std::move(m));
   }
   OstreamTemp error() final {
     return OstreamTemp(CLOG_ERROR, this);
@@ -117,11 +126,17 @@ public:
   void error(std::stringstream &s) final {
     do_log(CLOG_ERROR, s);
   }
+  void error(LogMsg &&m) final {
+    do_log(CLOG_ERROR, std::move(m));
+  }
   OstreamTemp sec() final {
     return OstreamTemp(CLOG_SEC, this);
   }
   void sec(std::stringstream &s) final {
     do_log(CLOG_SEC, s);
+  }
+  void sec(LogMsg &&m) final {
+    do_log(CLOG_SEC, std::move(m));
   }
 
   void set_log_to_monitors(bool v);
@@ -170,6 +185,7 @@ public:
 
   void do_log(clog_type prio, std::stringstream& ss) final;
   void do_log(clog_type prio, const std::string& s) final;
+  void do_log(clog_type prio, LogMsg &&m) final;
 
 private:
   CephContext *cct;
@@ -188,6 +204,8 @@ private:
   void update_config(const clog_targets_conf_t& conf_strings);
 
   clog_targets_conf_t parse_log_client_options(CephContext* conf_cct);
+
+  void _do_log(LogEntry &&e);
 };
 
 typedef LogChannel::Ref LogChannelRef;

--- a/src/common/LogEntry.cc
+++ b/src/common/LogEntry.cc
@@ -188,6 +188,31 @@ string clog_type_to_string(clog_type t)
       ceph_abort();
   }
 }
+void LogMsg::encode(bufferlist& bl, uint64_t features) const
+{
+  ENCODE_START(1, 1, bl);
+  encode(name, bl);
+  encode(addrs, bl, features);
+  encode(entity_name, bl);
+  encode(cmd, bl);
+  encode(cmd_args, bl);
+  encode(cmd_state, bl);
+  encode(cmd_retval, bl);
+  ENCODE_FINISH(bl);
+}
+
+void LogMsg::decode(bufferlist::const_iterator& p)
+{
+  DECODE_START(1, p);
+  decode(name, p);
+  decode(addrs, p);
+  decode(entity_name, p);
+  decode(cmd, p);
+  decode(cmd_args, p);
+  decode(cmd_state, p);
+  decode(cmd_retval, p);
+  DECODE_FINISH(p);
+}
 
 void LogEntry::log_to_syslog(string level, string facility) const
 {
@@ -206,7 +231,7 @@ void LogEntry::log_to_syslog(string level, string facility) const
 void LogEntry::encode(bufferlist& bl, uint64_t features) const
 {
   assert(HAVE_FEATURE(features, SERVER_NAUTILUS));
-  ENCODE_START(5, 5, bl);
+  ENCODE_START(6, 5, bl);
   __u16 t = prio;
   encode(name, bl);
   encode(rank, bl);
@@ -216,12 +241,14 @@ void LogEntry::encode(bufferlist& bl, uint64_t features) const
   encode(t, bl);
   encode(msg, bl);
   encode(channel, bl);
+  encode(epoch, bl);
+  encode(logmsg, bl, features);
   ENCODE_FINISH(bl);
 }
 
 void LogEntry::decode(bufferlist::const_iterator& bl)
 {
-  DECODE_START_LEGACY_COMPAT_LEN(5, 2, 2, bl);
+  DECODE_START_LEGACY_COMPAT_LEN(6, 2, 2, bl);
   if (struct_v < 5) {
     __u16 t;
     entity_inst_t who;
@@ -256,6 +283,10 @@ void LogEntry::decode(bufferlist::const_iterator& bl)
     prio = (clog_type)t;
     decode(msg, bl);
     decode(channel, bl);
+    if (struct_v >= 6) {
+      decode(epoch, bl);
+      decode(logmsg, bl);
+    }
   }
   DECODE_FINISH(bl);
 }

--- a/src/common/LogEntry.h
+++ b/src/common/LogEntry.h
@@ -114,6 +114,31 @@ template<> struct hash<LogEntryKey> {
 };
 } // namespace std
 
+struct LogMsg {
+  entity_name_t name;
+  entity_addrvec_t addrs;
+  EntityName entity_name;
+  std::string cmd;
+  std::string cmd_args;
+  std::string cmd_state;
+  int cmd_retval;
+
+  void encode(bufferlist& bl, uint64_t features) const;
+  void decode(bufferlist::const_iterator& p);
+};
+WRITE_CLASS_ENCODER_FEATURES(LogMsg)
+
+inline std::ostream& operator<<(std::ostream &os, const LogMsg &m) {
+  os << "from='" << m.name << " " << m.addrs << "' "
+     << "entity='" << m.entity_name << "' " << "cmd=" << m.cmd;
+  if (!m.cmd_args.empty()) {
+    os << " args=" << m.cmd_args;
+  }
+  os << " r=" << m.cmd_retval;
+  os << ": " << m.cmd_state;
+  return os;
+}
+
 struct LogEntry {
   EntityName name;
   entity_name_t rank;
@@ -123,8 +148,10 @@ struct LogEntry {
   clog_type prio;
   std::string msg;
   std::string channel;
+  version_t epoch;
+  LogMsg logmsg;
 
-  LogEntry() : seq(0), prio(CLOG_DEBUG) {}
+  LogEntry() : seq(0), prio(CLOG_DEBUG), epoch(0) {}
 
   LogEntryKey key() const { return LogEntryKey(rank, stamp, seq); }
 
@@ -151,6 +178,10 @@ struct LogEntry {
       return "UNKNOWN";
     }
     return "???";
+  }
+
+  bool has_logmsg() const {
+    return msg.empty();
   }
 };
 WRITE_CLASS_ENCODER_FEATURES(LogEntry)

--- a/src/common/ostream_temp.h
+++ b/src/common/ostream_temp.h
@@ -38,13 +38,20 @@ private:
   std::stringstream ss;
 };
 
+class LogMsg;
+
 class LoggerSinkSet : public OstreamTemp::OstreamTempSink {
 public:
   virtual void info(std::stringstream &s) = 0;
+  virtual void info(LogMsg &&e) = 0;
   virtual void warn(std::stringstream &s) = 0;
+  virtual void warn(LogMsg &&e) = 0;
   virtual void error(std::stringstream &s) = 0;
+  virtual void error(LogMsg &&e) = 0;
   virtual void sec(std::stringstream &s) = 0;
+  virtual void sec(LogMsg &&e) = 0;
   virtual void debug(std::stringstream &s) = 0;
+  virtual void debug(LogMsg &&e) = 0;
   virtual OstreamTemp info() = 0;
   virtual OstreamTemp warn() = 0;
   virtual OstreamTemp error() = 0;
@@ -52,5 +59,6 @@ public:
   virtual OstreamTemp debug() = 0;
   virtual void do_log(clog_type prio, std::stringstream& ss) = 0;
   virtual void do_log(clog_type prio, const std::string& ss) = 0;
+  virtual void do_log(clog_type prio, LogMsg &&m) = 0;
   virtual ~LoggerSinkSet() {};
 };

--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -567,6 +567,7 @@ void LogMonitor::encode_pending(MonitorDBStore::TransactionRef t)
   dout(20) << __func__ << " writing " << num << " entries" << dendl;
   for (auto& p : pending_log) {
     bufferlist ebl;
+    p.second.epoch = version;
     p.second.encode(ebl, mon.get_quorum_con_features());
 
     auto& bounds = pending_channel_info[p.second.channel];

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -79,6 +79,7 @@
 #include "common/admin_socket.h"
 #include "global/signal_handler.h"
 #include "common/Formatter.h"
+#include "common/LogEntry.h"
 #include "include/stringify.h"
 #include "include/color.h"
 #include "include/ceph_fs.h"
@@ -153,7 +154,11 @@ static ostream& _prefix(std::ostream *_dout, const Monitor *mon) {
 }
 
 void Monitor::C_Command::_finish(int r) {
+  LogMsg msg;
+  bool send_logmsg = false;
   auto m = op->get_req<MMonCommand>();
+  std::ostringstream oss;
+  oss << m->cmd;
   if (r >= 0) {
     std::ostringstream ss;
     if (!op->get_req()->get_connection()) {
@@ -163,10 +168,17 @@ void Monitor::C_Command::_finish(int r) {
 
       // if client drops we may not have a session to draw information from.
       if (s) {
-	ss << "from='" << s->name << " " << s->addrs << "' "
-	   << "entity='" << s->entity_name << "' ";
+        // TODO: reuse from handle_command?
+        send_logmsg = true;
+        msg.name = s->name;
+        msg.addrs = s->addrs;
+        msg.entity_name = s->entity_name;
+        msg.cmd = oss.str();
+        msg.cmd_args = "";
+        msg.cmd_state = "finished";
+        msg.cmd_retval = r;
       } else {
-	ss << "session dropped for command ";
+        ss << "session dropped for command";
       }
     }
     cmdmap_t cmdmap;
@@ -174,10 +186,15 @@ void Monitor::C_Command::_finish(int r) {
     std::string prefix;
     cmdmap_from_json(m->cmd, &cmdmap, ds);
     cmd_getval(cmdmap, "prefix", prefix);
-    if (prefix != "config set" && prefix != "config-key set")
-      ss << "cmd='" << m->cmd << "': finished";
+    if (prefix != "config set" && prefix != "config-key set") {
+      if (send_logmsg) {
+        mon.audit_clog->info(std::move(msg));
+      } else {
+        ss << "cmd='" << oss.str() << "' r=" << r << ": finished";
+        mon.audit_clog->info() << ss.str();
+      }
+    }
 
-    mon.audit_clog->info() << ss.str();
     mon.reply_command(op, rc, rs, rdata, version);
   }
   else if (r == -ECANCELED)
@@ -556,7 +573,7 @@ will start to track new ops received afterwards.";
     << "from='admin socket' "
     << "entity='admin socket' "
     << "cmd=" << command << " "
-    << "args=" << args << ": finished";
+    << "args=" << args << " r=" << r << ": finished";
   return r;
 
 abort:
@@ -564,7 +581,7 @@ abort:
     << "from='admin socket' "
     << "entity='admin socket' "
     << "cmd=" << command << " "
-    << "args=" << args << ": aborted";
+    << "args=" << args << " r=" << r << ": aborted";
   return r;
 }
 
@@ -3623,23 +3640,41 @@ void Monitor::handle_command(MonOpRequestRef op)
     return;
   }
 
+  LogMsg msg;
+  msg.name = session->name;
+  msg.addrs = session->addrs;
+  msg.entity_name = session->entity_name;
+  std::ostringstream oss;
+  oss << m->cmd;
+  msg.cmd = oss.str();
+  msg.cmd_args = "";
+  msg.cmd_retval = 0;
+
   if (!_allowed_command(session, service, prefix, cmdmap,
                         param_str_map, mon_cmd)) {
     dout(1) << __func__ << " access denied" << dendl;
-    if (prefix != "config set" && prefix != "config-key set")
-      (cmd_is_rw ? audit_clog->info() : audit_clog->debug())
-        << "from='" << session->name << " " << session->addrs << "' "
-        << "entity='" << session->entity_name << "' "
-        << "cmd=" << m->cmd << ":  access denied";
+    msg.cmd_state = "access denied";
+    msg.cmd_retval = -EPERM;
+    if (prefix != "config set" && prefix != "config-key set") {
+      if (cmd_is_rw) {
+        audit_clog->info(std::move(msg));
+      } else {
+        audit_clog->debug(std::move(msg));
+      }
+    }
+
     reply_command(op, -EACCES, "access denied", 0);
     return;
   }
 
-  if (prefix != "config set" && prefix != "config-key set")
-    (cmd_is_rw ? audit_clog->info() : audit_clog->debug())
-        << "from='" << session->name << " " << session->addrs << "' "
-        << "entity='" << session->entity_name << "' "
-        << "cmd=" << m->cmd << ": dispatch";
+  msg.cmd_state = "dispatch";
+  if (prefix != "config set" && prefix != "config-key set") {
+    if (cmd_is_rw) {
+      audit_clog->info(std::move(msg));
+    } else {
+      audit_clog->debug(std::move(msg));
+    }
+  }
 
   // compat kludge for legacy clients trying to tell commands that are
   // new.  see bottom of MonCommands.h.  we need to handle both (1)


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/71850

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
