### PR TITLE
crimson/os/seastore: enforce capacity in RBMCleaner::try_reserve_projected_usage

### DIFF
--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -2031,6 +2031,27 @@ void RBMCleaner::commit_space_used(paddr_t addr, extent_len_t len)
 bool RBMCleaner::try_reserve_projected_usage(std::size_t projected_usage)
 {
   assert(background_callback->is_ready());
+
+  // Capacity check. Without this, concurrent transactions over-commit the
+  // RBM device: each reserves but the cleaner has no clean_space() yet, so
+  // a write that physically can't be served reaches the allocator and
+  // surfaces as `unexpected enospc` asserts in the data path (object_data
+  // _handler.cc et al.). Return false so the EPM BackgroundProcess blocks
+  // the IO until committed transactions release space.
+  //
+  // Headroom carves out room for metadata writes (LBA btree, backref) and
+  // for fragmentation slack the allocator can't pack into. 5% is a starting
+  // point; until RBMCleaner::clean_space() exists we cannot reclaim from
+  // fragmented free space, so headroom doubles as a fragmentation guard.
+  assert(get_total_bytes() > get_journal_bytes());
+  auto data_capacity = get_total_bytes() - get_journal_bytes();
+  auto headroom = data_capacity / 20;
+  auto committed_and_projected = stats.used_bytes
+                               + stats.projected_used_bytes
+                               + projected_usage;
+  if (committed_and_projected + headroom > data_capacity) {
+    return false;
+  }
   stats.projected_used_bytes += projected_usage;
   return true;
 }


### PR DESCRIPTION
## Description
`RBMCleaner::try_reserve_projected_usage` always returned true and just incremented `stats.projected_used_bytes`. The EPM `BackgroundProcess` relies on the return value of `try_reserve_projected_usage` to block user IO when the device is full, meaning backpressure was effectively disabled for the `RANDOM_BLOCK_SSD` backend. Concurrent transactions could each reserve unbounded amounts, and the over-commit surfaced downstream as `unexpected enospc` asserts in the data path (e.g. in `object_data_handler.cc` where ENOSPC is treated as an assert failure because the existing infrastructure assumes ENOSPC is impossible). Under sustained random-write workloads exceeding RBM capacity, the OSD would abort.

This PR implements capacity enforcement in `RBMCleaner::try_reserve_projected_usage`:
- Computes the device's data capacity as `total - journal`.
- Subtracts a 5% headroom to account for metadata writes (LBA btree, backref) and fragmentation slack.
- Rejects reservations (`return false`) that would push the total of `used + projected + requested` over that threshold.

This converts a terminal data-path assert crash into a stall: once the device fills, new write transactions block in the existing EPM blocking-IO path until committed space is released.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [x] No tests
