### PR TITLE
crimson/seastore: normalize device path for both rbm and segmented

### DIFF
--- a/src/crimson/os/seastore/device.cc
+++ b/src/crimson/os/seastore/device.cc
@@ -3,6 +3,8 @@
 
 #include "device.h"
 
+#include <sys/stat.h>
+
 #include <seastar/core/smp.hh>
 
 #include "segment_manager.h"
@@ -12,6 +14,37 @@
 SET_SUBSYS(seastore);
 
 namespace crimson::os::seastore {
+
+std::string normalize_device_path(const std::string& device)
+{
+  std::string device_path = device;
+  if (device_path.rfind("/dev/", 0) == 0) {
+    return device_path;
+  }
+
+  const auto last_slash = device_path.find_last_of('/');
+  const std::string basename =
+    (last_slash == std::string::npos) ?
+      device_path :
+      device_path.substr(last_slash + 1);
+
+  // Concrete OSD device entry (file or symlink), e.g. .../block or .../block.db
+  if (basename == "block") {
+    return device_path;
+  }
+  if (basename.rfind("block.", 0) == 0) {
+    // SeaStore secondary devices use a directory named block.<id> that
+    // contains the actual block file (see SeaStore::_mkfs / _mount).
+    struct ::stat st;
+    if (::stat(device_path.c_str(), &st) == 0 && S_ISDIR(st.st_mode)) {
+      device_path += "/block";
+    }
+    return device_path;
+  }
+
+  device_path += "/block";
+  return device_path;
+}
 
 std::ostream& operator<<(std::ostream& out, const device_spec_t& ds)
 {

--- a/src/crimson/os/seastore/device.h
+++ b/src/crimson/os/seastore/device.h
@@ -394,6 +394,19 @@ public:
 
 using check_create_device_ertr = Device::access_ertr;
 using check_create_device_ret = check_create_device_ertr::future<>;
+
+/**
+ * Normalize device argument for both segmented and RBM backends.
+ *
+ * Examples:
+ * - "/var/lib/ceph/osd/osd.0" -> "/var/lib/ceph/osd/osd.0/block"
+ * - "/var/lib/ceph/osd/osd.0/block" -> unchanged
+ * - "/var/lib/ceph/osd/osd.0/block.db" (file/symlink) -> unchanged
+ * - "/var/lib/ceph/osd/osd.0/block.1" (directory) -> ".../block.1/block"
+ * - "/dev/nvme0n1" -> unchanged
+ */
+std::string normalize_device_path(const std::string& device);
+
 check_create_device_ret check_create_device(
   const std::string path,
   size_t size);

--- a/src/crimson/os/seastore/random_block_manager.cc
+++ b/src/crimson/os/seastore/random_block_manager.cc
@@ -13,16 +13,17 @@ seastar::future<random_block_device::RBMDeviceRef>
 get_rb_device(
   const std::string &device, device_type_t dtype)
 {
+  std::string device_path = normalize_device_path(device);
   if (dtype == device_type_t::RANDOM_BLOCK_HDD) {
     return seastar::make_ready_future<random_block_device::RBMDeviceRef>(
       std::make_unique<
         random_block_device::RotationalDevice
-      >(device + "/block"));
+      >(std::move(device_path)));
   } else {
     return seastar::make_ready_future<random_block_device::RBMDeviceRef>(
       std::make_unique<
         random_block_device::nvme::NVMeBlockDevice
-      >(device + "/block"));
+      >(std::move(device_path)));
   }
 }
 

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -4,6 +4,8 @@
 #include "seastore.h"
 
 #include <algorithm>
+#include <cctype>
+#include <string_view>
 
 #include <boost/algorithm/string/trim.hpp>
 #include <fmt/format.h>
@@ -669,16 +671,27 @@ seastar::future<> SeaStore::prepare_meta(uuid_d new_osd_fsid)
 }
 
 std::optional<device_id_t> parse_device_id(const seastar::sstring &name) {
-  auto prefix_len = sizeof("block.") - 1;
-  if (name.starts_with("block.") && name.length() > prefix_len) {
-    int id = 0;
-    std::string id_str = name.substr(prefix_len);
-    std::istringstream iss(id_str);
-    iss >> id;
-    assert(id < std::numeric_limits<uint8_t>::max());
-    return std::make_optional<device_id_t>(id);
+  constexpr std::string_view prefix = "block.";
+  if (!name.starts_with(prefix) || name.size() <= prefix.size()) {
+    return std::nullopt;
   }
-  return std::nullopt;
+  const auto id_str = name.substr(prefix.size());
+  // Only accept block.<numeric-id>. Names like block.db / block.wal are
+  // concrete device entries, not SeaStore secondary device directories.
+  if (!std::all_of(id_str.begin(), id_str.end(),
+                   [](unsigned char c) { return std::isdigit(c); })) {
+    return std::nullopt;
+  }
+  int id = 0;
+  try {
+    id = std::stoi(std::string(id_str));
+  } catch (const std::exception&) {
+    return std::nullopt;
+  }
+  if (id < 0 || id >= std::numeric_limits<uint8_t>::max()) {
+    return std::nullopt;
+  }
+  return std::make_optional<device_id_t>(static_cast<device_id_t>(id));
 }
 
 Device::access_ertr::future<> SeaStore::_mkfs(uuid_d new_osd_fsid)

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -4,6 +4,8 @@
 #include "seastore.h"
 
 #include <algorithm>
+#include <charconv>
+#include <string_view>
 
 #include <boost/algorithm/string/trim.hpp>
 #include <fmt/format.h>
@@ -669,16 +671,25 @@ seastar::future<> SeaStore::prepare_meta(uuid_d new_osd_fsid)
 }
 
 std::optional<device_id_t> parse_device_id(const seastar::sstring &name) {
-  auto prefix_len = sizeof("block.") - 1;
-  if (name.starts_with("block.") && name.length() > prefix_len) {
-    int id = 0;
-    std::string id_str = name.substr(prefix_len);
-    std::istringstream iss(id_str);
-    iss >> id;
-    assert(id < std::numeric_limits<uint8_t>::max());
-    return std::make_optional<device_id_t>(id);
+  constexpr std::string_view prefix = "block.";
+  if (!name.starts_with(prefix) || name.size() <= prefix.size()) {
+    return std::nullopt;
   }
-  return std::nullopt;
+  // Only accept block.<numeric-id>. Names like block.db / block.wal are
+  // concrete device entries, not SeaStore secondary device directories.
+  std::string_view id_str(name.data() + prefix.size(),
+                          name.size() - prefix.size());
+  unsigned int id = 0;
+  auto [ptr, ec] = std::from_chars(id_str.data(),
+                                   id_str.data() + id_str.size(), id);
+  // Reject non-digits, parse failures, or trailing garbage (e.g. block.1a).
+  if (ec != std::errc() || ptr != id_str.data() + id_str.size()) {
+    return std::nullopt;
+  }
+  if (id >= std::numeric_limits<device_id_t>::max()) {
+    return std::nullopt;
+  }
+  return std::make_optional<device_id_t>(static_cast<device_id_t>(id));
 }
 
 Device::access_ertr::future<> SeaStore::_mkfs(uuid_d new_osd_fsid)

--- a/src/crimson/os/seastore/segment_manager.cc
+++ b/src/crimson/os/seastore/segment_manager.cc
@@ -32,14 +32,14 @@ SegmentManager::get_segment_manager(
     const std::string& device,
     device_type_t dtype)
 {
-  const std::string device_block = device + "/block";
+  const std::string device_path = normalize_device_path(device);
 #ifdef HAVE_ZNS
   if (dtype == device_type_t::ZBD) {
     co_return std::make_unique<segment_manager::zbd::ZBDSegmentManager>(
-        device_block);
+        device_path);
   }
 #endif
   co_return std::make_unique<segment_manager::block::BlockSegmentManager>(
-      device_block, dtype);
+      device_path, dtype);
 }
 } // namespace crimson::os::seastore


### PR DESCRIPTION
Introduce normalize_device_path() and use it before backend-specific device creation so RBM and segmented accept the same path formats.

Avoid appending /block when a concrete block path is already provided, preventing ENOENT on startup.

Example: --device /dev/nvme0n1 now stays /dev/nvme0n1 (no /block suffix), while an OSD dir path like /var/lib/ceph/osd/osd.0 still maps to /var/lib/ceph/osd/osd.0/block.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
