### PR TITLE
crimson/os/seastore/log_manager: reduce unnecessary log node operations

### DIFF
--- a/src/crimson/os/seastore/omap_manager/log/log_manager.cc
+++ b/src/crimson/os/seastore/omap_manager/log/log_manager.cc
@@ -251,7 +251,7 @@ LogManager::omap_set_keys(
   }
 
   if (!dup_kvs.empty()) {
-    laddr_t last_addr = co_await get_dup_addr_from_root(t, log_root.addr);
+    laddr_t last_addr = ext->get_dup_tail_addr();
     ext = co_await log_load_extent<LogNode>(t, last_addr, BEGIN_KEY, END_KEY);
     for (auto &p: dup_kvs) {
       co_await f(p.first, p.second);

--- a/src/crimson/os/seastore/omap_manager/log/log_manager.cc
+++ b/src/crimson/os/seastore/omap_manager/log/log_manager.cc
@@ -185,9 +185,9 @@ LogManager::omap_set_keys(
 
   std::map<std::string, ceph::bufferlist> dup_kvs;
   if (kvs.size() > BATCH_CREATE_SIZE) {
-    LogNodeRef e = co_await alloc_log_node(ext->get_laddr());
-    LogNodeRef dup_e = co_await alloc_log_node(
-      co_await get_dup_addr_from_root(t, ext->get_laddr()));
+    LogNodeRef e = ext;
+    LogNodeRef dup_e;
+    laddr_t dup_tail = co_await get_dup_addr_from_root(t, ext->get_laddr());
     for (auto &p : kvs) {
       if (!is_log_key(p.first)) {
 	co_await remove_kv(t, log_root.addr, p.first, nullptr);
@@ -197,6 +197,9 @@ LogManager::omap_set_keys(
       }
       LogNodeRef cur = e;
       if (is_dup_log_key(p.first)) {
+	if (!dup_e) {
+	  dup_e = co_await alloc_log_node(dup_tail);
+	}
 	cur = dup_e;
       }
       if (e->get_max_val_length(p.first.size()) < p.second.length()) {
@@ -215,20 +218,29 @@ LogManager::omap_set_keys(
 	cur = co_await alloc_log_node(cur->get_laddr());
 	if (!is_dup_log_key(p.first)) {
 	  e = cur;
+	  log_root.update(e->get_laddr(), log_root.depth,
+	    log_root.hint, log_root.type);
 	} else {
 	  dup_e = cur;
 	}
       }
-      cur->append_kv(t, p.first, p.second);
+      if (cur->is_initial_pending()) {
+	cur->append_kv(t, p.first, p.second);
+      } else {
+	assert(!is_dup_log_key(p.first));
+	auto mut = tm.get_mutable_extent(t, cur)->cast<LogNode>();
+	mut->append_kv(t, p.first, p.second);
+	e = mut;
+      }
     }
-    if (e->is_initial_pending()) {
-      e->set_dup_tail_addr(dup_e->get_laddr());
-    } else {
-      auto mut = tm.get_mutable_extent(t, e)->cast<LogNode>();
-      mut->set_dup_tail_addr(dup_e->get_laddr());
+    laddr_t new_dup_tail = dup_e ? dup_e->get_laddr() : dup_tail;
+    if (e->get_dup_tail_addr() != new_dup_tail) {
+      if (e->is_initial_pending()) {
+	e->set_dup_tail_addr(new_dup_tail);
+      } else {
+	tm.get_mutable_extent(t, e)->cast<LogNode>()->set_dup_tail_addr(new_dup_tail);
+      }
     }
-    log_root.update(e->get_laddr(), log_root.depth,
-      log_root.hint, log_root.type);
     co_return;
   }
 

--- a/src/crimson/os/seastore/omap_manager/log/log_manager.cc
+++ b/src/crimson/os/seastore/omap_manager/log/log_manager.cc
@@ -65,7 +65,7 @@ LogManager::omap_set_keys(
   auto ext = co_await log_load_extent<LogNode>(
     t, log_root.addr, BEGIN_KEY, END_KEY);
   ceph_assert(ext);
-  auto resync_node = [&](LogNodeRef e)
+  auto resync_log_node = [&](LogNodeRef e)
     -> log_load_extent_iertr::future<CachedExtentRef> {
     CachedExtentRef node;
     Transaction::get_extent_ret ret;
@@ -80,9 +80,9 @@ LogManager::omap_set_keys(
     ceph_assert(node);
     co_return std::move(node);
   };
-  auto f = [&](const std::string &k, const bufferlist &v) 
+  auto set_log_node_entry = [&](const std::string &k, const bufferlist &v) 
     -> omap_set_key_ret {
-    CachedExtentRef node = co_await resync_node(ext);
+    CachedExtentRef node = co_await resync_log_node(ext);
     LogNodeRef log_node = node->template cast<LogNode>();
     // If multiple blocks are needed to store the kv pair
     if (log_node->get_max_val_length(k.size()) < v.length()) {
@@ -140,7 +140,7 @@ LogManager::omap_set_keys(
     if (has_ow_key) {
       if (!cur->can_ow()) {
 	co_await remove_kv(t, log_root.addr, get_ow_key(), nullptr);
-	CachedExtentRef node = co_await resync_node(cur);
+	CachedExtentRef node = co_await resync_log_node(cur);
 	cur = node->template cast<LogNode>();
       }
       for (auto &p : kvs_for_ow) {
@@ -192,7 +192,7 @@ LogManager::omap_set_keys(
       if (!is_log_key(p.first)) {
 	co_await remove_kv(t, log_root.addr, p.first, nullptr);
 	// reload latest log list e because e was updated if the key is in e
-	CachedExtentRef node = co_await resync_node(e);
+	CachedExtentRef node = co_await resync_log_node(e);
 	e = node->template cast<LogNode>();
       }
       LogNodeRef cur = e;
@@ -254,7 +254,7 @@ LogManager::omap_set_keys(
       co_await remove_kv(t, log_root.addr, p.first, nullptr);
     }
     laddr_t last_addr = log_root.addr;
-    co_await f(p.first, p.second);
+    co_await set_log_node_entry(p.first, p.second);
     if (last_addr != log_root.addr) {
       ext = co_await log_load_extent<LogNode>(
 	t, log_root.addr, BEGIN_KEY, END_KEY);
@@ -266,7 +266,7 @@ LogManager::omap_set_keys(
     laddr_t last_addr = ext->get_dup_tail_addr();
     ext = co_await log_load_extent<LogNode>(t, last_addr, BEGIN_KEY, END_KEY);
     for (auto &p: dup_kvs) {
-      co_await f(p.first, p.second);
+      co_await set_log_node_entry(p.first, p.second);
       if (&p != &*dup_kvs.rbegin()) {
 	laddr_t current_addr = co_await get_dup_addr_from_root(t, log_root.addr);
 	if (last_addr != current_addr) {

--- a/src/crimson/os/seastore/omap_manager/log/log_node.cc
+++ b/src/crimson/os/seastore/omap_manager/log/log_node.cc
@@ -265,6 +265,9 @@ bool LogNode::log_less_than(std::string_view str) const
   while(iter != iter_end()) {
     std::string key = iter->get_key();
     if (is_log_key(key)) {
+      if (key >= str) {
+        return false;
+      }
       all_less = key < str;
     }
     iter++;

--- a/src/crimson/os/seastore/omap_manager/log/log_node.cc
+++ b/src/crimson/os/seastore/omap_manager/log/log_node.cc
@@ -366,4 +366,29 @@ int LogNode::ow_gap_from_last_entry(const size_t key, const size_t val) {
   return gap;
 }
 
+LogNode::range_t LogNode::has_between(const std::optional<std::string>& start,
+  const std::optional<std::string>& end) {
+  assert(start);
+  if (get_size() == 0) {
+    return range_t::NO_BETWEEN;
+  }
+  std::string_view s(*start);
+  auto in_range = [&](std::string_view k) {
+    return k >= s && (!end || k <= std::string_view(*end));
+  };
+  
+  // The newest entry is the one the loop below reaches last, so test it up
+  // front: trimming the most recent keys is the common case and this answers
+  // it without a scan.
+  if (in_range(get_last_key())) {
+    return range_t::HAS_BETWEEN;
+  }
+  for (auto iter = iter_begin(); iter != iter_end(); ++iter) {
+    if (in_range(iter->get_key())) {
+      return range_t::HAS_BETWEEN;
+    }
+  }
+  return range_t::NO_BETWEEN;
+}
+
 }

--- a/src/crimson/os/seastore/omap_manager/log/log_node.h
+++ b/src/crimson/os/seastore/omap_manager/log/log_node.h
@@ -894,20 +894,8 @@ struct LogNode
     NO_BETWEEN,
   };
 
-  range_t has_between(std::optional<std::string> start,
-    std::optional<std::string> end) {
-    std::string_view s(*start);
-    std::string_view e(*end);
-    auto iter = iter_begin();
-    while(iter != iter_end()) {
-      std::string k = iter->get_key();
-      if (k <= e && k >= s) {
-	return range_t::HAS_BETWEEN;
-      } 
-      iter++;
-    };
-    return range_t::NO_BETWEEN;
-  }
+  range_t has_between(const std::optional<std::string>& start,
+    const std::optional<std::string>& end);
 
   template <typename F>
   void for_each_live_entry(F&& fn);


### PR DESCRIPTION

Signed-off-by: Myoungwon Oh <ohmyoungwon@gmail.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
