### PR TITLE
rbd-mirror: Forcing image replayer to update state before and after snapshot sync

### DIFF
--- a/qa/workunits/rbd/rbd_mirror.sh
+++ b/qa/workunits/rbd/rbd_mirror.sh
@@ -212,6 +212,31 @@ write_image ${CLUSTER2} ${POOL} ${image} 100
 wait_for_replay_complete ${CLUSTER1} ${CLUSTER2} ${POOL} ${POOL} ${image}
 wait_for_status_in_pool_dir ${CLUSTER1} ${POOL} ${image} 'up+replaying'
 
+if [ "${RBD_MIRROR_MODE}" = "snapshot" ]; then
+  testlog "TEST: replay_state transition while syncing snapshot"
+  start_mirrors ${CLUSTER2}
+  big_image=test_big_image
+  REPLAY_STATE_FORCE_TRANSITION_TIMEOUT=15
+  create_image_and_enable_mirror ${CLUSTER2} ${POOL} ${big_image} ${RBD_MIRROR_MODE} 1024
+  wait_for_image_present ${CLUSTER1} ${POOL} ${big_image} 'present'
+  wait_for_image_replay_started ${CLUSTER1} ${POOL} ${big_image}
+  wait_for_status_in_pool_dir ${CLUSTER1} ${POOL} ${big_image} 'up+replaying' '"replay_state":"idle"'
+  wait_for_status_in_pool_dir ${CLUSTER2} ${POOL} ${big_image} 'up+stopped'
+  write_image ${CLUSTER2} ${POOL} ${big_image} 1024 1048576
+  mirror_image_snapshot ${CLUSTER2} ${POOL} ${big_image}
+
+  wait_for_replay_state_transition ${CLUSTER1} ${POOL} ${big_image} 'idle' 'syncing' state_transition_time
+  test ${state_transition_time} -lt ${REPLAY_STATE_FORCE_TRANSITION_TIMEOUT}
+
+  wait_for_replay_state_transition ${CLUSTER1} ${POOL} ${big_image} 'syncing' 'idle' state_transition_time
+  test ${state_transition_time} -lt ${REPLAY_STATE_FORCE_TRANSITION_TIMEOUT}
+
+  test_snapshot_sync_complete ${CLUSTER1} ${CLUSTER2} ${POOL} ${POOL} ${big_image}
+  remove_image_retry ${CLUSTER2} ${POOL} ${big_image}
+  wait_for_image_present ${CLUSTER1} ${POOL} ${big_image} 'deleted'
+  stop_mirrors ${CLUSTER2}
+fi
+
 testlog "TEST: failover and failback"
 start_mirrors ${CLUSTER2}
 

--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -892,6 +892,26 @@ wait_for_snapshot_sync_complete()
     return 1
 }
 
+test_snapshot_sync_complete()
+{
+    local local_cluster=$1
+    local remote_cluster=$2
+    local local_pool=$3
+    local remote_pool=$4
+    local image=$5
+
+    local status_log=${TEMPDIR}/$(mkfname ${remote_cluster}-${remote_pool}-${image}.status)
+    local local_status_log=${TEMPDIR}/$(mkfname ${local_cluster}-${local_pool}-${image}.status)
+
+    get_newest_mirror_snapshot "${remote_cluster}" "${remote_pool}" "${image}" "${status_log}"
+    local snapshot_id=$(xmlstarlet sel -t -v "//snapshot/id" < ${status_log})
+
+    get_newest_mirror_snapshot "${local_cluster}" "${local_pool}" "${image}" "${local_status_log}"
+    local primary_snapshot_id=$(xmlstarlet sel -t -v "//snapshot/namespace/primary_snap_id" < ${local_status_log})
+
+    test "${snapshot_id}" = "${primary_snapshot_id}"
+}
+
 wait_for_replay_complete()
 {
     local local_cluster=$1
@@ -996,6 +1016,49 @@ wait_for_replaying_status_in_pool_dir()
     else
         wait_for_status_in_pool_dir ${cluster} ${pool} ${image} 'up+replaying'
     fi
+}
+
+wait_for_replay_state_transition()
+{
+    local cluster=$1
+    local pool=$2
+    local image=$3
+    local old_replay_state=$4
+    local new_replay_state=$5
+    local -n replay_state_transition_time=$6
+    local status
+    local replay_state
+    local last_update
+    local sleep_interval
+    local old_state_last_update
+
+    # replay_state could change multiple times in small time frame for force updates,
+    # hence the small sleep intervals. It could also take up to 30 seconds, hence total
+    # timeout of ~30 seconds.
+    for sleep_interval in 0.1 0.2 0.4 0.8 1 1 1 1 1 1 1 1 1 1 2 2 4 4 4 4; do
+        status=$(CEPH_ARGS='' rbd --cluster ${cluster} mirror image status \
+                 ${pool}/${image} 2>/dev/null)
+
+        replay_state=$(sed -nE 's/^  description:.*"replay_state":"([^"]*)".*$/\1/p' <<< "$status")
+        last_update=$(sed -nE 's/^  last_update: *(.*) *$/\1/p' <<< "$status")
+        last_update=$(date -d "$last_update" +%s)
+
+        if [ "$replay_state" = "$old_replay_state" ]; then
+            old_state_last_update=$last_update
+        elif [ "$replay_state" = "$new_replay_state" ]; then
+            if [[ -z "$old_state_last_update" ]]; then
+                replay_state_transition_time=0
+            else
+                replay_state_transition_time=$((last_update - old_state_last_update))
+            fi
+            return 0
+        else
+            echo "Unexpected replay_state: '${replay_state}'"
+            return 1
+        fi
+        sleep ${sleep_interval}
+    done
+    return 1
 }
 
 create_image()

--- a/src/test/rbd_mirror/image_replayer/journal/test_mock_Replayer.cc
+++ b/src/test/rbd_mirror/image_replayer/journal/test_mock_Replayer.cc
@@ -118,7 +118,7 @@ struct Threads<librbd::MockTestImageCtx> {
 namespace {
 
 struct MockReplayerListener : public image_replayer::ReplayerListener {
-  MOCK_METHOD0(handle_notification, void());
+  MOCK_METHOD1(handle_notification, void(bool));
 };
 
 } // anonymous namespace
@@ -447,8 +447,8 @@ public:
 
   void expect_notification(MockThreads& mock_threads,
                            MockReplayerListener& mock_replayer_listener) {
-    EXPECT_CALL(mock_replayer_listener, handle_notification())
-      .WillOnce(Invoke([this]() {
+    EXPECT_CALL(mock_replayer_listener, handle_notification(_))
+      .WillOnce(Invoke([this](bool) {
           std::unique_lock locker{m_lock};
           m_notified = true;
           m_cond.notify_all();

--- a/src/test/rbd_mirror/image_replayer/snapshot/test_mock_Replayer.cc
+++ b/src/test/rbd_mirror/image_replayer/snapshot/test_mock_Replayer.cc
@@ -283,7 +283,7 @@ struct Threads<librbd::MockTestImageCtx> {
 namespace {
 
 struct MockReplayerListener : public image_replayer::ReplayerListener {
-  MOCK_METHOD0(handle_notification, void());
+  MOCK_METHOD1(handle_notification, void(bool));
 };
 
 } // anonymous namespace
@@ -387,6 +387,7 @@ using ::testing::Return;
 using ::testing::ReturnArg;
 using ::testing::StrEq;
 using ::testing::WithArg;
+using ::testing::ElementsAre;
 
 class TestMockImageReplayerSnapshotReplayer : public TestMockFixture {
 public:
@@ -644,14 +645,18 @@ public:
           }));
   }
 
-  void expect_notification(MockThreads& mock_threads,
-                           MockReplayerListener& mock_replayer_listener) {
-    EXPECT_CALL(mock_replayer_listener, handle_notification())
-      .WillRepeatedly(Invoke([this]() {
-          std::unique_lock locker{m_lock};
-          ++m_notifications;
-          m_cond.notify_all();
-        }));
+  void expect_notifications(MockThreads& mock_threads,
+    MockReplayerListener& mock_replayer_listener,
+    std::vector<bool>* notification_forces = nullptr) {
+    EXPECT_CALL(mock_replayer_listener, handle_notification(_))
+      .WillRepeatedly(Invoke([this, notification_forces](bool force) {
+        std::unique_lock locker{m_lock};
+        if (notification_forces) {
+          notification_forces->push_back(force);
+        }
+        ++m_notifications;
+        m_cond.notify_all();
+      }));
   }
 
   int wait_for_notification(uint32_t count) {
@@ -724,7 +729,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, InitShutDown) {
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -779,7 +784,9 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, SyncSnapshot) {
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+
+  std::vector<bool> notification_forces;
+  expect_notifications(mock_threads, mock_replayer_listener, &notification_forces);
 
   InSequence seq;
 
@@ -942,7 +949,9 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, SyncSnapshot) {
   ASSERT_EQ(0, init_ctx.wait());
 
   // wait for sync to complete
-  ASSERT_EQ(0, wait_for_notification(4));
+  ASSERT_EQ(0, wait_for_notification(6));
+  EXPECT_THAT(notification_forces,
+              ElementsAre(false, true, true, true, true, true));
 
   // shut down
   ASSERT_EQ(0, shut_down_entry_replayer(mock_replayer, mock_threads,
@@ -958,7 +967,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, InterruptedSyncInitial) {
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -1029,7 +1038,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, InterruptedSyncInitial) {
   update_watch_ctx->handle_notify();
 
   // wait for sync to complete
-  ASSERT_EQ(0, wait_for_notification(2));
+  ASSERT_EQ(0, wait_for_notification(3));
 
   ASSERT_EQ(0, shut_down_entry_replayer(mock_replayer, mock_threads,
                                         mock_local_image_ctx,
@@ -1044,7 +1053,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, InterruptedSyncDelta) {
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -1151,7 +1160,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, InterruptedSyncDelta) {
   update_watch_ctx->handle_notify();
 
   // wait for sync to complete
-  ASSERT_EQ(0, wait_for_notification(2));
+  ASSERT_EQ(0, wait_for_notification(3));
 
   ASSERT_EQ(0, shut_down_entry_replayer(mock_replayer, mock_threads,
                                         mock_local_image_ctx,
@@ -1166,7 +1175,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, InterruptedSyncDeltaDemote) {
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -1274,7 +1283,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, InterruptedSyncDeltaDemote) {
   update_watch_ctx->handle_notify();
 
   // wait for sync to complete
-  ASSERT_EQ(0, wait_for_notification(2));
+  ASSERT_EQ(0, wait_for_notification(3));
 
   ASSERT_EQ(0, shut_down_entry_replayer(mock_replayer, mock_threads,
                                         mock_local_image_ctx,
@@ -1289,7 +1298,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, InterruptedPendingSyncInitial) {
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -1359,7 +1368,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, InterruptedPendingSyncInitial) {
   update_watch_ctx->handle_notify();
 
   // wait for sync to complete
-  ASSERT_EQ(0, wait_for_notification(2));
+  ASSERT_EQ(0, wait_for_notification(3));
 
   ASSERT_EQ(0, shut_down_entry_replayer(mock_replayer, mock_threads,
                                         mock_local_image_ctx,
@@ -1374,7 +1383,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, InterruptedPendingSyncDelta) {
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -1500,7 +1509,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, InterruptedPendingSyncDelta) {
   update_watch_ctx->handle_notify();
 
   // wait for sync to complete
-  ASSERT_EQ(0, wait_for_notification(2));
+  ASSERT_EQ(0, wait_for_notification(3));
 
   ASSERT_EQ(0, shut_down_entry_replayer(mock_replayer, mock_threads,
                                         mock_local_image_ctx,
@@ -1515,7 +1524,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, InterruptedPendingSyncDeltaDemote)
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -1642,7 +1651,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, InterruptedPendingSyncDeltaDemote)
   update_watch_ctx->handle_notify();
 
   // wait for sync to complete
-  ASSERT_EQ(0, wait_for_notification(2));
+  ASSERT_EQ(0, wait_for_notification(3));
 
   ASSERT_EQ(0, shut_down_entry_replayer(mock_replayer, mock_threads,
                                         mock_local_image_ctx,
@@ -1657,7 +1666,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, RemoteImageDemoted) {
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -1731,7 +1740,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, RemoteImageDemoted) {
   update_watch_ctx->handle_notify();
 
   // wait for sync to complete and expect replay complete
-  ASSERT_EQ(0, wait_for_notification(2));
+  ASSERT_EQ(0, wait_for_notification(3));
   ASSERT_FALSE(mock_replayer.is_replaying());
 
   ASSERT_EQ(0, shut_down_entry_replayer(mock_replayer, mock_threads,
@@ -1747,7 +1756,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, LocalImagePromoted) {
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -1804,7 +1813,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, ResyncRequested) {
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -1861,7 +1870,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, ResyncRequestedRemoteNotPrimary) {
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -1937,7 +1946,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, ResyncRequestedRemoteNotPrimary) {
   // wake-up replayer
   update_watch_ctx->handle_notify();
 
-  ASSERT_EQ(0, wait_for_notification(2));
+  ASSERT_EQ(0, wait_for_notification(3));
   ASSERT_FALSE(mock_replayer.is_resync_requested());
   ASSERT_FALSE(mock_replayer.is_replaying());
 
@@ -2026,7 +2035,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, UnregisterRemoteUpdateWatcherError
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -2069,7 +2078,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, UnregisterLocalUpdateWatcherError)
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -2112,7 +2121,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, LoadImageMetaError) {
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -2161,7 +2170,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, RefreshLocalImageError) {
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -2213,7 +2222,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, RefreshRemoteImageError) {
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -2264,7 +2273,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, CopySnapshotsError) {
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -2308,7 +2317,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, CopySnapshotsError) {
   update_watch_ctx->handle_notify();
 
   // wait for sync to complete and expect replay complete
-  ASSERT_EQ(0, wait_for_notification(1));
+  ASSERT_EQ(0, wait_for_notification(2));
   ASSERT_FALSE(mock_replayer.is_replaying());
   ASSERT_EQ(-EINVAL, mock_replayer.get_error_code());
 
@@ -2325,7 +2334,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, GetImageStateError) {
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -2371,7 +2380,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, GetImageStateError) {
   update_watch_ctx->handle_notify();
 
   // wait for sync to complete and expect replay complete
-  ASSERT_EQ(0, wait_for_notification(1));
+  ASSERT_EQ(0, wait_for_notification(2));
   ASSERT_FALSE(mock_replayer.is_replaying());
   ASSERT_EQ(-EINVAL, mock_replayer.get_error_code());
 
@@ -2388,7 +2397,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, CreateNonPrimarySnapshotError) {
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -2438,7 +2447,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, CreateNonPrimarySnapshotError) {
   update_watch_ctx->handle_notify();
 
   // wait for sync to complete and expect replay complete
-  ASSERT_EQ(0, wait_for_notification(1));
+  ASSERT_EQ(0, wait_for_notification(2));
   ASSERT_FALSE(mock_replayer.is_replaying());
   ASSERT_EQ(-EINVAL, mock_replayer.get_error_code());
 
@@ -2455,7 +2464,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, UpdateMirrorImageStateError) {
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -2507,7 +2516,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, UpdateMirrorImageStateError) {
   update_watch_ctx->handle_notify();
 
   // wait for sync to complete and expect replay complete
-  ASSERT_EQ(0, wait_for_notification(1));
+  ASSERT_EQ(0, wait_for_notification(2));
   ASSERT_FALSE(mock_replayer.is_replaying());
   ASSERT_EQ(-EIO, mock_replayer.get_error_code());
 
@@ -2524,7 +2533,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, RequestSyncError) {
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -2578,7 +2587,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, RequestSyncError) {
   update_watch_ctx->handle_notify();
 
   // wait for sync to complete and expect replay complete
-  ASSERT_EQ(0, wait_for_notification(1));
+  ASSERT_EQ(0, wait_for_notification(2));
   ASSERT_FALSE(mock_replayer.is_replaying());
   ASSERT_EQ(-ECANCELED, mock_replayer.get_error_code());
 
@@ -2595,7 +2604,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, CopyImageError) {
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -2652,7 +2661,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, CopyImageError) {
   update_watch_ctx->handle_notify();
 
   // wait for sync to complete and expect replay complete
-  ASSERT_EQ(0, wait_for_notification(1));
+  ASSERT_EQ(0, wait_for_notification(2));
   ASSERT_FALSE(mock_replayer.is_replaying());
   ASSERT_EQ(-EINVAL, mock_replayer.get_error_code());
 
@@ -2669,7 +2678,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, UpdateNonPrimarySnapshotError) {
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -2730,7 +2739,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, UpdateNonPrimarySnapshotError) {
   update_watch_ctx->handle_notify();
 
   // wait for sync to complete and expect replay complete
-  ASSERT_EQ(0, wait_for_notification(1));
+  ASSERT_EQ(0, wait_for_notification(2));
   ASSERT_FALSE(mock_replayer.is_replaying());
   ASSERT_EQ(-EINVAL, mock_replayer.get_error_code());
 
@@ -2747,7 +2756,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, UnlinkPeerError) {
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -2819,7 +2828,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, UnlinkPeerError) {
   update_watch_ctx->handle_notify();
 
   // wait for sync to complete and expect replay complete
-  ASSERT_EQ(0, wait_for_notification(1));
+  ASSERT_EQ(0, wait_for_notification(2));
   ASSERT_FALSE(mock_replayer.is_replaying());
   ASSERT_EQ(-EINVAL, mock_replayer.get_error_code());
 
@@ -2836,7 +2845,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, SplitBrain) {
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -2900,7 +2909,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, RemoteSnapshotMissingSplitBrain) {
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -2969,7 +2978,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, RemoteFailover) {
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -3097,7 +3106,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, RemoteFailover) {
   update_watch_ctx->handle_notify();
 
   // wait for sync to complete and expect replay complete
-  ASSERT_EQ(0, wait_for_notification(2));
+  ASSERT_EQ(0, wait_for_notification(3));
   ASSERT_EQ(0, shut_down_entry_replayer(mock_replayer, mock_threads,
                                         mock_local_image_ctx,
                                         mock_remote_image_ctx));
@@ -3128,7 +3137,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, UnlinkRemoteSnapshot) {
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -3207,7 +3216,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, SkipImageSync) {
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -3271,7 +3280,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, SkipImageSync) {
   ASSERT_EQ(0, init_ctx.wait());
 
   // wait for sync to complete
-  ASSERT_EQ(0, wait_for_notification(3));
+  ASSERT_EQ(0, wait_for_notification(4));
 
   // shut down
   ASSERT_EQ(0, shut_down_entry_replayer(mock_replayer, mock_threads,
@@ -3287,7 +3296,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, ImageNameUpdated) {
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -3350,7 +3359,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, ApplyImageStatePendingShutdown) {
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -3423,7 +3432,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, ApplyImageStatePendingShutdown) {
   // wake-up replayer
   update_watch_ctx->handle_notify();
 
-  ASSERT_EQ(0, wait_for_notification(1));
+  ASSERT_EQ(0, wait_for_notification(2));
   ASSERT_FALSE(mock_replayer.is_replaying());
   ASSERT_EQ(0, mock_replayer.get_error_code());
 
@@ -3438,7 +3447,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, ApplyImageStateErrorPendingShutdow
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 
@@ -3519,7 +3528,7 @@ TEST_F(TestMockImageReplayerSnapshotReplayer, PruneObsoleteNonPrimaryDemotedSnap
   expect_work_queue_repeatedly(mock_threads);
 
   MockReplayerListener mock_replayer_listener;
-  expect_notification(mock_threads, mock_replayer_listener);
+  expect_notifications(mock_threads, mock_replayer_listener);
 
   InSequence seq;
 

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -209,8 +209,8 @@ struct ImageReplayer<I>::ReplayerListener
     : image_replayer(image_replayer) {
   }
 
-  void handle_notification() override {
-    image_replayer->handle_replayer_notification();
+  void handle_notification(bool force) override {
+    image_replayer->handle_replayer_notification(force);
   }
 };
 
@@ -1029,7 +1029,7 @@ void ImageReplayer<I>::handle_shut_down(int r) {
 }
 
 template <typename I>
-void ImageReplayer<I>::handle_replayer_notification() {
+void ImageReplayer<I>::handle_replayer_notification(bool force) {
   dout(10) << dendl;
 
   std::unique_lock locker{m_lock};
@@ -1071,7 +1071,7 @@ void ImageReplayer<I>::handle_replayer_notification() {
     return;
   }
 
-  update_mirror_image_status(false, {});
+  update_mirror_image_status(force, {});
 }
 
 template <typename I>

--- a/src/tools/rbd_mirror/ImageReplayer.h
+++ b/src/tools/rbd_mirror/ImageReplayer.h
@@ -255,7 +255,7 @@ private:
   void start_replay();
   void handle_start_replay(int r);
 
-  void handle_replayer_notification();
+  void handle_replayer_notification(bool force=false);
 
   void register_admin_socket_hook();
   void unregister_admin_socket_hook();

--- a/src/tools/rbd_mirror/image_replayer/ReplayerListener.h
+++ b/src/tools/rbd_mirror/image_replayer/ReplayerListener.h
@@ -11,7 +11,7 @@ namespace image_replayer {
 struct ReplayerListener {
   virtual ~ReplayerListener() {}
 
-  virtual void handle_notification() = 0;
+  virtual void handle_notification(bool force=false) = 0;
 };
 
 } // namespace image_replayer

--- a/src/tools/rbd_mirror/image_replayer/snapshot/Replayer.cc
+++ b/src/tools/rbd_mirror/image_replayer/snapshot/Replayer.cc
@@ -762,8 +762,8 @@ void Replayer<I>::scan_remote_mirror_snapshots(
                << "remote_snap_id_end=" << m_remote_snap_id_end << ", "
                << "remote_snap_ns=" << m_remote_mirror_snap_ns << dendl;
       if (m_remote_mirror_snap_ns.complete) {
+        notify_status_updated(true);
         locker->unlock();
-
         if (m_local_snap_id_end != CEPH_NOSNAP &&
             !m_local_mirror_snap_ns.complete) {
           // attempt to resume image-sync
@@ -813,7 +813,7 @@ void Replayer<I>::scan_remote_mirror_snapshots(
   ceph_assert(m_state == STATE_REPLAYING);
   m_state = STATE_IDLE;
 
-  notify_status_updated();
+  notify_status_updated(true);
 }
 
 template <typename I>
@@ -1372,7 +1372,7 @@ void Replayer<I>::finish_sync() {
 
   {
     std::unique_lock locker{m_lock};
-    notify_status_updated();
+    notify_status_updated(true);
 
     if (m_sync_in_progress) {
       m_sync_in_progress = false;
@@ -1593,13 +1593,13 @@ void Replayer<I>::handle_replay_complete(std::unique_lock<ceph::mutex>* locker,
 }
 
 template <typename I>
-void Replayer<I>::notify_status_updated() {
+void Replayer<I>::notify_status_updated(bool force) {
   ceph_assert(ceph_mutex_is_locked_by_me(m_lock));
 
   dout(10) << dendl;
   auto ctx = new C_TrackedOp(m_in_flight_op_tracker, new LambdaContext(
-    [this](int) {
-      m_replayer_listener->handle_notification();
+    [this, force](int) {
+      m_replayer_listener->handle_notification(force);
     }));
   m_threads->work_queue->queue(ctx, 0);
 }

--- a/src/tools/rbd_mirror/image_replayer/snapshot/Replayer.h
+++ b/src/tools/rbd_mirror/image_replayer/snapshot/Replayer.h
@@ -336,7 +336,7 @@ private:
   void handle_replay_complete(int r, const std::string& description);
   void handle_replay_complete(std::unique_lock<ceph::mutex>* locker,
                               int r, const std::string& description);
-  void notify_status_updated();
+  void notify_status_updated(bool force=false);
 
   bool is_replay_interrupted();
   bool is_replay_interrupted(std::unique_lock<ceph::mutex>* lock);


### PR DESCRIPTION
rbd-mirror: Forcing image replayer to update state before and after snapshot sync
Issues:
1. When image replayer starts syncing snapshot, the replay_state
reported by ImageReplayer doesn't change to 'syncing' from 'idle'
So replay_state reported by `mirror image status` is incorrect.
2. When issue 1 is fixed and image replayer is done syncing snapshot,
the replay_state is not updated to 'idle' from 'syncing' immediately.
It can take upto 30 seconds to change reported replay_state from
'syncing' to 'idle'.

Fix:
1. Triggering force status update to ImageReplayer when image_replayer
starts syncing new snapshot.
2. Triggering force status update to ImageReplayer when syncing is finished
and image_replayer doesn't have any other pending task.

Signed-off-by: Miki Patel <miki.patel132@gmail.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
