### PR TITLE
qa: ensure nvmeof/mon thrashers are in sync

### DIFF
--- a/qa/suites/nvmeof/thrash/thrashers/nvmeof_mon_thrash.yaml
+++ b/qa/suites/nvmeof/thrash/thrashers/nvmeof_mon_thrash.yaml
@@ -27,10 +27,12 @@ tasks:
 - nvmeof.thrash:
     checker_host: 'client.0'
     switch_thrashers: True
+    switch_thrashers_wait: 1000
 
 - mon_thrash:
     revive_delay: 60
     thrash_delay: 60
     thrash_many: true
     switch_thrashers: True
+    switch_thrashers_wait: 1000
     logger: '[nvmeof.thrasher.mon_thrasher]'

--- a/qa/tasks/mon_thrash.py
+++ b/qa/tasks/mon_thrash.py
@@ -106,8 +106,9 @@ class MonitorThrasher(Thrasher):
         if self.config is None:
             self.config = dict()
 
-        if self.config.get("switch_thrashers"): 
+        if self.config.get("switch_thrashers"):
             self.switch_thrasher = Event()
+            self.switch_thrashers_wait = int(self.config.get('switch_thrashers_wait', 600))
 
         """ Test reproducibility """
         self.random_seed = self.config.get('seed', None)
@@ -304,8 +305,11 @@ class MonitorThrasher(Thrasher):
             ):
                 other_thrasher = t
                 self.log('switch_task: waiting for others thrashers')
-                other_thrasher.switch_thrasher.wait(300)
+                synced = other_thrasher.switch_thrasher.wait(self.switch_thrashers_wait)
                 self.log('switch_task: done waiting for the other thrasher')
+                if not synced:
+                    self.log(f'switch_task: WARNING - timed out after {self.switch_thrashers_wait}s '
+                             f'waiting for other thrasher, thrashers are now out of sync')
                 other_thrasher.switch_thrasher.clear()
 
     def _do_thrash(self):

--- a/qa/tasks/nvmeof.py
+++ b/qa/tasks/nvmeof.py
@@ -334,8 +334,9 @@ class NvmeofThrasher(Thrasher, Greenlet):
         self.daemons = daemons
         self.logger = log.getChild('[nvmeof.thrasher]')
         self.stopping = Event()
-        if self.config.get("switch_thrashers"): 
+        if self.config.get("switch_thrashers"):
             self.switch_thrasher = Event()
+            self.switch_thrashers_wait = int(self.config.get('switch_thrashers_wait', 600))
         self.checker_host = get_remote_for_role(self.ctx, self.config.get('checker_host'))
         self.devices = self._get_devices(self.checker_host)
 
@@ -446,8 +447,11 @@ class NvmeofThrasher(Thrasher, Greenlet):
             ):
                 other_thrasher = t
                 self.log('switch_task: waiting for other thrasher')
-                other_thrasher.switch_thrasher.wait(600)
+                synced = other_thrasher.switch_thrasher.wait(self.switch_thrashers_wait)
                 self.log('switch_task: done waiting for the other thrasher')
+                if not synced:
+                    self.log(f'switch_task: WARNING - timed out after {self.switch_thrashers_wait}s '
+                             f'waiting for other thrasher, thrashers are now out of sync')
                 other_thrasher.switch_thrasher.clear()
 
     def kill_daemon(self, daemon):


### PR DESCRIPTION
Ensure mon and nvmeof thrasher wait for each
other enough so they remain in sync in their
teardown/reviving cycles.

Fixes: https://tracker.ceph.com/issues/76798

Tested with fix: https://pulpito.ceph.com/vallariag-2026-06-01_06:15:09-nvmeof-wip-leonidc-osd-not-writable-fix1705_2-distro-default-trial/



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
