### PR TITLE
NVMe-oF – Design cards for the gateway group, subsystem, namespace page when the table has data

### DIFF
--- a/monitoring/ceph-mixin/prometheus_alerts.libsonnet
+++ b/monitoring/ceph-mixin/prometheus_alerts.libsonnet
@@ -849,7 +849,7 @@
           alert: 'NVMeoFSubsystemNamespaceLimit',
           'for': '1m',
           expr: '(count by(nqn, cluster, instance) (ceph_nvmeof_subsystem_namespace_metadata)) >= on(nqn, instance) group_right(cluster) ceph_nvmeof_subsystem_namespace_limit',
-          labels: { severity: 'warning', type: 'ceph_default' },
+          labels: { severity: 'warning', type: 'ceph_default', category: 'subsystem' },
           annotations: {
             summary: '{{ $labels.nqn }} subsystem has reached its maximum number of namespaces%(cluster)s' % $.MultiClusterSummary(),
             description: 'Subsystems have a max namespace limit defined at creation time. This alert means that no more namespaces can be added to {{ $labels.nqn }}',
@@ -859,7 +859,7 @@
           alert: 'NVMeoFMultipleNamespacesOfRBDImage',
           'for': '1m',
           expr: 'count by(pool_name, rbd_name) (count by(bdev_name, pool_name, rbd_name) (ceph_nvmeof_bdev_metadata and on (bdev_name) ceph_nvmeof_subsystem_namespace_metadata)) > 1',
-          labels: { severity: 'warning', type: 'ceph_default' },
+          labels: { severity: 'warning', type: 'ceph_default', category: 'namespace' },
           annotations: {
             summary: 'RBD image {{ $labels.pool_name }}/{{ $labels.rbd_name }} cannot be reused for multiple NVMeoF namespace ',
             description: 'Each NVMeoF namespace must have a unique RBD pool and image, across all different gateway groups.',
@@ -869,7 +869,7 @@
           alert: 'NVMeoFTooManyGateways',
           'for': '1m',
           expr: 'count(ceph_nvmeof_gateway_info) by (cluster) > %.2f' % [$._config.NVMeoFMaxGatewaysPerCluster],
-          labels: { severity: 'warning', type: 'ceph_default' },
+          labels: { severity: 'warning', type: 'ceph_default', category: 'gateway' },
           annotations: {
             summary: 'Max supported gateways exceeded%(cluster)s' % $.MultiClusterSummary(),
             description: 'You may create many gateways, but %(NVMeoFMaxGatewaysPerCluster)d is the tested limit' % $._config,
@@ -879,7 +879,7 @@
           alert: 'NVMeoFMaxGatewayGroupSize',
           'for': '1m',
           expr: 'count(ceph_nvmeof_gateway_info) by (cluster,group) > %.2f' % [$._config.NVMeoFMaxGatewaysPerGroup],
-          labels: { severity: 'warning', type: 'ceph_default' },
+          labels: { severity: 'warning', type: 'ceph_default', category: 'gateway' },
           annotations: {
             summary: 'Max gateways within a gateway group ({{ $labels.group }}) exceeded%(cluster)s' % $.MultiClusterSummary(),
             description: 'You may create many gateways in a gateway group, but %(NVMeoFMaxGatewaysPerGroup)d is the tested limit' % $._config,
@@ -889,7 +889,7 @@
           alert: 'NVMeoFMaxGatewayGroups',
           'for': '1m',
           expr: 'count(count by (group, cluster) (ceph_nvmeof_gateway_info)) by (cluster) > %.2f' % [$._config.NVMeoFMaxGatewayGroups],
-          labels: { severity: 'warning', type: 'ceph_default' },
+          labels: { severity: 'warning', type: 'ceph_default', category: 'gateway' },
           annotations: {
             summary: 'Max gateway groups exceeded%(cluster)s' % $.MultiClusterSummary(),
             description: 'You may create many gateway groups, but %(NVMeoFMaxGatewayGroups)d is the tested limit' % $._config,
@@ -899,7 +899,7 @@
           alert: 'NVMeoFSingleGateway',
           'for': '5m',
           expr: 'count(ceph_nvmeof_gateway_info) by(cluster,group) == 1',
-          labels: { severity: 'warning', type: 'ceph_default' },
+          labels: { severity: 'warning', type: 'ceph_default', category: 'gateway' },
           annotations: {
             summary: 'The gateway group {{ $labels.group }} consists of a single gateway - HA is not possible%(cluster)s' % $.MultiClusterSummary(),
             description: 'Although a single member gateway group is valid, it should only be used for test purposes',
@@ -909,7 +909,7 @@
           alert: 'NVMeoFHighGatewayCPU',
           'for': '10m',
           expr: 'label_replace(avg by(instance, cluster) (rate(ceph_nvmeof_reactor_seconds_total{mode="busy"}[1m])),"instance","$1","instance","(.*):.*") > %.2f' % [$._config.NVMeoFHighGatewayCPU],
-          labels: { severity: 'warning', type: 'ceph_default' },
+          labels: { severity: 'warning', type: 'ceph_default', category: 'gateway' },
           annotations: {
             summary: 'CPU used by {{ $labels.instance }} NVMe-oF Gateway is high%(cluster)s' % $.MultiClusterSummary(),
             description: 'Typically, high CPU may indicate degraded performance. Consider increasing the number of reactor cores',
@@ -919,7 +919,7 @@
           alert: 'NVMeoFGatewayOpenSecurity',
           'for': '5m',
           expr: 'ceph_nvmeof_subsystem_metadata{allow_any_host="yes"}',
-          labels: { severity: 'warning', type: 'ceph_default' },
+          labels: { severity: 'warning', type: 'ceph_default', category: 'subsystem' },
           annotations: {
             summary: 'Subsystem {{ $labels.nqn }} has been defined without host level security%(cluster)s' % $.MultiClusterSummary(),
             description: 'It is good practice to ensure subsystems use host security to reduce the risk of unexpected data loss',
@@ -929,7 +929,7 @@
           alert: 'NVMeoFTooManySubsystems',
           'for': '1m',
           expr: 'count by(gateway_host, cluster) (label_replace(ceph_nvmeof_subsystem_metadata,"gateway_host","$1","instance","(.*?)(?::.*)?")) >= %.2f' % [$._config.NVMeoFMaxSubsystemsPerGateway],
-          labels: { severity: 'warning', type: 'ceph_default' },
+          labels: { severity: 'warning', type: 'ceph_default', category: 'subsystem' },
           annotations: {
             summary: 'The number of subsystems defined to the NVMeoF gateway reached or exceeded the supported values%(cluster)s' % $.MultiClusterSummary(),
             description: 'NVMeoF gateway {{ $labels.gateway_host }} has reached or exceeded the supported maximum of %(NVMeoFMaxSubsystemsPerGateway)d subsystems. Current count: {{ $value }}.' % $._config,
@@ -939,7 +939,7 @@
           alert: 'NVMeoFTooManyNamespaces',
           'for': '1m',
           expr: 'sum by(gateway_host, cluster) (label_replace(ceph_nvmeof_subsystem_namespace_count,"gateway_host","$1","instance","(.*?)(?::.*)?")) >= %.2f' % [$._config.NVMeoFMaxNamespaces],
-          labels: { severity: 'warning', type: 'ceph_default' },
+          labels: { severity: 'warning', type: 'ceph_default', category: 'namespace' },
           annotations: {
             summary: 'The number of namespaces defined to the NVMeoF gateway reached or exceeded supported values%(cluster)s' % $.MultiClusterSummary(),
             description: 'NVMeoF gateway {{ $labels.gateway_host }} has reached or exceeded the supported maximum of %(NVMeoFMaxNamespaces)d namespaces. Current count: {{ $value }}.' % $._config,
@@ -949,7 +949,7 @@
           alert: 'NVMeoFVersionMismatch',
           'for': '1h',
           expr: 'count(count(ceph_nvmeof_gateway_info) by (cluster, version)) by (cluster) > 1',
-          labels: { severity: 'warning', type: 'ceph_default' },
+          labels: { severity: 'warning', type: 'ceph_default', category: 'gateway' },
           annotations: {
             summary: 'Too many different NVMe-oF gateway releases active%(cluster)s' % $.MultiClusterSummary(),
             description: 'This may indicate an issue with deployment. Check cephadm logs',
@@ -959,7 +959,7 @@
           alert: 'NVMeoFHighClientCount',
           'for': '1m',
           expr: 'ceph_nvmeof_subsystem_host_count > %.2f' % [$._config.NVMeoFHighClientCount],
-          labels: { severity: 'warning', type: 'ceph_default' },
+          labels: { severity: 'warning', type: 'ceph_default', category: 'subsystem' },
           annotations: {
             summary: 'The number of clients connected to {{ $labels.nqn }} is too high%(cluster)s' % $.MultiClusterSummary(),
             description: 'The supported limit for clients connecting to a subsystem is %(NVMeoFHighClientCount)d' % $._config,
@@ -969,7 +969,7 @@
           alert: 'NVMeoFMissingListener',
           'for': '10m',
           expr: 'ceph_nvmeof_subsystem_listener_count == 0 and on(nqn) sum(ceph_nvmeof_subsystem_listener_count) by (nqn) > 0',
-          labels: { severity: 'warning', type: 'ceph_default' },
+          labels: { severity: 'warning', type: 'ceph_default', category: 'listener' },
           annotations: {
             summary: 'No listener added for {{ $labels.instance }} NVMe-oF Gateway to {{ $labels.nqn }} subsystem',
             description: 'For every subsystem, each gateway should have a listener to balance traffic between gateways.',
@@ -979,7 +979,7 @@
           alert: 'NVMeoFZeroListenerSubsystem',
           'for': '10m',
           expr: 'sum(ceph_nvmeof_subsystem_listener_count) by (nqn) == 0',
-          labels: { severity: 'warning', type: 'ceph_default' },
+          labels: { severity: 'warning', type: 'ceph_default', category: 'listener' },
           annotations: {
             summary: 'No listeners added to {{ $labels.nqn }} subsystem',
             description: 'NVMeoF gateway configuration incomplete; one of the subsystems have zero listeners.',
@@ -989,7 +989,7 @@
           alert: 'NVMeoFHighHostCPU',
           'for': '10m',
           expr: '100-((100*(avg by(cluster,host) (label_replace(rate(node_cpu_seconds_total{mode="idle"}[5m]),"host","$1","instance","(.*):.*")) * on(cluster, host) group_right label_replace(ceph_nvmeof_gateway_info,"host","$1","instance","(.*):.*")))) >= %.2f' % [$._config.NVMeoFHighHostCPU],
-          labels: { severity: 'warning', type: 'ceph_default' },
+          labels: { severity: 'warning', type: 'ceph_default', category: 'host' },
           annotations: {
             summary: 'The CPU is high ({{ $value }}%%) on NVMeoF Gateway host ({{ $labels.host }})%(cluster)s' % $.MultiClusterSummary(),
             description: 'High CPU on a gateway host can lead to CPU contention and performance degradation',
@@ -999,7 +999,7 @@
           alert: 'NVMeoFInterfaceDown',
           'for': '30s',
           expr: 'ceph_nvmeof_subsystem_listener_iface_info{operstate="down"}',
-          labels: { severity: 'warning', type: 'ceph_default', oid: '1.3.6.1.4.1.50495.1.2.1.14.1' },
+          labels: { severity: 'warning', type: 'ceph_default', oid: '1.3.6.1.4.1.50495.1.2.1.14.1', category: 'listener' },
           annotations: {
             summary: 'Network interface {{ $labels.device }} is down%(cluster)s' % $.MultiClusterSummary(),
             description: 'A NIC used by one or more subsystems is in a down state',
@@ -1009,7 +1009,7 @@
           alert: 'NVMeoFInterfaceDuplex',
           'for': '30s',
           expr: 'ceph_nvmeof_subsystem_listener_iface_info{duplex!="full"}',
-          labels: { severity: 'warning', type: 'ceph_default' },
+          labels: { severity: 'warning', type: 'ceph_default', category: 'listener' },
           annotations: {
             summary: 'Network interface {{ $labels.device }} is not running in full duplex mode%(cluster)s' % $.MultiClusterSummary(),
             description: 'Until this is resolved, performance from the gateway will be degraded',
@@ -1019,7 +1019,7 @@
           alert: 'NVMeoFHighReadLatency',
           'for': '5m',
           expr: 'label_replace((avg by(instance) ((rate(ceph_nvmeof_bdev_read_seconds_total[1m]) / rate(ceph_nvmeof_bdev_reads_completed_total[1m])))),"gateway","$1","instance","(.*):.*") > %.2f' % [$._config.NVMeoFHighClientReadLatency / 1000],
-          labels: { severity: 'warning', type: 'ceph_default' },
+          labels: { severity: 'warning', type: 'ceph_default', category: 'performance' },
           annotations: {
             summary: 'The average read latency over the last 5 mins has reached %(NVMeoFHighClientReadLatency)d ms or more on {{ $labels.gateway }}' % $._config,
             description: 'High latencies may indicate a constraint within the cluster e.g. CPU, network. Please investigate',
@@ -1029,7 +1029,7 @@
           alert: 'NVMeoFHighWriteLatency',
           'for': '5m',
           expr: 'label_replace((avg by(instance) ((rate(ceph_nvmeof_bdev_write_seconds_total[5m]) / rate(ceph_nvmeof_bdev_writes_completed_total[5m])))),"gateway","$1","instance","(.*):.*") > %.2f' % [$._config.NVMeoFHighClientWriteLatency / 1000],
-          labels: { severity: 'warning', type: 'ceph_default' },
+          labels: { severity: 'warning', type: 'ceph_default', category: 'performance' },
           annotations: {
             summary: 'The average write latency over the last 5 mins has reached %(NVMeoFHighClientWriteLatency)d ms or more on {{ $labels.gateway }}' % $._config,
             description: 'High latencies may indicate a constraint within the cluster e.g. CPU, network. Please investigate',
@@ -1039,7 +1039,7 @@
           alert: 'NVMeoFHostKeepAliveTimeout',
           'for': '1m',
           expr: 'ceil(changes(ceph_nvmeof_host_keepalive_timeout[%(NVMeoFHostKeepAliveTimeoutTrackDurationHours)dh:]) / 2) > 0' % $._config,
-          labels: { severity: 'warning', type: 'ceph_default' },
+          labels: { severity: 'warning', type: 'ceph_default', category: 'host' },
           annotations: {
             summary: 'Host ({{ $labels.host_nqn }}) was disconnected {{ $value }} times from subsystem ({{ $labels.nqn }}) in last %(NVMeoFHostKeepAliveTimeoutTrackDurationHours)d hours' % $._config,
             description: 'Host was disconnected due to host keep alive timeout',

--- a/monitoring/ceph-mixin/prometheus_alerts.yml
+++ b/monitoring/ceph-mixin/prometheus_alerts.yml
@@ -799,6 +799,7 @@ groups:
         expr: "(count by(nqn, cluster, instance) (ceph_nvmeof_subsystem_namespace_metadata)) >= on(nqn, instance) group_right(cluster) ceph_nvmeof_subsystem_namespace_limit"
         for: "1m"
         labels:
+          category: "subsystem"
           severity: "warning"
           type: "ceph_default"
       - alert: "NVMeoFMultipleNamespacesOfRBDImage"
@@ -808,6 +809,7 @@ groups:
         expr: "count by(pool_name, rbd_name) (count by(bdev_name, pool_name, rbd_name) (ceph_nvmeof_bdev_metadata and on (bdev_name) ceph_nvmeof_subsystem_namespace_metadata)) > 1"
         for: "1m"
         labels:
+          category: "namespace"
           severity: "warning"
           type: "ceph_default"
       - alert: "NVMeoFTooManyGateways"
@@ -817,6 +819,7 @@ groups:
         expr: "count(ceph_nvmeof_gateway_info) by (cluster) > 32.00"
         for: "1m"
         labels:
+          category: "gateway"
           severity: "warning"
           type: "ceph_default"
       - alert: "NVMeoFMaxGatewayGroupSize"
@@ -826,6 +829,7 @@ groups:
         expr: "count(ceph_nvmeof_gateway_info) by (cluster,group) > 8.00"
         for: "1m"
         labels:
+          category: "gateway"
           severity: "warning"
           type: "ceph_default"
       - alert: "NVMeoFMaxGatewayGroups"
@@ -835,6 +839,7 @@ groups:
         expr: "count(count by (group, cluster) (ceph_nvmeof_gateway_info)) by (cluster) > 4.00"
         for: "1m"
         labels:
+          category: "gateway"
           severity: "warning"
           type: "ceph_default"
       - alert: "NVMeoFSingleGateway"
@@ -844,6 +849,7 @@ groups:
         expr: "count(ceph_nvmeof_gateway_info) by(cluster,group) == 1"
         for: "5m"
         labels:
+          category: "gateway"
           severity: "warning"
           type: "ceph_default"
       - alert: "NVMeoFHighGatewayCPU"
@@ -853,6 +859,7 @@ groups:
         expr: "label_replace(avg by(instance, cluster) (rate(ceph_nvmeof_reactor_seconds_total{mode=\"busy\"}[1m])),\"instance\",\"$1\",\"instance\",\"(.*):.*\") > 80.00"
         for: "10m"
         labels:
+          category: "gateway"
           severity: "warning"
           type: "ceph_default"
       - alert: "NVMeoFGatewayOpenSecurity"
@@ -862,6 +869,7 @@ groups:
         expr: "ceph_nvmeof_subsystem_metadata{allow_any_host=\"yes\"}"
         for: "5m"
         labels:
+          category: "subsystem"
           severity: "warning"
           type: "ceph_default"
       - alert: "NVMeoFTooManySubsystems"
@@ -871,6 +879,7 @@ groups:
         expr: "count by(gateway_host, cluster) (label_replace(ceph_nvmeof_subsystem_metadata,\"gateway_host\",\"$1\",\"instance\",\"(.*?)(?::.*)?\")) >= 128.00"
         for: "1m"
         labels:
+          category: "subsystem"
           severity: "warning"
           type: "ceph_default"
       - alert: "NVMeoFTooManyNamespaces"
@@ -880,6 +889,7 @@ groups:
         expr: "sum by(gateway_host, cluster) (label_replace(ceph_nvmeof_subsystem_namespace_count,\"gateway_host\",\"$1\",\"instance\",\"(.*?)(?::.*)?\")) >= 4096.00"
         for: "1m"
         labels:
+          category: "namespace"
           severity: "warning"
           type: "ceph_default"
       - alert: "NVMeoFVersionMismatch"
@@ -889,6 +899,7 @@ groups:
         expr: "count(count(ceph_nvmeof_gateway_info) by (cluster, version)) by (cluster) > 1"
         for: "1h"
         labels:
+          category: "gateway"
           severity: "warning"
           type: "ceph_default"
       - alert: "NVMeoFHighClientCount"
@@ -898,6 +909,7 @@ groups:
         expr: "ceph_nvmeof_subsystem_host_count > 128.00"
         for: "1m"
         labels:
+          category: "subsystem"
           severity: "warning"
           type: "ceph_default"
       - alert: "NVMeoFMissingListener"
@@ -907,6 +919,7 @@ groups:
         expr: "ceph_nvmeof_subsystem_listener_count == 0 and on(nqn) sum(ceph_nvmeof_subsystem_listener_count) by (nqn) > 0"
         for: "10m"
         labels:
+          category: "listener"
           severity: "warning"
           type: "ceph_default"
       - alert: "NVMeoFZeroListenerSubsystem"
@@ -916,6 +929,7 @@ groups:
         expr: "sum(ceph_nvmeof_subsystem_listener_count) by (nqn) == 0"
         for: "10m"
         labels:
+          category: "listener"
           severity: "warning"
           type: "ceph_default"
       - alert: "NVMeoFHighHostCPU"
@@ -925,6 +939,7 @@ groups:
         expr: "100-((100*(avg by(cluster,host) (label_replace(rate(node_cpu_seconds_total{mode=\"idle\"}[5m]),\"host\",\"$1\",\"instance\",\"(.*):.*\")) * on(cluster, host) group_right label_replace(ceph_nvmeof_gateway_info,\"host\",\"$1\",\"instance\",\"(.*):.*\")))) >= 80.00"
         for: "10m"
         labels:
+          category: "host"
           severity: "warning"
           type: "ceph_default"
       - alert: "NVMeoFInterfaceDown"
@@ -934,6 +949,7 @@ groups:
         expr: "ceph_nvmeof_subsystem_listener_iface_info{operstate=\"down\"}"
         for: "30s"
         labels:
+          category: "listener"
           oid: "1.3.6.1.4.1.50495.1.2.1.14.1"
           severity: "warning"
           type: "ceph_default"
@@ -944,6 +960,7 @@ groups:
         expr: "ceph_nvmeof_subsystem_listener_iface_info{duplex!=\"full\"}"
         for: "30s"
         labels:
+          category: "listener"
           severity: "warning"
           type: "ceph_default"
       - alert: "NVMeoFHighReadLatency"
@@ -953,6 +970,7 @@ groups:
         expr: "label_replace((avg by(instance) ((rate(ceph_nvmeof_bdev_read_seconds_total[1m]) / rate(ceph_nvmeof_bdev_reads_completed_total[1m])))),\"gateway\",\"$1\",\"instance\",\"(.*):.*\") > 0.01"
         for: "5m"
         labels:
+          category: "performance"
           severity: "warning"
           type: "ceph_default"
       - alert: "NVMeoFHighWriteLatency"
@@ -962,6 +980,7 @@ groups:
         expr: "label_replace((avg by(instance) ((rate(ceph_nvmeof_bdev_write_seconds_total[5m]) / rate(ceph_nvmeof_bdev_writes_completed_total[5m])))),\"gateway\",\"$1\",\"instance\",\"(.*):.*\") > 0.02"
         for: "5m"
         labels:
+          category: "performance"
           severity: "warning"
           type: "ceph_default"
       - alert: "NVMeoFHostKeepAliveTimeout"
@@ -971,6 +990,7 @@ groups:
         expr: "ceil(changes(ceph_nvmeof_host_keepalive_timeout[24h:]) / 2) > 0"
         for: "1m"
         labels:
+          category: "host"
           severity: "warning"
           type: "ceph_default"
   - name: "certmgr"

--- a/monitoring/ceph-mixin/tests_alerts/test_alerts.yml
+++ b/monitoring/ceph-mixin/tests_alerts/test_alerts.yml
@@ -2271,6 +2271,7 @@ tests:
           severity: warning
           cluster: mycluster
           type: ceph_default
+          category: subsystem
         exp_annotations:
           summary: "wah subsystem has reached its maximum number of namespaces on cluster mycluster"
           description: "Subsystems have a max namespace limit defined at creation time. This alert means that no more namespaces can be added to wah"
@@ -2316,9 +2317,10 @@ tests:
       exp_alerts:
       - exp_labels:
           pool_name: mypool
-          rbd_name: myimage1 
+          rbd_name: myimage1
           severity: warning
           type: ceph_default
+          category: namespace
         exp_annotations:
           summary: "RBD image mypool/myimage1 cannot be reused for multiple NVMeoF namespace "
           description: "Each NVMeoF namespace must have a unique RBD pool and image, across all different gateway groups."
@@ -2407,6 +2409,7 @@ tests:
           severity: warning
           cluster: mycluster
           type: ceph_default
+          category: gateway
         exp_annotations:
           summary: "Max supported gateways exceeded on cluster mycluster"
           description: "You may create many gateways, but 32 is the tested limit"
@@ -2451,6 +2454,7 @@ tests:
           severity: warning
           cluster: mycluster
           type: ceph_default
+          category: gateway
         exp_annotations:
           summary: "Max gateways within a gateway group (group-1) exceeded on cluster mycluster"
           description: "You may create many gateways in a gateway group, but 8 is the tested limit"
@@ -2483,6 +2487,7 @@ tests:
           severity: warning
           cluster: mycluster
           type: ceph_default
+          category: gateway
         exp_annotations:
           summary: "Max gateway groups exceeded on cluster mycluster"
           description: "You may create many gateway groups, but 4 is the tested limit"
@@ -2511,6 +2516,7 @@ tests:
           severity: warning
           cluster: mycluster
           type: ceph_default
+          category: gateway
         exp_annotations:
           summary: "The gateway group group-1 consists of a single gateway - HA is not possible on cluster mycluster"
           description: "Although a single member gateway group is valid, it should only be used for test purposes"
@@ -2535,6 +2541,7 @@ tests:
           severity: warning
           cluster: mycluster
           type: ceph_default
+          category: gateway
         exp_annotations:
           summary: "CPU used by node-1 NVMe-oF Gateway is high on cluster mycluster"
           description: "Typically, high CPU may indicate degraded performance. Consider increasing the number of reactor cores"
@@ -2562,6 +2569,7 @@ tests:
           severity: warning
           cluster: mycluster
           type: ceph_default
+          category: subsystem
         exp_annotations:
           summary: "Subsystem nqn.bad has been defined without host level security on cluster mycluster"
           description: "It is good practice to ensure subsystems use host security to reduce the risk of unexpected data loss"
@@ -2842,6 +2850,7 @@ tests:
           severity: warning
           cluster: mycluster
           type: ceph_default
+          category: subsystem
         exp_annotations:
           summary: "The number of subsystems defined to the NVMeoF gateway reached or exceeded the supported values on cluster mycluster"
           description: "NVMeoF gateway node-1 has reached or exceeded the supported maximum of 128 subsystems. Current count: 129."
@@ -2886,6 +2895,7 @@ tests:
           severity: warning
           cluster: mycluster
           type: ceph_default
+          category: namespace
         exp_annotations:
           summary: "The number of namespaces defined to the NVMeoF gateway reached or exceeded supported values on cluster mycluster"
           description: "NVMeoF gateway node-1 has reached or exceeded the supported maximum of 4096 namespaces. Current count: 4400."
@@ -2911,6 +2921,7 @@ tests:
           severity: warning
           cluster: mycluster
           type: ceph_default
+          category: gateway
         exp_annotations:
           summary: "Too many different NVMe-oF gateway releases active on cluster mycluster"
           description: "This may indicate an issue with deployment. Check cephadm logs"
@@ -2937,6 +2948,7 @@ tests:
           severity: warning
           cluster: mycluster
           type: ceph_default
+          category: subsystem
         exp_annotations:
           summary: "The number of clients connected to nqn1 is too high on cluster mycluster"
           description: "The supported limit for clients connecting to a subsystem is 128"
@@ -2973,6 +2985,7 @@ tests:
           nqn: nqn1
           severity: warning
           type: ceph_default
+          category: listener
         exp_annotations:
           summary: "No listener added for node-1:9100 NVMe-oF Gateway to nqn1 subsystem"
           description: "For every subsystem, each gateway should have a listener to balance traffic between gateways." 
@@ -3006,6 +3019,7 @@ tests:
           nqn: nqn1
           severity: warning
           type: ceph_default
+          category: listener
         exp_annotations:
           summary: "No listeners added to nqn1 subsystem"
           description: "NVMeoF gateway configuration incomplete; one of the subsystems have zero listeners."
@@ -3039,6 +3053,7 @@ tests:
           cluster: mycluster
           severity: warning
           type: ceph_default
+          category: host
         exp_annotations:
           summary: "The CPU is high (85%) on NVMeoF Gateway host (node-1) on cluster mycluster"
           description: "High CPU on a gateway host can lead to CPU contention and performance degradation"
@@ -3067,6 +3082,7 @@ tests:
           cluster: mycluster
           severity: warning
           type: ceph_default
+          category: listener
         exp_annotations:
           summary: "Network interface eth0 is down on cluster mycluster"
           description: "A NIC used by one or more subsystems is in a down state"
@@ -3094,6 +3110,7 @@ tests:
           cluster: mycluster
           severity: warning
           type: ceph_default
+          category: listener
         exp_annotations:
           summary: "Network interface eth1 is not running in full duplex mode on cluster mycluster"
           description: "Until this is resolved, performance from the gateway will be degraded"
@@ -3124,6 +3141,7 @@ tests:
           instance: node-1:10008
           severity: warning
           type: ceph_default
+          category: performance
         exp_annotations:
           summary: "The average read latency over the last 5 mins has reached 10 ms or more on node-1"
           description: "High latencies may indicate a constraint within the cluster e.g. CPU, network. Please investigate"
@@ -3154,6 +3172,7 @@ tests:
           instance: node-1:10008
           severity: warning
           type: ceph_default
+          category: performance
         exp_annotations:
           summary: "The average write latency over the last 5 mins has reached 20 ms or more on node-1"
           description: "High latencies may indicate a constraint within the cluster e.g. CPU, network. Please investigate"
@@ -3196,6 +3215,7 @@ tests:
           nqn: nqn.2016-06.io.spdk:cnode1.mygroup
           severity: warning
           type: ceph_default
+          category: host
         exp_annotations:
           summary: "Host (nqn.1) was disconnected 3 times from subsystem (nqn.2016-06.io.spdk:cnode1.mygroup) in last 24 hours"
           description: "Host was disconnected due to host keep alive timeout"
@@ -3206,6 +3226,7 @@ tests:
           nqn: nqn.2016-06.io.spdk:cnode1.mygroup
           severity: warning
           type: ceph_default
+          category: host
         exp_annotations:
           summary: "Host (nqn.2) was disconnected 1 times from subsystem (nqn.2016-06.io.spdk:cnode1.mygroup) in last 24 hours"
           description: "Host was disconnected due to host keep alive timeout"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
@@ -90,6 +90,7 @@ import SubtractAlt from '@carbon/icons/es/subtract--alt/20';
 import ProgressBarRound from '@carbon/icons/es/progress-bar--round/32';
 import Search from '@carbon/icons/es/search/32';
 import Datastore from '@carbon/icons/es/datastore/16';
+import ArrowRight from '@carbon/icons/es/arrow--right/16';
 import { NvmeofGatewaySubsystemComponent } from './nvmeof-gateway-subsystem/nvmeof-gateway-subsystem.component';
 import { NvmeofNamespaceExpandModalComponent } from './nvmeof-namespace-expand-modal/nvmeof-namespace-expand-modal.component';
 import { NvmeGatewayViewComponent } from './nvme-gateway-view/nvme-gateway-view.component';
@@ -104,6 +105,7 @@ import { NvmeofSubsystemPerformanceComponent } from './nvmeof-subsystem-performa
 import { NvmeofTabsComponent } from './nvmeof-tabs/nvmeof-tabs.component';
 import { NvmeofSetupCardsComponent } from './nvmeof-setup-cards/nvmeof-setup-cards.component';
 import { NvmeofGatewayGroupFilterComponent } from './nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component';
+import { ProductiveCardComponent } from '~/app/shared/components/productive-card/productive-card.component';
 
 @NgModule({
   imports: [
@@ -139,7 +141,8 @@ import { NvmeofGatewayGroupFilterComponent } from './nvmeof-gateway-group-filter
     LayoutModule,
     ThemeModule,
     NvmeofSetupCardsComponent,
-    NvmeofGatewayGroupFilterComponent
+    NvmeofGatewayGroupFilterComponent,
+    ProductiveCardComponent
   ],
   declarations: [
     RbdListComponent,
@@ -208,7 +211,8 @@ export class BlockModule {
       ProgressBarRound,
       SubtractAlt,
       Search,
-      Datastore
+      Datastore,
+      ArrowRight
     ]);
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
@@ -61,13 +61,10 @@ import {
   CheckboxModule,
   ComboBoxModule,
   DatePickerModule,
-  FileUploaderModule,
   GridModule,
   IconModule,
   IconService,
-  InlineLoadingModule,
   InputModule,
-  LoadingModule,
   ModalModule,
   NumberModule,
   RadioModule,
@@ -105,6 +102,8 @@ import { NvmeSubsystemViewBreadcrumbResolver } from './nvme-subsystem-view/nvme-
 import { NvmeSubsystemViewComponent } from './nvme-subsystem-view/nvme-subsystem-view.component';
 import { NvmeofSubsystemPerformanceComponent } from './nvmeof-subsystem-performance/nvmeof-subsystem-performance.component';
 import { NvmeofTabsComponent } from './nvmeof-tabs/nvmeof-tabs.component';
+import { NvmeofSetupCardsComponent } from './nvmeof-setup-cards/nvmeof-setup-cards.component';
+import { NvmeofGatewayGroupFilterComponent } from './nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component';
 
 @NgModule({
   imports: [
@@ -124,15 +123,12 @@ import { NvmeofTabsComponent } from './nvmeof-tabs/nvmeof-tabs.component';
     ButtonModule,
     GridModule,
     IconModule,
-    InlineLoadingModule,
-    LoadingModule,
     CheckboxModule,
     RadioModule,
     SelectModule,
     NumberModule,
     ModalModule,
     DatePickerModule,
-    FileUploaderModule,
     ComboBoxModule,
     TabsModule,
     TagModule,
@@ -141,7 +137,9 @@ import { NvmeofTabsComponent } from './nvmeof-tabs/nvmeof-tabs.component';
     ContainedListModule,
     SideNavModule,
     LayoutModule,
-    ThemeModule
+    ThemeModule,
+    NvmeofSetupCardsComponent,
+    NvmeofGatewayGroupFilterComponent
   ],
   declarations: [
     RbdListComponent,
@@ -335,6 +333,7 @@ const routes: Routes = [
   {
     path: 'nvmeof',
     canActivate: [ModuleStatusGuardService],
+    component: NvmeofTabsComponent,
     data: {
       breadcrumbs: true,
       text: 'NVMe/TCP',

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component.html
@@ -1,0 +1,13 @@
+<div class="nvmeof-gateway-group-filter">
+  <span class="nvmeof-gateway-group-filter__label cds--type-body-compact-01"
+        i18n>Gateway group:</span>
+  <cds-combo-box type="single"
+                 class="nvmeof-gateway-group-filter__combo"
+                 [placeholder]="placeholder"
+                 [items]="items"
+                 [disabled]="disabled"
+                 (selected)="onSelected($event)"
+                 (clear)="onClear()">
+    <cds-dropdown-list></cds-dropdown-list>
+  </cds-combo-box>
+</div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component.scss
@@ -1,0 +1,20 @@
+:host {
+  display: contents;
+}
+
+.nvmeof-gateway-group-filter {
+  display: flex;
+  align-items: center;
+  gap: var(--cds-spacing-03);
+  margin-left: var(--cds-spacing-05);
+
+  &__label {
+    white-space: nowrap;
+    color: var(--cds-text-secondary);
+  }
+
+  &__combo {
+    min-inline-size: 14rem;
+    max-inline-size: 20rem;
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component.spec.ts
@@ -1,0 +1,26 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NvmeofGatewayGroupFilterComponent } from './nvmeof-gateway-group-filter.component';
+
+describe('NvmeofGatewayGroupFilterComponent', () => {
+  let fixture: ComponentFixture<NvmeofGatewayGroupFilterComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NvmeofGatewayGroupFilterComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NvmeofGatewayGroupFilterComponent);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should render combo box with filter class', () => {
+    const combo = fixture.nativeElement.querySelector('cds-combo-box');
+    expect(combo).toBeTruthy();
+    expect(combo.classList.contains('nvmeof-gateway-group-filter__combo')).toBe(true);
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component.ts
@@ -1,0 +1,27 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { ComboBoxModule } from 'carbon-components-angular';
+import { GroupsComboboxItem } from '~/app/shared/api/nvmeof.service';
+
+@Component({
+  selector: 'cd-nvmeof-gateway-group-filter',
+  templateUrl: './nvmeof-gateway-group-filter.component.html',
+  styleUrls: ['./nvmeof-gateway-group-filter.component.scss'],
+  standalone: true,
+  imports: [ComboBoxModule]
+})
+export class NvmeofGatewayGroupFilterComponent {
+  @Input() items: GroupsComboboxItem[] = [];
+  @Input() disabled = false;
+  @Input() placeholder = $localize`Enter group name`;
+
+  @Output() selected = new EventEmitter<GroupsComboboxItem>();
+  @Output() cleared = new EventEmitter<void>();
+
+  onSelected(item: GroupsComboboxItem): void {
+    this.selected.emit(item);
+  }
+
+  onClear(): void {
+    this.cleared.emit();
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group.component.html
@@ -1,5 +1,3 @@
-<cd-nvmeof-tabs></cd-nvmeof-tabs>
-
 <ng-container *ngIf="gatewayGroup$ | async as gateways">
   <cd-table
     #table

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group.component.html
@@ -1,24 +1,28 @@
-<ng-container *ngIf="gatewayGroup$ | async as gateways">
-  <cd-table
-    #table
-    [data]="gateways"
-    [columns]="columns"
-    columnMode="flex"
-    selectionType="single"
-    identifier="name"
-    (updateSelection)="updateSelection($event)"
-    (fetchData)="fetchData()"
-    emptyStateTitle="No gateway group created"
-    i18n-emptyStateTitle
-    emptyStateMessage="Set up your first gateway group to start using NVMe over Fabrics. This will allow you to create high-performance block storage with NVMe/TCP protocol."
-    i18n-emptyStateMessage>
-  <cd-table-actions class="table-actions"
-                    [permission]="permission"
-                    [selection]="selection"
-                    [tableActions]="tableActions">
-  </cd-table-actions>
-  </cd-table>
-</ng-container>
+<div class="nvmeof-content-layout">
+  <div class="nvmeof-content-main">
+    <ng-container *ngIf="gatewayGroup$ | async as gateways">
+      <cd-table
+        #table
+        [data]="gateways"
+        [columns]="columns"
+        columnMode="flex"
+        selectionType="single"
+        identifier="name"
+        (updateSelection)="updateSelection($event)"
+        (fetchData)="fetchData()"
+        emptyStateTitle="No gateway group created"
+        i18n-emptyStateTitle
+        emptyStateMessage="Set up your first gateway group to start using NVMe over Fabrics. This will allow you to create high-performance block storage with NVMe/TCP protocol."
+        i18n-emptyStateMessage>
+      <cd-table-actions class="table-actions"
+                        [permission]="permission"
+                        [selection]="selection"
+                        [tableActions]="tableActions">
+      </cd-table-actions>
+      </cd-table>
+    </ng-container>
+  </div>
+</div>
 
 <ng-template #dateTpl
              let-created="data.value">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group.component.spec.ts
@@ -1,7 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { NvmeofGatewayGroupComponent } from './nvmeof-gateway-group.component';
 import { GridModule, TabsModule } from 'carbon-components-angular';
 import { NvmeofService } from '~/app/shared/api/nvmeof.service';
+import { NvmeofStateService } from '../nvmeof-state.service';
 import { of } from 'rxjs';
 import { HttpClientModule } from '@angular/common/http';
 import { SharedModule } from '~/app/shared/shared.module';
@@ -16,11 +18,16 @@ describe('NvmeofGatewayGroupComponent', () => {
       listGatewayGroups: jest.fn().mockReturnValue(of([])),
       listSubsystems: jest.fn().mockReturnValue(of([]))
     };
+    const nvmeofStateServiceSpy = { requestRefresh: jest.fn() };
 
     await TestBed.configureTestingModule({
       imports: [HttpClientModule, SharedModule, TabsModule, GridModule],
       declarations: [NvmeofGatewayGroupComponent],
-      providers: [{ provide: NvmeofService, useValue: nvmeofServiceSpy }]
+      providers: [
+        { provide: NvmeofService, useValue: nvmeofServiceSpy },
+        { provide: NvmeofStateService, useValue: nvmeofStateServiceSpy }
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
 
     fixture = TestBed.createComponent(NvmeofGatewayGroupComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, TemplateRef, ViewChild, ViewEncapsulation } from '@angular/core';
 import { Router } from '@angular/router';
 import { BehaviorSubject, forkJoin, Observable, of } from 'rxjs';
-import { catchError, map, switchMap } from 'rxjs/operators';
+import { catchError, map, shareReplay, switchMap, tap } from 'rxjs/operators';
 import { GatewayGroup, NvmeofService } from '~/app/shared/api/nvmeof.service';
 import { HostService } from '~/app/shared/api/host.service';
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
@@ -24,6 +24,7 @@ import { DeletionImpact } from '~/app/shared/enum/delete-confirmation-modal-impa
 import { NotificationService } from '~/app/shared/services/notification.service';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
 import { URLBuilderService } from '~/app/shared/services/url-builder.service';
+import { NvmeofStateService } from '../nvmeof-state.service';
 
 const BASE_URL = 'block/nvmeof/gateways';
 
@@ -65,7 +66,6 @@ export class NvmeofGatewayGroupComponent implements OnInit {
 
   viewUrl = `/${BASE_URL}/view`;
   icons = Icons;
-
   iconSize = IconSize;
 
   constructor(
@@ -78,7 +78,8 @@ export class NvmeofGatewayGroupComponent implements OnInit {
     public taskWrapper: TaskWrapperService,
     private notificationService: NotificationService,
     private urlBuilder: URLBuilderService,
-    private router: Router
+    private router: Router,
+    private nvmeofStateService: NvmeofStateService
   ) {}
 
   ngOnInit(): void {
@@ -171,7 +172,9 @@ export class NvmeofGatewayGroupComponent implements OnInit {
             return of([]);
           })
         )
-      )
+      ),
+      tap(() => this.nvmeofStateService.requestRefresh()),
+      shareReplay({ bufferSize: 1, refCount: true })
     );
     this.checkNodesAvailability();
   }
@@ -209,7 +212,9 @@ export class NvmeofGatewayGroupComponent implements OnInit {
       submitActionObservable: () => {
         return this.taskWrapper
           .wrapTaskAroundCall({
-            task: new FinishedTask('nvmeof/gateway/delete', { group: selectedGroup.spec.group }),
+            task: new FinishedTask('service/delete', {
+              service_name: serviceName
+            }),
             call: this.cephServiceService.delete(serviceName)
           })
           .pipe(

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway/nvmeof-gateway.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway/nvmeof-gateway.component.html
@@ -1,9 +1,173 @@
 <fieldset>
   <legend>
     <h1 class="cds--type-heading-03">NVMe over Fabrics (TCP)</h1>
-  <cd-help-text>Monitor and manage NVMe-over-TCP resources for high-performance block storage.</cd-help-text>
+    <cd-help-text i18n>Monitor and manage NVMe-over-TCP resources for high-performance block storage.</cd-help-text>
   </legend>
 </fieldset>
+
+<ng-container *ngIf="nvmeof$ | async as stats">
+  <ng-container *ngIf="stats?.hasData">
+    <div cdsGrid
+         [fullWidth]="true"
+         [narrow]="true"
+         class="nvmeof-overview-cards cds-mt-5 cds-mb-5">
+      <div cdsRow>
+        <div cdsCol
+             [columnNumbers]="{lg: 5, md: 8, sm: 16}"
+             class="cds-mb-5">
+          <cd-productive-card>
+            <ng-template #header>
+              <h2 class="cds--type-heading-compact-02"
+                  i18n>Resources status</h2>
+            </ng-template>
+            <div class="nvmeof-resources-status">
+              <div class="nvmeof-resources-status__item">
+                <span class="cds--type-label-01"
+                      i18n>Gateway groups</span>
+                <div [cdsStack]="'horizontal'"
+                     gap="3">
+                  <cd-icon type="success"></cd-icon>
+                  <a cdsLink
+                     class="cds--type-body-compact-01"
+                     (click)="onSelected(Tabs.gateways)">{{ stats.gatewayGroups }}</a>
+                </div>
+              </div>
+              <div class="nvmeof-resources-status__item">
+                <span class="cds--type-label-01"
+                      i18n>Subsystems</span>
+                <div [cdsStack]="'horizontal'"
+                     gap="3">
+                  <cd-icon type="success"></cd-icon>
+                  <a cdsLink
+                     class="cds--type-body-compact-01"
+                     (click)="onSelected(Tabs.subsystem)">{{ stats.subsystems }}</a>
+                </div>
+              </div>
+              <div class="nvmeof-resources-status__item">
+                <span class="cds--type-label-01"
+                      i18n>Namespaces</span>
+                <div [cdsStack]="'horizontal'"
+                     gap="3">
+                  <cd-icon type="success"></cd-icon>
+                  <a cdsLink
+                     class="cds--type-body-compact-01"
+                     (click)="onSelected(Tabs.namespace)">{{ stats.namespaces }}</a>
+                </div>
+              </div>
+              <div class="nvmeof-resources-status__item">
+                <span class="cds--type-label-01"
+                      i18n>Hosts</span>
+                <div [cdsStack]="'horizontal'"
+                     gap="3">
+                  <cd-icon type="success"></cd-icon>
+                  <span class="cds--type-body-compact-01">{{ stats.hosts }}</span>
+                </div>
+              </div>
+            </div>
+          </cd-productive-card>
+        </div>
+
+        <div cdsCol
+             [columnNumbers]="{lg: 5, md: 8, sm: 16}"
+             class="cds-mb-5">
+          <cd-productive-card class="nvmeof-alerts-card">
+            <ng-template #header>
+              <h2 class="cds--type-heading-compact-02"
+                  i18n>Alert notifications</h2>
+              <a cdsLink
+                 [routerLink]="['/monitoring/active-alerts']"
+                 [queryParams]="alertQueryParams('all')"
+                 i18n>View alerts</a>
+            </ng-template>
+            <ng-container *ngIf="nvmeofAlerts$ | async as alertVM">
+              <div [cdsStack]="'horizontal'" gap="2">
+                <span class="cds--type-heading-07">{{ alertVM.total }}</span>
+                <cd-icon [type]="alertVM.total === 0 ? 'success' : alertVM.critical > 0 ? 'error' : 'warning'"></cd-icon>
+              </div>
+              <p class="cds--type-label-01 nvmeof-alerts-card__status cds-mb-5">
+                {{ alertVM.total > 0 ? 'Need attention' : 'No active alerts' }}
+              </p>
+              <div *ngIf="alertVM.total > 0"
+                   [cdsStack]="'horizontal'"
+                   gap="4">
+                <span *ngIf="alertVM.critical > 0"
+                      class="nvmeof-alerts-card__badge">
+                  <a cdsLink
+                     [routerLink]="['/monitoring/active-alerts']"
+                     [queryParams]="alertQueryParams('critical')">
+                    <cd-icon type="error"></cd-icon>
+                    <span class="cds-ml-2">{{ alertVM.critical }}</span>
+                  </a>
+                </span>
+                <span *ngIf="alertVM.warning > 0"
+                      class="nvmeof-alerts-card__badge">
+                  <a cdsLink
+                     [routerLink]="['/monitoring/active-alerts']"
+                     [queryParams]="alertQueryParams('warning')">
+                    <cd-icon type="warning"></cd-icon>
+                    <span class="cds-ml-2">{{ alertVM.warning }}</span>
+                  </a>
+                </span>
+              </div>
+              <div *ngIf="alertVM.total > 0"
+                   class="nvmeof-alerts-card__categories cds-mt-4">
+                <div *ngFor="let entry of alertVM.byCategory | keyvalue"
+                     class="nvmeof-alerts-card__category-row">
+                  <span class="cds--type-label-01 nvmeof-alerts-card__category-name">{{ entry.key | titlecase }}</span>
+                  <a cdsLink
+                     class="cds--type-body-compact-01"
+                     [routerLink]="['/monitoring/active-alerts']"
+                     [queryParams]="alertQueryParams('all', entry.key)">{{ entry.value }}</a>
+                </div>
+              </div>
+            </ng-container>
+          </cd-productive-card>
+        </div>
+
+        <div cdsCol
+             [columnNumbers]="{lg: 6, md: 8, sm: 16}"
+             class="cds-mb-5">
+          <cd-productive-card class="nvmeof-throughput-card">
+            <ng-template #header>
+              <h2 class="cds--type-heading-compact-02"
+                  i18n>Throughput</h2>
+            </ng-template>
+            <p class="cds--type-heading-05 cds-mb-1">
+              {{ (stats.reads + stats.writes) | number:'1.2-2' }} MB/s
+            </p>
+            <p class="cds--type-label-01 cds-mb-5"
+               i18n>combined R/W</p>
+            <div class="nvmeof-throughput__row">
+              <span class="cds--type-label-01"
+                    i18n>Reads</span>
+              <a cdsLink
+                 class="cds--type-body-compact-01">{{ stats.reads | number:'1.2-2' }} MB/s</a>
+            </div>
+            <div class="nvmeof-throughput__row">
+              <span class="cds--type-label-01"
+                    i18n>Writes</span>
+              <a cdsLink
+                 class="cds--type-body-compact-01">{{ stats.writes | number:'1.2-2' }} MB/s</a>
+            </div>
+            <p class="cds--type-label-01 cds-mt-5">
+              <span i18n>Active connections</span>: {{ stats.activeConnections }}
+            </p>
+            <ng-template #footer>
+              <a cdsLink
+                 class="nvmeof-throughput__footer-link"
+                 (click)="onSelected(Tabs.gateways)">
+                <span i18n>View detailed information</span>
+                <svg cdsIcon="arrow--right"
+                     size="16"></svg>
+              </a>
+            </ng-template>
+          </cd-productive-card>
+        </div>
+      </div>
+    </div>
+  </ng-container>
+</ng-container>
+
 <section>
   <cds-tabs type="contained"
             followFocus="true"
@@ -18,7 +182,7 @@
     (selected)="onSelected(Tabs.gateways)">
   </cds-tab>
   <cds-tab
-    heading="Subsystem"
+    heading="Subsystems"
     [tabContent]="subsystem_content"
 
     i18n-heading
@@ -26,7 +190,7 @@
     (selected)="onSelected(Tabs.subsystem)">
   </cds-tab>
   <cds-tab
-    heading="Namespace"
+    heading="Namespaces"
     [tabContent]="namespace_content"
 
     i18n-heading

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway/nvmeof-gateway.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway/nvmeof-gateway.component.scss
@@ -1,0 +1,62 @@
+.nvmeof-overview-cards {
+  .nvmeof-resources-status {
+    &__item {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 0.75rem 0;
+      border-bottom: 1px solid var(--cds-layer-accent-01, #e0e0e0);
+
+      &:last-child {
+        border-bottom: none;
+      }
+    }
+  }
+
+  .nvmeof-throughput {
+    &__row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 0.5rem 0;
+    }
+
+    &__footer-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+  }
+
+  .nvmeof-alerts-card {
+    height: 100%;
+
+    &__status {
+      margin-top: 0.25rem;
+    }
+
+    &__badge {
+      a {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
+      }
+    }
+
+    &__categories {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+
+    &__category-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    &__category-name {
+      text-transform: capitalize;
+    }
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway/nvmeof-gateway.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway/nvmeof-gateway.component.ts
@@ -44,8 +44,6 @@ export class NvmeofGatewayComponent implements OnInit, OnDestroy {
     this.route.queryParams.subscribe((params) => {
       if (params['tab'] && Object.values(TABS).includes(params['tab'])) {
         this.activeTab = params['tab'] as TABS;
-      } else {
-        this.activeTab = TABS.gateways;
       }
       this.breadcrumbService.setTabCrumb(TAB_LABELS[this.activeTab]);
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway/nvmeof-gateway.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway/nvmeof-gateway.component.ts
@@ -100,7 +100,7 @@ export class NvmeofGatewayComponent implements OnInit, OnDestroy {
           .pipe(catchError(() => of([] as AlertmanagerAlert[])));
       }),
       map((alerts: AlertmanagerAlert[]) => {
-        const nvmeAlerts = alerts.filter(isNvmeofAlert);
+        const nvmeAlerts = alerts.filter((alert) => this.isNvmeofCardAlert(alert));
         const critical = nvmeAlerts.filter(
           (a) => a.labels.severity === 'critical' && a.status.state === 'active'
         ).length;
@@ -203,6 +203,23 @@ export class NvmeofGatewayComponent implements OnInit, OnDestroy {
 
   public get Tabs(): typeof TABS {
     return TABS;
+  }
+
+  /**
+   * Keep NVMe-oF card matching strict without changing shared alert filters.
+   */
+  private isNvmeofCardAlert(alert: AlertmanagerAlert): boolean {
+    if (!isNvmeofAlert(alert)) {
+      return false;
+    }
+
+    const job = alert.labels?.job?.toLowerCase();
+    if (job === 'nvme' || job === 'nvmeof') {
+      return true;
+    }
+
+    const alertName = alert.labels?.alertname?.toLowerCase() ?? '';
+    return alertName.includes('nvme');
   }
 
   readonly alertQueryParams = nvmeofAlertQueryParams;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway/nvmeof-gateway.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway/nvmeof-gateway.component.ts
@@ -1,11 +1,39 @@
 import { Component, OnDestroy, OnInit, TemplateRef, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { Observable, Subject, forkJoin, of, timer } from 'rxjs';
+import { catchError, map, shareReplay, switchMap, takeUntil } from 'rxjs/operators';
 
 import _ from 'lodash';
 
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
 import { BreadcrumbService } from '~/app/shared/services/breadcrumb.service';
+import { NvmeofService } from '~/app/shared/api/nvmeof.service';
+import { PrometheusService } from '~/app/shared/api/prometheus.service';
+import { CephServiceSpec } from '~/app/shared/models/service.interface';
+import { NvmeofSubsystem, NvmeofSubsystemNamespace } from '~/app/shared/models/nvmeof';
+import { AlertmanagerAlert } from '~/app/shared/models/prometheus-alerts';
+import { isNvmeofAlert, nvmeofAlertQueryParams } from '~/app/shared/helpers/nvmeof-alert.helper';
+
+const ALERT_POLL_INTERVAL = 30000;
+
+export interface NvmeAlerts {
+  critical: number;
+  warning: number;
+  total: number;
+  byCategory: Record<string, number>;
+}
+
+export interface ResourceStats {
+  gatewayGroups: number;
+  subsystems: number;
+  namespaces: number;
+  hosts: number;
+  reads: number;
+  writes: number;
+  activeConnections: number;
+  hasData: boolean;
+}
 
 enum TABS {
   gateways = 'gateways',
@@ -32,24 +60,132 @@ export class NvmeofGatewayComponent implements OnInit, OnDestroy {
   @ViewChild('statusTpl', { static: true })
   statusTpl: TemplateRef<any>;
   selection = new CdTableSelection();
+  nvmeof$: Observable<ResourceStats | null> = of(null);
+  nvmeofAlerts$: Observable<NvmeAlerts> = of({
+    critical: 0,
+    warning: 0,
+    total: 0,
+    byCategory: {}
+  });
+
+  private destroy$ = new Subject<void>();
 
   constructor(
     public actionLabels: ActionLabelsI18n,
     private route: ActivatedRoute,
     private router: Router,
-    private breadcrumbService: BreadcrumbService
+    private breadcrumbService: BreadcrumbService,
+    private nvmeofService: NvmeofService,
+    private prometheusService: PrometheusService
   ) {}
 
   ngOnInit() {
-    this.route.queryParams.subscribe((params) => {
+    this.route.queryParams.pipe(takeUntil(this.destroy$)).subscribe((params) => {
       if (params['tab'] && Object.values(TABS).includes(params['tab'])) {
         this.activeTab = params['tab'] as TABS;
       }
       this.breadcrumbService.setTabCrumb(TAB_LABELS[this.activeTab]);
     });
+    this.loadResourceStats();
+    this.loadAlerts();
+  }
+
+  loadAlerts(): void {
+    this.nvmeofAlerts$ = timer(0, ALERT_POLL_INTERVAL).pipe(
+      switchMap(() => this.prometheusService.isAlertmanagerUsable()),
+      switchMap((usable) => {
+        if (!usable) return of([] as AlertmanagerAlert[]);
+        return this.prometheusService
+          .getAlerts(true)
+          .pipe(catchError(() => of([] as AlertmanagerAlert[])));
+      }),
+      map((alerts: AlertmanagerAlert[]) => {
+        const nvmeAlerts = alerts.filter(isNvmeofAlert);
+        const critical = nvmeAlerts.filter(
+          (a) => a.labels.severity === 'critical' && a.status.state === 'active'
+        ).length;
+        const warning = nvmeAlerts.filter(
+          (a) => a.labels.severity === 'warning' && a.status.state === 'active'
+        ).length;
+        const byCategory: Record<string, number> = {};
+        nvmeAlerts
+          .filter((a) => a.status.state === 'active' && a.labels.category)
+          .forEach((a) => {
+            const cat = a.labels.category!;
+            byCategory[cat] = (byCategory[cat] ?? 0) + 1;
+          });
+        return { critical, warning, total: critical + warning, byCategory };
+      }),
+      catchError(() => of({ critical: 0, warning: 0, total: 0, byCategory: {} })),
+      takeUntil(this.destroy$),
+      shareReplay({ bufferSize: 1, refCount: true })
+    );
+  }
+
+  loadResourceStats() {
+    this.nvmeof$ = this.nvmeofService.listGatewayGroups().pipe(
+      switchMap((gatewayGroups: CephServiceSpec[][]) => {
+        const firstItem = (gatewayGroups as any)?.[0];
+        const rawGroups: CephServiceSpec[] = Array.isArray(firstItem)
+          ? (firstItem as CephServiceSpec[])
+          : Array.isArray(gatewayGroups)
+          ? ((gatewayGroups as unknown) as CephServiceSpec[])
+          : [];
+        const groups = rawGroups.filter((g: CephServiceSpec) => g?.spec?.group);
+        if (groups.length === 0) {
+          return of(null);
+        }
+        const hostsSet = new Set<string>();
+        groups.forEach((group: CephServiceSpec) => {
+          (group.placement?.hosts ?? []).forEach((h: string) => hostsSet.add(h));
+        });
+        const subsystemCalls = groups.map((group: CephServiceSpec) =>
+          this.nvmeofService.listSubsystems(group.spec.group).pipe(catchError(() => of([])))
+        );
+        const namespaceCalls = groups.map((group: CephServiceSpec) =>
+          this.nvmeofService.listNamespaces(group.spec.group).pipe(catchError(() => of([])))
+        );
+        return forkJoin([forkJoin(subsystemCalls), forkJoin(namespaceCalls)]).pipe(
+          map(([subsystemsPerGroup, namespacesPerGroup]: [any[], any[]]) => {
+            const allSubs: NvmeofSubsystem[] = (subsystemsPerGroup as NvmeofSubsystem[][]).flat();
+            const allNs: NvmeofSubsystemNamespace[] = (namespacesPerGroup as NvmeofSubsystemNamespace[][]).flat();
+            const totalNamespaces = allSubs.reduce((sum, s) => sum + (s.namespace_count || 0), 0);
+            const reads = allNs.reduce((s, ns) => s + (Number(ns.r_mbytes_per_second) || 0), 0);
+            const writes = allNs.reduce((s, ns) => s + (Number(ns.w_mbytes_per_second) || 0), 0);
+            const activeConnections = allSubs.reduce((s, sub) => s + (sub.initiator_count || 0), 0);
+            return {
+              gatewayGroups: groups.length,
+              subsystems: allSubs.length,
+              namespaces: totalNamespaces,
+              hosts: hostsSet.size,
+              reads,
+              writes,
+              activeConnections,
+              hasData: true
+            } as ResourceStats;
+          }),
+          catchError(() =>
+            of({
+              gatewayGroups: groups.length,
+              subsystems: 0,
+              namespaces: 0,
+              hosts: hostsSet.size,
+              reads: 0,
+              writes: 0,
+              activeConnections: 0,
+              hasData: true
+            } as ResourceStats)
+          )
+        );
+      }),
+      catchError(() => of(null)),
+      shareReplay({ bufferSize: 1, refCount: true })
+    );
   }
 
   ngOnDestroy() {
+    this.destroy$.next();
+    this.destroy$.complete();
     this.breadcrumbService.clearTabCrumb();
   }
 
@@ -68,4 +204,6 @@ export class NvmeofGatewayComponent implements OnInit, OnDestroy {
   public get Tabs(): typeof TABS {
     return TABS;
   }
+
+  readonly alertQueryParams = nvmeofAlertQueryParams;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.html
@@ -1,5 +1,3 @@
-<cd-nvmeof-tabs></cd-nvmeof-tabs>
-
 <div cdsGrid
      [useCssGrid]="true"
      [narrow]="true"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.html
@@ -1,28 +1,8 @@
-<div cdsGrid
-     [useCssGrid]="true"
-     [narrow]="true"
-     [fullWidth]="true">
-<div cdsCol
-     [columnNumbers]="{sm: 4, md: 8}">
-  <div class="cds-mt-3 form-item"
-       cdsRow>
-    <cds-combo-box
-        type="single"
-        label="Selected Gateway Group"
-        i18n-label
-        [placeholder]="gwGroupPlaceholder"
-        [items]="gwGroups"
-        (selected)="onGroupSelection($event)"
-        (clear)="onGroupClear()"
-        [disabled]="gwGroupsEmpty">
-      <cds-dropdown-list></cds-dropdown-list>
-    </cds-combo-box>
-  </div>
-</div>
-</div>
-
+<div class="nvmeof-content-layout">
+  <div class="nvmeof-content-main">
 <ng-container *ngIf="namespaces$ | async as namespaces">
   <cd-table [data]="namespaces"
+            [compactSearchField]="true"
             columnMode="flex"
             (fetchData)="fetchData()"
             [columns]="namespacesColumns"
@@ -35,6 +15,15 @@
             emptyStateMessage="Namespaces are storage volumes mapped to subsystems for host access. Create a namespace to start provisioning storage within a subsystem."
             i18n-emptyStateMessage>
 
+    <div class="table-filter">
+      <cd-nvmeof-gateway-group-filter [items]="gwGroups"
+                                      [placeholder]="gwGroupPlaceholder"
+                                      [disabled]="gwGroupsEmpty"
+                                      (selected)="onGroupSelection($event)"
+                                      (cleared)="onGroupClear()">
+      </cd-nvmeof-gateway-group-filter>
+    </div>
+
   <div class="table-actions">
     <cd-table-actions [permission]="permission"
                       [selection]="selection"
@@ -44,5 +33,7 @@
   </div>
 </cd-table>
 </ng-container>
+  </div>
+</div>
 
 <router-outlet name="modal"></router-outlet>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.spec.ts
@@ -12,6 +12,7 @@ import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { NvmeofSubsystemsDetailsComponent } from '../nvmeof-subsystems-details/nvmeof-subsystems-details.component';
 import { NvmeofNamespacesListComponent } from './nvmeof-namespaces-list.component';
+import { NvmeofGatewayGroupFilterComponent } from '../nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component';
 
 const mockNamespaces = [
   {
@@ -65,7 +66,12 @@ describe('NvmeofNamespacesListComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [NvmeofNamespacesListComponent, NvmeofSubsystemsDetailsComponent],
-      imports: [HttpClientModule, RouterTestingModule, SharedModule],
+      imports: [
+        HttpClientModule,
+        RouterTestingModule,
+        SharedModule,
+        NvmeofGatewayGroupFilterComponent
+      ],
       providers: [
         { provide: NvmeofService, useClass: MockNvmeOfService },
         { provide: AuthStorageService, useClass: MockAuthStorageService },

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.ts
@@ -17,8 +17,9 @@ import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
-import { BehaviorSubject, Observable, of, Subject } from 'rxjs';
-import { catchError, map, switchMap, takeUntil } from 'rxjs/operators';
+import { NvmeofStateService } from '../nvmeof-state.service';
+import { BehaviorSubject, Observable, forkJoin, of, Subject } from 'rxjs';
+import { catchError, map, shareReplay, switchMap, takeUntil, tap } from 'rxjs/operators';
 
 const DEFAULT_PLACEHOLDER = $localize`Enter group name`;
 
@@ -41,9 +42,9 @@ export class NvmeofNamespacesListComponent implements OnInit, OnDestroy {
   permission: Permission;
   namespaces$: Observable<NvmeofSubsystemNamespace[]>;
   private namespaceSubject = new BehaviorSubject<void>(undefined);
-
   // Gateway group dropdown properties
   gwGroups: GroupsComboboxItem[] = [];
+  groupSelectionCleared = false;
   gwGroupsEmpty: boolean = false;
   gwGroupPlaceholder: string = DEFAULT_PLACEHOLDER;
 
@@ -58,14 +59,26 @@ export class NvmeofNamespacesListComponent implements OnInit, OnDestroy {
     private authStorageService: AuthStorageService,
     private taskWrapper: TaskWrapperService,
     private nvmeofService: NvmeofService,
-    private dimlessBinaryPipe: DimlessBinaryPipe
+    private dimlessBinaryPipe: DimlessBinaryPipe,
+    private nvmeofStateService: NvmeofStateService
   ) {
     this.permission = this.authStorageService.getPermissions().nvmeof;
   }
 
   ngOnInit() {
     this.route.queryParams.pipe(takeUntil(this.destroy$)).subscribe((params) => {
-      if (params?.['group']) this.onGroupSelection({ content: params?.['group'] });
+      const hasGroupParam = Object.prototype.hasOwnProperty.call(params ?? {}, 'group');
+      if (params?.['group']) {
+        this.groupSelectionCleared = false;
+        this.onGroupSelection({ content: params?.['group'] }, false);
+      } else if (hasGroupParam) {
+        this.groupSelectionCleared = true;
+        if (this.group) {
+          this.onGroupClear(false);
+        }
+      } else {
+        this.groupSelectionCleared = false;
+      }
     });
     this.setGatewayGroups();
     this.namespacesColumns = [
@@ -142,29 +155,63 @@ export class NvmeofNamespacesListComponent implements OnInit, OnDestroy {
     this.namespaces$ = this.namespaceSubject.pipe(
       switchMap(() => {
         if (!this.group) {
-          return of([]);
+          if (this.groupSelectionCleared) {
+            return of([]);
+          }
+          return this.fetchAllGroupsNamespaces();
         }
         return this.nvmeofService.listNamespaces(this.group).pipe(
-          map((res: NvmeofSubsystemNamespace[] | { namespaces: NvmeofSubsystemNamespace[] }) => {
-            const namespaces = Array.isArray(res) ? res : res.namespaces || [];
-            // Deduplicate by nsid + subsystem NQN (API with wildcard can return duplicates per gateway)
-            const seen = new Set<string>();
-            return namespaces
-              .filter((ns) => {
-                const key = `${ns.nsid}_${ns['ns_subsystem_nqn']}`;
-                if (seen.has(key)) return false;
-                seen.add(key);
-                return true;
-              })
-              .map((ns) => ({
-                ...ns,
-                unique_id: `${ns.nsid}_${ns['ns_subsystem_nqn']}`
-              }));
-          }),
+          map((res: any) => this.normalizeAndDedup(res)),
           catchError(() => of([]))
         );
       }),
+      shareReplay({ bufferSize: 1, refCount: true }),
       takeUntil(this.destroy$)
+    );
+  }
+
+  private normalizeAndDedup(
+    res: NvmeofSubsystemNamespace[] | { namespaces: NvmeofSubsystemNamespace[] }
+  ): (NvmeofSubsystemNamespace & { unique_id: string })[] {
+    const namespaces = Array.isArray(res) ? res : res.namespaces || [];
+    const seen = new Set<string>();
+    return namespaces
+      .filter((ns) => {
+        const key = `${ns.nsid}_${ns['ns_subsystem_nqn']}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      })
+      .map((ns) => ({ ...ns, unique_id: `${ns.nsid}_${ns['ns_subsystem_nqn']}` }));
+  }
+
+  private fetchAllGroupsNamespaces() {
+    return this.nvmeofService.listGatewayGroups().pipe(
+      switchMap((gatewayGroups: CephServiceSpec[][]) => {
+        const firstItem = (gatewayGroups as any)?.[0];
+        const groups: CephServiceSpec[] = Array.isArray(firstItem) ? firstItem : [];
+        const validGroups = groups.filter((g) => g?.spec?.group);
+        if (validGroups.length === 0) return of([]);
+        return forkJoin(
+          validGroups.map((g) =>
+            this.nvmeofService.listNamespaces(g.spec.group).pipe(
+              map((res: any) => this.normalizeAndDedup(res)),
+              catchError(() => of([]))
+            )
+          )
+        ).pipe(
+          map((results) => {
+            // Deduplicate again across groups
+            const seen = new Set<string>();
+            return (results as any[]).flat().filter((ns: any) => {
+              if (seen.has(ns.unique_id)) return false;
+              seen.add(ns.unique_id);
+              return true;
+            });
+          })
+        );
+      }),
+      catchError(() => of([]))
     );
   }
 
@@ -181,14 +228,22 @@ export class NvmeofNamespacesListComponent implements OnInit, OnDestroy {
   }
 
   // Gateway groups methods
-  onGroupSelection(selected: GroupsComboboxItem) {
+  onGroupSelection(selected: GroupsComboboxItem, syncQueryParam = true) {
     selected.selected = true;
     this.group = selected.content;
+    this.groupSelectionCleared = false;
+    if (syncQueryParam) {
+      this.syncGroupQueryParam(this.group);
+    }
     this.listNamespaces();
   }
 
-  onGroupClear() {
+  onGroupClear(syncQueryParam = true) {
     this.group = null;
+    this.groupSelectionCleared = true;
+    if (syncQueryParam) {
+      this.syncGroupQueryParam(null);
+    }
     this.listNamespaces();
   }
 
@@ -213,12 +268,17 @@ export class NvmeofNamespacesListComponent implements OnInit, OnDestroy {
 
   updateGroupSelectionState() {
     if (this.gwGroups.length) {
-      if (!this.group) {
+      if (this.group) {
+        this.gwGroups = this.gwGroups.map((g) => ({
+          ...g,
+          selected: g.content === this.group
+        }));
+      } else if (!this.groupSelectionCleared) {
         this.onGroupSelection(this.gwGroups[0]);
       } else {
         this.gwGroups = this.gwGroups.map((g) => ({
           ...g,
-          selected: g.content === this.group
+          selected: false
         }));
       }
       this.gwGroupsEmpty = false;
@@ -227,6 +287,14 @@ export class NvmeofNamespacesListComponent implements OnInit, OnDestroy {
       this.gwGroupsEmpty = true;
       this.gwGroupPlaceholder = $localize`No groups available`;
     }
+  }
+
+  private syncGroupQueryParam(group: string | null) {
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { group: group ?? '' },
+      queryParamsHandling: 'merge'
+    });
   }
 
   handleGatewayGroupsError(error: any) {
@@ -251,13 +319,15 @@ export class NvmeofNamespacesListComponent implements OnInit, OnDestroy {
         deletionMessage: $localize`Deleting the namespace <strong>${namespace.nsid}</strong> will permanently remove all resources, services, and configurations within it. This action cannot be undone.`
       },
       submitActionObservable: () =>
-        this.taskWrapper.wrapTaskAroundCall({
-          task: new FinishedTask('nvmeof/namespace/delete', {
-            nqn: subsystemNqn,
-            nsid: namespace.nsid
-          }),
-          call: this.nvmeofService.deleteNamespace(subsystemNqn, namespace.nsid, this.group)
-        })
+        this.taskWrapper
+          .wrapTaskAroundCall({
+            task: new FinishedTask('nvmeof/namespace/delete', {
+              nqn: subsystemNqn,
+              nsid: namespace.nsid
+            }),
+            call: this.nvmeofService.deleteNamespace(subsystemNqn, namespace.nsid, this.group)
+          })
+          .pipe(tap({ complete: () => this.nvmeofStateService.requestRefresh() }))
     });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-setup-cards/nvmeof-setup-cards.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-setup-cards/nvmeof-setup-cards.component.html
@@ -96,7 +96,8 @@
   @if (isAllConfigured) {
   <div class="nvmeof-setup-cards__completion">
     <a cdsLink
-       (click)="viewStatus.emit()"
+       href=""
+       (click)="onViewStatus($event)"
        i18n>Configuration complete. View status →</a>
   </div>
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-setup-cards/nvmeof-setup-cards.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-setup-cards/nvmeof-setup-cards.component.html
@@ -1,0 +1,103 @@
+<cd-productive-card class="nvmeof-setup-cards">
+  <ng-template #header>
+    <div cdsStack="vertical"
+         gap="3">
+      <h2 class="cds--type-heading-compact-03"
+          i18n>Recommended first-time setup</h2>
+      <p class="cds--type-body-01"
+         i18n>
+        Start your NVMe over Fabrics configuration by creating the essential resources in sequence.
+      </p>
+    </div>
+  </ng-template>
+
+  <div class="nvmeof-setup-cards__columns">
+
+    <div class="nvmeof-setup-cards__column">
+      <div class="nvmeof-setup-cards__column-content">
+        <div class="nvmeof-setup-cards__step-row">
+          <span class="cds--type-label-01"
+                i18n>1.</span>
+          <span class="cds--type-heading-compact-01"
+                i18n>Create Gateway groups</span>
+        </div>
+        <p class="cds--type-label-01"
+           i18n>
+          Group NVMe gateway nodes to enable high availability and<br>load balancing for storage targets.
+        </p>
+        <div class="nvmeof-setup-cards__info">
+          @if (hasGatewayGroups) {
+          <cd-icon type="success"></cd-icon>
+          <span class="cds--type-label-01"
+                i18n>Gateway group configured successfully.</span>
+          } @else {
+          <cd-icon type="info"></cd-icon>
+          <span class="cds--type-label-01"
+                i18n>No gateway groups configured for this cluster yet.</span>
+          }
+        </div>
+      </div>
+    </div>
+
+    <div class="nvmeof-setup-cards__column">
+      <div class="nvmeof-setup-cards__column-content">
+        <div class="nvmeof-setup-cards__step-row">
+          <span class="cds--type-label-01"
+                i18n>2.</span>
+          <span class="cds--type-heading-compact-01"
+                i18n>Create Subsystems</span>
+        </div>
+        <p class="cds--type-label-01"
+           i18n>
+         Define storage targets by creating NVMe subsystems and <br> configuring security, listeners, and host access.
+        </p>
+        <div class="nvmeof-setup-cards__info">
+          @if (hasSubsystems) {
+          <cd-icon type="success"></cd-icon>
+          <span class="cds--type-label-01"
+                i18n>Subsystem configured successfully.</span>
+          } @else {
+          <cd-icon type="info"></cd-icon>
+          <span class="cds--type-label-01"
+                i18n>No subsystem configured for this cluster yet.</span>
+          }
+        </div>
+      </div>
+    </div>
+
+    <div class="nvmeof-setup-cards__column">
+      <div class="nvmeof-setup-cards__column-content">
+        <div class="nvmeof-setup-cards__step-row">
+          <span class="cds--type-label-01"
+                i18n>3.</span>
+          <span class="cds--type-heading-compact-01"
+                i18n>Create Namespaces</span>
+        </div>
+        <p class="cds--type-label-01"
+           i18n>
+          Create storage namespaces backed by Ceph block images. This <br>completes your NVMe over Fabrics setup.
+        </p>
+        <div class="nvmeof-setup-cards__info">
+          @if (hasNamespaces) {
+          <cd-icon type="success"></cd-icon>
+          <span class="cds--type-label-01"
+                i18n>Namespaces mapped successfully.</span>
+          } @else {
+          <cd-icon type="info"></cd-icon>
+          <span class="cds--type-label-01"
+                i18n>No namespace allocated or mapped yet.</span>
+          }
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  @if (isAllConfigured) {
+  <div class="nvmeof-setup-cards__completion">
+    <a cdsLink
+       (click)="viewStatus.emit()"
+       i18n>Configuration complete. View status →</a>
+  </div>
+  }
+</cd-productive-card>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-setup-cards/nvmeof-setup-cards.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-setup-cards/nvmeof-setup-cards.component.scss
@@ -1,0 +1,59 @@
+.nvmeof-setup-cards__columns {
+  display: flex;
+  align-items: stretch;
+  padding-bottom: var(--cds-spacing-05);
+}
+
+.nvmeof-setup-cards__column {
+  flex: 1 1 0;
+  min-width: 0;
+  padding: var(--cds-spacing-03) var(--cds-spacing-05) var(--cds-spacing-05);
+  display: flex;
+  flex-direction: column;
+}
+
+.nvmeof-setup-cards__column-content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  gap: var(--cds-spacing-03);
+}
+
+.nvmeof-setup-cards__step-row {
+  display: flex;
+  align-items: center;
+  gap: var(--cds-spacing-03);
+}
+
+.nvmeof-setup-cards__step-icon {
+  flex-shrink: 0;
+}
+
+.nvmeof-setup-cards__info {
+  display: flex;
+  align-items: center;
+  margin-top: auto;
+  gap: var(--cds-spacing-03);
+}
+
+.nvmeof-setup-cards__completion {
+  padding: var(--cds-spacing-04) var(--cds-spacing-05);
+
+  a {
+    cursor: pointer;
+  }
+}
+
+:host ::ng-deep .nvmeof-setup-cards {
+  &.productive-card .productive-card-header {
+    padding: var(--cds-spacing-03) var(--cds-spacing-05);
+  }
+
+  &.productive-card .productive-card-section {
+    padding: 0;
+  }
+
+  .productive-card-section {
+    padding: var(--cds-spacing-02);
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-setup-cards/nvmeof-setup-cards.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-setup-cards/nvmeof-setup-cards.component.ts
@@ -27,4 +27,9 @@ export class NvmeofSetupCardsComponent {
   @Input() hasNamespaces = false;
   @Input() isAllConfigured = false;
   @Output() viewStatus = new EventEmitter<void>();
+
+  onViewStatus(event: Event): void {
+    event.preventDefault();
+    this.viewStatus.emit();
+  }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-setup-cards/nvmeof-setup-cards.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-setup-cards/nvmeof-setup-cards.component.ts
@@ -1,0 +1,30 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { LayoutModule, LayerModule, LinkModule, TilesModule } from 'carbon-components-angular';
+import { ProductiveCardComponent } from '~/app/shared/components/productive-card/productive-card.component';
+import { ComponentsModule } from '~/app/shared/components/components.module';
+
+@Component({
+  selector: 'cd-nvmeof-setup-cards',
+  templateUrl: './nvmeof-setup-cards.component.html',
+  styleUrl: './nvmeof-setup-cards.component.scss',
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterModule,
+    LayoutModule,
+    LayerModule,
+    TilesModule,
+    LinkModule,
+    ProductiveCardComponent,
+    ComponentsModule
+  ]
+})
+export class NvmeofSetupCardsComponent {
+  @Input() hasGatewayGroups = false;
+  @Input() hasSubsystems = false;
+  @Input() hasNamespaces = false;
+  @Input() isAllConfigured = false;
+  @Output() viewStatus = new EventEmitter<void>();
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-state.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-state.service.spec.ts
@@ -1,0 +1,187 @@
+import { TestBed } from '@angular/core/testing';
+
+import { Subject } from 'rxjs';
+
+import { NvmeofStateService } from './nvmeof-state.service';
+import { SummaryService } from '~/app/shared/services/summary.service';
+
+describe('NvmeofStateService', () => {
+  let service: NvmeofStateService;
+  let summaryData$: Subject<any>;
+  let summaryServiceSpy: any;
+
+  const emitSummary = (tasks: any[]) => summaryData$.next({ finished_tasks: tasks });
+
+  beforeEach(() => {
+    summaryData$ = new Subject<any>();
+    summaryServiceSpy = {
+      subscribe: jest.fn().mockImplementation((callback: (s: any) => void) => {
+        return summaryData$.subscribe(callback);
+      })
+    };
+
+    TestBed.configureTestingModule({
+      providers: [NvmeofStateService, { provide: SummaryService, useValue: summaryServiceSpy }]
+    });
+
+    service = TestBed.inject(NvmeofStateService);
+  });
+
+  it('should create', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should emit refresh$ when requestRefresh is called', (done) => {
+    service.refresh$.subscribe(() => done());
+    service.requestRefresh();
+  });
+
+  it('should not emit refresh$ on the first summary update (initialization baseline)', () => {
+    const refreshSpy = jest.fn();
+    service.refresh$.subscribe(refreshSpy);
+
+    emitSummary([
+      {
+        name: 'service/delete',
+        end_time: '2026-01-01T00:00:00Z',
+        metadata: { service_name: 'nvmeof.rbd.default' }
+      }
+    ]);
+
+    expect(refreshSpy).not.toHaveBeenCalled();
+  });
+
+  it('should emit refresh$ when a new NVMe service/delete task appears', () => {
+    const refreshSpy = jest.fn();
+    service.refresh$.subscribe(refreshSpy);
+
+    emitSummary([]); // init
+    emitSummary([
+      {
+        name: 'service/delete',
+        end_time: '2026-01-01T00:00:00Z',
+        metadata: { service_name: 'nvmeof.rbd.default' }
+      }
+    ]);
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should emit refresh$ when a new NVMe service/create task appears', () => {
+    const refreshSpy = jest.fn();
+    service.refresh$.subscribe(refreshSpy);
+
+    emitSummary([]); // init
+    emitSummary([
+      {
+        name: 'service/create',
+        end_time: '2026-01-01T00:00:00Z',
+        metadata: { service_name: 'nvmeof.rbd.default' }
+      }
+    ]);
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should emit refresh$ when a nvmeof/subsystem/delete task appears', () => {
+    const refreshSpy = jest.fn();
+    service.refresh$.subscribe(refreshSpy);
+
+    emitSummary([]); // init
+    emitSummary([
+      {
+        name: 'nvmeof/subsystem/delete',
+        end_time: '2026-01-01T00:00:00Z',
+        metadata: { nqn: 'sub1' }
+      }
+    ]);
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should emit refresh$ when a nvmeof/namespace/create task appears', () => {
+    const refreshSpy = jest.fn();
+    service.refresh$.subscribe(refreshSpy);
+
+    emitSummary([]); // init
+    emitSummary([
+      {
+        name: 'nvmeof/namespace/create',
+        end_time: '2026-01-01T00:00:00Z',
+        metadata: { nqn: 'sub1' }
+      }
+    ]);
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should emit refresh$ when a nvmeof/namespace/delete task appears', () => {
+    const refreshSpy = jest.fn();
+    service.refresh$.subscribe(refreshSpy);
+
+    emitSummary([]); // init
+    emitSummary([
+      {
+        name: 'nvmeof/namespace/delete',
+        end_time: '2026-01-01T00:00:00Z',
+        metadata: { nsid: 1, nqn: 'sub1' }
+      }
+    ]);
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not emit refresh$ for non-NVMe tasks', () => {
+    const refreshSpy = jest.fn();
+    service.refresh$.subscribe(refreshSpy);
+
+    emitSummary([]); // init
+    emitSummary([{ name: 'rbd/create', end_time: '2026-01-01T00:00:00Z', metadata: {} }]);
+
+    expect(refreshSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not emit refresh$ for service/delete of a non-NVMe service', () => {
+    const refreshSpy = jest.fn();
+    service.refresh$.subscribe(refreshSpy);
+
+    emitSummary([]); // init
+    emitSummary([
+      {
+        name: 'service/delete',
+        end_time: '2026-01-01T00:00:00Z',
+        metadata: { service_name: 'rbd.default' }
+      }
+    ]);
+
+    expect(refreshSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not emit refresh$ for the same task appearing again', () => {
+    const refreshSpy = jest.fn();
+    service.refresh$.subscribe(refreshSpy);
+
+    const task = {
+      name: 'service/delete',
+      end_time: '2026-01-01T00:00:00Z',
+      metadata: { service_name: 'nvmeof.rbd.default' }
+    };
+
+    emitSummary([]); // init
+    emitSummary([task]); // new task — emits once
+    emitSummary([task]); // same task — no second emit
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should unsubscribe from SummaryService on destroy', () => {
+    const unsubscribeSpy = jest.fn();
+    const mockSubscription = { unsubscribe: unsubscribeSpy };
+    summaryServiceSpy.subscribe.mockReturnValueOnce(mockSubscription);
+
+    const freshService = new NvmeofStateService(summaryServiceSpy as any);
+    freshService.ngOnDestroy();
+
+    expect(unsubscribeSpy).toHaveBeenCalled();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-state.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-state.service.ts
@@ -1,0 +1,77 @@
+import { Injectable, OnDestroy } from '@angular/core';
+
+import { merge, Subject, Subscription } from 'rxjs';
+
+import { FinishedTask } from '~/app/shared/models/finished-task';
+import { Summary } from '~/app/shared/models/summary.model';
+import { SummaryService } from '~/app/shared/services/summary.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class NvmeofStateService implements OnDestroy {
+  private readonly explicitRefreshSource = new Subject<void>();
+  private readonly taskRefreshSource = new Subject<void>();
+  private summarySubscription: Subscription;
+  private seenTaskSignatures = new Set<string>();
+  private summaryInitialized = false;
+
+  readonly refresh$ = merge(
+    this.explicitRefreshSource.asObservable(),
+    this.taskRefreshSource.asObservable()
+  );
+
+  constructor(private summaryService: SummaryService) {
+    this.summarySubscription = this.summaryService.subscribe((summary: Summary) => {
+      const nvmeTasks = (summary?.finished_tasks ?? []).filter((t: FinishedTask) =>
+        this.isNvmeTask(t)
+      );
+      const currentSignatures = new Set(
+        nvmeTasks.map((t: FinishedTask) => this.getTaskSignature(t))
+      );
+
+      if (!this.summaryInitialized) {
+        this.summaryInitialized = true;
+        this.seenTaskSignatures = currentSignatures;
+        return;
+      }
+
+      const hasNewTask = [...currentSignatures].some((sig) => !this.seenTaskSignatures.has(sig));
+      this.seenTaskSignatures = currentSignatures;
+
+      if (hasNewTask) {
+        this.taskRefreshSource.next();
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.summarySubscription?.unsubscribe();
+  }
+
+  requestRefresh(): void {
+    this.explicitRefreshSource.next();
+  }
+
+  private isNvmeTask(task: FinishedTask): boolean {
+    if (task?.name === 'service/create' || task?.name === 'service/delete') {
+      return (
+        typeof task?.metadata?.['service_name'] === 'string' &&
+        (task.metadata['service_name'] as string).startsWith('nvmeof.')
+      );
+    }
+    return [
+      'nvmeof/subsystem/delete',
+      'nvmeof/namespace/create',
+      'nvmeof/namespace/delete'
+    ].includes(task?.name);
+  }
+
+  private getTaskSignature(task: FinishedTask): string {
+    return JSON.stringify({
+      name: task.name,
+      end_time: task.end_time,
+      metadata: task.metadata
+    });
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.html
@@ -1,5 +1,3 @@
-<cd-nvmeof-tabs></cd-nvmeof-tabs>
-
 <div cdsGrid
      [useCssGrid]="true"
      [narrow]="true"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.html
@@ -1,29 +1,10 @@
-<div cdsGrid
-     [useCssGrid]="true"
-     [narrow]="true"
-     [fullWidth]="true">
-<div cdsCol
-     [columnNumbers]="{sm: 4, md: 8}">
-  <div class="cds-mt-3 form-item"
-       cdsRow>
-    <cds-combo-box
-        type="single"
-        label="Selected Gateway Group"
-        i18n-label
-        [placeholder]="gwGroupPlaceholder"
-        [items]="gwGroups"
-        (selected)="onGroupSelection($event)"
-        (clear)="onGroupClear()"
-        [disabled]="gwGroupsEmpty">
-      <cds-dropdown-list></cds-dropdown-list>
-    </cds-combo-box>
-  </div>
-</div>
-</div>
+<div class="nvmeof-content-layout">
+  <div class="nvmeof-content-main">
 <ng-container *ngIf="subsystems$ | async as subsystems">
   <cd-table #table
             [data]="subsystems"
             [columns]="subsystemsColumns"
+            [compactSearchField]="true"
             columnMode="flex"
             selectionType="single"
             (updateSelection)="updateSelection($event)"
@@ -32,6 +13,15 @@
             i18n-emptyStateTitle
             emptyStateMessage="Subsystems group NVMe namespaces and manage host access. Create a subsystem to start mapping NVMe volumes to hosts."
             i18n-emptyStateMessage>
+
+    <div class="table-filter">
+      <cd-nvmeof-gateway-group-filter [items]="gwGroups"
+                                      [placeholder]="gwGroupPlaceholder"
+                                      [disabled]="gwGroupsEmpty"
+                                      (selected)="onGroupSelection($event)"
+                                      (cleared)="onGroupClear()">
+      </cd-nvmeof-gateway-group-filter>
+    </div>
 
     <div class="table-actions">
       <cd-table-actions [permission]="permissions.nvmeof"
@@ -48,6 +38,8 @@
     </cd-nvmeof-subsystems-details>
   </cd-table>
 </ng-container>
+  </div>
+</div>
 
 <ng-template #customTableItemTemplate
              let-value="data.value"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientModule } from '@angular/common/http';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { of } from 'rxjs';
+import { take } from 'rxjs/operators';
 import { RouterTestingModule } from '@angular/router/testing';
 import { SharedModule } from '~/app/shared/shared.module';
 
@@ -10,7 +12,7 @@ import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { NvmeofSubsystemsComponent } from './nvmeof-subsystems.component';
 import { NvmeofSubsystemsDetailsComponent } from '../nvmeof-subsystems-details/nvmeof-subsystems-details.component';
-import { ComboBoxModule, GridModule } from 'carbon-components-angular';
+import { NvmeofGatewayGroupFilterComponent } from '../nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component';
 import { CephServiceSpec } from '~/app/shared/models/service.interface';
 
 const mockSubsystems = [
@@ -93,13 +95,19 @@ describe('NvmeofSubsystemsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [NvmeofSubsystemsComponent, NvmeofSubsystemsDetailsComponent],
-      imports: [HttpClientModule, RouterTestingModule, SharedModule, ComboBoxModule, GridModule],
+      imports: [
+        HttpClientModule,
+        RouterTestingModule,
+        SharedModule,
+        NvmeofGatewayGroupFilterComponent
+      ],
       providers: [
         { provide: NvmeofService, useClass: MockNvmeOfService },
         { provide: AuthStorageService, useClass: MockAuthStorageService },
         { provide: ModalCdsService, useClass: MockModalService },
         { provide: TaskWrapperService, useClass: MockTaskWrapperService }
-      ]
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
 
     fixture = TestBed.createComponent(NvmeofSubsystemsComponent);
@@ -132,5 +140,14 @@ describe('NvmeofSubsystemsComponent', () => {
 
   it('should set first group as default initially', () => {
     expect(component.group).toBe(mockGroups[0][0].spec.group);
+  });
+
+  it('should not show existing subsystem records when dropdown selection is empty', (done) => {
+    component.onGroupClear();
+    component.subsystems$.pipe(take(1)).subscribe((subsystems) => {
+      expect(subsystems).toEqual([]);
+      done();
+    });
+    component.getSubsystems();
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.ts
@@ -22,8 +22,9 @@ import { NvmeofService, GroupsComboboxItem } from '~/app/shared/api/nvmeof.servi
 import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 import { CephServiceSpec } from '~/app/shared/models/service.interface';
 import { BehaviorSubject, forkJoin, Observable, of, Subject } from 'rxjs';
-import { catchError, map, switchMap, takeUntil, tap } from 'rxjs/operators';
+import { catchError, map, shareReplay, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { DeletionImpact } from '~/app/shared/enum/delete-confirmation-modal-impact.enum';
+import { NvmeofStateService } from '../nvmeof-state.service';
 
 const BASE_URL = 'block/nvmeof/subsystems';
 const DEFAULT_PLACEHOLDER = $localize`Enter group name`;
@@ -57,10 +58,12 @@ export class NvmeofSubsystemsComponent extends ListWithDetails implements OnInit
   context: CdTableFetchDataContext;
   gwGroups: GroupsComboboxItem[] = [];
   group: string = null;
+  groupSelectionCleared = false;
   gwGroupsEmpty: boolean = false;
   gwGroupPlaceholder: string = DEFAULT_PLACEHOLDER;
   authType = NvmeofSubsystemAuthType;
   subsystems$: Observable<(NvmeofSubsystem & { gw_group?: string; initiator_count?: number })[]>;
+
   private subsystemSubject = new BehaviorSubject<void>(undefined);
 
   private destroy$ = new Subject<void>();
@@ -72,7 +75,8 @@ export class NvmeofSubsystemsComponent extends ListWithDetails implements OnInit
     private router: Router,
     private route: ActivatedRoute,
     private modalService: ModalCdsService,
-    private taskWrapper: TaskWrapperService
+    private taskWrapper: TaskWrapperService,
+    private nvmeofStateService: NvmeofStateService
   ) {
     super();
     this.permissions = this.authStorageService.getPermissions();
@@ -80,7 +84,18 @@ export class NvmeofSubsystemsComponent extends ListWithDetails implements OnInit
 
   ngOnInit() {
     this.route.queryParams.pipe(takeUntil(this.destroy$)).subscribe((params) => {
-      if (params?.['group']) this.onGroupSelection({ content: params?.['group'] });
+      const hasGroupParam = Object.prototype.hasOwnProperty.call(params ?? {}, 'group');
+      if (params?.['group']) {
+        this.groupSelectionCleared = false;
+        this.onGroupSelection({ content: params?.['group'] }, false);
+      } else if (hasGroupParam) {
+        this.groupSelectionCleared = true;
+        if (this.group) {
+          this.onGroupClear(false);
+        }
+      } else {
+        this.groupSelectionCleared = false;
+      }
     });
     this.setGatewayGroups();
     this.subsystemsColumns = [
@@ -133,13 +148,16 @@ export class NvmeofSubsystemsComponent extends ListWithDetails implements OnInit
     this.subsystems$ = this.subsystemSubject.pipe(
       switchMap(() => {
         if (!this.group) {
-          return of([]);
+          if (this.groupSelectionCleared) {
+            return of([]);
+          }
+          return this.fetchAllGroupsSubsystems();
         }
         return this.nvmeofService.listSubsystems(this.group).pipe(
-          switchMap((subsystems: NvmeofSubsystem[] | NvmeofSubsystem) => {
-            const subs = Array.isArray(subsystems) ? subsystems : [subsystems];
+          switchMap((subsystems: any) => {
+            const subs: NvmeofSubsystem[] = Array.isArray(subsystems) ? subsystems : [subsystems];
             if (subs.length === 0) return of([]);
-            return forkJoin(subs.map((sub) => this.enrichSubsystemWithInitiators(sub)));
+            return forkJoin(subs.map((sub) => this.enrichSubsystemForGroup(sub, this.group)));
           }),
           catchError((error) => {
             this.handleError(error);
@@ -150,6 +168,7 @@ export class NvmeofSubsystemsComponent extends ListWithDetails implements OnInit
       tap((subs) => {
         this.subsystems = subs;
       }),
+      shareReplay({ bufferSize: 1, refCount: true }),
       takeUntil(this.destroy$)
     );
   }
@@ -179,21 +198,31 @@ export class NvmeofSubsystemsComponent extends ListWithDetails implements OnInit
         forceDeleteAcknowledgementMessage: $localize`I understand this may remove resources still attached to this subsystem.`
       },
       submitActionObservable: () =>
-        this.taskWrapper.wrapTaskAroundCall({
-          task: new FinishedTask('nvmeof/subsystem/delete', { nqn: subsystem.nqn }),
-          call: this.nvmeofService.deleteSubsystem(subsystem.nqn, this.group)
-        })
+        this.taskWrapper
+          .wrapTaskAroundCall({
+            task: new FinishedTask('nvmeof/subsystem/delete', { nqn: subsystem.nqn }),
+            call: this.nvmeofService.deleteSubsystem(subsystem.nqn, this.group)
+          })
+          .pipe(tap({ complete: () => this.nvmeofStateService.requestRefresh() }))
     });
   }
 
-  onGroupSelection(selected: GroupsComboboxItem) {
+  onGroupSelection(selected: GroupsComboboxItem, syncQueryParam = true) {
     selected.selected = true;
     this.group = selected.content;
+    this.groupSelectionCleared = false;
+    if (syncQueryParam) {
+      this.syncGroupQueryParam(this.group);
+    }
     this.getSubsystems();
   }
 
-  onGroupClear() {
+  onGroupClear(syncQueryParam = true) {
     this.group = null;
+    this.groupSelectionCleared = true;
+    if (syncQueryParam) {
+      this.syncGroupQueryParam(null);
+    }
     this.getSubsystems();
   }
 
@@ -220,18 +249,31 @@ export class NvmeofSubsystemsComponent extends ListWithDetails implements OnInit
     if (this.gwGroups.length) {
       this.gwGroupsEmpty = false;
       this.gwGroupPlaceholder = DEFAULT_PLACEHOLDER;
-      if (!this.group) {
+      if (this.group) {
+        this.gwGroups = this.gwGroups.map((g) => ({
+          ...g,
+          selected: g.content === this.group
+        }));
+      } else if (!this.groupSelectionCleared) {
         this.onGroupSelection(this.gwGroups[0]);
       } else {
         this.gwGroups = this.gwGroups.map((g) => ({
           ...g,
-          selected: g.content === this.group
+          selected: false
         }));
       }
     } else {
       this.gwGroupsEmpty = true;
       this.gwGroupPlaceholder = $localize`No groups available`;
     }
+  }
+
+  private syncGroupQueryParam(group: string | null) {
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { group: group ?? '' },
+      queryParamsHandling: 'merge'
+    });
   }
 
   handleGatewayGroupsError(error: any) {
@@ -248,8 +290,8 @@ export class NvmeofSubsystemsComponent extends ListWithDetails implements OnInit
     this.context?.error?.(error);
   }
 
-  private enrichSubsystemWithInitiators(sub: NvmeofSubsystem) {
-    return this.nvmeofService.getInitiators(sub.nqn, this.group).pipe(
+  private enrichSubsystemForGroup(sub: NvmeofSubsystem, group: string) {
+    return this.nvmeofService.getInitiators(sub.nqn, group).pipe(
       catchError(() => of([])),
       map((initiators: NvmeofSubsystemInitiator[] | { hosts?: NvmeofSubsystemInitiator[] }) => {
         let count = 0;
@@ -257,14 +299,39 @@ export class NvmeofSubsystemsComponent extends ListWithDetails implements OnInit
         else if (initiators?.hosts && Array.isArray(initiators.hosts)) {
           count = initiators.hosts.length;
         }
-
         return {
           ...sub,
-          gw_group: this.group,
+          gw_group: group,
           initiator_count: count,
           auth: getSubsystemAuthStatus(sub, initiators)
         } as NvmeofSubsystem & { initiator_count?: number; auth?: string };
       })
+    );
+  }
+
+  private fetchAllGroupsSubsystems() {
+    return this.nvmeofService.listGatewayGroups().pipe(
+      switchMap((gatewayGroups: CephServiceSpec[][]) => {
+        const firstItem = (gatewayGroups as any)?.[0];
+        const groups: CephServiceSpec[] = Array.isArray(firstItem) ? firstItem : [];
+        const validGroups = groups.filter((g) => g?.spec?.group);
+        if (validGroups.length === 0) return of([]);
+        return forkJoin(
+          validGroups.map((g) =>
+            this.nvmeofService.listSubsystems(g.spec.group).pipe(
+              switchMap((subsystems: any) => {
+                const subs: NvmeofSubsystem[] = Array.isArray(subsystems)
+                  ? subsystems
+                  : [subsystems];
+                if (subs.length === 0) return of([]);
+                return forkJoin(subs.map((sub) => this.enrichSubsystemForGroup(sub, g.spec.group)));
+              }),
+              catchError(() => of([]))
+            )
+          )
+        ).pipe(map((results) => (results as any[][]).flat()));
+      }),
+      catchError(() => of([]))
     );
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.html
@@ -22,22 +22,10 @@
                         i18n>Gateway groups</span>
                   <div [cdsStack]="'horizontal'"
                        gap="3">
-                    @if (stats.gatewayGroups - stats.gatewayGroupsDown > 0) {
-                    <span [ngClass]="stats.gatewayGroupsDown > 0 ? 'cds-mr-3' : ''">
-                      <cd-icon type="success"></cd-icon>
-                      <a cdsLink
-                         class="cds--type-body-compact-01 cds-ml-3"
-                         (click)="onSelected(Tabs.gateways)">{{ stats.gatewayGroups - stats.gatewayGroupsDown }}</a>
-                    </span>
-                    }
-                    @if (stats.gatewayGroupsDown > 0) {
-                    <span>
-                      <cd-icon type="error"></cd-icon>
-                      <a cdsLink
-                         class="cds--type-body-compact-01 cds-ml-3"
-                         (click)="onSelected(Tabs.gateways)">{{ stats.gatewayGroupsDown }}</a>
-                    </span>
-                    }
+                    <cd-icon type="success"></cd-icon>
+                    <a cdsLink
+                       class="cds--type-body-compact-01"
+                       (click)="onSelected(Tabs.gateways)">{{ stats.gatewayGroups }}</a>
                   </div>
                 </div>
                 <div class="nvmeof-resources-status__item">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.html
@@ -1,31 +1,46 @@
-<fieldset>
-  <legend>
-    <h1 class="cds--type-heading-03">NVMe over Fabrics (TCP)</h1>
-  <cd-help-text>Monitor and manage NVMe-over-TCP resources for high-performance block storage.</cd-help-text>
-  </legend>
-</fieldset>
-<section>
-  <cds-tabs type="contained"
-            followFocus="true"
-            isNavigation="true"
-            [cacheActive]="false">
-  <cds-tab
-    heading="Gateways"
-    i18n-heading
-    [active]="activeTab === Tabs.gateways"
-    (selected)="onSelected(Tabs.gateways)">
-  </cds-tab>
-  <cds-tab
-    heading="Subsystems"
-    i18n-heading
-    [active]="activeTab === Tabs.subsystems"
-    (selected)="onSelected(Tabs.subsystems)">
-  </cds-tab>
-  <cds-tab
-    heading="Namespaces"
-    i18n-heading
-    [active]="activeTab === Tabs.namespaces"
-    (selected)="onSelected(Tabs.namespaces)">
-  </cds-tab>
-</cds-tabs>
-</section>
+@if (showTabsShell) {
+  <fieldset>
+    <legend class="cds-mb-5">
+      <h1 class="cds--type-heading-03">NVMe over Fabrics (TCP)</h1>
+      <cd-help-text>Monitor and manage NVMe-over-TCP resources for high-<br>performance block storage.</cd-help-text>
+    </legend>
+  </fieldset>
+
+  @if (showSetupCards) {
+  <cd-nvmeof-setup-cards class="cds-mt-5"
+                         [hasGatewayGroups]="hasGatewayGroups"
+                         [hasSubsystems]="hasSubsystems"
+                         [hasNamespaces]="hasNamespaces"
+                         [isAllConfigured]="isAllConfigured"
+                         (viewStatus)="dismissOnboarding()">
+  </cd-nvmeof-setup-cards>
+  }
+
+  <section class="cds-mt-5">
+    <cds-tabs type="contained"
+              followFocus="true"
+              isNavigation="true"
+              [cacheActive]="false">
+    <cds-tab
+      heading="Gateways"
+      i18n-heading
+      [active]="activeTab === Tabs.gateways"
+      (selected)="onSelected(Tabs.gateways)">
+    </cds-tab>
+    <cds-tab
+      heading="Subsystems"
+      i18n-heading
+      [active]="activeTab === Tabs.subsystems"
+      (selected)="onSelected(Tabs.subsystems)">
+    </cds-tab>
+    <cds-tab
+      heading="Namespaces"
+      i18n-heading
+      [active]="activeTab === Tabs.namespaces"
+      (selected)="onSelected(Tabs.namespaces)">
+    </cds-tab>
+  </cds-tabs>
+  </section>
+}
+
+<router-outlet></router-outlet>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.html
@@ -6,6 +6,174 @@
     </legend>
   </fieldset>
 
+  <ng-container *ngIf="nvmeof$ | async as stats">
+    <ng-container *ngIf="stats?.hasData && !showSetupCards">
+      <div class="nvmeof-overview-cards cds-mt-5 cds-mb-5">
+        <div class="nvmeof-overview-cards__row">
+          <div class="nvmeof-overview-cards__col">
+            <cd-productive-card class="nvmeof-resources-status-card">
+              <ng-template #header>
+                <h2 class="cds--type-heading-compact-02"
+                    i18n>Resources status</h2>
+              </ng-template>
+              <div class="nvmeof-resources-status">
+                <div class="nvmeof-resources-status__item">
+                  <span class="cds--type-label-01"
+                        i18n>Gateway groups</span>
+                  <div [cdsStack]="'horizontal'"
+                       gap="3">
+                    @if (stats.gatewayGroups - stats.gatewayGroupsDown > 0) {
+                    <span [ngClass]="stats.gatewayGroupsDown > 0 ? 'cds-mr-3' : ''">
+                      <cd-icon type="success"></cd-icon>
+                      <a cdsLink
+                         class="cds--type-body-compact-01 cds-ml-3"
+                         (click)="onSelected(Tabs.gateways)">{{ stats.gatewayGroups - stats.gatewayGroupsDown }}</a>
+                    </span>
+                    }
+                    @if (stats.gatewayGroupsDown > 0) {
+                    <span>
+                      <cd-icon type="error"></cd-icon>
+                      <a cdsLink
+                         class="cds--type-body-compact-01 cds-ml-3"
+                         (click)="onSelected(Tabs.gateways)">{{ stats.gatewayGroupsDown }}</a>
+                    </span>
+                    }
+                  </div>
+                </div>
+                <div class="nvmeof-resources-status__item">
+                  <span class="cds--type-label-01"
+                        i18n>Subsystems</span>
+                  <div [cdsStack]="'horizontal'"
+                       gap="3">
+                    <cd-icon type="success"></cd-icon>
+                    <a cdsLink
+                       class="cds--type-body-compact-01"
+                       (click)="onSelected(Tabs.subsystems)">{{ stats.subsystems }}</a>
+                  </div>
+                </div>
+                <div class="nvmeof-resources-status__item">
+                  <span class="cds--type-label-01"
+                        i18n>Namespaces</span>
+                  <div [cdsStack]="'horizontal'"
+                       gap="3">
+                    <cd-icon type="success"></cd-icon>
+                    <a cdsLink
+                       class="cds--type-body-compact-01"
+                       (click)="onSelected(Tabs.namespaces)">{{ stats.namespaces }}</a>
+                  </div>
+                </div>
+                <div class="nvmeof-resources-status__item">
+                  <span class="cds--type-label-01"
+                        i18n>Hosts</span>
+                  <div [cdsStack]="'horizontal'"
+                       gap="3">
+                    <cd-icon type="success"></cd-icon>
+                    <span class="cds--type-body-compact-01">{{ stats.hosts }}</span>
+                  </div>
+                </div>
+              </div>
+            </cd-productive-card>
+          </div>
+
+          <div class="nvmeof-overview-cards__col">
+            <cd-productive-card class="nvmeof-alerts-card">
+              <ng-template #header>
+                <h2 class="cds--type-heading-compact-02"
+                    i18n>Alert notifications</h2>
+                <a cdsLink
+                   [routerLink]="['/monitoring/active-alerts']"
+                   [queryParams]="alertQueryParams('all')"
+                   i18n>View alerts</a>
+              </ng-template>
+              <ng-container *ngIf="nvmeofAlerts$ | async as alertVM">
+                <div [cdsStack]="'horizontal'" gap="2">
+                  <span class="cds--type-heading-07">{{ alertVM.total }}</span>
+                  <cd-icon [type]="alertVM.total === 0 ? 'success' : alertVM.critical > 0 ? 'error' : 'warning'"></cd-icon>
+                </div>
+                <p class="cds--type-label-01 nvmeof-alerts-card__status cds-mb-5">
+                  {{ alertVM.total > 0 ? 'Need attention' : 'No active alerts' }}
+                </p>
+                <div *ngIf="alertVM.total > 0"
+                     [cdsStack]="'horizontal'"
+                     gap="4">
+                  <span *ngIf="alertVM.critical > 0"
+                        class="nvmeof-alerts-card__badge">
+                    <a cdsLink
+                       [routerLink]="['/monitoring/active-alerts']"
+                       [queryParams]="alertQueryParams('critical')">
+                      <cd-icon type="error"></cd-icon>
+                      <span class="cds-ml-2">{{ alertVM.critical }}</span>
+                    </a>
+                  </span>
+                  <span *ngIf="alertVM.warning > 0"
+                        class="nvmeof-alerts-card__badge">
+                    <a cdsLink
+                       [routerLink]="['/monitoring/active-alerts']"
+                       [queryParams]="alertQueryParams('warning')">
+                      <cd-icon type="warning"></cd-icon>
+                      <span class="cds-ml-2">{{ alertVM.warning }}</span>
+                    </a>
+                  </span>
+                </div>
+                <div *ngIf="alertVM.total > 0"
+                     class="nvmeof-alerts-card__categories cds-mt-4">
+                  <div *ngFor="let entry of alertVM.byCategory | keyvalue"
+                       class="nvmeof-alerts-card__category-row">
+                    <span class="cds--type-label-01 nvmeof-alerts-card__category-name">{{ entry.key | titlecase }}</span>
+                    <a cdsLink
+                       class="cds--type-body-compact-01"
+                       [routerLink]="['/monitoring/active-alerts']"
+                       [queryParams]="alertQueryParams('all', entry.key)">{{ entry.value }}</a>
+                  </div>
+                </div>
+              </ng-container>
+            </cd-productive-card>
+          </div>
+
+          <div class="nvmeof-overview-cards__col">
+            <cd-productive-card class="nvmeof-throughput-card">
+              <ng-template #header>
+                <h2 class="cds--type-heading-compact-02"
+                    i18n>Throughput</h2>
+              </ng-template>
+              <ng-container *ngIf="nvmeofThroughput$ | async as throughput">
+                <p class="cds--type-heading-05 cds-mb-1">
+                  {{ throughput.combined | number:'1.2-2' }} MB/s
+                </p>
+                <p class="cds--type-label-01 cds-mb-5"
+                   i18n>combined R/W</p>
+                <div class="nvmeof-throughput__row">
+                  <span class="cds--type-label-01"
+                        i18n>Reads</span>
+                  <a cdsLink
+                     class="cds--type-body-compact-01">{{ throughput.reads | number:'1.2-2' }} MB/s</a>
+                </div>
+                <div class="nvmeof-throughput__row">
+                  <span class="cds--type-label-01"
+                        i18n>Writes</span>
+                  <a cdsLink
+                     class="cds--type-body-compact-01">{{ throughput.writes | number:'1.2-2' }} MB/s</a>
+                </div>
+              </ng-container>
+              <p class="cds--type-label-01 cds-mt-5">
+                <span i18n>Active connections</span>: {{ (nvmeof$ | async)?.activeConnections ?? 0 }}
+              </p>
+              <ng-template #footer>
+                <a cdsLink
+                   class="nvmeof-throughput__footer-link"
+                   (click)="onSelected(Tabs.gateways)">
+                  <span i18n>View detailed information</span>
+                  <svg cdsIcon="arrow--right"
+                       size="16"></svg>
+                </a>
+              </ng-template>
+            </cd-productive-card>
+          </div>
+        </div>
+      </div>
+    </ng-container>
+  </ng-container>
+
   @if (showSetupCards) {
   <cd-nvmeof-setup-cards class="cds-mt-5"
                          [hasGatewayGroups]="hasGatewayGroups"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.scss
@@ -1,0 +1,93 @@
+:host {
+  display: block;
+}
+
+.nvmeof-overview-cards {
+  &__row {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1rem;
+  }
+
+  &__col {
+    display: flex;
+    flex-direction: column;
+
+    cd-productive-card {
+      display: block;
+      width: 100%;
+      flex: 1;
+
+      ::ng-deep cds-tile,
+      ::ng-deep .productive-card {
+        width: 100%;
+        height: 100%;
+      }
+    }
+  }
+
+  .nvmeof-resources-status-card {
+    height: 100%;
+  }
+
+  .nvmeof-resources-status {
+    &__item {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 0.75rem 0;
+      border-bottom: 1px solid var(--cds-layer-accent-01, #e0e0e0);
+
+      &:last-child {
+        border-bottom: none;
+      }
+    }
+  }
+
+  .nvmeof-throughput {
+    &__row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 0.5rem 0;
+    }
+
+    &__footer-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+  }
+
+  .nvmeof-alerts-card {
+    height: 100%;
+
+    &__status {
+      margin-top: 0.25rem;
+    }
+
+    &__badge {
+      a {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
+      }
+    }
+  }
+}
+
+@media (width <= 82rem) {
+  .nvmeof-overview-cards {
+    &__row {
+      grid-template-columns: 1fr 1fr;
+    }
+  }
+}
+
+@media (width <= 62rem) {
+  .nvmeof-overview-cards {
+    &__row {
+      grid-template-columns: 1fr;
+    }
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.spec.ts
@@ -13,8 +13,8 @@ import { TabsModule } from 'carbon-components-angular';
 
 import { NvmeofService } from '~/app/shared/api/nvmeof.service';
 import { PerformanceCardService } from '~/app/shared/api/performance-card.service';
-import { PrometheusService } from '~/app/shared/api/prometheus.service';
 import { CephServiceSpec } from '~/app/shared/models/service.interface';
+import { PrometheusAlertService } from '~/app/shared/services/prometheus-alert.service';
 import { SharedModule } from '~/app/shared/shared.module';
 import { NvmeofStateService } from '../nvmeof-state.service';
 import { NvmeofTabsComponent } from './nvmeof-tabs.component';
@@ -44,7 +44,7 @@ describe('NvmeofTabsComponent', () => {
   let nvmeofServiceSpy: any;
   let nvmeofService: NvmeofService;
   let performanceCardService: PerformanceCardService;
-  let prometheusService: PrometheusService;
+  let prometheusAlertService: PrometheusAlertService;
   let queryParams$: BehaviorSubject<any>;
   let refresh$: Subject<void>;
   let routerEvents$: Subject<RouterEvent>;
@@ -75,14 +75,22 @@ describe('NvmeofTabsComponent', () => {
         {
           provide: PerformanceCardService,
           useValue: {
+            getNvmeofResourceStats: jest.fn().mockReturnValue(
+              of({
+                gatewayGroups: 1,
+                subsystems: 1,
+                namespaces: 2,
+                hosts: 1,
+                activeConnections: 0
+              })
+            ),
             getNvmeofThroughput: jest.fn().mockReturnValue(of({ reads: 0, writes: 0, combined: 0 }))
           }
         },
         {
-          provide: PrometheusService,
+          provide: PrometheusAlertService,
           useValue: {
-            isAlertmanagerUsable: jest.fn().mockReturnValue(of(false)),
-            getAlerts: jest.fn().mockReturnValue(of([]))
+            fetchGroupedAlerts: jest.fn().mockReturnValue(of([]))
           }
         },
         { provide: ActivatedRoute, useValue: { queryParams: queryParams$.asObservable() } },
@@ -95,7 +103,7 @@ describe('NvmeofTabsComponent', () => {
     router = TestBed.inject(Router);
     nvmeofService = TestBed.inject(NvmeofService);
     performanceCardService = TestBed.inject(PerformanceCardService);
-    prometheusService = TestBed.inject(PrometheusService);
+    prometheusAlertService = TestBed.inject(PrometheusAlertService);
     routerEvents$ = new Subject<RouterEvent>();
     jest.spyOn(router, 'events', 'get').mockReturnValue(routerEvents$.asObservable());
   });
@@ -443,7 +451,7 @@ describe('NvmeofTabsComponent', () => {
     });
   });
 
-  describe('loadResourceStats – gatewayGroupsDown', () => {
+  describe('loadResourceStats', () => {
     it('should load stats when gateway groups response is indexable object with numeric keys', fakeAsync(() => {
       const indexedResponse = {
         0: [makeGroup('default', 1, 1)],
@@ -460,7 +468,6 @@ describe('NvmeofTabsComponent', () => {
       tick();
 
       expect(stats.gatewayGroups).toBe(1);
-      expect(stats.gatewayGroupsDown).toBe(0);
       expect(stats.hasData).toBe(true);
     }));
 
@@ -475,53 +482,19 @@ describe('NvmeofTabsComponent', () => {
       tick();
 
       expect(stats.gatewayGroups).toBe(1);
-      expect(stats.gatewayGroupsDown).toBe(0);
       expect(stats.hasData).toBe(true);
     }));
 
-    it('should set gatewayGroupsDown to 0 when all gateways are running', fakeAsync(() => {
-      jest
-        .spyOn(nvmeofService, 'listGatewayGroups')
-        .mockReturnValue(of([[makeGroup('default', 1, 1), makeGroup('default1', 2, 2)]]));
-
-      component.loadResourceStats();
-      let stats: any;
-      component.nvmeof$.subscribe((s) => (stats = s));
-      tick();
-
-      expect(stats.gatewayGroups).toBe(2);
-      expect(stats.gatewayGroupsDown).toBe(0);
-    }));
-
-    it('should count groups with at least one down gateway in gatewayGroupsDown', fakeAsync(() => {
-      jest
-        .spyOn(nvmeofService, 'listGatewayGroups')
-        .mockReturnValue(of([[makeGroup('default', 0, 1), makeGroup('default1', 1, 2)]]));
-
-      component.loadResourceStats();
-      let stats: any;
-      component.nvmeof$.subscribe((s) => (stats = s));
-      tick();
-
-      expect(stats.gatewayGroups).toBe(2);
-      expect(stats.gatewayGroupsDown).toBe(2);
-    }));
-
-    it('should count only the groups that have errors', fakeAsync(() => {
-      jest
-        .spyOn(nvmeofService, 'listGatewayGroups')
-        .mockReturnValue(of([[makeGroup('default', 1, 1), makeGroup('default1', 0, 1)]]));
-
-      component.loadResourceStats();
-      let stats: any;
-      component.nvmeof$.subscribe((s) => (stats = s));
-      tick();
-
-      expect(stats.gatewayGroups).toBe(2);
-      expect(stats.gatewayGroupsDown).toBe(1);
-    }));
-
     it('should return null when no gateway groups exist', fakeAsync(() => {
+      jest.spyOn(performanceCardService, 'getNvmeofResourceStats').mockReturnValue(
+        of({
+          gatewayGroups: 0,
+          subsystems: 0,
+          namespaces: 0,
+          hosts: 0,
+          activeConnections: 0
+        })
+      );
       jest.spyOn(nvmeofService, 'listGatewayGroups').mockReturnValue(of([[]]));
 
       component.loadResourceStats();
@@ -550,8 +523,8 @@ describe('NvmeofTabsComponent', () => {
   });
 
   describe('loadAlerts', () => {
-    it('should return zero counts when alertmanager is not usable', fakeAsync(() => {
-      jest.spyOn(prometheusService, 'isAlertmanagerUsable').mockReturnValue(of(false));
+    it('should return zero counts when there are no alert groups', fakeAsync(() => {
+      jest.spyOn(prometheusAlertService, 'fetchGroupedAlerts').mockReturnValue(of([]));
 
       component.loadAlerts();
       let alerts: any;
@@ -565,31 +538,42 @@ describe('NvmeofTabsComponent', () => {
     }));
 
     it('should count active nvmeof critical and warning alerts', fakeAsync(() => {
-      const mockAlerts = [
+      const mockGroups = [
         {
-          labels: { alertname: 'NVMeoFHighGatewayCPU', category: 'gateway', severity: 'critical' },
-          status: { state: 'active' }
-        },
-        {
-          labels: {
-            alertname: 'NVMeoFInterfaceDuplex',
-            category: 'listener',
-            severity: 'warning'
-          },
-          status: { state: 'active' }
-        },
-        {
-          labels: { alertname: 'NVMeoFMissingListener', category: 'listener', severity: 'warning' },
-          status: { state: 'suppressed' }
-        },
-        {
-          labels: { alertname: 'CephDaemonCrash', severity: 'critical' },
-          status: { state: 'active' }
+          alerts: [
+            {
+              labels: {
+                alertname: 'NVMeoFHighGatewayCPU',
+                category: 'gateway',
+                severity: 'critical'
+              },
+              status: { state: 'active' }
+            },
+            {
+              labels: {
+                alertname: 'NVMeoFInterfaceDuplex',
+                category: 'listener',
+                severity: 'warning'
+              },
+              status: { state: 'active' }
+            },
+            {
+              labels: {
+                alertname: 'NVMeoFMissingListener',
+                category: 'listener',
+                severity: 'warning'
+              },
+              status: { state: 'suppressed' }
+            },
+            {
+              labels: { alertname: 'CephDaemonCrash', severity: 'critical' },
+              status: { state: 'active' }
+            }
+          ]
         }
       ];
 
-      jest.spyOn(prometheusService, 'isAlertmanagerUsable').mockReturnValue(of(true));
-      jest.spyOn(prometheusService, 'getAlerts').mockReturnValue(of(mockAlerts as any));
+      jest.spyOn(prometheusAlertService, 'fetchGroupedAlerts').mockReturnValue(of(mockGroups as any));
 
       component.loadAlerts();
       let alerts: any;
@@ -604,15 +588,18 @@ describe('NvmeofTabsComponent', () => {
     }));
 
     it('should match nvmeof alerts by prometheus job label', fakeAsync(() => {
-      const mockAlerts = [
+      const mockGroups = [
         {
-          labels: { job: 'nvmeof', severity: 'warning', alertname: 'SomeAlert' },
-          status: { state: 'active' }
+          alerts: [
+            {
+              labels: { job: 'nvmeof', severity: 'warning', alertname: 'SomeAlert' },
+              status: { state: 'active' }
+            }
+          ]
         }
       ];
 
-      jest.spyOn(prometheusService, 'isAlertmanagerUsable').mockReturnValue(of(true));
-      jest.spyOn(prometheusService, 'getAlerts').mockReturnValue(of(mockAlerts as any));
+      jest.spyOn(prometheusAlertService, 'fetchGroupedAlerts').mockReturnValue(of(mockGroups as any));
 
       component.loadAlerts();
       let alerts: any;
@@ -625,15 +612,18 @@ describe('NvmeofTabsComponent', () => {
     }));
 
     it('should not match alerts by alertname when nvme labels are absent', fakeAsync(() => {
-      const mockAlerts = [
+      const mockGroups = [
         {
-          labels: { alertname: 'NVMeofInterfaceDuplex', severity: 'warning' },
-          status: { state: 'active' }
+          alerts: [
+            {
+              labels: { alertname: 'NVMeofInterfaceDuplex', severity: 'warning' },
+              status: { state: 'active' }
+            }
+          ]
         }
       ];
 
-      jest.spyOn(prometheusService, 'isAlertmanagerUsable').mockReturnValue(of(true));
-      jest.spyOn(prometheusService, 'getAlerts').mockReturnValue(of(mockAlerts as any));
+      jest.spyOn(prometheusAlertService, 'fetchGroupedAlerts').mockReturnValue(of(mockGroups as any));
 
       component.loadAlerts();
       let alerts: any;
@@ -645,20 +635,69 @@ describe('NvmeofTabsComponent', () => {
       expect(alerts.total).toBe(0);
     }));
 
-    it('should not count inactive nvmeof alerts', fakeAsync(() => {
-      const mockAlerts = [
+    it('should not count non-nvme alerts that only match nvme categories', fakeAsync(() => {
+      const mockGroups = [
         {
-          labels: { alertname: 'NVMeoFHighGatewayCPU', category: 'gateway', severity: 'critical' },
-          status: { state: 'inactive' }
-        },
-        {
-          labels: { alertname: 'NVMeoFInterfaceDuplex', category: 'listener', severity: 'warning' },
-          status: { state: 'pending' }
+          alerts: [
+            {
+              labels: {
+                alertname: 'SomeGatewayAlert',
+                category: 'gateway',
+                severity: 'critical'
+              },
+              status: { state: 'active' }
+            },
+            {
+              labels: {
+                alertname: 'NVMeoFInterfaceDuplex',
+                category: 'listener',
+                severity: 'warning'
+              },
+              status: { state: 'active' }
+            }
+          ]
         }
       ];
 
-      jest.spyOn(prometheusService, 'isAlertmanagerUsable').mockReturnValue(of(true));
-      jest.spyOn(prometheusService, 'getAlerts').mockReturnValue(of(mockAlerts as any));
+      jest.spyOn(prometheusAlertService, 'fetchGroupedAlerts').mockReturnValue(of(mockGroups as any));
+
+      component.loadAlerts();
+      let alerts: any;
+      component.nvmeofAlerts$.subscribe((a) => (alerts = a));
+      tick(0);
+      discardPeriodicTasks();
+
+      expect(alerts.critical).toBe(0);
+      expect(alerts.warning).toBe(1);
+      expect(alerts.total).toBe(1);
+      expect(alerts.byCategory).toEqual({ listener: 1 });
+    }));
+
+    it('should not count inactive nvmeof alerts', fakeAsync(() => {
+      const mockGroups = [
+        {
+          alerts: [
+            {
+              labels: {
+                alertname: 'NVMeoFHighGatewayCPU',
+                category: 'gateway',
+                severity: 'critical'
+              },
+              status: { state: 'inactive' }
+            },
+            {
+              labels: {
+                alertname: 'NVMeoFInterfaceDuplex',
+                category: 'listener',
+                severity: 'warning'
+              },
+              status: { state: 'pending' }
+            }
+          ]
+        }
+      ];
+
+      jest.spyOn(prometheusAlertService, 'fetchGroupedAlerts').mockReturnValue(of(mockGroups as any));
 
       component.loadAlerts();
       let alerts: any;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.spec.ts
@@ -1,26 +1,58 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Event as RouterEvent, NavigationEnd, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { BehaviorSubject, Subject, of } from 'rxjs';
 
 import { TabsModule } from 'carbon-components-angular';
 
+import { NvmeofService } from '~/app/shared/api/nvmeof.service';
+import { NvmeofStateService } from '../nvmeof-state.service';
 import { NvmeofTabsComponent } from './nvmeof-tabs.component';
 import { SharedModule } from '~/app/shared/shared.module';
+import { NvmeofSetupCardsComponent } from '../nvmeof-setup-cards/nvmeof-setup-cards.component';
 
 describe('NvmeofTabsComponent', () => {
   let component: NvmeofTabsComponent;
   let fixture: ComponentFixture<NvmeofTabsComponent>;
   let router: Router;
+  let nvmeofServiceSpy: any;
+  let queryParams$: BehaviorSubject<any>;
+  let refresh$: Subject<void>;
+  let routerEvents$: Subject<RouterEvent>;
+
+  const mockGroups = [
+    [{ spec: { group: 'grp1' }, placement: { hosts: ['h1'] }, status: { running: 1, size: 1 } }]
+  ];
+  const mockSubsystems = [{ nqn: 'sub1', namespace_count: 2, initiator_count: 0 }];
+  const mockNamespaces = [{ nsid: 1, rbd_image_name: 'img1', rbd_pool_name: 'rbd' }];
+
+  const setQueryParams = (params: any) => queryParams$.next(params);
+  const emitRefresh = () => refresh$.next();
 
   beforeEach(async () => {
+    queryParams$ = new BehaviorSubject<any>({ group: 'grp1' });
+    refresh$ = new Subject<void>();
+    nvmeofServiceSpy = {
+      listGatewayGroups: jest.fn().mockReturnValue(of(mockGroups)),
+      listSubsystems: jest.fn().mockReturnValue(of(mockSubsystems)),
+      listNamespaces: jest.fn().mockReturnValue(of(mockNamespaces))
+    };
+
     await TestBed.configureTestingModule({
       declarations: [NvmeofTabsComponent],
-      imports: [RouterTestingModule, SharedModule, TabsModule]
+      imports: [RouterTestingModule, SharedModule, TabsModule, NvmeofSetupCardsComponent],
+      providers: [
+        { provide: NvmeofService, useValue: nvmeofServiceSpy },
+        { provide: ActivatedRoute, useValue: { queryParams: queryParams$.asObservable() } },
+        { provide: NvmeofStateService, useValue: { refresh$: refresh$.asObservable() } }
+      ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(NvmeofTabsComponent);
     component = fixture.componentInstance;
     router = TestBed.inject(Router);
+    routerEvents$ = new Subject<RouterEvent>();
+    jest.spyOn(router, 'events', 'get').mockReturnValue(routerEvents$.asObservable());
   });
 
   it('should create', () => {
@@ -51,25 +83,59 @@ describe('NvmeofTabsComponent', () => {
     expect(component.activeTab).toBe(component.Tabs.gateways);
   });
 
+  it('should hide the shell on namespace create routes', () => {
+    jest.spyOn(router, 'url', 'get').mockReturnValue('/block/nvmeof/namespaces/create');
+    component.ngOnInit();
+    expect(component.showTabsShell).toBe(false);
+  });
+
+  it('should keep the shell visible on namespace list routes', () => {
+    jest.spyOn(router, 'url', 'get').mockReturnValue('/block/nvmeof/namespaces');
+    component.ngOnInit();
+    expect(component.showTabsShell).toBe(true);
+  });
+
+  it('should keep the shell visible on list routes with a secondary outlet', () => {
+    jest
+      .spyOn(router, 'url', 'get')
+      .mockReturnValue('/block/nvmeof/subsystems(modal:create)?group=default');
+    component.ngOnInit();
+    expect(component.showTabsShell).toBe(true);
+  });
+
+  it('should hide the shell when primary route is a create page with secondary outlet', () => {
+    jest
+      .spyOn(router, 'url', 'get')
+      .mockReturnValue('/block/nvmeof/subsystems/create(modal:create)?group=default');
+    component.ngOnInit();
+    expect(component.showTabsShell).toBe(false);
+  });
+
   it('should navigate to correct path on tab selection', () => {
     spyOn(router, 'navigate');
     component.onSelected(component.Tabs.subsystems);
-    expect(component.selectedTab).toBe(component.Tabs.subsystems);
-    expect(router.navigate).toHaveBeenCalledWith(['block/nvmeof/subsystems']);
+    expect(component.activeTab).toBe(component.Tabs.subsystems);
+    expect(router.navigate).toHaveBeenCalledWith(['block/nvmeof/subsystems'], {
+      queryParamsHandling: 'preserve'
+    });
   });
 
   it('should navigate to gateways on selecting gateways tab', () => {
     spyOn(router, 'navigate');
     component.onSelected(component.Tabs.gateways);
-    expect(component.selectedTab).toBe(component.Tabs.gateways);
-    expect(router.navigate).toHaveBeenCalledWith(['block/nvmeof/gateways']);
+    expect(component.activeTab).toBe(component.Tabs.gateways);
+    expect(router.navigate).toHaveBeenCalledWith(['block/nvmeof/gateways'], {
+      queryParamsHandling: 'preserve'
+    });
   });
 
   it('should navigate to namespaces on selecting namespaces tab', () => {
     spyOn(router, 'navigate');
     component.onSelected(component.Tabs.namespaces);
-    expect(component.selectedTab).toBe(component.Tabs.namespaces);
-    expect(router.navigate).toHaveBeenCalledWith(['block/nvmeof/namespaces']);
+    expect(component.activeTab).toBe(component.Tabs.namespaces);
+    expect(router.navigate).toHaveBeenCalledWith(['block/nvmeof/namespaces'], {
+      queryParamsHandling: 'preserve'
+    });
   });
 
   it('should expose TABS enum via Tabs getter', () => {
@@ -77,5 +143,231 @@ describe('NvmeofTabsComponent', () => {
     expect(tabs.gateways).toBe('gateways');
     expect(tabs.subsystems).toBe('subsystems');
     expect(tabs.namespaces).toBe('namespaces');
+  });
+
+  describe('setup cards scenarios', () => {
+    it('should show setup cards', () => {
+      component.ngOnInit();
+      expect(component.showSetupCards).toBe(true);
+    });
+
+    it('should show setup cards when no group is selected in dropdown', () => {
+      component.ngOnInit();
+      nvmeofServiceSpy.listSubsystems.mockReturnValue(of(mockSubsystems));
+      nvmeofServiceSpy.listNamespaces.mockReturnValue(of(mockNamespaces));
+      setQueryParams({});
+      expect(component.hasGatewayGroups).toBe(true);
+      expect(component.hasSubsystems).toBe(false);
+      expect(component.hasNamespaces).toBe(false);
+      expect(component.isAllConfigured).toBe(false);
+      expect(component.showSetupCards).toBe(true);
+    });
+
+    it('scenario: no gateway groups — all steps pending', () => {
+      nvmeofServiceSpy.listGatewayGroups.mockReturnValue(of([[]]));
+      component.ngOnInit();
+      expect(component.hasGatewayGroups).toBe(false);
+      expect(component.hasSubsystems).toBe(false);
+      expect(component.hasNamespaces).toBe(false);
+      expect(component.isAllConfigured).toBe(false);
+      expect(component.showSetupCards).toBe(true);
+    });
+
+    it('scenario: selected gateway group exists, no subsystems — step 1 complete', () => {
+      component.ngOnInit();
+      nvmeofServiceSpy.listSubsystems.mockReturnValue(of([]));
+      nvmeofServiceSpy.listNamespaces.mockReturnValue(of([]));
+      setQueryParams({ group: 'grp1' });
+      expect(component.hasGatewayGroups).toBe(true);
+      expect(component.hasSubsystems).toBe(false);
+      expect(component.hasNamespaces).toBe(false);
+      expect(component.isAllConfigured).toBe(false);
+    });
+
+    it('scenario: selected gateway group does not exist — step 1 complete only', () => {
+      component.ngOnInit();
+      setQueryParams({ group: 'grp-other' });
+      expect(component.hasGatewayGroups).toBe(true);
+      expect(component.hasSubsystems).toBe(false);
+      expect(component.hasNamespaces).toBe(false);
+      expect(component.isAllConfigured).toBe(false);
+    });
+
+    it('scenario: selected gateway groups exists, no subsystems in object response — step 1 complete', () => {
+      component.ngOnInit();
+      nvmeofServiceSpy.listSubsystems.mockReturnValue(of({ subsystems: [] }));
+      nvmeofServiceSpy.listNamespaces.mockReturnValue(of([]));
+      setQueryParams({ group: 'grp1' });
+      expect(component.hasGatewayGroups).toBe(true);
+      expect(component.hasSubsystems).toBe(false);
+      expect(component.hasNamespaces).toBe(false);
+      expect(component.isAllConfigured).toBe(false);
+    });
+
+    it('scenario: selected gateway group + subsystems, no namespaces — steps 1 & 2 complete', () => {
+      component.ngOnInit();
+      nvmeofServiceSpy.listSubsystems.mockReturnValue(
+        of([{ nqn: 'sub1', namespace_count: 0, initiator_count: 0 }])
+      );
+      nvmeofServiceSpy.listNamespaces.mockReturnValue(of([]));
+      setQueryParams({ group: 'grp1' });
+      expect(component.hasGatewayGroups).toBe(true);
+      expect(component.hasSubsystems).toBe(true);
+      expect(component.hasNamespaces).toBe(false);
+      expect(component.isAllConfigured).toBe(false);
+    });
+
+    it('scenario: selected gateway group all configured — isAllConfigured is true', () => {
+      component.ngOnInit();
+      setQueryParams({ group: 'grp1' });
+      expect(component.hasGatewayGroups).toBe(true);
+      expect(component.hasSubsystems).toBe(true);
+      expect(component.hasNamespaces).toBe(true);
+      expect(component.isAllConfigured).toBe(true);
+    });
+
+    it('scenario: selected gateway group all configured in object response — isAllConfigured is true', () => {
+      component.ngOnInit();
+      nvmeofServiceSpy.listSubsystems.mockReturnValue(
+        of({ subsystems: [{ nqn: 'sub1', namespace_count: 2, initiator_count: 0 }] })
+      );
+      nvmeofServiceSpy.listNamespaces.mockReturnValue(
+        of({ namespaces: [{ nsid: 1, rbd_image_name: 'img1', rbd_pool_name: 'rbd' }] })
+      );
+      setQueryParams({ group: 'grp1' });
+      expect(component.hasGatewayGroups).toBe(true);
+      expect(component.hasSubsystems).toBe(true);
+      expect(component.hasNamespaces).toBe(true);
+      expect(component.isAllConfigured).toBe(true);
+    });
+
+    it('should hide setup cards on dismissOnboarding', () => {
+      component.ngOnInit();
+      component.loadSetupState();
+      component.showSetupCards = true;
+      component.dismissOnboarding();
+      expect(component.showSetupCards).toBe(false);
+    });
+
+    it('should keep setup cards hidden after refresh when onboarding was dismissed', () => {
+      component.ngOnInit();
+      component.dismissOnboarding();
+
+      emitRefresh();
+
+      expect(component.showSetupCards).toBe(false);
+    });
+
+    it('should refresh setup cards when a relevant delete task finishes', () => {
+      const loadSetupStateSpy = jest.spyOn(component, 'loadSetupState');
+
+      component.ngOnInit();
+      loadSetupStateSpy.mockClear();
+
+      emitRefresh();
+
+      expect(loadSetupStateSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should refresh setup cards when an NVMeoF gateway service delete task finishes', () => {
+      const loadSetupStateSpy = jest.spyOn(component, 'loadSetupState');
+
+      component.ngOnInit();
+      loadSetupStateSpy.mockClear();
+
+      emitRefresh();
+
+      expect(loadSetupStateSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should refresh setup cards when an NVMeoF gateway service create task finishes', () => {
+      const loadSetupStateSpy = jest.spyOn(component, 'loadSetupState');
+
+      component.ngOnInit();
+      loadSetupStateSpy.mockClear();
+
+      emitRefresh();
+
+      expect(loadSetupStateSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should refresh setup cards when a namespace create task finishes', () => {
+      const loadSetupStateSpy = jest.spyOn(component, 'loadSetupState');
+
+      component.ngOnInit();
+      loadSetupStateSpy.mockClear();
+
+      emitRefresh();
+
+      expect(loadSetupStateSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call loadSetupState on NavigationEnd (e.g. navigating back from a form)', () => {
+      const loadSetupStateSpy = jest.spyOn(component, 'loadSetupState');
+
+      component.ngOnInit();
+      loadSetupStateSpy.mockClear();
+
+      routerEvents$.next(
+        new NavigationEnd(1, '/block/nvmeof/namespaces', '/block/nvmeof/namespaces')
+      );
+
+      expect(loadSetupStateSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should show the initial gateway-only state after the last subsystem and namespace are removed', () => {
+      component.ngOnInit();
+
+      nvmeofServiceSpy.listSubsystems.mockReturnValue(of([]));
+      nvmeofServiceSpy.listNamespaces.mockReturnValue(of([]));
+
+      emitRefresh();
+
+      expect(component.hasGatewayGroups).toBe(true);
+      expect(component.hasSubsystems).toBe(false);
+      expect(component.hasNamespaces).toBe(false);
+      expect(component.isAllConfigured).toBe(false);
+    });
+
+    it('should show the initial empty state after the last gateway is removed', () => {
+      component.ngOnInit();
+
+      nvmeofServiceSpy.listGatewayGroups.mockReturnValue(of([[]]));
+
+      emitRefresh();
+
+      expect(component.hasGatewayGroups).toBe(false);
+      expect(component.hasSubsystems).toBe(false);
+      expect(component.hasNamespaces).toBe(false);
+      expect(component.isAllConfigured).toBe(false);
+    });
+
+    it('should refresh setup cards when the gateway list refreshes to empty', () => {
+      component.ngOnInit();
+
+      nvmeofServiceSpy.listGatewayGroups.mockReturnValue(of([[]]));
+      emitRefresh();
+
+      expect(component.hasGatewayGroups).toBe(false);
+      expect(component.hasSubsystems).toBe(false);
+      expect(component.hasNamespaces).toBe(false);
+      expect(component.isAllConfigured).toBe(false);
+    });
+
+    it('should show gateway step complete after a gateway is created', () => {
+      nvmeofServiceSpy.listGatewayGroups.mockReturnValueOnce(of([[]]));
+      component.ngOnInit();
+
+      nvmeofServiceSpy.listGatewayGroups.mockReturnValue(of(mockGroups));
+      nvmeofServiceSpy.listSubsystems.mockReturnValue(of([]));
+      nvmeofServiceSpy.listNamespaces.mockReturnValue(of([]));
+
+      emitRefresh();
+
+      expect(component.hasGatewayGroups).toBe(true);
+      expect(component.hasSubsystems).toBe(false);
+      expect(component.hasNamespaces).toBe(false);
+      expect(component.isAllConfigured).toBe(false);
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.spec.ts
@@ -1,4 +1,10 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  TestBed,
+  discardPeriodicTasks,
+  fakeAsync,
+  tick
+} from '@angular/core/testing';
 import { ActivatedRoute, Event as RouterEvent, NavigationEnd, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { BehaviorSubject, Subject, of } from 'rxjs';
@@ -6,16 +12,39 @@ import { BehaviorSubject, Subject, of } from 'rxjs';
 import { TabsModule } from 'carbon-components-angular';
 
 import { NvmeofService } from '~/app/shared/api/nvmeof.service';
+import { PerformanceCardService } from '~/app/shared/api/performance-card.service';
+import { PrometheusService } from '~/app/shared/api/prometheus.service';
+import { CephServiceSpec } from '~/app/shared/models/service.interface';
+import { SharedModule } from '~/app/shared/shared.module';
 import { NvmeofStateService } from '../nvmeof-state.service';
 import { NvmeofTabsComponent } from './nvmeof-tabs.component';
-import { SharedModule } from '~/app/shared/shared.module';
 import { NvmeofSetupCardsComponent } from '../nvmeof-setup-cards/nvmeof-setup-cards.component';
+
+const makeGroup = (name: string, running: number, size: number): CephServiceSpec => ({
+  service_name: `nvmeof.${name}`,
+  service_type: 'nvmeof',
+  service_id: name,
+  unmanaged: false,
+  spec: { group: name } as CephServiceSpec['spec'],
+  status: {
+    container_image_id: '',
+    container_image_name: '',
+    size,
+    running,
+    last_refresh: new Date('2026-05-25T00:00:00'),
+    created: new Date('2026-05-25T00:00:00')
+  },
+  placement: { hosts: [`host-${name}`] }
+});
 
 describe('NvmeofTabsComponent', () => {
   let component: NvmeofTabsComponent;
   let fixture: ComponentFixture<NvmeofTabsComponent>;
   let router: Router;
   let nvmeofServiceSpy: any;
+  let nvmeofService: NvmeofService;
+  let performanceCardService: PerformanceCardService;
+  let prometheusService: PrometheusService;
   let queryParams$: BehaviorSubject<any>;
   let refresh$: Subject<void>;
   let routerEvents$: Subject<RouterEvent>;
@@ -43,6 +72,19 @@ describe('NvmeofTabsComponent', () => {
       imports: [RouterTestingModule, SharedModule, TabsModule, NvmeofSetupCardsComponent],
       providers: [
         { provide: NvmeofService, useValue: nvmeofServiceSpy },
+        {
+          provide: PerformanceCardService,
+          useValue: {
+            getNvmeofThroughput: jest.fn().mockReturnValue(of({ reads: 0, writes: 0, combined: 0 }))
+          }
+        },
+        {
+          provide: PrometheusService,
+          useValue: {
+            isAlertmanagerUsable: jest.fn().mockReturnValue(of(false)),
+            getAlerts: jest.fn().mockReturnValue(of([]))
+          }
+        },
         { provide: ActivatedRoute, useValue: { queryParams: queryParams$.asObservable() } },
         { provide: NvmeofStateService, useValue: { refresh$: refresh$.asObservable() } }
       ]
@@ -51,6 +93,9 @@ describe('NvmeofTabsComponent', () => {
     fixture = TestBed.createComponent(NvmeofTabsComponent);
     component = fixture.componentInstance;
     router = TestBed.inject(Router);
+    nvmeofService = TestBed.inject(NvmeofService);
+    performanceCardService = TestBed.inject(PerformanceCardService);
+    prometheusService = TestBed.inject(PrometheusService);
     routerEvents$ = new Subject<RouterEvent>();
     jest.spyOn(router, 'events', 'get').mockReturnValue(routerEvents$.asObservable());
   });
@@ -254,7 +299,6 @@ describe('NvmeofTabsComponent', () => {
       component.dismissOnboarding();
 
       emitRefresh();
-
       expect(component.showSetupCards).toBe(false);
     });
 
@@ -267,6 +311,23 @@ describe('NvmeofTabsComponent', () => {
       emitRefresh();
 
       expect(loadSetupStateSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should refresh overview cards when a relevant task finishes', () => {
+      const loadResourceStatsSpy = jest.spyOn(component, 'loadResourceStats');
+      const loadThroughputSpy = jest.spyOn(component, 'loadThroughput');
+      const loadAlertsSpy = jest.spyOn(component, 'loadAlerts');
+
+      component.ngOnInit();
+      loadResourceStatsSpy.mockClear();
+      loadThroughputSpy.mockClear();
+      loadAlertsSpy.mockClear();
+
+      emitRefresh();
+
+      expect(loadResourceStatsSpy).toHaveBeenCalledTimes(1);
+      expect(loadThroughputSpy).toHaveBeenCalledTimes(1);
+      expect(loadAlertsSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should refresh setup cards when an NVMeoF gateway service delete task finishes', () => {
@@ -342,6 +403,17 @@ describe('NvmeofTabsComponent', () => {
       expect(component.isAllConfigured).toBe(false);
     });
 
+    it('should show setup cards after everything is deleted even when onboarding was dismissed', () => {
+      component.ngOnInit();
+      component.dismissOnboarding();
+
+      nvmeofServiceSpy.listGatewayGroups.mockReturnValue(of([[]]));
+      emitRefresh();
+
+      expect(component.hasGatewayGroups).toBe(false);
+      expect(component.showSetupCards).toBe(true);
+    });
+
     it('should refresh setup cards when the gateway list refreshes to empty', () => {
       component.ngOnInit();
 
@@ -369,5 +441,234 @@ describe('NvmeofTabsComponent', () => {
       expect(component.hasNamespaces).toBe(false);
       expect(component.isAllConfigured).toBe(false);
     });
+  });
+
+  describe('loadResourceStats – gatewayGroupsDown', () => {
+    it('should load stats when gateway groups response is indexable object with numeric keys', fakeAsync(() => {
+      const indexedResponse = {
+        0: [makeGroup('default', 1, 1)],
+        1: 1
+      };
+
+      jest
+        .spyOn(nvmeofService, 'listGatewayGroups')
+        .mockReturnValue(of((indexedResponse as unknown) as CephServiceSpec[][]));
+
+      component.loadResourceStats();
+      let stats: any;
+      component.nvmeof$.subscribe((s) => (stats = s));
+      tick();
+
+      expect(stats.gatewayGroups).toBe(1);
+      expect(stats.gatewayGroupsDown).toBe(0);
+      expect(stats.hasData).toBe(true);
+    }));
+
+    it('should load stats when gateway groups response is a flat array', fakeAsync(() => {
+      jest
+        .spyOn(nvmeofService, 'listGatewayGroups')
+        .mockReturnValue(of(([makeGroup('default', 1, 1)] as unknown) as CephServiceSpec[][]));
+
+      component.loadResourceStats();
+      let stats: any;
+      component.nvmeof$.subscribe((s) => (stats = s));
+      tick();
+
+      expect(stats.gatewayGroups).toBe(1);
+      expect(stats.gatewayGroupsDown).toBe(0);
+      expect(stats.hasData).toBe(true);
+    }));
+
+    it('should set gatewayGroupsDown to 0 when all gateways are running', fakeAsync(() => {
+      jest
+        .spyOn(nvmeofService, 'listGatewayGroups')
+        .mockReturnValue(of([[makeGroup('default', 1, 1), makeGroup('default1', 2, 2)]]));
+
+      component.loadResourceStats();
+      let stats: any;
+      component.nvmeof$.subscribe((s) => (stats = s));
+      tick();
+
+      expect(stats.gatewayGroups).toBe(2);
+      expect(stats.gatewayGroupsDown).toBe(0);
+    }));
+
+    it('should count groups with at least one down gateway in gatewayGroupsDown', fakeAsync(() => {
+      jest
+        .spyOn(nvmeofService, 'listGatewayGroups')
+        .mockReturnValue(of([[makeGroup('default', 0, 1), makeGroup('default1', 1, 2)]]));
+
+      component.loadResourceStats();
+      let stats: any;
+      component.nvmeof$.subscribe((s) => (stats = s));
+      tick();
+
+      expect(stats.gatewayGroups).toBe(2);
+      expect(stats.gatewayGroupsDown).toBe(2);
+    }));
+
+    it('should count only the groups that have errors', fakeAsync(() => {
+      jest
+        .spyOn(nvmeofService, 'listGatewayGroups')
+        .mockReturnValue(of([[makeGroup('default', 1, 1), makeGroup('default1', 0, 1)]]));
+
+      component.loadResourceStats();
+      let stats: any;
+      component.nvmeof$.subscribe((s) => (stats = s));
+      tick();
+
+      expect(stats.gatewayGroups).toBe(2);
+      expect(stats.gatewayGroupsDown).toBe(1);
+    }));
+
+    it('should return null when no gateway groups exist', fakeAsync(() => {
+      jest.spyOn(nvmeofService, 'listGatewayGroups').mockReturnValue(of([[]]));
+
+      component.loadResourceStats();
+      let stats: any;
+      component.nvmeof$.subscribe((s) => (stats = s));
+      tick();
+
+      expect(stats).toBeNull();
+    }));
+  });
+
+  describe('loadThroughput', () => {
+    it('should load throughput from PerformanceCardService', fakeAsync(() => {
+      jest
+        .spyOn(performanceCardService, 'getNvmeofThroughput')
+        .mockReturnValue(of({ reads: 12.5, writes: 7.25, combined: 19.75 }));
+
+      component.loadThroughput();
+      let throughput: any;
+      component.nvmeofThroughput$.subscribe((t) => (throughput = t));
+      tick();
+
+      expect(performanceCardService.getNvmeofThroughput).toHaveBeenCalled();
+      expect(throughput).toEqual({ reads: 12.5, writes: 7.25, combined: 19.75 });
+    }));
+  });
+
+  describe('loadAlerts', () => {
+    it('should return zero counts when alertmanager is not usable', fakeAsync(() => {
+      jest.spyOn(prometheusService, 'isAlertmanagerUsable').mockReturnValue(of(false));
+
+      component.loadAlerts();
+      let alerts: any;
+      component.nvmeofAlerts$.subscribe((a) => (alerts = a));
+      tick(0);
+      discardPeriodicTasks();
+
+      expect(alerts.total).toBe(0);
+      expect(alerts.critical).toBe(0);
+      expect(alerts.warning).toBe(0);
+    }));
+
+    it('should count active nvmeof critical and warning alerts', fakeAsync(() => {
+      const mockAlerts = [
+        {
+          labels: { alertname: 'NVMeoFHighGatewayCPU', category: 'gateway', severity: 'critical' },
+          status: { state: 'active' }
+        },
+        {
+          labels: {
+            alertname: 'NVMeoFInterfaceDuplex',
+            category: 'listener',
+            severity: 'warning'
+          },
+          status: { state: 'active' }
+        },
+        {
+          labels: { alertname: 'NVMeoFMissingListener', category: 'listener', severity: 'warning' },
+          status: { state: 'suppressed' }
+        },
+        {
+          labels: { alertname: 'CephDaemonCrash', severity: 'critical' },
+          status: { state: 'active' }
+        }
+      ];
+
+      jest.spyOn(prometheusService, 'isAlertmanagerUsable').mockReturnValue(of(true));
+      jest.spyOn(prometheusService, 'getAlerts').mockReturnValue(of(mockAlerts as any));
+
+      component.loadAlerts();
+      let alerts: any;
+      component.nvmeofAlerts$.subscribe((a) => (alerts = a));
+      tick(0);
+      discardPeriodicTasks();
+
+      expect(alerts.critical).toBe(1);
+      expect(alerts.warning).toBe(1);
+      expect(alerts.total).toBe(2);
+      expect(alerts.byCategory).toEqual({ gateway: 1, listener: 1 });
+    }));
+
+    it('should match nvmeof alerts by prometheus job label', fakeAsync(() => {
+      const mockAlerts = [
+        {
+          labels: { job: 'nvmeof', severity: 'warning', alertname: 'SomeAlert' },
+          status: { state: 'active' }
+        }
+      ];
+
+      jest.spyOn(prometheusService, 'isAlertmanagerUsable').mockReturnValue(of(true));
+      jest.spyOn(prometheusService, 'getAlerts').mockReturnValue(of(mockAlerts as any));
+
+      component.loadAlerts();
+      let alerts: any;
+      component.nvmeofAlerts$.subscribe((a) => (alerts = a));
+      tick(0);
+      discardPeriodicTasks();
+
+      expect(alerts.warning).toBe(1);
+      expect(alerts.total).toBe(1);
+    }));
+
+    it('should not match alerts by alertname when nvme labels are absent', fakeAsync(() => {
+      const mockAlerts = [
+        {
+          labels: { alertname: 'NVMeofInterfaceDuplex', severity: 'warning' },
+          status: { state: 'active' }
+        }
+      ];
+
+      jest.spyOn(prometheusService, 'isAlertmanagerUsable').mockReturnValue(of(true));
+      jest.spyOn(prometheusService, 'getAlerts').mockReturnValue(of(mockAlerts as any));
+
+      component.loadAlerts();
+      let alerts: any;
+      component.nvmeofAlerts$.subscribe((a) => (alerts = a));
+      tick(0);
+      discardPeriodicTasks();
+
+      expect(alerts.warning).toBe(0);
+      expect(alerts.total).toBe(0);
+    }));
+
+    it('should not count inactive nvmeof alerts', fakeAsync(() => {
+      const mockAlerts = [
+        {
+          labels: { alertname: 'NVMeoFHighGatewayCPU', category: 'gateway', severity: 'critical' },
+          status: { state: 'inactive' }
+        },
+        {
+          labels: { alertname: 'NVMeoFInterfaceDuplex', category: 'listener', severity: 'warning' },
+          status: { state: 'pending' }
+        }
+      ];
+
+      jest.spyOn(prometheusService, 'isAlertmanagerUsable').mockReturnValue(of(true));
+      jest.spyOn(prometheusService, 'getAlerts').mockReturnValue(of(mockAlerts as any));
+
+      component.loadAlerts();
+      let alerts: any;
+      component.nvmeofAlerts$.subscribe((a) => (alerts = a));
+      tick(0);
+      discardPeriodicTasks();
+
+      expect(alerts.critical).toBe(0);
+      expect(alerts.warning).toBe(0);
+      expect(alerts.total).toBe(0);
+    }));
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.ts
@@ -5,6 +5,7 @@ import {
   catchError,
   filter,
   map,
+  mergeMap,
   shareReplay,
   startWith,
   switchMap,
@@ -14,14 +15,15 @@ import {
 
 import { NvmeofService } from '~/app/shared/api/nvmeof.service';
 import {
+  NvmeofResourceStats,
   NvmeofThroughput,
   PerformanceCardService
 } from '~/app/shared/api/performance-card.service';
-import { PrometheusService } from '~/app/shared/api/prometheus.service';
 import { CephServiceSpec } from '~/app/shared/models/service.interface';
 import { NvmeofSubsystem, NvmeofSubsystemNamespace } from '~/app/shared/models/nvmeof';
-import { AlertmanagerAlert } from '~/app/shared/models/prometheus-alerts';
+import { AlertmanagerAlert, GroupAlertmanagerAlert } from '~/app/shared/models/prometheus-alerts';
 import { isNvmeofAlert, nvmeofAlertQueryParams } from '~/app/shared/helpers/nvmeof-alert.helper';
+import { PrometheusAlertService } from '~/app/shared/services/prometheus-alert.service';
 import { NvmeofStateService } from '../nvmeof-state.service';
 
 const NVMEOF_PATH = 'block/nvmeof';
@@ -36,7 +38,6 @@ const DEFAULT_ALERTS: NvmeAlerts = {
 
 export interface ResourceStats {
   gatewayGroups: number;
-  gatewayGroupsDown: number;
   subsystems: number;
   namespaces: number;
   hosts: number;
@@ -96,7 +97,7 @@ export class NvmeofTabsComponent implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     private nvmeofService: NvmeofService,
     private performanceCardService: PerformanceCardService,
-    private prometheusService: PrometheusService,
+    private prometheusAlertService: PrometheusAlertService,
     private nvmeofStateService: NvmeofStateService
   ) {}
 
@@ -117,60 +118,18 @@ export class NvmeofTabsComponent implements OnInit, OnDestroy {
   }
 
   loadResourceStats(): void {
-    this.nvmeof$ = this.nvmeofService.listGatewayGroups().pipe(
-      switchMap((gatewayGroups: CephServiceSpec[][]) => {
-        const firstItem = (gatewayGroups as any)?.[0];
-        const rawGroups: CephServiceSpec[] = Array.isArray(firstItem)
-          ? (firstItem as CephServiceSpec[])
-          : Array.isArray(gatewayGroups)
-          ? ((gatewayGroups as unknown) as CephServiceSpec[])
-          : [];
-        const groups = rawGroups.filter((g: CephServiceSpec) => g?.spec?.group);
-        if (groups.length === 0) {
-          return of(null);
+    this.nvmeof$ = this.performanceCardService.getNvmeofResourceStats().pipe(
+      mergeMap((stats: NvmeofResourceStats) => {
+        if (stats.gatewayGroups > 0) {
+          return of({
+            ...stats,
+            hasData: true
+          } as ResourceStats);
         }
-        const hostsSet = new Set<string>();
-        groups.forEach((group: CephServiceSpec) => {
-          (group.placement?.hosts ?? []).forEach((h: string) => hostsSet.add(h));
-        });
-        const subsystemCalls = groups.map((group: CephServiceSpec) =>
-          this.nvmeofService.listSubsystems(group.spec.group).pipe(catchError(() => of([])))
-        );
-        const namespaceCalls = groups.map((group: CephServiceSpec) =>
-          this.nvmeofService.listNamespaces(group.spec.group).pipe(catchError(() => of([])))
-        );
-        const gatewayGroupsDown = groups.filter(
-          (g: CephServiceSpec) => (g.status?.running ?? 0) < (g.status?.size ?? 0)
-        ).length;
-        return forkJoin([forkJoin(subsystemCalls), forkJoin(namespaceCalls)]).pipe(
-          map(([subsystemsPerGroup]: [any[], any[]]) => {
-            const allSubs: NvmeofSubsystem[] = (subsystemsPerGroup as NvmeofSubsystem[][]).flat();
-            const totalNamespaces = allSubs.reduce((sum, s) => sum + (s.namespace_count || 0), 0);
-            const activeConnections = allSubs.reduce((s, sub) => s + (sub.initiator_count || 0), 0);
-            return {
-              gatewayGroups: groups.length,
-              gatewayGroupsDown,
-              subsystems: allSubs.length,
-              namespaces: totalNamespaces,
-              hosts: hostsSet.size,
-              activeConnections,
-              hasData: true
-            } as ResourceStats;
-          }),
-          catchError(() =>
-            of({
-              gatewayGroups: groups.length,
-              gatewayGroupsDown,
-              subsystems: 0,
-              namespaces: 0,
-              hosts: hostsSet.size,
-              activeConnections: 0,
-              hasData: true
-            } as ResourceStats)
-          )
-        );
+
+        return this.loadResourceStatsFromNvmeofApi();
       }),
-      catchError(() => of(null)),
+      catchError(() => this.loadResourceStatsFromNvmeofApi()),
       tap((stats) => {
         this.cachedResourceStats = stats?.hasData ? stats : null;
       }),
@@ -194,30 +153,8 @@ export class NvmeofTabsComponent implements OnInit, OnDestroy {
 
   loadAlerts(): void {
     this.nvmeofAlerts$ = timer(0, ALERT_POLL_INTERVAL).pipe(
-      switchMap(() => this.prometheusService.isAlertmanagerUsable()),
-      switchMap((usable) => {
-        if (!usable) return of([] as AlertmanagerAlert[]);
-        return this.prometheusService
-          .getAlerts(true)
-          .pipe(catchError(() => of([] as AlertmanagerAlert[])));
-      }),
-      map((alerts: AlertmanagerAlert[]) => {
-        const nvmeAlerts = alerts.filter(isNvmeofAlert);
-        const critical = nvmeAlerts.filter(
-          (a) => a.labels.severity === 'critical' && a.status.state === 'active'
-        ).length;
-        const warning = nvmeAlerts.filter(
-          (a) => a.labels.severity === 'warning' && a.status.state === 'active'
-        ).length;
-        const byCategory: Record<string, number> = {};
-        nvmeAlerts
-          .filter((a) => a.status.state === 'active' && a.labels.category)
-          .forEach((a) => {
-            const cat = a.labels.category!;
-            byCategory[cat] = (byCategory[cat] ?? 0) + 1;
-          });
-        return { critical, warning, total: critical + warning, byCategory };
-      }),
+      switchMap(() => this.prometheusAlertService.fetchGroupedAlerts(true)),
+      map((alertGroups) => this.toNvmeofAlerts(alertGroups)),
       catchError(() => of(DEFAULT_ALERTS)),
       tap((alerts) => {
         this.cachedAlerts = alerts;
@@ -370,6 +307,7 @@ export class NvmeofTabsComponent implements OnInit, OnDestroy {
   dismissOnboarding(): void {
     this.dismissed = true;
     this.showSetupCards = false;
+    this.refreshOverviewCards();
   }
 
   onSelected(tab: TABS) {
@@ -381,6 +319,100 @@ export class NvmeofTabsComponent implements OnInit, OnDestroy {
 
   public get Tabs(): typeof TABS {
     return TABS;
+  }
+
+  private loadResourceStatsFromNvmeofApi(): Observable<ResourceStats | null> {
+    return this.nvmeofService.listGatewayGroups().pipe(
+      switchMap((gatewayGroups: CephServiceSpec[][]) => {
+        const firstItem = (gatewayGroups as any)?.[0];
+        const rawGroups: CephServiceSpec[] = Array.isArray(firstItem)
+          ? (firstItem as CephServiceSpec[])
+          : Array.isArray(gatewayGroups)
+          ? ((gatewayGroups as unknown) as CephServiceSpec[])
+          : [];
+        const groups = rawGroups.filter((g: CephServiceSpec) => g?.spec?.group);
+        if (groups.length === 0) {
+          return of(null);
+        }
+
+        const hostsSet = new Set<string>();
+        groups.forEach((group: CephServiceSpec) => {
+          (group.placement?.hosts ?? []).forEach((h: string) => hostsSet.add(h));
+        });
+
+        const subsystemCalls = groups.map((group: CephServiceSpec) =>
+          this.nvmeofService.listSubsystems(group.spec.group).pipe(catchError(() => of([])))
+        );
+
+        return forkJoin(subsystemCalls).pipe(
+          map((subsystemsPerGroup) => {
+            const allSubs: NvmeofSubsystem[] = (subsystemsPerGroup as NvmeofSubsystem[][]).flat();
+            const totalNamespaces = allSubs.reduce((sum, s) => sum + (s.namespace_count || 0), 0);
+            const activeConnections = allSubs.reduce((s, sub) => s + (sub.initiator_count || 0), 0);
+
+            return {
+              gatewayGroups: groups.length,
+              subsystems: allSubs.length,
+              namespaces: totalNamespaces,
+              hosts: hostsSet.size,
+              activeConnections,
+              hasData: true
+            } as ResourceStats;
+          }),
+          catchError(() =>
+            of({
+              gatewayGroups: groups.length,
+              subsystems: 0,
+              namespaces: 0,
+              hosts: hostsSet.size,
+              activeConnections: 0,
+              hasData: true
+            } as ResourceStats)
+          )
+        );
+      }),
+      catchError(() => of(null))
+    );
+  }
+
+  private toNvmeofAlerts(alertGroups: GroupAlertmanagerAlert[]): NvmeAlerts {
+    const groupedAlerts = alertGroups.flatMap((group) => group.alerts ?? []);
+    return this.summarizeNvmeofAlerts(groupedAlerts);
+  }
+
+  private summarizeNvmeofAlerts(alerts: AlertmanagerAlert[]): NvmeAlerts {
+    const nvmeAlerts = alerts.filter(
+      (alert) => this.isNvmeofCardAlert(alert) && alert.status?.state === 'active'
+    );
+    const critical = nvmeAlerts.filter((alert) => alert.labels?.severity === 'critical').length;
+    const warning = nvmeAlerts.filter((alert) => alert.labels?.severity === 'warning').length;
+    const byCategory: Record<string, number> = {};
+
+    nvmeAlerts.forEach((alert) => {
+      const category = alert.labels?.category;
+      if (category) {
+        byCategory[category] = (byCategory[category] ?? 0) + 1;
+      }
+    });
+
+    return { critical, warning, total: critical + warning, byCategory };
+  }
+
+  /**
+   * Keep NVMe-oF card matching strict without changing shared alert filters.
+   */
+  private isNvmeofCardAlert(alert: AlertmanagerAlert): boolean {
+    if (!isNvmeofAlert(alert)) {
+      return false;
+    }
+
+    const job = alert.labels?.job?.toLowerCase();
+    if (job === 'nvme' || job === 'nvmeof') {
+      return true;
+    }
+
+    const alertName = alert.labels?.alertname?.toLowerCase() ?? '';
+    return alertName.includes('nvme');
   }
 
   readonly alertQueryParams = nvmeofAlertQueryParams;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.ts
@@ -1,14 +1,55 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
-import { Observable, Subject, forkJoin, of } from 'rxjs';
-import { catchError, filter, map, switchMap, takeUntil } from 'rxjs/operators';
+import { Observable, Subject, forkJoin, of, timer } from 'rxjs';
+import {
+  catchError,
+  filter,
+  map,
+  shareReplay,
+  startWith,
+  switchMap,
+  takeUntil,
+  tap
+} from 'rxjs/operators';
 
 import { NvmeofService } from '~/app/shared/api/nvmeof.service';
+import {
+  NvmeofThroughput,
+  PerformanceCardService
+} from '~/app/shared/api/performance-card.service';
+import { PrometheusService } from '~/app/shared/api/prometheus.service';
 import { CephServiceSpec } from '~/app/shared/models/service.interface';
 import { NvmeofSubsystem, NvmeofSubsystemNamespace } from '~/app/shared/models/nvmeof';
+import { AlertmanagerAlert } from '~/app/shared/models/prometheus-alerts';
+import { isNvmeofAlert, nvmeofAlertQueryParams } from '~/app/shared/helpers/nvmeof-alert.helper';
 import { NvmeofStateService } from '../nvmeof-state.service';
 
 const NVMEOF_PATH = 'block/nvmeof';
+const ALERT_POLL_INTERVAL = 30000;
+const DEFAULT_THROUGHPUT: NvmeofThroughput = { reads: 0, writes: 0, combined: 0 };
+const DEFAULT_ALERTS: NvmeAlerts = {
+  critical: 0,
+  warning: 0,
+  total: 0,
+  byCategory: {}
+};
+
+export interface ResourceStats {
+  gatewayGroups: number;
+  gatewayGroupsDown: number;
+  subsystems: number;
+  namespaces: number;
+  hosts: number;
+  activeConnections: number;
+  hasData: boolean;
+}
+
+export interface NvmeAlerts {
+  critical: number;
+  warning: number;
+  total: number;
+  byCategory: Record<string, number>;
+}
 
 enum TABS {
   gateways = 'gateways',
@@ -29,15 +70,23 @@ type SetupState = {
   standalone: false
 })
 export class NvmeofTabsComponent implements OnInit, OnDestroy {
+  @Input() showSetupCards = false;
+
+  selectedTab: TABS | undefined;
   activeTab: TABS = TABS.gateways;
   showTabsShell = true;
-  showSetupCards = false;
   hasGatewayGroups = false;
   hasSubsystems = false;
   hasNamespaces = false;
   isAllConfigured = false;
   selectedGatewayGroup: string | null = null;
-  private onboardingDismissed = false;
+  private dismissed = false;
+  private cachedResourceStats: ResourceStats | null = null;
+  private cachedThroughput: NvmeofThroughput = DEFAULT_THROUGHPUT;
+  private cachedAlerts: NvmeAlerts = DEFAULT_ALERTS;
+  nvmeof$: Observable<ResourceStats | null> = of(null);
+  nvmeofThroughput$: Observable<NvmeofThroughput> = of(DEFAULT_THROUGHPUT);
+  nvmeofAlerts$: Observable<NvmeAlerts> = of(DEFAULT_ALERTS);
 
   private destroy$ = new Subject<void>();
   private setupStateRefresh$ = new Subject<void>();
@@ -46,11 +95,137 @@ export class NvmeofTabsComponent implements OnInit, OnDestroy {
     private router: Router,
     private route: ActivatedRoute,
     private nvmeofService: NvmeofService,
+    private performanceCardService: PerformanceCardService,
+    private prometheusService: PrometheusService,
     private nvmeofStateService: NvmeofStateService
   ) {}
 
   private updateActiveTab(currentPath: string): void {
     this.activeTab = Object.values(TABS).find((tab) => currentPath.includes(tab)) || TABS.gateways;
+    this.refreshOverviewCards();
+  }
+
+  private refreshOverviewCards(): void {
+    this.loadResourceStats();
+    this.loadThroughput();
+    this.loadAlerts();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  loadResourceStats(): void {
+    this.nvmeof$ = this.nvmeofService.listGatewayGroups().pipe(
+      switchMap((gatewayGroups: CephServiceSpec[][]) => {
+        const firstItem = (gatewayGroups as any)?.[0];
+        const rawGroups: CephServiceSpec[] = Array.isArray(firstItem)
+          ? (firstItem as CephServiceSpec[])
+          : Array.isArray(gatewayGroups)
+          ? ((gatewayGroups as unknown) as CephServiceSpec[])
+          : [];
+        const groups = rawGroups.filter((g: CephServiceSpec) => g?.spec?.group);
+        if (groups.length === 0) {
+          return of(null);
+        }
+        const hostsSet = new Set<string>();
+        groups.forEach((group: CephServiceSpec) => {
+          (group.placement?.hosts ?? []).forEach((h: string) => hostsSet.add(h));
+        });
+        const subsystemCalls = groups.map((group: CephServiceSpec) =>
+          this.nvmeofService.listSubsystems(group.spec.group).pipe(catchError(() => of([])))
+        );
+        const namespaceCalls = groups.map((group: CephServiceSpec) =>
+          this.nvmeofService.listNamespaces(group.spec.group).pipe(catchError(() => of([])))
+        );
+        const gatewayGroupsDown = groups.filter(
+          (g: CephServiceSpec) => (g.status?.running ?? 0) < (g.status?.size ?? 0)
+        ).length;
+        return forkJoin([forkJoin(subsystemCalls), forkJoin(namespaceCalls)]).pipe(
+          map(([subsystemsPerGroup]: [any[], any[]]) => {
+            const allSubs: NvmeofSubsystem[] = (subsystemsPerGroup as NvmeofSubsystem[][]).flat();
+            const totalNamespaces = allSubs.reduce((sum, s) => sum + (s.namespace_count || 0), 0);
+            const activeConnections = allSubs.reduce((s, sub) => s + (sub.initiator_count || 0), 0);
+            return {
+              gatewayGroups: groups.length,
+              gatewayGroupsDown,
+              subsystems: allSubs.length,
+              namespaces: totalNamespaces,
+              hosts: hostsSet.size,
+              activeConnections,
+              hasData: true
+            } as ResourceStats;
+          }),
+          catchError(() =>
+            of({
+              gatewayGroups: groups.length,
+              gatewayGroupsDown,
+              subsystems: 0,
+              namespaces: 0,
+              hosts: hostsSet.size,
+              activeConnections: 0,
+              hasData: true
+            } as ResourceStats)
+          )
+        );
+      }),
+      catchError(() => of(null)),
+      tap((stats) => {
+        this.cachedResourceStats = stats?.hasData ? stats : null;
+      }),
+      startWith(this.cachedResourceStats),
+      takeUntil(this.destroy$),
+      shareReplay({ bufferSize: 1, refCount: true })
+    );
+  }
+
+  loadThroughput(): void {
+    this.nvmeofThroughput$ = this.performanceCardService.getNvmeofThroughput().pipe(
+      catchError(() => of(DEFAULT_THROUGHPUT)),
+      tap((throughput) => {
+        this.cachedThroughput = throughput;
+      }),
+      startWith(this.cachedThroughput),
+      takeUntil(this.destroy$),
+      shareReplay({ bufferSize: 1, refCount: true })
+    );
+  }
+
+  loadAlerts(): void {
+    this.nvmeofAlerts$ = timer(0, ALERT_POLL_INTERVAL).pipe(
+      switchMap(() => this.prometheusService.isAlertmanagerUsable()),
+      switchMap((usable) => {
+        if (!usable) return of([] as AlertmanagerAlert[]);
+        return this.prometheusService
+          .getAlerts(true)
+          .pipe(catchError(() => of([] as AlertmanagerAlert[])));
+      }),
+      map((alerts: AlertmanagerAlert[]) => {
+        const nvmeAlerts = alerts.filter(isNvmeofAlert);
+        const critical = nvmeAlerts.filter(
+          (a) => a.labels.severity === 'critical' && a.status.state === 'active'
+        ).length;
+        const warning = nvmeAlerts.filter(
+          (a) => a.labels.severity === 'warning' && a.status.state === 'active'
+        ).length;
+        const byCategory: Record<string, number> = {};
+        nvmeAlerts
+          .filter((a) => a.status.state === 'active' && a.labels.category)
+          .forEach((a) => {
+            const cat = a.labels.category!;
+            byCategory[cat] = (byCategory[cat] ?? 0) + 1;
+          });
+        return { critical, warning, total: critical + warning, byCategory };
+      }),
+      catchError(() => of(DEFAULT_ALERTS)),
+      tap((alerts) => {
+        this.cachedAlerts = alerts;
+      }),
+      startWith(this.cachedAlerts),
+      takeUntil(this.destroy$),
+      shareReplay({ bufferSize: 1, refCount: true })
+    );
   }
 
   private updateShellVisibility(currentPath: string): void {
@@ -94,7 +269,10 @@ export class NvmeofTabsComponent implements OnInit, OnDestroy {
         this.hasSubsystems = hasSubsystems;
         this.hasNamespaces = hasNamespaces;
         this.isAllConfigured = hasGatewayGroups && hasSubsystems && hasNamespaces;
-        this.showSetupCards = !this.onboardingDismissed;
+        if (!hasGatewayGroups) {
+          this.dismissed = false;
+        }
+        this.showSetupCards = !hasGatewayGroups || !this.dismissed;
       });
 
     this.router.events
@@ -115,12 +293,10 @@ export class NvmeofTabsComponent implements OnInit, OnDestroy {
 
     this.nvmeofStateService.refresh$
       .pipe(takeUntil(this.destroy$))
-      .subscribe(() => this.loadSetupState());
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
+      .subscribe(() => {
+        this.loadSetupState();
+        this.refreshOverviewCards();
+      });
   }
 
   private fetchSetupState(): Observable<SetupState> {
@@ -192,7 +368,7 @@ export class NvmeofTabsComponent implements OnInit, OnDestroy {
   }
 
   dismissOnboarding(): void {
-    this.onboardingDismissed = true;
+    this.dismissed = true;
     this.showSetupCards = false;
   }
 
@@ -206,4 +382,6 @@ export class NvmeofTabsComponent implements OnInit, OnDestroy {
   public get Tabs(): typeof TABS {
     return TABS;
   }
+
+  readonly alertQueryParams = nvmeofAlertQueryParams;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.ts
@@ -1,5 +1,12 @@
-import { Component, OnInit } from '@angular/core';
-import { Router } from '@angular/router';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
+import { Observable, Subject, forkJoin, of } from 'rxjs';
+import { catchError, filter, map, switchMap, takeUntil } from 'rxjs/operators';
+
+import { NvmeofService } from '~/app/shared/api/nvmeof.service';
+import { CephServiceSpec } from '~/app/shared/models/service.interface';
+import { NvmeofSubsystem, NvmeofSubsystemNamespace } from '~/app/shared/models/nvmeof';
+import { NvmeofStateService } from '../nvmeof-state.service';
 
 const NVMEOF_PATH = 'block/nvmeof';
 
@@ -9,26 +16,191 @@ enum TABS {
   namespaces = 'namespaces'
 }
 
+type SetupState = {
+  hasGatewayGroups: boolean;
+  hasSubsystems: boolean;
+  hasNamespaces: boolean;
+};
+
 @Component({
   selector: 'cd-nvmeof-tabs',
   templateUrl: './nvmeof-tabs.component.html',
   styleUrls: ['./nvmeof-tabs.component.scss'],
   standalone: false
 })
-export class NvmeofTabsComponent implements OnInit {
-  selectedTab: TABS;
+export class NvmeofTabsComponent implements OnInit, OnDestroy {
   activeTab: TABS = TABS.gateways;
+  showTabsShell = true;
+  showSetupCards = false;
+  hasGatewayGroups = false;
+  hasSubsystems = false;
+  hasNamespaces = false;
+  isAllConfigured = false;
+  selectedGatewayGroup: string | null = null;
+  private onboardingDismissed = false;
 
-  constructor(private router: Router) {}
+  private destroy$ = new Subject<void>();
+  private setupStateRefresh$ = new Subject<void>();
 
-  ngOnInit(): void {
-    const currentPath = this.router.url;
+  constructor(
+    private router: Router,
+    private route: ActivatedRoute,
+    private nvmeofService: NvmeofService,
+    private nvmeofStateService: NvmeofStateService
+  ) {}
+
+  private updateActiveTab(currentPath: string): void {
     this.activeTab = Object.values(TABS).find((tab) => currentPath.includes(tab)) || TABS.gateways;
   }
 
+  private updateShellVisibility(currentPath: string): void {
+    const urlTree = this.router.parseUrl(currentPath);
+    const primarySegments =
+      urlTree.root.children['primary']?.segments.map((segment) => segment.path) ?? [];
+    const primaryPath = `/${primarySegments.join('/')}`;
+
+    this.showTabsShell = /^\/block\/nvmeof\/(gateways|subsystems|namespaces)$/.test(primaryPath);
+  }
+
+  private normalizeSubsystemsResponse(response: unknown): NvmeofSubsystem[] {
+    if (Array.isArray(response)) {
+      return response as NvmeofSubsystem[];
+    }
+
+    const subsystems = (response as { subsystems?: NvmeofSubsystem[] } | null)?.subsystems;
+    return Array.isArray(subsystems) ? subsystems : [];
+  }
+
+  private normalizeNamespacesResponse(response: unknown): NvmeofSubsystemNamespace[] {
+    if (Array.isArray(response)) {
+      return response as NvmeofSubsystemNamespace[];
+    }
+
+    const namespaces = (response as { namespaces?: NvmeofSubsystemNamespace[] } | null)?.namespaces;
+    return Array.isArray(namespaces) ? namespaces : [];
+  }
+
+  ngOnInit(): void {
+    this.updateActiveTab(this.router.url);
+    this.updateShellVisibility(this.router.url);
+
+    this.setupStateRefresh$
+      .pipe(
+        switchMap(() => this.fetchSetupState()),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(({ hasGatewayGroups, hasSubsystems, hasNamespaces }) => {
+        this.hasGatewayGroups = hasGatewayGroups;
+        this.hasSubsystems = hasSubsystems;
+        this.hasNamespaces = hasNamespaces;
+        this.isAllConfigured = hasGatewayGroups && hasSubsystems && hasNamespaces;
+        this.showSetupCards = !this.onboardingDismissed;
+      });
+
+    this.router.events
+      .pipe(
+        filter((event): event is NavigationEnd => event instanceof NavigationEnd),
+        takeUntil(this.destroy$)
+      )
+      .subscribe((event) => {
+        this.updateActiveTab(event.urlAfterRedirects);
+        this.updateShellVisibility(event.urlAfterRedirects);
+        this.loadSetupState();
+      });
+
+    this.route.queryParams.pipe(takeUntil(this.destroy$)).subscribe((params) => {
+      this.selectedGatewayGroup = params?.['group']?.trim() || null;
+      this.loadSetupState();
+    });
+
+    this.nvmeofStateService.refresh$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => this.loadSetupState());
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  private fetchSetupState(): Observable<SetupState> {
+    return this.nvmeofService.listGatewayGroups().pipe(
+      switchMap((gatewayGroups: CephServiceSpec[][]) => {
+        const firstItem = (gatewayGroups as any)?.[0];
+        const rawGroups: CephServiceSpec[] = Array.isArray(firstItem)
+          ? (firstItem as CephServiceSpec[])
+          : Array.isArray(gatewayGroups)
+          ? ((gatewayGroups as unknown) as CephServiceSpec[])
+          : [];
+        const groups = rawGroups.filter((g: CephServiceSpec) => g?.spec?.group);
+        const hasGatewayGroups = groups.length > 0;
+
+        if (!hasGatewayGroups) {
+          return of({ hasGatewayGroups: false, hasSubsystems: false, hasNamespaces: false });
+        }
+
+        // Empty dropdown selection: keep setup in initial state for steps 2 and 3.
+        if (!this.selectedGatewayGroup) {
+          return of({ hasGatewayGroups, hasSubsystems: false, hasNamespaces: false });
+        }
+
+        const selectedGroupExists = groups.some(
+          (group: CephServiceSpec) => group.spec.group === this.selectedGatewayGroup
+        );
+        if (!selectedGroupExists) {
+          return of({ hasGatewayGroups, hasSubsystems: false, hasNamespaces: false });
+        }
+
+        return forkJoin({
+          subsystemsResponse: this.nvmeofService
+            .listSubsystems(this.selectedGatewayGroup)
+            .pipe(catchError(() => of([]))),
+          namespacesResponse: this.nvmeofService
+            .listNamespaces(this.selectedGatewayGroup)
+            .pipe(catchError(() => of([])))
+        }).pipe(
+          map(
+            ({
+              subsystemsResponse,
+              namespacesResponse
+            }: {
+              subsystemsResponse: unknown;
+              namespacesResponse: unknown;
+            }) => {
+              const subsystems = this.normalizeSubsystemsResponse(subsystemsResponse);
+              const namespaces = this.normalizeNamespacesResponse(namespacesResponse);
+              const totalNamespaces = subsystems.reduce(
+                (sum, s) => sum + (s.namespace_count || 0),
+                0
+              );
+              return {
+                hasGatewayGroups,
+                hasSubsystems: subsystems.length > 0,
+                hasNamespaces: namespaces.length > 0 || totalNamespaces > 0
+              };
+            }
+          ),
+          catchError(() => of({ hasGatewayGroups, hasSubsystems: false, hasNamespaces: false }))
+        );
+      }),
+      catchError(() => of({ hasGatewayGroups: false, hasSubsystems: false, hasNamespaces: false }))
+    );
+  }
+
+  loadSetupState(): void {
+    this.setupStateRefresh$.next();
+  }
+
+  dismissOnboarding(): void {
+    this.onboardingDismissed = true;
+    this.showSetupCards = false;
+  }
+
   onSelected(tab: TABS) {
-    this.selectedTab = tab;
-    this.router.navigate([`${NVMEOF_PATH}/${tab}`]);
+    this.activeTab = tab;
+    this.router.navigate([`${NVMEOF_PATH}/${tab}`], {
+      queryParamsHandling: 'preserve'
+    });
   }
 
   public get Tabs(): typeof TABS {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/active-alert-list/active-alert-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/active-alert-list/active-alert-list.component.ts
@@ -11,6 +11,14 @@ import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
 import { Permission } from '~/app/shared/models/permissions';
 import { AlertState } from '~/app/shared/models/prometheus-alerts';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
+import {
+  isNvmeofAlert,
+  NVMEOF_ALERT_SCOPE,
+  NVMEOF_CATEGORY_FILTER_OPTIONS,
+  NVMEOF_CATEGORY_LABELS,
+  NVMEOF_SCOPE_LABELS,
+  nvmeofCategoryFilterPredicate
+} from '~/app/shared/helpers/nvmeof-alert.helper';
 import { PrometheusAlertService } from '~/app/shared/services/prometheus-alert.service';
 import { URLBuilderService } from '~/app/shared/services/url-builder.service';
 
@@ -21,6 +29,9 @@ const SeverityMap = {
   warning: $localize`Warning`,
   all: $localize`All`
 };
+
+const ScopeFilterIndex = 2;
+const CategoryFilterIndex = 3;
 
 @Component({
   selector: 'cd-active-alert-list',
@@ -65,6 +76,25 @@ export class ActiveAlertListComponent extends PrometheusListHelper implements On
         if (value === SeverityMap['all']) return true;
         return false;
       }
+    },
+    {
+      name: $localize`Service`,
+      prop: 'labels.job',
+      filterOptions: [NVMEOF_SCOPE_LABELS.all, NVMEOF_SCOPE_LABELS.nvmeof],
+      filterInitValue: NVMEOF_SCOPE_LABELS.all,
+      filterPredicate: (row, value) => {
+        if (value === NVMEOF_SCOPE_LABELS.nvmeof) {
+          return isNvmeofAlert(row);
+        }
+        return true;
+      }
+    },
+    {
+      name: $localize`Category`,
+      prop: 'labels.category',
+      filterOptions: NVMEOF_CATEGORY_FILTER_OPTIONS,
+      filterInitValue: NVMEOF_CATEGORY_LABELS.all,
+      filterPredicate: (row, value) => nvmeofCategoryFilterPredicate(row, value)
     }
   ];
 
@@ -161,7 +191,17 @@ export class ActiveAlertListComponent extends PrometheusListHelper implements On
     this.prometheusAlertService.getGroupedAlerts(true);
     this.route.queryParams.subscribe((params) => {
       const severity = params['severity'];
-      this.filters[1].filterInitValue = SeverityMap[severity];
+      if (severity && SeverityMap[severity]) {
+        this.filters[1].filterInitValue = SeverityMap[severity];
+      }
+      const scope = params['scope'];
+      if (scope === NVMEOF_ALERT_SCOPE) {
+        this.filters[ScopeFilterIndex].filterInitValue = NVMEOF_SCOPE_LABELS.nvmeof;
+      }
+      const category = params['category'];
+      if (category && NVMEOF_CATEGORY_LABELS[category]) {
+        this.filters[CategoryFilterIndex].filterInitValue = NVMEOF_CATEGORY_LABELS[category];
+      }
     });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/performance-card.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/performance-card.service.spec.ts
@@ -101,6 +101,29 @@ describe('PerformanceCardService', () => {
     });
   });
 
+  describe('convertNvmeofThroughput', () => {
+    it('should convert raw NVMe-oF throughput to MB/s using the latest sample', () => {
+      const raw: Record<string, [number, string][]> = {
+        NVMEOF_READ_BYTES: [
+          [1609459200, String(2 * 1024 * 1024)],
+          [1609459260, String(4 * 1024 * 1024)]
+        ],
+        NVMEOF_WRITE_BYTES: [[1609459260, String(1024 * 1024)]],
+        NVMEOF_COMBINED_BYTES: [[1609459260, String(5 * 1024 * 1024)]]
+      };
+
+      const result = service.convertNvmeofThroughput(raw);
+
+      expect(result.reads).toBe(4);
+      expect(result.writes).toBe(1);
+      expect(result.combined).toBe(5);
+    });
+
+    it('should return zero throughput when metrics are missing', () => {
+      expect(service.convertNvmeofThroughput({})).toEqual({ reads: 0, writes: 0, combined: 0 });
+    });
+  });
+
   describe('mergeSeries', () => {
     it('should merge multiple series into one', () => {
       const series1 = [

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/performance-card.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/performance-card.service.ts
@@ -1,15 +1,27 @@
 import { inject, Injectable } from '@angular/core';
 import { PrometheusService } from './prometheus.service';
 import { PerformanceData } from '../models/performance-data';
-import { AllStoragetypesQueries, NvmeofPromqls } from '../enum/dashboard-promqls.enum';
+import {
+  AllStoragetypesQueries,
+  NvmeofPromqls,
+  NvmeofResourcePromqls
+} from '../enum/dashboard-promqls.enum';
 import { map } from 'rxjs/operators';
-import { Observable } from 'rxjs';
+import { forkJoin, Observable } from 'rxjs';
 import { ChartPoint } from '../models/area-chart-point';
 
 export interface NvmeofThroughput {
   reads: number;
   writes: number;
   combined: number;
+}
+
+export interface NvmeofResourceStats {
+  gatewayGroups: number;
+  subsystems: number;
+  namespaces: number;
+  hosts: number;
+  activeConnections: number;
 }
 
 const BYTES_PER_MB = 1024 * 1024;
@@ -26,6 +38,25 @@ export class PerformanceCardService {
     return this.prometheusService
       .getRangeQueriesData(time, NvmeofPromqls, true)
       .pipe(map((raw) => this.convertNvmeofThroughput(raw)));
+  }
+
+  getNvmeofResourceStats(): Observable<NvmeofResourceStats> {
+    const queries = NvmeofResourcePromqls;
+    return forkJoin({
+      gatewayGroups: this.prometheusService.getGaugeQueryData(queries.NVMEOF_GATEWAY_GROUPS),
+      subsystems: this.prometheusService.getGaugeQueryData(queries.NVMEOF_SUBSYSTEMS),
+      namespaces: this.prometheusService.getGaugeQueryData(queries.NVMEOF_NAMESPACES),
+      hosts: this.prometheusService.getGaugeQueryData(queries.NVMEOF_HOSTS),
+      activeConnections: this.prometheusService.getGaugeQueryData(queries.NVMEOF_ACTIVE_CONNECTIONS)
+    }).pipe(
+      map((raw) => ({
+        gatewayGroups: this.toGaugeValue(raw.gatewayGroups),
+        subsystems: this.toGaugeValue(raw.subsystems),
+        namespaces: this.toGaugeValue(raw.namespaces),
+        hosts: this.toGaugeValue(raw.hosts),
+        activeConnections: this.toGaugeValue(raw.activeConnections)
+      }))
+    );
   }
 
   convertNvmeofThroughput(raw: Record<string, [number, string][]>): NvmeofThroughput {
@@ -103,11 +134,20 @@ export class PerformanceCardService {
             values: { ...item.values }
           });
         } else {
-          Object.assign(map.get(time).values, item.values);
+          const existingPoint = map.get(time);
+          if (existingPoint) {
+            Object.assign(existingPoint.values, item.values);
+          }
         }
       }
     }
 
     return [...map.values()].sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+  }
+
+  private toGaugeValue(metric: { result?: Array<{ value?: [number, string] }> }): number {
+    const rawValue = metric?.result?.[0]?.value?.[1];
+    const parsed = Number(rawValue);
+    return Number.isFinite(parsed) ? parsed : 0;
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/performance-card.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/performance-card.service.ts
@@ -1,16 +1,48 @@
 import { inject, Injectable } from '@angular/core';
 import { PrometheusService } from './prometheus.service';
 import { PerformanceData } from '../models/performance-data';
-import { AllStoragetypesQueries } from '../enum/dashboard-promqls.enum';
+import { AllStoragetypesQueries, NvmeofPromqls } from '../enum/dashboard-promqls.enum';
 import { map } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 import { ChartPoint } from '../models/area-chart-point';
+
+export interface NvmeofThroughput {
+  reads: number;
+  writes: number;
+  combined: number;
+}
+
+const BYTES_PER_MB = 1024 * 1024;
 
 @Injectable({
   providedIn: 'root'
 })
 export class PerformanceCardService {
   private prometheusService = inject(PrometheusService);
+
+  getNvmeofThroughput(
+    time: { start: number; end: number; step: number } = this.prometheusService.lastHourDateObject
+  ): Observable<NvmeofThroughput> {
+    return this.prometheusService
+      .getRangeQueriesData(time, NvmeofPromqls, true)
+      .pipe(map((raw) => this.convertNvmeofThroughput(raw)));
+  }
+
+  convertNvmeofThroughput(raw: Record<string, [number, string][]>): NvmeofThroughput {
+    const readValues = raw?.NVMEOF_READ_BYTES ?? [];
+    const writeValues = raw?.NVMEOF_WRITE_BYTES ?? [];
+    const combinedValues = raw?.NVMEOF_COMBINED_BYTES ?? [];
+    const lastRead = readValues.length ? Number(readValues[readValues.length - 1][1]) : 0;
+    const lastWrite = writeValues.length ? Number(writeValues[writeValues.length - 1][1]) : 0;
+    const lastCombined = combinedValues.length
+      ? Number(combinedValues[combinedValues.length - 1][1])
+      : lastRead + lastWrite;
+    return {
+      reads: lastRead / BYTES_PER_MB,
+      writes: lastWrite / BYTES_PER_MB,
+      combined: lastCombined / BYTES_PER_MB
+    };
+  }
 
   getChartData(time: { start: number; end: number; step: number }): Observable<PerformanceData> {
     return this.prometheusService.getRangeQueriesData(time, AllStoragetypesQueries, true).pipe(

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
@@ -363,7 +363,7 @@
              let-value="data.value">
   <span *ngFor="let item of (value | array); last as last">
     <cds-tag [size]="'md'"
-             [ngClass]="['table-tag', (column?.customTemplateConfig?.map && column?.customTemplateConfig?.map[item]?.class) ? column.customTemplateConfig.map[item].class : (column?.customTemplateConfig?.class ? column.customTemplateConfig.class : 'tag-primary')]"
+             [class]="'table-tag ' + ((column?.customTemplateConfig?.map && column?.customTemplateConfig?.map[item]?.class) ? column.customTemplateConfig.map[item].class : (column?.customTemplateConfig?.class ? column.customTemplateConfig.class : 'tag-primary'))"
              *ngIf="(column?.customTemplateConfig?.map && column?.customTemplateConfig?.map[item]?.value) ? column.customTemplateConfig.map[item].value : column?.customTemplateConfig?.prefix ? column.customTemplateConfig.prefix + item : item">
       {{(column?.customTemplateConfig?.map && column?.customTemplateConfig?.map[item]?.value) ? column.customTemplateConfig.map[item].value : column?.customTemplateConfig?.prefix ? column.customTemplateConfig.prefix + item : item }}
     </cds-tag>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
@@ -41,6 +41,9 @@
     </cds-table-toolbar-actions>
     <!-- end batch actions -->
     <cds-table-toolbar-content>
+      <!-- gateway group / custom filter slot -->
+      <ng-content select=".table-filter"></ng-content>
+      <!-- end custom filter slot -->
       <!-- search -->
       <cds-table-toolbar-search *ngIf="searchField"
                                 [expandable]="false"
@@ -52,29 +55,28 @@
       <!-- end search -->
       <!-- column filters -->
       <ng-container *ngIf="columnFilters.length !== 0">
-        <div class="filter-wrapper">
-          <svg [cdsIcon]="icons.filter"
-               [size]="icons.size16"
-               class="cds--toolbar-action__icon"></svg>
-          <cds-select (valueChange)="onSelectFilter($event)"
-                      display="inline"
-                      id="filter_name">
-            <ng-container *ngFor="let filter of columnFilters">
-              <option [value]="filter.column.name"
-                      [selected]="filter.column.name === selectedFilter.column.name">{{ filter.column.name }}</option>
-            </ng-container>
-          </cds-select>
-          <cds-select (valueChange)="onChangeFilter($event)"
-                      display="inline"
-                      id="filter_option">
-            <option *ngIf="!selectedFilter.value"
-                    i18n>Any</option>
-            <ng-container *ngFor="let option of selectedFilter.options">
-              <option [value]="option.raw"
-                      [selected]="option.raw === selectedFilter?.value?.raw">{{ option.formatted }}</option>
-            </ng-container>
-          </cds-select>
+        <div class="d-inline-flex position-relative">
+        <svg [cdsIcon]="icons.filter"
+             [size]="icons.size16"></svg>
         </div>
+        <cds-select (valueChange)="onSelectFilter($event)"
+                    display="inline"
+                    id="filter_name">
+          <ng-container *ngFor="let filter of columnFilters">
+            <option [value]="filter.column.name"
+                    [selected]="filter.column.name === selectedFilter.column.name">{{ filter.column.name }}</option>
+          </ng-container>
+        </cds-select>
+        <cds-select (valueChange)="onChangeFilter($event)"
+                    display="inline"
+                    id="filter_option">
+          <option *ngIf="!selectedFilter.value"
+                  i18n>Any</option>
+          <ng-container *ngFor="let option of selectedFilter.options">
+            <option [value]="option.raw"
+                    [selected]="option.raw === selectedFilter?.value?.raw">{{ option.formatted }}</option>
+          </ng-container>
+        </cds-select>
       </ng-container>
       <!-- end column filters -->
       <!-- refresh button -->
@@ -335,9 +337,9 @@
              let-column="data.column"
              let-row="data.row"
              let-value="data.value">
-  <cds-inline-loading *ngIf="row.cdExecuting"
-                      state="active"></cds-inline-loading>
-  <span [ngClass]="column?.customTemplateConfig?.valueClass">
+  <i [ngClass]="icons.spinner"
+     *ngIf="row.cdExecuting"></i>
+  <span [ngClass]="column?.customTemplateConfig?.valueClass || ''">
     {{ value }}
   </span>
   <span *ngIf="row.cdExecuting"
@@ -361,7 +363,7 @@
              let-value="data.value">
   <span *ngFor="let item of (value | array); last as last">
     <cds-tag [size]="'md'"
-             [class]="'table-tag ' + ((column?.customTemplateConfig?.map && column?.customTemplateConfig?.map[item]?.class) ? column.customTemplateConfig.map[item].class : (column?.customTemplateConfig?.class ? column.customTemplateConfig.class : 'tag-primary'))"
+             [ngClass]="['table-tag', (column?.customTemplateConfig?.map && column?.customTemplateConfig?.map[item]?.class) ? column.customTemplateConfig.map[item].class : (column?.customTemplateConfig?.class ? column.customTemplateConfig.class : 'tag-primary')]"
              *ngIf="(column?.customTemplateConfig?.map && column?.customTemplateConfig?.map[item]?.value) ? column.customTemplateConfig.map[item].value : column?.customTemplateConfig?.prefix ? column.customTemplateConfig.prefix + item : item">
       {{(column?.customTemplateConfig?.map && column?.customTemplateConfig?.map[item]?.value) ? column.customTemplateConfig.map[item].value : column?.customTemplateConfig?.prefix ? column.customTemplateConfig.prefix + item : item }}
     </cds-tag>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
@@ -130,6 +130,9 @@ export class TableComponent implements AfterViewInit, OnInit, OnChanges, OnDestr
   // Display search field inside tool header?
   @Input()
   searchField? = true;
+  // Limit toolbar search width (e.g. when a prefix filter is shown).
+  @Input()
+  compactSearchField? = false;
   // Display the table header?
   @Input()
   header? = true;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/dashboard-promqls.enum.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/dashboard-promqls.enum.ts
@@ -77,3 +77,12 @@ export const NvmeofPromqls = {
   NVMEOF_COMBINED_BYTES:
     'sum(rate(ceph_nvmeof_bdev_read_bytes_total[1m])) + sum(rate(ceph_nvmeof_bdev_written_bytes_total[1m]))'
 };
+
+export const NvmeofResourcePromqls = {
+  NVMEOF_GATEWAY_GROUPS: 'count(count by (group) (ceph_nvmeof_gateway_info)) or vector(0)',
+  NVMEOF_SUBSYSTEMS: 'count(count by (nqn) (ceph_nvmeof_subsystem_metadata)) or vector(0)',
+  NVMEOF_NAMESPACES:
+    'count(count by (nqn, nsid) (ceph_nvmeof_subsystem_namespace_metadata)) or vector(0)',
+  NVMEOF_HOSTS: 'count(count by (hostname) (ceph_nvmeof_gateway_info)) or vector(0)',
+  NVMEOF_ACTIVE_CONNECTIONS: 'sum(ceph_nvmeof_host_connection_state) or vector(0)'
+};

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/dashboard-promqls.enum.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/dashboard-promqls.enum.ts
@@ -70,3 +70,10 @@ export const AllStoragetypesQueries = {
 
   WRITELATENCY: 'avg_over_time(ceph_osd_commit_latency_ms[1m])'
 };
+
+export const NvmeofPromqls = {
+  NVMEOF_READ_BYTES: 'sum(rate(ceph_nvmeof_bdev_read_bytes_total[1m]))',
+  NVMEOF_WRITE_BYTES: 'sum(rate(ceph_nvmeof_bdev_written_bytes_total[1m]))',
+  NVMEOF_COMBINED_BYTES:
+    'sum(rate(ceph_nvmeof_bdev_read_bytes_total[1m])) + sum(rate(ceph_nvmeof_bdev_written_bytes_total[1m]))'
+};

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/helpers/nvmeof-alert.helper.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/helpers/nvmeof-alert.helper.spec.ts
@@ -1,0 +1,77 @@
+import {
+  isNvmeofAlert,
+  nvmeofAlertQueryParams,
+  nvmeofCategoryFilterPredicate
+} from './nvmeof-alert.helper';
+import { AlertmanagerAlert } from '~/app/shared/models/prometheus-alerts';
+
+describe('nvmeof-alert.helper', () => {
+  const alert = (labels: Record<string, string>, state = 'active'): AlertmanagerAlert => {
+    const alertLabels: AlertmanagerAlert['labels'] = {
+      alertname: labels.alertname ?? '',
+      instance: labels.instance ?? '',
+      job: labels.job ?? '',
+      severity: labels.severity ?? '',
+      category: labels.category,
+      ...labels
+    };
+
+    return {
+      labels: alertLabels,
+      annotations: { description: '', summary: '' },
+      startsAt: new Date().toISOString(),
+      endsAt: new Date().toISOString(),
+      generatorURL: '',
+      status: {
+        state: state as AlertmanagerAlert['status']['state'],
+        silencedBy: null,
+        inhibitedBy: null
+      },
+      receivers: [],
+      fingerprint: 'test-fingerprint',
+      alert_count: 1
+    };
+  };
+
+  describe('isNvmeofAlert', () => {
+    it('should match job nvmeof', () => {
+      expect(isNvmeofAlert(alert({ job: 'nvmeof', alertname: 'X' }))).toBe(true);
+    });
+
+    it('should match known category labels', () => {
+      expect(isNvmeofAlert(alert({ category: 'gateway', alertname: 'X' }))).toBe(true);
+    });
+
+    it('should not match by alertname without nvme labels', () => {
+      expect(isNvmeofAlert(alert({ alertname: 'NVMeoFHighGatewayCPU' }))).toBe(false);
+    });
+
+    it('should not match unrelated alerts', () => {
+      expect(isNvmeofAlert(alert({ alertname: 'CephDaemonCrash', severity: 'critical' }))).toBe(
+        false
+      );
+    });
+  });
+
+  describe('nvmeofCategoryFilterPredicate', () => {
+    it('should pass all rows when filter is All', () => {
+      expect(nvmeofCategoryFilterPredicate(alert({ category: 'gateway' }), 'All' as any)).toBe(
+        true
+      );
+    });
+  });
+
+  describe('nvmeofAlertQueryParams', () => {
+    it('should include scope and optional category', () => {
+      expect(nvmeofAlertQueryParams('critical')).toEqual({
+        severity: 'critical',
+        scope: 'nvmeof'
+      });
+      expect(nvmeofAlertQueryParams('all', 'gateway')).toEqual({
+        severity: 'all',
+        scope: 'nvmeof',
+        category: 'gateway'
+      });
+    });
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/helpers/nvmeof-alert.helper.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/helpers/nvmeof-alert.helper.ts
@@ -1,0 +1,69 @@
+import { AlertmanagerAlert } from '~/app/shared/models/prometheus-alerts';
+
+/** Query param value used by NVMe-oF dashboard links to pre-filter active alerts. */
+export const NVMEOF_ALERT_SCOPE = 'nvmeof';
+
+/** Matches monitoring/ceph-mixin NVMe-oF alert rule category labels. */
+export const NVMEOF_ALERT_CATEGORIES = new Set([
+  'gateway',
+  'subsystem',
+  'listener',
+  'namespace',
+  'performance',
+  'host'
+]);
+
+export const NVMEOF_SCOPE_LABELS = {
+  all: $localize`All`,
+  nvmeof: $localize`NVMe-oF`
+};
+
+export const NVMEOF_CATEGORY_LABELS: Record<string, string> = {
+  all: $localize`All`,
+  gateway: $localize`Gateway`,
+  subsystem: $localize`Subsystem`,
+  listener: $localize`Listener`,
+  namespace: $localize`Namespace`,
+  performance: $localize`Performance`,
+  host: $localize`Host`
+};
+
+export const NVMEOF_CATEGORY_FILTER_OPTIONS = Object.values(NVMEOF_CATEGORY_LABELS);
+
+export function isNvmeofAlert(alert: AlertmanagerAlert): boolean {
+  const labels = alert.labels;
+  if (!labels) {
+    return false;
+  }
+  const job = labels.job?.toLowerCase();
+  if (job === 'nvme' || job === 'nvmeof') {
+    return true;
+  }
+  if (labels.category && NVMEOF_ALERT_CATEGORIES.has(labels.category)) {
+    return true;
+  }
+  return false;
+}
+
+export function nvmeofCategoryFilterPredicate(row: AlertmanagerAlert, value: string): boolean {
+  const key =
+    Object.entries(NVMEOF_CATEGORY_LABELS).find(([, label]) => label === value)?.[0] ?? 'all';
+  if (key === 'all') {
+    return true;
+  }
+  return row.labels?.category === key;
+}
+
+export function nvmeofAlertQueryParams(
+  severity: string,
+  category?: string
+): { severity: string; scope: string; category?: string } {
+  const params: { severity: string; scope: string; category?: string } = {
+    severity,
+    scope: NVMEOF_ALERT_SCOPE
+  };
+  if (category) {
+    params.category = category;
+  }
+  return params;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/prometheus-alerts.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/prometheus-alerts.ts
@@ -5,6 +5,7 @@ export class PrometheusAlertLabels {
   instance: string;
   job: string;
   severity: string;
+  category?: string;
 }
 
 class Annotations {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert.service.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@angular/core';
 
 import _ from 'lodash';
+import { BehaviorSubject, Observable, of } from 'rxjs';
+import { catchError, switchMap } from 'rxjs/operators';
 
 import { PrometheusService } from '../api/prometheus.service';
 import {
@@ -11,7 +13,6 @@ import {
   AlertState
 } from '../models/prometheus-alerts';
 import { PrometheusAlertFormatter } from './prometheus-alert-formatter';
-import { BehaviorSubject } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
@@ -39,21 +40,27 @@ export class PrometheusAlertService {
     private prometheusService: PrometheusService
   ) {}
 
-  getGroupedAlerts(clusterFilteredAlerts = false) {
-    this.prometheusService.isAlertmanagerUsable().subscribe((usable) => {
-      if (!usable) {
-        return;
-      }
-
-      this.prometheusService.getGroupedAlerts(clusterFilteredAlerts).subscribe(
-        (alerts) => this.handleAlerts(alerts),
-        (resp) => {
-          if ([404, 504].includes(resp.status)) {
-            this.prometheusService.disableAlertmanagerConfig();
-          }
+  fetchGroupedAlerts(clusterFilteredAlerts = false): Observable<GroupAlertmanagerAlert[]> {
+    return this.prometheusService.isAlertmanagerUsable().pipe(
+      switchMap((usable) => {
+        if (!usable) {
+          return of([]);
         }
-      );
-    });
+
+        return this.prometheusService.getGroupedAlerts(clusterFilteredAlerts).pipe(
+          catchError((resp) => {
+            if ([404, 504].includes(resp.status)) {
+              this.prometheusService.disableAlertmanagerConfig();
+            }
+            return of([]);
+          })
+        );
+      })
+    );
+  }
+
+  getGroupedAlerts(clusterFilteredAlerts = false) {
+    this.fetchGroupedAlerts(clusterFilteredAlerts).subscribe((alerts) => this.handleAlerts(alerts));
   }
 
   getRules() {


### PR DESCRIPTION

<img width="3840" height="2116" alt="image" src="https://github.com/user-attachments/assets/15f7de0c-b501-481d-a181-81aa851381bb" />



https://github.com/user-attachments/assets/5250ce39-78fd-4c2b-9e1a-1bd9dbab0163


Fixes:https://tracker.ceph.com/issues/75683

Signed-off-by: pujaoshahu <pshahu@redhat.com>

---
Summery:

This change adds a new NVMe-oF dashboard card experience on the gateway/subsystem/namespace pages when data exists, and wires alert/throughput data into those cards.
It also adds NVMe-oF-specific alert filtering support in Active Alerts.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
