### PR TITLE
crimson: fix intrusive_ptr_add_ref ADL lookup for Boost 1.89+

### DIFF
--- a/src/crimson/common/type_helpers.h
+++ b/src/crimson/common/type_helpers.h
@@ -6,3 +6,15 @@
 #include "boost/intrusive_ptr.hpp"
 
 template<typename T> using Ref = boost::intrusive_ptr<T>;
+
+// Forward-declare intrusive_ptr ADL functions for PG in its own namespace.
+// Required by Boost 1.89+ constexpr intrusive_ptr — with constexpr,
+// ordinary unqualified lookup at the template definition point takes
+// precedence over ADL.  Since boost/intrusive_ptr.hpp is included early
+// (via Seastar headers), we place the declarations in crimson::osd so
+// that ADL on crimson::osd::PG* finds them.
+namespace crimson::osd {
+class PG;
+void intrusive_ptr_add_ref(const PG* p) noexcept;
+void intrusive_ptr_release(const PG* p) noexcept;
+} // namespace crimson::osd

--- a/src/crimson/os/futurized_collection.h
+++ b/src/crimson/os/futurized_collection.h
@@ -33,5 +33,19 @@ private:
   const coll_t cid;
 };
 
-using CollectionRef =  boost::intrusive_ptr<FuturizedCollection>;
+// Provide intrusive_ptr ADL functions in the global namespace.
+// boost::intrusive_ref_counter defines them in boost::sp_adl_block,
+// which is not reachable by ADL when FuturizedCollection is in crimson::os.
+inline void intrusive_ptr_add_ref(const FuturizedCollection* p) noexcept {
+  boost::sp_adl_block::intrusive_ptr_add_ref(
+    static_cast<const boost::intrusive_ref_counter<
+      FuturizedCollection, boost::thread_safe_counter>*>(p));
 }
+inline void intrusive_ptr_release(const FuturizedCollection* p) noexcept {
+  boost::sp_adl_block::intrusive_ptr_release(
+    static_cast<const boost::intrusive_ref_counter<
+      FuturizedCollection, boost::thread_safe_counter>*>(p));
+}
+
+using CollectionRef = boost::intrusive_ptr<FuturizedCollection>;
+} // namespace crimson::os

--- a/src/crimson/os/futurized_store.h
+++ b/src/crimson/os/futurized_store.h
@@ -11,6 +11,7 @@
 #include <seastar/core/future.hh>
 
 #include "os/Transaction.h"
+#include "crimson/os/futurized_collection.h"
 #include "crimson/common/config_proxy.h"
 #include "crimson/common/smp_helpers.h"
 #include "crimson/osd/exceptions.h"
@@ -24,7 +25,6 @@ class Transaction;
 }
 
 namespace crimson::os {
-class FuturizedCollection;
 class FuturizedStore;
 struct BackendStore {
   FuturizedStore &f_store;  // indicate alienstore/seastore/cyanstore, not shard store

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
@@ -9,8 +9,6 @@
 #include <ostream>
 #include <boost/smart_ptr/intrusive_ref_counter.hpp>
 
-#include "crimson/common/type_helpers.h"
-
 #include "node_extent_mutable.h"
 #include "stages/key_layout.h"
 #include "stages/stage_types.h"
@@ -47,6 +45,28 @@ namespace crimson::os::seastore::onode {
 
 class LeafNode;
 class InternalNode;
+class Node;
+class tree_cursor_t;
+
+// Provide intrusive_ptr ADL functions for Node hierarchy.
+// boost::intrusive_ref_counter defines them in boost::sp_adl_block,
+// which is not reachable by ADL when these types are in crimson::os::seastore::onode.
+// These must be declared before boost/intrusive_ptr.hpp is included.
+inline void intrusive_ptr_add_ref(const tree_cursor_t* p) noexcept;
+inline void intrusive_ptr_release(const tree_cursor_t* p) noexcept;
+inline void intrusive_ptr_add_ref(const Node* p) noexcept;
+inline void intrusive_ptr_release(const Node* p) noexcept;
+inline void intrusive_ptr_add_ref(const InternalNode* p) noexcept;
+inline void intrusive_ptr_release(const InternalNode* p) noexcept;
+inline void intrusive_ptr_add_ref(const LeafNode* p) noexcept;
+inline void intrusive_ptr_release(const LeafNode* p) noexcept;
+
+} // namespace crimson::os::seastore::onode
+
+#include <boost/intrusive_ptr.hpp>
+#include "crimson/common/type_helpers.h"
+
+namespace crimson::os::seastore::onode {
 
 using layout_version_t = uint32_t;
 struct node_version_t {
@@ -739,5 +759,44 @@ class LeafNode final : public Node {
   LeafNodeImpl* impl;
   layout_version_t layout_version = 0;
 };
+
+// Provide intrusive_ptr ADL functions for Node hierarchy.
+// boost::intrusive_ref_counter defines them in boost::sp_adl_block,
+// which is not reachable by ADL when these types are in crimson::os::seastore::onode.
+inline void intrusive_ptr_add_ref(const tree_cursor_t* p) noexcept {
+  boost::sp_adl_block::intrusive_ptr_add_ref(
+    static_cast<const boost::intrusive_ref_counter<
+      tree_cursor_t, boost::thread_unsafe_counter>*>(p));
+}
+inline void intrusive_ptr_release(const tree_cursor_t* p) noexcept {
+  boost::sp_adl_block::intrusive_ptr_release(
+    static_cast<const boost::intrusive_ref_counter<
+      tree_cursor_t, boost::thread_unsafe_counter>*>(p));
+}
+
+inline void intrusive_ptr_add_ref(const Node* p) noexcept {
+  boost::sp_adl_block::intrusive_ptr_add_ref(
+    static_cast<const boost::intrusive_ref_counter<
+      Node, boost::thread_unsafe_counter>*>(p));
+}
+inline void intrusive_ptr_release(const Node* p) noexcept {
+  boost::sp_adl_block::intrusive_ptr_release(
+    static_cast<const boost::intrusive_ref_counter<
+      Node, boost::thread_unsafe_counter>*>(p));
+}
+
+inline void intrusive_ptr_add_ref(const InternalNode* p) noexcept {
+  intrusive_ptr_add_ref(static_cast<const Node*>(p));
+}
+inline void intrusive_ptr_release(const InternalNode* p) noexcept {
+  intrusive_ptr_release(static_cast<const Node*>(p));
+}
+
+inline void intrusive_ptr_add_ref(const LeafNode* p) noexcept {
+  intrusive_ptr_add_ref(static_cast<const Node*>(p));
+}
+inline void intrusive_ptr_release(const LeafNode* p) noexcept {
+  intrusive_ptr_release(static_cast<const Node*>(p));
+}
 
 }

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -29,6 +29,10 @@
 #include "messages/MOSDPGUpdateLogMissingReply.h"
 #include "messages/MOSDRepOpReply.h"
 #include "messages/MOSDScrub2.h"
+#include "messages/MOSDECSubOpWrite.h"
+#include "messages/MOSDECSubOpWriteReply.h"
+#include "messages/MOSDECSubOpRead.h"
+#include "messages/MOSDECSubOpReadReply.h"
 #include "messages/MOSDPGPCT.h"
 #include "messages/MPGStats.h"
 

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <optional>
 #include <boost/smart_ptr/intrusive_ref_counter.hpp>
+
 #include <seastar/core/future.hh>
 #include <seastar/core/shared_future.hh>
 
@@ -1259,6 +1260,17 @@ struct PG::do_osd_ops_params_t {
 };
 
 std::ostream& operator<<(std::ostream&, const PG& pg);
+
+inline void intrusive_ptr_add_ref(const PG* p) noexcept {
+  boost::sp_adl_block::intrusive_ptr_add_ref(
+    static_cast<const boost::intrusive_ref_counter<
+      PG, boost::thread_unsafe_counter>*>(p));
+}
+inline void intrusive_ptr_release(const PG* p) noexcept {
+  boost::sp_adl_block::intrusive_ptr_release(
+    static_cast<const boost::intrusive_ref_counter<
+      PG, boost::thread_unsafe_counter>*>(p));
+}
 
 }
 


### PR DESCRIPTION
Boost 1.89+ makes boost::intrusive_ptr constructors/destructors constexpr (via BOOST_SP_CXX20_CONSTEXPR). This triggers two-phase name lookup on the template body:

  Phase 1 (definition context): ordinary unqualified lookup
  Phase 2 (instantiation context): ADL only

The problem: intrusive_ptr<PG> is instantiated when PG is still an incomplete type (only forward-declared). ADL on an incomplete type can only see the type's own associated namespace — it cannot traverse base classes. The friend functions live in boost::sp_adl_block (via intrusive_ref_counter), which ADL cannot reach for an incomplete type. Ordinary lookup also fails because boost/intrusive_ptr.hpp enters the include chain early via Seastar headers (reactor.hh → pollable_fd.hh), before any ceph header declaring the ADL functions.

Without constexpr (pre-Boost 1.89), the function body was checked in a single pass at instantiation time, so ADL worked despite the incomplete type. The constexpr change exposed this latent bug.

This is the same root cause as cbdd9c4b1f69 (TrackedOp fix).

Fix by providing explicit ADL functions in the correct namespace for:
- FuturizedCollection: global namespace, with the include added to futurized_store.h to ensure visibility before instantiation
- Node hierarchy (crimson::os::seastore::onode namespace)
- PG (crimson::osd namespace): declarations in type_helpers.h, implementations in pg.h. Must be in PG's own namespace so that ADL on crimson::osd::PG* finds them without needing to traverse the base class.

Also add missing MOSDECSubOp* includes to osd.cc for the boost::static_pointer_cast calls.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
