### PR TITLE
rgw/admin: fix infinite loop in role list pagination

### DIFF
--- a/qa/suites/rgw/verify/tasks/admin-pagination.yaml
+++ b/qa/suites/rgw/verify/tasks/admin-pagination.yaml
@@ -3,3 +3,4 @@ tasks:
     clients:
       client.0:
         - rgw/run-admin-pagination.sh
+        - rgw/test_rgw_role_pagination.sh

--- a/qa/workunits/rgw/test_rgw_role_pagination.sh
+++ b/qa/workunits/rgw/test_rgw_role_pagination.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# test_rgw_role_pagination.sh
+# Verify that 'radosgw-admin role list' paginates correctly beyond the 100-item chunk limit.
+
+set -e
+
+# Fallback to standard command if the variable isn't provided by the environment
+RGW_ADMIN=${RGW_ADMIN:-radosgw-admin}
+
+NUM_ROLES=105
+PREFIX="TestRole"
+POLICY_DOC='{"Statement": [{"Effect": "Allow", "Principal": {"AWS": ["*"]}, "Action": ["sts:AssumeRole"]}]}'
+
+echo "Creating ${NUM_ROLES} roles to trigger pagination limit..."
+for i in $(seq 1 $NUM_ROLES); do
+    "$RGW_ADMIN" role create --role-name="${PREFIX}${i}" --assume-role-policy-doc="${POLICY_DOC}" > /dev/null
+done
+
+echo "Fetching role list (if the pagination bug exists, this will hang infinitely)..."
+# We pipe the JSON output into 'jq' to count the total number of objects in the 'Roles' array
+ROLE_COUNT=$("$RGW_ADMIN" role list 2>/dev/null | jq 'length')
+
+echo "Found ${ROLE_COUNT} roles."
+
+# Assert that we successfully retrieved at least the 105 roles we just created
+if [ "$ROLE_COUNT" -lt "$NUM_ROLES" ]; then
+    echo "FAIL: Expected at least ${NUM_ROLES} roles, but only retrieved ${ROLE_COUNT}."
+    exit 1
+fi
+
+echo "Cleaning up test roles..."
+for i in $(seq 1 $NUM_ROLES); do
+    "$RGW_ADMIN" role delete --role-name="${PREFIX}${i}" > /dev/null
+done
+
+echo "SUCCESS: Role pagination works correctly!"
+exit 0

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -7298,15 +7298,21 @@ int main(int argc, const char **argv)
         constexpr int32_t max_chunk = 100;
         int32_t count = std::min(max_chunk, remaining);
 
+        // Copy the marker to a separate local variable to break the reference alias
+        std::string current_marker = listing.next_marker;
+        // Clear the roles list to prevent appending duplicates across loop iterations
+        listing.roles.clear();
+        listing.next_marker.clear();
+
         if (!account_id.empty()) {
           // list roles in the account
           ret = driver->list_account_roles(dpp(), null_yield, account_id,
-                                           path_prefix, listing.next_marker,
+                                           path_prefix, current_marker,
                                            count, listing);
         } else {
           // list roles in the tenant
           ret = driver->list_roles(dpp(), null_yield, tenant, path_prefix,
-                                   listing.next_marker, count, listing);
+                                   current_marker, count, listing);
         }
         if (ret < 0) {
           return -ret;


### PR DESCRIPTION
The `radosgw-admin role list` command was getting stuck in an infinite loop when paginating through more than 100 roles.

Fixes: https://tracker.ceph.com/issues/76776

Tested via local vstart cluster by generating 105 roles and running `radosgw-admin role list`.

```
for i in {1..105}; do
  bin/radosgw-admin role create \
    --role-name=TestRole$i \
    --assume-role-policy-doc='{"Statement": [{"Effect": "Allow", "Principal": {"AWS": ["*"]}, "Action": ["sts:AssumeRole"]}]}' > /dev/null
done
```

```
$ bin/radosgw-admin role list | grep "Arn"  | wc -l
105
```

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
