### PR TITLE
squid: qa: ignore cephadm failed daemon warnings during thrashing

### DIFF
--- a/qa/suites/upgrade/quincy-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/quincy-x/stress-split/1-start.yaml
@@ -26,6 +26,8 @@ overrides:
       - MDS_UP_LESS_THAN_MAX
       - filesystem is offline
       - with fewer MDS than max_mds
+      - CEPHADM_FAILED_DAEMON
+      - failed cephadm daemon
 tasks:
 - install:
     branch: quincy

--- a/qa/suites/upgrade/reef-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/reef-x/stress-split/1-start.yaml
@@ -26,6 +26,8 @@ overrides:
       - MDS_UP_LESS_THAN_MAX
       - filesystem is offline
       - with fewer MDS than max_mds
+      - CEPHADM_FAILED_DAEMON
+      - failed cephadm daemon
 tasks:
 - install:
     branch: reef


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76743

---

backport of https://github.com/ceph/ceph/pull/68896
parent tracker: https://tracker.ceph.com/issues/73079

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh