### PR TITLE
rgw: add HEAD Object op metrics to perf counters and Prometheus export

### DIFF
--- a/doc/radosgw/metrics.rst
+++ b/doc/radosgw/metrics.rst
@@ -74,6 +74,12 @@ The following metrics related to S3 or Swift operations are tracked per Ceph Obj
    * - list_bucket_lat
      - Gauge
      - Total latency of list bucket operations
+   * - head_obj_ops
+     - Counter
+     - Number of successful HEAD Object operations
+   * - head_obj_lat
+     - Gauge
+     - Total latency of HEAD Object operations
 
 There are three different sections in the output of the ``counter dump`` and ``counter schema`` commands that show the op metrics and their information.
 The sections are ``rgw_op``, ``rgw_op_per_user``, and ``rgw_op_per_bucket``.
@@ -109,6 +115,12 @@ To view op metrics in the Ceph Object Gateway go to the ``rgw_op`` sections of t
                     "avgcount": 1,
                     "sum": 0.002300000,
                     "avgtime": 0.002300000
+                },
+                "head_obj_ops": 3,
+                "head_obj_lat": {
+                    "avgcount": 3,
+                    "sum": 0.006123456,
+                    "avgtime": 0.002041152
                 }
             }
         },
@@ -146,6 +158,12 @@ Op metrics can also be tracked per-user or per-bucket. These metrics are exporte
                     "avgcount": 1,
                     "sum": 0.002300000,
                     "avgtime": 0.002300000
+                },
+                "head_obj_ops": 3,
+                "head_obj_lat": {
+                    "avgcount": 3,
+                    "sum": 0.006123456,
+                    "avgtime": 0.002041152
                 }
             }
         },

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2639,6 +2639,7 @@ void RGWGetObj::execute(optional_yield y)
   if (get_type() == RGW_OP_STAT_OBJ) {
     return;
   }
+  
   if (s->info.env->exists("HTTP_X_RGW_AUTH")) {
     op_ret = 0;
     goto done_err;
@@ -2815,6 +2816,10 @@ void RGWGetObj::execute(optional_yield y)
 
   if (!get_data || ofs > end) {
     send_response_data(bl, 0, 0);
+    if (!get_data) {
+      rgw::op_counters::inc(counters, l_rgw_op_head_obj, 1);
+      rgw::op_counters::tinc(counters, l_rgw_op_head_obj_lat, s->time_elapsed());
+    }
     return;
   }
 

--- a/src/rgw/rgw_perf_counters.cc
+++ b/src/rgw/rgw_perf_counters.cc
@@ -93,6 +93,9 @@ void add_rgw_op_counters(PerfCountersBuilder *lpcb) {
 
   lpcb->add_u64_counter(l_rgw_op_list_buckets, "list_buckets_ops", "List buckets");
   lpcb->add_time_avg(l_rgw_op_list_buckets_lat, "list_buckets_lat", "List buckets latency");
+
+  lpcb->add_u64_counter(l_rgw_op_head_obj, "head_obj_ops","Head object operations");
+  lpcb->add_time_avg(l_rgw_op_head_obj_lat, "head_obj_lat","Head object latency");
 }
 
 void add_rgw_topic_counters(PerfCountersBuilder *lpcb) {

--- a/src/rgw/rgw_perf_counters.h
+++ b/src/rgw/rgw_perf_counters.h
@@ -83,7 +83,10 @@ enum {
 
   l_rgw_op_list_buckets,
   l_rgw_op_list_buckets_lat,
-
+  
+  l_rgw_op_head_obj,
+  l_rgw_op_head_obj_lat,
+  
   l_rgw_op_last
 };
 


### PR DESCRIPTION
Expose HEAD Object operation metrics in the same format as existing RGW op metrics so operators can track HEAD request volume and latency at gateway, user, and bucket scope.

Previously, HEAD Object requests were silently counted under get_obj_ops because RGWGetObj handles both GET and HEAD. The HEAD-specific early-return path (get_data == false) had no counter instrumentation.

Fixes: ISCE-3042






## Checklist
- Tracker (select at least one)
  - [ X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ X] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
