### PR TITLE
mgr/smb: add RGW-backed SMB share support

### DIFF
--- a/doc/mgr/smb.rst
+++ b/doc/mgr/smb.rst
@@ -382,6 +382,51 @@ Create a read-only share at a custom path in the CephFS volume:
         --path=/qbranch/top/secret/plans --readonly
 
 
+Create RGW Share
+++++++++++++++++
+
+.. prompt:: bash #
+
+   ceph smb share create rgw <cluster_id> <share_id> <bucket> [--share-name=<share_name>] [--user-id=<user_id>] [--readonly]
+
+Create a new SMB share, hosted by the named cluster, that maps to a RADOS
+Gateway (RGW) bucket. This allows S3-compatible object storage to be accessed
+via the SMB protocol.
+
+Options:
+
+cluster_id
+    A short string uniquely identifying the cluster
+share_id
+    A short string uniquely identifying the share
+bucket
+    The name of the RGW bucket to be shared
+share_name
+    Optional. The public name of the share, visible to clients. If not provided
+    the ``share_id`` will be used automatically
+user_id
+    Optional. The RGW user ID that owns the bucket. If not provided, the system
+    will attempt to determine the bucket owner automatically
+readonly
+    Creates a read-only share
+
+Examples
+~~~~~~~~
+
+Create a share for an RGW bucket:
+
+.. prompt:: bash #
+
+    ceph smb share create rgw test1 photos my-photos-bucket
+
+Create a share with a custom name and specific user:
+
+.. prompt:: bash #
+
+    ceph smb share create rgw test1 photos my-photos-bucket \
+        --share-name="Photo Archive" --user-id=s3user
+
+
 .. _qos-parameters:
 
 QoS Parameters
@@ -1099,7 +1144,8 @@ max_connections
     connections to a specific share. The default value is 0 and it indicates
     that there is no limit on the number of connections
 cephfs
-    Required object. Fields:
+    Object. Configures CephFS-backed storage for the share. Either a ``cephfs``
+    or ``rgw`` object must be specified, but not both. Fields:
 
     volume
         Required string. Name of the cephfs volume to use
@@ -1169,6 +1215,18 @@ cephfs
         name
             String. A value indicating what FSCrypt key to fetch. The specific
             value of the name depends on the scope being used.
+rgw
+    Object. Configures RADOS Gateway (RGW) backed storage for the share. Either
+    a ``cephfs`` or ``rgw`` object must be specified, but not both. This allows
+    S3-compatible object storage to be accessed via the SMB protocol. Fields:
+
+    bucket
+        Required string. The name of the RGW bucket to be shared.
+    user_id
+        Optional string. The RGW user ID that owns the bucket. If not provided,
+        the system will automatically determine the bucket owner and fetch the
+        necessary credentials.
+
 restrict_access
     Optional boolean, defaulting to false. If true the share will only permit
     access by users explicitly listed in ``login_control``.
@@ -1216,7 +1274,32 @@ custom_smb_share_options
     things in ways that the Ceph team can not help with. This special key will
     automatically be removed from the list of options passed to Samba.
 
-The following is an example of a share with QoS settings including burst
+The following is an example of an RGW-backed share with minimal configuration
+(credentials auto-fetched):
+
+.. code-block:: yaml
+
+    resource_type: ceph.smb.share
+    cluster_id: tango
+    share_id: s3share
+    name: "S3 Storage"
+    rgw:
+      bucket: my-bucket
+
+Another example of an RGW-backed share with explicit user_id:
+
+.. code-block:: yaml
+
+    resource_type: ceph.smb.share
+    cluster_id: tango
+    share_id: s3share
+    name: "S3 Storage"
+    rgw:
+      bucket: my-bucket
+      user_id: s3user
+
+
+The following is an example of a CephFS share with QoS settings including burst
 multipliers and human-readable bandwidth limits:
 
 .. code-block:: yaml
@@ -1364,6 +1447,43 @@ Example:
         - name: steves
           password: F00Bar123
         groups: []
+
+
+RGW Credential Resource
+------------------------
+
+An RGW credential resource stores RADOS Gateway (RGW) access credentials that can be used by RGW-backed shares to authenticate with the object storage system.
+
+A RGW credential resource supports the following fields:
+
+resource_type
+    A literal string ``ceph.smb.rgw.credential``
+rgw_credential_id
+    A short string identifying the RGW credential resource.
+intent
+    One of ``present`` or ``removed``. If not provided, ``present`` is assumed.
+    If ``removed`` all following fields are optional
+user_id
+    Required string. The RGW user ID that owns the credentials
+access_key
+    Required string. The RGW access key for authentication
+secret_key
+    Required string. The RGW secret key for authentication
+linked_to_cluster:
+    Optional. A string containing a cluster ID. If set, the resource may only
+    be used with the linked cluster and will automatically be removed when the
+    linked cluster is removed.
+
+
+Example:
+
+.. code-block:: yaml
+
+    resource_type: ceph.smb.rgw.credential
+    rgw_credential_id: s3user 
+    user_id: s3user
+    access_key: AKIAIOSFODNN7EXAMPLE
+    secret_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 
 
 TLS Credential Resource

--- a/src/cephadm/cephadmlib/daemons/smb.py
+++ b/src/cephadm/cephadmlib/daemons/smb.py
@@ -245,6 +245,7 @@ class Config:
     debug_delay: int = 0
     join_sources: List[str] = dataclasses.field(default_factory=list)
     user_sources: List[str] = dataclasses.field(default_factory=list)
+    extra_config_uris: List[str] = dataclasses.field(default_factory=list)
     custom_dns: List[str] = dataclasses.field(default_factory=list)
     smb_port: int = 0
     ctdb_port: int = 0
@@ -267,6 +268,7 @@ class Config:
 
     def config_uris(self) -> List[str]:
         uris = [self.source_config]
+        uris.extend(self.extra_config_uris or [])
         uris.extend(self.user_sources or [])
         if self.clustered:
             # When clustered, we inject certain clustering related config vars
@@ -702,6 +704,7 @@ class SMB(ContainerDaemonForm):
         source_config = configs.get('config_uri', '')
         join_sources = configs.get('join_sources', [])
         user_sources = configs.get('user_sources', [])
+        extra_config_uris = configs.get('extra_config_uris', [])
         custom_dns = configs.get('custom_dns', [])
         instance_features = configs.get('features', [])
         files = data_utils.dict_get(configs, 'files', {})
@@ -768,6 +771,7 @@ class SMB(ContainerDaemonForm):
             source_config=source_config,
             join_sources=join_sources,
             user_sources=user_sources,
+            extra_config_uris=extra_config_uris,
             custom_dns=custom_dns,
             # major features
             domain_member=Features.DOMAIN.value in instance_features,

--- a/src/pybind/mgr/cephadm/services/smb.py
+++ b/src/pybind/mgr/cephadm/services/smb.py
@@ -206,6 +206,16 @@ class SMBService(CephService):
             ca_cert=ssl_params.ssl_ca_cert or '',
         )
 
+    def _rgw_creds_uri(self, cluster_id: str) -> Optional[str]:
+        from smb.external import rgw_config_key as _smb_rgw_config_key
+        from smb.mon_store import MonKeyConfigStore
+        _rgw_entry = MonKeyConfigStore(self.mgr)[
+            _smb_rgw_config_key(cluster_id)
+        ]
+        if _rgw_entry.exists():
+            return _rgw_entry.uri
+        return None
+
     def generate_config(
         self, daemon_spec: CephadmDaemonDeploySpec
     ) -> Tuple[Dict[str, Any], List[str]]:
@@ -220,6 +230,14 @@ class SMBService(CephService):
         config_blobs['cluster_id'] = smb_spec.cluster_id
         config_blobs['features'] = smb_spec.features
         config_blobs['config_uri'] = smb_spec.config_uri
+        # For RGW clusters, append the private-store config as an extra URI
+        # loaded after the public config.  sambacc's config:merge is a general
+        # merge mechanism; here the mgr populates it with only the RGW
+        # credential fields, keeping the public config the primary source of
+        # truth.
+        rgw_creds_uri = self._rgw_creds_uri(smb_spec.cluster_id)
+        if rgw_creds_uri:
+            config_blobs['extra_config_uris'] = [rgw_creds_uri]
         _add_cfg(config_blobs, 'join_sources', smb_spec.join_sources)
         _add_cfg(config_blobs, 'user_sources', smb_spec.user_sources)
         _add_cfg(config_blobs, 'custom_dns', smb_spec.custom_dns)
@@ -228,6 +246,7 @@ class SMBService(CephService):
         cluster_public_addrs = smb_spec.strict_cluster_ip_specs()
         _add_cfg(config_blobs, 'cluster_public_addrs', cluster_public_addrs)
         ceph_users = smb_spec.include_ceph_users or []
+
         config_blobs.update(
             self._ceph_config_and_keyring_for(
                 smb_spec, daemon_spec.daemon_id, ceph_users

--- a/src/pybind/mgr/cephadm/tests/services/test_smb.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_smb.py
@@ -55,6 +55,7 @@ class TestSMB:
                 'cluster_id': 'foxtrot',
                 'features': [],
                 'config_uri': 'rados://.smb/foxtrot/config.json',
+                'extra_config_uris': ['rados:mon-config-key:smb/config/foxtrot/config.smb.rgw'],
                 'config': '',
                 'keyring': '[client.smb.config.tango.briskly]\nkey = None\n',
                 'config_auth_entity': 'client.smb.config.tango.briskly',
@@ -125,6 +126,7 @@ class TestSMB:
                 'cluster_id': 'foxtrot',
                 'features': ['domain'],
                 'config_uri': 'rados://.smb/foxtrot/config2.json',
+                'extra_config_uris': ['rados:mon-config-key:smb/config/foxtrot/config.smb.rgw'],
                 'join_sources': [
                     'rados://.smb/foxtrot/join1.json',
                     'rados:mon-config-key:smb/config/foxtrot/join2.json',

--- a/src/pybind/mgr/smb/enums.py
+++ b/src/pybind/mgr/smb/enums.py
@@ -80,6 +80,7 @@ class ConfigNS(_StrEnum):
     USERS_AND_GROUPS = 'users_and_groups'
     JOIN_AUTHS = 'join_auths'
     TLS_CREDENTIALS = 'tls_creds'
+    RGW_CREDENTIALS = 'rgw_creds'
     EXTERNAL_CEPH_CLUSTERS = 'ext_ceph_clusters'
 
 

--- a/src/pybind/mgr/smb/external.py
+++ b/src/pybind/mgr/smb/external.py
@@ -49,6 +49,11 @@ def spec_backup_key(cluster_id: str) -> EntryKey:
     return (cluster_id, 'spec.smb')
 
 
+def rgw_credentials_key(cluster_id: str, share_id: str) -> EntryKey:
+    """Return key identifying RGW credentials for a share in an external store."""
+    return (cluster_id, f'rgw-creds.{share_id}.json')
+
+
 def tls_credential_key(
     cluster_id: str, tls_credential_id: str, cred_type: str
 ) -> EntryKey:

--- a/src/pybind/mgr/smb/external.py
+++ b/src/pybind/mgr/smb/external.py
@@ -49,9 +49,9 @@ def spec_backup_key(cluster_id: str) -> EntryKey:
     return (cluster_id, 'spec.smb')
 
 
-def rgw_credentials_key(cluster_id: str, share_id: str) -> EntryKey:
-    """Return key identifying RGW credentials for a share in an external store."""
-    return (cluster_id, f'rgw-creds.{share_id}.json')
+def rgw_config_key(cluster_id: str) -> EntryKey:
+    """Return key for the RGW credential stub in the private store."""
+    return (cluster_id, 'config.smb.rgw')
 
 
 def tls_credential_key(

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -27,7 +27,7 @@ from ceph.deployment.service_spec import (
 )
 from ceph.fs.earmarking import EarmarkTopScope
 
-from . import config_store, external, resources
+from . import config_store, external, resources, rgw
 from .enums import (
     AuthMode,
     CephFSStorageProvider,
@@ -318,6 +318,7 @@ class ClusterConfigHandler:
         authorizer: Optional[AccessAuthorizer] = None,
         orch: Optional[OrchSubmitter] = None,
         earmark_resolver: Optional[EarmarkResolver] = None,
+        tool_execer: 'rgw.ToolExecer',
     ) -> None:
         self.internal_store = internal_store
         self.public_store = public_store
@@ -332,6 +333,7 @@ class ClusterConfigHandler:
         if earmark_resolver is None:
             earmark_resolver = cast(EarmarkResolver, _FakeEarmarkResolver())
         self._earmark_resolver = earmark_resolver
+        self._tool_execer = tool_execer
         log.info(
             'Initialized new ClusterConfigHandler with'
             f' internal store {self.internal_store!r},'
@@ -351,7 +353,7 @@ class ClusterConfigHandler:
         """
         log.debug('applying changes to internal data store')
         results = ResultGroup()
-        staging = Staging(self.internal_store)
+        staging = Staging(self.internal_store, self._tool_execer)
         try:
             incoming = order_resources(inputs)
             for resource in incoming:
@@ -639,18 +641,43 @@ class ClusterConfigHandler:
         assert isinstance(cluster, resources.Cluster)
         # vols: hold the cephfs volumes our shares touch. some operations are
         # disabled/skipped unless we touch volumes.
-        vols = {share.checked_cephfs.volume for share in change_group.shares}
+        vols = {
+            share.checked_cephfs.volume
+            for share in change_group.shares
+            if share.cephfs is not None
+        }
+        # rgw_buckets: hold the RGW buckets our shares touch
+        rgw_buckets = {
+            share.rgw.bucket
+            for share in change_group.shares
+            if share.rgw is not None
+        }
         # save the various object types
         previous_info = _swap_pending_cluster_info(
             self.public_store,
             change_group,
-            orch_needed=bool(vols and self._orch),
+            orch_needed=bool((vols or rgw_buckets) and self._orch),
         )
         _save_pending_join_auths(self.priv_store, change_group)
         _save_pending_users_and_groups(self.priv_store, change_group)
         _save_pending_tls_credentials(self.priv_store, change_group)
+        _save_pending_rgw_credentials(self.priv_store, change_group)
+        rgw_credential_entries = {
+            share.share_id: change_group.cache[
+                external.rgw_credentials_key(
+                    change_group.cluster.cluster_id, share.share_id
+                )
+            ]
+            for share in change_group.shares
+            if share.rgw is not None
+            and share.rgw.access_key_id
+            and share.rgw.secret_access_key
+        }
         cluster_conf = _ClusterConf.assemble(
-            change_group, self._path_resolver, self._authorizer
+            change_group,
+            self._path_resolver,
+            self._authorizer,
+            rgw_credential_entries,
         )
         _save_pending_config(self.public_store, cluster_conf)
         # remove any stray objects
@@ -689,6 +716,17 @@ class ClusterConfigHandler:
             ]
             for tc in change_group.tls_credentials
         }
+        rgw_credential_entries = {
+            share.share_id: change_group.cache[
+                external.rgw_credentials_key(
+                    cluster.cluster_id, share.share_id
+                )
+            ]
+            for share in change_group.shares
+            if share.rgw is not None
+            and share.rgw.access_key_id
+            and share.rgw.secret_access_key
+        }
         ext_ceph_cluster = None
         if change_group.ext_ceph_clusters:
             assert len(change_group.ext_ceph_clusters) == 1
@@ -713,9 +751,31 @@ class ClusterConfigHandler:
         # via orch.  This differs from NFS because ganesha embeds the cephx
         # keys directly in each export definition block while samba needs the
         # ceph keyring to load keys.
+        # For RGW shares, we don't need CephFS volumes but still need orchestration.
         previous_orch = previous_info.get('orch_needed', False)
-        if self._orch and (vols or previous_orch):
+        if self._orch and (vols or rgw_buckets or previous_orch):
+            log.debug(
+                'Submitting SMB service spec for cluster %s: '
+                'shares=%d (cephfs_vols=%d, rgw_buckets=%d), '
+                'previous_orch=%s',
+                cluster.cluster_id,
+                len(change_group.shares),
+                len(vols),
+                len(rgw_buckets),
+                previous_orch,
+            )
             self._orch.submit_smb_spec(smb_spec)
+        else:
+            log.debug(
+                'Skipping SMB service orchestration for cluster %s: '
+                'orch_enabled=%s, shares=%d, cephfs_vols=%d, rgw_buckets=%d, previous_orch=%s',
+                cluster.cluster_id,
+                bool(self._orch),
+                len(change_group.shares),
+                len(vols),
+                len(rgw_buckets),
+                previous_orch,
+            )
 
     def _remove_cluster(self, cluster_id: str) -> None:
         log.info('Removing cluster: %s', cluster_id)
@@ -770,6 +830,8 @@ class _ShareConf:
     resolver: PathResolver
     cephx_entity: str
     ceph_cluster: str
+    rgw_access_key_uri: Optional[str] = None
+    rgw_secret_key_uri: Optional[str] = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -785,6 +847,7 @@ class _ClusterConf:
         change_group: ClusterChangeGroup,
         default_resolver: PathResolver,
         authorizer: AccessAuthorizer,
+        rgw_credential_entries: Dict[str, ConfigEntry],
     ) -> Self:
         extcc = None
         assert isinstance(change_group.cluster, resources.Cluster)
@@ -802,31 +865,116 @@ class _ClusterConf:
             ceph_cluster = 'exo'
             cephx_entity = checked(extcc.cluster).cephfs_user.name
         elif change_group.shares:
-            log.debug('local ceph cluster with shares')
-            cephx_entity = _cephx_data_entity(change_group.cluster)
-            # ensure an entity exists with access to the volumes
-            for share in change_group.shares:
-                authorizer.authorize_entity(
-                    share.checked_cephfs.volume, cephx_entity
+            # Check if we have any CephFS shares that need CephX auth
+            has_cephfs_shares = any(
+                s.cephfs is not None for s in change_group.shares
+            )
+            if has_cephfs_shares:
+                log.debug('local ceph cluster with CephFS shares')
+                cephx_entity = _cephx_data_entity(change_group.cluster)
+                # ensure an entity exists with access to the volumes (CephFS only)
+                for share in change_group.shares:
+                    if share.cephfs:
+                        authorizer.authorize_entity(
+                            share.checked_cephfs.volume, cephx_entity
+                        )
+                cephadm_data_entity = cephx_entity
+            else:
+                log.debug(
+                    'local ceph cluster with RGW shares only (no CephX auth needed)'
                 )
-            cephadm_data_entity = cephx_entity
         else:
             log.debug('local cluster without shares: skipping ceph auth')
         return cls(
             change_group.cluster,
             [
-                _ShareConf(
+                _make_share_conf(
                     s,
                     change_group.cluster,
                     resolver,
                     cephx_entity,
                     ceph_cluster,
+                    rgw_credential_entries,
                 )
                 for s in change_group.shares
             ],
             change_group,
             cephadm_data_entity,
         )
+
+
+def _make_share_conf(
+    s: resources.Share,
+    cluster: resources.Cluster,
+    resolver: PathResolver,
+    cephx_entity: str,
+    ceph_cluster: str,
+    rgw_credential_entries: Dict[str, ConfigEntry],
+) -> _ShareConf:
+    creds_entry = rgw_credential_entries.get(s.share_id)
+    # Get the URI from the ConfigEntry object, not from the data
+    access_key_uri = (
+        f'URI:{creds_entry.uri}:access_key_id' if creds_entry else None
+    )
+    secret_key_uri = (
+        f'URI:{creds_entry.uri}:secret_access_key' if creds_entry else None
+    )
+    return _ShareConf(
+        s,
+        cluster,
+        resolver,
+        cephx_entity,
+        ceph_cluster,
+        rgw_access_key_uri=access_key_uri,
+        rgw_secret_key_uri=secret_key_uri,
+    )
+
+
+def _generate_rgw_share(
+    conf: _ShareConf,
+) -> Dict[str, Dict[str, str]]:
+    """Generate Samba configuration for an RGW-backed share."""
+    share = conf.resource
+    rgw = share.rgw
+    assert rgw is not None, "RGW storage configuration missing"
+
+    # Use URI-based credential references (already formatted in _make_share_conf)
+    access_key_uri = conf.rgw_access_key_uri or ''
+    secret_key_uri = conf.rgw_secret_key_uri or ''
+
+    cfg = {
+        # smb.conf options
+        'options': {
+            'path': '/',
+            'vfs objects': 'ceph_rgw',
+            'ceph_rgw:config_file': '/etc/ceph/ceph.conf',
+            'ceph_rgw:keyring_file': '/etc/ceph/ceph.client.admin.keyring',
+            'ceph_rgw:bucket': rgw.bucket,
+            'ceph_rgw:user_id': rgw.user_id or '',
+            'ceph_rgw:access_key': access_key_uri,
+            'ceph_rgw:secret_access_key': secret_key_uri,
+            'ceph_rgw:debug': 'off',
+            'read only': ynbool(share.readonly),
+            'browseable': ynbool(share.browseable),
+            'kernel share modes': 'no',
+            'smbd profiling share': 'yes',
+        }
+    }
+
+    if share.comment is not None:
+        cfg['options']['comment'] = share.comment
+    if share.max_connections is not None:
+        cfg['options']['max connections'] = str(share.max_connections)
+
+    # extend share with user+group login access lists
+    _generate_share_login_control(share, cfg)
+    _generate_share_hosts_access(share, cfg)
+    # extend share with custom options
+    custom_opts = share.cleaned_custom_smb_share_options
+    if custom_opts:
+        cfg['options'].update(custom_opts)
+        cfg['options']['x:ceph:has_custom_options'] = 'yes'
+    return cfg
 
 
 def _generate_share(conf: _ShareConf) -> Dict[str, Dict[str, str]]:
@@ -1009,7 +1157,12 @@ def _generate_config(conf: _ClusterConf) -> Dict[str, Any]:
     _set_debug_level(cluster_global_opts, conf)
 
     share_configs = {
-        share.resource.name: _generate_share(share) for share in conf.shares
+        share.resource.name: (
+            _generate_rgw_share(share)
+            if share.resource.rgw
+            else _generate_share(share)
+        )
+        for share in conf.shares
     }
 
     instance_features = []
@@ -1309,6 +1462,31 @@ def _save_pending_tls_credentials(
         change_group.cache_updated_entry(tc_entry)
 
 
+def _save_pending_rgw_credentials(
+    store: ConfigStore,
+    change_group: ClusterChangeGroup,
+) -> None:
+    """Save RGW credentials for shares in the priv store."""
+    cluster = change_group.cluster
+    assert isinstance(cluster, resources.Cluster)
+
+    # Save credentials for each RGW share
+    for share in change_group.shares:
+        if share.rgw is not None:
+            # Only save if credentials are present
+            if share.rgw.access_key_id and share.rgw.secret_access_key:
+                ext_key = external.rgw_credentials_key(
+                    cluster.cluster_id, share.share_id
+                )
+                creds_entry = store[ext_key]
+                creds_data = {
+                    'access_key_id': share.rgw.access_key_id,
+                    'secret_access_key': share.rgw.secret_access_key,
+                }
+                creds_entry.set(creds_data)
+                change_group.cache_updated_entry(creds_entry)
+
+
 def _save_pending_config(
     store: ConfigStore,
     cluster_conf: _ClusterConf,
@@ -1350,11 +1528,12 @@ def _store_transaction(store: ConfigStore) -> Iterator[None]:
 
 
 def _has_proxied_vfs(change_group: ClusterChangeGroup) -> bool:
-    """Return true if any shares in the change group use the new vfs module
-    with the proxied cephfs library.
+    """Return true if any CephFS-backed shares in the change group use the
+    new vfs module with the proxied cephfs library.
     """
     return any(
-        s.checked_cephfs.provider.expand()
+        s.cephfs is not None
+        and s.checked_cephfs.provider.expand()
         == CephFSStorageProvider.SAMBA_VFS_PROXIED
         for s in change_group.shares
     )

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -45,6 +45,7 @@ from .internal import (
     CommonResourceEntry,
     ExternalCephClusterEntry,
     JoinAuthEntry,
+    RGWCredentialEntry,
     ShareEntry,
     TLSCredentialEntry,
     UsersAndGroupsEntry,
@@ -55,6 +56,7 @@ from .proto import (
     ConfigEntry,
     ConfigStore,
     EarmarkResolver,
+    MonCommandIssuer,
     OrchSubmitter,
     PathResolver,
     Self,
@@ -62,11 +64,13 @@ from .proto import (
 )
 from .resources import SMBResource
 from .results import ErrorResult, Result, ResultGroup
+from .rgw_auth import RGWAuthorizer
 from .staging import (
     Staging,
     auth_refs,
     cross_check_resource,
     ext_cluster_refs,
+    rgw_credential_refs,
     tls_refs,
     ug_refs,
 )
@@ -99,6 +103,7 @@ class ClusterChangeGroup:
         join_auths: List[resources.JoinAuth],
         users_and_groups: List[resources.UsersAndGroups],
         tls_credentials: List[resources.TLSCredential],
+        rgw_credentials: List[resources.RGWCredential],
         ext_ceph_clusters: List[resources.ExternalCephCluster],
     ):
         self.cluster = cluster
@@ -106,6 +111,7 @@ class ClusterChangeGroup:
         self.join_auths = join_auths
         self.users_and_groups = users_and_groups
         self.tls_credentials = tls_credentials
+        self.rgw_credentials = rgw_credentials
         self.ext_ceph_clusters = ext_ceph_clusters
         # a cache for modified entries
         self.cache = config_store.EntryCache()
@@ -180,6 +186,15 @@ class _FakeAuthorizer:
         pass
 
 
+class _FakeMonCommandIssuer:
+    """A stub MonCommandIssuer for unit testing."""
+
+    def mon_command(
+        self, cmd_dict: dict, inbuf: Optional[str] = None
+    ) -> Tuple[int, str, str]:
+        return (0, '', '')
+
+
 class _Matcher:
     _match_resources = (
         resources.Cluster,
@@ -187,6 +202,7 @@ class _Matcher:
         resources.JoinAuth,
         resources.UsersAndGroups,
         resources.TLSCredential,
+        resources.RGWCredential,
         resources.ExternalCephCluster,
     )
 
@@ -316,6 +332,7 @@ class ClusterConfigHandler:
         priv_store: ConfigStore,
         path_resolver: Optional[PathResolver] = None,
         authorizer: Optional[AccessAuthorizer] = None,
+        mon_cmd_issuer: Optional[MonCommandIssuer] = None,
         orch: Optional[OrchSubmitter] = None,
         earmark_resolver: Optional[EarmarkResolver] = None,
         tool_execer: 'rgw.ToolExecer',
@@ -329,6 +346,9 @@ class ClusterConfigHandler:
         if authorizer is None:
             authorizer = _FakeAuthorizer()
         self._authorizer: AccessAuthorizer = authorizer
+        if mon_cmd_issuer is None:
+            mon_cmd_issuer = _FakeMonCommandIssuer()
+        self._mon_cmd_issuer: MonCommandIssuer = mon_cmd_issuer
         self._orch = orch  # if None, disables updating the spec via orch
         if earmark_resolver is None:
             earmark_resolver = cast(EarmarkResolver, _FakeEarmarkResolver())
@@ -404,6 +424,9 @@ class ClusterConfigHandler:
 
     def user_and_group_ids(self) -> List[str]:
         return list(UsersAndGroupsEntry.ids(self.internal_store))
+
+    def rgw_credential_ids(self) -> List[str]:
+        return list(RGWCredentialEntry.ids(self.internal_store))
 
     def all_resources(self) -> List[SMBResource]:
         with _store_transaction(self.internal_store):
@@ -536,13 +559,14 @@ class ClusterConfigHandler:
                 removed_cluster_ids.add(cluster_id)
                 continue
             present_cluster_ids.add(cluster_id)
+            cluster_shares = [
+                self._share_entry(cid, shid).get_share()
+                for cid, shid in share_ids
+                if cid == cluster_id
+            ]
             change_group = ClusterChangeGroup(
                 cluster,
-                [
-                    self._share_entry(cid, shid).get_share()
-                    for cid, shid in share_ids
-                    if cid == cluster_id
-                ],
+                cluster_shares,
                 [
                     self._join_auth_entry(_id).get_join_auth()
                     for _id in auth_refs(cluster)
@@ -556,6 +580,12 @@ class ClusterConfigHandler:
                         self.internal_store, _id
                     ).get_tls_credential()
                     for _id in tls_refs(cluster)
+                ],
+                [
+                    RGWCredentialEntry.from_store(
+                        self.internal_store, _id
+                    ).get_rgw_credential()
+                    for _id in rgw_credential_refs(cluster_shares)
                 ],
                 [
                     ExternalCephClusterEntry.from_store(
@@ -597,6 +627,7 @@ class ClusterConfigHandler:
         chg_join_ids: Set[str] = set()
         chg_ug_ids: Set[str] = set()
         chg_tls_ids: Set[str] = set()
+        chg_rgw_cred_ids: Set[str] = set()
         chg_extc_ids: Set[str] = set()
         for result in updated:
             state = (result.status or {}).get('state', None)
@@ -618,13 +649,21 @@ class ClusterConfigHandler:
                 chg_ug_ids.add(result.src.users_groups_id)
             elif isinstance(result.src, resources.TLSCredential):
                 chg_tls_ids.add(result.src.tls_credential_id)
+            elif isinstance(result.src, resources.RGWCredential):
+                chg_rgw_cred_ids.add(result.src.rgw_credential_id)
             elif isinstance(result.src, resources.ExternalCephCluster):
                 chg_extc_ids.add(result.src.external_ceph_cluster_id)
 
         # TODO: here's a lazy bit. if any join auths or users/groups changed we
         # will regen all clusters because these can be shared by >1 cluster.
         # In future, make this only pick clusters using the named resources.
-        if chg_join_ids or chg_ug_ids or chg_tls_ids or chg_extc_ids:
+        if (
+            chg_join_ids
+            or chg_ug_ids
+            or chg_tls_ids
+            or chg_extc_ids
+            or chg_rgw_cred_ids
+        ):
             chg_cluster_ids.update(ClusterEntry.ids(self.internal_store))
         return chg_cluster_ids
 
@@ -661,25 +700,16 @@ class ClusterConfigHandler:
         _save_pending_join_auths(self.priv_store, change_group)
         _save_pending_users_and_groups(self.priv_store, change_group)
         _save_pending_tls_credentials(self.priv_store, change_group)
-        _save_pending_rgw_credentials(self.priv_store, change_group)
-        rgw_credential_entries = {
-            share.share_id: change_group.cache[
-                external.rgw_credentials_key(
-                    change_group.cluster.cluster_id, share.share_id
-                )
-            ]
-            for share in change_group.shares
-            if share.rgw is not None
-            and share.rgw.access_key_id
-            and share.rgw.secret_access_key
-        }
+        # Create RGW authorizer for this cluster configuration
+        rgw_authorizer = RGWAuthorizer(self._mon_cmd_issuer)
         cluster_conf = _ClusterConf.assemble(
             change_group,
             self._path_resolver,
             self._authorizer,
-            rgw_credential_entries,
+            rgw_authorizer,
         )
         _save_pending_config(self.public_store, cluster_conf)
+        _save_pending_rgw_config(self.priv_store, cluster_conf)
         # remove any stray objects
         external.rm_other_in_ns(
             self.priv_store,
@@ -716,17 +746,6 @@ class ClusterConfigHandler:
             ]
             for tc in change_group.tls_credentials
         }
-        rgw_credential_entries = {
-            share.share_id: change_group.cache[
-                external.rgw_credentials_key(
-                    cluster.cluster_id, share.share_id
-                )
-            ]
-            for share in change_group.shares
-            if share.rgw is not None
-            and share.rgw.access_key_id
-            and share.rgw.secret_access_key
-        }
         ext_ceph_cluster = None
         if change_group.ext_ceph_clusters:
             assert len(change_group.ext_ceph_clusters) == 1
@@ -738,7 +757,7 @@ class ClusterConfigHandler:
             join_source_entries=join_source_entries,
             user_source_entries=user_source_entries,
             tls_credential_entries=tls_credential_entries,
-            data_entity=cluster_conf.data_entity,
+            user_entities=cluster_conf.user_entities,
             needs_proxy=_has_proxied_vfs(change_group),
             ext_ceph_cluster=ext_ceph_cluster,
             ssl_certificates=ssl_certificates,
@@ -830,8 +849,7 @@ class _ShareConf:
     resolver: PathResolver
     cephx_entity: str
     ceph_cluster: str
-    rgw_access_key_uri: Optional[str] = None
-    rgw_secret_key_uri: Optional[str] = None
+    rgw_entity: str = ''
 
 
 @dataclasses.dataclass(frozen=True)
@@ -839,7 +857,7 @@ class _ClusterConf:
     resource: resources.Cluster
     shares: Iterable[_ShareConf]
     change_group: ClusterChangeGroup
-    data_entity: str
+    user_entities: List[str]
 
     @classmethod
     def assemble(
@@ -847,7 +865,7 @@ class _ClusterConf:
         change_group: ClusterChangeGroup,
         default_resolver: PathResolver,
         authorizer: AccessAuthorizer,
-        rgw_credential_entries: Dict[str, ConfigEntry],
+        rgw_authorizer: RGWAuthorizer,
     ) -> Self:
         extcc = None
         assert isinstance(change_group.cluster, resources.Cluster)
@@ -857,102 +875,99 @@ class _ClusterConf:
 
         resolver = default_resolver
         cephx_entity = ''  # default to no entity for data access
-        cephadm_data_entity = ''  # passed to cephadm service spec
+        cephfs_entity = ''  # CephFS-specific entity
+        rgw_entity = ''  # RGW-specific entity
+        cephadm_data_entities: List[
+            str
+        ] = []  # passed to cephadm service spec
         ceph_cluster = ''  # empty string means local cluster
         if extcc:
             log.debug('external ceph cluster')
             resolver = ExoResolver(change_group.cluster)
             ceph_cluster = 'exo'
             cephx_entity = checked(extcc.cluster).cephfs_user.name
+            cephfs_entity = cephx_entity
+            cephadm_data_entities = [cephx_entity]
         elif change_group.shares:
             # Check if we have any CephFS shares that need CephX auth
             has_cephfs_shares = any(
                 s.cephfs is not None for s in change_group.shares
             )
+            has_rgw_shares = any(
+                s.rgw is not None for s in change_group.shares
+            )
             if has_cephfs_shares:
                 log.debug('local ceph cluster with CephFS shares')
-                cephx_entity = _cephx_data_entity(change_group.cluster)
+                cephfs_entity = _cephx_data_entity(change_group.cluster)
                 # ensure an entity exists with access to the volumes (CephFS only)
                 for share in change_group.shares:
                     if share.cephfs:
                         authorizer.authorize_entity(
-                            share.checked_cephfs.volume, cephx_entity
+                            share.checked_cephfs.volume, cephfs_entity
                         )
-                cephadm_data_entity = cephx_entity
-            else:
-                log.debug(
-                    'local ceph cluster with RGW shares only (no CephX auth needed)'
-                )
+                cephx_entity = cephfs_entity
+                cephadm_data_entities.append(cephfs_entity)
+            if has_rgw_shares:
+                log.debug('local ceph cluster with RGW shares')
+                # RGW shares need a CephX entity for RADOS access
+                rgw_entity = _cephx_rgw_entity(change_group.cluster)
+                # Authorize the entity using the provided RGW authorizer
+                rgw_authorizer.authorize_entity(rgw_entity)
+                cephadm_data_entities.append(rgw_entity)
         else:
             log.debug('local cluster without shares: skipping ceph auth')
         return cls(
             change_group.cluster,
             [
-                _make_share_conf(
+                _ShareConf(
                     s,
                     change_group.cluster,
                     resolver,
-                    cephx_entity,
+                    cephfs_entity,
                     ceph_cluster,
-                    rgw_credential_entries,
+                    rgw_entity=rgw_entity,
                 )
                 for s in change_group.shares
             ],
             change_group,
-            cephadm_data_entity,
+            cephadm_data_entities,
         )
-
-
-def _make_share_conf(
-    s: resources.Share,
-    cluster: resources.Cluster,
-    resolver: PathResolver,
-    cephx_entity: str,
-    ceph_cluster: str,
-    rgw_credential_entries: Dict[str, ConfigEntry],
-) -> _ShareConf:
-    creds_entry = rgw_credential_entries.get(s.share_id)
-    # Get the URI from the ConfigEntry object, not from the data
-    access_key_uri = (
-        f'URI:{creds_entry.uri}:access_key_id' if creds_entry else None
-    )
-    secret_key_uri = (
-        f'URI:{creds_entry.uri}:secret_access_key' if creds_entry else None
-    )
-    return _ShareConf(
-        s,
-        cluster,
-        resolver,
-        cephx_entity,
-        ceph_cluster,
-        rgw_access_key_uri=access_key_uri,
-        rgw_secret_key_uri=secret_key_uri,
-    )
 
 
 def _generate_rgw_share(
     conf: _ShareConf,
+    cred_map: Dict[str, resources.RGWCredential],
 ) -> Dict[str, Dict[str, str]]:
     """Generate Samba configuration for an RGW-backed share."""
     share = conf.resource
     rgw = share.rgw
     assert rgw is not None, "RGW storage configuration missing"
 
-    # Use URI-based credential references (already formatted in _make_share_conf)
-    access_key_uri = conf.rgw_access_key_uri or ''
-    secret_key_uri = conf.rgw_secret_key_uri or ''
+    # Get user_id from credential (credential_ref is guaranteed by validation)
+    assert rgw.credential_ref is not None
+    cred = cred_map.get(rgw.credential_ref)
+    if cred is None:
+        log.error(
+            "share %r references missing RGW credential %r",
+            share.name,
+            rgw.credential_ref,
+        )
+        user_id = ""
+    else:
+        user_id = cred.user_id or ""
 
     cfg = {
         # smb.conf options
         'options': {
             'path': '/',
             'vfs objects': 'ceph_rgw',
-            'ceph_rgw:config_file': '/etc/ceph/ceph.conf',
-            'ceph_rgw:keyring_file': '/etc/ceph/ceph.client.admin.keyring',
             'ceph_rgw:bucket': rgw.bucket,
-            'ceph_rgw:user_id': rgw.user_id or '',
-            'ceph_rgw:access_key': access_key_uri,
-            'ceph_rgw:secret_access_key': secret_key_uri,
+            'ceph_rgw:user_id': user_id,
+            # Credential values are left empty here; they are injected at
+            # deploy time via a config:merge stub in the private store so
+            # they never appear in the public RADOS config.
+            'ceph_rgw:access_key': '',
+            'ceph_rgw:secret_access_key': '',
             'ceph_rgw:debug': 'off',
             'read only': ynbool(share.readonly),
             'browseable': ynbool(share.browseable),
@@ -977,12 +992,7 @@ def _generate_rgw_share(
     return cfg
 
 
-def _generate_share(conf: _ShareConf) -> Dict[str, Dict[str, str]]:
-    share = conf.resource
-    cephx_entity = conf.cephx_entity
-    cephfs = share.checked_cephfs
-    assert cephfs.provider.is_vfs(), "not a vfs provider"
-    assert cephx_entity, "cephx entity name missing"
+def cephx_stripped_entity(cephx_entity: str) -> str:
     # very annoyingly, samba's ceph module absolutely must NOT have the
     # "client." bit in front. JJM has been tripped up by this multiple times -
     # seemingly every time this module is touched.
@@ -990,6 +1000,16 @@ def _generate_share(conf: _ShareConf) -> Dict[str, Dict[str, str]]:
     plen = len(_prefix)
     if cephx_entity.startswith(_prefix):
         cephx_entity = cephx_entity[plen:]
+    return cephx_entity
+
+
+def _generate_share(conf: _ShareConf) -> Dict[str, Dict[str, str]]:
+    share = conf.resource
+    cephx_entity = conf.cephx_entity
+    cephfs = share.checked_cephfs
+    assert cephfs.provider.is_vfs(), "not a vfs provider"
+    assert cephx_entity, "cephx entity name missing"
+    cephx_entity = cephx_stripped_entity(cephx_entity)
     path = conf.resolver.resolve(
         cephfs.volume,
         cephfs.subvolumegroup,
@@ -1156,9 +1176,30 @@ def _generate_config(conf: _ClusterConf) -> Dict[str, Any]:
     cluster_global_opts['smb ports'] = str(_smb_port(cluster))
     _set_debug_level(cluster_global_opts, conf)
 
+    # Check if cluster has RGW shares and add global RGW options
+    has_rgw_shares = any(share.resource.rgw for share in conf.shares)
+    if has_rgw_shares:
+        # Get pre-calculated stripped RGW entity from first RGW share
+        rgw_entity = next(
+            (share.rgw_entity for share in conf.shares if share.resource.rgw),
+            '',
+        )
+        if rgw_entity:
+            cluster_global_opts[
+                'ceph_rgw:config_file'
+            ] = '/etc/ceph/ceph.conf'
+            cluster_global_opts['ceph_rgw:keyring_file'] = '/etc/ceph/keyring'
+            cluster_global_opts['ceph_rgw:id'] = cephx_stripped_entity(
+                rgw_entity
+            )
+
+    cred_map = {
+        c.rgw_credential_id: c for c in conf.change_group.rgw_credentials
+    }
+
     share_configs = {
         share.resource.name: (
-            _generate_rgw_share(share)
+            _generate_rgw_share(share, cred_map)
             if share.resource.rgw
             else _generate_share(share)
         )
@@ -1215,7 +1256,7 @@ def _generate_smb_service_spec(
     join_source_entries: List[ConfigEntry],
     user_source_entries: List[ConfigEntry],
     tls_credential_entries: Dict[str, ConfigEntry],
-    data_entity: str = '',
+    user_entities: List[str],
     needs_proxy: bool = False,
     ext_ceph_cluster: Optional[resources.ExternalCephCluster],
     ssl_certificates: Dict[str, SSLParameters],
@@ -1250,9 +1291,6 @@ def _generate_smb_service_spec(
     user_sources: List[str] = []
     for entry in user_source_entries:
         user_sources.append(entry.uri)
-    user_entities: Optional[List[str]] = None
-    if data_entity:
-        user_entities = [data_entity]
 
     rc_cert = rc_key = rc_ca_cert = None
     if cluster.is_feature_enabled(_REMOTE_CONTROL):
@@ -1462,31 +1500,6 @@ def _save_pending_tls_credentials(
         change_group.cache_updated_entry(tc_entry)
 
 
-def _save_pending_rgw_credentials(
-    store: ConfigStore,
-    change_group: ClusterChangeGroup,
-) -> None:
-    """Save RGW credentials for shares in the priv store."""
-    cluster = change_group.cluster
-    assert isinstance(cluster, resources.Cluster)
-
-    # Save credentials for each RGW share
-    for share in change_group.shares:
-        if share.rgw is not None:
-            # Only save if credentials are present
-            if share.rgw.access_key_id and share.rgw.secret_access_key:
-                ext_key = external.rgw_credentials_key(
-                    cluster.cluster_id, share.share_id
-                )
-                creds_entry = store[ext_key]
-                creds_data = {
-                    'access_key_id': share.rgw.access_key_id,
-                    'secret_access_key': share.rgw.secret_access_key,
-                }
-                creds_entry.set(creds_data)
-                change_group.cache_updated_entry(creds_entry)
-
-
 def _save_pending_config(
     store: ConfigStore,
     cluster_conf: _ClusterConf,
@@ -1495,6 +1508,49 @@ def _save_pending_config(
     cconfig = _generate_config(cluster_conf)
     centry = store[external.config_key(cluster_conf.resource.cluster_id)]
     centry.set(cconfig)
+    cluster_conf.change_group.cache_updated_entry(centry)
+
+
+def _save_pending_rgw_config(
+    store: ConfigStore,
+    cluster_conf: _ClusterConf,
+) -> None:
+    """Save an RGW credential stub to the private store for RGW clusters.
+
+    Writes a stub using sambacc's config:merge mechanism, which merges the
+    provided JSON on top of the primary config at load time.  The mgr
+    populates the stub with only the RGW credential fields here; everything else
+    stays in the public RADOS config.  The stub URI is passed to the container
+    via extra_config_uris so credentials never appear in the public pool.
+    """
+    cluster_id = cluster_conf.resource.cluster_id
+    rgw_shares = [s for s in cluster_conf.shares if s.resource.rgw]
+    if not rgw_shares:
+        return
+    cred_map = {
+        c.rgw_credential_id: c
+        for c in cluster_conf.change_group.rgw_credentials
+    }
+    merge_shares: Dict[str, Any] = {}
+    for sc in rgw_shares:
+        rgw = sc.resource.rgw
+        assert rgw is not None
+        assert rgw.credential_ref is not None
+        cred = cred_map[rgw.credential_ref]
+        access_key = cred.access_key_id or ''
+        secret_key = cred.secret_access_key or ''
+        merge_shares[sc.resource.name] = {
+            'options': {
+                'ceph_rgw:access_key': access_key,
+                'ceph_rgw:secret_access_key': secret_key,
+            }
+        }
+    stub = {
+        'samba-container-config': 'v0',
+        'config:merge': {'shares': merge_shares},
+    }
+    centry = store[external.rgw_config_key(cluster_id)]
+    centry.set(stub)
     cluster_conf.change_group.cache_updated_entry(centry)
 
 
@@ -1513,6 +1569,15 @@ def _cephx_data_entity(cluster: resources.Cluster) -> str:
     if cluster.external_ceph_cluster:
         return ''
     return f'client.smb.fs.cluster.{cluster.cluster_id}'
+
+
+def _cephx_rgw_entity(cluster: resources.Cluster) -> str:
+    """Generate a name for the cephx key that a cluster (smbd) will
+    use for RGW data access.
+    """
+    if cluster.external_ceph_cluster:
+        return ''
+    return f'client.smb.rgw.cluster.{cluster.cluster_id}'
 
 
 @contextlib.contextmanager

--- a/src/pybind/mgr/smb/internal.py
+++ b/src/pybind/mgr/smb/internal.py
@@ -223,6 +223,23 @@ class TLSCredentialEntry(CommonResourceEntry):
         return self.get_resource_type(resources.TLSCredential)
 
 
+class RGWCredentialEntry(CommonResourceEntry):
+    """RGWCredentialEntry resource getter/setter for the smb internal data
+    store(s).
+    """
+
+    namespace = ConfigNS.RGW_CREDENTIALS
+    _for_resource = resources.RGWCredential
+
+    @classmethod
+    def to_key(cls, resource: SMBResource) -> ResourceKey:
+        assert isinstance(resource, cls._for_resource)
+        return ResourceIDKey(resource.rgw_credential_id)
+
+    def get_rgw_credential(self) -> resources.RGWCredential:
+        return self.get_resource_type(resources.RGWCredential)
+
+
 class ExternalCephClusterEntry(CommonResourceEntry):
     """ExternalCephCluster resource getter/setter for internal store."""
 
@@ -251,6 +268,7 @@ def map_resource_entry(
         resources.JoinAuth: JoinAuthEntry,
         resources.UsersAndGroups: UsersAndGroupsEntry,
         resources.TLSCredential: TLSCredentialEntry,
+        resources.RGWCredential: RGWCredentialEntry,
         resources.ExternalCephCluster: ExternalCephClusterEntry,
     }
     try:

--- a/src/pybind/mgr/smb/module.py
+++ b/src/pybind/mgr/smb/module.py
@@ -100,6 +100,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             public_store=self._public_store,
             path_resolver=path_resolver,
             authorizer=authorizer,
+            mon_cmd_issuer=self,
             orch=self._orch_backend(enable_orch=uo),
             earmark_resolver=earmark_resolver,
             tool_execer=self,
@@ -630,12 +631,12 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         """Create an SMB share backed by RGW"""
         try:
             # Pass 'self' which conforms to ToolExecer protocol
-            (
-                fetched_user_id,
-                access_key,
-                secret_key,
-            ) = rgw.fetch_rgw_credentials(self, bucket, user_id)
+            fetched_user_id = rgw.fetch_rgw_credentials(
+                self, bucket, user_id
+            )[0]
 
+            # Create share with user credentials
+            # The staging layer will auto-create the credential if needed
             share = resources.Share(
                 cluster_id=cluster_id,
                 share_id=share_id,
@@ -644,11 +645,11 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                 rgw=resources.RGWStorage(
                     bucket=bucket,
                     user_id=fetched_user_id,
-                    access_key_id=access_key,
-                    secret_access_key=secret_key,
                 ),
             )
-            return self._apply_res([share], create_only=True).one()
+
+            # Apply share resource (staging may create credential too)
+            return self._apply_res([share], create_only=True).squash(share)
         except ValueError as e:
             # Create a minimal share resource for error reporting
             error_share = resources.Share(

--- a/src/pybind/mgr/smb/module.py
+++ b/src/pybind/mgr/smb/module.py
@@ -25,6 +25,7 @@ from . import (
     rados_store,
     resources,
     results,
+    rgw,
     sqlite_store,
     utils,
 )
@@ -101,6 +102,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             authorizer=authorizer,
             orch=self._orch_backend(enable_orch=uo),
             earmark_resolver=earmark_resolver,
+            tool_execer=self,
         )
 
     def _backend_store(self, store_conf: str = '') -> ConfigStore:
@@ -614,6 +616,48 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             for cid, shid in self._handler.share_ids()
             if cid == cluster_id
         ]
+
+    @SMBCLICommand('share create rgw', perm='rw')
+    def share_create_rgw(
+        self,
+        cluster_id: str,
+        share_id: str,
+        bucket: str,
+        share_name: str = '',
+        user_id: str = '',
+        readonly: bool = False,
+    ) -> results.Result:
+        """Create an SMB share backed by RGW"""
+        try:
+            # Pass 'self' which conforms to ToolExecer protocol
+            (
+                fetched_user_id,
+                access_key,
+                secret_key,
+            ) = rgw.fetch_rgw_credentials(self, bucket, user_id)
+
+            share = resources.Share(
+                cluster_id=cluster_id,
+                share_id=share_id,
+                name=share_name or share_id,
+                readonly=readonly,
+                rgw=resources.RGWStorage(
+                    bucket=bucket,
+                    user_id=fetched_user_id,
+                    access_key_id=access_key,
+                    secret_access_key=secret_key,
+                ),
+            )
+            return self._apply_res([share], create_only=True).one()
+        except ValueError as e:
+            # Create a minimal share resource for error reporting
+            error_share = resources.Share(
+                cluster_id=cluster_id,
+                share_id=share_id,
+                name=share_name or share_id,
+                rgw=resources.RGWStorage(bucket='error'),
+            )
+            return results.ErrorResult(error_share, msg=str(e))
 
     @SMBCLICommand('share create', perm='rw')
     def share_create(

--- a/src/pybind/mgr/smb/resources.py
+++ b/src/pybind/mgr/smb/resources.py
@@ -406,8 +406,7 @@ class RGWStorage(_RBase):
 
     bucket: str
     user_id: Optional[str] = None
-    access_key_id: Optional[str] = None
-    secret_access_key: Optional[str] = None
+    credential_ref: Optional[str] = None
 
     def validate(self) -> None:
         if not self.bucket:
@@ -418,23 +417,12 @@ class RGWStorage(_RBase):
         return self.__class__(
             bucket=self.bucket,
             user_id=self.user_id,
-            access_key_id=(
-                _password_convert(self.access_key_id, operation)
-                if self.access_key_id
-                else None
-            ),
-            secret_access_key=(
-                _password_convert(self.secret_access_key, operation)
-                if self.secret_access_key
-                else None
-            ),
+            credential_ref=self.credential_ref,
         )
 
     @resourcelib.customize
     def _customize_resource(rc: resourcelib.Resource) -> resourcelib.Resource:
         rc.user_id.quiet = True
-        rc.access_key_id.quiet = True
-        rc.secret_access_key.quiet = True
         return rc
 
 
@@ -1199,6 +1187,52 @@ class TLSCredential(_RBase):
         return self
 
 
+@resourcelib.resource('ceph.smb.rgw.credential')
+class RGWCredential(_RBase):
+    """Contains RGW user credentials that can be referenced by multiple
+    SMB shares backed by RGW buckets.
+    """
+
+    rgw_credential_id: str
+    user_id: str
+    access_key_id: str
+    secret_access_key: str
+    intent: Intent = Intent.PRESENT
+    linked_to_cluster: Optional[str] = None
+
+    def validate(self) -> None:
+        if not self.rgw_credential_id:
+            raise ValueError('rgw_credential_id requires a value')
+        validation.check_id(self.rgw_credential_id)
+        if self.linked_to_cluster is not None:
+            validation.check_id(self.linked_to_cluster)
+        if self.intent is Intent.PRESENT:
+            if not self.user_id:
+                raise ValueError('user_id must be specified')
+            if not self.access_key_id:
+                raise ValueError('access_key_id must be specified')
+            if not self.secret_access_key:
+                raise ValueError('secret_access_key must be specified')
+
+    @resourcelib.customize
+    def _customize_resource(rc: resourcelib.Resource) -> resourcelib.Resource:
+        rc.linked_to_cluster.quiet = True
+        rc.on_construction_error(InvalidResourceError.wrap)
+        return rc
+
+    def convert(self, operation: ConversionOp) -> Self:
+        return self.__class__(
+            rgw_credential_id=self.rgw_credential_id,
+            intent=self.intent,
+            user_id=self.user_id,
+            access_key_id=_password_convert(self.access_key_id, operation),
+            secret_access_key=_password_convert(
+                self.secret_access_key, operation
+            ),
+            linked_to_cluster=self.linked_to_cluster,
+        )
+
+
 @resourcelib.component()
 class CephUserKey(_RBase):
     """A Ceph User Key name and value pair."""
@@ -1243,6 +1277,7 @@ SMBResource = Union[
     Share,
     UsersAndGroups,
     TLSCredential,
+    RGWCredential,
     ExternalCephCluster,
 ]
 

--- a/src/pybind/mgr/smb/resources.py
+++ b/src/pybind/mgr/smb/resources.py
@@ -401,6 +401,44 @@ class LoginAccessEntry(_RBase):
 
 
 @resourcelib.component()
+class RGWStorage(_RBase):
+    """Description of where in an RGW bucket a share is located."""
+
+    bucket: str
+    user_id: Optional[str] = None
+    access_key_id: Optional[str] = None
+    secret_access_key: Optional[str] = None
+
+    def validate(self) -> None:
+        if not self.bucket:
+            raise ValueError('bucket requires a value')
+
+    def convert(self, operation: ConversionOp) -> Self:
+        """Convert password fields based on the operation."""
+        return self.__class__(
+            bucket=self.bucket,
+            user_id=self.user_id,
+            access_key_id=(
+                _password_convert(self.access_key_id, operation)
+                if self.access_key_id
+                else None
+            ),
+            secret_access_key=(
+                _password_convert(self.secret_access_key, operation)
+                if self.secret_access_key
+                else None
+            ),
+        )
+
+    @resourcelib.customize
+    def _customize_resource(rc: resourcelib.Resource) -> resourcelib.Resource:
+        rc.user_id.quiet = True
+        rc.access_key_id.quiet = True
+        rc.secret_access_key.quiet = True
+        return rc
+
+
+@resourcelib.component()
 class HostAccessEntry(_RBase):
     access: HostAccess
     address: str = ''
@@ -461,6 +499,7 @@ class Share(_RBase):
     comment: Optional[str] = None
     max_connections: Optional[int] = None
     cephfs: Optional[CephFSStorage] = None
+    rgw: Optional[RGWStorage] = None
     custom_smb_share_options: Optional[Dict[str, str]] = None
     login_control: Optional[List[LoginAccessEntry]] = None
     restrict_access: bool = False
@@ -481,9 +520,14 @@ class Share(_RBase):
         validation.check_share_name(self.name)
         if self.intent != Intent.PRESENT:
             raise ValueError('Share must have present intent')
-        # currently only cephfs is supported
-        if self.cephfs is None:
-            raise ValueError('a cephfs configuration is required')
+        # Ensure exactly one storage backend is specified
+        storage_count = len([b for b in (self.cephfs, self.rgw) if b])
+        if storage_count == 0:
+            raise ValueError(
+                'a storage configuration is required (cephfs or rgw)'
+            )
+        if storage_count > 1:
+            raise ValueError('only one storage backend can be specified')
         if self.max_connections is not None and self.max_connections < 0:
             raise ValueError(
                 'max_connections must be 0 or a non-negative integer'
@@ -500,6 +544,25 @@ class Share(_RBase):
     def checked_cephfs(self) -> CephFSStorage:
         """Return the .cephfs storage object or raise ValueError if None."""
         return checked(self.cephfs)
+
+    def convert(self, operation: ConversionOp) -> Self:
+        """Convert password fields in nested storage components."""
+        return self.__class__(
+            cluster_id=self.cluster_id,
+            share_id=self.share_id,
+            intent=self.intent,
+            name=self.name,
+            readonly=self.readonly,
+            browseable=self.browseable,
+            comment=self.comment,
+            max_connections=self.max_connections,
+            cephfs=self.cephfs.convert(operation) if self.cephfs else None,
+            rgw=self.rgw.convert(operation) if self.rgw else None,
+            custom_smb_share_options=self.custom_smb_share_options,
+            login_control=self.login_control,
+            restrict_access=self.restrict_access,
+            hosts_access=self.hosts_access,
+        )
 
     @resourcelib.customize
     def _customize_resource(rc: resourcelib.Resource) -> resourcelib.Resource:

--- a/src/pybind/mgr/smb/rgw.py
+++ b/src/pybind/mgr/smb/rgw.py
@@ -1,0 +1,153 @@
+"""Utilities for RGW integration with SMB."""
+
+from typing import Protocol, Tuple, runtime_checkable
+
+import json
+import logging
+
+log = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class ToolExecer(Protocol):
+    """Protocol for executing tools (e.g., radosgw-admin)."""
+
+    def tool_exec(self, cmd: list[str]) -> Tuple[int, str, str]:
+        """Execute a tool and return (return_code, stdout, stderr)."""
+        ...
+
+
+def _fetch_bucket_stats(executor: ToolExecer, bucket: str) -> dict:
+    """
+    Fetch RGW bucket statistics.
+    Args:
+        executor: Any object with tool_exec() method
+        bucket: The RGW bucket name
+    Returns:
+        Parsed JSON bucket stats dictionary
+    Raises:
+        ValueError: If bucket stats cannot be fetched or parsed
+    """
+    log.debug(f"Fetching stats for bucket {bucket}")
+    ret, out, err = executor.tool_exec(
+        ['radosgw-admin', 'bucket', 'stats', '--bucket', bucket]
+    )
+    if ret:
+        raise ValueError(f'Failed to fetch stats for bucket {bucket}: {err}')
+
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError as e:
+        raise ValueError(f'Failed to parse bucket stats for {bucket}: {e}')
+
+
+def _get_rgw_owner(executor: ToolExecer, bucket: str) -> str:
+    """
+    Fetch RGW user bucket owner.
+    Args:
+        executor: Any object with tool_exec() method
+        bucket: The RGW bucket name
+    Returns:
+        user_id: RGW user ID that owns bucket.
+    Raises:
+        ValueError: If bucket owner cannot be determined
+    """
+
+    try:
+        stats = _fetch_bucket_stats(executor, bucket)
+        user_id = stats.get('owner', '')
+        if not user_id:
+            raise ValueError(f'No owner found for bucket {bucket}')
+
+        log.debug(f"Bucket {bucket} is owned by user {user_id}")
+        return user_id
+
+    except ValueError:
+        raise
+
+
+def _get_rgw_creds(executor: ToolExecer, user_id: str) -> Tuple[str, str]:
+    """
+    Fetch RGW user credentials.
+    Args:
+        executor: Any object with tool_exec() method
+        user_id: The RGW user ID
+    Returns:
+        Tuple of (access_key_id, secret_access_key)
+    Raises:
+        ValueError: If credentials cannot be fetched
+    """
+    log.debug(f"Fetching credentials for user {user_id}")
+    ret, out, err = executor.tool_exec(
+        ['radosgw-admin', 'user', 'info', '--uid', user_id]
+    )
+    if ret:
+        raise ValueError(
+            f'Failed to fetch credentials for user {user_id}: {err}'
+        )
+
+    try:
+        j = json.loads(out)
+        keys = j.get('keys', [])
+        if not keys:
+            raise ValueError(f'No keys found for user {user_id}')
+
+        access_key = keys[0].get('access_key', '')
+        secret_key = keys[0].get('secret_key', '')
+
+        if not access_key or not secret_key:
+            raise ValueError(
+                f'Invalid credentials for user {user_id}: '
+                f'access_key={bool(access_key)}, secret_key={bool(secret_key)}'
+            )
+
+        log.debug(f"Successfully fetched credentials for user {user_id}")
+        return access_key, secret_key
+
+    except (json.JSONDecodeError, KeyError, IndexError) as e:
+        raise ValueError(f'Failed to parse user info for {user_id}: {e}')
+
+
+def fetch_rgw_credentials(
+    executor: ToolExecer,
+    bucket: str,
+    user_id: str = '',
+) -> Tuple[str, str, str]:
+    """
+    Fetch RGW user credentials for a bucket.
+
+    Args:
+        executor: Any object with tool_exec() method
+        bucket: The RGW bucket name
+        user_id: Optional RGW user ID. If not provided, fetches bucket owner.
+
+    Returns:
+        Tuple of (user_id, access_key_id, secret_access_key)
+
+    Raises:
+        ValueError: If bucket owner cannot be determined or credentials not found
+    """
+    if not user_id:
+        user_id = _get_rgw_owner(executor, bucket)
+
+    access_key, secret_key = _get_rgw_creds(executor, user_id)
+    return user_id, access_key, secret_key
+
+
+def validate_rgw_bucket(executor: ToolExecer, bucket: str) -> bool:
+    """
+    Validate that an RGW bucket exists.
+    Args:
+        executor: Any object with tool_exec() method
+        bucket: The RGW bucket name
+    Returns:
+        True if bucket exists, False otherwise
+    """
+    log.debug(f"Validating bucket {bucket}")
+    try:
+        stats = _fetch_bucket_stats(executor, bucket)
+        # If we can parse the output and it has an owner, bucket exists
+        return bool(stats.get('owner'))
+    except ValueError as e:
+        log.debug(f"Bucket {bucket} validation failed: {e}")
+        return False

--- a/src/pybind/mgr/smb/rgw_auth.py
+++ b/src/pybind/mgr/smb/rgw_auth.py
@@ -1,0 +1,50 @@
+"""RGW authorization utilities for SMB."""
+
+from typing import List, Optional
+
+import logging
+
+from .proto import MonCommandIssuer
+
+log = logging.getLogger(__name__)
+
+
+class RGWAuthorizationGrantError(ValueError):
+    pass
+
+
+class RGWAuthorizer:
+    """Using the rados APIs provided by the ceph mgr, authorize cephx users for
+    RGW access via RADOS.
+    """
+
+    def __init__(self, mc: MonCommandIssuer) -> None:
+        self._mc = mc
+
+    def authorize_entity(
+        self, entity: str, caps: Optional[List[str]] = None
+    ) -> None:
+        """Create or update a CephX entity with RGW access capabilities."""
+
+        assert entity.startswith('client.')
+
+        # Default caps for RGW access via RADOS
+        # These allow the SMB daemon to access RGW data through RADOS
+        if not caps:
+            caps = [
+                'mon',
+                'allow r',
+                'osd',
+                'allow rwx tag rgw *=*',
+            ]
+
+        cmd = {
+            'prefix': 'auth get-or-create',
+            'entity': entity,
+            'caps': caps,
+        }
+        log.info('Requesting RGW authorization: %r', cmd)
+        ret, _, status = self._mc.mon_command(cmd)
+        if ret != 0:
+            raise RGWAuthorizationGrantError(status)
+        log.info('RGW authorization request success: %r', status)

--- a/src/pybind/mgr/smb/sqlite_store.py
+++ b/src/pybind/mgr/smb/sqlite_store.py
@@ -535,6 +535,22 @@ class MirrorExternalCephCluster(Mirror):
         return filtered
 
 
+class MirrorRGWCredentials(Mirror):
+    """Mirroring configuration for objects in the rgw_credentials namespace."""
+
+    def __init__(self, store: ConfigStore) -> None:
+        super().__init__('rgw_credentials', store)
+
+    def filter_object(self, obj: Simplified) -> Simplified:
+        """Filter rgw_credential for sqlite3 store."""
+        filtered = copy.deepcopy(obj)
+        if filtered.get('access_key_id'):
+            filtered.pop('access_key_id', None)
+        if filtered.get('secret_access_key'):
+            filtered.pop('secret_access_key', None)
+        return filtered
+
+
 def _tables(
     *,
     specialize: bool = True,
@@ -556,6 +572,7 @@ def _tables(
         SimpleTable('join_auths', 'join_auths'),
         SimpleTable('users_and_groups', 'users_and_groups'),
         SimpleTable('tls_creds', 'tls_creds'),
+        SimpleTable('rgw_creds', 'rgw_creds'),
         SimpleTable('ext_ceph_clusters', 'ext_ceph_clusters'),
     ]
 
@@ -580,6 +597,10 @@ def _mirror_external_ceph_clusters(
     opts: Optional[Dict[str, str]] = None
 ) -> bool:
     return (opts or {}).get('mirror_external_ceph_clusters') != 'no'
+
+
+def _mirror_rgw_credentials(opts: Optional[Dict[str, str]] = None) -> bool:
+    return (opts or {}).get('mirror_rgw_credentials') != 'no'
 
 
 def mgr_sqlite3_db(
@@ -611,6 +632,8 @@ def mgr_sqlite3_db_with_mirroring(
         mirrors.append(MirrorTLSCredentials(mirror_store))
     if _mirror_external_ceph_clusters(opts):
         mirrors.append(MirrorExternalCephCluster(mirror_store))
+    if _mirror_rgw_credentials(opts):
+        mirrors.append(MirrorRGWCredentials(mirror_store))
     return SqliteMirroringStore(mgr, tables, mirrors)
 
 

--- a/src/pybind/mgr/smb/staging.py
+++ b/src/pybind/mgr/smb/staging.py
@@ -15,7 +15,7 @@ import operator
 
 from ceph.fs.earmarking import EarmarkTopScope
 
-from . import config_store, resources
+from . import config_store, resources, rgw
 from .enums import (
     AuthMode,
     ConfigNS,
@@ -54,8 +54,9 @@ class Staging:
     the destination store.
     """
 
-    def __init__(self, store: ConfigStore) -> None:
+    def __init__(self, store: ConfigStore, tool_exec: rgw.ToolExecer) -> None:
         self.destination_store = store
+        self._tool_execer = tool_exec
         self.incoming: Dict[EntryKey, SMBResource] = {}
         self.deleted: Dict[EntryKey, SMBResource] = {}
         self._store_keycache: Set[EntryKey] = set()
@@ -358,6 +359,63 @@ def _check_share_resource(
             msg="no matching cluster id",
             status={"cluster_id": share.cluster_id},
         )
+
+    # Handle RGW shares - validate bucket existence and auto-fetch credentials
+    if share.rgw is not None:
+        # Validate bucket exists
+        if not rgw.validate_rgw_bucket(
+            staging._tool_execer, share.rgw.bucket
+        ):
+            raise ErrorResult(
+                share,
+                msg=f"RGW bucket '{share.rgw.bucket}' does not exist or is not accessible",
+            )
+
+        # Auto-fetch credentials if not provided
+        if (
+            not share.rgw.user_id
+            or not share.rgw.access_key_id
+            or not share.rgw.secret_access_key
+        ):
+            try:
+                log.debug(
+                    f"Auto-fetching RGW credentials for bucket {share.rgw.bucket}"
+                )
+                (
+                    fetched_user_id,
+                    access_key,
+                    secret_key,
+                ) = rgw.fetch_rgw_credentials(
+                    staging._tool_execer,
+                    share.rgw.bucket,
+                    share.rgw.user_id or '',
+                )
+                # Update the share's RGW storage with fetched credentials
+                share.rgw = resources.RGWStorage(
+                    bucket=share.rgw.bucket,
+                    user_id=fetched_user_id,
+                    access_key_id=access_key,
+                    secret_access_key=secret_key,
+                )
+                log.debug(
+                    f"Successfully fetched credentials for user {fetched_user_id}"
+                )
+            except ValueError as e:
+                raise ErrorResult(
+                    share,
+                    msg=f"Failed to fetch RGW credentials: {str(e)}",
+                )
+
+        name_used_by = _share_name_in_use(staging, share)
+        if name_used_by:
+            raise ErrorResult(
+                share,
+                msg="share name already in use",
+                status={"conflicting_share_id": name_used_by},
+            )
+        return
+
+    # Handle CephFS shares
     assert share.cephfs is not None
     try:
         volpath = path_resolver.resolve_exists(

--- a/src/pybind/mgr/smb/staging.py
+++ b/src/pybind/mgr/smb/staging.py
@@ -30,6 +30,7 @@ from .internal import (
     ClusterEntry,
     JoinAuthEntry,
     ResourceEntry,
+    RGWCredentialEntry,
     ShareEntry,
     TLSCredentialEntry,
     UsersAndGroupsEntry,
@@ -127,6 +128,18 @@ class Staging:
             self.destination_store, ug_id
         ).get_users_and_groups()
 
+    def get_rgw_credential(
+        self, rgw_credential_id: str
+    ) -> resources.RGWCredential:
+        ekey = (str(RGWCredentialEntry.namespace), rgw_credential_id)
+        if ekey in self.incoming:
+            res = self.incoming[ekey]
+            assert isinstance(res, resources.RGWCredential)
+            return res
+        return RGWCredentialEntry.from_store(
+            self.destination_store, rgw_credential_id
+        ).get_rgw_credential()
+
     def save(self) -> ResultGroup:
         results = ResultGroup()
         for res in self.deleted.values():
@@ -167,6 +180,7 @@ class Staging:
         self._prune(cids, JoinAuthEntry, resources.JoinAuth)
         self._prune(cids, UsersAndGroupsEntry, resources.UsersAndGroups)
         self._prune(cids, TLSCredentialEntry, resources.TLSCredential)
+        self._prune(cids, RGWCredentialEntry, resources.RGWCredential)
 
 
 def auth_refs(cluster: resources.Cluster) -> Collection[str]:
@@ -360,27 +374,12 @@ def _check_share_resource(
             status={"cluster_id": share.cluster_id},
         )
 
-    # Handle RGW shares - validate bucket existence and auto-fetch credentials
+    # Handle RGW shares
     if share.rgw is not None:
-        # Validate bucket exists
-        if not rgw.validate_rgw_bucket(
-            staging._tool_execer, share.rgw.bucket
-        ):
-            raise ErrorResult(
-                share,
-                msg=f"RGW bucket '{share.rgw.bucket}' does not exist or is not accessible",
-            )
-
-        # Auto-fetch credentials if not provided
-        if (
-            not share.rgw.user_id
-            or not share.rgw.access_key_id
-            or not share.rgw.secret_access_key
-        ):
+        # If credential_ref is not provided, auto-create credential
+        if not share.rgw.credential_ref:
+            # Fetch credentials from RGW
             try:
-                log.debug(
-                    f"Auto-fetching RGW credentials for bucket {share.rgw.bucket}"
-                )
                 (
                     fetched_user_id,
                     access_key,
@@ -390,21 +389,80 @@ def _check_share_resource(
                     share.rgw.bucket,
                     share.rgw.user_id or '',
                 )
-                # Update the share's RGW storage with fetched credentials
-                share.rgw = resources.RGWStorage(
-                    bucket=share.rgw.bucket,
-                    user_id=fetched_user_id,
-                    access_key_id=access_key,
-                    secret_access_key=secret_key,
-                )
-                log.debug(
-                    f"Successfully fetched credentials for user {fetched_user_id}"
-                )
             except ValueError as e:
                 raise ErrorResult(
                     share,
                     msg=f"Failed to fetch RGW credentials: {str(e)}",
                 )
+
+            # Create credential resource automatically
+            # Use user_id as credential_id (linked to cluster via linked_to_cluster field)
+            credential_id = fetched_user_id
+
+            # Check if credential already exists
+            try:
+                cred = staging.get_rgw_credential(credential_id)
+                # Credential exists, validate it's linked to correct cluster
+                if (
+                    cred.linked_to_cluster
+                    and cred.linked_to_cluster != share.cluster_id
+                ):
+                    raise ErrorResult(
+                        share,
+                        msg='RGW credential is linked to a different cluster',
+                        status={
+                            'credential_ref': credential_id,
+                            'other_cluster_id': cred.linked_to_cluster,
+                        },
+                    )
+            except KeyError:
+                # Credential doesn't exist, create it
+                cred = resources.RGWCredential(
+                    rgw_credential_id=credential_id,
+                    user_id=fetched_user_id,
+                    access_key_id=access_key,
+                    secret_access_key=secret_key,
+                    linked_to_cluster=share.cluster_id,
+                )
+                # Stage the credential
+                staging.stage(cred)
+
+            # Update share to use credential_ref
+            share.rgw = resources.RGWStorage(
+                bucket=share.rgw.bucket,
+                credential_ref=credential_id,
+            )
+        else:
+            # Validate existing credential_ref
+            try:
+                cred = staging.get_rgw_credential(share.rgw.credential_ref)
+            except KeyError:
+                raise ErrorResult(
+                    share,
+                    msg=f"RGW credential '{share.rgw.credential_ref}' not found",
+                    status={"credential_ref": share.rgw.credential_ref},
+                )
+
+            if (
+                cred.linked_to_cluster
+                and cred.linked_to_cluster != share.cluster_id
+            ):
+                raise ErrorResult(
+                    share,
+                    msg='RGW credential is linked to a different cluster',
+                    status={
+                        'credential_ref': share.rgw.credential_ref,
+                        'other_cluster_id': cred.linked_to_cluster,
+                    },
+                )
+        # Validate bucket exists
+        if not rgw.validate_rgw_bucket(
+            staging._tool_execer, share.rgw.bucket
+        ):
+            raise ErrorResult(
+                share,
+                msg=f"RGW bucket '{share.rgw.bucket}' does not exist or is not accessible",
+            )
 
         name_used_by = _share_name_in_use(staging, share)
         if name_used_by:
@@ -678,6 +736,59 @@ def _check_tls_credential_present(
 
 
 @cross_check_resource.register
+def _check_rgw_credential_resource(
+    resource: resources.RGWCredential, staging: Staging, **_kw: Any
+) -> None:
+    """Check that the RGW credential resource can be updated."""
+    if resource.intent == Intent.PRESENT:
+        return _check_rgw_credential_present(resource, staging)
+    return _check_rgw_credential_removed(resource, staging)
+
+
+def _check_rgw_credential_removed(
+    rgw_cred: resources.RGWCredential, staging: Staging
+) -> None:
+    refs_in_use: Dict[str, List[str]] = {}
+    for cid, sid in ShareEntry.ids(staging):
+        try:
+            share = ShareEntry.from_store(
+                staging.destination_store, cid, sid
+            ).get_share()
+        except KeyError:
+            continue
+        if (
+            share.rgw
+            and share.rgw.credential_ref == rgw_cred.rgw_credential_id
+        ):
+            refs_in_use.setdefault(rgw_cred.rgw_credential_id, []).append(
+                f'{cid}.{sid}'
+            )
+    if rgw_cred.rgw_credential_id in refs_in_use:
+        raise ErrorResult(
+            rgw_cred,
+            msg='RGW credential resource in use by shares',
+            status={
+                'shares': refs_in_use[rgw_cred.rgw_credential_id],
+            },
+        )
+
+
+def _check_rgw_credential_present(
+    rgw_cred: resources.RGWCredential, staging: Staging
+) -> None:
+    if rgw_cred.linked_to_cluster:
+        cids = set(ClusterEntry.ids(staging))
+        if rgw_cred.linked_to_cluster not in cids:
+            raise ErrorResult(
+                rgw_cred,
+                msg='linked_to_cluster id not valid',
+                status={
+                    'unknown_id': rgw_cred.linked_to_cluster,
+                },
+            )
+
+
+@cross_check_resource.register
 def _check_external_ceph_cluster_resource(
     ext_cluster: resources.ExternalCephCluster, staging: Staging, **_: Any
 ) -> None:
@@ -751,6 +862,17 @@ def ext_cluster_refs(cluster: resources.Cluster) -> Collection[str]:
 
 def tls_refs(cluster: resources.Cluster) -> Collection[str]:
     return _remotectl_tls_refs(cluster) | _keybridge_tls_refs(cluster)
+
+
+def rgw_credential_refs(
+    shares: List[resources.Share],
+) -> Collection[str]:
+    """Return all credential_ref IDs used by RGW-backed shares."""
+    return {
+        share.rgw.credential_ref
+        for share in shares
+        if share.rgw is not None and share.rgw.credential_ref
+    }
 
 
 def _keybridge_ids(

--- a/src/pybind/mgr/smb/tests/test_handler.py
+++ b/src/pybind/mgr/smb/tests/test_handler.py
@@ -4,6 +4,14 @@ import smb
 from smb.handler import _FakeEarmarkResolver
 
 
+class _FakeToolExecer:
+    """Mock tool executor for testing."""
+
+    def tool_exec(self, cmd: list[str]) -> tuple[int, str, str]:
+        """Mock tool_exec that returns success."""
+        return (0, '{}', '')
+
+
 def _cluster(**kwargs):
     if 'clustering' not in kwargs:
         kwargs['clustering'] = smb.enums.SMBClustering.NEVER
@@ -25,6 +33,8 @@ def thandler():
         # into a single store. Do that to simplify testing a bit.
         public_store=ext_store,
         priv_store=ext_store,
+        mon_cmd_issuer=None,
+        tool_execer=_FakeToolExecer(),
     )
 
 

--- a/src/pybind/mgr/smb/tests/test_resources.py
+++ b/src/pybind/mgr/smb/tests/test_resources.py
@@ -1283,3 +1283,308 @@ def test_share_qos_remove_individual_limit():
     assert updated_cephfs.qos.write_iops_limit == 200  # Preserved
     assert updated_cephfs.qos.read_bw_limit == "10M"  # Preserved
     assert updated_cephfs.qos.write_bw_limit == "20M"  # Preserved
+
+
+def test_rgw_storage_basic():
+    """Test basic RGWStorage creation and validation."""
+    import yaml
+
+    yaml_str = """
+resource_type: ceph.smb.share
+cluster_id: rgwcluster
+share_id: rgwshare
+name: RGW Share
+rgw:
+    bucket: my-bucket
+"""
+    data = yaml.safe_load_all(yaml_str)
+    loaded = smb.resources.load(data)
+    assert loaded
+
+    share = loaded[0]
+    assert isinstance(share.rgw, smb.resources.RGWStorage)
+    assert share.rgw.bucket == 'my-bucket'
+    assert share.rgw.user_id is None
+    assert share.rgw.credential_ref is None
+
+
+def test_rgw_storage_with_credentials():
+    """Test RGWStorage with credential_ref."""
+    import yaml
+
+    yaml_str = """
+resource_type: ceph.smb.share
+cluster_id: rgwcluster
+share_id: rgwshare
+name: RGW Share
+rgw:
+    bucket: my-bucket
+    user_id: testuser
+    credential_ref: testuser
+"""
+    data = yaml.safe_load_all(yaml_str)
+    loaded = smb.resources.load(data)
+    assert loaded
+
+    share = loaded[0]
+    assert share.rgw.bucket == 'my-bucket'
+    assert share.rgw.user_id == 'testuser'
+    assert share.rgw.credential_ref == 'testuser'
+
+
+def test_rgw_storage_missing_bucket():
+    """Test validation error when bucket is missing."""
+    import yaml
+
+    yaml_str = """
+resource_type: ceph.smb.share
+cluster_id: rgwcluster
+share_id: rgwshare
+name: RGW Share
+rgw:
+    bucket: ""
+"""
+    data = yaml.safe_load_all(yaml_str)
+    with pytest.raises(ValueError, match='bucket requires a value'):
+        smb.resources.load(data)
+
+
+def test_rgw_storage_convert_mask():
+    """Test RGWStorage conversion - credentials now in RGWCredential."""
+    storage = smb.resources.RGWStorage(
+        bucket='my-bucket',
+        user_id='testuser',
+        credential_ref='testuser',
+    )
+
+    masked = storage.convert(
+        (smb.enums.PasswordFilter.NONE, smb.enums.PasswordFilter.HIDDEN)
+    )
+    assert masked.bucket == 'my-bucket'
+    assert masked.user_id == 'testuser'
+    assert masked.credential_ref == 'testuser'
+
+
+def test_rgw_storage_convert_none_credentials():
+    """Test conversion when credential_ref is None."""
+    storage = smb.resources.RGWStorage(
+        bucket='my-bucket',
+    )
+
+    encoded = storage.convert(
+        (smb.enums.PasswordFilter.NONE, smb.enums.PasswordFilter.BASE64)
+    )
+    assert encoded.credential_ref is None
+
+    masked = storage.convert(
+        (smb.enums.PasswordFilter.NONE, smb.enums.PasswordFilter.HIDDEN)
+    )
+    assert masked.credential_ref is None
+
+
+def test_rgw_storage_to_simplified():
+    """Test RGWStorage serialization to simplified format."""
+    import yaml
+
+    yaml_str = """
+resource_type: ceph.smb.share
+cluster_id: rgwcluster
+share_id: rgwshare
+name: RGW Share
+rgw:
+    bucket: my-bucket
+    user_id: testuser
+    credential_ref: testuser
+"""
+    data = yaml.safe_load_all(yaml_str)
+    loaded = smb.resources.load(data)
+    assert loaded
+
+    share = loaded[0]
+    simplified = share.to_simplified()
+
+    assert 'rgw' in simplified
+    assert simplified['rgw']['bucket'] == 'my-bucket'
+    assert simplified['rgw']['user_id'] == 'testuser'
+    # Credentials are now referenced via credential_ref
+    assert simplified['rgw']['credential_ref'] == 'testuser'
+
+
+def test_rgw_storage_invalid_credentials():
+    """Test RGWStorage with invalid credential_ref."""
+    import yaml
+
+    yaml_str = """
+resource_type: ceph.smb.share
+cluster_id: rgwcluster
+share_id: rgwshare
+name: RGW Share
+rgw:
+    bucket: my-bucket
+    credential_ref: "invalid-ref-with-spaces"
+"""
+    data = yaml.safe_load_all(yaml_str)
+    # Note: Credential validation happens during staging, not at load time
+    # This test documents that RGWStorage accepts any credential_ref string
+    loaded = smb.resources.load(data)
+    assert loaded
+    assert loaded[0].rgw.credential_ref == "invalid-ref-with-spaces"
+
+
+def test_share_with_rgw_and_cephfs_mutual_exclusion():
+    """Test that share cannot have both rgw and cephfs."""
+    import yaml
+
+    yaml_str = """
+resource_type: ceph.smb.share
+cluster_id: testcluster
+share_id: testshare
+name: Invalid Share
+cephfs:
+    volume: cephfs
+    path: /
+rgw:
+    bucket: my-bucket
+    path: /
+"""
+    data = yaml.safe_load_all(yaml_str)
+    with pytest.raises(ValueError, match='only one storage backend'):
+        smb.resources.load(data)
+
+
+def test_rgw_credential_basic():
+    """Test basic RGWCredential creation and validation."""
+    import yaml
+
+    yaml_str = """
+resource_type: ceph.smb.rgw.credential
+rgw_credential_id: rgwcred1
+user_id: s3user
+access_key_id: AKIAIOSFODNN7EXAMPLE
+secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+"""
+    data = yaml.safe_load_all(yaml_str)
+    loaded = smb.resources.load(data)
+    assert loaded
+
+    cred = loaded[0]
+    assert isinstance(cred, smb.resources.RGWCredential)
+    assert cred.rgw_credential_id == 'rgwcred1'
+    assert cred.user_id == 's3user'
+    assert cred.access_key_id == 'AKIAIOSFODNN7EXAMPLE'
+    assert (
+        cred.secret_access_key == 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
+    )
+    assert cred.intent == smb.enums.Intent.PRESENT
+
+
+def test_rgw_credential_missing_required_fields():
+    """Test that RGWCredential requires user_id, access_key_id, and secret_access_key."""
+    import yaml
+
+    # Missing user_id
+    yaml_str = """
+resource_type: ceph.smb.rgw.credential
+rgw_credential_id: rgwcred1
+access_key_id: AKIAIOSFODNN7EXAMPLE
+secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+"""
+    data = yaml.safe_load_all(yaml_str)
+    with pytest.raises(Exception):  # Will fail during construction
+        smb.resources.load(data)
+
+    # Missing access_key_id
+    yaml_str = """
+resource_type: ceph.smb.rgw.credential
+rgw_credential_id: rgwcred1
+user_id: s3user
+secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+"""
+    data = yaml.safe_load_all(yaml_str)
+    with pytest.raises(Exception):  # Will fail during construction
+        smb.resources.load(data)
+
+    # Missing secret_access_key
+    yaml_str = """
+resource_type: ceph.smb.rgw.credential
+rgw_credential_id: rgwcred1
+user_id: s3user
+access_key_id: AKIAIOSFODNN7EXAMPLE
+"""
+    data = yaml.safe_load_all(yaml_str)
+    with pytest.raises(Exception):  # Will fail during construction
+        smb.resources.load(data)
+
+
+def test_rgw_credential_password_conversion():
+    """Test RGWCredential password field conversion."""
+    cred = smb.resources.RGWCredential(
+        rgw_credential_id='test_cred',
+        user_id='testuser',
+        access_key_id='AKIATEST',
+        secret_access_key='secretkey123',
+    )
+
+    # Test masking (NONE -> HIDDEN)
+    masked = cred.convert(
+        (smb.enums.PasswordFilter.NONE, smb.enums.PasswordFilter.HIDDEN)
+    )
+    assert masked.access_key_id == '****************'
+    assert masked.secret_access_key == '****************'
+    assert masked.user_id == 'testuser'  # user_id should not be masked
+
+    # Test base64 encoding (NONE -> BASE64)
+    encoded = cred.convert(
+        (smb.enums.PasswordFilter.NONE, smb.enums.PasswordFilter.BASE64)
+    )
+    assert encoded.access_key_id != 'AKIATEST'
+    assert encoded.secret_access_key != 'secretkey123'
+    assert encoded.user_id == 'testuser'
+
+    # Test base64 decoding (BASE64 -> NONE)
+    decoded = encoded.convert(
+        (smb.enums.PasswordFilter.BASE64, smb.enums.PasswordFilter.NONE)
+    )
+    assert decoded.access_key_id == 'AKIATEST'
+    assert decoded.secret_access_key == 'secretkey123'
+
+
+def test_rgw_credential_with_linked_cluster():
+    """Test RGWCredential with linked_to_cluster."""
+    import yaml
+
+    yaml_str = """
+resource_type: ceph.smb.rgw.credential
+rgw_credential_id: rgwcred1
+user_id: s3user
+access_key_id: AKIAIOSFODNN7EXAMPLE
+secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+linked_to_cluster: mysmb
+"""
+    data = yaml.safe_load_all(yaml_str)
+    loaded = smb.resources.load(data)
+    assert loaded
+
+    cred = loaded[0]
+    assert cred.linked_to_cluster == 'mysmb'
+
+
+def test_rgw_credential_removed():
+    """Test RGWCredential with removed intent."""
+    import yaml
+
+    yaml_str = """
+resource_type: ceph.smb.rgw.credential
+rgw_credential_id: rgwcred1
+user_id: placeholder
+access_key_id: placeholder
+secret_access_key: placeholder
+intent: removed
+"""
+    data = yaml.safe_load_all(yaml_str)
+    loaded = smb.resources.load(data)
+    assert loaded
+
+    cred = loaded[0]
+    assert cred.intent == smb.enums.Intent.REMOVED
+    assert cred.rgw_credential_id == 'rgwcred1'

--- a/src/pybind/mgr/smb/tests/test_rgw_shares.py
+++ b/src/pybind/mgr/smb/tests/test_rgw_shares.py
@@ -1,0 +1,508 @@
+import json
+
+import pytest
+
+import smb
+import smb.external
+
+
+class _FakeToolExecer:
+    """Mock tool executor for testing RGW operations."""
+
+    def tool_exec(self, cmd: list[str]) -> tuple[int, str, str]:
+        """Mock tool_exec that returns success for RGW commands."""
+        # Check if this is a radosgw-admin bucket stats command
+        if 'radosgw-admin' in cmd and 'bucket' in cmd and 'stats' in cmd:
+            # Return mock bucket stats with owner field
+            bucket_stats = json.dumps(
+                {'owner': 'testuser', 'bucket': 'my-bucket', 'usage': {}}
+            )
+            return (0, bucket_stats, '')
+        # Check if this is a radosgw-admin user info command
+        if 'radosgw-admin' in cmd and 'user' in cmd and 'info' in cmd:
+            # Return mock user info with credentials
+            user_info = json.dumps(
+                {
+                    'user_id': 'testuser',
+                    'keys': [
+                        {
+                            'access_key': 'AUTO_FETCHED_ACCESS_KEY',
+                            'secret_key': 'AUTO_FETCHED_SECRET_KEY',
+                        }
+                    ],
+                }
+            )
+            return (0, user_info, '')
+        # Default response for other commands
+        return (0, '{}', '')
+
+
+def _cluster(**kwargs):
+    """Helper to create cluster with default clustering setting."""
+    if 'clustering' not in kwargs:
+        kwargs['clustering'] = smb.enums.SMBClustering.NEVER
+    return smb.resources.Cluster(**kwargs)
+
+
+@pytest.fixture
+def thandler():
+    """Fixture for RGW tests with RGW-aware tool executor."""
+    ext_store = smb.config_store.MemConfigStore()
+    return smb.handler.ClusterConfigHandler(
+        internal_store=smb.config_store.MemConfigStore(),
+        public_store=ext_store,
+        priv_store=ext_store,
+        mon_cmd_issuer=None,
+        tool_execer=_FakeToolExecer(),
+    )
+
+
+def test_internal_apply_cluster_and_rgw_share(thandler):
+    """Test creating a cluster with an RGW share."""
+    cluster = _cluster(
+        cluster_id='rgwtest',
+        auth_mode=smb.enums.AuthMode.USER,
+        user_group_settings=[
+            smb.resources.UserGroupSource(
+                source_type=smb.resources.UserGroupSourceType.EMPTY,
+            ),
+        ],
+    )
+    share = smb.resources.Share(
+        cluster_id='rgwtest',
+        share_id='rgwshare1',
+        name='RGW Share One',
+        rgw=smb.resources.RGWStorage(
+            bucket='my-bucket',
+            user_id='testuser',
+        ),
+    )
+    rg = thandler.apply([cluster, share])
+    assert rg.success, rg.to_simplified()
+    assert ('clusters', 'rgwtest') in thandler.internal_store.data
+    assert ('shares', 'rgwtest.rgwshare1') in thandler.internal_store.data
+    # Check that credential was auto-created
+    assert ('rgw_creds', 'testuser') in thandler.internal_store.data
+
+    shares = thandler.share_ids()
+    assert len(shares) == 1
+    assert ('rgwtest', 'rgwshare1') in shares
+
+    # Verify share uses credential_ref
+    share_data = thandler.internal_store.data[('shares', 'rgwtest.rgwshare1')]
+    assert share_data['rgw']['credential_ref'] == 'testuser'
+
+
+def test_apply_rgw_share_with_credentials(thandler):
+    """Test applying an RGW share with full credentials."""
+    cluster = _cluster(
+        cluster_id='rgwcluster',
+        auth_mode=smb.enums.AuthMode.USER,
+        user_group_settings=[
+            smb.resources.UserGroupSource(
+                source_type=smb.resources.UserGroupSourceType.EMPTY,
+            ),
+        ],
+    )
+    share = smb.resources.Share(
+        cluster_id='rgwcluster',
+        share_id='s3share',
+        name='S3 Share',
+        rgw=smb.resources.RGWStorage(
+            bucket='test-bucket',
+            user_id='rgwuser',
+        ),
+    )
+    rg = thandler.apply([cluster, share])
+    assert rg.success, rg.to_simplified()
+
+    # Verify credential was auto-created with fetched credentials
+    assert ('rgw_creds', 'rgwuser') in thandler.internal_store.data
+    cred_dict = thandler.internal_store.data[('rgw_creds', 'rgwuser')]
+    assert cred_dict['user_id'] == 'rgwuser'
+    assert cred_dict['access_key_id'] == 'AUTO_FETCHED_ACCESS_KEY'
+    assert cred_dict['secret_access_key'] == 'AUTO_FETCHED_SECRET_KEY'
+
+    # Verify share uses credential_ref
+    share_dict = thandler.internal_store.data[
+        ('shares', 'rgwcluster.s3share')
+    ]
+    assert share_dict['rgw']['bucket'] == 'test-bucket'
+    assert share_dict['rgw']['credential_ref'] == 'rgwuser'
+
+
+def test_rgw_share_auto_fetch_credentials(thandler):
+    """Test RGW share with auto-fetched credentials (bucket only provided)."""
+    cluster = _cluster(
+        cluster_id='autofetch',
+        auth_mode=smb.enums.AuthMode.USER,
+        user_group_settings=[
+            smb.resources.UserGroupSource(
+                source_type=smb.resources.UserGroupSourceType.EMPTY,
+            ),
+        ],
+    )
+    share = smb.resources.Share(
+        cluster_id='autofetch',
+        share_id='autoshare',
+        name='Auto Fetch Share',
+        rgw=smb.resources.RGWStorage(
+            bucket='my-bucket',
+        ),
+    )
+    rg = thandler.apply([cluster, share])
+    assert rg.success, rg.to_simplified()
+
+    # Verify credential was auto-created with fetched credentials
+    assert ('rgw_creds', 'testuser') in thandler.internal_store.data
+    cred_dict = thandler.internal_store.data[('rgw_creds', 'testuser')]
+    assert cred_dict['user_id'] == 'testuser'
+    assert cred_dict['access_key_id'] == 'AUTO_FETCHED_ACCESS_KEY'
+    assert cred_dict['secret_access_key'] == 'AUTO_FETCHED_SECRET_KEY'
+
+    # Verify share uses credential_ref
+    share_dict = thandler.internal_store.data[
+        ('shares', 'autofetch.autoshare')
+    ]
+    assert share_dict['rgw']['bucket'] == 'my-bucket'
+    assert share_dict['rgw']['credential_ref'] == 'testuser'
+
+
+def test_rgw_share_remove(thandler):
+    """Test removing an RGW share."""
+    # First create a cluster and RGW share
+    cluster = _cluster(
+        cluster_id='rgwtest',
+        auth_mode=smb.enums.AuthMode.USER,
+        user_group_settings=[
+            smb.resources.UserGroupSource(
+                source_type=smb.resources.UserGroupSourceType.EMPTY,
+            ),
+        ],
+    )
+    share = smb.resources.Share(
+        cluster_id='rgwtest',
+        share_id='rgwshare1',
+        name='RGW Share One',
+        rgw=smb.resources.RGWStorage(
+            bucket='my-bucket',
+            user_id='testuser',
+        ),
+    )
+    rg = thandler.apply([cluster, share])
+    assert rg.success, rg.to_simplified()
+
+    # Now remove the share
+    rmshare = smb.resources.RemovedShare(
+        cluster_id='rgwtest',
+        share_id='rgwshare1',
+    )
+    rg = thandler.apply([rmshare])
+    assert rg.success, rg.to_simplified()
+
+    shares = thandler.share_ids()
+    assert len(shares) == 0
+    assert ('shares', 'rgwtest.rgwshare1') not in thandler.internal_store.data
+
+
+def test_rgw_share_minimal_config(thandler):
+    """Test RGW share with minimal configuration (bucket only)."""
+    cluster = _cluster(
+        cluster_id='minimalrgw',
+        auth_mode=smb.enums.AuthMode.USER,
+        user_group_settings=[
+            smb.resources.UserGroupSource(
+                source_type=smb.resources.UserGroupSourceType.EMPTY,
+            ),
+        ],
+    )
+    share = smb.resources.Share(
+        cluster_id='minimalrgw',
+        share_id='minimal',
+        name='Minimal RGW Share',
+        rgw=smb.resources.RGWStorage(
+            bucket='my-bucket',
+        ),
+    )
+    rg = thandler.apply([cluster, share])
+    assert rg.success, rg.to_simplified()
+
+    # Verify credential was auto-created with fetched credentials
+    assert ('rgw_creds', 'testuser') in thandler.internal_store.data
+    cred_dict = thandler.internal_store.data[('rgw_creds', 'testuser')]
+    assert cred_dict['user_id'] == 'testuser'
+    assert cred_dict['access_key_id'] == 'AUTO_FETCHED_ACCESS_KEY'
+    assert cred_dict['secret_access_key'] == 'AUTO_FETCHED_SECRET_KEY'
+
+    # Verify share uses credential_ref
+    share_dict = thandler.internal_store.data[
+        ('shares', 'minimalrgw.minimal')
+    ]
+    assert share_dict['rgw']['bucket'] == 'my-bucket'
+    assert share_dict['rgw']['credential_ref'] == 'testuser'
+
+
+def test_multiple_rgw_shares_same_cluster(thandler):
+    """Test creating multiple RGW shares in the same cluster."""
+    cluster = _cluster(
+        cluster_id='multirgw',
+        auth_mode=smb.enums.AuthMode.USER,
+        user_group_settings=[
+            smb.resources.UserGroupSource(
+                source_type=smb.resources.UserGroupSourceType.EMPTY,
+            ),
+        ],
+    )
+    share1 = smb.resources.Share(
+        cluster_id='multirgw',
+        share_id='share1',
+        name='RGW Share 1',
+        rgw=smb.resources.RGWStorage(
+            bucket='bucket1',
+            user_id='user1',
+        ),
+    )
+    share2 = smb.resources.Share(
+        cluster_id='multirgw',
+        share_id='share2',
+        name='RGW Share 2',
+        rgw=smb.resources.RGWStorage(
+            bucket='bucket2',
+            user_id='user2',
+        ),
+    )
+    rg = thandler.apply([cluster, share1, share2])
+    assert rg.success, rg.to_simplified()
+
+    shares = thandler.share_ids()
+    assert len(shares) == 2
+    assert ('multirgw', 'share1') in shares
+    assert ('multirgw', 'share2') in shares
+
+    # Verify credentials were auto-created for both users
+    assert ('rgw_creds', 'user1') in thandler.internal_store.data
+    assert ('rgw_creds', 'user2') in thandler.internal_store.data
+
+    # Verify both shares use credential_ref
+    share1_dict = thandler.internal_store.data[('shares', 'multirgw.share1')]
+    share2_dict = thandler.internal_store.data[('shares', 'multirgw.share2')]
+    assert share1_dict['rgw']['bucket'] == 'bucket1'
+    assert share1_dict['rgw']['credential_ref'] == 'user1'
+    assert share2_dict['rgw']['bucket'] == 'bucket2'
+    assert share2_dict['rgw']['credential_ref'] == 'user2'
+
+
+def test_rgw_credential_reuse_same_user(thandler):
+    """Test that multiple shares with same user_id reuse the same credential."""
+    cluster = _cluster(
+        cluster_id='reusetest',
+        auth_mode=smb.enums.AuthMode.USER,
+        user_group_settings=[
+            smb.resources.UserGroupSource(
+                source_type=smb.resources.UserGroupSourceType.EMPTY,
+            ),
+        ],
+    )
+    share1 = smb.resources.Share(
+        cluster_id='reusetest',
+        share_id='share1',
+        name='RGW Share 1',
+        rgw=smb.resources.RGWStorage(
+            bucket='bucket1',
+            user_id='shareduser',
+        ),
+    )
+    share2 = smb.resources.Share(
+        cluster_id='reusetest',
+        share_id='share2',
+        name='RGW Share 2',
+        rgw=smb.resources.RGWStorage(
+            bucket='bucket2',
+            user_id='shareduser',
+        ),
+    )
+    rg = thandler.apply([cluster, share1, share2])
+    assert rg.success, rg.to_simplified()
+
+    # Verify only ONE credential was created for the shared user
+    rgw_creds = [
+        k for k in thandler.internal_store.data.keys() if k[0] == 'rgw_creds'
+    ]
+    assert len(rgw_creds) == 1
+    assert ('rgw_creds', 'shareduser') in thandler.internal_store.data
+
+    # Verify both shares reference the same credential
+    share1_dict = thandler.internal_store.data[('shares', 'reusetest.share1')]
+    share2_dict = thandler.internal_store.data[('shares', 'reusetest.share2')]
+    assert share1_dict['rgw']['credential_ref'] == 'shareduser'
+    assert share2_dict['rgw']['credential_ref'] == 'shareduser'
+
+
+# ---- priv-store credential isolation tests ----
+# These tests use SEPARATE public and private stores so each can be
+# independently inspected.  The real credential values must
+# only ever appear in the private store (via a config:merge stub), never in
+# the public RADOS config.
+
+
+@pytest.fixture
+def split_handler():
+    """Handler with separate public and private stores."""
+    pub = smb.config_store.MemConfigStore()
+    priv = smb.config_store.MemConfigStore()
+    h = smb.handler.ClusterConfigHandler(
+        internal_store=smb.config_store.MemConfigStore(),
+        public_store=pub,
+        priv_store=priv,
+        tool_execer=_FakeToolExecer(),
+    )
+    return h, pub, priv
+
+
+def _rgw_cluster_and_share(cluster_id, share_id, share_name, **rgw_kwargs):
+    cluster = _cluster(
+        cluster_id=cluster_id,
+        auth_mode=smb.enums.AuthMode.USER,
+        user_group_settings=[
+            smb.resources.UserGroupSource(
+                source_type=smb.resources.UserGroupSourceType.EMPTY,
+            ),
+        ],
+    )
+    share = smb.resources.Share(
+        cluster_id=cluster_id,
+        share_id=share_id,
+        name=share_name,
+        rgw=smb.resources.RGWStorage(**rgw_kwargs),
+    )
+    return cluster, share
+
+
+def test_rgw_credentials_absent_from_public_config(split_handler):
+    """Credential values must be empty strings in the public RADOS config."""
+    h, pub, priv = split_handler
+    cluster, share = _rgw_cluster_and_share(
+        'c1',
+        's1',
+        'mybucket',
+        bucket='mybucket',
+        user_id='testuser',
+    )
+    rg = h.apply([cluster, share])
+    assert rg.success, rg.to_simplified()
+
+    # Verify credential was auto-created
+    assert ('rgw_creds', 'testuser') in h.internal_store.data
+
+    pub_cfg = pub['c1', 'config.smb'].get()
+    opts = pub_cfg['shares']['mybucket']['options']
+    assert opts['ceph_rgw:access_key'] == ''
+    assert opts['ceph_rgw:secret_access_key'] == ''
+
+
+def test_rgw_credential_stub_written_to_priv_store(split_handler):
+    """Private store must hold config:merge stub with real credential values."""
+    h, pub, priv = split_handler
+    cluster, share = _rgw_cluster_and_share(
+        'c1',
+        's1',
+        'mybucket',
+        bucket='mybucket',
+        user_id='testuser',
+    )
+    rg = h.apply([cluster, share])
+    assert rg.success, rg.to_simplified()
+
+    # Verify credential was auto-created with fetched credentials
+    assert ('rgw_creds', 'testuser') in h.internal_store.data
+    cred_dict = h.internal_store.data[('rgw_creds', 'testuser')]
+    assert cred_dict['access_key_id'] == 'AUTO_FETCHED_ACCESS_KEY'
+    assert cred_dict['secret_access_key'] == 'AUTO_FETCHED_SECRET_KEY'
+
+    stub = priv['c1', 'config.smb.rgw'].get()
+    assert stub['samba-container-config'] == 'v0'
+    assert 'config:merge' in stub
+    opts = stub['config:merge']['shares']['mybucket']['options']
+    assert opts['ceph_rgw:access_key'] == 'AUTO_FETCHED_ACCESS_KEY'
+    assert opts['ceph_rgw:secret_access_key'] == 'AUTO_FETCHED_SECRET_KEY'
+
+
+def test_no_priv_store_entry_for_non_rgw_cluster(split_handler):
+    """A cluster with no RGW shares must not write a credential stub."""
+    h, pub, priv = split_handler
+    cluster = _cluster(
+        cluster_id='cephfs1',
+        auth_mode=smb.enums.AuthMode.USER,
+        user_group_settings=[
+            smb.resources.UserGroupSource(
+                source_type=smb.resources.UserGroupSourceType.EMPTY,
+            ),
+        ],
+    )
+    share = smb.resources.Share(
+        cluster_id='cephfs1',
+        share_id='fsshare',
+        name='FS Share',
+        cephfs=smb.resources.CephFSStorage(
+            volume='cephfs',
+            path='/',
+        ),
+    )
+    rg = h.apply([cluster, share])
+    assert rg.success, rg.to_simplified()
+
+    stub_entry = priv['cephfs1', 'config.smb.rgw']
+    assert not stub_entry.exists()
+
+
+def test_multi_share_stub_covers_all_rgw_shares(split_handler):
+    """Credential stub must contain entries for every RGW share."""
+    h, pub, priv = split_handler
+    cluster = _cluster(
+        cluster_id='multi',
+        auth_mode=smb.enums.AuthMode.USER,
+        user_group_settings=[
+            smb.resources.UserGroupSource(
+                source_type=smb.resources.UserGroupSourceType.EMPTY,
+            ),
+        ],
+    )
+    share1 = smb.resources.Share(
+        cluster_id='multi',
+        share_id='s1',
+        name='bucket1',
+        rgw=smb.resources.RGWStorage(
+            bucket='bucket1',
+            user_id='u1',
+        ),
+    )
+    share2 = smb.resources.Share(
+        cluster_id='multi',
+        share_id='s2',
+        name='bucket2',
+        rgw=smb.resources.RGWStorage(
+            bucket='bucket2',
+            user_id='u2',
+        ),
+    )
+    rg = h.apply([cluster, share1, share2])
+    assert rg.success, rg.to_simplified()
+
+    # Verify credentials were auto-created for both users with fetched credentials
+    assert ('rgw_creds', 'u1') in h.internal_store.data
+    assert ('rgw_creds', 'u2') in h.internal_store.data
+    cred1 = h.internal_store.data[('rgw_creds', 'u1')]
+    cred2 = h.internal_store.data[('rgw_creds', 'u2')]
+    assert cred1['access_key_id'] == 'AUTO_FETCHED_ACCESS_KEY'
+    assert cred1['secret_access_key'] == 'AUTO_FETCHED_SECRET_KEY'
+    assert cred2['access_key_id'] == 'AUTO_FETCHED_ACCESS_KEY'
+    assert cred2['secret_access_key'] == 'AUTO_FETCHED_SECRET_KEY'
+
+    stub = priv['multi', 'config.smb.rgw'].get()
+    merge_shares = stub['config:merge']['shares']
+    b1opts = merge_shares['bucket1']['options']
+    b2opts = merge_shares['bucket2']['options']
+    assert b1opts['ceph_rgw:access_key'] == 'AUTO_FETCHED_ACCESS_KEY'
+    assert b1opts['ceph_rgw:secret_access_key'] == 'AUTO_FETCHED_SECRET_KEY'
+    assert b2opts['ceph_rgw:access_key'] == 'AUTO_FETCHED_ACCESS_KEY'
+    assert b2opts['ceph_rgw:secret_access_key'] == 'AUTO_FETCHED_SECRET_KEY'


### PR DESCRIPTION
Add support for creating SMB shares backed by RGW buckets,
allowing S3-compatible object storage to be exported over SMB.

Key changes:

Add share create rgw CLI command for RGW share creation
Implement RGW credential retrieval using radosgw-admin
Add RGWStorage resource class with S3 authentication support
Track rgw_buckets in orchestration alongside CephFS volumes
Create CephX entities conditionally for CephFS shares only
Implementation details:

Register share create rgw before share create for correct CLI routing
Trigger orchestration when either vols or rgw_buckets are present
Use S3 access and secret keys for RGW share authentication
Improve logging with CephFS and RGW share breakdown details

New CLI :
ceph smb share create rgw <cluster_id> <bkt_id> <share_id> <bucket> [--share-name=<share_name>] [--user-id=<user_id>]  [--readonly]

example: ceph smb share create rgw mysmb share2 bkt2 --share-name=s2 user1

Declarative :
# Define share
- resource_type: ceph.smb.share
  cluster_id: mysmb
  share_id: ds1
  name: dshare1
  rgw:
    bucket: bkt1
    user_id: user1


Testing:

Created a cluster with a CephFS share, then added an RGW share.
Verified both shares inside the container using net conf list.
Created a cluster with an RGW share first, then added a CephFS share.
Verified both shares successfully.
Verified successful deletion of both CephFS and RGW shares.
Signed-off-by: Shweta Sodani [ssodani@redhat.com](mailto:ssodani@redhat.com)

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

