### PR TITLE
crush/CrushWrapper: fix verify_upmap for nested choose rules

### DIFF
--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -952,6 +952,14 @@ int CrushWrapper::verify_upmap(CephContext *cct,
   int root_bucket = 0;
   int cursor = 0;
   std::map<int, int> type_stack;
+  // Running product of numrep from prior choose/chooseleaf steps in the
+  // current TAKE..EMIT scope. For a nested rule like
+  //   choose_indep 5 pod ; choose_indep 2 rack ; chooseleaf_indep 1 osd
+  // the inner step's numrep is per-outer-bucket, so the maximum number of
+  // distinct buckets of `type` allowed at that step is
+  //   numrep * outer_numrep_product
+  // (e.g. 2 racks/pod * 5 pods = 10 racks total).
+  int outer_numrep_product = 1;
   for (unsigned step = 0; step < rule->len; ++step) {
     auto curstep = &rule->steps[step];
     ldout(cct, 10) << __func__ << " step " << step << dendl;
@@ -959,6 +967,7 @@ int CrushWrapper::verify_upmap(CephContext *cct,
     case CRUSH_RULE_TAKE:
       {
         root_bucket = curstep->arg1;
+        outer_numrep_product = 1;
       }
       break;
     case CRUSH_RULE_CHOOSELEAF_FIRSTN:
@@ -969,8 +978,10 @@ int CrushWrapper::verify_upmap(CephContext *cct,
         if (numrep <= 0)
           numrep += pool_size;
         type_stack.emplace(type, numrep);
-        if (type == 0) // osd
+        if (type == 0) { // osd
+          outer_numrep_product *= numrep;
           break;
+        }
         map<int, set<int>> osds_by_parent; // parent_of_desired_type -> osds
         for (auto osd : up) {
           auto parent = get_parent_of_type(osd, type, rule_id);
@@ -990,6 +1001,7 @@ int CrushWrapper::verify_upmap(CephContext *cct,
             return -EINVAL;
           }
         }
+        outer_numrep_product *= numrep;
       }
       break;
 
@@ -1001,8 +1013,10 @@ int CrushWrapper::verify_upmap(CephContext *cct,
         if (numrep <= 0)
           numrep += pool_size;
         type_stack.emplace(type, numrep);
-        if (type == 0) // osd
+        if (type == 0) { // osd
+          outer_numrep_product *= numrep;
           break;
+        }
         set<int> parents_of_type;
         for (auto osd : up) {
           auto parent = get_parent_of_type(osd, type, rule_id);
@@ -1014,12 +1028,18 @@ int CrushWrapper::verify_upmap(CephContext *cct,
                           << dendl;
           }
         }
-        if ((int)parents_of_type.size() > numrep) {
+        // Inner choose steps select numrep buckets of `type` per
+        // outer-bucket-result, so the total expected count is
+        // numrep * outer_numrep_product.
+        int max_expected = numrep * outer_numrep_product;
+        if ((int)parents_of_type.size() > max_expected) {
           lderr(cct) << __func__ << " number of buckets "
-                     << parents_of_type.size() << " exceeds desired " << numrep
+                     << parents_of_type.size() << " exceeds desired "
+                     << max_expected
                      << dendl;
           return -EINVAL;
         }
+        outer_numrep_product = max_expected;
       }
       break;
 
@@ -1041,6 +1061,7 @@ int CrushWrapper::verify_upmap(CephContext *cct,
         }
         type_stack.clear();
         root_bucket = 0;
+        outer_numrep_product = 1;
       }
       break;
     default:

--- a/src/test/crush/CrushWrapper.cc
+++ b/src/test/crush/CrushWrapper.cc
@@ -1454,6 +1454,160 @@ TEST_F(CrushWrapperTest, try_remap_rule) {
   }
 }
 
+TEST_F(CrushWrapperTest, verify_upmap_nested_choose) {
+  // Reproduce a multi-level EC pod/rack topology that triggers the
+  // verify_upmap nested-choose bug (see tracker #57348):
+  //
+  //   take <root>
+  //   choose_indep   2 type pod
+  //   choose_indep   2 type rack
+  //   chooseleaf_indep 1 type osd
+  //   emit
+  //
+  // pool_size = 4 (2 pods * 2 racks * 1 osd). A natural CRUSH output
+  // legitimately contains 4 distinct racks; the buggy validator
+  // compared 4 against the local numrep (2) and rejected. The fix
+  // compares against numrep * outer_numrep_product (= 2 * 2 = 4).
+  //
+  // The topology has 3 pods (more than the rule asks for) so that we
+  // can also construct an invalid up set that legitimately exceeds the
+  // pod count and exercises the negative path.
+  CrushWrapper c;
+  c.create();
+  c.set_type_name(0, "osd");
+  c.set_type_name(1, "host");
+  c.set_type_name(2, "rack");
+  c.set_type_name(3, "pod");
+  c.set_type_name(4, "root");
+
+  int bno;
+  int r = c.add_bucket(0, CRUSH_BUCKET_STRAW2,
+                       CRUSH_HASH_DEFAULT, 4, 0, NULL,
+                       NULL, &bno);
+  ASSERT_EQ(0, r);
+  c.set_item_name(bno, "default");
+
+  c.set_max_devices(12);
+
+  // 3 pods x 2 racks/pod x 1 host/rack x 2 osds/host = 12 osds
+  auto add = [&](int osd, const string& pod, const string& rack,
+                 const string& host) {
+    map<string, string> loc;
+    loc["host"] = host;
+    loc["rack"] = rack;
+    loc["pod"] = pod;
+    loc["root"] = "default";
+    c.insert_item(cct, osd, 1, "osd." + stringify(osd), loc);
+  };
+  add(0,  "pod0", "r00", "h00");
+  add(1,  "pod0", "r00", "h00");
+  add(2,  "pod0", "r01", "h01");
+  add(3,  "pod0", "r01", "h01");
+  add(4,  "pod1", "r10", "h10");
+  add(5,  "pod1", "r10", "h10");
+  add(6,  "pod1", "r11", "h11");
+  add(7,  "pod1", "r11", "h11");
+  add(8,  "pod2", "r20", "h20");
+  add(9,  "pod2", "r20", "h20");
+  add(10, "pod2", "r21", "h21");
+  add(11, "pod2", "r21", "h21");
+  c.finalize();
+
+  // build the nested rule (rule type doesn't affect verify_upmap)
+  int rule = c.add_rule(-1, 5, 0);
+  ASSERT_GE(rule, 0);
+  c.set_rule_step_take(rule, 0, bno);
+  c.set_rule_step_choose_indep(rule, 1, 2, c.get_type_id("pod"));
+  c.set_rule_step_choose_indep(rule, 2, 2, c.get_type_id("rack"));
+  c.set_rule_step_choose_leaf_indep(rule, 3, 1, 0);
+  c.set_rule_step_emit(rule, 4);
+
+  const int pool_size = 4;
+
+  // A valid up set: one osd from each (pod, rack) combination spanning
+  // 2 pods. The four OSDs come from four distinct racks. Pre-fix this
+  // returned -EINVAL because 4 > 2 (the inner numrep) at the rack step.
+  {
+    vector<int> up = {0, 2, 4, 6};
+    ASSERT_EQ(0, c.verify_upmap(cct, rule, pool_size, up));
+  }
+
+  // Same shape but swap one OSD inside its rack -- another legitimate
+  // upmap target. Still 4 distinct racks, must still pass.
+  {
+    vector<int> up = {1, 2, 4, 6};   // 1 instead of 0, same rack r00
+    ASSERT_EQ(0, c.verify_upmap(cct, rule, pool_size, up));
+    vector<int> up2 = {0, 2, 5, 6};  // 5 instead of 4, same rack r10
+    ASSERT_EQ(0, c.verify_upmap(cct, rule, pool_size, up2));
+  }
+
+  // Choose any 2 of the 3 pods -- all three pairings must validate.
+  {
+    vector<int> up_p1p2 = {4, 6, 8, 10};
+    ASSERT_EQ(0, c.verify_upmap(cct, rule, pool_size, up_p1p2));
+    vector<int> up_p0p2 = {0, 2, 8, 10};
+    ASSERT_EQ(0, c.verify_upmap(cct, rule, pool_size, up_p0p2));
+  }
+
+  // Negative: an up set spanning 3 pods exceeds the pod count limit
+  // (3 distinct pods > numrep=2 at the pod step). Must be rejected.
+  {
+    vector<int> up = {0, 4, 8, 6}; // pods: pod0, pod1, pod2, pod1
+    ASSERT_LT(c.verify_upmap(cct, rule, pool_size, up), 0);
+  }
+  {
+    vector<int> up = {0, 2, 4, 8}; // pods: pod0, pod0, pod1, pod2
+    ASSERT_LT(c.verify_upmap(cct, rule, pool_size, up), 0);
+  }
+}
+
+TEST_F(CrushWrapperTest, verify_upmap_single_level) {
+  // Regression guard: the nested-choose fix must not change behavior
+  // for plain single-level rules.
+  //
+  //   take <root>
+  //   chooseleaf_firstn 3 type host
+  //   emit
+  CrushWrapper c;
+  c.create();
+  c.set_type_name(0, "osd");
+  c.set_type_name(1, "host");
+  c.set_type_name(2, "root");
+
+  int bno;
+  ASSERT_EQ(0, c.add_bucket(0, CRUSH_BUCKET_STRAW2, CRUSH_HASH_DEFAULT,
+                            2, 0, NULL, NULL, &bno));
+  c.set_item_name(bno, "default");
+  c.set_max_devices(6);
+
+  auto add = [&](int osd, const string& host) {
+    map<string, string> loc;
+    loc["host"] = host;
+    loc["root"] = "default";
+    c.insert_item(cct, osd, 1, "osd." + stringify(osd), loc);
+  };
+  add(0, "h0"); add(1, "h0");
+  add(2, "h1"); add(3, "h1");
+  add(4, "h2"); add(5, "h2");
+  c.finalize();
+
+  ostringstream err;
+  int rule = c.add_simple_rule("simple", "default", "host", "",
+                               "firstn", pg_pool_t::TYPE_REPLICATED, &err);
+  ASSERT_GE(rule, 0);
+
+  // 3 OSDs across 3 distinct hosts -- must pass.
+  {
+    vector<int> up = {0, 2, 4};
+    ASSERT_EQ(0, c.verify_upmap(cct, rule, 3, up));
+  }
+  // 3 OSDs but two share a host -- must fail (chooseleaf check).
+  {
+    vector<int> up = {0, 1, 4};
+    ASSERT_LT(c.verify_upmap(cct, rule, 3, up), 0);
+  }
+}
+
 // Local Variables:
 // compile-command: "cd ../../../build ; make -j4 unittest_crush_wrapper && valgrind --tool=memcheck bin/unittest_crush_wrapper"
 // End:


### PR DESCRIPTION
## Summary

`verify_upmap()` checks each choose step's `numrep` against the count of distinct parents in the candidate up set, but ignores that an inner choose step's `numrep` is **per outer-bucket-result**. For multi-level rules (e.g. `choose pod -> choose rack -> chooseleaf osd`) a legitimate up set spans `numrep * outer_numrep_product` distinct buckets, so valid upmaps are rejected and silently removed by `check_pg_upmaps` in the next osdmap epoch.

This fix tracks a running product of `numrep` across prior choose/chooseleaf steps in the current `TAKE..EMIT` scope and compares each inner step against `numrep * outer_numrep_product`. Single-level rules are unaffected (the product is 1 for the first step after TAKE).

Issue tracker: https://tracker.ceph.com/issues/51729

## Test plan

- [x] `unittest_crush_wrapper` -- new `verify_upmap_nested_choose` (asserts previously-rejected nested-choose up sets now validate, and genuinely invalid sets still fail) and `verify_upmap_single_level` regression guard.
- [x] Patch was deployed against an EC 6+4 pool with a `pod -> rack -> osd` rule; `pg-upmap-items` entries persist across osdmap epochs (pre-fix they were silently removed).
