### PR TITLE
tentacle: neorados/cls/log: fix infinite trim loop on empty data log shards

### DIFF
--- a/src/neorados/cls/log.h
+++ b/src/neorados/cls/log.h
@@ -493,10 +493,10 @@ trim(RADOS& r, Object oid, IOContext ioc,
 			 ua);
     } catch (const system_error& e) {
       if (e.code() != no_message_available) {
-	co_return e.code();
+	throw;
       }
+      co_return;
     }
-  co_return error_code{};
 }
 
 /// \brief List log entries

--- a/src/neorados/cls/log.h
+++ b/src/neorados/cls/log.h
@@ -462,8 +462,8 @@ trim(RADOS& r, Object oid, IOContext ioc,
       if (e.code() != no_message_available) {
 	throw;
       }
+      co_return;
     }
-  co_return;
 }
 
 /// \brief Trim entries from the log

--- a/src/rgw/driver/rados/rgw_datalog.cc
+++ b/src/rgw/driver/rados/rgw_datalog.cc
@@ -337,7 +337,15 @@ public:
   }
   asio::awaitable<void> trim(const DoutPrefixProvider *dpp, int index,
 	   std::string_view marker) override {
-    co_await fifos[index].trim(dpp, std::string{marker}, false);
+    try {
+      co_await fifos[index].trim(dpp, std::string{marker}, false);
+    } catch (const sys::system_error& e) {
+      if (e.code() != sys::errc::no_message_available) {
+	ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
+			   << ": trim failed: " << e.what() << dendl;
+	throw;
+      }
+    }
   }
   std::string_view max_marker() const override {
     static const auto max_mark = fifo::FIFO::max_marker();

--- a/src/rgw/driver/rados/rgw_datalog.cc
+++ b/src/rgw/driver/rados/rgw_datalog.cc
@@ -1183,7 +1183,7 @@ asio::awaitable<void> DataLogBackends::trim_entries(
     l.unlock();
     auto c = be->gen_id == target_gen ? cursor : be->max_marker();
     co_await be->trim(dpp, shard_id, c);
-    if (be->gen_id == target_gen)
+    if (be->gen_id == target_gen || be->gen_id >= head_gen)
       break;
     l.lock();
   };

--- a/src/test/cls_log/test_neocls_log.cc
+++ b/src/test/cls_log/test_neocls_log.cc
@@ -511,6 +511,32 @@ CORO_TEST_F(neocls_log, trim_loop_empty_log_by_marker, NeoRadosTest)
 }
 
 
+CORO_TEST_F(neocls_log, trim_loop_all_entries_by_time, NeoRadosTest)
+{
+  co_await create_obj(oid);
+  auto start_time = real_clock::now();
+  co_await generate_log(rados(), oid, pool(), 10, start_time, true,
+			asio::use_awaitable);
+
+  auto end_time = start_time + 100s;
+  co_await neorados::cls::log::trim(
+    rados(), oid, pool(), real_time{}, end_time, asio::use_awaitable);
+
+  std::vector<l::entry> entries{neorados::cls::log::max_list_entries};
+  std::span<l::entry> result;
+  co_await list(rados(), oid, pool(), entries, &result, asio::use_awaitable);
+  EXPECT_EQ(0u, result.size());
+}
+
+CORO_TEST_F(neocls_log, trim_loop_empty_log_by_time, NeoRadosTest)
+{
+  co_await create_obj(oid);
+
+  auto end_time = real_clock::now() + 100s;
+  co_await neorados::cls::log::trim(
+    rados(), oid, pool(), real_time{}, end_time, asio::use_awaitable);
+}
+
 #if 0 // Disable until we get rid of GCC11
 TEST(neocls_log_bare, lambdata)
 {

--- a/src/test/cls_log/test_neocls_log.cc
+++ b/src/test/cls_log/test_neocls_log.cc
@@ -473,9 +473,7 @@ CORO_TEST_F(neocls_log, trim_by_marker, NeoRadosTest)
 }
 
 // Test the neorados::trim() loop function (use_awaitable overloads) to verify
-// it terminates. Before any fix in neorados/cls/log.h, the use_awaitable_t
-// overloads had the try-catch for ENODATA inside the for(;;) loop, causing
-// the loop to never exit in certain cluster configs and this CPU hogging.
+// it terminates.
 CORO_TEST_F(neocls_log, trim_loop_all_entries_by_marker, NeoRadosTest)
 {
   co_await create_obj(oid);
@@ -485,8 +483,7 @@ CORO_TEST_F(neocls_log, trim_loop_all_entries_by_marker, NeoRadosTest)
   co_await generate_log(rados(), oid, pool(), 10, start_time, true,
 			asio::use_awaitable);
 
-  // call trim() loop function. Without a fix, this never returns
-  // because of where the try-catch sits relative to the for(;;)
+  // call trim() loop function.
   co_await neorados::cls::log::trim(
     rados(), oid, pool(),
     std::string_view{neorados::cls::log::begin_marker},

--- a/src/test/cls_log/test_neocls_log.cc
+++ b/src/test/cls_log/test_neocls_log.cc
@@ -472,6 +472,48 @@ CORO_TEST_F(neocls_log, trim_by_marker, NeoRadosTest)
   }
 }
 
+// Test the neorados::trim() loop function (use_awaitable overloads) to verify
+// it terminates. Before any fix in neorados/cls/log.h, the use_awaitable_t
+// overloads had the try-catch for ENODATA inside the for(;;) loop, causing
+// the loop to never exit in certain cluster configs and this CPU hogging.
+CORO_TEST_F(neocls_log, trim_loop_all_entries_by_marker, NeoRadosTest)
+{
+  co_await create_obj(oid);
+  auto start_time = real_clock::now();
+
+  // write 10 cls_log entries into the object
+  co_await generate_log(rados(), oid, pool(), 10, start_time, true,
+			asio::use_awaitable);
+
+  // call trim() loop function. Without a fix, this never returns
+  // because of where the try-catch sits relative to the for(;;)
+  co_await neorados::cls::log::trim(
+    rados(), oid, pool(),
+    std::string_view{neorados::cls::log::begin_marker},
+    std::string_view{neorados::cls::log::end_marker},
+    asio::use_awaitable);
+
+  // Verify all entries are gone
+  std::vector<l::entry> entries{neorados::cls::log::max_list_entries};
+  std::span<l::entry> result;
+  co_await list(rados(), oid, pool(), entries, &result, asio::use_awaitable);
+  EXPECT_EQ(0u, result.size());
+}
+
+CORO_TEST_F(neocls_log, trim_loop_empty_log_by_marker, NeoRadosTest)
+{
+  co_await create_obj(oid);
+
+  // Trim an empty log object. With the bug, cls_log_trim returns ENODATA,
+  // which is caught and swallowed inside the for(;;), looping forever.
+  co_await neorados::cls::log::trim(
+    rados(), oid, pool(),
+    std::string_view{neorados::cls::log::begin_marker},
+    std::string_view{neorados::cls::log::end_marker},
+    asio::use_awaitable);
+}
+
+
 #if 0 // Disable until we get rid of GCC11
 TEST(neocls_log_bare, lambdata)
 {

--- a/src/test/rgw/test_datalog.cc
+++ b/src/test/rgw/test_datalog.cc
@@ -442,8 +442,6 @@ CORO_TEST_F(DataLogBulky, BulkyCycleRecovery, DataLogBulky) {
 }
 
 // trim_entries with max_marker() must not crash on a single-generation cluster.
-// Without the fix, the loop increment would call upper_bound(head_gen)->second,
-// dereferencing end() and causing a SIGSEGV.
 CORO_TEST_F(DataLogBulky, TrimWithMaxMarker, DataLogBulky) {
   for (const auto& bg : bulky) {
     co_await add_entry(dpp(), bg);

--- a/src/test/rgw/test_datalog.cc
+++ b/src/test/rgw/test_datalog.cc
@@ -441,6 +441,18 @@ CORO_TEST_F(DataLogBulky, BulkyCycleRecovery, DataLogBulky) {
   co_return;
 }
 
+// trim_entries with max_marker() must not crash on a single-generation cluster.
+// Without the fix, the loop increment would call upper_bound(head_gen)->second,
+// dereferencing end() and causing a SIGSEGV.
+CORO_TEST_F(DataLogBulky, TrimWithMaxMarker, DataLogBulky) {
+  for (const auto& bg : bulky) {
+    co_await add_entry(dpp(), bg);
+  }
+  co_await renew_entries(dpp());
+  co_await datalog->trim_entries(dpp(), 0, datalog->max_marker());
+  co_return;
+}
+
 CORO_TEST_F(DataLogBulky, BulkySemaphoresRecovery, DataLogBulky) {
   for (const auto& bg : bulky) {
     co_await rados().execute(sem_set_oid(bg), loc(),


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76818

---

backport of https://github.com/ceph/ceph/pull/68874
parent tracker: https://tracker.ceph.com/issues/76563

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh