### PR TITLE
tentacle: mgr/smb: fix incorrect referenced variable

### DIFF
--- a/src/pybind/mgr/smb/module.py
+++ b/src/pybind/mgr/smb/module.py
@@ -167,7 +167,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             # passwords - this will be the inverse of the filter applied to
             # the input
             out_op = (PasswordFilter.NONE, out_pf)
-            log.debug('Password filtering for smb apply output: %r', in_op)
+            log.debug('Password filtering for smb apply output: %r', out_op)
             all_results = all_results.convert_results(out_op)
         return all_results
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76971

---

backport of https://github.com/ceph/ceph/pull/69128
parent tracker: https://tracker.ceph.com/issues/76947

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh