### PR TITLE
cephadm: prevent Docker container restarts during docker daemon event

### DIFF
--- a/src/cephadm/cephadmlib/container_engine_base.py
+++ b/src/cephadm/cephadmlib/container_engine_base.py
@@ -1,5 +1,6 @@
 # container_engine_base.py - container engine base class
 
+from .context import CephadmContext
 from .exe_utils import find_program
 
 
@@ -17,6 +18,14 @@ class ContainerEngine:
         pids (processes).
         """
         return '--pids-limit=0'
+
+    def is_live_restore_enabled(self, ctx: CephadmContext) -> bool:
+        """Return True if the container engine supports and has enabled live-restore.
+        Live-restore is a feature that keeps containers running when the container
+        engine daemon is stopped or restarted, preventing service interruption.
+        Returns False by default; container engines that support this feature
+        should override this method."""
+        return False
 
     def __str__(self) -> str:
         return f'{self.EXE} ({self.path})'

--- a/src/cephadm/cephadmlib/container_engines.py
+++ b/src/cephadm/cephadmlib/container_engines.py
@@ -112,6 +112,20 @@ class Podman(ContainerEngine):
 class Docker(ContainerEngine):
     EXE = 'docker'
 
+    def is_live_restore_enabled(self, ctx: CephadmContext) -> bool:
+        """Return True if Docker's live-restore feature is enabled, meaning
+        containers remain running when the Docker daemon is stopped or restarted.
+        This property is set in /etc/docker/daemon.json and is False by default.
+        """
+        out, _, code = call(
+            ctx,
+            [self.path, 'info', '--format', '{{.LiveRestoreEnabled}}'],
+            verbosity=CallVerbosity.QUIET,
+        )
+        if code != 0:
+            return False
+        return out.strip() == 'true'
+
 
 CONTAINER_PREFERENCE = (Podman, Docker)  # prefer podman to docker
 

--- a/src/cephadm/cephadmlib/container_types.py
+++ b/src/cephadm/cephadmlib/container_types.py
@@ -251,6 +251,7 @@ class CephContainer(BasicContainer):
         self.host_network = host_network
         self.memory_request = memory_request
         self.memory_limit = memory_limit
+        self.restart_on_failure = False
         self.remove = True
         self.ipc = 'host'
         self.network = 'host' if self.host_network else ''
@@ -324,6 +325,12 @@ class CephContainer(BasicContainer):
         if not self._cname and self.identity:
             return self.identity.legacy_container_name
         return self._cname
+
+    def build_engine_run_args(self) -> List[str]:
+        cmd_args = super().build_engine_run_args()
+        if not self.remove and self.restart_on_failure:
+            return ['--restart=on-failure'] + cmd_args
+        return cmd_args
 
     def run_cmd(self) -> List[str]:
         if not (self.envs and self.envs[0].startswith('NODE_NAME=')):

--- a/src/cephadm/cephadmlib/runscripts.py
+++ b/src/cephadm/cephadmlib/runscripts.py
@@ -63,10 +63,19 @@ def write_service_scripts(
     with contextlib.ExitStack() as estack:
         # write out the main file to run (start) a service
         runf = estack.enter_context(write_new(run_file_path))
-        runf.write('set -e\n')
+        if _should_exit_on_error(ctx):
+            runf.write('set -e\n')
         for command in pre_start_commands or []:
             _write_command(ctx, runf, command)
+        if _is_live_restore_enabled(ctx):
+            container.restart_on_failure = True
+            container.remove = False
         _write_container_cmd_to_bash(ctx, runf, container, ident.daemon_name)
+
+        if _is_live_restore_enabled(ctx):
+            _write_container_state_poll_loop(
+                ctx, runf, container.cname, ctx.container_engine.path
+            )
 
         # some metadata about the deploy
         metaf = estack.enter_context(write_new(meta_file_path))
@@ -253,3 +262,26 @@ def _write_command(
         fh.write(cmd)
         if not cmd.endswith('\n'):
             fh.write('\n')
+
+
+def _write_container_state_poll_loop(
+    ctx: CephadmContext,
+    file_obj: IO[str],
+    cname: str,
+    engine_path: str,
+) -> None:
+    templating.render_to_file(
+        file_obj,
+        ctx,
+        templating.Templates.live_restore_wait_loop,
+        cname=cname,
+        engine_path=engine_path,
+    )
+
+
+def _should_exit_on_error(ctx: CephadmContext) -> bool:
+    return not _is_live_restore_enabled(ctx)
+
+
+def _is_live_restore_enabled(ctx: CephadmContext) -> bool:
+    return ctx.container_engine.is_live_restore_enabled(ctx)

--- a/src/cephadm/cephadmlib/templates/live_restore_wait_loop.sh.j2
+++ b/src/cephadm/cephadmlib/templates/live_restore_wait_loop.sh.j2
@@ -1,0 +1,25 @@
+# Docker live-restore keeps containers running when the docker daemon is down.
+# When this happens, the 'docker run' CLI exits but the container remains alive.
+# This loop keeps unit.run alive (and thus the systemd service active) by polling
+# the container's running state. It exits only when the container genuinely stops
+# or when the daemon is unresponsive for longer than DAEMON_UNAVAILABLE_TIMEOUT seconds.
+DAEMON_UNAVAILABLE_TIMEOUT=120
+POLL_INTERVAL=5
+daemon_down_since=0
+while true; do
+    {{ engine_path }} wait {{ cname }} 2>/dev/null
+    state=$({{ engine_path }} inspect --format '{{ '{{.State.Running}}' }}' {{ cname }} 2>/dev/null)
+    inspect_rc=$?
+    if [ $inspect_rc -eq 0 ]; then
+        daemon_down_since=0
+        [ "$state" != "true" ] && break
+    else
+        if [ "$daemon_down_since" -eq 0 ]; then
+            daemon_down_since=$(date +%s)
+        else
+            elapsed=$(( $(date +%s) - daemon_down_since ))
+            [ "$elapsed" -ge "$DAEMON_UNAVAILABLE_TIMEOUT" ] && break
+        fi
+    fi
+    sleep $POLL_INTERVAL
+done

--- a/src/cephadm/cephadmlib/templating.py
+++ b/src/cephadm/cephadmlib/templating.py
@@ -29,6 +29,7 @@ class Templates(str, enum.Enum):
     cephadm_logrotate_config = 'cephadm.logrotate.config.j2'
     sidecar_run = 'sidecar.run.j2'
     init_ctr_run = 'init_containers.run.j2'
+    live_restore_wait_loop = 'live_restore_wait_loop.sh.j2'
 
     def __str__(self) -> str:
         return self.value

--- a/src/cephadm/tests/fixtures.py
+++ b/src/cephadm/tests/fixtures.py
@@ -22,6 +22,7 @@ def mock_docker():
 
     docker = mock.Mock(Docker)
     docker.path = '/usr/bin/docker'
+    docker.is_live_restore_enabled.return_value = False
     type(docker).unlimited_pids_option = Docker.unlimited_pids_option
     return docker
 
@@ -32,6 +33,7 @@ def mock_podman():
     podman = mock.Mock(Podman)
     podman.path = '/usr/bin/podman'
     podman.version = (2, 1, 0)
+    podman.is_live_restore_enabled.return_value = False
     # This next little bit of black magic was adapated from the mock docs for
     # PropertyMock. We don't use a PropertyMock but the suggestion to call
     # type(...) from the doc allows us to "borrow" the real

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -350,6 +350,7 @@ class TestCephAdm(object):
         _get_container = funkypatch.patch('cephadm.get_container')
 
         ctx = _cephadm.CephadmContext()
+        ctx.container_engine = mock_podman()
         ctx.config_json = '-'
         ctx.extra_container_args = [
             '--pids-limit=12345',


### PR DESCRIPTION


When Docker is configured with live-restore=true, containers remain alive when dockerd is stopped or restarted. However, the 'docker run' CLI exits at that point, causing systemd to incorrectly treat the service as failed and triggering unnecessary container restarts via ExecStopPost.

This change detects when Docker live-restore is enabled and adapts the generated unit.run script accordingly:
- Replaces --rm with --restart=on-failure on the main container run command
- Appends a polling loop that keeps unit.run alive by monitoring the container's running state via 'docker inspect', exiting only when the container genuinely stops or the daemon is unresponsive

Short-lived pre_start_command containers (e.g. OSD ceph-volume activate) are unaffected and continue to use --rm.

Fixes: https://tracker.ceph.com/issues/72274
Signed-off-by: Yonatan Zaken <yzaken@redhat.com>


An example of the behavior with this change, given a Ceph host with some running daemons on it:
```
[root@ceph-node-0 ~]# date; docker ps -a
Sat May 23 11:57:02 AM UTC 2026
CONTAINER ID   IMAGE                                 COMMAND                  CREATED          STATUS          PORTS     NAMES
35fd78a103a9   192.168.100.254:5000/ceph/ceph        "/usr/bin/ceph-osd -…"   12 minutes ago   Up 12 minutes             ceph-4513cff6-569c-11f1-a56d-5254002a957e-osd-0
cc31de13e843   192.168.100.254:5000/ceph/ceph        "/usr/bin/ceph-crash…"   13 minutes ago   Up 13 minutes             ceph-4513cff6-569c-11f1-a56d-5254002a957e-crash-ceph-node-0
fab92646045d   192.168.100.254:5000/ceph/ceph:main   "/usr/bin/ceph-mgr -…"   15 minutes ago   Up 15 minutes             ceph-4513cff6-569c-11f1-a56d-5254002a957e-mgr-ceph-node-0-knwpwc
825656291c39   192.168.100.254:5000/ceph/ceph:main   "/usr/bin/ceph-mon -…"   15 minutes ago   Up 15 minutes             ceph-4513cff6-569c-11f1-a56d-5254002a957e-mon-ceph-node-0

```

We restart the docker daemon via:
```
[root@ceph-node-0 ~]# systemctl restart docker.service
```

Containers remain up and running:
```
[root@ceph-node-0 ~]# date; docker ps -a
Sat May 23 11:59:55 AM UTC 2026
CONTAINER ID   IMAGE                                 COMMAND                  CREATED          STATUS          PORTS     NAMES
35fd78a103a9   192.168.100.254:5000/ceph/ceph        "/usr/bin/ceph-osd -…"   15 minutes ago   Up 15 minutes             ceph-4513cff6-569c-11f1-a56d-5254002a957e-osd-0
cc31de13e843   192.168.100.254:5000/ceph/ceph        "/usr/bin/ceph-crash…"   16 minutes ago   Up 16 minutes             ceph-4513cff6-569c-11f1-a56d-5254002a957e-crash-ceph-node-0
fab92646045d   192.168.100.254:5000/ceph/ceph:main   "/usr/bin/ceph-mgr -…"   17 minutes ago   Up 17 minutes             ceph-4513cff6-569c-11f1-a56d-5254002a957e-mgr-ceph-node-0-knwpwc
825656291c39   192.168.100.254:5000/ceph/ceph:main   "/usr/bin/ceph-mon -…"   17 minutes ago   Up 17 minutes             ceph-4513cff6-569c-11f1-a56d-5254002a957e-mon-ceph-node-0

```



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
