### PR TITLE
crimson: replace assert_all class with a format-safe function template

### DIFF
--- a/src/crimson/common/errorator.h
+++ b/src/crimson/common/errorator.h
@@ -369,7 +369,7 @@ public:
     auto ep = take_exception_from_future();
 
     // Any assert_* handler we have:
-    // assert_failure, assert_all and assert_all_func_t
+    // assert_failure, assert_all, and assert_all_func_t
     // are expected to return void since we actually abort in them.
     // This is why we need a way to diffreciate between them and between
     // non-aborting error handlers (e.g handle) - for that we use the dedicated
@@ -938,25 +938,17 @@ public:
     return std::move(fut);
   }
 
-  class assert_all {
-    const char* const msg = nullptr;
-  public:
-    assert_all(const char* msg)
-      : msg(msg) {
-    }
-    assert_all() = default;
-
-    template <class ErrorT, EnableIf<ErrorT>...>
-    no_touch_error_marker operator()(ErrorT&& raw_error) {
-      using decayed_t = std::decay_t<ErrorT>;
-      static_assert(contains_once_v<decayed_t>,
-                    "discarding disallowed ErrorT");
-      decayed_t::error_t::handle([this] (auto&& error_v) {
-        ceph_abort_msgf("%s: %s", msg ? msg : "", error_v.message().c_str());
-      })(std::forward<ErrorT>(raw_error));
-      return no_touch_error_marker{};
-    }
-  };
+  template <typename... Args>
+  static auto assert_all(fmt::format_string<Args...> fmt_str, Args&&... args) {
+    // Extract string_view before the lambda: the consteval format-string check
+    // already ran at the call site; re-passing fmt_str into fmt::format()
+    // inside a lambda would re-trigger the consteval constructor at runtime.
+    fmt::string_view sv = fmt_str;
+    return assert_all_func(
+      [sv, ...captured = std::forward<Args>(args)](const auto&) mutable {
+        ceph_abort_msg(fmt::vformat(sv, fmt::make_format_args(captured...)));
+      });
+  }
 
   template <typename Func>
   class assert_all_func_t {
@@ -1304,23 +1296,15 @@ namespace ct_error {
     }
   };
 
-  class assert_all {
-    const char* const msg = nullptr;
-  public:
-    assert_all(const char* msg)
-      : msg(msg) {
-    }
-    assert_all() = default;
-
-    template <class ErrorT>
-    no_touch_error_marker operator()(ErrorT&& raw_error) {
-      using decayed_t = std::decay_t<ErrorT>;
-      decayed_t::error_t::handle([this] (auto&& error_v) {
-        ceph_abort_msgf("%s: %s", msg ? msg : "", error_v.message().c_str());
-      })(std::forward<ErrorT>(raw_error));
+  template <typename... Args>
+  static auto assert_all(fmt::format_string<Args...> fmt_str, Args&&... args) {
+    fmt::string_view sv = fmt_str;
+    return [sv, ...captured = std::forward<Args>(args)](auto&&) mutable
+        -> no_touch_error_marker {
+      ceph_abort_msg(fmt::vformat(sv, fmt::make_format_args(captured...)));
       return no_touch_error_marker{};
-    }
-  };
+    };
+  }
 
   template <class ErrorFunc>
   static decltype(auto) all_same_way(ErrorFunc&& error_func) {

--- a/src/crimson/os/cyanstore/cyan_store.cc
+++ b/src/crimson/os/cyanstore/cyan_store.cc
@@ -97,9 +97,9 @@ CyanStore::mount_ertr::future<> CyanStore::mount()
   return shard_stores.invoke_on_all([](auto &local_store) {
     return seastar::do_for_each(local_store.mshard_stores, [](auto& mshard_store) {
       return mshard_store->mount().handle_error(
-        crimson::ct_error::assert_all{
+        crimson::ct_error::assert_all(
           "Invalid error in CyanStore::mount"
-        });
+        ));
     });
   });
 }

--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -607,9 +607,9 @@ seastar::future<> JournalTrimmerImpl::trim() {
       if (should_trim_alloc()) {
         return trim_alloc(
         ).handle_error(
-          crimson::ct_error::assert_all{
+          crimson::ct_error::assert_all(
             "encountered invalid error in trim_alloc"
-          }
+          )
         );
       } else {
         return seastar::now();
@@ -619,9 +619,9 @@ seastar::future<> JournalTrimmerImpl::trim() {
       if (should_start_trim_dirty()) {
         return trim_dirty(
         ).handle_error(
-          crimson::ct_error::assert_all{
+          crimson::ct_error::assert_all(
             "encountered invalid error in trim_dirty"
-          }
+          )
         );
       } else {
         return seastar::now();
@@ -1429,9 +1429,9 @@ SegmentCleaner::clean_space_ret SegmentCleaner::clean_space()
           return sm_group->release_segment(segment_to_release
           ).handle_error(
             clean_space_ertr::pass_further{},
-            crimson::ct_error::assert_all{
+            crimson::ct_error::assert_all(
               "SegmentCleaner::clean_space encountered invalid error in release_segment"
-            }
+            )
           ).safe_then([this, FNAME, segment_to_release] {
             auto old_usage = calc_utilization(segment_to_release);
             if(unlikely(old_usage != 0)) {
@@ -1564,7 +1564,7 @@ SegmentCleaner::mount_ret SegmentCleaner::mount()
         return mount_ertr::now();
       }),
       crimson::ct_error::input_output_error::pass_further{},
-      crimson::ct_error::assert_all{"unexpected error"}
+      crimson::ct_error::assert_all("unexpected error")
     );
   }).safe_then([this, FNAME] {
     INFO("done, {}", segments);
@@ -1970,8 +1970,8 @@ RBMCleaner::mount_ret RBMCleaner::mount()
       return it->open(
       ).handle_error(
 	crimson::ct_error::input_output_error::pass_further(),
-	crimson::ct_error::assert_all{
-	"Invalid error when opening RBM"}
+	crimson::ct_error::assert_all(
+	"Invalid error when opening RBM")
       );
     });
   });

--- a/src/crimson/os/seastore/backref/btree_backref_manager.cc
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.cc
@@ -77,9 +77,9 @@ BtreeBackrefManager::mkfs(
     return mkfs_iertr::now();
   }).handle_error_interruptible(
     mkfs_iertr::pass_further{},
-    crimson::ct_error::assert_all{
+    crimson::ct_error::assert_all(
       "Invalid error in BtreeBackrefManager::mkfs"
-    }
+    )
   );
 }
 

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -2206,9 +2206,9 @@ Cache::mkfs_iertr::future<> Cache::mkfs(Transaction &t)
     return mkfs_iertr::now();
   }).handle_error_interruptible(
     mkfs_iertr::pass_further{},
-    crimson::ct_error::assert_all{
+    crimson::ct_error::assert_all(
       "Invalid error in Cache::mkfs"
-    }
+    )
   );
 }
 
@@ -2382,9 +2382,9 @@ Cache::replay_delta(
 	delta.paddr)
     ).handle_error(
       replay_delta_ertr::pass_further{},
-      crimson::ct_error::assert_all{
+      crimson::ct_error::assert_all(
 	"Invalid error in Cache::replay_delta"
-      }
+      )
     );
     return extent_fut.safe_then([=, this, &delta](auto extent) {
       if (!extent) {

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1444,9 +1444,9 @@ public:
       });
     }).handle_error_interruptible(
       init_cached_extents_iertr::pass_further{},
-      crimson::ct_error::assert_all{
+      crimson::ct_error::assert_all(
         "Invalid error in Cache::init_cached_extents"
-      }
+      )
     ).si_then([this, FNAME, &t] {
       SUBINFOT(seastore_cache,
           "finish with {}(0x{:x}B) extents, {} dirty, dirty_from={}, alloc_from={}",
@@ -2051,9 +2051,9 @@ void stage_visibility_handoff(Transaction& t,
           std::move(extent));
       },
       get_extent_ertr::pass_further{},
-      crimson::ct_error::assert_all{
+      crimson::ct_error::assert_all(
         "Cache::read_extent: invalid error"
-      }
+      )
     );
   }
 
@@ -2153,9 +2153,9 @@ void stage_visibility_handoff(Transaction& t,
       futs, [](auto &fut) { return std::move(fut);
     }).handle_error(
       get_extent_ertr::pass_further{},
-      crimson::ct_error::assert_all{
+      crimson::ct_error::assert_all(
 	"Cache::read_extent: invalid error"
-      }
+      )
     );
     for (auto &ext : extents_read) {
       auto &extent = ext.extent;

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -712,9 +712,9 @@ ExtentPlacementManager::BackgroundProcess::run_cleaner_until_done()
     [this] {
       return main_cleaner->clean_space(
       ).handle_error(
-        crimson::ct_error::assert_all{
+        crimson::ct_error::assert_all(
           "run_cleaner_until_done encountered error in clean_space"
-        }
+        )
       );
     }
   ).finally([FNAME] {
@@ -1018,9 +1018,9 @@ ExtentPlacementManager::BackgroundProcess::do_background_cycle()
               main_cleaner_should_fast_evict());
         return main_cleaner->clean_space(
         ).handle_error(
-          crimson::ct_error::assert_all{
+          crimson::ct_error::assert_all(
             "do_background_cycle encountered invalid error in main clean_space"
-          }
+          )
         ).finally([this, main_cold_usage, FNAME] {
           DEBUG("finished clean main");
           abort_cold_usage(main_cold_usage, true);
@@ -1038,9 +1038,9 @@ ExtentPlacementManager::BackgroundProcess::do_background_cycle()
               should_clean_cold_for_main);
         return cold_cleaner->clean_space(
         ).handle_error(
-          crimson::ct_error::assert_all{
+          crimson::ct_error::assert_all(
             "do_background_cycle encountered invalid error in cold clean_space"
-          }
+          )
         ).finally([FNAME] {
           DEBUG("finished clean cold");
         });
@@ -1204,8 +1204,8 @@ RandomBlockOolWriter::do_write(
         return info.rbm->write(info.offset, info.bp
         ).handle_error(
           alloc_write_ertr::pass_further{},
-          crimson::ct_error::assert_all{
-            "Invalid error when writing record"}
+          crimson::ct_error::assert_all(
+            "Invalid error when writing record")
         );
       });
     })

--- a/src/crimson/os/seastore/journal/circular_bounded_journal.cc
+++ b/src/crimson/os/seastore/journal/circular_bounded_journal.cc
@@ -222,9 +222,9 @@ Journal::replay_ret CircularBoundedJournal::replay_segment(
         dhandler
       ).handle_error(
         replay_ertr::pass_further{},
-        crimson::ct_error::assert_all{
+        crimson::ct_error::assert_all(
           "shouldn't meet with any other error other replay_ertr"
-        }
+        )
       );
     }
   );
@@ -336,9 +336,9 @@ Journal::replay_ret CircularBoundedJournal::replay(
   return cjs.read_header(
   ).handle_error(
     open_for_mount_ertr::pass_further{},
-    crimson::ct_error::assert_all{
+    crimson::ct_error::assert_all(
       "Invalid error read_header"
-  }).safe_then([this, FNAME, delta_handler=std::move(delta_handler)](auto p)
+  )).safe_then([this, FNAME, delta_handler=std::move(delta_handler)](auto p)
     mutable {
     auto &[head, bl] = *p;
     cjs.set_cbj_header(head);

--- a/src/crimson/os/seastore/journal/circular_journal_space.cc
+++ b/src/crimson/os/seastore/journal/circular_journal_space.cc
@@ -72,7 +72,7 @@ CircularJournalSpace::write(ceph::bufferlist&& to_write) {
   return device_write_bl(target, to_write
   ).handle_error(
     write_ertr::pass_further{},
-    crimson::ct_error::assert_all{ "Invalid error" }
+    crimson::ct_error::assert_all( "Invalid error" )
   );
 }
 
@@ -117,9 +117,9 @@ CircularJournalSpace::open_ret CircularJournalSpace::open(bool is_mkfs) {
     co_await write_header(
     ).handle_error(
       open_ertr::pass_further{},
-      crimson::ct_error::assert_all{
+      crimson::ct_error::assert_all(
         "Invalid error write_header"
-      }
+      )
     );
 
     co_return get_written_to();
@@ -166,7 +166,7 @@ CircularJournalSpace::device_write_bl(
   co_await device->writev(offset, bl
   ).handle_error(
     submit_ertr::pass_further{},
-    crimson::ct_error::assert_all{ "Invalid error device->write" }
+    crimson::ct_error::assert_all( "Invalid error device->write" )
   );
 }
 
@@ -227,7 +227,7 @@ CircularJournalSpace::write_header()
   co_await device->write(device->get_shard_journal_start(), std::move(bp)
   ).handle_error(
     submit_ertr::pass_further{},
-    crimson::ct_error::assert_all{ "Invalid error device->write" }
+    crimson::ct_error::assert_all( "Invalid error device->write" )
   );
 }
 

--- a/src/crimson/os/seastore/journal/circular_journal_space.h
+++ b/src/crimson/os/seastore/journal/circular_journal_space.h
@@ -61,9 +61,9 @@ class CircularJournalSpace : public JournalAllocator {
       return close_ertr::now();
     }).handle_error(
       Journal::open_for_mount_ertr::pass_further{},
-      crimson::ct_error::assert_all{
+      crimson::ct_error::assert_all(
 	"Invalid error write_header"
-      }
+      )
     );
   }
 
@@ -227,9 +227,9 @@ class CircularJournalSpace : public JournalAllocator {
     header.alloc_tail = alloc;
     return write_header(
     ).handle_error(
-      crimson::ct_error::assert_all{
+      crimson::ct_error::assert_all(
       "encountered invalid error in update_journal_tail"
-    });
+    ));
   }
 
   void set_initialized(bool init) {

--- a/src/crimson/os/seastore/journal/segment_allocator.cc
+++ b/src/crimson/os/seastore/journal/segment_allocator.cc
@@ -63,9 +63,9 @@ SegmentAllocator::do_open(bool is_mkfs)
   return sm_group.open(new_segment_id
   ).handle_error(
     open_ertr::pass_further{},
-    crimson::ct_error::assert_all{
+    crimson::ct_error::assert_all(
       "Invalid error in SegmentAllocator::do_open open"
-    }
+    )
   ).safe_then([this, is_mkfs, FNAME, new_segment_seq](auto sref) {
     // initialize new segment
     segment_id_t segment_id = sref->get_segment_id();
@@ -125,9 +125,9 @@ SegmentAllocator::do_open(bool is_mkfs)
     return sref->write(0, std::move(bl)
     ).handle_error(
       open_ertr::pass_further{},
-      crimson::ct_error::assert_all{
+      crimson::ct_error::assert_all(
         "Invalid error in SegmentAllocator::do_open write"
-      }
+      )
     ).safe_then([this,
                  FNAME,
                  new_journal_seq,
@@ -205,9 +205,9 @@ SegmentAllocator::write(ceph::bufferlist&& to_write)
     write_start_offset, std::move(to_write)
   ).handle_error(
     write_ertr::pass_further{},
-    crimson::ct_error::assert_all{
+    crimson::ct_error::assert_all(
       "Invalid error in SegmentAllocator::write"
-    }
+    )
   ).finally([cs=current_segment] {});
 }
 
@@ -278,9 +278,8 @@ SegmentAllocator::close_segment()
     segment_provider.close_segment(seg_to_close->get_segment_id());
   }).handle_error(
     close_segment_ertr::pass_further{},
-    crimson::ct_error::assert_all {
-    "Invalid error in SegmentAllocator::close_segment"
-  });
+    crimson::ct_error::assert_all(
+    "Invalid error in SegmentAllocator::close_segment"));
 
 }
 

--- a/src/crimson/os/seastore/journal/segmented_journal.cc
+++ b/src/crimson/os/seastore/journal/segmented_journal.cc
@@ -317,9 +317,9 @@ SegmentedJournal::replay_segment(
 	dhandler
       ).handle_error(
 	replay_ertr::pass_further{},
-	crimson::ct_error::assert_all{
+	crimson::ct_error::assert_all(
 	  "shouldn't meet with any other error other replay_ertr"
-	}
+	)
       );
     }
   );

--- a/src/crimson/os/seastore/lba/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.cc
@@ -807,9 +807,9 @@ BtreeLBAManager::update_mapping(
   ).handle_error_interruptible(
     update_mapping_iertr::pass_further{},
     /* ENOENT in particular should be impossible */
-    crimson::ct_error::assert_all{
+    crimson::ct_error::assert_all(
       "Invalid error in BtreeLBAManager::update_mapping"
-    }
+    )
   );
   DEBUGT("laddr={}, paddr {}~0x{:x} => {}~0x{:x}, crc=0x{:x} done -- {}",
 	 t, laddr, prev_addr, prev_len, addr, len, checksum, *cursor);
@@ -872,9 +872,9 @@ BtreeLBAManager::update_mappings(
 	    },
 	    update_mapping_iertr::pass_further{},
 	    /* ENOENT in particular should be impossible */
-	    crimson::ct_error::assert_all{
+	    crimson::ct_error::assert_all(
 	      "Invalid error in BtreeLBAManager::update_mappings"
-	    }
+	    )
 	  );
 	});
       });
@@ -1224,7 +1224,7 @@ BtreeLBAManager::_move_mapping(
     c.trans, ret.src, -1
   ).handle_error_interruptible(
     move_mapping_iertr::pass_further{},
-    crimson::ct_error::assert_all{"unexpected error"});
+    crimson::ct_error::assert_all("unexpected error"));
 
   co_await ret.dest->refresh();
   auto iter = btree.make_partial_iter(c, *ret.dest);
@@ -1269,7 +1269,7 @@ BtreeLBAManager::move_and_clone_direct_mapping(
     nullptr
   ).handle_error_interruptible(
     move_mapping_iertr::pass_further{},
-    crimson::ct_error::assert_all{"unexpected error"});
+    crimson::ct_error::assert_all("unexpected error"));
 
   assert(cursor->is_indirect());
   auto iter = btree.make_partial_iter(c, *cursor);

--- a/src/crimson/os/seastore/lba/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.h
@@ -226,7 +226,7 @@ public:
       nullptr
     ).handle_error_interruptible(
       base_iertr::pass_further{},
-      crimson::ct_error::assert_all{}
+      crimson::ct_error::assert_all("unexpected error")
     );
   }
 

--- a/src/crimson/os/seastore/object_data_handler.cc
+++ b/src/crimson/os/seastore/object_data_handler.cc
@@ -238,9 +238,9 @@ ObjectDataHandler::delta_based_overwrite(
     overwrite_mapping
   ).handle_error_interruptible(
     base_iertr::pass_further{},
-    crimson::ct_error::assert_all{
+    crimson::ct_error::assert_all(
       "ObjectDataHandler::do_remapping hit invalid error"
-    }
+    )
   );
   assert(!maybe_indirect_extent.is_indirect());
   auto extent = ctx.tm.get_mutable_extent(ctx.t, maybe_indirect_extent.extent);
@@ -278,7 +278,7 @@ ObjectDataHandler::write_ret do_zero(
       TransactionManager::get_pin_iertr::pass_further{}
     ).handle_error_interruptible(
       ObjectDataHandler::write_iertr::pass_further{},
-      crimson::ct_error::assert_all{"unexpected error"}
+      crimson::ct_error::assert_all("unexpected error")
     );
     assert(extents.size() == 1);
     auto &extent = extents.back();
@@ -290,7 +290,7 @@ ObjectDataHandler::write_ret do_zero(
       TransactionManager::get_pin_iertr::pass_further{}
     ).handle_error_interruptible(
       ObjectDataHandler::write_iertr::pass_further{},
-      crimson::ct_error::assert_all{"unexpected error"}
+      crimson::ct_error::assert_all("unexpected error")
     );
   }
 
@@ -312,7 +312,7 @@ ObjectDataHandler::write_ret do_zero(
       TransactionManager::get_pin_iertr::pass_further{}
     ).handle_error_interruptible(
       ObjectDataHandler::write_iertr::pass_further{},
-      crimson::ct_error::assert_all{"unexpected error"}
+      crimson::ct_error::assert_all("unexpected error")
     );
   }
 
@@ -330,7 +330,7 @@ ObjectDataHandler::write_ret do_zero(
       TransactionManager::get_pin_iertr::pass_further{}
     ).handle_error_interruptible(
       ObjectDataHandler::write_iertr::pass_further{},
-      crimson::ct_error::assert_all{"unexpected error"}
+      crimson::ct_error::assert_all("unexpected error")
     );
     assert(extents.size() == 1);
     auto &extent = extents.back();
@@ -788,7 +788,7 @@ ObjectDataHandler::do_merge_based_edge_punch(
     return ctx.tm.remove(ctx.t, std::move(edge_mapping));
   }).handle_error_interruptible(
     base_iertr::pass_further{},
-    crimson::ct_error::assert_all{"unexpected error"}
+    crimson::ct_error::assert_all("unexpected error")
   );
 }
 
@@ -847,7 +847,7 @@ ObjectDataHandler::do_remap_based_edge_punch(
 	return ctx.tm.remove(ctx.t, std::move(edge_mapping)
 	).handle_error_interruptible(
 	  base_iertr::pass_further{},
-	  crimson::ct_error::assert_all{"unexpected error"}
+	  crimson::ct_error::assert_all("unexpected error")
 	);
       }
     }
@@ -980,7 +980,7 @@ ObjectDataHandler::punch_hole_in_pending_mapping(
     return ctx.tm.remove(ctx.t, std::move(mapping));
   }).handle_error_interruptible(
     base_iertr::pass_further{},
-    crimson::ct_error::assert_all{"impossible"}
+    crimson::ct_error::assert_all("impossible")
   );
 }
 
@@ -1225,7 +1225,7 @@ ObjectDataHandler::read_edge_for_clone_range(
       data.bl = std::move(bl);
     }).handle_error_interruptible(
       read_iertr::pass_further{},
-      crimson::ct_error::assert_all{"unexpected error"}
+      crimson::ct_error::assert_all("unexpected error")
     );
   }
   if (!begin.is_aligned(block_size)) {
@@ -1269,7 +1269,7 @@ ObjectDataHandler::read_edge_for_clone_range(
     read_paddings, [](auto &fut) { return std::move(fut); }
   ).handle_error_interruptible(
     read_iertr::pass_further{},
-    crimson::ct_error::assert_all{"unexpected error"}
+    crimson::ct_error::assert_all("unexpected error")
   );
 }
 
@@ -1303,7 +1303,7 @@ ObjectDataHandler::clone_ret ObjectDataHandler::clone_range(
       dest_mapping = co_await ctx.tm.get_containing_pin(ctx.t, laddr
       ).handle_error_interruptible(
 	clone_iertr::pass_further{},
-	crimson::ct_error::assert_all{"unexpected enoent"}
+	crimson::ct_error::assert_all("unexpected enoent")
       );
     }
     // For unaligned range cloning, we need to read data.head_padding
@@ -1318,7 +1318,7 @@ ObjectDataHandler::clone_ret ObjectDataHandler::clone_range(
       ctx.t, begin.get_aligned_laddr(block_size)
     ).handle_error_interruptible(
       clone_iertr::pass_further{},
-      crimson::ct_error::assert_all{"unexpected enoent"}
+      crimson::ct_error::assert_all("unexpected enoent")
     );
     auto d_base = d_object_data.get_reserved_data_base();
     auto unaligned_begin = d_base + srcoff;
@@ -1432,7 +1432,7 @@ ObjectDataHandler::write_ret ObjectDataHandler::write(
 	    bufferlist(bl), std::move(pin));
 	}).handle_error_interruptible(
 	  write_iertr::pass_further{},
-	  crimson::ct_error::assert_all{"unexpected enoent"}
+	  crimson::ct_error::assert_all("unexpected enoent")
 	);
       });
     });
@@ -1461,7 +1461,7 @@ ObjectDataHandler::clear_ret ObjectDataHandler::trim_data_reservation(
       std::nullopt, std::move(mapping));
   }).handle_error_interruptible(
     clear_iertr::pass_further{},
-    crimson::ct_error::assert_all{"unexpected enoent"}
+    crimson::ct_error::assert_all("unexpected enoent")
   );
 }
 
@@ -1572,9 +1572,9 @@ ObjectDataHandler::read_ret ObjectDataHandler::read(
   co_await ctx.tm.read_pins<ObjectDataBlock>(ctx.t, rpins
   ).handle_error_interruptible(
     read_iertr::pass_further{},
-    crimson::ct_error::assert_all{
+    crimson::ct_error::assert_all(
       "ObjectDataHandler::read hit invalid error"
-    }
+    )
   );
   for (auto &pin : rpins) {
     if (pin.mapping.is_zero_reserved()) {
@@ -1723,7 +1723,7 @@ ObjectDataHandler::copy_on_write(
       ctx.t, object_data.get_reserved_data_base()
     ).handle_error_interruptible(
       clone_iertr::pass_further{},
-      crimson::ct_error::assert_all{"unexpected enoent"}
+      crimson::ct_error::assert_all("unexpected enoent")
     );
     co_await do_clone(ctx, object_data, d_object_data, mapping, false);
     DEBUGT("{} -> {}",
@@ -1738,7 +1738,7 @@ ObjectDataHandler::copy_on_write(
       ctx.t, old_base, old_len, std::move(mapping), {false, true}
     ).handle_error_interruptible(
       clone_iertr::pass_further{},
-      crimson::ct_error::assert_all{"unexpected enoent"}
+      crimson::ct_error::assert_all("unexpected enoent")
     ).discard_result();
 
     auto old_md_start = old_base.with_metadata().with_offset_by_blocks(0);
@@ -1782,7 +1782,7 @@ ObjectDataHandler::do_clone(
   auto pos = co_await ctx.tm.remove(ctx.t, std::move(*mapping)
   ).handle_error_interruptible(
     clone_iertr::pass_further{},
-    crimson::ct_error::assert_all{"unexpected enoent"}
+    crimson::ct_error::assert_all("unexpected enoent")
   );
   auto base = d_object_data.get_reserved_data_base();
   auto len = d_object_data.get_reserved_data_len();
@@ -1810,7 +1810,7 @@ ObjectDataHandler::clone_ret ObjectDataHandler::clone(
       return do_clone(ctx, object_data, d_object_data, std::move(mapping), true);
     }).handle_error_interruptible(
       clone_iertr::pass_further{},
-      crimson::ct_error::assert_all{"unexpected enoent"}
+      crimson::ct_error::assert_all("unexpected enoent")
     );
   });
 }

--- a/src/crimson/os/seastore/omap_manager/btree/btree_omap_manager.cc
+++ b/src/crimson/os/seastore/omap_manager/btree/btree_omap_manager.cc
@@ -125,9 +125,9 @@ BtreeOMapManager::handle_root_merge(
     return seastar::now();
   }).handle_error_interruptible(
     handle_root_merge_iertr::pass_further{},
-    crimson::ct_error::assert_all{
+    crimson::ct_error::assert_all(
       "Invalid error in handle_root_merge"
-    }
+    )
   );
 }
 
@@ -314,9 +314,9 @@ BtreeOMapManager::omap_clear(
     });
   }).handle_error_interruptible(
     omap_clear_iertr::pass_further{},
-    crimson::ct_error::assert_all{
+    crimson::ct_error::assert_all(
       "Invalid error in BtreeOMapManager::omap_clear"
-    }
+    )
   );
 }
 

--- a/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.cc
+++ b/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.cc
@@ -45,9 +45,9 @@ template <typename T>
 dec_ref_ret dec_ref(omap_context_t oc, T&& addr) {
   return oc.tm.remove(oc.t, std::forward<T>(addr)).handle_error_interruptible(
     dec_ref_iertr::pass_further{},
-    crimson::ct_error::assert_all{
+    crimson::ct_error::assert_all(
       "Invalid error in OMapInnerNode helper dec_ref"
-    }
+    )
   ).discard_result();
 }
 
@@ -204,7 +204,7 @@ OMapInnerNode::rm_key(omap_context_t oc, std::string key)
       co_return co_await handle_split(oc, child_pt, mresult
           ).handle_error_interruptible(
 	          rm_key_iertr::pass_further{},
-	          crimson::ct_error::assert_all{"unexpected error"}
+	          crimson::ct_error::assert_all("unexpected error")
 	  );
     default:
       co_return mresult;
@@ -255,7 +255,7 @@ OMapInnerNode::rm_key_range(omap_context_t oc, key_range_t &key_range)
       co_return co_await handle_split(oc, child_pt, mresult
           ).handle_error_interruptible(
 	          rm_key_range_iertr::pass_further{},
-	          crimson::ct_error::assert_all{"unexpected error"}
+	          crimson::ct_error::assert_all("unexpected error")
           );
     default:
       co_return mresult;

--- a/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.h
+++ b/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.h
@@ -551,7 +551,7 @@ omap_load_extent(
     }
   ).handle_error_interruptible(
     omap_load_extent_iertr::pass_further{},
-    crimson::ct_error::assert_all{ "Invalid error in omap_load_extent" }
+    crimson::ct_error::assert_all( "Invalid error in omap_load_extent" )
   ).si_then([](auto maybe_indirect_extent) {
     assert(!maybe_indirect_extent.is_indirect());
     assert(!maybe_indirect_extent.is_clone);

--- a/src/crimson/os/seastore/omap_manager/log/log_manager.cc
+++ b/src/crimson/os/seastore/omap_manager/log/log_manager.cc
@@ -410,7 +410,7 @@ LogManager::log_load_extent(
     }
   ).handle_error_interruptible(
     log_load_extent_iertr::pass_further{},
-    crimson::ct_error::assert_all{ "Invalid error in log_load_extent" }
+    crimson::ct_error::assert_all( "Invalid error in log_load_extent" )
   );
 
   assert(!maybe_indirect_extent.is_indirect());
@@ -574,7 +574,7 @@ LogManager::remove_node(Transaction &t, LogNodeRef mut, LogNodeRef prev)
   co_await tm.remove(t, mut->get_laddr()
   ).handle_error_interruptible(
     omap_rm_key_iertr::pass_further{},
-    crimson::ct_error::assert_all{"Invalid error in remove_node"}
+    crimson::ct_error::assert_all("Invalid error in remove_node")
   );
   auto mut_prev = tm.get_mutable_extent(t, prev)->template cast<LogNode>();
   assert(mut_prev);
@@ -830,12 +830,12 @@ LogManager::omap_clear(omap_root_t &root, Transaction &t)
   co_await tm.remove(t, co_await get_dup_addr_from_root(t, root.addr)
   ).handle_error_interruptible(
     omap_clear_iertr::pass_further{},
-    crimson::ct_error::assert_all{"Invalid error in omap_clear"}
+    crimson::ct_error::assert_all("Invalid error in omap_clear")
   );
   co_await tm.remove(t, root.get_location()
   ).handle_error_interruptible(
     omap_clear_iertr::pass_further{},
-    crimson::ct_error::assert_all{"Invalid error in omap_clear"}
+    crimson::ct_error::assert_all("Invalid error in omap_clear")
   );
   root.update(
     L_ADDR_NULL,

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
@@ -1390,7 +1390,7 @@ eagain_ifuture<> InternalNode::test_clone_root(
     return c_other.nm.get_super(c_other.t, tracker_other
     ).handle_error_interruptible(
       eagain_iertr::pass_further{},
-      crimson::ct_error::assert_all{"Invalid error during test clone"}
+      crimson::ct_error::assert_all("Invalid error during test clone")
     ).si_then([c_other, cloned_root](auto&& super_other) {
       assert(super_other);
       cloned_root->make_root_new(c_other, std::move(super_other));
@@ -2038,7 +2038,7 @@ eagain_ifuture<> LeafNode::test_clone_root(
     return c_other.nm.get_super(c_other.t, tracker_other
     ).handle_error_interruptible(
       eagain_iertr::pass_further{},
-      crimson::ct_error::assert_all{"Invalid error during test clone"}
+      crimson::ct_error::assert_all("Invalid error during test clone")
     ).si_then([c_other, cloned_root](auto&& super_other) {
       assert(super_other);
       cloned_root->make_root_new(c_other, std::move(super_other));

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
@@ -550,9 +550,9 @@ class NodeExtentAccessorT {
       return c.nm.retire_extent(c.t, to_discard
       ).handle_error_interruptible(
         eagain_iertr::pass_further{},
-        crimson::ct_error::assert_all(fmt::format(
+        crimson::ct_error::assert_all(
           "{} during retire -- to_disgard={}, fresh={}",
-          FNAME, to_discard->get_laddr(), fresh_extent->get_laddr()).c_str())
+          FNAME, to_discard->get_laddr(), fresh_extent->get_laddr())
       );
     }).si_then([this, c] {
       boost::ignore_unused(c);  // avoid clang warning;
@@ -568,8 +568,7 @@ class NodeExtentAccessorT {
     return c.nm.retire_extent(c.t, std::move(extent)
     ).handle_error_interruptible(
       eagain_iertr::pass_further{},
-      crimson::ct_error::assert_all(fmt::format(
-        "{} addr={}", FNAME, addr).c_str())
+      crimson::ct_error::assert_all("{} addr={}", FNAME, addr)
 #ifndef NDEBUG
     ).si_then([c] {
       assert(!c.t.is_conflicted());

--- a/src/crimson/os/seastore/random_block_manager/nvme_block_device.cc
+++ b/src/crimson/os/seastore/random_block_manager/nvme_block_device.cc
@@ -100,9 +100,9 @@ NVMeBlockDevice::mount_ret NVMeBlockDevice::mount()
     return seastar::do_for_each(local_device.mshard_devices, [](auto& mshard_device) {
       return mshard_device->do_shard_mount(
       ).handle_error(
-        crimson::ct_error::assert_all{
+        crimson::ct_error::assert_all(
           "Invalid error in NVMeBlockDevice::do_shard_mount"
-      });
+      ));
     });
   });
 

--- a/src/crimson/os/seastore/random_block_manager/rbm_device.cc
+++ b/src/crimson/os/seastore/random_block_manager/rbm_device.cc
@@ -75,16 +75,16 @@ RBMDevice::mkfs_ret RBMDevice::do_primary_mkfs(device_config_t config,
     seastar::open_flags::rw | seastar::open_flags::dsync
   ).handle_error(
     mkfs_ertr::pass_further{},
-    crimson::ct_error::assert_all{
-    "Invalid error open in RBMDevice::do_primary_mkfs"}
+    crimson::ct_error::assert_all(
+    "Invalid error open in RBMDevice::do_primary_mkfs")
   );
   co_await initialize_nvme_features();
   co_await write_rbm_superblock(
   ).handle_error(
     mkfs_ertr::pass_further{},
-    crimson::ct_error::assert_all{
+    crimson::ct_error::assert_all(
     "Invalid error write_rbm_superblock in RBMDevice::do_primary_mkfs"
-  });
+  ));
   co_await close();
 }
 
@@ -192,8 +192,8 @@ RBMDevice::mount_ret RBMDevice::do_shard_mount()
     seastar::open_flags::rw | seastar::open_flags::dsync
   ).handle_error(
     mkfs_ertr::pass_further{},
-    crimson::ct_error::assert_all{
-    "Invalid error open in RBMDevice::do_shard_mount"}
+    crimson::ct_error::assert_all(
+    "Invalid error open in RBMDevice::do_shard_mount")
   );
 
   auto st = co_await stat_device(
@@ -213,8 +213,8 @@ RBMDevice::mount_ret RBMDevice::do_shard_mount()
   auto s = co_await read_rbm_superblock(RBM_START_ADDRESS
   ).handle_error(
     mount_ertr::pass_further{},
-    crimson::ct_error::assert_all{
-    "Invalid error read_rbm_superblock in RBMDevice::do_shard_mount"}
+    crimson::ct_error::assert_all(
+    "Invalid error read_rbm_superblock in RBMDevice::do_shard_mount")
   );
   LOG_PREFIX(RBMDevice::do_shard_mount);
   if(seastar::this_shard_id() + seastar::smp::count * store_index >= s.shard_num) {
@@ -235,22 +235,22 @@ read_ertr::future<uint32_t> RBMDevice::get_shard_nums()
   co_await open(get_device_path(),
     seastar::open_flags::rw | seastar::open_flags::dsync
   ).handle_error(
-    crimson::ct_error::assert_all{
-    "Invalid error open in RBMDevice::get_shard_nums"}
+    crimson::ct_error::assert_all(
+    "Invalid error open in RBMDevice::get_shard_nums")
   );
 
   auto st = co_await stat_device(
   ).handle_error(
-    crimson::ct_error::assert_all{
-      "Invalid error stat_device in RBMDevice::get_shard_nums"}
+    crimson::ct_error::assert_all(
+      "Invalid error stat_device in RBMDevice::get_shard_nums")
   );
 
   assert(st.block_size > 0);
   super.block_size = st.block_size;
   auto sb = co_await read_rbm_superblock(RBM_START_ADDRESS
   ).handle_error(
-    crimson::ct_error::assert_all{
-      "Invalid error in RBMDevice::get_shard_nums"}
+    crimson::ct_error::assert_all(
+      "Invalid error in RBMDevice::get_shard_nums")
   );
 
   co_return sb.shard_num;

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -232,9 +232,9 @@ seastar::future<> SeaStore::get_shard_nums()
     INFO("seastore mkfs done");
     auto shard_nums = co_await device->get_shard_nums(
       ).handle_error(
-        crimson::ct_error::assert_all{
+        crimson::ct_error::assert_all(
           "Invalid error in device->get_shard_nums"
-      });
+      ));
     INFO("seastore shard nums {}", shard_nums);
     store_shard_nums = shard_nums;
     if(crimson::common::get_conf<bool>("seastore_require_partition_count_match_reactor_count")) {
@@ -387,9 +387,9 @@ seastar::future<> SeaStore::Shard::mount_managers()
   init_managers();
   return transaction_manager->mount(
   ).handle_error(
-    crimson::ct_error::assert_all{
+    crimson::ct_error::assert_all(
       "Invalid error in mount_managers"
-  });
+  ));
 }
 
 seastar::future<> SeaStore::umount()
@@ -401,9 +401,9 @@ seastar::future<> SeaStore::umount()
   co_await shard_stores.invoke_on_all([](auto &local_store) {
     return seastar::do_for_each(local_store.mshard_stores, [](auto& mshard_store) {
       return mshard_store->umount().handle_error(
-        crimson::ct_error::assert_all{
+        crimson::ct_error::assert_all(
           "Invalid error in shard_store->umount"
-      });
+      ));
     });
   });
   INFO("done");
@@ -526,7 +526,7 @@ SeaStore::mkfs_ertr::future<> SeaStore::test_mkfs(uuid_d new_osd_fsid)
     co_return;
   }
   co_await shard_stores.local().mshard_stores[0]->mkfs_managers().handle_error(
-    crimson::ct_error::assert_all{"Invalid error in SeaStore::mkfs"});
+    crimson::ct_error::assert_all("Invalid error in SeaStore::mkfs"));
   co_await prepare_meta(new_osd_fsid);
   INFO("done");
 }
@@ -590,7 +590,7 @@ Device::access_ertr::future<> SeaStore::_mkfs(uuid_d new_osd_fsid)
         sds.emplace((device_id_t)id, device_spec_t{magic, dtype, (device_id_t)id});
         co_await p_sec_dev->mkfs(
           device_config_t::create_secondary(new_osd_fsid, id, dtype, magic)
-          ).handle_error(crimson::ct_error::assert_all{"not possible"});
+          ).handle_error(crimson::ct_error::assert_all("not possible"));
         co_await set_secondaries();
       }
     }
@@ -616,7 +616,7 @@ Device::access_ertr::future<> SeaStore::_mkfs(uuid_d new_osd_fsid)
   co_await shard_stores.invoke_on_all([] (auto &local_store) {
     return seastar::do_for_each(local_store.mshard_stores, [](auto& mshard_store) {
       return mshard_store->mkfs_managers().handle_error(
-        crimson::ct_error::assert_all{"Invalid error in SeaStoreS::mkfs_managers"});
+        crimson::ct_error::assert_all("Invalid error in SeaStoreS::mkfs_managers"));
     });
   });
   co_await prepare_meta(new_osd_fsid);
@@ -1057,9 +1057,9 @@ SeaStore::Shard::list_objects(CollectionRef ch,
     }).safe_then([&ret] {
       return std::move(ret);
     }).handle_error(
-      crimson::ct_error::assert_all{
+      crimson::ct_error::assert_all(
         "Invalid error in SeaStoreS::list_objects"
-      }
+      )
     );
   }).finally([this] {
     assert(shard_stats.pending_read_num);
@@ -1148,9 +1148,9 @@ SeaStore::Shard::list_collections()
       });
     }
   ).handle_error(
-    crimson::ct_error::assert_all{
+    crimson::ct_error::assert_all(
       "Invalid error in SeaStoreS::list_collections"
-    }
+    )
   ).finally([this] {
     assert(shard_stats.pending_read_num);
     --(shard_stats.pending_read_num);
@@ -1247,7 +1247,7 @@ SeaStore::Shard::exists(
       DEBUG("not exists");
       return seastar::make_ready_future<bool>(false);
     }),
-    crimson::ct_error::assert_all{"unexpected error"}
+    crimson::ct_error::assert_all("unexpected error")
   ).finally([this] {
     assert(shard_stats.pending_read_num);
     --(shard_stats.pending_read_num);
@@ -1438,9 +1438,9 @@ seastar::future<struct stat> SeaStore::Shard::stat(
     crimson::ct_error::enoent::handle([] {
       return seastar::make_ready_future<struct stat>();
     }),
-    crimson::ct_error::assert_all{
+    crimson::ct_error::assert_all(
       "Invalid error in SeaStoreS::stat"
-    }
+    )
   ).finally([this] {
     assert(shard_stats.pending_read_num);
     --(shard_stats.pending_read_num);
@@ -2091,9 +2091,9 @@ SeaStore::Shard::_do_transaction_step(
       }
       return seastar::now();
     }),
-    crimson::ct_error::assert_all{
+    crimson::ct_error::assert_all(
       "Invalid error in SeaStoreS::do_transaction_step"
-    }
+    )
   );
 }
 
@@ -2159,8 +2159,8 @@ SeaStore::Shard::_rename(
     *ctx.transaction, onode
   ).handle_error_interruptible(
     crimson::ct_error::input_output_error::pass_further(),
-    crimson::ct_error::assert_all{
-      "Invalid error in SeaStoreS::_rename"});
+    crimson::ct_error::assert_all(
+      "Invalid error in SeaStoreS::_rename"));
 }
 
 SeaStore::Shard::tm_ret
@@ -2588,9 +2588,9 @@ SeaStore::Shard::_split_collection(
     );
   }).handle_error_interruptible(
     tm_iertr::pass_further{},
-    crimson::ct_error::assert_all{
+    crimson::ct_error::assert_all(
       "Invalid error in SeaStoreS::_create_collection"
-    }
+    )
   );
 }
 
@@ -2606,11 +2606,11 @@ SeaStore::Shard::_merge_collection(
   co_await collection_manager->update(cmroot, *ctx.transaction, dest_cid, bits)
     .handle_error_interruptible(
       tm_iertr::pass_further{},
-      crimson::ct_error::assert_all{"unexpected error from update in _merge_collection"});
+      crimson::ct_error::assert_all("unexpected error from update in _merge_collection"));
   co_await collection_manager->remove(cmroot, *ctx.transaction, cid)
     .handle_error_interruptible(
       tm_iertr::pass_further{},
-      crimson::ct_error::assert_all{"unexpected error from remove in _merge_collection"});
+      crimson::ct_error::assert_all("unexpected error from remove in _merge_collection"));
 }
 
 SeaStore::Shard::tm_ret
@@ -2640,9 +2640,9 @@ SeaStore::Shard::_create_collection(
     );
   }).handle_error_interruptible(
     tm_iertr::pass_further{},
-    crimson::ct_error::assert_all{
+    crimson::ct_error::assert_all(
       "Invalid error in SeaStoreS::_create_collection"
-    }
+    )
   );
 }
 
@@ -2672,9 +2672,9 @@ SeaStore::Shard::_remove_collection(
       });
   }).handle_error_interruptible(
     tm_iertr::pass_further{},
-    crimson::ct_error::assert_all{
+    crimson::ct_error::assert_all(
       "Invalid error in SeaStoreS::_create_collection"
-    }
+    )
   );
 }
 
@@ -2699,7 +2699,7 @@ seastar::future<> SeaStore::write_meta(
     }).safe_then([FNAME, &key, &value] {
       DEBUG("key={} value={} done", key, value);
     }).handle_error(
-      crimson::ct_error::assert_all{"Invalid error in SeaStore::write_meta"}
+      crimson::ct_error::assert_all("Invalid error in SeaStore::write_meta")
     );
   });
 }
@@ -2732,7 +2732,7 @@ seastar::future<> SeaStore::Shard::write_meta(
       });
     });
   }).handle_error(
-    crimson::ct_error::assert_all{"Invalid error in SeaStoreS::write_meta"}
+    crimson::ct_error::assert_all("Invalid error in SeaStoreS::write_meta")
   ).finally([this] {
     assert(shard_stats.pending_io_num);
     --(shard_stats.pending_io_num);
@@ -2759,9 +2759,9 @@ SeaStore::read_meta(const std::string& key)
       return std::make_tuple(-1, std::string(""));
     }
   }).handle_error(
-    crimson::ct_error::assert_all{
+    crimson::ct_error::assert_all(
       "Invalid error in SeaStore::read_meta"
-    }
+    )
   );
 }
 
@@ -3212,7 +3212,7 @@ SeaStore::Shard::omaptree_clone(
 	  }
 	}).handle_error_interruptible(
 	  base_iertr::pass_further{},
-	  crimson::ct_error::assert_all{"unexpected value_too_large"}
+	  crimson::ct_error::assert_all("unexpected value_too_large")
 	);
       });
     });

--- a/src/crimson/os/seastore/segment_manager/block.cc
+++ b/src/crimson/os/seastore/segment_manager/block.cc
@@ -520,9 +520,9 @@ SegmentManager::read_ertr::future<uint32_t> BlockSegmentManager::get_shard_nums(
   }).safe_then([](auto sb) {
     return read_ertr::make_ready_future<uint32_t>(sb.shard_num);
   }).handle_error(
-    crimson::ct_error::assert_all{
+    crimson::ct_error::assert_all(
       "Invalid error in BlockSegmentManager::get_shard_nums"
-    }
+    )
   );
 }
 
@@ -532,9 +532,9 @@ BlockSegmentManager::mount_ret BlockSegmentManager::mount()
     return seastar::do_for_each(local_device.mshard_devices, [](auto& mshard_device) {
       return mshard_device->shard_mount(
       ).handle_error(
-        crimson::ct_error::assert_all{
+        crimson::ct_error::assert_all(
           "Invalid error in BlockSegmentManager::mount"
-      });
+      ));
     });
   });
 }
@@ -598,9 +598,9 @@ BlockSegmentManager::mkfs_ret BlockSegmentManager::mkfs(
       return seastar::do_for_each(local_device.mshard_devices, [](auto& mshard_device) {
         return mshard_device->shard_mkfs(
         ).handle_error(
-          crimson::ct_error::assert_all{
+          crimson::ct_error::assert_all(
             "Invalid error in BlockSegmentManager::mkfs"
-        });
+        ));
       });
     });
   });

--- a/src/crimson/os/seastore/segment_manager/zbd.cc
+++ b/src/crimson/os/seastore/segment_manager/zbd.cc
@@ -489,9 +489,9 @@ ZBDSegmentManager::read_ertr::future<uint32_t> ZBDSegmentManager::get_shard_nums
   }).safe_then([](auto meta){
     return read_ertr::make_ready_future<uint32_t>(meta.shard_num);
   }).handle_error(
-    crimson::ct_error::assert_all{
+    crimson::ct_error::assert_all(
       "Invalid error in ZBDSegmentManager::get_shard_nums"
-  });
+  ));
 }
 
 ZBDSegmentManager::mount_ret ZBDSegmentManager::mount()
@@ -500,9 +500,9 @@ ZBDSegmentManager::mount_ret ZBDSegmentManager::mount()
     return seastar::do_for_each(local_device.mshard_devices, [](auto& mshard_device) {
       return mshard_device->shard_mount(
       ).handle_error(
-        crimson::ct_error::assert_all{
+        crimson::ct_error::assert_all(
           "Invalid error in ZBDSegmentManager::mount"
-      });
+      ));
     });
   });
 }
@@ -540,9 +540,9 @@ ZBDSegmentManager::mkfs_ret ZBDSegmentManager::mkfs(
       return seastar::do_for_each(local_device.mshard_devices, [](auto& mshard_device) {
         return mshard_device->shard_mkfs(
         ).handle_error(
-          crimson::ct_error::assert_all{
+          crimson::ct_error::assert_all(
             "Invalid error in ZBDSegmentManager::mkfs"
-        });
+        ));
       });
     });
   });

--- a/src/crimson/os/seastore/segment_manager_group.cc
+++ b/src/crimson/os/seastore/segment_manager_group.cc
@@ -21,9 +21,9 @@ SegmentManagerGroup::read_segment_tail(segment_id_t segment)
     get_rounded_tail_length()
   ).handle_error(
     read_segment_header_ertr::pass_further{},
-    crimson::ct_error::assert_all{
+    crimson::ct_error::assert_all(
       "Invalid error in SegmentManagerGroup::read_segment_tail"
-    }
+    )
   ).safe_then([=, &segment_manager](bufferptr bptr) -> read_segment_tail_ret {
     LOG_PREFIX(SegmentManagerGroup::read_segment_tail);
     DEBUG("segment {} bptr size 0x{:x}", segment, bptr.length());
@@ -61,9 +61,9 @@ SegmentManagerGroup::read_segment_header(segment_id_t segment)
     get_rounded_header_length()
   ).handle_error(
     read_segment_header_ertr::pass_further{},
-    crimson::ct_error::assert_all{
+    crimson::ct_error::assert_all(
       "Invalid error in SegmentManagerGroup::read_segment_header"
-    }
+    )
   ).safe_then([=, &segment_manager](bufferptr bptr) -> read_segment_header_ret {
     LOG_PREFIX(SegmentManagerGroup::read_segment_header);
     DEBUG("segment {} bptr size 0x{:x}", segment, bptr.length());

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -196,7 +196,7 @@ TransactionManager::mount()
     INFO("done");
   }).handle_error(
     mount_ertr::pass_further{},
-    crimson::ct_error::assert_all{"unhandled error"}
+    crimson::ct_error::assert_all("unhandled error")
   );
 }
 
@@ -646,7 +646,7 @@ TransactionManager::do_submit_transaction(
       cache->get_oldest_backref_dirty_from().value_or(start_seq));
     }).handle_error(
       submit_transaction_iertr::pass_further{},
-      crimson::ct_error::assert_all{"Hit error submitting to journal"}
+      crimson::ct_error::assert_all("Hit error submitting to journal")
     );
 
   co_await trans_intr::make_interruptible(
@@ -723,7 +723,7 @@ TransactionManager::rewrite_logical_extent(
       t, *extent
     ).handle_error_interruptible(
       rewrite_extent_iertr::pass_further{},
-      crimson::ct_error::assert_all{"unexpected enoent"}
+      crimson::ct_error::assert_all("unexpected enoent")
     );
     co_await lba_manager->update_mapping(
       t,
@@ -767,7 +767,7 @@ TransactionManager::rewrite_logical_extent(
 	  t, *extent
 	).handle_error_interruptible(
 	  rewrite_extent_iertr::pass_further{},
-	  crimson::ct_error::assert_all{"unexpected enoent"}
+	  crimson::ct_error::assert_all("unexpected enoent")
 	);
 	refcount = co_await lba_manager->update_mapping(
 	  t,
@@ -777,7 +777,7 @@ TransactionManager::rewrite_logical_extent(
 	  *nextent
 	).handle_error_interruptible(
 	  rewrite_extent_iertr::pass_further{},
-	  crimson::ct_error::assert_all{"unexpected enoent"}
+	  crimson::ct_error::assert_all("unexpected enoent")
 	);
       } else {
 	ceph_assert(refcount != 0);

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -785,7 +785,7 @@ public:
 	  mapping.get_extent_type()
 	).handle_error_interruptible(
 	  clone_iertr::pass_further{},
-	  crimson::ct_error::assert_all{"unexpected error"}
+	  crimson::ct_error::assert_all("unexpected error")
 	);
 	assert((dst_base + cloned_to).checked_to_laddr() == r.get_key());
 	cloned_to += clone_len;
@@ -940,7 +940,7 @@ public:
       }
     }).handle_error_interruptible(
       crimson::ct_error::input_output_error::pass_further{},
-      crimson::ct_error::assert_all{"unexpected error!"}
+      crimson::ct_error::assert_all("unexpected error!")
     );
   }
 
@@ -965,7 +965,7 @@ public:
       });
     }).handle_error_interruptible(
       crimson::ct_error::input_output_error::pass_further{},
-      crimson::ct_error::assert_all{"unexpected error!"}
+      crimson::ct_error::assert_all("unexpected error!")
     );
   }
 
@@ -1000,7 +1000,7 @@ public:
       return seastar::now();
     }).handle_error_interruptible(
       crimson::ct_error::input_output_error::pass_further{},
-      crimson::ct_error::assert_all{"unexpected error!"}
+      crimson::ct_error::assert_all("unexpected error!")
     );
   }
 
@@ -1100,7 +1100,7 @@ public:
 	t, std::move(mapping)
       ).handle_error_interruptible(
 	remap_mappings_iertr::pass_further{},
-	crimson::ct_error::assert_all{"unexpected error"}
+	crimson::ct_error::assert_all("unexpected error")
       );
       for (auto &remap : remaps) {
 	auto laddr = (orig_laddr + remap.offset).checked_to_laddr();
@@ -1112,7 +1112,7 @@ public:
           type
 	).handle_error_interruptible(
 	  remap_mappings_iertr::pass_further{},
-	  crimson::ct_error::assert_all{"unexpected error"}
+	  crimson::ct_error::assert_all("unexpected error")
 	);
 	ret.emplace_back(new_mapping);
 	pos = co_await new_mapping.next();
@@ -1181,7 +1181,7 @@ public:
       return remove(t, std::move(mapping)
       ).handle_error_interruptible(
 	punch_mappings_iertr::pass_further{},
-	crimson::ct_error::assert_all{"impossible"}
+	crimson::ct_error::assert_all("impossible")
       );
     }
   }
@@ -1264,18 +1264,18 @@ public:
 	mapping = co_await remove(t, std::move(mapping)
 	).handle_error_interruptible(
 	  punch_mappings_iertr::pass_further{},
-	  crimson::ct_error::assert_all{
+	  crimson::ct_error::assert_all(
 	    "remove_mappings_in_range hit invalid error"
-	  }
+	  )
 	);
       } else {
 	mapping = co_await _remove_indirect_mapping_only(
 	  t, std::move(mapping)
 	).handle_error_interruptible(
 	  punch_mappings_iertr::pass_further{},
-	  crimson::ct_error::assert_all{
+	  crimson::ct_error::assert_all(
 	    "remove_mappings_in_range hit invalid error"
-	  }
+	  )
 	);
       }
     }
@@ -1512,9 +1512,9 @@ private:
       std::vector<remap_entry_t>(remaps.begin(), remaps.end())
     ).handle_error_interruptible(
       remap_pin_iertr::pass_further{},
-      crimson::ct_error::assert_all{
+      crimson::ct_error::assert_all(
 	"TransactionManager::remap_pin hit invalid error"
-      }
+      )
     );
 
     std::vector<LBAMapping> ret;

--- a/src/crimson/osd/ec_backend.cc
+++ b/src/crimson/osd/ec_backend.cc
@@ -434,7 +434,7 @@ void ECBackend::handle_sub_write(
     logger().debug("ECBackend::{} from {}",
 		    "handle_sub_write::reply", reply.from);
     return handle_rep_write_reply(std::move(reply));
-  }, crimson::ct_error::assert_all{});
+  }, crimson::ct_error::assert_all("unexpected error"));
 }
 
 ECBackend::write_iertr::future<>
@@ -450,7 +450,7 @@ ECBackend::handle_rep_write_op(
   ).si_then([&pg] {
     assert(!pg.pgb_is_primary());
     return write_iertr::now();
-  }, crimson::ct_error::assert_all{});
+  }, crimson::ct_error::assert_all("unexpected error"));
 }
 
 ECBackend::write_iertr::future<>

--- a/src/crimson/osd/osd_meta.cc
+++ b/src/crimson/osd/osd_meta.cc
@@ -48,10 +48,8 @@ seastar::future<bufferlist> OSDMeta::load_map(epoch_t e)
                     store, coll,
                     osdmap_oid(e), 0, 0,
                     CEPH_OSD_OP_FLAG_FADVISE_WILLNEED).handle_error(
-    read_errorator::assert_all_func([e](const auto&) {
-      ceph_abort_msg(fmt::format("{} read gave enoent on {}",
-                                 __func__, osdmap_oid(e)));
-    }));
+    read_errorator::assert_all("{} read gave enoent on {}",
+                                   __func__, osdmap_oid(e)));
 }
 
 read_errorator::future<ceph::bufferlist> OSDMeta::load_inc_map(epoch_t e)

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -313,7 +313,7 @@ ClientRequest::recover_missing_snaps(
     }
     return seastar::now();
   }).handle_error_interruptible(
-    crimson::ct_error::assert_all(fmt::format("{} {} error", *pg, FNAME).c_str())
+    crimson::ct_error::assert_all("{} {} error", std::cref(*pg), FNAME)
   );
   co_await std::move(resolve_oids);
 

--- a/src/crimson/osd/osd_operations/ecrep_request.cc
+++ b/src/crimson/osd/osd_operations/ecrep_request.cc
@@ -79,7 +79,7 @@ seastar::future<> ECRepRequest::with_pg(
       [ec_backend] (Ref<MOSDECSubOpReadReply> concrete_req) {
         return ec_backend->handle_rep_read_reply(
 	  std::move(concrete_req)
-	).handle_error_interruptible(crimson::ct_error::assert_all{});
+	).handle_error_interruptible(crimson::ct_error::assert_all("unexpected error"));
       }}, req);
   }, [ref, this](std::exception_ptr) {
     logger().debug("{}: ECRepRequest::exception handling", *this);

--- a/src/crimson/osd/osd_operations/internal_client_request.cc
+++ b/src/crimson/osd/osd_operations/internal_client_request.cc
@@ -86,8 +86,8 @@ InternalClientRequest::with_interruption()
   co_await pg->obc_loader.load_and_lock(
     obc_manager, pg->get_lock_type(op_info)
   ).handle_error_interruptible(
-    crimson::ct_error::assert_all(
-      fmt::format("{} {} {} error when loading {}",*pg, FNAME, *this, get_target_oid()).c_str())
+    crimson::ct_error::assert_all("{} {} {} error when loading {}",
+      std::cref(*pg), FNAME, std::cref(*this), get_target_oid())
   );
 
   auto params = get_do_osd_ops_params();
@@ -97,8 +97,8 @@ InternalClientRequest::with_interruption()
   co_await pg->run_executer(
     ox, obc_manager.get_obc(), op_info, osd_ops
   ).handle_error_interruptible(
-    crimson::ct_error::assert_all(
-      fmt::format("{} {} {}: got unexpected error {}", *pg, FNAME, *this, get_target_oid()).c_str())
+    crimson::ct_error::assert_all("{} {} {}: got unexpected error {}",
+      std::cref(*pg), FNAME, std::cref(*this), get_target_oid())
   );
 
   auto [submitted, completed] = co_await pg->submit_executer(

--- a/src/crimson/osd/osd_operations/snaptrim_event.cc
+++ b/src/crimson/osd/osd_operations/snaptrim_event.cc
@@ -419,8 +419,9 @@ SnapTrimObjSubEvent::start()
     obc_manager, RWState::RWWRITE
   ).handle_error_interruptible(
     remove_or_update_iertr::pass_further{},
-    crimson::ct_error::assert_all{fmt::format(
-      "{} error SnapTrimObjSubEvent::snap_trim_obj_subevent_ret_t with {}", *this, coid).c_str()}
+    crimson::ct_error::assert_all(
+      "{} error SnapTrimObjSubEvent::snap_trim_obj_subevent_ret_t with {}",
+      std::cref(*this), coid)
   );
 
   logger().debug("{}: got obc={}", *this, obc_manager.get_obc()->get_oid());

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -852,8 +852,8 @@ seastar::future<> PG::init(
       t.touch(coll_ref->get_cid(), pgid.make_snapmapper_oid());
     }
   },
-  ::crimson::ct_error::assert_all{fmt::format(
-    "{} {} unexpected eio", *this, __func__).c_str()}
+  ::crimson::ct_error::assert_all(
+    "{} {} unexpected eio", std::cref(*this), __func__)
 );
 }
 
@@ -1524,7 +1524,7 @@ PG::interruptible_future<> PG::handle_rep_write_op(Ref<MOSDECSubOpWrite> m)
     r->op.from = pg_whoami;
     r->set_priority(CEPH_MSG_PRIO_HIGH);
     return shard_services.send_to_osd(get_primary().osd, std::move(r), get_osdmap_epoch());
-  }).handle_error_interruptible(crimson::ct_error::assert_all{});
+  }).handle_error_interruptible(crimson::ct_error::assert_all("unexpected error"));
 }
 
 PG::interruptible_future<> PG::handle_rep_write_reply(Ref<MOSDECSubOpWriteReply> m)
@@ -1539,7 +1539,7 @@ PG::interruptible_future<> PG::handle_rep_write_reply(Ref<MOSDECSubOpWriteReply>
   assert(ec_backend);
   return ec_backend->handle_rep_write_reply(
     std::move(m->op)
-  ).handle_error_interruptible(crimson::ct_error::assert_all{});
+  ).handle_error_interruptible(crimson::ct_error::assert_all("unexpected error"));
 }
 
 PG::interruptible_future<> PG::handle_rep_read_op(Ref<MOSDECSubOpRead> m)
@@ -1557,7 +1557,7 @@ PG::interruptible_future<> PG::handle_rep_read_op(Ref<MOSDECSubOpRead> m)
     reply->op = std::move(rep);
     return shard_services.send_to_osd(
       get_primary().osd, std::move(reply), get_osdmap_epoch());
-  }).handle_error_interruptible(crimson::ct_error::assert_all{});
+  }).handle_error_interruptible(crimson::ct_error::assert_all("unexpected error"));
 }
 
 PG::interruptible_future<> PG::do_update_log_missing(

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -883,7 +883,7 @@ PGBackend::rollback_iertr::future<> PGBackend::rollback(
       );
     }),
     rollback_ertr::pass_further{},
-    crimson::ct_error::assert_all{"unexpected error in rollback"}
+    crimson::ct_error::assert_all("unexpected error in rollback")
   );
 }
 
@@ -1860,9 +1860,8 @@ PGBackend::tmapup_iertr::future<> PGBackend::tmapup(
       return seastar::make_ready_future<bufferlist>();
     }),
     PGBackend::write_iertr::pass_further{},
-    crimson::ct_error::assert_all{fmt::format(
-      "read error in mutate_object_contents of {}", os.oi.soid).c_str()
-    }).si_then([this, &os, &osd_op, &txn,
+    crimson::ct_error::assert_all(
+      "read error in mutate_object_contents of {}", os.oi.soid)).si_then([this, &os, &osd_op, &txn,
 	     &delta_stats, &osd_op_params]
 	    (auto &&bl) mutable -> PGBackend::tmapup_iertr::future<> {
     auto result = crimson::common::do_tmap_up(

--- a/src/crimson/osd/pg_meta.cc
+++ b/src/crimson/osd/pg_meta.cc
@@ -61,9 +61,9 @@ seastar::future<epoch_t> PGMeta::get_epoch()
         return seastar::make_ready_future<epoch_t>(*epoch);
       }
     },
-    FuturizedStore::Shard::read_errorator::assert_all{
+    FuturizedStore::Shard::read_errorator::assert_all(
       "PGMeta::get_epoch: unable to read pgmeta"
-    });
+    ));
   });
 }
 
@@ -112,7 +112,7 @@ seastar::future<std::tuple<pg_info_t, PastIntervals>> PGMeta::load()
     return seastar::make_ready_future<std::tuple<pg_info_t, PastIntervals>>(
       std::make_tuple(std::move(info), std::move(past_intervals)));
   },
-  FuturizedStore::Shard::read_errorator::assert_all{
+  FuturizedStore::Shard::read_errorator::assert_all(
     "PGMeta::load: unable to read pgmeta"
-  });
+  ));
 }

--- a/src/crimson/osd/recovery_backend.cc
+++ b/src/crimson/osd/recovery_backend.cc
@@ -255,7 +255,8 @@ RecoveryBackend::scan_for_backfill_primary(
       crimson::ct_error::enoent::handle([](auto) {
 	return false;
       }),
-      crimson::ct_error::assert_all(fmt::format("{} {} error when loading obc", pg, FNAME).c_str())
+      crimson::ct_error::assert_all("{} {} error when loading obc",
+                                        std::cref(pg), FNAME)
     );
     if (!found) {
       // if the object does not exist here, it must have been removed
@@ -330,7 +331,8 @@ RecoveryBackend::scan_for_backfill_replica(
       crimson::ct_error::enoent::handle([](auto) {
 	return false;
       }),
-      crimson::ct_error::assert_all(fmt::format("{} {} error when loading obc", pg, FNAME).c_str())
+      crimson::ct_error::assert_all("{} {} error when loading obc",
+                                        std::cref(pg), FNAME)
     );
     if (!found) {
       // if the object does not exist here, it must have been removed

--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -187,8 +187,8 @@ ReplicatedRecoveryBackend::maybe_pull_missing_obj(
            });
        });
   }).handle_error_interruptible(
-    crimson::ct_error::assert_all(fmt::format(
-      "{} {} error with {} need {} ", pg, FNAME, soid, need).c_str())
+    crimson::ct_error::assert_all("{} {} error with {} need {}",
+                                      std::cref(pg), FNAME, soid, need)
   );
 }
 
@@ -789,8 +789,9 @@ ReplicatedRecoveryBackend::read_omap_for_push_op(
         new_progress.omap_complete = false;
       }
     }).handle_error(
-      crimson::os::FuturizedStore::Shard::read_errorator::assert_all(fmt::format(
-        "{} ReplicatedRecoveryBackend::read_omap_for_push_op error with {}", pg, oid).c_str())
+      crimson::os::FuturizedStore::Shard::read_errorator::assert_all(
+        "{} ReplicatedRecoveryBackend::read_omap_for_push_op error with {}",
+        std::cref(pg), oid)
     )
   );
 }

--- a/src/crimson/tools/objectstore/objectstore_tool.cc
+++ b/src/crimson/tools/objectstore/objectstore_tool.cc
@@ -86,7 +86,7 @@ StoreTool::omap_iterate(
     ).safe_then([] (auto ret) {
       ceph_assert (ret == ObjectStore::omap_iter_ret_t::NEXT);
     }).handle_error(
-      crimson::os::FuturizedStore::Shard::read_errorator::assert_all{}
+      crimson::os::FuturizedStore::Shard::read_errorator::assert_all("unexpected error")
     );
   });
 }
@@ -113,7 +113,7 @@ seastar::future<std::string> StoreTool::get_omap(
     to_get.insert(key);
     auto&& vals = co_await store->get_sharded_store().omap_get_values(
       coll, oid, to_get).handle_error(
-      crimson::os::FuturizedStore::Shard::read_errorator::assert_all{}
+      crimson::os::FuturizedStore::Shard::read_errorator::assert_all("unexpected error")
     );
     auto it = vals.find(key);
     if (it != vals.end()) {

--- a/src/crimson/tools/store_nbd/fs_driver.cc
+++ b/src/crimson/tools/store_nbd/fs_driver.cc
@@ -168,7 +168,7 @@ seastar::future<bufferlist> FSDriver::read(
       bl.append_zero(size);
       return seastar::make_ready_future<bufferlist>(std::move(bl));
     }),
-    crimson::ct_error::assert_all{"Unrecoverable error in FSDriver::read"}
+    crimson::ct_error::assert_all("Unrecoverable error in FSDriver::read")
   ).then([size](auto &&bl) {
     if (bl.length() < size) {
       bl.append_zero(size - bl.length());

--- a/src/crimson/tools/store_nbd/tm_driver.cc
+++ b/src/crimson/tools/store_nbd/tm_driver.cc
@@ -57,7 +57,7 @@ seastar::future<> TMDriver::write(
       });
     });
   }).handle_error(
-    crimson::ct_error::assert_all{"store-nbd write"}
+    crimson::ct_error::assert_all("store-nbd write")
   );
 }
 
@@ -135,7 +135,7 @@ seastar::future<bufferlist> TMDriver::read(
       });
     });
   }).handle_error(
-    crimson::ct_error::assert_all{"store-nbd read"}
+    crimson::ct_error::assert_all("store-nbd read")
   ).then([blptrret=std::move(blptrret)]() mutable {
     logger().debug("read complete");
     return std::move(*blptrret);
@@ -200,9 +200,9 @@ seastar::future<> TMDriver::mkfs()
     logger().debug("mkfs complete");
     return TransactionManager::mkfs_ertr::now();
   }).handle_error(
-    crimson::ct_error::assert_all{
+    crimson::ct_error::assert_all(
       "Invalid errror during TMDriver::mkfs"
-    }
+    )
   );
 }
 
@@ -218,9 +218,9 @@ seastar::future<> TMDriver::mount()
     init();
     return tm->mount();
   }).handle_error(
-    crimson::ct_error::assert_all{
+    crimson::ct_error::assert_all(
       "Invalid errror during TMDriver::mount"
-    }
+    )
   );
 };
 
@@ -230,8 +230,8 @@ seastar::future<> TMDriver::close()
     clear();
     return device->close();
   }).handle_error(
-    crimson::ct_error::assert_all{
+    crimson::ct_error::assert_all(
       "Invalid errror during TMDriver::close"
-    }
+    )
   );
 }

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -1201,7 +1201,7 @@ namespace {
       ).safe_then([] (auto ret) {
         ceph_assert (ret == ObjectStore::omap_iter_ret_t::NEXT);
       }).handle_error(
-        crimson::os::FuturizedStore::Shard::read_errorator::assert_all{}
+        crimson::os::FuturizedStore::Shard::read_errorator::assert_all("unexpected error")
       );
 
       for (auto &p : kvs) {

--- a/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
+++ b/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
@@ -103,7 +103,7 @@ struct fltree_onode_manager_test_t
         });
       });
     }).handle_error(
-      crimson::ct_error::assert_all{"Invalid error in _mkfs"}
+      crimson::ct_error::assert_all("Invalid error in _mkfs")
     );
   }
 

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -215,7 +215,7 @@ struct b_dummy_tree_test_t : public seastar_test_suite_t {
       new UnboundedBtree(NodeExtentManager::create_dummy(IS_DUMMY_SYNC))
     );
     return INTR(tree->mkfs, *ref_t).handle_error(
-      crimson::ct_error::assert_all{"Unable to mkfs"}
+      crimson::ct_error::assert_all("Unable to mkfs")
     );
   }
 
@@ -1064,7 +1064,7 @@ class DummyChildPool {
       return c.nm.get_super(c.t, root_tracker
       ).handle_error_interruptible(
         eagain_iertr::pass_further{},
-        crimson::ct_error::assert_all{"Invalid error during create_initial()"}
+        crimson::ct_error::assert_all("Invalid error during create_initial()")
       ).si_then([c, initial](auto super) {
         initial->make_root_new(c, std::move(super));
         laddr_hint_t hint;

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -125,7 +125,7 @@ struct btree_test_base :
             submit_result.write_result.start_seq);
           complete_commit(t);
         }
-      ).handle_error(crimson::ct_error::assert_all{});
+      ).handle_error(crimson::ct_error::assert_all("unexpected error"));
     });
   }
 
@@ -197,7 +197,7 @@ struct btree_test_base :
 	  });
 	});
     }).handle_error(
-      crimson::ct_error::assert_all{"error"}
+      crimson::ct_error::assert_all("error")
     );
   }
 
@@ -216,7 +216,7 @@ struct btree_test_base :
       epm.reset();
       cache.reset();
     }).handle_error(
-      crimson::ct_error::assert_all{"Unable to close"}
+      crimson::ct_error::assert_all("Unable to close")
     );
   }
 };

--- a/src/test/crimson/seastore/test_cbjournal.cc
+++ b/src/test/crimson/seastore/test_cbjournal.cc
@@ -287,7 +287,7 @@ struct cbjournal_test_t : public seastar_test_suite_t, JournalTrimmer
     });
   }
   seastar::future<> close() {
-    return cbj->close().handle_error(crimson::ct_error::assert_all{});
+    return cbj->close().handle_error(crimson::ct_error::assert_all("unexpected error"));
   }
   auto get_records_available_size() {
     return cbj->get_cjs().get_records_available_size();
@@ -343,7 +343,7 @@ struct cbjournal_test_t : public seastar_test_suite_t, JournalTrimmer
 	  return replay();
 	});
       });
-    }).handle_error(crimson::ct_error::assert_all{});
+    }).handle_error(crimson::ct_error::assert_all("unexpected error"));
   }
 };
 

--- a/src/test/crimson/seastore/test_randomblock_manager.cc
+++ b/src/test/crimson/seastore/test_randomblock_manager.cc
@@ -57,20 +57,20 @@ struct rbm_test_t :
     size = device->get_available_size();
     rbm_manager.reset(new BlockRBManager(device.get(), std::string(), false));
     config = get_rbm_ephemeral_device_config(0, 1);
-    return device->mkfs(config).handle_error(crimson::ct_error::assert_all{}
+    return device->mkfs(config).handle_error(crimson::ct_error::assert_all("unexpected error")
     ).then([this] {
-      return device->mount().handle_error(crimson::ct_error::assert_all{}
+      return device->mount().handle_error(crimson::ct_error::assert_all("unexpected error")
       ).then([this] {
-	return rbm_manager->open().handle_error(crimson::ct_error::assert_all{});
+	return rbm_manager->open().handle_error(crimson::ct_error::assert_all("unexpected error"));
       });
     });
   }
 
   seastar::future<> tear_down_fut() final {
     co_await rbm_manager->close().handle_error(
-      crimson::ct_error::assert_all{});
+      crimson::ct_error::assert_all("unexpected error"));
     co_await device->close().handle_error(
-      crimson::ct_error::assert_all{});
+      crimson::ct_error::assert_all("unexpected error"));
     rbm_manager.reset();
     device.reset();
     co_return;

--- a/src/test/crimson/seastore/test_seastore.cc
+++ b/src/test/crimson/seastore/test_seastore.cc
@@ -609,7 +609,7 @@ struct seastore_test_t :
       SeaStoreShard &sharded_seastore) {
       return sharded_seastore.get_attrs(coll, oid)
 	.handle_error(
-	  SeaStoreShard::get_attrs_ertr::assert_all{"unexpected error"})
+	  SeaStoreShard::get_attrs_ertr::assert_all("unexpected error"))
 	.get();
     }
 
@@ -618,7 +618,7 @@ struct seastore_test_t :
       std::string_view name) {
       return sharded_seastore.get_attr(coll, oid, name)
 	.handle_error(
-	  SeaStoreShard::get_attr_errorator::assert_all{"unexpected error"})
+	  SeaStoreShard::get_attr_errorator::assert_all("unexpected error"))
 	.get();
     }
 

--- a/src/test/crimson/seastore/test_seastore_cache.cc
+++ b/src/test/crimson/seastore/test_seastore_cache.cc
@@ -81,7 +81,7 @@ struct cache_test_t : public seastar_test_suite_t {
 	cache->complete_commit(*t, prev, seq /* TODO */);
         return prev;
       },
-      crimson::ct_error::assert_all{"failed to submit"}
+      crimson::ct_error::assert_all("failed to submit")
      );
   }
 
@@ -131,7 +131,7 @@ struct cache_test_t : public seastar_test_suite_t {
         });
       });
     }).handle_error(
-      crimson::ct_error::assert_all{"failed to submit"}
+      crimson::ct_error::assert_all("failed to submit")
     );
   }
 
@@ -142,7 +142,7 @@ struct cache_test_t : public seastar_test_suite_t {
       epm.reset();
       cache.reset();
     }).handle_error(
-      Cache::close_ertr::assert_all{}
+      Cache::close_ertr::assert_all("unexpected error")
     );
   }
 };

--- a/src/test/crimson/seastore/test_seastore_journal.cc
+++ b/src/test/crimson/seastore/test_seastore_journal.cc
@@ -164,7 +164,7 @@ struct journal_test_t : seastar_test_suite_t, SegmentProvider, JournalTrimmer {
     }).safe_then([this](auto) {
       dummy_tail = journal_seq_t{0,
         paddr_t::make_seg_paddr(segment_id_t(segment_manager->get_device_id(), 0), 0)};
-    }, crimson::ct_error::assert_all{"Unable to mount"});
+    }, crimson::ct_error::assert_all("Unable to mount"));
   }
 
   seastar::future<> tear_down_fut() final {
@@ -174,7 +174,7 @@ struct journal_test_t : seastar_test_suite_t, SegmentProvider, JournalTrimmer {
       sms.reset();
       journal.reset();
     }).handle_error(
-      crimson::ct_error::assert_all{"Unable to close"}
+      crimson::ct_error::assert_all("Unable to close")
     );
   }
 

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -602,9 +602,9 @@ struct transaction_manager_test_t :
       [](const crimson::ct_error::eagain &e) {
 	return seastar::make_ready_future<TestBlockRef>();
       },
-      crimson::ct_error::assert_all{
+      crimson::ct_error::assert_all(
 	"get_extent got invalid error"
-      }
+      )
     ).get();
     if (t.t->is_conflicted()) {
       return nullptr;
@@ -632,9 +632,9 @@ struct transaction_manager_test_t :
       [](const crimson::ct_error::eagain &e) {
 	return seastar::make_ready_future<TestBlockRef>();
       },
-      crimson::ct_error::assert_all{
+      crimson::ct_error::assert_all(
 	"get_extent got invalid error"
-      }
+      )
     ).get();
     if (t.t->is_conflicted()) {
       return nullptr;
@@ -661,9 +661,9 @@ struct transaction_manager_test_t :
       [](const crimson::ct_error::eagain &e) {
 	return seastar::make_ready_future<TestBlockRef>();
       },
-      crimson::ct_error::assert_all{
+      crimson::ct_error::assert_all(
 	"read_pin got invalid error"
-      }
+      )
     ).get();
     if (ext) {
       if (indirect) {
@@ -760,9 +760,9 @@ struct transaction_manager_test_t :
       [](const crimson::ct_error::eagain &e) {
 	return seastar::make_ready_future<std::optional<LBAMapping>>();
       },
-      crimson::ct_error::assert_all{
+      crimson::ct_error::assert_all(
 	"get_extent got invalid error"
-      }
+      )
     ).get();
     if (pin) {
       EXPECT_EQ(offset, pin->get_key());
@@ -845,9 +845,9 @@ struct transaction_manager_test_t :
       [](const crimson::ct_error::eagain &e) {
 	return seastar::make_ready_future<bool>(false);
       },
-      crimson::ct_error::assert_all{
+      crimson::ct_error::assert_all(
 	"try_submit_transaction hit invalid error"
-      }
+      )
     ).then([this](auto ret) {
       return epm->run_background_work_until_halt(
       ).then([ret] { return ret; });
@@ -916,9 +916,9 @@ struct transaction_manager_test_t :
         return epm->background_process.trimmer->trim();
       }
     }).handle_error(
-      crimson::ct_error::assert_all{
+      crimson::ct_error::assert_all(
 	"Invalid error in SeaStore::list_collections"
-      }
+      )
     );
   }
 

--- a/src/test/crimson/seastore/transaction_manager_test_state.h
+++ b/src/test/crimson/seastore/transaction_manager_test_state.h
@@ -94,7 +94,7 @@ public:
         });
       });
     }).handle_error(
-      crimson::ct_error::assert_all{}
+      crimson::ct_error::assert_all("unexpected error")
     );
   }
 
@@ -144,7 +144,7 @@ public:
   seastar::future<> setup() final {
     rb_device = random_block_device::create_test_ephemeral();
     device_config_t config = get_rbm_ephemeral_device_config(0, 1);
-    return rb_device->mkfs(config).handle_error(crimson::ct_error::assert_all{});
+    return rb_device->mkfs(config).handle_error(crimson::ct_error::assert_all("unexpected error"));
   }
 
   void remount() final {}
@@ -211,7 +211,7 @@ protected:
     return teardown().then([this] {
       devices->remount();
       return _init().then([this] {
-        return _mount().handle_error(crimson::ct_error::assert_all{});
+        return _mount().handle_error(crimson::ct_error::assert_all("unexpected error"));
       });
     }).then([FNAME] {
       SUBINFO(test, "finish");
@@ -249,7 +249,7 @@ protected:
       ).safe_then([this] {
 	return restart_fut();
       }).handle_error(
-	crimson::ct_error::assert_all{}
+	crimson::ct_error::assert_all("unexpected error")
       ).then([FNAME] {
 	SUBINFO(test, "finish");
       });
@@ -311,14 +311,14 @@ protected:
 
   virtual seastar::future<> _teardown() {
     return tm->close().handle_error(
-      crimson::ct_error::assert_all{"Error in teardown"}
+      crimson::ct_error::assert_all("Error in teardown")
     );
   }
 
   virtual FuturizedStore::mount_ertr::future<> _mount() {
     return tm->mount(
     ).handle_error(
-      crimson::ct_error::assert_all{"Error in mount"}
+      crimson::ct_error::assert_all("Error in mount")
     ).then([this] {
       return epm->stop_background();
     }).then([this] {
@@ -329,7 +329,7 @@ protected:
   virtual FuturizedStore::mkfs_ertr::future<> _mkfs() {
     return tm->mkfs(
     ).handle_error(
-      crimson::ct_error::assert_all{"Error in mkfs"}
+      crimson::ct_error::assert_all("Error in mkfs")
     );
   }
 

--- a/src/test/crimson/test_alien_echo.cc
+++ b/src/test/crimson/test_alien_echo.cc
@@ -180,7 +180,7 @@ seastar_echo(const entity_addr_t addr, echo_role role, unsigned count)
       return server.msgr->bind(entity_addrvec_t{addr}
       ).safe_then([&server] {
         return server.msgr->start({&server.dispatcher});
-      }, crimson::net::Messenger::bind_ertr::assert_all{"bind failed"}
+      }, crimson::net::Messenger::bind_ertr::assert_all("bind failed")
       ).then([&dispatcher=server.dispatcher, count] {
         return dispatcher.on_reply.wait([&dispatcher, count] {
           return dispatcher.count >= count;

--- a/src/test/crimson/test_interruptible_future.cc
+++ b/src/test/crimson/test_interruptible_future.cc
@@ -378,7 +378,7 @@ TEST_F(seastar_test_suite_t, handle_error)
 	  1
 	).handle_error_interruptible(
 	  base_iertr::pass_further{},
-	  ct_error::assert_all{"crash on eio"}
+	  ct_error::assert_all("crash on eio")
 	).si_then([](auto) {
 	  return base_iertr::now();
 	});


### PR DESCRIPTION
27b232ecc058 relaxed `assert_all` to accept any `const char*` instead of only array-ref literals, after which callers started passing `fmt::format(...).c_str()`, which returns a pointer into a temporary `std::string` that dies at the semicolon, leaving the stored pointer dangling when an error eventually fires.

the immediate fix was to revert to a literal-only constructor and add a separate `assert_all_fmt` for formatted messages. but two entry points for the same operation are redundant. fmtlib solves the same problem with one `format()` function and `fmt::format_string<T...>`, which validates the format string at compile time and accepts only literals or `fmt::runtime()` at the call site, with no `const char*` path at all.

apply the same approach here: replace the `assert_all` class in both the errorator class template and the `ct_error` namespace with a `static auto assert_all(fmt::format_string<Args...>, Args&&...)` function template. the format string is validated at the call site; inside the lambda the args are captured by value and `fmt::vformat` is used for runtime dispatch, avoiding the consteval re-entry that `fmt::format` would trigger. all 56 call sites are migrated from brace-init syntax to function-call syntax, and format arguments can now be passed directly instead of requiring a pre-formatted string.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
