### PR TITLE
crimson/os/seastore: adaptive cleaner thresholds from observed workload

### DIFF
--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -1,6 +1,8 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
 // vim: ts=8 sw=2 sts=2 expandtab
 
+#include <cmath>
+
 #include <fmt/chrono.h>
 #include <seastar/core/metrics.hh>
 
@@ -1135,14 +1137,19 @@ void SegmentCleaner::maybe_adjust_thresholds()
       peak_open_segments_window, segments.get_num_open());
 
   // Only recompute hard_limit every 30s.
-  using namespace std::chrono_literals;
   LOG_PREFIX(SegmentCleaner::maybe_adjust_thresholds);
   auto now = seastar::lowres_clock::now();
-  if (adaptive_last_time != seastar::lowres_clock::time_point{} &&
-      now - adaptive_last_time < 30s) {
-    return;
+  double elapsed_sec = 0.0;
+  if (adaptive_last_time != seastar::lowres_clock::time_point{}) {
+    elapsed_sec = std::chrono::duration<double>(
+        now - adaptive_last_time).count();
+    if (elapsed_sec < 30.0) {
+      return;
+    }
   }
   adaptive_last_time = now;
+  double old_hard_limit = config.available_ratio_hard_limit;
+  double old_gc_max = config.available_ratio_gc_max;
 
   // Architectural floor: named writers (journal + hot/cold gens + metadata).
   auto hot = crimson::common::get_conf<uint64_t>(
@@ -1156,34 +1163,54 @@ void SegmentCleaner::maybe_adjust_thresholds()
     return;
   }
 
-  // hard_limit = (max(peak, named) + 1) * seg / total. "+1" is the minimum
+  double segment_ratio =
+      static_cast<double>(seg_size) /
+      static_cast<double>(total_bytes);
+
+  // hard_limit = (max(peak, named) + 1) * segment_ratio. "+1" is the minimum
   // safety unit: allow one more open segment than ever observed.
   std::size_t observed_peak =
       std::max<std::size_t>(peak_open_segments_window, named_writers);
   double new_hard_limit =
-      static_cast<double>(observed_peak + 1) *
-      static_cast<double>(seg_size) /
-      static_cast<double>(total_bytes);
+      static_cast<double>(observed_peak + 1) * segment_ratio;
 
   double crash_floor =
-      static_cast<double>(named_writers) *
-      static_cast<double>(seg_size) /
-      static_cast<double>(total_bytes);
+      static_cast<double>(named_writers) * segment_ratio;
   new_hard_limit = std::max(new_hard_limit, crash_floor);
 
-  // Keep gc_max strictly greater than hard_limit.
+  // Apply lazy decay covering elapsed time (allows gc_max to gradually fall
+  // when workload eases) so peaks fade even when the background process was
+  // idle and this hook went uncalled for many cycles.
+  if (elapsed_sec > 0.0) {
+    peak_projected_used_decayed *= std::pow(0.995, elapsed_sec / 30.0);
+  }
+
+  // gc_max decays halfway each window toward (hard_limit + recent peak burst).
+  double burst_floor_ratio =
+      peak_projected_used_decayed /
+      static_cast<double>(total_bytes);
+  double target_gc_max = new_hard_limit + burst_floor_ratio;
+  double decayed_gc_max =
+      (config.available_ratio_gc_max + target_gc_max) / 2.0;
+  config.available_ratio_gc_max = std::max(decayed_gc_max, target_gc_max);
   if (config.available_ratio_gc_max <= new_hard_limit) {
-    config.available_ratio_gc_max = new_hard_limit + 0.001;
+    config.available_ratio_gc_max = new_hard_limit + segment_ratio;
   }
   config.available_ratio_hard_limit = new_hard_limit;
 
-  INFO("[ADAPTIVE_GC] peak_open={} named={} hard_limit={:.4f} "
-       "gc_max={:.4f} crash_floor={:.4f}",
-       peak_open_segments_window, named_writers,
-       config.available_ratio_hard_limit,
-       config.available_ratio_gc_max, crash_floor);
+  if (old_hard_limit != new_hard_limit || old_gc_max != config.available_ratio_gc_max) {
+    INFO("[ADAPTIVE_GC] update: hard_limit {:.4f} -> {:.4f}, gc_max {:.4f} -> {:.4f} "
+         "(peak_open={} named={} peak_proj_decayed={:.0f} crash_floor={:.4f})",
+         old_hard_limit, new_hard_limit,
+         old_gc_max, config.available_ratio_gc_max,
+         peak_open_segments_window, named_writers,
+         peak_projected_used_decayed, crash_floor);
+  } else {
+    DEBUG("[ADAPTIVE_GC] no-op: hard_limit {:.4f}, gc_max {:.4f}",
+          old_hard_limit, old_gc_max);
+  }
 
-  // Reset window: record current open count as the new baseline.
+  // Reset per-window open-segment peak.
   peak_open_segments_window = segments.get_num_open();
 }
 
@@ -1883,6 +1910,11 @@ bool SegmentCleaner::try_reserve_projected_usage(std::size_t projected_usage)
 {
   assert(background_callback->is_ready());
   stats.projected_used_bytes += projected_usage;
+  // Update decayed peak; the slow decay in maybe_adjust_thresholds() lets old
+  // peaks fade so gc_max can eventually re-discover lower floors.
+  peak_projected_used_decayed = std::max(
+      peak_projected_used_decayed,
+      static_cast<double>(stats.projected_used_bytes));
   if (should_block_io_on_clean()) {
     stats.projected_used_bytes -= projected_usage;
     return false;

--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -1176,7 +1176,8 @@ void SegmentCleaner::maybe_adjust_thresholds()
 
   double crash_floor =
       static_cast<double>(named_writers) * segment_ratio;
-  new_hard_limit = std::max(new_hard_limit, crash_floor);
+  crash_floor = std::min(crash_floor, 0.95);
+  new_hard_limit = std::min(std::max(new_hard_limit, crash_floor), 0.95);
 
   // Apply lazy decay covering elapsed time (allows gc_max to gradually fall
   // when workload eases) so peaks fade even when the background process was

--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -1128,6 +1128,65 @@ segment_id_t SegmentCleaner::allocate_segment(
   return NULL_SEG_ID;
 }
 
+void SegmentCleaner::maybe_adjust_thresholds()
+{
+  // Sample current open-segment count into the window peak each call.
+  peak_open_segments_window = std::max(
+      peak_open_segments_window, segments.get_num_open());
+
+  // Only recompute hard_limit every 30s.
+  using namespace std::chrono_literals;
+  LOG_PREFIX(SegmentCleaner::maybe_adjust_thresholds);
+  auto now = seastar::lowres_clock::now();
+  if (adaptive_last_time != seastar::lowres_clock::time_point{} &&
+      now - adaptive_last_time < 30s) {
+    return;
+  }
+  adaptive_last_time = now;
+
+  // Architectural floor: named writers (journal + hot/cold gens + metadata).
+  auto hot = crimson::common::get_conf<uint64_t>(
+      "seastore_hot_tier_generations");
+  auto cold = crimson::common::get_conf<uint64_t>(
+      "seastore_cold_tier_generations");
+  std::size_t named_writers = hot + cold + 2;
+  std::size_t seg_size = segments.get_segment_size();
+  std::size_t total_bytes = segments.get_total_bytes();
+  if (total_bytes == 0 || seg_size == 0) {
+    return;
+  }
+
+  // hard_limit = (max(peak, named) + 1) * seg / total. "+1" is the minimum
+  // safety unit: allow one more open segment than ever observed.
+  std::size_t observed_peak =
+      std::max<std::size_t>(peak_open_segments_window, named_writers);
+  double new_hard_limit =
+      static_cast<double>(observed_peak + 1) *
+      static_cast<double>(seg_size) /
+      static_cast<double>(total_bytes);
+
+  double crash_floor =
+      static_cast<double>(named_writers) *
+      static_cast<double>(seg_size) /
+      static_cast<double>(total_bytes);
+  new_hard_limit = std::max(new_hard_limit, crash_floor);
+
+  // Keep gc_max strictly greater than hard_limit.
+  if (config.available_ratio_gc_max <= new_hard_limit) {
+    config.available_ratio_gc_max = new_hard_limit + 0.001;
+  }
+  config.available_ratio_hard_limit = new_hard_limit;
+
+  INFO("[ADAPTIVE_GC] peak_open={} named={} hard_limit={:.4f} "
+       "gc_max={:.4f} crash_floor={:.4f}",
+       peak_open_segments_window, named_writers,
+       config.available_ratio_hard_limit,
+       config.available_ratio_gc_max, crash_floor);
+
+  // Reset window: record current open count as the new baseline.
+  peak_open_segments_window = segments.get_num_open();
+}
+
 void SegmentCleaner::close_segment(segment_id_t segment)
 {
   LOG_PREFIX(SegmentCleaner::close_segment);
@@ -1343,11 +1402,12 @@ SegmentCleaner::clean_space_ret SegmentCleaner::clean_space()
   }
   reclaim_state->advance(config.reclaim_bytes_per_cycle);
 
-  DEBUG("reclaiming {} {}~{}",
+  double pavail_ratio = get_projected_available_ratio();
+  DEBUG("reclaiming {} {}~{}, projected_avail_ratio={}",
         rewrite_gen_printer_t{reclaim_state->generation},
         reclaim_state->start_pos,
-        reclaim_state->end_pos);
-  double pavail_ratio = get_projected_available_ratio();
+        reclaim_state->end_pos,
+        pavail_ratio);
   sea_time_point start = seastar::lowres_system_clock::now();
 
   // Backref-tree doesn't support tree-read during tree-updates with parallel

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -1669,6 +1669,11 @@ private:
   std::size_t peak_open_segments_window = 0;
   seastar::lowres_clock::time_point adaptive_last_time;
 
+  // Peak projected_used with slow exponential decay per adjust cycle. Decay
+  // 0.5% per 30s window = half-life ~1 hour: long enough not to forget peaks
+  // mid-workload, short enough to re-discover lower floors over time.
+  double peak_projected_used_decayed = 0.0;
+
   SegmentManagerGroupRef sm_group;
   BackrefManager &backref_manager;
 

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -1245,6 +1245,9 @@ public:
 
   virtual std::size_t get_reclaim_size_per_cycle() const = 0;
 
+  // Periodic hook for adaptive threshold control. Default: no-op.
+  virtual void maybe_adjust_thresholds() {}
+
 #ifdef UNIT_TESTS_BUILT
   virtual void prefill_fragmented_devices() {}
 #endif
@@ -1458,6 +1461,8 @@ public:
            greedy_free >= ratio * picked_free;
   }
 
+  void maybe_adjust_thresholds() final;
+
   const std::set<device_id_t>& get_device_ids() const final {
     return sm_group->get_device_ids();
   }
@@ -1657,7 +1662,12 @@ private:
   store_index_t store_index;
   const bool detailed;
   const bool is_cold;
-  const config_t config;
+  // Mutated by maybe_adjust_thresholds(): hard_limit tracks observed open-segment peak.
+  config_t config;
+
+  // Adaptive state: peak open segments observed since last adjust.
+  std::size_t peak_open_segments_window = 0;
+  seastar::lowres_clock::time_point adaptive_last_time;
 
   SegmentManagerGroupRef sm_group;
   BackrefManager &backref_manager;

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -829,6 +829,13 @@ ExtentPlacementManager::BackgroundProcess::run()
         pending_user_io_wake = false;
         co_await seastar::yield();
       }
+      // Adaptive threshold hook: each cleaner has its own state and floor.
+      if (main_cleaner) {
+        main_cleaner->maybe_adjust_thresholds();
+      }
+      if (cold_cleaner) {
+        cold_cleaner->maybe_adjust_thresholds();
+      }
     } else {
       log_state("run(block)");
       assert(!blocking_background);


### PR DESCRIPTION
## Dependency

**This PR depends on #68964** (auto-tune GC segment pick under random-write).
Without #68964's autotune, the adaptive thresholds can still fire but the
GC pick formula may select high-utilization segments; the two patches work
best together.

## Summary

The cleaner's `hard_limit` (IO-block threshold) and `gc_max` (GC trigger
threshold) are hard-coded constants that don't scale with cluster geometry
or workload. On a 32 GiB OSD the default `hard_limit = 0.10` reserves ~3 GiB
of always-empty space; the cleaner's actual named-writer working set is only
~640 MiB (2%). Operating at a 10% floor means the cluster fills to ~90%
effective capacity, accumulates fewer dead bytes per segment, and pays 4–5×
WAF on GC cycles.

This patch set makes both thresholds adaptive:

**Commit 1 — adaptive `hard_limit`** (`AsyncCleaner::maybe_adjust_thresholds`)

Tracks peak open-segment count in a 30 s sliding window and derives:

```
hard_limit = max(observed_peak, named_writers) + 1
             ─────────────────────────────────────
                      total_segments
```

`named_writers` = journal + hot gens + cold gens + metadata writer — the
architectural floor below which the cleaner cannot allocate without aborting.
`+1` is the minimum safety unit. Recomputed every 30 s; the window resets
after each recompute.

**Commit 2 — adaptive `gc_max`**

Tracks `projected_used_bytes` peak with slow exponential decay (half-life
~1 hour, elapsed-time-based so it catches up correctly when idle) and drives:

```
target_gc_max = hard_limit + (peak_projected_used_decayed / total_bytes)
gc_max        = decay_toward(target_gc_max)          # half-step per window
```

This converges `gc_max` to the smallest gap the cluster needs to absorb its
observed worst-case in-flight user reservation, without forgetting recent peaks.

## Bench results (32 GiB/OSD, null_blk, 70% fill, 1280 GiB target)

| Metric | static (gc_max=0.15, hard_limit=0.10) | adaptive |
|---|---|---|
| user_written | 1,374 GiB | 1,374 GiB |
| device_written | 7,901 GiB | 4,503 GiB |
| WAF | 5.749 | 3.276 |
| duration | 33 min | 17 min |
| computed hard_limit | — | 0.0215 |

WAF drops 43% and end-to-end throughput nearly doubles.

## Test plan

- [x] qa/standalone/crimson randwrite 70% fill, 1280 GiB target — completes, WAF 3.276 vs 5.749 baseline
- [x] Both cleaners (main + cold) receive the hook via `BackgroundProcess::run()`
- [x] Build clean

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes unit test(s)
  - [x] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [ ] No tests
