### PR TITLE
tentacle: qa: Handle TypeError in test_filelock

### DIFF
--- a/qa/tasks/cephfs/test_client_recovery.py
+++ b/qa/tasks/cephfs/test_client_recovery.py
@@ -349,9 +349,23 @@ class TestClientRecovery(CephFSTestCase):
                             count, num_caps
                         ))
 
+    def _fuse_package_version(self, client_remote):
+        for pkg in ("fuse", "fuse3"):
+            ver = get_package_version(client_remote, pkg)
+            if ver:
+                log.debug(f'using {pkg} package version {ver} for flock check')
+                return ver
+        return None
+
     def _is_flockable(self):
-        a_version_str = get_package_version(self.mount_a.client_remote, "fuse")
-        b_version_str = get_package_version(self.mount_b.client_remote, "fuse")
+        a_version_str = self._fuse_package_version(self.mount_a.client_remote)
+        b_version_str = self._fuse_package_version(self.mount_b.client_remote)
+
+        if (a_version_str is None or b_version_str is None):
+            log.info("not testing flock locks, could not determine fuse version(s) {av} and {bv}".format(
+                av=a_version_str, bv=b_version_str))
+            return False
+
         flock_version_str = "2.9"
 
         version_regex = re.compile(r"[0-9\.]+")


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76557

---

backport of https://github.com/ceph/ceph/pull/68389
parent tracker: https://tracker.ceph.com/issues/75959

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh