### PR TITLE
crimson/os/seastore/lba, TM: prevent of the users of LBACursor/LBAMapping from pass the paddr/lba_map_val_t across the boundaries of coroutines

### DIFF
--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -1135,6 +1135,89 @@ public:
     return iter;
   }
 
+  /**
+   * replace
+   *
+   * Replace the entry pointed by iter with the key and val. key
+   * must be within the range iter.get_key()~iter.get_length()
+   *
+   * @param c [in] op context
+   * @param iter [in] iterator to element to update, must not be end
+   * @param key [in] key with which to replace
+   * @param val [in] val with which to replace
+   * @return iterator to newly replaced element
+   */
+  using replace_iertr = base_iertr;
+  using replace_ret = replace_iertr::future<iterator>;
+  using get_val_func_t = std::function<node_val_t ()>;
+  replace_ret replace(
+    op_context_t c,
+    iterator iter,
+    node_key_t key,
+    get_val_func_t func,
+    BaseChildNode<leaf_node_t, node_key_t> *child)
+  {
+    LOG_PREFIX(FixedKVBtree::replace);
+    SUBTRACET(
+      seastore_fixedkv_tree,
+      "replace element at {} with {}",
+      c.trans,
+      iter.is_end() ? min_max_t<node_key_t>::max : iter.get_key(),
+      key);
+    if (likely(iter.leaf.node->get_meta().end > key)) {
+      // the replacing key is also within the range of the current
+      // leaf node, so do the replacing directly
+      if (!iter.leaf.node->is_mutable()) {
+        CachedExtentRef mut = c.cache.duplicate_for_write(
+          c.trans, iter.leaf.node
+        );
+        iter.leaf.node = mut->cast<leaf_node_t>();
+      }
+      ++(get_tree_stats<self_type>(c.trans).num_updates);
+      iter.leaf.node->replace(
+        iter.leaf.node->iter_idx(iter.leaf.pos),
+        key,
+        func());
+      if constexpr (std::is_base_of_v<
+          ParentNode<leaf_node_t, node_key_t>, leaf_node_t>) {
+        if (child) {
+          iter.leaf.node->update_child_ptr(iter.leaf.pos, child);
+        }
+      }
+      co_return iter;
+    }
+    // the replacing key fall beyond the end of the current leaf
+    // node, insert it into the next leaf node and remove the
+    // original key
+    auto niter = co_await iter.next(c);
+    assert(!niter.is_end());
+    assert(niter.get_key() > key);
+    co_await handle_split(c, niter);
+    if (!niter.leaf.node->is_mutable()) {
+      CachedExtentRef mut = c.cache.duplicate_for_write(
+        c.trans, niter.leaf.node
+      );
+      niter.leaf.node = mut->cast<leaf_node_t>();
+    }
+    auto it = typename leaf_node_t::const_iterator(
+        niter.leaf.node.get(), niter.leaf.pos);
+    assert(key >= niter.leaf.node->get_meta().begin &&
+           key < niter.leaf.node->get_meta().end);
+    niter.leaf.node->insert(it, key, func());
+    if constexpr (std::is_base_of_v<
+        ParentNode<leaf_node_t, node_key_t>, leaf_node_t>) {
+      niter.leaf.node->insert_child_ptr(
+        niter.leaf.pos, child, niter.leaf.node->get_size() - 1);
+    }
+    (void)child;
+    // TODO: the keys pointed by iter and niter are overlapped which
+    // is against the invariant of the lba/backref tree, but since
+    // remove directly removes the iter, it wouldn't cause any issue
+    // for the time being.
+    niter = co_await remove(c, std::move(iter));
+    assert(niter.get_key() == key);
+    co_return niter;
+  }
 
   /**
    * remove

--- a/src/crimson/os/seastore/lba/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.cc
@@ -1086,38 +1086,54 @@ BtreeLBAManager::remap_mappings(
 	 (orig_val.pladdr.is_paddr() &&
 	  orig_val.pladdr.get_paddr().is_absolute()));
   auto type = cursor->get_extent_type();
-  cursor = co_await update_mapping_refcount(
-    c.trans, cursor, -1);
-  iter = btree.make_partial_iter(c, *cursor);
+  auto off = 0;
+  auto last_iter = iter;
   for (auto &remap : remaps) {
     assert(remap.offset + remap.len <= orig_len);
     assert((bool)remap.extent == !orig_indirect);
-    lba_map_val_t val = orig_val;
     auto new_key = (orig_laddr + remap.offset).checked_to_laddr();
-    val.len = remap.len;
-    if (val.pladdr.is_laddr()) {
-      DEBUGT("{} + {:#x}",
-        t,
-        val.pladdr.get_local_clone_id(),
-        remap.offset);
-    } else {
-      auto paddr = val.pladdr.get_paddr();
-      val.pladdr = paddr + remap.offset;
-    }
-    val.refcount = EXTENT_DEFAULT_REF_COUNT;
-    // Checksum will be updated when the committing the transaction
-    val.checksum = CRC_NULL;
-    val.type = type;
+    auto f = [&last_iter, &remap, &off, &t, FNAME, type] {
+      lba_map_val_t val = last_iter.get_val();
+      auto cur_off = remap.offset - off;
+      if (val.pladdr.is_laddr()) {
+        DEBUGT("{} + {:#x}",
+          t,
+          val.pladdr.get_local_clone_id(),
+          remap.offset);
+      } else {
+        auto paddr = val.pladdr.get_paddr();
+        val.pladdr = paddr + cur_off;
+      }
+      val.len = remap.len;
+      val.refcount = EXTENT_DEFAULT_REF_COUNT;
+      // Checksum will be updated when the committing the transaction
+      val.checksum = CRC_NULL;
+      val.type = type;
+      return val;
+    };
     // committing the transaction
-    auto p = co_await btree.insert(
-      c, iter, new_key, std::move(val),
-      orig_indirect
-        ? get_reserved_ptr<LBALeafNode, laddr_t>()
-        : remap.extent);
-    auto &[it, inserted] = p;
-    ceph_assert(inserted);
-    ret.push_back(it.get_cursor(c));
-    iter = co_await it.next(c);
+    if (remap.offset == remaps.front().offset) {
+      iter = co_await btree.replace(
+        c, std::move(iter), new_key,
+        std::move(f),
+        orig_indirect
+          ? get_reserved_ptr<LBALeafNode, laddr_t>()
+          : remap.extent);
+      ret.push_back(iter.get_cursor(c));
+      iter = co_await iter.next(c);
+    } else {
+      auto p = co_await btree.insert(
+        c, iter, new_key, f(),
+        orig_indirect
+          ? get_reserved_ptr<LBALeafNode, laddr_t>()
+          : remap.extent);
+      auto &[it, inserted] = p;
+      ceph_assert(inserted);
+      ret.push_back(it.get_cursor(c));
+      last_iter = it;
+      iter = co_await it.next(c);
+    }
+    off = remap.offset;
   }
   co_await trans_intr::parallel_for_each(
     ret,

--- a/src/crimson/os/seastore/lba/lba_btree_node.h
+++ b/src/crimson/os/seastore/lba/lba_btree_node.h
@@ -148,6 +148,24 @@ struct LBALeafNode
     laddr_t addr,
     lba_map_val_t val) final;
 
+  void replace(
+    internal_const_iterator_t iter,
+    laddr_t pivot,
+    lba_map_val_t val) {
+    LOG_PREFIX(FixedKVInternalNode::replace);
+    SUBTRACE(seastore_fixedkv_tree, "trans.{}, pos {}, old key {}, key {}",
+      this->pending_for_transaction,
+      iter.get_offset(),
+      iter.get_key(),
+      pivot);
+    this->on_modify();
+    return this->journal_replace(
+      iter,
+      pivot,
+      std::move(val),
+      maybe_get_delta_buffer());
+  }
+
   void remove(internal_const_iterator_t iter) final {
     LOG_PREFIX(LBALeafNode::remove);
     SUBTRACE(seastore_fixedkv_tree, "trans.{}, pos {}, key {}",

--- a/src/crimson/os/seastore/linked_tree_node.h
+++ b/src/crimson/os/seastore/linked_tree_node.h
@@ -426,7 +426,9 @@ public:
 
   void update_child_ptr(btreenode_pos_t pos, BaseChildNode<T, node_key_t>* child) {
     children[pos] = child;
-    set_child_ptracker(child);
+    if (!is_reserved_ptr(child)) {
+      set_child_ptracker(child);
+    }
   }
 
   // copy dests points from a stable node back to its pending nodes

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -1411,10 +1411,10 @@ private:
     }
 #endif
 
+    co_await pin.co_refresh();
     if (pin.is_indirect()) {
       SUBDEBUGT(seastore_tm, "{} into {} remaps ...",
         t, pin, remaps.size());
-      co_await pin.co_refresh();
       pin = co_await complete_mapping(t, std::move(pin));
     } else {
       laddr_t original_laddr = pin.get_key();
@@ -1425,7 +1425,6 @@ private:
       ceph_assert(!pin.is_clone());
 
       TCachedExtentRef<T> extent;
-      co_await pin.co_refresh();
       if (full_extent_integrity_check) {
         SUBTRACET(seastore_tm, "{} reading pin...", t, pin);
         // read the entire extent from disk (See: pin_to_extent)
@@ -1447,7 +1446,7 @@ private:
           auto &child_pos = ret.get_child_pos();
           auto laddr = pin.get_key();
           std::ignore = cache->retire_absent_extent_addr_by_type(
-            t, laddr, original_paddr, original_len, pin.get_extent_type(),
+            t, laddr, pin.get_val(), original_len, pin.get_extent_type(),
             [&child_pos, laddr](auto &extent) mutable {
               auto lextent = extent.template cast<LogicalChildNode>();
               assert(extent.is_logical());
@@ -1473,7 +1472,7 @@ private:
         SUBDEBUGT(seastore_tm, "extent fully loaded...", t);
         ceph_assert(extent->is_data_stable());
         ceph_assert(extent->get_length() >= original_len);
-        ceph_assert(extent->get_paddr() == original_paddr);
+        ceph_assert(extent->get_paddr() == pin.get_val());
         original_bptr = extent->get_bptr();
       }
       if (extent) {
@@ -1485,7 +1484,7 @@ private:
         auto remap_offset = remap.offset;
         auto remap_len = remap.len;
         auto remap_laddr = (original_laddr + remap_offset).checked_to_laddr();
-        auto remap_paddr = original_paddr.add_offset(remap_offset);
+        auto remap_paddr = pin.get_val().add_offset(remap_offset);
         SUBDEBUGT(seastore_tm, "remap direct pin into {}~0x{:x} {} ...",
                   t, remap_laddr, remap_len, remap_paddr);
         ceph_assert(remap_len < original_len);


### PR DESCRIPTION
With pessimistic cc between rewriting transactions and client transactions in place, users of LBACursor/LBAMapping , like `TransactionManager::remap_pin()` and `LBAManager::remap_mappings()`, shouldn't pass the retrieved paddr/lba_map_val_t across the boundaries of coroutines, because the paddr/lba_map_val_t might be modified by a background rewrite transaction during that time. See the commit messages for details.

The issue was introduced since https://github.com/ceph/ceph/commit/bd0ce704f24afbe11830d31b46d8b22771f54456

Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
