### PR TITLE
tcmalloc/rgw: mark background threads as idle

### DIFF
--- a/src/perfglue/disabled_heap_profiler.cc
+++ b/src/perfglue/disabled_heap_profiler.cc
@@ -22,6 +22,8 @@ void ceph_heap_profiler_stats(char *buf, int length) { return; }
 
 void ceph_heap_release_free_memory() { return; }
 
+void ceph_heap_mark_thread_temporarily_idle() { return; }
+
 double ceph_heap_get_release_rate() { return 0; }
 
 void ceph_heap_set_release_rate(double value) { return; }

--- a/src/perfglue/heap_profiler.cc
+++ b/src/perfglue/heap_profiler.cc
@@ -56,6 +56,11 @@ void ceph_heap_release_free_memory()
   MallocExtension::instance()->ReleaseFreeMemory();
 }
 
+void ceph_heap_mark_thread_temporarily_idle()
+{
+  MallocExtension::instance()->MarkThreadTemporarilyIdle();
+}
+
 double ceph_heap_get_release_rate()
 {
   return MallocExtension::instance()->GetMemoryReleaseRate();

--- a/src/perfglue/heap_profiler.h
+++ b/src/perfglue/heap_profiler.h
@@ -36,6 +36,8 @@ void ceph_heap_profiler_stats(char *buf, int length);
 
 void ceph_heap_release_free_memory();
 
+void ceph_heap_mark_thread_temporarily_idle();
+
 double ceph_heap_get_release_rate();
 
 void ceph_heap_get_release_rate(double value);

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -299,6 +299,7 @@ target_link_libraries(rgw_common
   PRIVATE
     legacy-option-headers
     global
+    heap_profiler
     cls_rgw_client
     rt
     ICU::uc

--- a/src/rgw/driver/rados/rgw_dedup.cc
+++ b/src/rgw/driver/rados/rgw_dedup.cc
@@ -21,6 +21,7 @@
 #include "common/Cond.h"
 #include "common/debug.h"
 #include "common/errno.h"
+#include "perfglue/heap_profiler.h"
 #include "rgw_common.h"
 #include "rgw_sal.h"
 #include "rgw_zone.h"
@@ -3490,6 +3491,7 @@ namespace rgw::dedup {
         d_cond.notify_all();
         ldpp_dout(dpp, 5) << __func__ << "::Dedup was aborted on a remote req" << dendl;
       }
+      ceph_heap_mark_thread_temporarily_idle();
       d_cond.wait(cond_lock, [this]{return d_ctl.remote_restart_req || d_ctl.should_stop() || d_ctl.should_pause();});
       if (!d_ctl.should_stop() && !d_ctl.should_pause()) {
         if (d_cluster.can_start_new_scan(store)) {

--- a/src/rgw/driver/rados/rgw_gc.cc
+++ b/src/rgw/driver/rados/rgw_gc.cc
@@ -15,6 +15,7 @@
 #include "cls/lock/cls_lock_client.h"
 #include "include/random.h"
 #include "rgw_gc_log.h"
+#include "perfglue/heap_profiler.h"
 
 #include <list> // XXX
 #include <sstream>
@@ -814,6 +815,7 @@ void *RGWGC::GCWorker::entry() {
     secs -= end.sec();
 
     std::unique_lock locker{lock};
+    ceph_heap_mark_thread_temporarily_idle();
     cond.wait_for(locker, std::chrono::seconds(secs));
   } while (!gc->going_down());
 

--- a/src/rgw/driver/rados/rgw_notify.cc
+++ b/src/rgw/driver/rados/rgw_notify.cc
@@ -17,6 +17,7 @@
 #include "rgw_pubsub_push.h"
 #include "rgw_zone_features.h"
 #include "rgw_perf_counters.h"
+#include "perfglue/heap_profiler.h"
 #include "services/svc_zone.h"
 #include "common/dout.h"
 #include "rgw_url.h"
@@ -406,6 +407,7 @@ private:
     while (!shutdown) {
       // if queue was empty the last time, sleep for idle timeout
       if (is_idle) {
+        ceph_heap_mark_thread_temporarily_idle();
         async_sleep(yield, queue_idle_sleep);
       }
 

--- a/src/rgw/driver/rados/rgw_object_expirer_core.cc
+++ b/src/rgw/driver/rados/rgw_object_expirer_core.cc
@@ -16,6 +16,7 @@
 #include "common/ceph_argparse.h"
 #include "common/Formatter.h"
 #include "common/errno.h"
+#include "perfglue/heap_profiler.h"
 
 #include "global/global_init.h"
 
@@ -417,6 +418,7 @@ void *RGWObjectExpirer::OEWorker::entry() {
     secs -= end.sec();
 
     std::unique_lock l{lock};
+    ceph_heap_mark_thread_temporarily_idle();
     cond.wait_for(l, std::chrono::seconds(secs));
   } while (!oe->going_down());
 

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -22,6 +22,7 @@
 #include "common/Throttle.h"
 #include "common/BackTrace.h"
 #include "common/ceph_time.h"
+#include "perfglue/heap_profiler.h"
 #include "common/async/blocked_completion.h"
 
 #include "rgw_asio_thread.h"
@@ -923,6 +924,7 @@ void RGWIndexCompletionManager::process()
 
     {
       std::unique_lock l{retry_completions_lock};
+      ceph_heap_mark_thread_temporarily_idle();
       cond.wait(l, [this](){return _stop || !retry_completions.empty();});
       if (_stop) {
         return;

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -18,6 +18,7 @@
 #include "common/ceph_json.h"
 
 #include "common/dout.h"
+#include "perfglue/heap_profiler.h"
 
 #include "services/svc_zone.h"
 #include "services/svc_sys_obj.h"
@@ -1840,6 +1841,7 @@ void *RGWReshard::ReshardWorker::entry() {
     // note: this will likely wait for the intended period of
     // time, but could wait for less
     std::unique_lock locker{lock};
+    ceph_heap_mark_thread_temporarily_idle();
     cond.wait_for(locker, std::chrono::seconds(secs));
   } while (!reshard->going_down());
 

--- a/src/rgw/rgw_amqp.cc
+++ b/src/rgw/rgw_amqp.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 sts=2 expandtab ft=cpp
 
 #include "rgw_amqp.h"
+#include "perfglue/heap_profiler.h"
 #if __has_include(<rabbitmq-c/amqp.h>)
 #include <rabbitmq-c/amqp.h>
 #include <rabbitmq-c/ssl_socket.h>
@@ -812,6 +813,7 @@ private:
       }
       // if no messages were received or published, sleep for 100ms
       if (count == 0 && !incoming_message) {
+        ceph_heap_mark_thread_temporarily_idle();
         std::this_thread::sleep_for(idle_time);
       }
     }

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -17,6 +17,7 @@
 #include "common/RefCountedObj.h"
 
 #include "rgw_coroutine.h"
+#include "perfglue/heap_profiler.h"
 
 #include <atomic>
 #include <string_view>
@@ -220,6 +221,7 @@ void* RGWCurlHandles::entry()
       if (saved_curl.empty())
         break;
     } else {
+      ceph_heap_mark_thread_temporarily_idle();
       cleaner_cond.wait_for(lock, std::chrono::seconds(MAXIDLE));
     }
     mono_time now = mono_clock::now();

--- a/src/rgw/rgw_kafka.cc
+++ b/src/rgw/rgw_kafka.cc
@@ -3,6 +3,7 @@
 
 #include "rgw_kafka.h"
 #include "rgw_url.h"
+#include "perfglue/heap_profiler.h"
 #include <librdkafka/rdkafka.h>
 #include "include/ceph_assert.h"
 #include <sstream>
@@ -561,6 +562,7 @@ private:
       }
       // sleep if no messages were received or published across all connection
       if (send_count == 0 && reply_count == 0) {
+        ceph_heap_mark_thread_temporarily_idle();
         std::this_thread::sleep_for(std::chrono::milliseconds(read_timeout*3));
         // TODO: add exponential backoff to sleep time
       }

--- a/src/rgw/rgw_kmip_client_impl.cc
+++ b/src/rgw/rgw_kmip_client_impl.cc
@@ -10,6 +10,7 @@
 #include "common/errno.h"
 #include "rgw_common.h"
 #include "rgw_kmip_client.h"
+#include "perfglue/heap_profiler.h"
 #include "rgw_kmip_client_impl.h"
 
 #include <openssl/err.h>
@@ -333,6 +334,7 @@ RGWKmipHandles::entry()
       if (saved_kmip.empty())
 	break;
     } else {
+      ceph_heap_mark_thread_temporarily_idle();
       cleaner_cond.wait_for(lock, std::chrono::seconds(MAXIDLE));
     }
     mono_time now = mono_clock::now();

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -25,6 +25,7 @@
 #include "cls/lock/cls_lock_client.h"
 #include "rgw_perf_counters.h"
 #include "rgw_asio_thread.h"
+#include "perfglue/heap_profiler.h"
 #include "rgw_common.h"
 #include "rgw_bucket.h"
 #include "rgw_bucket_layout.h"
@@ -221,6 +222,7 @@ void *RGWLC::LCWorker::entry() {
 		      << rgw_to_asctime(next) << " worker=" << ix << dendl;
 
     std::unique_lock l{lock};
+    ceph_heap_mark_thread_temporarily_idle();
     cond.wait_for(l, std::chrono::seconds(secs));
   } while (!lc->going_down());
 

--- a/src/rgw/rgw_lib.cc
+++ b/src/rgw/rgw_lib.cc
@@ -19,6 +19,7 @@
 
 #include "include/rados/librgw.h"
 #include "rgw_acl.h"
+#include "perfglue/heap_profiler.h"
 
 #include "include/str_list.h"
 #include "global/signal_handler.h"
@@ -106,6 +107,7 @@ namespace rgw {
 	if (cur_gen != gen)
 	  goto restart; /* invalidated */
       }
+      ceph_heap_mark_thread_temporarily_idle();
       cv.wait_for(uniq, std::chrono::seconds(delay_s));
       uniq.unlock();
     }

--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -14,6 +14,7 @@
 #include "rgw_rest.h"
 #include "rgw_zone.h"
 #include "driver/rados/rgw_rados.h"
+#include "perfglue/heap_profiler.h"
 
 #include "services/svc_zone.h"
 
@@ -437,6 +438,7 @@ void* OpsLogFile::entry() {
       lock.lock();
       continue;
     }
+    ceph_heap_mark_thread_temporarily_idle();
     cond.wait(lock);
   }
   lock.unlock();

--- a/src/rgw/rgw_lua_background.cc
+++ b/src/rgw/rgw_lua_background.cc
@@ -3,6 +3,7 @@
 #include "rgw_lua.h"
 #include "rgw_lua_utils.h"
 #include "rgw_perf_counters.h"
+#include "perfglue/heap_profiler.h"
 #include "include/ceph_assert.h"
 #include <lua.hpp>
 
@@ -197,7 +198,8 @@ void Background::run() {
     }
     process_scripts();
     std::unique_lock cond_lock(cond_mutex);
-    cond.wait_for(cond_lock, std::chrono::seconds(execute_interval), [this]{return stopped;}); 
+    ceph_heap_mark_thread_temporarily_idle();
+    cond.wait_for(cond_lock, std::chrono::seconds(execute_interval), [this]{return stopped;});
   }
   ldpp_dout(dpp, 10) << "Lua background thread stopped" << dendl;
 }

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -23,6 +23,7 @@
 #include "common/ceph_mutex.h"
 
 #include "rgw_common.h"
+#include "perfglue/heap_profiler.h"
 #include "rgw_sal.h"
 #ifdef WITH_RADOSGW_RADOS
 #include "rgw_sal_rados.h"
@@ -400,6 +401,7 @@ class RGWOwnerStatsCache : public RGWQuotaCache<rgw_owner> {
 	// note: this will likely wait for the intended period of
 	// time, but could wait for less
 	std::unique_lock locker{lock};
+	ceph_heap_mark_thread_temporarily_idle();
 	cond.wait_for(locker, std::chrono::seconds(wait_secs));
       } while (!stats->going_down());
 
@@ -448,6 +450,7 @@ class RGWOwnerStatsCache : public RGWQuotaCache<rgw_owner> {
           break;
 
 	std::unique_lock l{lock};
+	ceph_heap_mark_thread_temporarily_idle();
         cond.wait_for(l, std::chrono::seconds(cct->_conf->rgw_user_quota_sync_interval));
       } while (!stats->going_down());
       ldout(cct, 20) << "OwnerSyncThread: done" << dendl;

--- a/src/rgw/rgw_restore.cc
+++ b/src/rgw/rgw_restore.cc
@@ -16,6 +16,7 @@
 
 #include "include/scope_guard.h"
 #include "include/function2.hpp"
+#include "perfglue/heap_profiler.h"
 #include "common/Clock.h" // for ceph_clock_now()
 #include "common/Formatter.h"
 #include "common/containers.h"
@@ -289,6 +290,7 @@ void *Restore::RestoreWorker::entry() {
       continue; // next round
 
     std::unique_lock locker{lock};
+    ceph_heap_mark_thread_temporarily_idle();
     cond.wait_for(locker, std::chrono::seconds(secs));
   } while (!restore->going_down());
 


### PR DESCRIPTION
allow tcmalloc to free unused memory of backround threads before they become idle. this should allow more thread local memory for the frontend threads, with minimal perf impact on the background threads.
shoudl be used together with TCMALLOC_RELEASE_RATE=0

The following places were NOT part of this work:

Coroutine-based threads (OS thread shared with active coroutines):
- Bucket Log Commits  : driver/rados/rgw_bl_rados.cc
- Global Log Commits  : driver/rados/rgw_bl_rados.cc
- Data Sync Increment : driver/rados/rgw_data_sync.cc
- D4N Cache Policy    : driver/d4n/d4n_policy.cc

Inline header (link dependency issue):
- Rate Limiter Replace :


## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
