### PR TITLE
mgr/smb: add RGW-backed SMB share support

### DIFF
--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -314,7 +314,7 @@ class ClusterConfigHandler:
         authorizer: Optional[AccessAuthorizer] = None,
         orch: Optional[OrchSubmitter] = None,
         earmark_resolver: Optional[EarmarkResolver] = None,
-        mgr: Optional[Any] = None,
+        mgr: Any,
     ) -> None:
         self.internal_store = internal_store
         self.public_store = public_store
@@ -641,11 +641,17 @@ class ClusterConfigHandler:
             for share in change_group.shares
             if share.cephfs is not None
         }
+        # rgw_buckets: hold the RGW buckets our shares touch
+        rgw_buckets = {
+            share.rgw.bucket
+            for share in change_group.shares
+            if share.rgw is not None
+        }
         # save the various object types
         previous_info = _swap_pending_cluster_info(
             self.public_store,
             change_group,
-            orch_needed=bool(vols and self._orch),
+            orch_needed=bool((vols or rgw_buckets) and self._orch),
         )
         _save_pending_join_auths(self.priv_store, change_group)
         _save_pending_users_and_groups(self.priv_store, change_group)
@@ -712,9 +718,31 @@ class ClusterConfigHandler:
         # via orch.  This differs from NFS because ganesha embeds the cephx
         # keys directly in each export definition block while samba needs the
         # ceph keyring to load keys.
+        # For RGW shares, we don't need CephFS volumes but still need orchestration.
         previous_orch = previous_info.get('orch_needed', False)
-        if self._orch and (vols or previous_orch):
+        if self._orch and (vols or rgw_buckets or previous_orch):
+            log.info(
+                'Submitting SMB service spec for cluster %s: '
+                'shares=%d (cephfs_vols=%d, rgw_buckets=%d), '
+                'previous_orch=%s',
+                cluster.cluster_id,
+                len(change_group.shares),
+                len(vols),
+                len(rgw_buckets),
+                previous_orch,
+            )
             self._orch.submit_smb_spec(smb_spec)
+        else:
+            log.warning(
+                'Skipping SMB service orchestration for cluster %s: '
+                'orch_enabled=%s, shares=%d, cephfs_vols=%d, rgw_buckets=%d, previous_orch=%s',
+                cluster.cluster_id,
+                bool(self._orch),
+                len(change_group.shares),
+                len(vols),
+                len(rgw_buckets),
+                previous_orch,
+            )
 
     def _remove_cluster(self, cluster_id: str) -> None:
         log.info('Removing cluster: %s', cluster_id)
@@ -800,15 +828,24 @@ class _ClusterConf:
             ceph_cluster = 'exo'
             cephx_entity = checked(extcc.cluster).cephfs_user.name
         elif change_group.shares:
-            log.debug('local ceph cluster with shares')
-            cephx_entity = _cephx_data_entity(change_group.cluster)
-            # ensure an entity exists with access to the volumes (CephFS only)
-            for share in change_group.shares:
-                if share.cephfs:
-                    authorizer.authorize_entity(
-                        share.checked_cephfs.volume, cephx_entity
-                    )
-            cephadm_data_entity = cephx_entity
+            # Check if we have any CephFS shares that need CephX auth
+            has_cephfs_shares = any(
+                s.cephfs is not None for s in change_group.shares
+            )
+            if has_cephfs_shares:
+                log.debug('local ceph cluster with CephFS shares')
+                cephx_entity = _cephx_data_entity(change_group.cluster)
+                # ensure an entity exists with access to the volumes (CephFS only)
+                for share in change_group.shares:
+                    if share.cephfs:
+                        authorizer.authorize_entity(
+                            share.checked_cephfs.volume, cephx_entity
+                        )
+                cephadm_data_entity = cephx_entity
+            else:
+                log.debug(
+                    'local ceph cluster with RGW shares only (no CephX auth needed)'
+                )
         else:
             log.debug('local cluster without shares: skipping ceph auth')
         return cls(

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -314,10 +314,12 @@ class ClusterConfigHandler:
         authorizer: Optional[AccessAuthorizer] = None,
         orch: Optional[OrchSubmitter] = None,
         earmark_resolver: Optional[EarmarkResolver] = None,
+        mgr: Optional[Any] = None,
     ) -> None:
         self.internal_store = internal_store
         self.public_store = public_store
         self.priv_store = priv_store
+        self.mgr = mgr
         if path_resolver is None:
             path_resolver = _FakePathResolver()
         self._path_resolver: PathResolver = path_resolver
@@ -347,7 +349,7 @@ class ClusterConfigHandler:
         """
         log.debug('applying changes to internal data store')
         results = ResultGroup()
-        staging = Staging(self.internal_store)
+        staging = Staging(self.internal_store, self.mgr)
         try:
             incoming = order_resources(inputs)
             for resource in incoming:
@@ -634,7 +636,11 @@ class ClusterConfigHandler:
         assert isinstance(cluster, resources.Cluster)
         # vols: hold the cephfs volumes our shares touch. some operations are
         # disabled/skipped unless we touch volumes.
-        vols = {share.checked_cephfs.volume for share in change_group.shares}
+        vols = {
+            share.checked_cephfs.volume
+            for share in change_group.shares
+            if share.cephfs is not None
+        }
         # save the various object types
         previous_info = _swap_pending_cluster_info(
             self.public_store,
@@ -796,11 +802,12 @@ class _ClusterConf:
         elif change_group.shares:
             log.debug('local ceph cluster with shares')
             cephx_entity = _cephx_data_entity(change_group.cluster)
-            # ensure an entity exists with access to the volumes
+            # ensure an entity exists with access to the volumes (CephFS only)
             for share in change_group.shares:
-                authorizer.authorize_entity(
-                    share.checked_cephfs.volume, cephx_entity
-                )
+                if share.cephfs:
+                    authorizer.authorize_entity(
+                        share.checked_cephfs.volume, cephx_entity
+                    )
             cephadm_data_entity = cephx_entity
         else:
             log.debug('local cluster without shares: skipping ceph auth')
@@ -813,6 +820,49 @@ class _ClusterConf:
             change_group,
             cephadm_data_entity,
         )
+
+
+def _generate_rgw_share(conf: _ShareConf) -> Dict[str, Dict[str, str]]:
+    """Generate Samba configuration for an RGW-backed share."""
+    share = conf.resource
+    rgw = share.rgw
+    assert rgw is not None, "RGW storage configuration missing"
+
+    path = '/'
+
+    cfg = {
+        # smb.conf options
+        'options': {
+            'path': path,
+            'vfs objects': 'ceph_rgw',
+            'ceph_rgw:config_file': '/etc/ceph/ceph.conf',
+            'ceph_rgw:keyring_file': '/etc/ceph/ceph.client.admin.keyring',
+            'ceph_rgw:bucket': rgw.bucket,
+            'ceph_rgw:user_id': rgw.user_id or '',
+            'ceph_rgw:access_key': rgw.access_key_id or '',
+            'ceph_rgw:secret_access_key': rgw.secret_access_key or '',
+            'ceph_rgw:debug': 'off',
+            'read only': ynbool(share.readonly),
+            'browseable': ynbool(share.browseable),
+            'kernel share modes': 'no',
+            'smbd profiling share': 'yes',
+        }
+    }
+
+    if share.comment is not None:
+        cfg['options']['comment'] = share.comment
+    if share.max_connections is not None:
+        cfg['options']['max connections'] = str(share.max_connections)
+
+    # extend share with user+group login access lists
+    _generate_share_login_control(share, cfg)
+    _generate_share_hosts_access(share, cfg)
+    # extend share with custom options
+    custom_opts = share.cleaned_custom_smb_share_options
+    if custom_opts:
+        cfg['options'].update(custom_opts)
+        cfg['options']['x:ceph:has_custom_options'] = 'yes'
+    return cfg
 
 
 def _generate_share(conf: _ShareConf) -> Dict[str, Dict[str, str]]:
@@ -988,7 +1038,12 @@ def _generate_config(conf: _ClusterConf) -> Dict[str, Any]:
     _set_debug_level(cluster_global_opts, conf)
 
     share_configs = {
-        share.resource.name: _generate_share(share) for share in conf.shares
+        share.resource.name: (
+            _generate_rgw_share(share)
+            if share.resource.rgw
+            else _generate_share(share)
+        )
+        for share in conf.shares
     }
 
     instance_features = []
@@ -1313,11 +1368,12 @@ def _store_transaction(store: ConfigStore) -> Iterator[None]:
 
 
 def _has_proxied_vfs(change_group: ClusterChangeGroup) -> bool:
-    """Return true if any shares in the change group use the new vfs module
-    with the proxied cephfs library.
+    """Return true if any CephFS-backed shares in the change group use the
+    new vfs module with the proxied cephfs library.
     """
     return any(
-        s.checked_cephfs.provider.expand()
+        s.cephfs is not None
+        and s.checked_cephfs.provider.expand()
         == CephFSStorageProvider.SAMBA_VFS_PROXIED
         for s in change_group.shares
     )

--- a/src/pybind/mgr/smb/module.py
+++ b/src/pybind/mgr/smb/module.py
@@ -25,6 +25,7 @@ from . import (
     rados_store,
     resources,
     results,
+    rgw_utils,
     sqlite_store,
     utils,
 )
@@ -100,6 +101,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             authorizer=authorizer,
             orch=self._orch_backend(enable_orch=uo),
             earmark_resolver=earmark_resolver,
+            mgr=self,
         )
 
     def _backend_store(self, store_conf: str = '') -> ConfigStore:
@@ -542,6 +544,50 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             for cid, shid in self._handler.share_ids()
             if cid == cluster_id
         ]
+
+    @SMBCLICommand('share create rgw', perm='rw')
+    def share_create_rgw(
+        self,
+        cluster_id: str,
+        share_id: str,
+        bucket: str,
+        share_name: str = '',
+        user_id: str = '',
+        path: str = '/',
+        readonly: bool = False,
+    ) -> results.Result:
+        """Create an SMB share backed by RGW"""
+        try:
+            # Fetch RGW credentials
+            (
+                fetched_user_id,
+                access_key,
+                secret_key,
+            ) = rgw_utils.fetch_rgw_credentials(self, bucket, user_id)
+
+            share = resources.Share(
+                cluster_id=cluster_id,
+                share_id=share_id,
+                name=share_name or share_id,
+                readonly=readonly,
+                rgw=resources.RGWStorage(
+                    bucket=bucket,
+                    user_id=fetched_user_id,
+                    path=path,
+                    access_key_id=access_key,
+                    secret_access_key=secret_key,
+                ),
+            )
+            return self._apply_res([share], create_only=True).one()
+        except ValueError as e:
+            # Create a minimal share resource for error reporting
+            error_share = resources.Share(
+                cluster_id=cluster_id,
+                share_id=share_id,
+                name=share_name or share_id,
+                cephfs=resources.CephFSStorage(volume='error', path='/'),
+            )
+            return results.ErrorResult(error_share, msg=str(e))
 
     @SMBCLICommand('share create', perm='rw')
     def share_create(

--- a/src/pybind/mgr/smb/resources.py
+++ b/src/pybind/mgr/smb/resources.py
@@ -399,6 +399,51 @@ class LoginAccessEntry(_RBase):
 
 
 @resourcelib.component()
+class RGWStorage(_RBase):
+    """Description of where in an RGW bucket a share is located."""
+
+    bucket: str
+    user_id: Optional[str] = None
+    path: str = '/'
+    access_key_id: Optional[str] = None
+    secret_access_key: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        # remove extra slashes, relative path components, etc.
+        self.path = validation.normalize_path(self.path)
+
+    def validate(self) -> None:
+        if not self.bucket:
+            raise ValueError('bucket requires a value')
+        validation.check_path(self.path)
+
+    def convert(self, operation: ConversionOp) -> Self:
+        """Convert password fields based on the operation."""
+        return self.__class__(
+            bucket=self.bucket,
+            user_id=self.user_id,
+            path=self.path,
+            access_key_id=(
+                _password_convert(self.access_key_id, operation)
+                if self.access_key_id
+                else None
+            ),
+            secret_access_key=(
+                _password_convert(self.secret_access_key, operation)
+                if self.secret_access_key
+                else None
+            ),
+        )
+
+    @resourcelib.customize
+    def _customize_resource(rc: resourcelib.Resource) -> resourcelib.Resource:
+        rc.user_id.quiet = True
+        rc.access_key_id.quiet = True
+        rc.secret_access_key.quiet = True
+        return rc
+
+
+@resourcelib.component()
 class HostAccessEntry(_RBase):
     access: HostAccess
     address: str = ''
@@ -459,6 +504,7 @@ class Share(_RBase):
     comment: Optional[str] = None
     max_connections: Optional[int] = None
     cephfs: Optional[CephFSStorage] = None
+    rgw: Optional[RGWStorage] = None
     custom_smb_share_options: Optional[Dict[str, str]] = None
     login_control: Optional[List[LoginAccessEntry]] = None
     restrict_access: bool = False
@@ -479,9 +525,19 @@ class Share(_RBase):
         validation.check_share_name(self.name)
         if self.intent != Intent.PRESENT:
             raise ValueError('Share must have present intent')
-        # currently only cephfs is supported
-        if self.cephfs is None:
-            raise ValueError('a cephfs configuration is required')
+        # Ensure exactly one storage backend is specified
+        storage_count = sum(
+            [
+                self.cephfs is not None,
+                self.rgw is not None,
+            ]
+        )
+        if storage_count == 0:
+            raise ValueError(
+                'a storage configuration is required (cephfs or rgw)'
+            )
+        if storage_count > 1:
+            raise ValueError('only one storage backend can be specified')
         if self.max_connections is not None and self.max_connections < 0:
             raise ValueError(
                 'max_connections must be 0 or a non-negative integer'

--- a/src/pybind/mgr/smb/rgw_utils.py
+++ b/src/pybind/mgr/smb/rgw_utils.py
@@ -1,0 +1,114 @@
+"""Utilities for RGW integration with SMB."""
+
+import json
+import logging
+from typing import TYPE_CHECKING, Tuple
+
+if TYPE_CHECKING:
+    from .module import Module
+
+log = logging.getLogger(__name__)
+
+
+def fetch_rgw_credentials(
+    mgr: 'Module',
+    bucket: str,
+    user_id: str = '',
+) -> Tuple[str, str, str]:
+    """
+    Fetch RGW user credentials for a bucket.
+
+    Args:
+        mgr: The SMB manager module instance
+        bucket: The RGW bucket name
+        user_id: Optional RGW user ID. If not provided, fetches bucket owner.
+
+    Returns:
+        Tuple of (user_id, access_key_id, secret_access_key)
+
+    Raises:
+        ValueError: If bucket owner cannot be determined or credentials not found
+    """
+    if not user_id:
+        # Fetch bucket owner
+        log.debug(f"Fetching owner for bucket {bucket}")
+        ret, out, err = mgr.tool_exec(
+            ['radosgw-admin', 'bucket', 'stats', '--bucket', bucket]
+        )
+        if ret:
+            raise ValueError(
+                f'Failed to fetch owner for bucket {bucket}: {err}'
+            )
+
+        try:
+            j = json.loads(out)
+            user_id = j.get('owner', '')
+            if not user_id:
+                raise ValueError(f'No owner found for bucket {bucket}')
+        except (json.JSONDecodeError, KeyError) as e:
+            raise ValueError(
+                f'Failed to parse bucket stats for {bucket}: {e}'
+            )
+
+        log.info(f"Bucket {bucket} is owned by user {user_id}")
+
+    # Fetch user credentials
+    log.debug(f"Fetching credentials for user {user_id}")
+    ret, out, err = mgr.tool_exec(
+        ['radosgw-admin', 'user', 'info', '--uid', user_id]
+    )
+    if ret:
+        raise ValueError(
+            f'Failed to fetch credentials for user {user_id}: {err}'
+        )
+
+    try:
+        j = json.loads(out)
+        keys = j.get('keys', [])
+        if not keys:
+            raise ValueError(f'No keys found for user {user_id}')
+
+        access_key = keys[0].get('access_key', '')
+        secret_key = keys[0].get('secret_key', '')
+
+        if not access_key or not secret_key:
+            raise ValueError(
+                f'Invalid credentials for user {user_id}: '
+                f'access_key={bool(access_key)}, secret_key={bool(secret_key)}'
+            )
+
+        log.info(f"Successfully fetched credentials for user {user_id}")
+        return user_id, access_key, secret_key
+
+    except (json.JSONDecodeError, KeyError, IndexError) as e:
+        raise ValueError(f'Failed to parse user info for {user_id}: {e}')
+
+
+def validate_rgw_bucket(mgr: 'Module', bucket: str) -> bool:
+    """
+    Validate that an RGW bucket exists.
+
+    Args:
+        mgr: The SMB manager module instance
+        bucket: The RGW bucket name
+
+    Returns:
+        True if bucket exists, False otherwise
+    """
+    log.debug(f"Validating bucket {bucket}")
+    ret, out, err = mgr.tool_exec(
+        ['radosgw-admin', 'bucket', 'stats', '--bucket', bucket]
+    )
+    if ret:
+        log.warning(
+            f"Bucket {bucket} does not exist or is not accessible: {err}"
+        )
+        return False
+
+    try:
+        j = json.loads(out)
+        # If we can parse the output and it has an owner, bucket exists
+        return bool(j.get('owner'))
+    except (json.JSONDecodeError, KeyError):
+        log.warning(f"Failed to parse bucket stats for {bucket}")
+        return False

--- a/src/pybind/mgr/smb/staging.py
+++ b/src/pybind/mgr/smb/staging.py
@@ -54,8 +54,9 @@ class Staging:
     the destination store.
     """
 
-    def __init__(self, store: ConfigStore) -> None:
+    def __init__(self, store: ConfigStore, mgr: Any = None) -> None:
         self.destination_store = store
+        self._mgr = mgr
         self.incoming: Dict[EntryKey, SMBResource] = {}
         self.deleted: Dict[EntryKey, SMBResource] = {}
         self._store_keycache: Set[EntryKey] = set()
@@ -359,8 +360,17 @@ def _check_share_resource(
             status={"cluster_id": share.cluster_id},
         )
 
-    # Handle RGW shares - no path validation needed
+    # Handle RGW shares - validate bucket existence
     if share.rgw is not None:
+        from . import rgw_utils
+
+        # Validate bucket exists
+        if not rgw_utils.validate_rgw_bucket(staging._mgr, share.rgw.bucket):
+            raise ErrorResult(
+                share,
+                msg=f"RGW bucket '{share.rgw.bucket}' does not exist or is not accessible",
+            )
+
         name_used_by = _share_name_in_use(staging, share)
         if name_used_by:
             raise ErrorResult(

--- a/src/pybind/mgr/smb/staging.py
+++ b/src/pybind/mgr/smb/staging.py
@@ -358,6 +358,19 @@ def _check_share_resource(
             msg="no matching cluster id",
             status={"cluster_id": share.cluster_id},
         )
+
+    # Handle RGW shares - no path validation needed
+    if share.rgw is not None:
+        name_used_by = _share_name_in_use(staging, share)
+        if name_used_by:
+            raise ErrorResult(
+                share,
+                msg="share name already in use",
+                status={"conflicting_share_id": name_used_by},
+            )
+        return
+
+    # Handle CephFS shares
     assert share.cephfs is not None
     try:
         volpath = path_resolver.resolve_exists(

--- a/src/pybind/mgr/smb/tests/test_handler.py
+++ b/src/pybind/mgr/smb/tests/test_handler.py
@@ -25,6 +25,7 @@ def thandler():
         # into a single store. Do that to simplify testing a bit.
         public_store=ext_store,
         priv_store=ext_store,
+        mgr=None,
     )
 
 


### PR DESCRIPTION
Add support for creating SMB shares backed by RGW buckets,
allowing S3-compatible object storage to be exported over SMB.

Key changes:

Add share create rgw CLI command for RGW share creation
Implement RGW credential retrieval using radosgw-admin
Add RGWStorage resource class with S3 authentication support
Track rgw_buckets in orchestration alongside CephFS volumes
Create CephX entities conditionally for CephFS shares only
Implementation details:

Register share create rgw before share create for correct CLI routing
Trigger orchestration when either vols or rgw_buckets are present
Use S3 access and secret keys for RGW share authentication
Improve logging with CephFS and RGW share breakdown details
CLI :
ceph smb share create rgw mysmb share1 bkt1
Here bkt1 is the bucket and already created.

Testing:

Created a cluster with a CephFS share, then added an RGW share.
Verified both shares inside the container using net conf list.
Created a cluster with an RGW share first, then added a CephFS share.
Verified both shares successfully.
Verified successful deletion of both CephFS and RGW shares.
Signed-off-by: Shweta Sodani [ssodani@redhat.com]


## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [X] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

