### PR TITLE
mgr/dashboard : Support wildcard sans and zonegroup hostnames

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
@@ -403,6 +403,37 @@
           }
         </ng-template>
       </div>
+
+      @if (!rgwModuleEnabled) {
+      <cd-alert-panel type="warning"
+                      spacingClass="mb-3"
+                      actionName="Enable"
+                      (action)="enableRgwModule()"
+                      i18n-actionName
+                      i18n>
+        The RGW mgr module must be enabled to configure S3 hostnames.
+        Enabling the module will cause temporary manager downtime while it loads.
+      </cd-alert-panel>
+      }
+      <div class="form-item">
+        <cds-checkbox i18n-label
+                      formControlName="virtual_host_enabled">
+          Enable virtual-host style bucket access
+          <cd-help-text i18n>
+            Allows bucket access via hostnames such as mybucket.s3.example.com.
+          </cd-help-text>
+        </cds-checkbox>
+      </div>
+      @if (serviceForm.controls.virtual_host_enabled.value) {
+      <div class="form-item">
+        <cd-text-label-list formControlName="zonegroup_hostnames"
+                            label="S3 hostname"
+                            i18n-label
+                            helperText="Domain names for S3 virtual-host bucket access (e.g., s3.example.com). Enables bucket URLs like bucket.s3.example.com instead of s3.example.com/bucket."
+                            i18n-helperText>
+        </cd-text-label-list>
+      </div>
+      }
       }
 
       <!-- iSCSI -->
@@ -1218,13 +1249,13 @@
           <cds-radio-group formControlName="certificateType"
                            orientation="horizontal"
                            helperText="Select how certificates will be signed for this service. Choose internal to use the cluster’s CA, or external to upload certificates signed by your organization.">
-            <cds-radio value="internal"
-                       (change)="onCertificateTypeChange('internal')"
+            <cds-radio [value]="CertificateType.internal"
+                       (change)="onCertificateTypeChange(CertificateType.internal)"
                        i18n>
               Internal
             </cds-radio>
-            <cds-radio value="external"
-                       (change)="onCertificateTypeChange('external')"
+            <cds-radio [value]="CertificateType.external"
+                       (change)="onCertificateTypeChange(CertificateType.external)"
                        i18n>
               External
             </cds-radio>
@@ -1239,7 +1270,7 @@
           </cd-alert-panel>
         }
 
-        @if (serviceForm.controls.certificateType.value === 'internal') {
+        @if (serviceForm.controls.certificateType.value === CertificateType.internal) {
         <cd-alert-panel type="info"
                         spacingClass="mb-3"
                         i18n>
@@ -1253,6 +1284,18 @@
                               i18n-helperText>
           </cd-text-label-list>
         </div>
+        @if (serviceForm.controls.service_type.value === 'rgw'
+             && serviceForm.controls.virtual_host_enabled.value) {
+        <div class="form-item">
+          <cds-checkbox i18n-label
+                        formControlName="wildcard_enabled">
+            Include wildcard certificate for bucket subdomains
+            <cd-help-text i18n>
+              Add wildcard certificates (*.domain) to allow SSL for all bucket subdomains. Required for virtual-host style with SSL.
+            </cd-help-text>
+          </cds-checkbox>
+        </div>
+        }
         }
       </div>
       }
@@ -1288,7 +1331,7 @@
         </ng-template>
       </div>
       <!-- ssl_ca_cert - Only show for NFS when SSL is enabled AND certificate type is external -->
-      @if (serviceForm.controls.ssl.value && serviceForm.controls.certificateType.value === 'external' && serviceForm.controls.service_type.value === 'nfs') {
+      @if (serviceForm.controls.ssl.value && serviceForm.controls.certificateType.value === CertificateType.external && serviceForm.controls.service_type.value === 'nfs') {
       <div class="form-item">
         <ng-container *ngTemplateOutlet="fileUploaderTextarea; context: { controlName: 'ssl_ca_cert', title: 'CA Certificate Input', helperText: 'Uploaded files will populate the CA certificate details automatically. Or paste the PEM content directly in the text area.', description: 'Upload a CA certificate file, or paste the CA certificate PEM content directly.', invalidTemplate: invalidSslCaCertError, isRequired: false }"></ng-container>
         <ng-template #invalidSslCaCertError>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.spec.ts
@@ -263,6 +263,64 @@ describe('ServiceFormComponent', () => {
         });
       });
 
+      it('should submit rgw with virtual-host style bucket access and SSL', () => {
+        formHelper.setValue('virtual_host_enabled', true);
+        formHelper.setValue('ssl', true);
+        formHelper.setValue('zonegroup_hostnames', ['s3.cephlab.com']);
+        formHelper.setValue('wildcard_enabled', true);
+        component.onSubmit();
+        expect(cephServiceService.create).toHaveBeenCalledWith({
+          service_type: 'rgw',
+          service_id: 'svc',
+          rgw_realm: null,
+          rgw_zone: null,
+          rgw_zonegroup: null,
+          placement: {},
+          unmanaged: false,
+          ssl: true,
+          certificate_source: 'cephadm-signed',
+          zonegroup_hostnames: ['s3.cephlab.com'],
+          wildcard_enabled: true
+        });
+      });
+
+      it('should submit rgw with SSL and without virtual-host style bucket access', () => {
+        formHelper.setValue('ssl', true);
+        component.onSubmit();
+        expect(cephServiceService.create).toHaveBeenCalledWith({
+          service_type: 'rgw',
+          service_id: 'svc',
+          rgw_realm: null,
+          rgw_zone: null,
+          rgw_zonegroup: null,
+          placement: {},
+          unmanaged: false,
+          ssl: true,
+          certificate_source: 'cephadm-signed'
+        });
+      });
+
+      it('should submit rgw with virtual-host style bucket access and SSL without wildcard certificate', () => {
+        formHelper.setValue('virtual_host_enabled', true);
+        formHelper.setValue('ssl', true);
+        formHelper.setValue('zonegroup_hostnames', ['s3.cephlab.com']);
+        formHelper.setValue('wildcard_enabled', false);
+        component.onSubmit();
+        expect(cephServiceService.create).toHaveBeenCalledWith({
+          service_type: 'rgw',
+          service_id: 'svc',
+          rgw_realm: null,
+          rgw_zone: null,
+          rgw_zonegroup: null,
+          placement: {},
+          unmanaged: false,
+          ssl: true,
+          certificate_source: 'cephadm-signed',
+          zonegroup_hostnames: ['s3.cephlab.com'],
+          wildcard_enabled: false
+        });
+      });
+
       it('should submit valid rgw port (1)', () => {
         formHelper.setValue('rgw_frontend_port', 1);
         component.onSubmit();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
@@ -18,6 +18,7 @@ import { HostService } from '~/app/shared/api/host.service';
 import { PoolService } from '~/app/shared/api/pool.service';
 import { RbdService } from '~/app/shared/api/rbd.service';
 import { RgwMultisiteService } from '~/app/shared/api/rgw-multisite.service';
+import { MgrModuleService } from '~/app/shared/api/mgr-module.service';
 import { RgwRealmService } from '~/app/shared/api/rgw-realm.service';
 import { RgwZoneService } from '~/app/shared/api/rgw-zone.service';
 import { RgwZonegroupService } from '~/app/shared/api/rgw-zonegroup.service';
@@ -37,6 +38,7 @@ import { Host } from '~/app/shared/models/host.interface';
 import {
   CephServiceCertificate,
   CephServiceSpec,
+  CertificateType,
   QatOptions,
   QatSepcs,
   CERTIFICATE_STATUS_ICON_MAP
@@ -54,6 +56,7 @@ import { TimerService } from '~/app/shared/services/timer.service';
 export class ServiceFormComponent extends CdForm implements OnInit {
   public sub = new Subscription();
 
+  readonly CertificateType = CertificateType;
   readonly MDS_SVC_ID_PATTERN = /^[a-zA-Z_.-][a-zA-Z0-9_.-]*$/;
   readonly SNMP_DESTINATION_PATTERN = /^[^\:]+:[0-9]/;
   readonly SNMP_ENGINE_ID_PATTERN = /^[0-9A-Fa-f]{10,64}/g;
@@ -115,6 +118,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
   }));
   showMgmtGatewayMessage: boolean = false;
   showCertSourceChangeWarning: boolean = false;
+  rgwModuleEnabled = false;
   qatCompressionOptions = [
     { value: QatOptions.hw, label: 'Hardware' },
     { value: QatOptions.sw, label: 'Software' },
@@ -141,6 +145,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
     public rgwZonegroupService: RgwZonegroupService,
     public rgwZoneService: RgwZoneService,
     public rgwMultisiteService: RgwMultisiteService,
+    private mgrModuleService: MgrModuleService,
     private route: ActivatedRoute,
     public modalService: ModalCdsService,
     private location: Location
@@ -422,7 +427,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
               service_type: 'rgw',
               unmanaged: false,
               ssl: true,
-              certificateType: 'external'
+              certificateType: CertificateType.external
             },
             [Validators.required, CdValidators.pemCert()]
           ),
@@ -431,7 +436,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
               service_type: 'iscsi',
               unmanaged: false,
               ssl: true,
-              certificateType: 'external'
+              certificateType: CertificateType.external
             },
             [Validators.required, CdValidators.sslCert()]
           ),
@@ -440,7 +445,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
               service_type: 'ingress',
               unmanaged: false,
               ssl: true,
-              certificateType: 'external'
+              certificateType: CertificateType.external
             },
             [Validators.required, CdValidators.pemCert()]
           ),
@@ -449,7 +454,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
               service_type: 'oauth2-proxy',
               unmanaged: false,
               ssl: true,
-              certificateType: 'external'
+              certificateType: CertificateType.external
             },
             [Validators.required, CdValidators.sslCert()]
           ),
@@ -458,7 +463,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
               service_type: 'mgmt-gateway',
               unmanaged: false,
               ssl: true,
-              certificateType: 'external'
+              certificateType: CertificateType.external
             },
             [Validators.required, CdValidators.sslCert()]
           ),
@@ -467,7 +472,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
               service_type: 'nfs',
               unmanaged: false,
               ssl: true,
-              certificateType: 'external'
+              certificateType: CertificateType.external
             },
             [Validators.required, CdValidators.pemCert()]
           )
@@ -481,7 +486,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
               service_type: 'iscsi',
               unmanaged: false,
               ssl: true,
-              certificateType: 'external'
+              certificateType: CertificateType.external
             },
             [Validators.required, CdValidators.sslPrivKey()]
           ),
@@ -490,7 +495,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
               service_type: 'oauth2-proxy',
               unmanaged: false,
               ssl: true,
-              certificateType: 'external'
+              certificateType: CertificateType.external
             },
             [Validators.required, CdValidators.sslPrivKey()]
           ),
@@ -499,7 +504,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
               service_type: 'mgmt-gateway',
               unmanaged: false,
               ssl: true,
-              certificateType: 'external'
+              certificateType: CertificateType.external
             },
             [Validators.required, CdValidators.sslPrivKey()]
           ),
@@ -508,14 +513,17 @@ export class ServiceFormComponent extends CdForm implements OnInit {
               service_type: 'nfs',
               unmanaged: false,
               ssl: true,
-              certificateType: 'external'
+              certificateType: CertificateType.external
             },
             [Validators.required, CdValidators.sslPrivKey()]
           )
         ]
       ],
-      certificateType: ['internal'],
+      certificateType: [CertificateType.internal],
       custom_sans: [null],
+      virtual_host_enabled: [false],
+      zonegroup_hostnames: [null],
+      wildcard_enabled: [true],
       ssl_ca_cert: [
         '',
         [
@@ -524,7 +532,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
               service_type: 'nfs',
               unmanaged: false,
               ssl: true,
-              certificateType: 'external'
+              certificateType: CertificateType.external
             },
             [Validators.required, CdValidators.pemCert()]
           )
@@ -686,6 +694,8 @@ export class ServiceFormComponent extends CdForm implements OnInit {
     this.open = true;
     this.action = this.actionLabels.CREATE;
     this.resolveRoute();
+    this.getRgwModuleStatus();
+    this.mgrModuleService.updateCompleted$.subscribe(() => this.getRgwModuleStatus());
 
     this.cephServiceService
       .list(new HttpParams({ fromObject: { limit: -1, offset: 0 } }))
@@ -792,10 +802,21 @@ export class ServiceFormComponent extends CdForm implements OnInit {
                 response[0].spec?.qat
               );
               this.serviceForm.get('ssl').setValue(response[0].spec?.ssl);
+              if (response[0].spec?.zonegroup_hostnames?.length) {
+                this.serviceForm
+                  .get('zonegroup_hostnames')
+                  .setValue(response[0].spec.zonegroup_hostnames);
+                if (this.rgwModuleEnabled) {
+                  this.serviceForm.get('virtual_host_enabled').setValue(true);
+                }
+              }
+              this.serviceForm
+                .get('wildcard_enabled')
+                .setValue(response[0].spec?.wildcard_enabled ?? true);
               if (response[0].spec?.ssl) {
                 // Special case for rgw: if certificate_source is not cephadm-signed, set certificateType to external
                 if (response[0].spec?.certificate_source != 'cephadm-signed') {
-                  this.serviceForm.get('certificateType').setValue('external');
+                  this.serviceForm.get('certificateType').setValue(CertificateType.external);
                 }
                 let certValue = response[0].spec?.rgw_frontend_ssl_certificate || '';
                 if (response[0].spec?.ssl_cert) {
@@ -805,6 +826,9 @@ export class ServiceFormComponent extends CdForm implements OnInit {
                   }
                 }
                 this.serviceForm.get('ssl_cert').setValue(certValue);
+                if (response[0].spec?.custom_sans) {
+                  this.serviceForm.get('custom_sans').setValue(response[0].spec.custom_sans);
+                }
               }
               break;
             case 'ingress':
@@ -830,7 +854,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
               this.port = response[0].spec?.port;
               this.serviceForm.get('ssl').setValue(true);
               if (response[0].spec?.certificate_source !== 'cephadm-signed') {
-                this.serviceForm.get('certificateType').setValue('external');
+                this.serviceForm.get('certificateType').setValue(CertificateType.external);
               }
               if (response[0].spec?.ssl_protocols) {
                 let selectedValues: Array<ListItem> = [];
@@ -1232,13 +1256,35 @@ export class ServiceFormComponent extends CdForm implements OnInit {
     }
   }
 
-  onCertificateTypeChange(type: string) {
+  onCertificateTypeChange(type: CertificateType) {
     this.serviceForm.get('certificateType').setValue(type);
     if (this.editing && this.currentCertificate?.has_certificate) {
       const originalSource =
-        this.currentSpecCertificateSource === 'cephadm-signed' ? 'internal' : 'external';
+        this.currentSpecCertificateSource === 'cephadm-signed'
+          ? CertificateType.internal
+          : CertificateType.external;
       this.showCertSourceChangeWarning = type !== originalSource;
     }
+  }
+
+  private getRgwModuleStatus(): void {
+    this.rgwMultisiteService.getRgwModuleStatus().subscribe((enabled: boolean) => {
+      this.rgwModuleEnabled = enabled;
+      const virtualHostControl = this.serviceForm.get('virtual_host_enabled');
+      if (enabled) {
+        virtualHostControl.enable({ emitEvent: false });
+        if (this.serviceForm.get('zonegroup_hostnames').value?.length) {
+          virtualHostControl.setValue(true, { emitEvent: false });
+        }
+      } else {
+        virtualHostControl.setValue(false, { emitEvent: false });
+        virtualHostControl.disable({ emitEvent: false });
+      }
+    });
+  }
+
+  enableRgwModule(): void {
+    this.mgrModuleService.updateModuleState('rgw', false, null, '', $localize`Enabled RGW Module`);
   }
 
   prePopulateId() {
@@ -1386,11 +1432,21 @@ export class ServiceFormComponent extends CdForm implements OnInit {
             serviceSpec['rgw_frontend_port'] = values['rgw_frontend_port'];
           }
           serviceSpec['ssl'] = values['ssl'];
+          if (values['virtual_host_enabled'] && values['zonegroup_hostnames']?.length > 0) {
+            serviceSpec['zonegroup_hostnames'] = values['zonegroup_hostnames'];
+          }
           if (values['ssl']) {
             this.applySslCertificateConfig(serviceSpec, values, {
               sslCertField: 'rgw_frontend_ssl_certificate',
               includeSslKey: false
             });
+            if (
+              values['certificateType'] === CertificateType.internal &&
+              values['virtual_host_enabled'] &&
+              values['zonegroup_hostnames']?.length > 0
+            ) {
+              serviceSpec['wildcard_enabled'] = values['wildcard_enabled'];
+            }
           }
           break;
         case 'iscsi':
@@ -1538,7 +1594,8 @@ export class ServiceFormComponent extends CdForm implements OnInit {
 
   get showExternalSslCert(): boolean {
     const serviceType = this.serviceForm.controls.service_type?.value;
-    const isExternalCert = this.serviceForm.controls.certificateType?.value === 'external';
+    const isExternalCert =
+      this.serviceForm.controls.certificateType?.value === CertificateType.external;
     const isSslEnabled = this.serviceForm.controls.ssl?.value;
 
     if (serviceType === 'mgmt-gateway') {
@@ -1551,7 +1608,8 @@ export class ServiceFormComponent extends CdForm implements OnInit {
 
   get showExternalSslKey(): boolean {
     const serviceType = this.serviceForm.controls.service_type?.value;
-    const isExternalCert = this.serviceForm.controls.certificateType?.value === 'external';
+    const isExternalCert =
+      this.serviceForm.controls.certificateType?.value === CertificateType.external;
     const isSslEnabled = this.serviceForm.controls.ssl?.value;
 
     const sslKeyServices = ['iscsi', 'grafana', 'oauth2-proxy', 'nvmeof', 'nfs', 'mgmt-gateway'];
@@ -1585,13 +1643,16 @@ export class ServiceFormComponent extends CdForm implements OnInit {
     } = options;
 
     serviceSpec['certificate_source'] =
-      values['certificateType'] === 'internal' ? 'cephadm-signed' : 'inline';
+      values['certificateType'] === CertificateType.internal ? 'cephadm-signed' : 'inline';
 
-    if (values['certificateType'] === 'internal' && values['custom_sans']?.length > 0) {
+    if (
+      values['certificateType'] === CertificateType.internal &&
+      values['custom_sans']?.length > 0
+    ) {
       serviceSpec['custom_sans'] = values['custom_sans'];
     }
 
-    if (values['certificateType'] === 'external') {
+    if (values['certificateType'] === CertificateType.external) {
       serviceSpec[sslCertField] = values['ssl_cert']?.trim();
       if (includeSslKey) {
         serviceSpec[sslKeyField] = values['ssl_key']?.trim();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/service.interface.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/service.interface.ts
@@ -91,6 +91,9 @@ export interface CephServiceAdditionalSpec {
   ssl_protocols: string[];
   ssl_ciphers: string[];
   certificate_source: string;
+  custom_sans?: string[];
+  zonegroup_hostnames?: string[];
+  wildcard_enabled?: boolean;
   port: number;
   initial_admin_password: string;
   rgw_realm: string;
@@ -121,6 +124,11 @@ export interface CephServicePlacement {
 
 export interface QatSepcs {
   [key: string]: string;
+}
+
+export enum CertificateType {
+  internal = 'internal',
+  external = 'external'
 }
 
 export enum QatOptions {


### PR DESCRIPTION
PS : 

Add zonegroup_hostname support for RGW service 

UTC : 

```
[ceph: root@ceph-node-00 /]# ceph orch ls --export  rgw
service_type: rgw
service_id: test1
service_name: rgw.test1
placement:
  count: 2
spec:
  certificate_source: cephadm-signed
  rgw_exit_timeout_secs: 120
  ssl: true
  wildcard_enabled: true
  zonegroup_hostnames:
  - s3.abc.com
---
service_type: rgw
service_id: test2
service_name: rgw.test2
placement:
  count: 2
spec:
  certificate_source: cephadm-signed
  rgw_exit_timeout_secs: 120
  ssl: true
  zonegroup_hostnames:
  - s3.xyx.com
[ceph: root@ceph-node-00 /]# 

```

https://github.com/user-attachments/assets/9bd2db4e-bc46-44a5-93b1-3d4514522735




fixes : https://tracker.ceph.com/issues/76795
Signed-off-by: Abhishek Desai <abhishek.desai1@ibm.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
