### PR TITLE
cephadm: set Grafana http_addr to 0.0.0.0 when unset

### DIFF
--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -2,7 +2,6 @@ import errno
 import logging
 import os
 from typing import List, Any, Tuple, Dict, Optional, cast, TYPE_CHECKING
-import ipaddress
 import time
 import requests
 
@@ -74,8 +73,15 @@ class GrafanaService(CephadmService):
             if ip_to_bind_to:
                 daemon_spec.port_ips = {str(grafana_port): ip_to_bind_to}
                 grafana_ip = ip_to_bind_to
-                if ipaddress.ip_network(grafana_ip).version == 6:
-                    grafana_ip = f"[{grafana_ip}]"
+
+        if not grafana_ip:
+            # Grafana 11.1+ validates http_addr with net.ParseIP; hostnames such as
+            # localhost fail in grafana-apiserver. Use a literal address (bind all IPv4).
+            # Check if the primary manager or orchestrator is configured for IPv6
+            if self.mgr.get_mgr_ip().startswith('::') or ':' in self.mgr.get_mgr_ip():
+                grafana_ip = '::'
+            else:
+                grafana_ip = '0.0.0.0'
 
         domain = self.mgr.get_fqdn(daemon_spec.host)
         mgmt_gw_ips = []

--- a/src/pybind/mgr/cephadm/tests/services/test_monitoring.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_monitoring.py
@@ -1329,7 +1329,7 @@ class TestMonitoring:
                           cert_file = /etc/grafana/certs/cert_file
                           cert_key = /etc/grafana/certs/cert_key
                           http_port = 3000
-                          http_addr = 
+                          http_addr = ::
                           root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana/
                           serve_from_sub_path = true
                         [snapshots]
@@ -1490,7 +1490,7 @@ class TestMonitoring:
                           cert_file = /etc/grafana/certs/cert_file
                           cert_key = /etc/grafana/certs/cert_key
                           http_port = 3000
-                          http_addr = 
+                          http_addr = ::
                           root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana/
                           serve_from_sub_path = true
                         [snapshots]
@@ -1590,7 +1590,7 @@ class TestMonitoring:
                           cert_file = /etc/grafana/certs/cert_file
                           cert_key = /etc/grafana/certs/cert_key
                           http_port = 3000
-                          http_addr = 
+                          http_addr = ::
                         [snapshots]
                           external_enabled = false
                         [security]
@@ -1681,6 +1681,7 @@ class TestMonitoring:
                 )
 
     @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '192.0.2.1')
     def test_grafana_initial_admin_pw(self, cephadm_module: CephadmOrchestrator):
         with with_host(cephadm_module, 'test'):
             with with_service(cephadm_module, ServiceSpec('mgr')) as _, \
@@ -1705,7 +1706,7 @@ class TestMonitoring:
                                     '  cert_file = /etc/grafana/certs/cert_file\n'
                                     '  cert_key = /etc/grafana/certs/cert_key\n'
                                     '  http_port = 3000\n'
-                                    '  http_addr = \n'
+                                    '  http_addr = 0.0.0.0\n'
                                     '[snapshots]\n'
                                     '  external_enabled = false\n'
                                     '[security]\n'
@@ -1750,6 +1751,33 @@ class TestMonitoring:
                             }}, ['certificate_source: cephadm-signed', 'secure_monitoring_stack:False'])
 
     @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '192.0.2.1')
+    def test_grafana_http_addr_binds_all_by_default_ipv4(self, cephadm_module: CephadmOrchestrator):
+        grafana_svc = service_registry.get_service('grafana')
+        with with_host(cephadm_module, 'test'):
+            with with_service(cephadm_module, GrafanaSpec()):
+                ini = grafana_svc.generate_grafana_ini(
+                    CephadmDaemonDeploySpec('test', 'daemon', 'grafana'),
+                    mgmt_gw_enabled=False,
+                    oauth2_enabled=False,
+                )
+                assert 'http_addr = 0.0.0.0' in ini
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '1::4')
+    def test_grafana_http_addr_binds_all_by_default_ipv6(self, cephadm_module: CephadmOrchestrator):
+        grafana_svc = service_registry.get_service('grafana')
+        with with_host(cephadm_module, 'test'):
+            with with_service(cephadm_module, GrafanaSpec()):
+                ini = grafana_svc.generate_grafana_ini(
+                    CephadmDaemonDeploySpec('test', 'daemon', 'grafana'),
+                    mgmt_gw_enabled=False,
+                    oauth2_enabled=False,
+                )
+                assert 'http_addr = ::' in ini
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '192.0.2.1')
     def test_grafana_no_anon_access(self, cephadm_module: CephadmOrchestrator):
         # with anonymous_access set to False, expecting the [auth.anonymous] section
         # to not be present in the grafana config. Note that we require an initial_admin_password
@@ -1774,7 +1802,7 @@ class TestMonitoring:
                                     '  cert_file = /etc/grafana/certs/cert_file\n'
                                     '  cert_key = /etc/grafana/certs/cert_key\n'
                                     '  http_port = 3000\n'
-                                    '  http_addr = \n'
+                                    '  http_addr = 0.0.0.0\n'
                                     '[snapshots]\n'
                                     '  external_enabled = false\n'
                                     '[security]\n'


### PR DESCRIPTION
Grafana 11.1+ rejects non-literal http_addr values (e.g. localhost) in grafana-apiserver. 

Use 0.0.0.0 by default; stop bracket-wrapping IPv6 addresses in http_addr.
Fixes: https://tracker.ceph.com/issues/75365
Signed-off-by: Kobi Ginon <kginon@redhat.com>

 **Verification steps:**

On a running ceph cluster define grafana configuration
pin it to a node where we can find the grafana.ini value
in y case it is ceph-node-0:

```
[ceph: root@ceph-node-0 /]# cat graphana.yaml
service_type: grafana
placement:
  hosts:
    - ceph-node-0
spec:
  protocol: https
  anonymous_access: true
  
  [ceph: root@ceph-node-0 /]# ceph orch apply -i graphana.yaml
Scheduled grafana update...

get out of the cephadmshell to the host 
[root@ceph-node-0 grafana]# cd /var/lib/ceph/fd6b0566-5835-11f1-829b-52540006a93f/grafana.ceph-node-0/etc/
replace fd6b0566-5835-11f1-829b-52540006a93f with your ceph fsid
replace folder name grafana.ceph-node-0 with grafana.<ceph node name>

[root@ceph-node-0 etc]# grep -B 6 http_addr grafana/grafana.ini
[server]
  domain = 'ceph-node-0'
  protocol = https
  cert_file = /etc/grafana/certs/cert_file
  cert_key = /etc/grafana/certs/cert_key
  http_port = 3000
  **http_addr = 0.0.0.0**

if the value confirmed to be 0.0.0.0 then it is OK 
Can extend the validation to real listenning port also and adress *
[root@ceph-node-0 etc]# podman ps | grep grafana
f1966090866c  quay.io/ceph/grafana:12.3.1                                                                                                   18 minutes ago  Up 18 minutes  3000/tcp    ceph-fd6b0566-5835-11f1-829b-52540006a93f-grafana-ceph-node-0
[root@ceph-node-0 etc]# ss -tlnp | grep 3000
LISTEN 0      4096                 *:3000            *:*    users:(("grafana",pid=36856,fd=14))

```
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
