### PR TITLE
tool/cephfs_mirror: Adding checkpoints for mirroring

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -203,6 +203,17 @@
   ``metrics_updated_at`` (time of the last omap write). Optional filters by
   mirrored directory path and peer UUID are supported. For more information,
   see https://tracker.ceph.com/issues/76686
+* CephFS Mirroring: Introduced snapshot checkpoints feature that allows users to mark
+  specific snapshots as important milestones and track their replication status to remote
+  sites. Checkpoints automatically detect if a snapshot has already been synced and provide
+  visibility into disaster recovery readiness. The feature includes four new CLI commands:
+  ``ceph fs snapshot mirror checkpoint add`` to mark a snapshot,
+  ``ceph fs snapshot mirror checkpoint now`` to checkpoint the latest snapshot,
+  ``ceph fs snapshot mirror checkpoint ls`` to list all checkpoints with their status
+  (created/complete/failed), and ``ceph fs snapshot mirror checkpoint remove`` to remove
+  a checkpoint. Checkpoint metadata is persistent across daemon restarts. This feature is
+  useful for compliance auditing, application consistency verification, and SLA tracking.
+  For more information, see https://tracker.ceph.com/issues/73454
 * RBD: Mirror snapshot creation and trash purge schedules are now automatically
   staggered when no explicit "start-time" is specified. This reduces scheduling
   spikes and distributes work more evenly over time.

--- a/doc/cephfs/cephfs-mirroring-checkpoints.rst
+++ b/doc/cephfs/cephfs-mirroring-checkpoints.rst
@@ -1,0 +1,360 @@
+========================================
+CephFS Snapshot Mirroring Checkpoints
+========================================
+
+.. contents::
+   :depth: 3
+   :local:
+
+Introduction
+============
+
+CephFS Snapshot Mirroring Checkpoints allow you to mark specific snapshots as important
+milestones and track whether they have been successfully replicated to your remote site.
+This feature provides visibility into your disaster recovery readiness by showing which
+critical data states have been safely mirrored.
+
+**Use Cases:**
+
+- **Compliance & Auditing**: Verify that end-of-day or end-of-month snapshots are replicated
+- **Application Consistency**: Ensure application-consistent snapshots reach the DR site
+- **Migration Tracking**: Monitor progress when migrating data between sites
+- **SLA Verification**: Confirm that critical snapshots meet replication SLAs
+
+What is a Checkpoint?
+=====================
+
+A checkpoint is a marker you place on a snapshot to track its replication status. When you
+checkpoint a snapshot, the system monitors whether that snapshot (and all previous snapshots)
+have been successfully synchronized to the remote filesystem.
+
+**Key Concepts:**
+
+- **Automatic Status Tracking**: Checkpoints automatically detect if a snapshot has already been synced
+- **Persistent**: Checkpoint information survives daemon restarts
+- **Per-Directory**: Each mirrored directory has its own set of checkpoints
+
+Checkpoint Lifecycle
+--------------------
+
+Every checkpoint goes through these states:
+
+.. code-block:: text
+
+    ┌─────────┐
+    │ CREATED │  ← Checkpoint added, snapshot not yet synced
+    └────┬────┘
+         │
+         ├──→ ┌──────────┐
+         │    │ COMPLETE │  ← Snapshot successfully synced to remote
+         │    └──────────┘
+         │
+         └──→ ┌────────┐
+              │ FAILED │  ← Sync failed (will be retried automatically)
+              └────────┘
+
+- **created**: Waiting for synchronization or sync in progress
+- **complete**: Successfully replicated to remote site
+- **failed**: Sync encountered an error (check error message for details)
+
+Prerequisites
+=============
+
+Before using checkpoints, ensure:
+
+1. **CephFS Mirroring is Enabled**:
+
+   .. code-block:: bash
+
+       ceph fs snapshot mirror enable <fs_name>
+
+2. **Remote Peer is Configured**:
+
+   .. code-block:: bash
+
+       ceph fs snapshot mirror peer_add <fs_name> <peer_spec>
+
+3. **Directory is Being Mirrored**:
+
+   .. code-block:: bash
+
+       ceph fs snapshot mirror add <fs_name> <dir_path>
+
+4. **Snapshots Exist**: You need snapshots to checkpoint
+
+For detailed mirroring setup, see :doc:`cephfs-mirroring`.
+
+Getting Started
+===============
+
+Basic Workflow
+--------------
+
+Here's a typical workflow for using checkpoints:
+
+**Step 1: Create Snapshots**
+
+.. code-block:: bash
+
+    # Create snapshots in your mirrored directory
+    mkdir /mnt/cephfs/data/.snap/daily_backup_2026_06_01
+    mkdir /mnt/cephfs/data/.snap/daily_backup_2026_06_02
+    mkdir /mnt/cephfs/data/.snap/daily_backup_2026_06_03
+
+**Step 2: Add Checkpoints**
+
+.. code-block:: bash
+
+    # Mark important snapshots as checkpoints
+    ceph fs snapshot mirror checkpoint add myfs /data daily_backup_2026_06_01
+    ceph fs snapshot mirror checkpoint add myfs /data daily_backup_2026_06_03
+
+**Step 3: Monitor Status**
+
+.. code-block:: bash
+
+    # Check checkpoint status
+    ceph fs snapshot mirror checkpoint ls myfs /data --format json-pretty
+
+**Example Output:**
+
+.. code-block:: json
+
+    {
+      "dir_root": "/data",
+      "checkpoints": [
+        {
+          "snap_id": 100,
+          "snap_name": "daily_backup_2026_06_01",
+          "status": "complete",
+          "created_at": "2026-06-01T23:00:00.000000+0000",
+          "updated_at": "2026-06-01T23:15:00.000000+0000"
+        },
+        {
+          "snap_id": 102,
+          "snap_name": "daily_backup_2026_06_03",
+          "status": "created",
+          "created_at": "2026-06-03T23:00:00.000000+0000",
+          "updated_at": "2026-06-03T23:00:00.000000+0000"
+        }
+      ]
+    }
+
+Command Reference
+=================
+
+checkpoint add
+--------------
+
+Add a checkpoint to a specific snapshot.
+
+**Syntax:**
+
+.. code-block:: bash
+
+    ceph fs snapshot mirror checkpoint add <fs_name> <dir_path> <snap_name>
+
+**Parameters:**
+
+- ``fs_name``: Name of the filesystem
+- ``dir_path``: Path to the mirrored directory (e.g., ``/data``)
+- ``snap_name``: Name of the snapshot to checkpoint
+
+**Example:**
+
+.. code-block:: bash
+
+    ceph fs snapshot mirror checkpoint add myfs /data backup_snapshot_1
+
+**Output:**
+
+.. code-block:: json
+
+    {
+      "status": "success",
+      "message": "checkpoint added for snapshot backup_snapshot_1",
+      "dir_root": "/data",
+      "snap_id": 123,
+      "snap_name": "backup_snapshot_1",
+      "checkpoint_status": "created"
+    }
+
+**Notes:**
+
+- If the snapshot has already been synced, status will be ``complete`` immediately
+- You cannot checkpoint the same snapshot twice
+- The snapshot must exist in the directory
+
+checkpoint now
+--------------
+
+Add a checkpoint to the most recent snapshot in a directory.
+
+**Syntax:**
+
+.. code-block:: bash
+
+    ceph fs snapshot mirror checkpoint now <fs_name> <dir_path>
+
+**Example:**
+
+.. code-block:: bash
+
+    ceph fs snapshot mirror checkpoint now myfs /data
+
+**Output:**
+
+.. code-block:: json
+
+    {
+      "status": "success",
+      "message": "checkpoint created on latest snapshot",
+      "dir_root": "/data",
+      "snap_id": 125,
+      "snap_name": "daily_backup_2026_06_03",
+      "checkpoint_status": "created"
+    }
+
+**Use Case:**
+
+Useful when you want to checkpoint the latest state without knowing the exact snapshot name.
+
+checkpoint ls
+-------------
+
+List all checkpoints for a directory.
+
+**Syntax:**
+
+.. code-block:: bash
+
+    ceph fs snapshot mirror checkpoint ls <fs_name> <dir_path> [--format <format>]
+
+**Parameters:**
+
+- ``format``: Output format (``json`` or ``json-pretty``), default is ``json``
+
+**Example:**
+
+.. code-block:: bash
+
+    ceph fs snapshot mirror checkpoint ls myfs /data --format json-pretty
+
+**Output Fields:**
+
+- ``snap_id``: Internal snapshot ID
+- ``snap_name``: Snapshot name
+- ``status``: Current status (created/complete/failed)
+- ``created_at``: When checkpoint was created
+- ``updated_at``: Last status update time
+- ``error_msg``: Error description (only present if status is failed)
+
+checkpoint remove
+-----------------
+
+Remove a checkpoint from a specific snapshot.
+
+**Syntax:**
+
+.. code-block:: bash
+
+    ceph fs snapshot mirror checkpoint remove <fs_name> <dir_path> <snap_name>
+
+**Example:**
+
+.. code-block:: bash
+
+    # Remove checkpoint from a specific snapshot
+    ceph fs snapshot mirror checkpoint remove myfs /data backup_snapshot_1
+
+**Output:**
+
+.. code-block:: json
+
+    {
+      "status": "success",
+      "message": "checkpoint removed for snapshot backup_snapshot_1",
+      "dir_root": "/data",
+      "snap_name": "backup_snapshot_1"
+    }
+
+**Notes:**
+
+- Removing a checkpoint does NOT delete the snapshot itself
+- The snapshot and its data remain intact
+- This operation only removes the checkpoint tracking metadata
+- This operation cannot be undone
+- To remove multiple checkpoints, run the command multiple times
+
+Important Notes
+===============
+
+Snapshot Deletion Behavior
+---------------------------
+
+.. warning::
+
+   **If a snapshot with a checkpoint is deleted, the checkpoint metadata is permanently lost.**
+
+When you delete a snapshot that has a checkpoint:
+
+1. **Before Sync Completes**: The checkpoint is lost and will never reach "complete" status
+2. **After Sync Completes**: The checkpoint history is lost, but the data was already replicated
+
+**Impact on Commands:**
+
+- ``checkpoint ls``: Will not show the deleted snapshot's checkpoint
+- ``checkpoint remove``: Will fail with "snapshot not found" error
+
+**Best Practice:**
+
+- Do not delete snapshots with active checkpoints until they reach "complete" status
+- Use ``checkpoint ls`` to verify checkpoint status before deleting snapshots
+- Consider removing checkpoints explicitly before deleting important snapshots
+
+Snapshot Rename Behavior
+-------------------------
+
+.. note::
+
+   **Checkpoints survive snapshot renames, but you must use the new snapshot name in commands.**
+
+When you rename a snapshot that has a checkpoint:
+
+1. **Checkpoint Persists**: The checkpoint metadata remains attached to the snapshot
+2. **Name Updates Automatically**: ``checkpoint ls`` will show the new snapshot name
+3. **Old Name No Longer Works**: You must use the new name for ``checkpoint remove``
+
+**Example:**
+
+.. code-block:: bash
+
+    # Original snapshot with checkpoint
+    ceph fs snapshot mirror checkpoint add myfs /data old_name
+
+    # Rename the snapshot (using CephFS snapshot rename)
+    # ... snapshot renamed from 'old_name' to 'new_name' ...
+
+    # List checkpoints - shows new name
+    ceph fs snapshot mirror checkpoint ls myfs /data
+    # Output shows: "snap_name": "new_name"
+
+    # Remove using NEW name (this works)
+    ceph fs snapshot mirror checkpoint remove myfs /data new_name
+
+    # Remove using OLD name (this fails)
+    ceph fs snapshot mirror checkpoint remove myfs /data old_name
+    # Error: snapshot 'old_name' not found
+
+**Best Practice:**
+
+- Always use ``checkpoint ls`` to verify current snapshot names before removing checkpoints
+- Update any automation scripts if you rename snapshots
+
+
+Additional Resources
+====================
+
+- **CephFS Mirroring Guide**: :doc:`cephfs-mirroring`
+- **Snapshot Documentation**: :doc:`/cephfs/snapshots`
+- **Tracker Issue**: https://tracker.ceph.com/issues/73454

--- a/doc/cephfs/cephfs-mirroring.rst
+++ b/doc/cephfs/cephfs-mirroring.rst
@@ -1425,3 +1425,36 @@ transfers. Users can fine-tune these operations using configuration parameters:
 - ``cephfs_mirror_max_concurrent_directory_syncs``: controls the number of concurrent snapshots being crawled.
 - ``cephfs_mirror_max_datasync_threads``: controls the total threads available for data sync.
 For more information, see https://tracker.ceph.com/issues/73452
+
+
+Snapshot Mirroring Checkpoints
+-------------------------------
+
+CephFS mirroring supports checkpoints to track the replication status of specific snapshots.
+Checkpoints allow you to mark important snapshots and monitor whether they have been successfully
+synchronized to the remote site, providing visibility into disaster recovery readiness.
+
+**Key Features:**
+
+- Mark snapshots as checkpoints to track their replication status
+- Automatic status detection (created/complete/failed)
+- Per-directory tracking with persistent metadata
+
+**Basic Usage:**
+
+.. code-block:: bash
+
+    # Add a checkpoint to a snapshot
+    ceph fs snapshot mirror checkpoint add <fs_name> <dir_path> <snap_name>
+
+    # List all checkpoints for a directory
+    ceph fs snapshot mirror checkpoint ls <fs_name> <dir_path>
+
+    # Remove a checkpoint
+    ceph fs snapshot mirror checkpoint remove <fs_name> <dir_path> <snap_name>
+
+    # Create checkpoint on latest snapshot
+    ceph fs snapshot mirror checkpoint now <fs_name> <dir_path>
+
+For detailed information about checkpoint commands, lifecycle, and best practices, see
+:doc:`cephfs-mirroring-checkpoints`.

--- a/doc/cephfs/index.rst
+++ b/doc/cephfs/index.rst
@@ -93,6 +93,7 @@ Administration
     cephfs-tool <cephfs-tool>
     Scheduled Snapshots <snap-schedule>
     CephFS Snapshot Mirroring <cephfs-mirroring>
+    CephFS Snapshot Mirroring Checkpoints <cephfs-mirroring-checkpoints>
     Purge Queue <purge-queue>
 
 .. raw:: html

--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -370,6 +370,22 @@ class TestMirroring(CephFSTestCase):
                                  f'for {dir_path}')
         return entry['counters']
 
+    def get_peer_perf_counters(self):
+        res = self.mirror_daemon_command(
+            f'counter dump for fs: {self.primary_fs_name}', 'counter', 'dump')
+        self.assertIn(self.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR_PEER, res)
+        self.assertGreater(len(res[self.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR_PEER]), 0)
+        return res[self.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR_PEER][0]['counters']
+
+    @retry_assert(timeout=60, interval=1)
+    def wait_peer_add_directory_counter(self, expected):
+        counters = self.get_peer_perf_counters()
+        self.assertIn('add_directory', counters)
+        actual = counters['add_directory']
+        if actual != expected:
+            raise AssertionError(
+                f'expected add_directory={expected}, got {actual}')
+
     def assert_directory_perf_labels(self, labels, dir_path, peer_uuid):
         self.assertEqual(labels['source_fscid'], str(self.primary_fs_id))
         self.assertEqual(labels['source_filesystem'], self.primary_fs_name)
@@ -717,6 +733,27 @@ class TestMirroring(CephFSTestCase):
             e.res = res
             raise
 
+    @retry_assert(timeout=120, interval=1)
+    def stop_daemon_when_peer_snap_in_progress(self, fs_name, fs_id,
+                                               peer_spec, dir_name, snap_name):
+        peer_uuid = self.get_peer_uuid(peer_spec)
+        res = self.mirror_daemon_command(f'peer status for fs: {fs_name}',
+                                         'fs', 'mirror', 'peer', 'status',
+                                         f'{fs_name}@{fs_id}', peer_uuid)
+        try:
+            dir_stat = self.peer_dir_status(res, dir_name, peer_uuid)
+            if dir_stat.get('last_synced_snap', {}).get('name') == snap_name:
+                raise RuntimeError(
+                    f'snapshot {snap_name!r} synced before caps could be restricted')
+            self.assertTrue('syncing' == dir_stat['state'])
+            self.assertTrue(dir_stat['current_syncing_snap']['name'] == snap_name)
+        except RETRY_EXCEPTIONS as e:
+            e.res = res
+            raise
+
+        log.debug('peer syncing %s, stopping mirror daemon', snap_name)
+        self.stop_mirror_daemon()
+
     def verify_snapshot(self, dir_name, snap_name):
         snap_list = self.mount_b.ls(path=f'{dir_name}/.snap')
         self.assertTrue(snap_name in snap_list)
@@ -802,6 +839,117 @@ class TestMirroring(CephFSTestCase):
         log.debug(f'status: {status}')
         return status
 
+    def checkpoint_list(self, fs_name, dir_path):
+        return json.loads(self.get_ceph_cmd_stdout(
+            "fs", "snapshot", "mirror", "checkpoint", "ls",
+            fs_name, dir_path))
+
+    def checkpoint_add(self, fs_name, dir_path, snap_name):
+        out = json.loads(self.get_ceph_cmd_stdout(
+            "fs", "snapshot", "mirror", "checkpoint", "add",
+            fs_name, dir_path, snap_name))
+        self.assertEqual(out['status'], 'success')
+        return out
+
+    def checkpoint_remove(self, fs_name, dir_path, snap_name):
+        out = json.loads(self.get_ceph_cmd_stdout(
+            "fs", "snapshot", "mirror", "checkpoint", "remove",
+            fs_name, dir_path, snap_name))
+        self.assertEqual(out['status'], 'success')
+        return out
+
+    def checkpoint_now(self, fs_name, dir_path):
+        out = json.loads(self.get_ceph_cmd_stdout(
+            "fs", "snapshot", "mirror", "checkpoint", "now",
+            fs_name, dir_path))
+        self.assertEqual(out['status'], 'success')
+        return out
+
+    @staticmethod
+    def find_checkpoint(checkpoints, snap_name):
+        for cp in checkpoints:
+            if cp['snap_name'] == snap_name:
+                return cp
+        return None
+
+    def assert_checkpoint_listed(self, fs_name, dir_path, snap_name):
+        res = self.checkpoint_list(fs_name, dir_path)
+        cp = self.find_checkpoint(res['checkpoints'], snap_name)
+        self.assertIsNotNone(cp, f'checkpoint {snap_name} should be listed')
+
+    def assert_checkpoint_not_listed(self, fs_name, dir_path, snap_name):
+        res = self.checkpoint_list(fs_name, dir_path)
+        cp = self.find_checkpoint(res['checkpoints'], snap_name)
+        self.assertIsNone(cp, f'checkpoint {snap_name} should not be listed')
+
+    def start_mirror_daemon(self):
+        self.mount_a.run_shell_payload(
+            'nohup cephfs-mirror --id mirror </dev/null >/dev/null 2>&1 &')
+
+        @retry_assert(timeout=60, interval=2)
+        def wait_ready():
+            res = self.mirror_daemon_command(
+                f'counter dump for fs: {self.primary_fs_name}', 'counter', 'dump')
+            self.assertIn(TestMirroring.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR_FS, res)
+
+        wait_ready()
+
+    def stop_mirror_daemon(self, wait=5):
+        pid = self.get_mirror_daemon_pid()
+        log.debug(f'stopping cephfs-mirror (pid={pid})')
+        self.mount_a.run_shell_payload(f'kill -TERM {pid} || true')
+        time.sleep(wait)
+
+    def restart_mirroring_module(self, wait=10):
+        log.debug('restarting mirroring mgr module')
+        self.run_ceph_cmd("mgr", "module", "disable", self.MODULE_NAME)
+        time.sleep(2)
+        self.run_ceph_cmd("mgr", "module", "enable", self.MODULE_NAME)
+        time.sleep(wait)
+
+    def _setup_mirrored_directory(self, dir_path, peer_spec=None, mount_b=False):
+        """Enable mirroring and track a directory; optionally mount backup FS and add peer."""
+        if mount_b:
+            self.setup_mount_b(mds_perm='rw')
+        self.mount_a.run_shell(["mkdir", "-p", dir_path.lstrip('/')])
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, dir_path)
+        if peer_spec:
+            self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec,
+                          self.secondary_fs_name)
+
+    def _add_checkpoint_snapshot(self, dir_path, snap_name, verify_listed=False):
+        """Create a snapshot and add a checkpoint on it."""
+        self.mount_a.run_shell(["mkdir", f"{dir_path.lstrip('/')}/.snap/{snap_name}"])
+        self.checkpoint_add(self.primary_fs_name, dir_path, snap_name)
+        if verify_listed:
+            self.assert_checkpoint_listed(self.primary_fs_name, dir_path, snap_name)
+
+    def _setup_checkpoint_dir(self, dir_path, snap_name, peer_spec=None, mount_b=True):
+        """Create a tracked directory with a checkpointed snapshot."""
+        self._setup_mirrored_directory(dir_path, peer_spec=peer_spec, mount_b=mount_b)
+        self._add_checkpoint_snapshot(dir_path, snap_name, verify_listed=True)
+
+    def _teardown_mirroring(self, dir_path, peer_spec=None):
+        """Untrack directory, remove peer, and disable mirroring on the filesystem."""
+        self.remove_directory(self.primary_fs_name, self.primary_fs_id, dir_path)
+        if peer_spec:
+            self.peer_remove(self.primary_fs_name, self.primary_fs_id, peer_spec)
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+    @retry_assert(timeout=600, interval=10)
+    def check_checkpoint_status(self, fs_name, dir_path, snap_name, expected_status):
+        res = self.checkpoint_list(fs_name, dir_path)
+        cp = self.find_checkpoint(res['checkpoints'], snap_name)
+        if cp is None or cp['status'] != expected_status:
+            raise AssertionError(
+                f'checkpoint {snap_name}: expected status {expected_status}, '
+                f'got {None if cp is None else cp["status"]!r}')
+
+    def check_checkpoint_statuses(self, fs_name, dir_path, snap_names, expected_status):
+        for snap_name in snap_names:
+            self.check_checkpoint_status(fs_name, dir_path, snap_name, expected_status)
+
     def setup_mount_b(self, mds_perm):
         log.debug('reconfigure client auth caps')
         self.get_ceph_cmd_result(
@@ -812,6 +960,29 @@ class TestMirroring(CephFSTestCase):
         self.mount_b.umount_wait()
         log.debug(f'mounting filesystem {self.secondary_fs_name}')
         self.mount_b.mount_wait(cephfs_name=self.secondary_fs_name)
+
+    def _restrict_mirror_remote_caps(self):
+        """Restrict mirror remote client OSD write to force snapshot sync failure.
+
+        The remote mirrored directory must already exist (created while the
+        client still has OSD write).  OSD read-only blocks file data transfer
+        during snapshot sync, where checkpoint_sync_failed() is recorded.
+        """
+        self.get_ceph_cmd_result(
+            'auth', 'caps', 'client.mirror_remote',
+            'mds', 'allow rwps',
+            'mon', 'allow r',
+            'osd', "allow r tag cephfs *=*",
+            'mgr', 'allow r')
+
+    def _restore_mirror_remote_caps(self):
+        """Restore mirror remote client caps used by the mirror test suite."""
+        self.get_ceph_cmd_result(
+            'auth', 'caps', 'client.mirror_remote',
+            'mds', 'allow rwps',
+            'mon', 'allow r',
+            'osd', "allow rw tag cephfs *=*",
+            'mgr', 'allow r')
 
     def test_basic_mirror_commands(self):
         self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
@@ -959,6 +1130,350 @@ class TestMirroring(CephFSTestCase):
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
         self.mount_a.run_shell(["rmdir", dir1])
         self.mount_a.run_shell(["rmdir",  dir2])
+
+    def test_checkpoint_cli_add_list_remove_now(self):
+        """Test mgr checkpoint add/list/remove/now on snapshot metadata."""
+        dir_path = '/cp_cli'
+        snap0 = 'snap0'
+        snap1 = 'snap1'
+
+        self._setup_mirrored_directory(dir_path)
+        self._add_checkpoint_snapshot(dir_path, snap0)
+
+        res = self.checkpoint_list(self.primary_fs_name, dir_path)
+        self.assertEqual(res['dir_root'], dir_path)
+        cp = self.find_checkpoint(res['checkpoints'], snap0)
+        self.assertIsNotNone(cp)
+        self.assertEqual(cp['status'], 'created')
+        self.assertTrue(cp['created_at'])
+        self.assertTrue(cp['updated_at'])
+
+        self.mount_a.run_shell(["mkdir", f"{dir_path.lstrip('/')}/.snap/{snap1}"])
+        out = self.checkpoint_now(self.primary_fs_name, dir_path)
+        self.assertEqual(out['snap_name'], snap1)
+
+        res = self.checkpoint_list(self.primary_fs_name, dir_path)
+        self.assertEqual(len(res['checkpoints']), 2)
+
+        self.checkpoint_remove(self.primary_fs_name, dir_path, snap0)
+        res = self.checkpoint_list(self.primary_fs_name, dir_path)
+        self.assertEqual(len(res['checkpoints']), 1)
+        self.assertEqual(res['checkpoints'][0]['snap_name'], snap1)
+
+        self.checkpoint_remove(self.primary_fs_name, dir_path, snap1)
+        res = self.checkpoint_list(self.primary_fs_name, dir_path)
+        self.assertEqual(res['checkpoints'], [])
+
+        self._teardown_mirroring(dir_path)
+
+    def test_checkpoint_cli_errors(self):
+        """Test checkpoint CLI validation errors."""
+        dir_path = '/cp_err'
+        tracked = '/cp_err/tracked'
+        snap = 'snap0'
+
+        self._setup_mirrored_directory(tracked)
+        self.mount_a.run_shell(["mkdir", f"{tracked.lstrip('/')}/.snap/{snap}"])
+
+        try:
+            self.checkpoint_add(self.primary_fs_name, dir_path, snap)
+        except CommandFailedError as ce:
+            if ce.exitstatus != errno.ENOENT:
+                raise RuntimeError(
+                    f'expected ENOENT for untracked directory, got {ce.exitstatus}')
+        else:
+            raise RuntimeError('expected checkpoint add to fail for untracked directory')
+
+        try:
+            self.checkpoint_remove(self.primary_fs_name, tracked, snap)
+        except CommandFailedError as ce:
+            if ce.exitstatus != errno.ENOENT:
+                raise RuntimeError(
+                    f'expected ENOENT when removing non-checkpoint snap, got {ce.exitstatus}')
+        else:
+            raise RuntimeError('expected checkpoint remove to fail')
+
+        self.checkpoint_add(self.primary_fs_name, tracked, snap)
+        try:
+            self.checkpoint_add(self.primary_fs_name, tracked, snap)
+        except CommandFailedError as ce:
+            if ce.exitstatus != errno.EEXIST:
+                raise RuntimeError(
+                    f'expected EEXIST when re-adding checkpoint, got {ce.exitstatus}')
+        else:
+            raise RuntimeError('expected checkpoint add to fail for duplicate')
+        self.checkpoint_remove(self.primary_fs_name, tracked, snap)
+
+        self.remove_directory(self.primary_fs_name, self.primary_fs_id, tracked)
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        try:
+            self.checkpoint_list(self.primary_fs_name, tracked)
+        except CommandFailedError as ce:
+            if ce.exitstatus != errno.EINVAL:
+                raise RuntimeError(
+                    f'expected EINVAL with mirroring disabled, got {ce.exitstatus}')
+        else:
+            raise RuntimeError('expected checkpoint list to fail')
+
+    def test_checkpoint_sync_status_reaches_complete(self):
+        """Test mirror daemon updates checkpoint status after snapshot sync."""
+        dir_path = '/cp_sync'
+        snap_name = 'snap0'
+        peer_spec = "client.mirror_remote@ceph"
+
+        self._setup_mirrored_directory(dir_path, mount_b=True)
+        self._add_checkpoint_snapshot(dir_path, snap_name)
+        self.check_checkpoint_status(self.primary_fs_name, dir_path, snap_name, 'created')
+
+        res = self.checkpoint_list(self.primary_fs_name, dir_path)
+        cp = self.find_checkpoint(res['checkpoints'], snap_name)
+        created_at = cp['created_at']
+        updated_at = cp['updated_at']
+
+        self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec, self.secondary_fs_name)
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               peer_spec, dir_path, snap_name, 1)
+        self.verify_snapshot(dir_path.lstrip('/'), snap_name)
+        self.check_checkpoint_status(self.primary_fs_name, dir_path, snap_name, 'complete')
+
+        res = self.checkpoint_list(self.primary_fs_name, dir_path)
+        cp = self.find_checkpoint(res['checkpoints'], snap_name)
+        self.assertEqual(cp['created_at'], created_at)
+        self.assertTrue(cp['updated_at'])
+        self.assertNotEqual(cp['updated_at'], updated_at)
+
+        self._teardown_mirroring(dir_path, peer_spec)
+
+    def test_checkpoint_deleted_snapshot_not_listed(self):
+        """Deleted checkpointed snapshots must not appear in checkpoint ls."""
+        dir_path = '/cp_del'
+        snap_name = 'snap0'
+
+        self._setup_mirrored_directory(dir_path)
+        self._add_checkpoint_snapshot(dir_path, snap_name)
+
+        res = self.checkpoint_list(self.primary_fs_name, dir_path)
+        self.assertEqual(len(res['checkpoints']), 1)
+
+        self.mount_a.run_shell(["rmdir", f"{dir_path.lstrip('/')}/.snap/{snap_name}"])
+        res = self.checkpoint_list(self.primary_fs_name, dir_path)
+        self.assertEqual(res['checkpoints'], [])
+
+        self._teardown_mirroring(dir_path)
+
+    def test_checkpoint_renamed_snapshot_shows_new_name(self):
+        """Renamed checkpointed snapshots must appear under the new name in ls."""
+        dir_path = '/cp_rename'
+        old_name = 'snap0'
+        new_name = 'snap1'
+
+        self._setup_mirrored_directory(dir_path)
+        self._add_checkpoint_snapshot(dir_path, old_name)
+
+        self.mount_a.run_shell([
+            "mv",
+            f"{dir_path.lstrip('/')}/.snap/{old_name}",
+            f"{dir_path.lstrip('/')}/.snap/{new_name}",
+        ])
+
+        self.assert_checkpoint_not_listed(self.primary_fs_name, dir_path, old_name)
+        self.check_checkpoint_status(self.primary_fs_name, dir_path, new_name, 'created')
+
+        self._teardown_mirroring(dir_path)
+
+    def test_checkpoint_add_after_rename_allows_same_snap_name(self):
+        """A new snapshot can reuse a name after the checkpointed one is renamed."""
+        dir_path = '/cp_reuse_name'
+        old_name = 'snap0'
+        new_name = 'snap1'
+
+        self._setup_mirrored_directory(dir_path)
+        self._add_checkpoint_snapshot(dir_path, old_name)
+
+        self.mount_a.run_shell([
+            "mv",
+            f"{dir_path.lstrip('/')}/.snap/{old_name}",
+            f"{dir_path.lstrip('/')}/.snap/{new_name}",
+        ])
+        self.mount_a.run_shell(["mkdir", f"{dir_path.lstrip('/')}/.snap/{old_name}"])
+        self.checkpoint_add(self.primary_fs_name, dir_path, old_name)
+
+        res = self.checkpoint_list(self.primary_fs_name, dir_path)
+        self.assertEqual(len(res['checkpoints']), 2)
+        self.check_checkpoint_status(self.primary_fs_name, dir_path, old_name, 'created')
+        self.check_checkpoint_status(self.primary_fs_name, dir_path, new_name, 'created')
+
+        self._teardown_mirroring(dir_path)
+
+    def test_checkpoint_persisted_across_mirror_daemon_restart(self):
+        """Checkpoints survive mirror daemon restart and reach complete after sync."""
+        dir_path = '/cp_mirror_restart'
+        snap_name = 'snap0'
+        peer_spec = "client.mirror_remote@ceph"
+
+        self._setup_checkpoint_dir(dir_path, snap_name)
+        res = self.checkpoint_list(self.primary_fs_name, dir_path)
+        self.assertEqual(len(res['checkpoints']), 1)
+
+        self.stop_mirror_daemon()
+        self.start_mirror_daemon()
+
+        res = self.checkpoint_list(self.primary_fs_name, dir_path)
+        self.assertEqual(len(res['checkpoints']), 1)
+        self.check_checkpoint_status(self.primary_fs_name, dir_path, snap_name, 'created')
+
+        self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec, self.secondary_fs_name)
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               peer_spec, dir_path, snap_name, 1)
+        self.verify_snapshot(dir_path.lstrip('/'), snap_name)
+        self.check_checkpoint_status(self.primary_fs_name, dir_path, snap_name, 'complete')
+
+        self._teardown_mirroring(dir_path, peer_spec)
+
+    def test_checkpoint_persisted_across_mgr_module_restart(self):
+        """Checkpoints survive mirroring mgr module restart and reach complete after sync."""
+        dir_path = '/cp_mgr_restart'
+        snap_name = 'snap0'
+        peer_spec = "client.mirror_remote@ceph"
+
+        self._setup_checkpoint_dir(dir_path, snap_name)
+        res = self.checkpoint_list(self.primary_fs_name, dir_path)
+        self.assertEqual(len(res['checkpoints']), 1)
+
+        self.restart_mirroring_module()
+
+        res = self.checkpoint_list(self.primary_fs_name, dir_path)
+        self.assertEqual(len(res['checkpoints']), 1)
+        self.check_checkpoint_status(self.primary_fs_name, dir_path, snap_name, 'created')
+
+        self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec, self.secondary_fs_name)
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               peer_spec, dir_path, snap_name, 1)
+        self.verify_snapshot(dir_path.lstrip('/'), snap_name)
+        self.check_checkpoint_status(self.primary_fs_name, dir_path, snap_name, 'complete')
+
+        self._teardown_mirroring(dir_path, peer_spec)
+
+    def test_checkpoint_add_on_already_synced_snapshot_is_complete(self):
+        """Checkpoint added after sync should be marked complete by the daemon."""
+        dir_path = '/cp_already_synced'
+        snap_name = 'snap0'
+        peer_spec = "client.mirror_remote@ceph"
+
+        self._setup_mirrored_directory(dir_path, peer_spec=peer_spec, mount_b=True)
+        self.mount_a.run_shell(["mkdir", f"{dir_path.lstrip('/')}/.snap/{snap_name}"])
+
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               peer_spec, dir_path, snap_name, 1)
+        self.verify_snapshot(dir_path.lstrip('/'), snap_name)
+
+        self.checkpoint_add(self.primary_fs_name, dir_path, snap_name)
+        self.check_checkpoint_status(self.primary_fs_name, dir_path, snap_name, 'complete')
+
+        self._teardown_mirroring(dir_path, peer_spec)
+
+    def test_checkpoint_on_synced_snaps_complete_after_daemon_restart(self):
+        """Checkpoints added on synced snaps while daemon is down reach complete after restart."""
+        dir_path = '/cp_daemon_down'
+        snap_names = [f'snap{i}' for i in range(5)]
+        checkpoint_snaps = ['snap0', 'snap2', 'snap4']
+        peer_spec = "client.mirror_remote@ceph"
+
+        self._setup_mirrored_directory(dir_path, peer_spec=peer_spec, mount_b=True)
+
+        for snap_name in snap_names:
+            self.mount_a.run_shell(["mkdir", f"{dir_path.lstrip('/')}/.snap/{snap_name}"])
+
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               peer_spec, dir_path, snap_names[-1], len(snap_names))
+        self.verify_snapshot(dir_path.lstrip('/'), snap_names[-1])
+
+        self.stop_mirror_daemon()
+        for snap_name in checkpoint_snaps:
+            self.checkpoint_add(self.primary_fs_name, dir_path, snap_name)
+        self.check_checkpoint_statuses(
+            self.primary_fs_name, dir_path, checkpoint_snaps, 'created')
+
+        self.start_mirror_daemon()
+        self.check_checkpoint_statuses(
+            self.primary_fs_name, dir_path, checkpoint_snaps, 'complete')
+
+        self._teardown_mirroring(dir_path, peer_spec)
+
+    def test_checkpoint_add_directory_notify_perf_counter(self):
+        """Each checkpoint add must notify the mirror daemon via add_directory()."""
+        snap_count = 100
+        dir_path = '/cp_add_dir_notify'
+        dir_name = dir_path.lstrip('/')
+        peer_spec = "client.mirror_remote@ceph"
+
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec,
+                      self.secondary_fs_name)
+        add_dir_baseline = self.get_peer_perf_counters()['add_directory']
+
+        self.mount_a.run_shell(['mkdir', '-p', dir_name])
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, dir_path,
+                           check_perf_counter=False)
+
+        for i in range(snap_count):
+            self.mount_a.run_shell(['touch', f'{dir_name}/file.{i}'])
+            self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/snap{i}'])
+            self.checkpoint_add(self.primary_fs_name, dir_path, f'snap{i}')
+
+        # Expect baseline + 101 add_directory calls: one for the initial
+        # mirror add directory and one per checkpoint add (each sends an
+        # acquire notify).
+        self.wait_peer_add_directory_counter(add_dir_baseline + 1 + snap_count)
+
+        res = self.checkpoint_list(self.primary_fs_name, dir_path)
+        self.assertEqual(len(res['checkpoints']), snap_count)
+
+        self._teardown_mirroring(dir_path, peer_spec)
+
+    def test_checkpoint_failed_then_complete(self):
+        """Checkpoint is marked failed on sync error and complete after recovery."""
+        dir_path = '/cp_failed'
+        snap_name = 'snap0'
+        peer_spec = "client.mirror_remote@ceph"
+
+        self._setup_mirrored_directory(dir_path, mount_b=True)
+        dir_name = dir_path.lstrip('/')
+        self.mount_a.create_n_files(f'{dir_name}/file', 10000, sync=True)
+        for i in range(20):
+            self.mount_a.write_n_mb(os.path.join(dir_name, f'large_file.{i}'), 100)
+        self._add_checkpoint_snapshot(dir_path, snap_name)
+        self.check_checkpoint_status(self.primary_fs_name, dir_path, snap_name, 'created')
+
+        # peer_add needs write access on the remote MDS (setxattr on ceph.mirror.info).
+        # Let the daemon create the remote dir with full caps, then stop it as soon as
+        # sync starts, restrict OSD write, and start again (checkpoint_sync_failed() path).
+        self.run_ceph_cmd("fs", "snapshot", "mirror", "peer_add",
+                          self.primary_fs_name, peer_spec, self.secondary_fs_name)
+        self.stop_daemon_when_peer_snap_in_progress(self.primary_fs_name, self.primary_fs_id,
+                                                    peer_spec, dir_path, snap_name)
+        self._restrict_mirror_remote_caps()
+        self.start_mirror_daemon()
+
+        self.check_checkpoint_status(self.primary_fs_name, dir_path, snap_name, 'failed')
+        res = self.checkpoint_list(self.primary_fs_name, dir_path)
+        cp = self.find_checkpoint(res['checkpoints'], snap_name)
+        self.assertIn('error_msg', cp)
+        self.assertTrue(cp['error_msg'])
+
+        self._restore_mirror_remote_caps()
+        self.restart_mirror_daemon()
+
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               peer_spec, dir_path, snap_name, 1)
+        self.verify_snapshot(dir_path.lstrip('/'), snap_name)
+        self.check_checkpoint_status(self.primary_fs_name, dir_path, snap_name, 'complete')
+
+        res = self.checkpoint_list(self.primary_fs_name, dir_path)
+        cp = self.find_checkpoint(res['checkpoints'], snap_name)
+        self.assertNotIn('error_msg', cp)
+
+        self._teardown_mirroring(dir_path, peer_spec)
 
     def test_add_relative_directory_path(self):
         self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
@@ -2835,6 +3350,8 @@ class TestMirroring(CephFSTestCase):
             sync_dir = 'mgr_nc_sync'
             self.mount_a.run_shell(['mkdir', sync_dir])
             self.mount_a.create_n_files(f'{sync_dir}/file', 10000, sync=True)
+            for i in range(20):
+                self.mount_a.write_n_mb(os.path.join(sync_dir, f'large_file.{i}'), 100)
             self.add_directory(self.primary_fs_name, self.primary_fs_id,
                                f'/{sync_dir}')
             snap_name = 'snap0'

--- a/src/pybind/mgr/mirroring/fs/checkpoint.py
+++ b/src/pybind/mgr/mirroring/fs/checkpoint.py
@@ -1,0 +1,147 @@
+import errno
+import os
+import time
+from datetime import datetime
+
+import cephfs
+
+from .exception import MirrorException
+
+# Snapshot metadata keys for mirroring checkpoints (must match Checkpoint.h).
+CHECKPOINT_STATUS_KEY = 'cephfs.mirror.checkpoint.status'
+CHECKPOINT_CREATED_AT_KEY = 'cephfs.mirror.checkpoint.created_at'
+CHECKPOINT_UPDATED_AT_KEY = 'cephfs.mirror.checkpoint.updated_at'
+CHECKPOINT_ERROR_MSG_KEY = 'cephfs.mirror.checkpoint.error_msg'
+CHECKPOINT_METADATA_KEYS = (
+    CHECKPOINT_STATUS_KEY,
+    CHECKPOINT_CREATED_AT_KEY,
+    CHECKPOINT_UPDATED_AT_KEY,
+    CHECKPOINT_ERROR_MSG_KEY,
+)
+CHECKPOINT_STATUS_CREATED = 0
+CHECKPOINT_STATUS_COMPLETE = 1
+CHECKPOINT_STATUS_FAILED = 2
+CHECKPOINT_STATUS_NAMES = {
+    CHECKPOINT_STATUS_CREATED: 'created',
+    CHECKPOINT_STATUS_COMPLETE: 'complete',
+    CHECKPOINT_STATUS_FAILED: 'failed',
+}
+
+
+def get_checkpoint_epoch():
+    """Get current time as UNIX epoch timestamp (9 decimal places, matches C++ %.9f)."""
+    return f'{time.time():.9f}'
+
+
+def format_epoch_timestamp(epoch_str):
+    """Format UNIX epoch timestamp for display in ISO format with timezone."""
+    try:
+        epoch = float(epoch_str)
+        dt = datetime.fromtimestamp(epoch).astimezone()
+        return dt.strftime('%Y-%m-%dT%H:%M:%S.%f%z')
+    except (ValueError, OSError):
+        return epoch_str
+
+
+def snap_path(dir_path, snap_dir, snap_name):
+    return os.path.join(dir_path, snap_dir, snap_name)
+
+
+def checkpoint_status_to_string(status_val):
+    try:
+        return CHECKPOINT_STATUS_NAMES[int(status_val)]
+    except (ValueError, KeyError):
+        return 'unknown'
+
+
+def checkpoint_from_snap(snap_id, snap_name, metadata):
+    created_at = metadata.get(CHECKPOINT_CREATED_AT_KEY, '')
+    updated_at = metadata.get(CHECKPOINT_UPDATED_AT_KEY, '')
+
+    cp = {
+        'snap_id': snap_id,
+        'snap_name': snap_name,
+        'status': checkpoint_status_to_string(
+            metadata.get(CHECKPOINT_STATUS_KEY, CHECKPOINT_STATUS_CREATED)),
+        'created_at': format_epoch_timestamp(created_at) if created_at else '',
+        'updated_at': format_epoch_timestamp(updated_at) if updated_at else '',
+    }
+    if CHECKPOINT_ERROR_MSG_KEY in metadata:
+        cp['error_msg'] = metadata[CHECKPOINT_ERROR_MSG_KEY]
+    return cp
+
+
+def is_checkpointed(metadata):
+    return CHECKPOINT_STATUS_KEY in metadata
+
+
+class Checkpoint:
+    def __init__(self, get_snapdir):
+        self.get_snapdir = get_snapdir
+
+    def list_directory_snapshots(self, fsh, dir_path):
+        snap_dir = self.get_snapdir()
+        snap_names = []
+        try:
+            with fsh.opendir(os.path.join(dir_path, snap_dir)) as d_handle:
+                ent = fsh.readdir(d_handle)
+                while ent:
+                    name = ent.d_name.decode('utf-8')
+                    if name not in ('.', '..') and not name.startswith('_'):
+                        snap_names.append(name)
+                    ent = fsh.readdir(d_handle)
+        except cephfs.Error as e:
+            if e.errno == errno.ENOENT:
+                return []
+            raise MirrorException(-e.errno, f'failed to list snapshots: {e}')
+        return snap_names
+
+    def snap_info(self, fsh, dir_path, snap_name):
+        path = snap_path(dir_path, self.get_snapdir(), snap_name)
+        try:
+            return fsh.snap_info(path)
+        except cephfs.Error as e:
+            raise MirrorException(-e.errno,
+                                  f"snapshot '{snap_name}' not found under {dir_path}")
+
+    def get_latest_snap(self, fsh, dir_path):
+        latest_id = 0
+        latest_name = None
+        latest_info = None
+
+        for snap_name in self.list_directory_snapshots(fsh, dir_path):
+            info = self.snap_info(fsh, dir_path, snap_name)
+            if info['id'] > latest_id:
+                latest_id = info['id']
+                latest_name = snap_name
+                latest_info = info
+
+        if latest_name is None:
+            raise MirrorException(-errno.ENOENT, f'no snapshots found under {dir_path}')
+        return latest_name, latest_info
+
+    def write_metadata(self, fsh, dir_path, snap_name, snap_info):
+        if is_checkpointed(snap_info.get('metadata', {})):
+            raise MirrorException(-errno.EEXIST, 'checkpoint already exists for snapshot')
+
+        path = snap_path(dir_path, self.get_snapdir(), snap_name)
+        now = get_checkpoint_epoch()
+        to_write = {
+            CHECKPOINT_STATUS_KEY: str(CHECKPOINT_STATUS_CREATED),
+            CHECKPOINT_CREATED_AT_KEY: now,
+            CHECKPOINT_UPDATED_AT_KEY: now,
+        }
+
+        op = cephfs.CEPH_SNAP_MD_OP_CREATE | cephfs.CEPH_SNAP_MD_OP_EXCL
+        for key, val in to_write.items():
+            fsh.do_snap_md_op(path, key, val, op)
+
+    def remove_metadata(self, fsh, dir_path, snap_name, snap_info):
+        metadata = snap_info.get('metadata', {})
+        if not is_checkpointed(metadata):
+            raise MirrorException(-errno.ENOENT, 'checkpoint not found for snapshot')
+
+        path = snap_path(dir_path, self.get_snapdir(), snap_name)
+        for key in CHECKPOINT_METADATA_KEYS:
+            if key in metadata:
+                fsh.do_snap_md_op(path, key, '', cephfs.CEPH_SNAP_MD_OP_REMOVE)

--- a/src/pybind/mgr/mirroring/fs/dir_map/policy.py
+++ b/src/pybind/mgr/mirroring/fs/dir_map/policy.py
@@ -102,7 +102,8 @@ class Policy:
             if dir_state:
                 return {'instance_id': dir_state.instance_id,
                         'mapped_time': dir_state.mapped_time,
-                        'purging': dir_state.purging}
+                        'purging': dir_state.purging,
+                        'state': dir_state.state}
             return None
 
     def get_tracked_instance_id(self, dir_path):

--- a/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
+++ b/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
@@ -31,6 +31,11 @@ from .dir_map.load import load_dir_map, load_instances
 from .dir_map.update import UpdateDirMapRequest, UpdateInstanceRequest
 from .dir_map.policy import Policy
 from .dir_map.state_transition import ActionType
+from .checkpoint import (
+    Checkpoint,
+    checkpoint_from_snap,
+    is_checkpointed,
+)
 
 log = logging.getLogger(__name__)
 
@@ -304,6 +309,7 @@ class FSSnapshotMirror:
         self.lock = threading.Lock()
         self.refresh_pool_policy()
         self.local_fs = CephfsClient(mgr)
+        self.checkpoint = Checkpoint(self._client_snapdir)
 
     def notify(self, notify_type: NotifyType):
         log.debug(f'got notify type {notify_type}')
@@ -992,3 +998,142 @@ class FSSnapshotMirror:
                     return 0, json.dumps(daemons), ''
         except MirrorException as me:
             return me.args[0], '', me.args[1]
+
+    def _validate_checkpoint_dir(self, fs_name, dir_path):
+        """Validate filesystem and mirrored directory; return normalized dir path."""
+        if not self.filesystem_exist(fs_name):
+            raise MirrorException(-errno.ENOENT, f'filesystem {fs_name} does not exist')
+
+        fspolicy = self.pool_policy.get(fs_name, None)
+        if not fspolicy:
+            raise MirrorException(-errno.EINVAL, f'filesystem {fs_name} is not mirrored')
+
+        dir_path = norm_path(dir_path)
+        if not dir_path:
+            raise MirrorException(-errno.EINVAL, 'directory path is required')
+
+        lookup_info = fspolicy.policy.lookup(dir_path)
+        if not lookup_info:
+            raise MirrorException(-errno.ENOENT, f'directory {dir_path} is not tracked')
+
+        if lookup_info['purging']:
+            raise MirrorException(-errno.EINVAL, f'directory {dir_path} is under removal')
+
+        return dir_path
+
+    def _client_snapdir(self):
+        return self.mgr.get_foreign_ceph_option('client', 'client_snapdir')
+
+    def checkpoint_add(self, fs_name, dir_path, snap_name):
+        """Add a checkpoint for a snapshot via snapshot metadata on the primary filesystem."""
+        try:
+            with self.lock:
+                dir_path = self._validate_checkpoint_dir(fs_name, dir_path)
+
+            with open_filesystem(self.local_fs, fs_name) as fsh:
+                info = self.checkpoint.snap_info(fsh, dir_path, snap_name)
+                self.checkpoint.write_metadata(fsh, dir_path, snap_name, info)
+
+            result = {
+                'status': 'success',
+                'message': f'checkpoint added for snapshot {snap_name}',
+                'dir_root': dir_path,
+                'snap_id': info['id'],
+                'snap_name': snap_name,
+                'checkpoint_status': 'created',
+            }
+            return 0, json.dumps(result), ''
+        except MirrorException as me:
+            return me.args[0], '', me.args[1]
+        except cephfs.Error as e:
+            return -e.errno, '', f'failed to add checkpoint: {e}'
+        except Exception as e:
+            log.error(f'failed to add checkpoint: {e}')
+            return -errno.EINVAL, '', f'failed to add checkpoint: {str(e)}'
+
+    def checkpoint_remove(self, fs_name, dir_path, snap_name):
+        """Remove a checkpoint from a snapshot via snapshot metadata on the primary filesystem."""
+        try:
+            with self.lock:
+                dir_path = self._validate_checkpoint_dir(fs_name, dir_path)
+
+            with open_filesystem(self.local_fs, fs_name) as fsh:
+                info = self.checkpoint.snap_info(fsh, dir_path, snap_name)
+                self.checkpoint.remove_metadata(fsh, dir_path, snap_name, info)
+
+            result = {
+                'status': 'success',
+                'message': f'checkpoint removed for snapshot {snap_name}',
+                'dir_root': dir_path,
+                'snap_name': snap_name,
+            }
+            return 0, json.dumps(result), ''
+        except MirrorException as me:
+            return me.args[0], '', me.args[1]
+        except cephfs.Error as e:
+            return -e.errno, '', f'failed to remove checkpoint: {e}'
+        except Exception as e:
+            log.error(f'failed to remove checkpoint: {e}')
+            return -errno.EINVAL, '', f'failed to remove checkpoint: {str(e)}'
+
+    def checkpoint_ls(self, fs_name, dir_path, format='json'):
+        """List all checkpoints for a directory from snapshot metadata on the primary filesystem."""
+        try:
+            with self.lock:
+                dir_path = self._validate_checkpoint_dir(fs_name, dir_path)
+
+            checkpoints = []
+            with open_filesystem(self.local_fs, fs_name) as fsh:
+                for snap_name in self.checkpoint.list_directory_snapshots(fsh, dir_path):
+                    try:
+                        info = self.checkpoint.snap_info(fsh, dir_path, snap_name)
+                    except MirrorException as me:
+                        log.warning(
+                            f'failed to get snapshot info for {snap_name!r} '
+                            f'under {dir_path}: {me.args[1]}')
+                        continue
+                    md = info.get('metadata', {})
+                    if is_checkpointed(md):
+                        checkpoints.append(
+                            checkpoint_from_snap(info['id'], snap_name, md))
+
+            checkpoints.sort(key=lambda cp: cp['snap_id'])
+            result = {'dir_root': dir_path, 'checkpoints': checkpoints}
+
+            if format == 'json-pretty':
+                return 0, json.dumps(result, indent=2), ''
+            return 0, json.dumps(result), ''
+        except MirrorException as me:
+            return me.args[0], '', me.args[1]
+        except cephfs.Error as e:
+            return -e.errno, '', f'failed to list checkpoints: {e}'
+        except Exception as e:
+            log.error(f'failed to list checkpoints: {e}')
+            return -errno.EINVAL, '', f'failed to list checkpoints: {str(e)}'
+
+    def checkpoint_now(self, fs_name, dir_path):
+        """Create a checkpoint on the latest snapshot via snapshot metadata."""
+        try:
+            with self.lock:
+                dir_path = self._validate_checkpoint_dir(fs_name, dir_path)
+
+            with open_filesystem(self.local_fs, fs_name) as fsh:
+                snap_name, info = self.checkpoint.get_latest_snap(fsh, dir_path)
+                self.checkpoint.write_metadata(fsh, dir_path, snap_name, info)
+
+            result = {
+                'status': 'success',
+                'message': 'checkpoint created on latest snapshot',
+                'dir_root': dir_path,
+                'snap_id': info['id'],
+                'snap_name': snap_name,
+                'checkpoint_status': 'created',
+            }
+            return 0, json.dumps(result), ''
+        except MirrorException as me:
+            return me.args[0], '', me.args[1]
+        except cephfs.Error as e:
+            return -e.errno, '', f'failed to create checkpoint: {e}'
+        except Exception as e:
+            log.error(f'failed to create checkpoint: {e}')
+            return -errno.EINVAL, '', f'failed to create checkpoint: {str(e)}'

--- a/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
+++ b/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
@@ -30,7 +30,7 @@ from .dir_map.create import create_mirror_object
 from .dir_map.load import load_dir_map, load_instances
 from .dir_map.update import UpdateDirMapRequest, UpdateInstanceRequest
 from .dir_map.policy import Policy
-from .dir_map.state_transition import ActionType
+from .dir_map.state_transition import ActionType, State
 from .checkpoint import (
     Checkpoint,
     checkpoint_from_snap,
@@ -190,6 +190,17 @@ class FSPolicy:
                     log.debug(f'handle_peer_ack: policy shutting down')
                     return
                 self.continue_action([dir_path], [], r)
+            finally:
+                self.op_tracker.finish_async_op()
+
+    def handle_checkpoint_acquire_ack(self, dir_path, r):
+        """Ack for checkpoint refresh acquire; does not advance the policy state machine."""
+        log.debug(f'handle_checkpoint_acquire_ack: {dir_path} r={r}')
+        with self.lock:
+            try:
+                if self.stopping.is_set():
+                    log.debug('handle_checkpoint_acquire_ack: policy shutting down')
+                    return
             finally:
                 self.op_tracker.finish_async_op()
 
@@ -1024,6 +1035,40 @@ class FSSnapshotMirror:
     def _client_snapdir(self):
         return self.mgr.get_foreign_ceph_option('client', 'client_snapdir')
 
+    def _send_acquire_notification(self, fs_name, dir_path):
+        """Send acquire notification directly to daemon for a directory."""
+        try:
+            with self.lock:
+                fspolicy = self.pool_policy.get(fs_name, None)
+                if not fspolicy:
+                    log.warning(f'filesystem {fs_name} is not mirrored')
+                    return
+
+                with fspolicy.lock:
+                    lookup_info = fspolicy.policy.lookup(dir_path)
+                    if not lookup_info:
+                        log.warning(f'directory {dir_path} not found in policy map')
+                        return
+
+                    if lookup_info.get('state') != State.ASSOCIATED:
+                        log.debug(f'directory {dir_path} is not associated yet '
+                                  f'(state={lookup_info.get("state")}), skipping acquire notification')
+                        return
+
+                    instance_id = lookup_info['instance_id']
+                    if not instance_id:
+                        log.warning(f'directory {dir_path} not mapped to any instance yet')
+                        return
+
+                    acquire_msg = json.dumps({'dir_path': dir_path, 'mode': 'acquire'})
+
+                    log.debug(f'sending acquire notification for {dir_path} to instance {instance_id}')
+                    fspolicy.op_tracker.start_async_op()
+                    fspolicy.notifier.notify(dir_path, (instance_id, acquire_msg),
+                                               fspolicy.handle_checkpoint_acquire_ack)
+        except Exception as e:
+            log.error(f'failed to send acquire notification for {dir_path}: {e}')
+
     def checkpoint_add(self, fs_name, dir_path, snap_name):
         """Add a checkpoint for a snapshot via snapshot metadata on the primary filesystem."""
         try:
@@ -1033,6 +1078,9 @@ class FSSnapshotMirror:
             with open_filesystem(self.local_fs, fs_name) as fsh:
                 info = self.checkpoint.snap_info(fsh, dir_path, snap_name)
                 self.checkpoint.write_metadata(fsh, dir_path, snap_name, info)
+
+            # Send acquire notification to trigger checkpoint state initialization
+            self._send_acquire_notification(fs_name, dir_path)
 
             result = {
                 'status': 'success',
@@ -1120,6 +1168,9 @@ class FSSnapshotMirror:
             with open_filesystem(self.local_fs, fs_name) as fsh:
                 snap_name, info = self.checkpoint.get_latest_snap(fsh, dir_path)
                 self.checkpoint.write_metadata(fsh, dir_path, snap_name, info)
+
+            # Send acquire notification to trigger checkpoint state initialization
+            self._send_acquire_notification(fs_name, dir_path)
 
             result = {
                 'status': 'success',

--- a/src/pybind/mgr/mirroring/module.py
+++ b/src/pybind/mgr/mirroring/module.py
@@ -141,3 +141,34 @@ class Module(MgrModule):
         """Get snapshot mirror metrics for a filesystem (optional mirrored directory and peer)"""
         return self.fs_snapshot_mirror.metrics_status(fs_name, mirrored_dir_path,
                                                       peer_uuid)
+
+    @MirroringCLICommand.Write('fs snapshot mirror checkpoint add')
+    def snapshot_mirror_checkpoint_add(self,
+                                       fs_name: str,
+                                       path: str,
+                                       snap_name: str):
+        """Add a checkpoint for a snapshot"""
+        return self.fs_snapshot_mirror.checkpoint_add(fs_name, path, snap_name)
+
+    @MirroringCLICommand.Write('fs snapshot mirror checkpoint remove')
+    def snapshot_mirror_checkpoint_remove(self,
+                                          fs_name: str,
+                                          path: str,
+                                          snap_name: str):
+        """Remove a checkpoint from a snapshot"""
+        return self.fs_snapshot_mirror.checkpoint_remove(fs_name, path, snap_name)
+
+    @MirroringCLICommand.Read('fs snapshot mirror checkpoint ls')
+    def snapshot_mirror_checkpoint_ls(self,
+                                       fs_name: str,
+                                       path: str,
+                                       format: str = 'json'):
+        """List all checkpoints for a directory"""
+        return self.fs_snapshot_mirror.checkpoint_ls(fs_name, path, format)
+
+    @MirroringCLICommand.Write('fs snapshot mirror checkpoint now')
+    def snapshot_mirror_checkpoint_now(self,
+                                       fs_name: str,
+                                       path: str):
+        """Create a checkpoint on the latest snapshot"""
+        return self.fs_snapshot_mirror.checkpoint_now(fs_name, path)

--- a/src/tools/cephfs_mirror/CMakeLists.txt
+++ b/src/tools/cephfs_mirror/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(cephfs_mirror_internal
+  Checkpoint.cc
   ClusterWatcher.cc
   Mirror.cc
   FSMirror.cc

--- a/src/tools/cephfs_mirror/Checkpoint.cc
+++ b/src/tools/cephfs_mirror/Checkpoint.cc
@@ -1,0 +1,170 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#include "Checkpoint.h"
+#include "Utils.h"
+
+#include "common/strtol.h"
+
+#include <cstdio>
+#include <vector>
+
+namespace cephfs {
+namespace mirror {
+
+namespace {
+
+const std::vector<std::string> CHECKPOINT_METADATA_KEY_LIST = {
+  CHECKPOINT_STATUS_KEY,
+  CHECKPOINT_CREATED_AT_KEY,
+  CHECKPOINT_UPDATED_AT_KEY,
+  CHECKPOINT_ERROR_MSG_KEY,
+};
+
+std::map<std::string, std::string> decode_snap_metadata(snap_metadata *md,
+                                                        size_t nr_snap_metadata) {
+  std::map<std::string, std::string> metadata;
+  for (size_t i = 0; i < nr_snap_metadata; ++i) {
+    metadata.emplace(md[i].key, md[i].value);
+  }
+  return metadata;
+}
+
+} // anonymous namespace
+
+std::string utime_to_epoch_string(const utime_t &t) {
+  double epoch = (double)t.sec() + (double)t.nsec() / 1000000000.0;
+  char buf[32];
+  snprintf(buf, sizeof(buf), "%.9f", epoch);
+  return std::string(buf);
+}
+
+bool utime_from_epoch_string(const std::string &s, utime_t *t) {
+  std::string err;
+  double epoch = strict_strtod(s, &err);
+  if (!err.empty()) {
+    return false;
+  }
+  t->set_from_double(epoch);
+  return true;
+}
+
+CheckpointInfo::CheckpointInfo()
+  : snap_id(0),
+    status(CheckpointStatus::CREATED) {
+}
+
+CheckpointInfo::CheckpointInfo(uint64_t snap_id_, const std::string &snap_name_)
+  : snap_id(snap_id_),
+    snap_name(snap_name_),
+    status(CheckpointStatus::CREATED) {
+}
+
+std::map<std::string, std::string> CheckpointInfo::to_metadata() const {
+  std::map<std::string, std::string> metadata;
+  metadata[CHECKPOINT_STATUS_KEY] = std::to_string(static_cast<uint8_t>(status));
+  metadata[CHECKPOINT_CREATED_AT_KEY] = utime_to_epoch_string(created_at);
+  metadata[CHECKPOINT_UPDATED_AT_KEY] = utime_to_epoch_string(updated_at);
+  if (!error_msg.empty()) {
+    metadata[CHECKPOINT_ERROR_MSG_KEY] = error_msg;
+  }
+  return metadata;
+}
+
+CheckpointInfo CheckpointInfo::from_metadata(uint64_t snap_id, const std::string &snap_name,
+                                              const std::map<std::string, std::string> &metadata) {
+  CheckpointInfo info(snap_id, snap_name);
+
+  auto it = metadata.find(CHECKPOINT_STATUS_KEY);
+  if (it != metadata.end()) {
+    info.status = static_cast<CheckpointStatus>(std::stoul(it->second));
+  }
+
+  it = metadata.find(CHECKPOINT_CREATED_AT_KEY);
+  if (it != metadata.end()) {
+    utime_from_epoch_string(it->second, &info.created_at);
+  }
+
+  it = metadata.find(CHECKPOINT_UPDATED_AT_KEY);
+  if (it != metadata.end()) {
+    utime_from_epoch_string(it->second, &info.updated_at);
+  }
+
+  it = metadata.find(CHECKPOINT_ERROR_MSG_KEY);
+  if (it != metadata.end()) {
+    info.error_msg = it->second;
+  }
+
+  return info;
+}
+
+int read_snap_metadata(MountRef mnt, const std::string &snap_path,
+                       std::map<std::string, std::string> *metadata) {
+  snap_info info;
+  int r = ceph_get_snap_info(mnt, snap_path.c_str(), &info);
+  if (r < 0) {
+    return r;
+  }
+
+  metadata->clear();
+  if (info.nr_snap_metadata) {
+    *metadata = decode_snap_metadata(info.snap_metadata, info.nr_snap_metadata);
+    ceph_free_snap_info_buffer(&info);
+  }
+  return 0;
+}
+
+CheckpointInfo read_checkpoint_metadata(uint64_t snap_id,
+                                        const std::string &snap_name,
+                                        const std::map<std::string, std::string> &snap_metadata) {
+  return CheckpointInfo::from_metadata(snap_id, snap_name, snap_metadata);
+}
+
+int write_checkpoint_metadata(CephContext *cct, MountRef mnt,
+                               const std::string &dir_root,
+                               const std::string &snap_name,
+                               const std::map<std::string, std::string> &snap_metadata,
+                               const CheckpointInfo &info) {
+  auto snap_path = snapshot_path(cct, dir_root, snap_name);
+  auto checkpoint_metadata = info.to_metadata();
+
+  // Write/update checkpoint metadata keys
+  for (const auto &[key, val] : checkpoint_metadata) {
+    // created_at is set by the mgr when the checkpoint is created; mirror
+    // daemon updates must not rewrite it.
+    if (key == CHECKPOINT_CREATED_AT_KEY && snap_metadata.count(key)) {
+      continue;
+    }
+
+    auto it = snap_metadata.find(key);
+    if (it != snap_metadata.end() && it->second == val) {
+      continue;
+    }
+
+    // For updates: use CREATE (allows both create and update)
+    // For new creates: use CREATE | EXCL (create only, reject update)
+    unsigned int op_flag = it != snap_metadata.end() ?
+      CEPH_SNAP_MD_OP_CREATE : (CEPH_SNAP_MD_OP_CREATE | CEPH_SNAP_MD_OP_EXCL);
+    int r = ceph_do_snap_md_op(mnt, snap_path.c_str(), key.c_str(), val.c_str(),
+                               op_flag);
+    if (r < 0) {
+      return r;
+    }
+  }
+
+  // Remove checkpoint metadata keys that are no longer present
+  for (const auto &key : CHECKPOINT_METADATA_KEY_LIST) {
+    if (snap_metadata.count(key) && !checkpoint_metadata.count(key)) {
+      int r = ceph_do_snap_md_op(mnt, snap_path.c_str(), key.c_str(), "",
+                                 CEPH_SNAP_MD_OP_REMOVE);
+      if (r < 0) {
+        return r;
+      }
+    }
+  }
+
+  return 0;
+}
+
+} // namespace mirror
+} // namespace cephfs

--- a/src/tools/cephfs_mirror/Checkpoint.h
+++ b/src/tools/cephfs_mirror/Checkpoint.h
@@ -1,0 +1,93 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#ifndef CEPHFS_MIRROR_CHECKPOINT_H
+#define CEPHFS_MIRROR_CHECKPOINT_H
+
+#include <string>
+#include <map>
+
+#include "include/utime.h"
+#include "Types.h"
+
+namespace cephfs {
+namespace mirror {
+
+// Checkpoint status enumeration
+enum class CheckpointStatus : uint8_t {
+  CREATED = 0,   // Checkpoint created but not yet synced
+  COMPLETE = 1,  // Checkpoint successfully synced to remote
+  FAILED = 2     // Checkpoint sync failed
+};
+
+// Convert checkpoint status to string
+inline std::string checkpoint_status_to_string(CheckpointStatus status) {
+  switch (status) {
+    case CheckpointStatus::CREATED:
+      return "created";
+    case CheckpointStatus::COMPLETE:
+      return "complete";
+    case CheckpointStatus::FAILED:
+      return "failed";
+    default:
+      return "unknown";
+  }
+}
+
+// Checkpoint metadata keys stored in snapshot metadata
+inline static const std::string CHECKPOINT_STATUS_KEY = "cephfs.mirror.checkpoint.status";
+inline static const std::string CHECKPOINT_CREATED_AT_KEY = "cephfs.mirror.checkpoint.created_at";
+inline static const std::string CHECKPOINT_UPDATED_AT_KEY = "cephfs.mirror.checkpoint.updated_at";
+inline static const std::string CHECKPOINT_ERROR_MSG_KEY = "cephfs.mirror.checkpoint.error_msg";
+
+// Snapshot metadata stores created_at/updated_at as UNIX epoch strings with
+// 9 decimal places (Python get_checkpoint_epoch() or utime_to_epoch_string()).
+std::string utime_to_epoch_string(const utime_t &t);
+bool utime_from_epoch_string(const std::string &s, utime_t *t);
+
+// Checkpoint information structure
+struct CheckpointInfo {
+  uint64_t snap_id;              // Snapshot ID (unique identifier)
+  std::string snap_name;         // Snapshot name
+  CheckpointStatus status;       // Current status of the checkpoint
+  utime_t created_at;            // When the checkpoint was created (epoch in metadata)
+  utime_t updated_at;            // Last status update time (epoch in metadata)
+  std::string error_msg;         // Error message if status is FAILED
+
+  CheckpointInfo();
+  CheckpointInfo(uint64_t snap_id_, const std::string &snap_name_);
+
+  // Convert to/from snapshot metadata map
+  std::map<std::string, std::string> to_metadata() const;
+  static CheckpointInfo from_metadata(uint64_t snap_id, const std::string &snap_name,
+                                       const std::map<std::string, std::string> &metadata);
+};
+
+
+// Helper functions for checkpoint metadata operations
+
+// Read snapshot metadata
+int read_snap_metadata(MountRef mnt, const std::string &snap_path,
+                       std::map<std::string, std::string> *metadata);
+
+// Read checkpoint metadata from a snapshot
+CheckpointInfo read_checkpoint_metadata(uint64_t snap_id,
+                                        const std::string &snap_name,
+                                        const std::map<std::string, std::string> &snap_metadata);
+
+// Write checkpoint metadata to a snapshot
+int write_checkpoint_metadata(CephContext *cct, MountRef mnt,
+                              const std::string &dir_root,
+                              const std::string &snap_name,
+                              const std::map<std::string, std::string> &snap_metadata,
+                              const CheckpointInfo &info);
+
+// Check if checkpoint key exists in snapshot metadata
+inline bool has_checkpoint(const std::map<std::string, std::string> &snap_metadata) {
+  return snap_metadata.find(CHECKPOINT_STATUS_KEY) != snap_metadata.end();
+}
+
+} // namespace mirror
+} // namespace cephfs
+
+#endif // CEPHFS_MIRROR_CHECKPOINT_H

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -1373,6 +1373,105 @@ int PeerReplayer::build_snap_map(const std::string &dir_root,
   return rv;
 }
 
+void PeerReplayer::checkpoint_sync_complete(const std::string &dir_root,
+                                            uint64_t synced_snap_id,
+                                            const std::string &snap_name) {
+  dout(10) << ": dir_root=" << dir_root << " synced_snap_id=" << synced_snap_id
+           << " snap_name=" << snap_name << dendl;
+
+  // Read snapshot metadata
+  auto snap_path = snapshot_path(m_cct, dir_root, snap_name);
+  std::map<std::string, std::string> snap_metadata;
+  int r = read_snap_metadata(m_local_mount, snap_path, &snap_metadata);
+  if (r < 0) {
+    derr << ": failed to read snap metadata for snap_name=" << snap_name
+         << " dir_root=" << dir_root << ": " << cpp_strerror(r) << dendl;
+    return;
+  }
+
+  // Check if this snapshot has a checkpoint
+  if (!has_checkpoint(snap_metadata)) {
+    dout(10) << ": no checkpoint for snap_id=" << synced_snap_id << dendl;
+    return;
+  }
+
+  // Read checkpoint info
+  CheckpointInfo info = read_checkpoint_metadata(synced_snap_id, snap_name, snap_metadata);
+
+  // Skip if already complete
+  if (info.status == CheckpointStatus::COMPLETE) {
+    dout(10) << ": checkpoint already complete for snap_id=" << synced_snap_id << dendl;
+    return;
+  }
+
+  // Update status to COMPLETE
+  info.status = CheckpointStatus::COMPLETE;
+  info.updated_at = ceph_clock_now();
+  info.error_msg.clear();
+
+  r = write_checkpoint_metadata(m_cct, m_local_mount, dir_root, snap_name, snap_metadata, info);
+  if (r < 0) {
+    derr << ": failed to mark checkpoint completed for snap_id=" << synced_snap_id
+         << " snap_name=" << snap_name << " dir_root=" << dir_root
+         << ": " << cpp_strerror(r) << dendl;
+    return;
+  }
+
+  dout(10) << ": marked checkpoint completed for snap_id=" << synced_snap_id
+           << " snap_name=" << snap_name << dendl;
+}
+
+void PeerReplayer::checkpoint_sync_failed(const std::string &dir_root,
+                                          uint64_t snap_id,
+                                          const std::string &snap_name,
+                                          int err) {
+  dout(10) << ": dir_root=" << dir_root << " snap_id=" << snap_id
+           << " snap_name=" << snap_name << " err=" << err
+           << " (" << cpp_strerror(err) << ")" << dendl;
+
+  // Read snapshot metadata
+  auto snap_path = snapshot_path(m_cct, dir_root, snap_name);
+  std::map<std::string, std::string> snap_metadata;
+  int r = read_snap_metadata(m_local_mount, snap_path, &snap_metadata);
+  if (r < 0) {
+    derr << ": failed to read snap metadata for snap_name=" << snap_name
+         << " dir_root=" << dir_root << ": " << cpp_strerror(r) << dendl;
+    return;
+  }
+
+  // Check if this snapshot has a checkpoint
+  if (!has_checkpoint(snap_metadata)) {
+    dout(10) << ": no checkpoint for snap_id=" << snap_id << dendl;
+    return;
+  }
+
+  // Read checkpoint info
+  CheckpointInfo info = read_checkpoint_metadata(snap_id, snap_name, snap_metadata);
+
+  // Only update if it's in CREATED or FAILED status (to update error message)
+  if (info.status != CheckpointStatus::CREATED && info.status != CheckpointStatus::FAILED) {
+    dout(10) << ": checkpoint not in CREATED or FAILED status, current status="
+             << checkpoint_status_to_string(info.status) << dendl;
+    return;
+  }
+
+  // Update status to FAILED with sync error message
+  info.status = CheckpointStatus::FAILED;
+  info.updated_at = ceph_clock_now();
+  info.error_msg = string("snapshot synchronization failed: ") + cpp_strerror(err);
+
+  r = write_checkpoint_metadata(m_cct, m_local_mount, dir_root, snap_name, snap_metadata, info);
+  if (r < 0) {
+    derr << ": failed to mark checkpoint failed for snap_id=" << snap_id
+         << " snap_name=" << snap_name << " dir_root=" << dir_root
+         << ": " << cpp_strerror(r) << dendl;
+    return;
+  }
+
+  dout(10) << ": marked checkpoint failed for snap_id=" << snap_id
+           << " snap_name=" << snap_name << dendl;
+}
+
 int PeerReplayer::propagate_snap_deletes(const std::string &dir_root,
                                          const std::set<std::string> &snaps) {
   dout(5) << ": dir_root=" << dir_root << ", deleted snapshots=" << snaps << dendl;
@@ -3058,6 +3157,7 @@ int PeerReplayer::do_sync_snaps(const std::string &dir_root) {
     if (r < 0) {
       derr << ": failed to synchronize dir_root=" << dir_root
            << ", snapshot=" << it->second << dendl;
+      checkpoint_sync_failed(dir_root, it->first, it->second, r);
       clear_current_syncing_snap(dir_root);
       return r;
     }
@@ -3076,6 +3176,7 @@ int PeerReplayer::do_sync_snaps(const std::string &dir_root) {
 
     set_last_synced_stat(dir_root, it->first, it->second, duration);
     persist_dir_sync_stat(dir_root);
+    checkpoint_sync_complete(dir_root, it->first, it->second);
     if (--snaps_per_cycle == 0) {
       break;
     }

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -47,6 +47,7 @@ enum {
   l_cephfs_mirror_peer_replayer_last_synced_end,
   l_cephfs_mirror_peer_replayer_last_synced_duration,
   l_cephfs_mirror_peer_replayer_last_synced_bytes,
+  l_cephfs_mirror_peer_replayer_add_directory,
   l_cephfs_mirror_peer_replayer_last,
 };
 
@@ -289,6 +290,8 @@ PeerReplayer::PeerReplayer(CephContext *cct, FSMirror *fs_mirror,
 	       "last_synced_duration", "Last Synced Duration", "lsdn", prio);
   plb.add_u64_counter(l_cephfs_mirror_peer_replayer_last_synced_bytes,
 		      "last_synced_bytes", "Last Synced Bytes", "lsbt", prio);
+  plb.add_u64_counter(l_cephfs_mirror_peer_replayer_add_directory,
+		      "add_directory", "Add Directory Calls", "adir", prio);
   m_perf_counters = plb.create_perf_counters();
   m_cct->get_perfcounters_collection()->add(m_perf_counters);
 }
@@ -724,10 +727,15 @@ void PeerReplayer::shutdown() {
 
 void PeerReplayer::add_directory(string_view dir_root) {
   dout(20) << ": dir_root=" << dir_root << dendl;
+  if (m_perf_counters) {
+    m_perf_counters->inc(l_cephfs_mirror_peer_replayer_add_directory);
+  }
   auto _dir_root = std::string(dir_root);
 
   {
     std::scoped_lock locker(m_lock);
+    m_checkpoint_init_pending.insert(_dir_root);
+
     if (std::find(m_directories.begin(), m_directories.end(), _dir_root) !=
         m_directories.end()) {
       dout(10) << ": dir_root=" << _dir_root << " already in replay list" << dendl;
@@ -766,6 +774,7 @@ void PeerReplayer::remove_directory(string_view dir_root, bool purging) {
     if (it1 == m_registered.end()) {
       if (purging) {
         remove_persisted_dir_sync_stat(_dir_root);
+        m_checkpoint_init_pending.erase(_dir_root);
       }
       remove_directory_perf_counters(_dir_root);
       m_snap_sync_stats.erase(_dir_root);
@@ -1419,6 +1428,82 @@ void PeerReplayer::checkpoint_sync_complete(const std::string &dir_root,
 
   dout(10) << ": marked checkpoint completed for snap_id=" << synced_snap_id
            << " snap_name=" << snap_name << dendl;
+}
+
+void PeerReplayer::initialize_checkpoints(const std::string &dir_root) {
+  dout(10) << ": dir_root=" << dir_root << dendl;
+
+  // Build local snapshot map
+  std::map<uint64_t, std::string> local_snap_map;
+  int r = build_snap_map(dir_root, &local_snap_map, false);
+  if (r < 0) {
+    derr << ": failed to build local snap map for dir_root=" << dir_root
+         << ": " << cpp_strerror(r) << dendl;
+    return;
+  }
+  if (local_snap_map.empty()) {
+    dout(10) << ": no local snapshots for dir_root=" << dir_root << dendl;
+    return;
+  }
+
+  // Build remote snapshot map
+  std::map<uint64_t, std::string> remote_snap_map;
+  r = build_snap_map(dir_root, &remote_snap_map, true);
+  if (r < 0) {
+    derr << ": failed to build remote snap map for dir_root=" << dir_root
+         << ": " << cpp_strerror(r) << dendl;
+    return;
+  }
+  if (remote_snap_map.empty()) {
+    dout(10) << ": no remote snapshots for dir_root=" << dir_root << dendl;
+    return;
+  }
+
+  // Get the highest snap_id from remote
+  uint64_t remote_highest_snap_id = remote_snap_map.rbegin()->first;
+
+  dout(10) << ": remote_highest_snap_id=" << remote_highest_snap_id << dendl;
+
+  // Iterate through local snapshots and mark checkpoints as COMPLETE
+  // if their snap_id is <= remote_highest_snap_id
+  for (const auto &[snap_id, snap_name] : local_snap_map) {
+    // Read snapshot metadata
+    auto snap_path = snapshot_path(m_cct, dir_root, snap_name);
+    std::map<std::string, std::string> snap_metadata;
+    r = read_snap_metadata(m_local_mount, snap_path, &snap_metadata);
+    if (r < 0) {
+      derr << ": failed to read snap metadata for snap_id=" << snap_id
+           << " snap_name=" << snap_name << ": " << cpp_strerror(r) << dendl;
+      continue;
+    }
+
+    if (!has_checkpoint(snap_metadata)) {
+      continue;
+    }
+
+    CheckpointInfo info = read_checkpoint_metadata(snap_id, snap_name, snap_metadata);
+    // Update checkpoints that are in CREATED or FAILED status and have snap_id <= remote_highest_snap_id
+    if ((info.status == CheckpointStatus::CREATED || info.status == CheckpointStatus::FAILED)
+        && snap_id <= remote_highest_snap_id) {
+      dout(10) << ": marking checkpoint as COMPLETE for snap_id=" << snap_id
+               << " snap_name=" << snap_name << " (previous status: "
+               << checkpoint_status_to_string(info.status) << ")" << dendl;
+
+      info.status = CheckpointStatus::COMPLETE;
+      info.updated_at = ceph_clock_now();
+      info.error_msg.clear(); // Clear any previous error message
+
+      r = write_checkpoint_metadata(m_cct, m_local_mount, dir_root, snap_name, snap_metadata, info);
+      if (r < 0) {
+        derr << ": failed to update checkpoint status for snap_id=" << snap_id
+             << " snap_name=" << snap_name << " dir_root=" << dir_root
+             << ": " << cpp_strerror(r) << dendl;
+      } else {
+        dout(10) << ": successfully marked checkpoint as COMPLETE for snap_id=" << snap_id
+                 << " snap_name=" << snap_name << dendl;
+      }
+    }
+  }
 }
 
 void PeerReplayer::checkpoint_sync_failed(const std::string &dir_root,
@@ -3232,6 +3317,10 @@ void PeerReplayer::run_tick() {
       refresh_directory_current_sync_perf_counters(kv.first);
     }
 
+    std::vector<std::string> checkpoint_dirs(
+      m_checkpoint_init_pending.begin(), m_checkpoint_init_pending.end());
+    m_checkpoint_init_pending.clear();
+
     // persist sync stats to omap for registered directories
     std::vector<std::string> dirs;
     dirs.reserve(m_registered.size());
@@ -3241,6 +3330,9 @@ void PeerReplayer::run_tick() {
     locker.unlock();
     for (const auto &dir_root : dirs) {
       persist_dir_sync_stat(dir_root);
+    }
+    for (const auto &dir_root : checkpoint_dirs) {
+      initialize_checkpoints(dir_root);
     }
     locker.lock();
   }

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -92,18 +92,6 @@ const std::string PEER_CONFIG_KEY_PREFIX = "cephfs/mirror/peer";
 // Matches the mgr mirroring omap read batch size (dir_map/load.py MAX_RETURN).
 constexpr size_t SYNC_STAT_OMAP_LOAD_BATCH_SIZE = 256;
 
-std::string snapshot_dir_path(CephContext *cct, const std::string &path) {
-  return path + "/" + cct->_conf->client_snapdir;
-}
-
-std::string snapshot_path(const std::string &snap_dir, const std::string &snap_name) {
-  return snap_dir + "/" + snap_name;
-}
-
-std::string snapshot_path(CephContext *cct, const std::string &path, const std::string &snap_name) {
-  return path + "/" + cct->_conf->client_snapdir + "/" + snap_name;
-}
-
 std::string entry_path(const std::string &dir, const std::string &name) {
   return dir + "/" + name;
 }

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -692,6 +692,7 @@ private:
   std::vector<std::string> m_directories;
   std::map<std::string, SnapSyncStat> m_snap_sync_stats;
   std::set<std::string> m_purging_directories;
+  std::set<std::string> m_checkpoint_init_pending;
   MountRef m_local_mount;
   ServiceDaemon *m_service_daemon;
   PeerReplayerAdminSocketHook *m_asok_hook = nullptr;
@@ -767,6 +768,7 @@ private:
   int build_snap_map(const std::string &dir_root, std::map<uint64_t, std::string> *snap_map,
                      bool is_remote=false);
 
+  void initialize_checkpoints(const std::string &dir_root);
   void checkpoint_sync_complete(const std::string &dir_root, uint64_t synced_snap_id,
                                 const std::string &snap_name);
   void checkpoint_sync_failed(const std::string &dir_root, uint64_t snap_id,

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -10,6 +10,7 @@
 #include "ServiceDaemon.h"
 #include "Types.h"
 #include "json_spirit/json_spirit.h"
+#include "Checkpoint.h"
 
 #include <deque>
 #include <functional>
@@ -765,6 +766,11 @@ private:
 
   int build_snap_map(const std::string &dir_root, std::map<uint64_t, std::string> *snap_map,
                      bool is_remote=false);
+
+  void checkpoint_sync_complete(const std::string &dir_root, uint64_t synced_snap_id,
+                                const std::string &snap_name);
+  void checkpoint_sync_failed(const std::string &dir_root, uint64_t snap_id,
+                              const std::string &snap_name, int err);
 
   int propagate_snap_deletes(const std::string &dir_root, const std::set<std::string> &snaps);
   int propagate_snap_renames(const std::string &dir_root,

--- a/src/tools/cephfs_mirror/Utils.cc
+++ b/src/tools/cephfs_mirror/Utils.cc
@@ -162,5 +162,18 @@ int mount(RadosRef cluster, const Filesystem &filesystem, bool cross_check_fscid
   return 0;
 }
 
+std::string snapshot_dir_path(CephContext *cct, const std::string &dir_root) {
+  return dir_root + "/" + cct->_conf->client_snapdir;
+}
+
+std::string snapshot_path(const std::string &snap_dir, const std::string &snap_name) {
+  return snap_dir + "/" + snap_name;
+}
+
+std::string snapshot_path(CephContext *cct, const std::string &dir_root,
+                          const std::string &snap_name) {
+  return snapshot_dir_path(cct, dir_root) + "/" + snap_name;
+}
+
 } // namespace mirror
 } // namespace cephfs

--- a/src/tools/cephfs_mirror/Utils.h
+++ b/src/tools/cephfs_mirror/Utils.h
@@ -4,10 +4,17 @@
 #ifndef CEPHFS_MIRROR_UTILS_H
 #define CEPHFS_MIRROR_UTILS_H
 
+#include <string>
+
 #include "Types.h"
 
 namespace cephfs {
 namespace mirror {
+
+std::string snapshot_dir_path(CephContext *cct, const std::string &dir_root);
+std::string snapshot_path(const std::string &snap_dir, const std::string &snap_name);
+std::string snapshot_path(CephContext *cct, const std::string &dir_root,
+                          const std::string &snap_name);
 
 int connect(std::string_view client_name, std::string_view cluster_name,
             RadosRef *cluster, std::string_view mon_host={}, std::string_view cephx_key={},


### PR DESCRIPTION
Allow users to mark a particular snapshot under a directory as checkpointed. The checkpoints will transition between the states CREATED->COMPLETE/FAILED. Once the state reaches COMPLETE, all the snapshots uptil and including the checkpointed one are mirrored onto the remote site. Users can also list the checkpoints to see the current list and status of the checkpoints, remove them as and when needed and there is also an option to mark a checkpoint on the most recent snapshot. The mirror daemon will keep track of only the last 10 checkpoints which have been reached.

CLIs:
ceph fs snapshot mirror checkpoint add <vol-name> <dir-root> <snap-name>
ceph fs snapshot mirror checkpoint remove <vol-name> <dir-root> <snap-name>
ceph fs snapshot mirror checkpoint ls <vol-name> <dir-root>
ceph fs snapshot mirror checkpoint now <vol-name> <dir-root>

Depends-on: #66723

Fixes: https://tracker.ceph.com/issues/73454
Signed-off-by: Karthik U S <karthik.u.s1@ibm.com>

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
