### PR TITLE
squid: qa/rgw: remove ragweed from verify subsuite

### DIFF
--- a/qa/suites/rgw/verify/tasks/ragweed.yaml
+++ b/qa/suites/rgw/verify/tasks/ragweed.yaml
@@ -1,6 +1,0 @@
-tasks:
-- ragweed:
-    client.0:
-      default-branch: ceph-squid
-      rgw_server: client.0
-      stages: prepare,check


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76817

---

backport of https://github.com/ceph/ceph/pull/68000
parent tracker: https://tracker.ceph.com/issues/76815

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh