### PR TITLE
crimson/os/seastore/onode_manager: avoid debug related info from occupying too much cpu time

### DIFF
--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
@@ -690,20 +690,25 @@ eagain_ifuture<Ref<Node>> Node::load(
   return c.nm.read_extent(c.t, addr
   ).handle_error_interruptible(
     eagain_iertr::pass_further{},
-    crimson::ct_error::assert_all(fmt::format(
-      "{} -- addr={}, is_level_tail={}", FNAME, addr, expect_is_level_tail).c_str())
+    crimson::ct_error::all_same_way(
+      [FNAME, c, addr, expect_is_level_tail](const auto &e) {
+      ERRORT("{} -- addr={}, is_level_tail={}",
+        c.t, addr, expect_is_level_tail);
+      ceph_abort();
+      return eagain_iertr::make_ready_future<NodeExtentRef>();
+    })
   ).si_then([FNAME, c, addr, expect_is_level_tail](auto extent)
 	      -> eagain_ifuture<Ref<Node>> {
     assert(extent);
     auto header = extent->get_header();
     auto field_type = header.get_field_type();
-    if (!field_type) {
+    if (unlikely(!field_type)) {
       ERRORT("load addr={}, is_level_tail={} error, "
              "got invalid header -- {}",
              c.t, addr, expect_is_level_tail, fmt::ptr(extent));
       ceph_abort_msg("fatal error");
     }
-    if (header.get_is_level_tail() != expect_is_level_tail) {
+    if (unlikely(header.get_is_level_tail() != expect_is_level_tail)) {
       ERRORT("load addr={}, is_level_tail={} error, "
              "is_level_tail mismatch -- {}",
              c.t, addr, expect_is_level_tail, fmt::ptr(extent));
@@ -712,7 +717,7 @@ eagain_ifuture<Ref<Node>> Node::load(
 
     auto node_type = header.get_node_type();
     if (node_type == node_type_t::LEAF) {
-      if (extent->get_length() != c.vb.get_leaf_node_size()) {
+      if (unlikely(extent->get_length() != c.vb.get_leaf_node_size())) {
         ERRORT("load addr={}, is_level_tail={} error, "
                "leaf length mismatch -- {}",
                c.t, addr, expect_is_level_tail, fmt::ptr(extent));
@@ -723,7 +728,7 @@ eagain_ifuture<Ref<Node>> Node::load(
       return eagain_iertr::make_ready_future<Ref<Node>>(
 	new LeafNode(derived_ptr, std::move(impl)));
     } else if (node_type == node_type_t::INTERNAL) {
-      if (extent->get_length() != c.vb.get_internal_node_size()) {
+      if (unlikely(extent->get_length() != c.vb.get_internal_node_size())) {
         ERRORT("load addr={}, is_level_tail={} error, "
                "internal length mismatch -- {}",
                c.t, addr, expect_is_level_tail, fmt::ptr(extent));

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
@@ -906,7 +906,9 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
 
  private:
   NodeLayoutT(NodeExtentRef extent) : extent{extent} {
+#ifndef NDEBUG
     build_name();
+#endif
   }
 
   extent_len_t filled_size() const {


### PR DESCRIPTION
According to the perf tests, constructing the info occupies about 5% of the total cpu overhead

<img width="1798" height="709" alt="image" src="https://github.com/user-attachments/assets/7b56aa66-36d5-4c3b-8621-430b2a227f4e" />

Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
