### PR TITLE
crimson/osd: give each split child its own PeeringCtx

### DIFF
--- a/src/crimson/osd/osd_operations/pg_advance_map.cc
+++ b/src/crimson/osd/osd_operations/pg_advance_map.cc
@@ -160,6 +160,7 @@ seastar::future<> PGAdvanceMap::split_pg(
   // be applied in order. 
   for (auto child_pgid : split_children) {
     children_pgids.insert(child_pgid);
+    PeeringCtx child_rctx;
 
     // Map each child pg ID to a core
     auto core = co_await shard_services.create_split_pg_mapping(child_pgid, seastar::this_shard_id(), pg->get_store_index());
@@ -176,13 +177,13 @@ seastar::future<> PGAdvanceMap::split_pg(
 	new_pg_num, child_pg->get_pgid().ps(), split_bits);
 
     co_await pg->split_colls(child_pg->get_pgid(), split_bits, child_pg->get_pgid().ps(),
-                             &child_pg->get_pgpool().info, rctx.transaction);
+                             &child_pg->get_pgpool().info, child_rctx.transaction);
     DEBUG(" {} split collection done", child_pg->get_pgid());
     pg->split_into(child_pg->get_pgid().pgid, child_pg, split_bits);
     auto child_coll_ref = child_pg->get_collection_ref();
-    rctx.transaction.touch(child_coll_ref->get_cid(), child_pg->get_pgid().make_snapmapper_oid());
+    child_rctx.transaction.touch(child_coll_ref->get_cid(), child_pg->get_pgid().make_snapmapper_oid());
 
-    co_await handle_split_pg_creation(child_pg, next_map);
+    co_await handle_split_pg_creation(child_pg, next_map, std::move(child_rctx));
     split_pgs.insert(child_pg);
   }
 
@@ -191,7 +192,8 @@ seastar::future<> PGAdvanceMap::split_pg(
 
 seastar::future<> PGAdvanceMap::handle_split_pg_creation(
     Ref<PG> child_pg,
-    cached_map_t next_map)
+    cached_map_t next_map,
+    PeeringCtx child_rctx)
 {
   LOG_PREFIX(PGAdvanceMap::handle_split_pg_creation);
   // We must create a new Trigger instance for each pg.
@@ -216,7 +218,7 @@ seastar::future<> PGAdvanceMap::handle_split_pg_creation(
   }));
   co_await shard_services.start_operation<PGAdvanceMap>(
       child_pg, shard_services, next_map->get_epoch(),
-      std::move(rctx), true).second;
+      std::move(child_rctx), true).second;
   co_await std::move(fut);
 }
 

--- a/src/crimson/osd/osd_operations/pg_advance_map.cc
+++ b/src/crimson/osd/osd_operations/pg_advance_map.cc
@@ -160,42 +160,40 @@ seastar::future<> PGAdvanceMap::split_pg(
   // be applied in order. 
   for (auto child_pgid : split_children) {
     children_pgids.insert(child_pgid);
-    PeeringCtx child_rctx;
-
-    // Map each child pg ID to a core
-    auto core = co_await shard_services.create_split_pg_mapping(child_pgid, seastar::this_shard_id(), pg->get_store_index());
-    DEBUG(" PG {} mapped to {}", child_pgid.pgid, core);
-    DEBUG(" {} map epoch: {}", child_pgid.pgid, pg_epoch);
-    auto map = next_map;
-    auto child_pg = co_await shard_services.make_pg(std::move(map), child_pgid, pg->get_store_index(), true);
-
-    DEBUG(" Parent pgid: {}", pg->get_pgid());
-    DEBUG(" Child pgid: {}", child_pg->get_pgid());
-    unsigned new_pg_num = next_map->get_pg_num(pg->get_pgid().pool());
-    unsigned split_bits = child_pg->get_pgid().get_split_bits(new_pg_num);
-    DEBUG(" pg num is {}, m_seed is {}, split bits is {}",
-	new_pg_num, child_pg->get_pgid().ps(), split_bits);
-
-    co_await pg->split_colls(child_pg->get_pgid(), split_bits, child_pg->get_pgid().ps(),
-                             &child_pg->get_pgpool().info, child_rctx.transaction);
-    DEBUG(" {} split collection done", child_pg->get_pgid());
-    pg->split_into(child_pg->get_pgid().pgid, child_pg, split_bits);
-    auto child_coll_ref = child_pg->get_collection_ref();
-    child_rctx.transaction.touch(child_coll_ref->get_cid(), child_pg->get_pgid().make_snapmapper_oid());
-
-    co_await handle_split_pg_creation(child_pg, next_map, std::move(child_rctx));
+    auto child_pg = co_await handle_split_pg_creation(child_pgid, next_map);
     split_pgs.insert(child_pg);
   }
 
   split_stats(split_pgs, children_pgids);
 }
 
-seastar::future<> PGAdvanceMap::handle_split_pg_creation(
-    Ref<PG> child_pg,
-    cached_map_t next_map,
-    PeeringCtx child_rctx)
+seastar::future<Ref<PG>> PGAdvanceMap::handle_split_pg_creation(
+    spg_t child_pgid,
+    cached_map_t next_map)
 {
   LOG_PREFIX(PGAdvanceMap::handle_split_pg_creation);
+
+  // Map each child pg ID to a core
+  auto core = co_await shard_services.create_split_pg_mapping(child_pgid, seastar::this_shard_id(), pg->get_store_index());
+  DEBUG(" PG {} mapped to {}", child_pgid.pgid, core);
+  DEBUG(" {} map epoch: {}", child_pgid.pgid, next_map->get_epoch());
+  auto child_pg = co_await shard_services.make_pg(next_map, child_pgid, pg->get_store_index(), true);
+
+  DEBUG(" Parent pgid: {}", pg->get_pgid());
+  DEBUG(" Child pgid: {}", child_pg->get_pgid());
+  unsigned new_pg_num = next_map->get_pg_num(pg->get_pgid().pool());
+  unsigned split_bits = child_pg->get_pgid().get_split_bits(new_pg_num);
+  DEBUG(" pg num is {}, m_seed is {}, split bits is {}",
+	new_pg_num, child_pg->get_pgid().ps(), split_bits);
+
+  PeeringCtx child_rctx;
+  co_await pg->split_colls(child_pg->get_pgid(), split_bits, child_pg->get_pgid().ps(),
+                           &child_pg->get_pgpool().info, child_rctx.transaction);
+  DEBUG(" {} split collection done", child_pg->get_pgid());
+  pg->split_into(child_pg->get_pgid().pgid, child_pg, split_bits);
+  auto child_coll_ref = child_pg->get_collection_ref();
+  child_rctx.transaction.touch(child_coll_ref->get_cid(), child_pg->get_pgid().make_snapmapper_oid());
+
   // We must create a new Trigger instance for each pg.
   // The BlockingEvent object which tracks whether a pg creation is complete
   // or still blocking, shouldn't be used across multiple pgs so we can track
@@ -220,6 +218,7 @@ seastar::future<> PGAdvanceMap::handle_split_pg_creation(
       child_pg, shard_services, next_map->get_epoch(),
       std::move(child_rctx), true).second;
   co_await std::move(fut);
+  co_return child_pg;
 }
 
 

--- a/src/crimson/osd/osd_operations/pg_advance_map.h
+++ b/src/crimson/osd/osd_operations/pg_advance_map.h
@@ -72,7 +72,8 @@ private:
   PGPeeringPipeline &peering_pp(PG &pg);
   seastar::future<> handle_split_pg_creation(
     Ref<PG> child_pg,
-    cached_map_t next_map);
+    cached_map_t next_map,
+    PeeringCtx child_rctx);
 };
 
 }

--- a/src/crimson/osd/osd_operations/pg_advance_map.h
+++ b/src/crimson/osd/osd_operations/pg_advance_map.h
@@ -70,10 +70,9 @@ public:
 
 private:
   PGPeeringPipeline &peering_pp(PG &pg);
-  seastar::future<> handle_split_pg_creation(
-    Ref<PG> child_pg,
-    cached_map_t next_map,
-    PeeringCtx child_rctx);
+  seastar::future<Ref<PG>> handle_split_pg_creation(
+    spg_t child_pgid,
+    cached_map_t next_map);
 };
 
 }


### PR DESCRIPTION
this is a readability cleanup, not a bugfix. The original "use-after-move" is actually well-defined: `split_pg()` reuses the parent's `PeeringCtx` by `std::move`-ing it into each child, and a moved-from `ceph::os::Transaction` comes back empty, so it works, just subtly.

in this changeset, we:

- give each split child its own `PeeringCtx`: each child gets a fresh `PeeringCtx` carrying its own `split_colls()` / `snapmapper touch()`, instead of reusing the parent's moved-from `rctx`.
- fold the split-child setup into `handle_split_pg_creation`: move the per-child setup out of `split_pg()`'s loop into the function, which now returns the child PG. No behaviour change. this makes the data dependency between functions more explicit.




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
