### PR TITLE
crimson/os/seastore: RBM metadata/data pool separation

### DIFF
--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -244,6 +244,11 @@ options:
   level: dev
   desc: Total size to use for CircularBoundedJournal if created, it is valid only if seastore_main_device_type is RANDOM_BLOCK
   default: 5_G
+- name: seastore_rbm_metadata_size
+  type: str
+  level: dev
+  desc: Size of the RBM metadata pool (LBA tree, backref tree, onode tree) carved between the journal and the data area at mkfs. Can be a percentage (e.g. 1.5%) or a size with K/M/G/T suffix. Set to 0 (default) to disable pool separation and revert to the legacy single-pool layout (data + metadata share one allocator).
+  default: 0
 - name: seastore_multiple_tiers_stop_evict_ratio
   type: float
   level: advanced

--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -247,8 +247,8 @@ options:
 - name: seastore_rbm_metadata_size
   type: str
   level: dev
-  desc: Size of the RBM metadata pool (LBA tree, backref tree, onode tree) carved between the journal and the data area at mkfs. Can be a percentage (e.g. 1.5%) or a size with K/M/G/T suffix. Set to 0 (default) to disable pool separation and revert to the legacy single-pool layout (data + metadata share one allocator).
-  default: 0
+  desc: Size of the RBM metadata pool (LBA tree, backref tree, onode tree) carved between the journal and the data area at mkfs. Can be a percentage (e.g. 1.5%) or a size with K/M/G/T suffix. Set to 0 to disable pool separation and revert to the legacy single-pool layout (data + metadata share one allocator). A size of 1.5% is default and covers the steady-state metadata ratio for all-4K-extent workloads.
+  default: 1.5%
 - name: seastore_multiple_tiers_stop_evict_ratio
   type: float
   level: advanced

--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -1,6 +1,8 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
 // vim: ts=8 sw=2 sts=2 expandtab
 
+#include <cmath>
+
 #include <fmt/chrono.h>
 #include <seastar/core/metrics.hh>
 
@@ -1135,14 +1137,19 @@ void SegmentCleaner::maybe_adjust_thresholds()
       peak_open_segments_window, segments.get_num_open());
 
   // Only recompute hard_limit every 30s.
-  using namespace std::chrono_literals;
   LOG_PREFIX(SegmentCleaner::maybe_adjust_thresholds);
   auto now = seastar::lowres_clock::now();
-  if (adaptive_last_time != seastar::lowres_clock::time_point{} &&
-      now - adaptive_last_time < 30s) {
-    return;
+  double elapsed_sec = 0.0;
+  if (adaptive_last_time != seastar::lowres_clock::time_point{}) {
+    elapsed_sec = std::chrono::duration<double>(
+        now - adaptive_last_time).count();
+    if (elapsed_sec < 30.0) {
+      return;
+    }
   }
   adaptive_last_time = now;
+  double old_hard_limit = config.available_ratio_hard_limit;
+  double old_gc_max = config.available_ratio_gc_max;
 
   // Architectural floor: named writers (journal + hot/cold gens + metadata).
   auto hot = crimson::common::get_conf<uint64_t>(
@@ -1156,34 +1163,54 @@ void SegmentCleaner::maybe_adjust_thresholds()
     return;
   }
 
-  // hard_limit = (max(peak, named) + 1) * seg / total. "+1" is the minimum
+  double segment_ratio =
+      static_cast<double>(seg_size) /
+      static_cast<double>(total_bytes);
+
+  // hard_limit = (max(peak, named) + 1) * segment_ratio. "+1" is the minimum
   // safety unit: allow one more open segment than ever observed.
   std::size_t observed_peak =
       std::max<std::size_t>(peak_open_segments_window, named_writers);
   double new_hard_limit =
-      static_cast<double>(observed_peak + 1) *
-      static_cast<double>(seg_size) /
-      static_cast<double>(total_bytes);
+      static_cast<double>(observed_peak + 1) * segment_ratio;
 
   double crash_floor =
-      static_cast<double>(named_writers) *
-      static_cast<double>(seg_size) /
-      static_cast<double>(total_bytes);
+      static_cast<double>(named_writers) * segment_ratio;
   new_hard_limit = std::max(new_hard_limit, crash_floor);
 
-  // Keep gc_max strictly greater than hard_limit.
+  // Apply lazy decay covering elapsed time (allows gc_max to gradually fall
+  // when workload eases) so peaks fade even when the background process was
+  // idle and this hook went uncalled for many cycles.
+  if (elapsed_sec > 0.0) {
+    peak_projected_used_decayed *= std::pow(0.995, elapsed_sec / 30.0);
+  }
+
+  // gc_max decays halfway each window toward (hard_limit + recent peak burst).
+  double burst_floor_ratio =
+      peak_projected_used_decayed /
+      static_cast<double>(total_bytes);
+  double target_gc_max = new_hard_limit + burst_floor_ratio;
+  double decayed_gc_max =
+      (config.available_ratio_gc_max + target_gc_max) / 2.0;
+  config.available_ratio_gc_max = std::max(decayed_gc_max, target_gc_max);
   if (config.available_ratio_gc_max <= new_hard_limit) {
-    config.available_ratio_gc_max = new_hard_limit + 0.001;
+    config.available_ratio_gc_max = new_hard_limit + segment_ratio;
   }
   config.available_ratio_hard_limit = new_hard_limit;
 
-  INFO("[ADAPTIVE_GC] peak_open={} named={} hard_limit={:.4f} "
-       "gc_max={:.4f} crash_floor={:.4f}",
-       peak_open_segments_window, named_writers,
-       config.available_ratio_hard_limit,
-       config.available_ratio_gc_max, crash_floor);
+  if (old_hard_limit != new_hard_limit || old_gc_max != config.available_ratio_gc_max) {
+    INFO("[ADAPTIVE_GC] update: hard_limit {:.4f} -> {:.4f}, gc_max {:.4f} -> {:.4f} "
+         "(peak_open={} named={} peak_proj_decayed={:.0f} crash_floor={:.4f})",
+         old_hard_limit, new_hard_limit,
+         old_gc_max, config.available_ratio_gc_max,
+         peak_open_segments_window, named_writers,
+         peak_projected_used_decayed, crash_floor);
+  } else {
+    DEBUG("[ADAPTIVE_GC] no-op: hard_limit {:.4f}, gc_max {:.4f}",
+          old_hard_limit, old_gc_max);
+  }
 
-  // Reset window: record current open count as the new baseline.
+  // Reset per-window open-segment peak.
   peak_open_segments_window = segments.get_num_open();
 }
 
@@ -1883,6 +1910,11 @@ bool SegmentCleaner::try_reserve_projected_usage(std::size_t projected_usage)
 {
   assert(background_callback->is_ready());
   stats.projected_used_bytes += projected_usage;
+  // Update decayed peak; the slow decay in maybe_adjust_thresholds() lets old
+  // peaks fade so gc_max can eventually re-discover lower floors.
+  peak_projected_used_decayed = std::max(
+      peak_projected_used_decayed,
+      static_cast<double>(stats.projected_used_bytes));
   if (should_block_io_on_clean()) {
     stats.projected_used_bytes -= projected_usage;
     return false;

--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -1176,7 +1176,8 @@ void SegmentCleaner::maybe_adjust_thresholds()
 
   double crash_floor =
       static_cast<double>(named_writers) * segment_ratio;
-  new_hard_limit = std::max(new_hard_limit, crash_floor);
+  crash_floor = std::min(crash_floor, 0.95);
+  new_hard_limit = std::min(std::max(new_hard_limit, crash_floor), 0.95);
 
   // Apply lazy decay covering elapsed time (allows gc_max to gradually fall
   // when workload eases) so peaks fade even when the background process was

--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -1128,6 +1128,65 @@ segment_id_t SegmentCleaner::allocate_segment(
   return NULL_SEG_ID;
 }
 
+void SegmentCleaner::maybe_adjust_thresholds()
+{
+  // Sample current open-segment count into the window peak each call.
+  peak_open_segments_window = std::max(
+      peak_open_segments_window, segments.get_num_open());
+
+  // Only recompute hard_limit every 30s.
+  using namespace std::chrono_literals;
+  LOG_PREFIX(SegmentCleaner::maybe_adjust_thresholds);
+  auto now = seastar::lowres_clock::now();
+  if (adaptive_last_time != seastar::lowres_clock::time_point{} &&
+      now - adaptive_last_time < 30s) {
+    return;
+  }
+  adaptive_last_time = now;
+
+  // Architectural floor: named writers (journal + hot/cold gens + metadata).
+  auto hot = crimson::common::get_conf<uint64_t>(
+      "seastore_hot_tier_generations");
+  auto cold = crimson::common::get_conf<uint64_t>(
+      "seastore_cold_tier_generations");
+  std::size_t named_writers = hot + cold + 2;
+  std::size_t seg_size = segments.get_segment_size();
+  std::size_t total_bytes = segments.get_total_bytes();
+  if (total_bytes == 0 || seg_size == 0) {
+    return;
+  }
+
+  // hard_limit = (max(peak, named) + 1) * seg / total. "+1" is the minimum
+  // safety unit: allow one more open segment than ever observed.
+  std::size_t observed_peak =
+      std::max<std::size_t>(peak_open_segments_window, named_writers);
+  double new_hard_limit =
+      static_cast<double>(observed_peak + 1) *
+      static_cast<double>(seg_size) /
+      static_cast<double>(total_bytes);
+
+  double crash_floor =
+      static_cast<double>(named_writers) *
+      static_cast<double>(seg_size) /
+      static_cast<double>(total_bytes);
+  new_hard_limit = std::max(new_hard_limit, crash_floor);
+
+  // Keep gc_max strictly greater than hard_limit.
+  if (config.available_ratio_gc_max <= new_hard_limit) {
+    config.available_ratio_gc_max = new_hard_limit + 0.001;
+  }
+  config.available_ratio_hard_limit = new_hard_limit;
+
+  INFO("[ADAPTIVE_GC] peak_open={} named={} hard_limit={:.4f} "
+       "gc_max={:.4f} crash_floor={:.4f}",
+       peak_open_segments_window, named_writers,
+       config.available_ratio_hard_limit,
+       config.available_ratio_gc_max, crash_floor);
+
+  // Reset window: record current open count as the new baseline.
+  peak_open_segments_window = segments.get_num_open();
+}
+
 void SegmentCleaner::close_segment(segment_id_t segment)
 {
   LOG_PREFIX(SegmentCleaner::close_segment);
@@ -1343,11 +1402,12 @@ SegmentCleaner::clean_space_ret SegmentCleaner::clean_space()
   }
   reclaim_state->advance(config.reclaim_bytes_per_cycle);
 
-  DEBUG("reclaiming {} {}~{}",
+  double pavail_ratio = get_projected_available_ratio();
+  DEBUG("reclaiming {} {}~{}, projected_avail_ratio={}",
         rewrite_gen_printer_t{reclaim_state->generation},
         reclaim_state->start_pos,
-        reclaim_state->end_pos);
-  double pavail_ratio = get_projected_available_ratio();
+        reclaim_state->end_pos,
+        pavail_ratio);
   sea_time_point start = seastar::lowres_system_clock::now();
 
   // Backref-tree doesn't support tree-read during tree-updates with parallel

--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -2031,6 +2031,26 @@ void RBMCleaner::commit_space_used(paddr_t addr, extent_len_t len)
 bool RBMCleaner::try_reserve_projected_usage(std::size_t projected_usage)
 {
   assert(background_callback->is_ready());
+
+  // Capacity check. Without this, concurrent transactions over-commit the
+  // RBM device: each reserves but the cleaner has no clean_space() yet, so
+  // a write that physically can't be served reaches the allocator and
+  // surfaces as `unexpected enospc` asserts in the data path (object_data
+  // _handler.cc et al.). Return false so the EPM BackgroundProcess blocks
+  // the IO until committed transactions release space.
+  //
+  // Headroom carves out room for metadata writes (LBA btree, backref) and
+  // for fragmentation slack the allocator can't pack into. 5% is a starting
+  // point; until RBMCleaner::clean_space() exists we cannot reclaim from
+  // fragmented free space, so headroom doubles as a fragmentation guard.
+  auto data_capacity = get_total_bytes() - get_journal_bytes();
+  auto headroom = data_capacity / 20;
+  auto committed_and_projected = stats.used_bytes
+                               + stats.projected_used_bytes
+                               + projected_usage;
+  if (committed_and_projected + headroom > data_capacity) {
+    return false;
+  }
   stats.projected_used_bytes += projected_usage;
   return true;
 }

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -1840,20 +1840,25 @@ public:
     return nullptr;
   }
 
-  paddr_t alloc_paddr(extent_len_t length) {
-    // TODO: implement allocation strategy (dirty metadata and multiple devices)
+  paddr_t alloc_paddr(extent_len_t length,
+                      data_category_t category = data_category_t::DATA) {
+    // TODO: implement allocation strategy across multiple RBM devices.
+    // For now device 0 owns both pools; routing between metadata and data
+    // allocators happens inside BlockRBManager based on category.
     auto rbs = rb_group->get_rb_managers();
-    auto paddr = rbs[0]->alloc_extent(length);
+    auto paddr = rbs[0]->alloc_extent(length, category);
     if (paddr != P_ADDR_NULL) {
       stats.used_bytes += length;
     }
     return paddr;
   }
 
-  std::list<alloc_paddr_result> alloc_paddrs(extent_len_t length) {
-    // TODO: implement allocation strategy (dirty metadata and multiple devices)
+  std::list<alloc_paddr_result> alloc_paddrs(
+      extent_len_t length,
+      data_category_t category = data_category_t::DATA) {
+    // TODO: implement allocation strategy across multiple RBM devices.
     auto rbs = rb_group->get_rb_managers();
-    auto ret = rbs[0]->alloc_extents(length);
+    auto ret = rbs[0]->alloc_extents(length, category);
     if (!ret.empty()) {
       stats.used_bytes += length;
     }

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -1669,6 +1669,11 @@ private:
   std::size_t peak_open_segments_window = 0;
   seastar::lowres_clock::time_point adaptive_last_time;
 
+  // Peak projected_used with slow exponential decay per adjust cycle. Decay
+  // 0.5% per 30s window = half-life ~1 hour: long enough not to forget peaks
+  // mid-workload, short enough to re-discover lower floors over time.
+  double peak_projected_used_decayed = 0.0;
+
   SegmentManagerGroupRef sm_group;
   BackrefManager &backref_manager;
 

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -1798,7 +1798,20 @@ public:
   void release_projected_usage(size_t) final;
 
   bool should_block_io_on_clean() const final {
-    return false;
+    size_t meta_cap = 0, meta_avail = 0;
+    size_t data_avail = 0;
+    for (auto *rbm : rb_group->get_rb_managers()) {
+      meta_cap  += rbm->get_metadata_pool_size();
+      meta_avail += rbm->get_metadata_pool_available();
+      data_avail += rbm->get_data_pool_available();
+    }
+    // v1 layout has no dedicated metadata pool.
+    if (meta_cap == 0) {
+      return false;
+    }
+    // Block if metadata pool is nearly full and data pool can't back it up.
+    size_t total_avail = meta_avail + data_avail;
+    return total_avail < std::min(meta_cap / 50, static_cast<size_t>(16ULL << 20));
   }
 
   bool can_clean_space() const final {

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -1245,6 +1245,9 @@ public:
 
   virtual std::size_t get_reclaim_size_per_cycle() const = 0;
 
+  // Periodic hook for adaptive threshold control. Default: no-op.
+  virtual void maybe_adjust_thresholds() {}
+
 #ifdef UNIT_TESTS_BUILT
   virtual void prefill_fragmented_devices() {}
 #endif
@@ -1458,6 +1461,8 @@ public:
            greedy_free >= ratio * picked_free;
   }
 
+  void maybe_adjust_thresholds() final;
+
   const std::set<device_id_t>& get_device_ids() const final {
     return sm_group->get_device_ids();
   }
@@ -1657,7 +1662,12 @@ private:
   store_index_t store_index;
   const bool detailed;
   const bool is_cold;
-  const config_t config;
+  // Mutated by maybe_adjust_thresholds(): hard_limit tracks observed open-segment peak.
+  config_t config;
+
+  // Adaptive state: peak open segments observed since last adjust.
+  std::size_t peak_open_segments_window = 0;
+  seastar::lowres_clock::time_point adaptive_last_time;
 
   SegmentManagerGroupRef sm_group;
   BackrefManager &backref_manager;

--- a/src/crimson/os/seastore/device.h
+++ b/src/crimson/os/seastore/device.h
@@ -113,7 +113,7 @@ static_assert(SUPERBLOCK_HEADER_PREFIX == 60);
 
 /// Current superblock format version.
 ///   v1: initial.
-///   v2: adds RBM metadata-pool fields (metadata_size, metadata_region_start).
+///   v2: adds RBM metadata-pool field (metadata_size).
 ///       v1 devices read with v2 code default these to 0 and behave as a
 ///       single-pool device (data + metadata sharing the same allocator).
 constexpr uint8_t CRIMSON_DEVICE_SUPERBLOCK_VERSION = 2;

--- a/src/crimson/os/seastore/device.h
+++ b/src/crimson/os/seastore/device.h
@@ -111,8 +111,12 @@ constexpr size_t SUPERBLOCK_MAGIC_PAD  = 37; // matching the UID block in BlueSt
 constexpr size_t SUPERBLOCK_HEADER_PREFIX = SUPERBLOCK_MAGIC_SIZE + SUPERBLOCK_MAGIC_PAD;
 static_assert(SUPERBLOCK_HEADER_PREFIX == 60);
 
-/// Current superblock format version
-constexpr uint8_t CRIMSON_DEVICE_SUPERBLOCK_VERSION = 1;
+/// Current superblock format version.
+///   v1: initial.
+///   v2: adds RBM metadata-pool fields (metadata_size, metadata_region_start).
+///       v1 devices read with v2 code default these to 0 and behave as a
+///       single-pool device (data + metadata sharing the same allocator).
+constexpr uint8_t CRIMSON_DEVICE_SUPERBLOCK_VERSION = 2;
 
 /// Feature bits stored in device_superblock_t::feature
 enum class device_feature_t : uint64_t {
@@ -163,6 +167,10 @@ struct device_superblock_t {
   // --- Device-type-specific size information (union concept) ---
   size_t total_size = 0;          ///< total device capacity in bytes (RBM)
   uint64_t journal_size = 0;      ///< journal area size in bytes (RBM)
+  // Metadata pool carved out at mkfs time, located immediately after the
+  // journal. If metadata_size == 0 the device is single-pool (legacy v1
+  // behavior): one allocator backs both data and metadata extents. (RBM v2)
+  uint64_t metadata_size = 0;     ///< metadata area size in bytes (RBM, v2+)
   size_t segment_capacity = 0;    ///< usable bytes/segment = zone_capacity*zones_per_segment (ZBD)
   size_t zones_per_segment = 0;   ///< zones per segment (ZBD)
   size_t zone_size = 0;           ///< physical zone size in bytes (ZBD)
@@ -177,7 +185,7 @@ struct device_superblock_t {
   uint32_t nvme_block_size = 0;  ///< NVMe logical block size (E2E protection)
 
   DENC(device_superblock_t, v, p) {
-    DENC_START(1, 1, p);
+    DENC_START(2, 1, p);
     denc(v.version, p);
     denc(v.shard_num, p);
     denc(v.segment_size, p);
@@ -193,6 +201,9 @@ struct device_superblock_t {
     denc(v.crc, p);
     denc(v.feature, p);
     denc(v.nvme_block_size, p);
+    if (struct_v >= 2) {
+      denc(v.metadata_size, p);
+    }
     DENC_FINISH(p);
   }
 
@@ -245,6 +256,7 @@ struct device_superblock_t {
     size_t block_size,
     size_t total_size,
     uint64_t journal_size,
+    uint64_t metadata_size,
     device_config_t config,
     std::vector<device_shard_info_t> shard_infos)
   {
@@ -253,6 +265,7 @@ struct device_superblock_t {
     sb.block_size = block_size;
     sb.total_size = total_size;
     sb.journal_size = journal_size;
+    sb.metadata_size = metadata_size;
     sb.config = std::move(config);
     sb.shard_infos = std::move(shard_infos);
     return sb;

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -829,6 +829,13 @@ ExtentPlacementManager::BackgroundProcess::run()
         pending_user_io_wake = false;
         co_await seastar::yield();
       }
+      // Adaptive threshold hook: each cleaner has its own state and floor.
+      if (main_cleaner) {
+        main_cleaner->maybe_adjust_thresholds();
+      }
+      if (cold_cleaner) {
+        cold_cleaner->maybe_adjust_thresholds();
+      }
     } else {
       log_state("run(block)");
       assert(!blocking_background);

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -39,9 +39,16 @@ public:
     crimson::ct_error::enospc>;
   virtual open_ertr::future<> open() = 0;
 
-  virtual paddr_t alloc_paddr(extent_len_t length) = 0;
+  // category routes between the data-pool and metadata-pool allocators on
+  // RBM v2 devices. Defaults to DATA so existing call sites that don't yet
+  // distinguish (e.g. segmented OOL writer, tests) keep their semantics.
+  virtual paddr_t alloc_paddr(
+      extent_len_t length,
+      data_category_t category = data_category_t::DATA) = 0;
 
-  virtual std::list<alloc_paddr_result> alloc_paddrs(extent_len_t length) = 0;
+  virtual std::list<alloc_paddr_result> alloc_paddrs(
+      extent_len_t length,
+      data_category_t category = data_category_t::DATA) = 0;
 
   using alloc_write_ertr = base_ertr;
   using alloc_write_iertr = trans_iertr<alloc_write_ertr>;
@@ -99,11 +106,12 @@ public:
     });
   }
 
-  paddr_t alloc_paddr(extent_len_t length) final {
+  paddr_t alloc_paddr(extent_len_t length, data_category_t) final {
     return make_delayed_temp_paddr(0);
   }
 
-  std::list<alloc_paddr_result> alloc_paddrs(extent_len_t length) final {
+  std::list<alloc_paddr_result> alloc_paddrs(
+      extent_len_t length, data_category_t) final {
     return {alloc_paddr_result{make_delayed_temp_paddr(0), length}};
   }
 
@@ -164,14 +172,15 @@ public:
     });
   }
 
-  paddr_t alloc_paddr(extent_len_t length) final {
+  paddr_t alloc_paddr(extent_len_t length, data_category_t category) final {
     assert(rb_cleaner);
-    return rb_cleaner->alloc_paddr(length);
+    return rb_cleaner->alloc_paddr(length, category);
   }
 
-  std::list<alloc_paddr_result> alloc_paddrs(extent_len_t length) final {
+  std::list<alloc_paddr_result> alloc_paddrs(
+      extent_len_t length, data_category_t category) final {
     assert(rb_cleaner);
-    return rb_cleaner->alloc_paddrs(length);
+    return rb_cleaner->alloc_paddrs(length, category);
   }
 
   bool can_inplace_rewrite(Transaction& t,
@@ -385,7 +394,7 @@ public:
       addr = make_record_relative_paddr(0);
     } else {
       assert(category == data_category_t::METADATA);
-      addr = get_writer(hint, category, gen)->alloc_paddr(length);
+      addr = get_writer(hint, category, gen)->alloc_paddr(length, category);
     }
     assert(!(category == data_category_t::DATA));
 
@@ -434,7 +443,7 @@ public:
     {
 #endif
       assert(category == data_category_t::DATA);
-      auto addrs = get_writer(hint, category, gen)->alloc_paddrs(length);
+      auto addrs = get_writer(hint, category, gen)->alloc_paddrs(length, category);
       for (auto &ext : addrs) {
         auto left = ext.len;
         while (left > 0) {

--- a/src/crimson/os/seastore/random_block_manager.h
+++ b/src/crimson/os/seastore/random_block_manager.h
@@ -93,6 +93,12 @@ public:
   virtual void complete_allocation(paddr_t addr, size_t size) = 0;
 
   virtual size_t get_size() const = 0;
+  // Free bytes in the data pool.
+  virtual size_t get_data_pool_available() const = 0;
+  // Size of the metadata pool.
+  virtual size_t get_metadata_pool_size() const = 0;
+  // Free bytes in the metadata pool.
+  virtual size_t get_metadata_pool_available() const = 0;
   virtual extent_len_t get_block_size() const = 0;
   virtual uint64_t get_free_blocks() const = 0;
   virtual device_id_t get_device_id() const = 0;

--- a/src/crimson/os/seastore/random_block_manager.h
+++ b/src/crimson/os/seastore/random_block_manager.h
@@ -72,12 +72,20 @@ public:
     crimson::ct_error::enospc
     >;
   using allocate_ret = allocate_ertr::future<paddr_t>;
-  // allocator, return start addr of allocated blocks
-  virtual paddr_t alloc_extent(size_t size) = 0;
+  // allocator, return start addr of allocated blocks.
+  // category routes between the metadata-pool and data-pool allocators on
+  // v2 (pool-separated) devices; on v1 single-pool devices the parameter
+  // is ignored. Defaults to DATA so existing call sites keep their
+  // semantics until they're updated to pass an explicit category.
+  virtual paddr_t alloc_extent(
+      size_t size,
+      data_category_t category = data_category_t::DATA) = 0;
 
   using allocate_ret_bare = std::list<alloc_paddr_result>;
   using allo_extents_ret = allocate_ertr::future<allocate_ret_bare>;
-  virtual allocate_ret_bare alloc_extents(size_t size) = 0;
+  virtual allocate_ret_bare alloc_extents(
+      size_t size,
+      data_category_t category = data_category_t::DATA) = 0;
 
   virtual void mark_space_used(paddr_t paddr, size_t len) = 0;
   virtual void mark_space_free(paddr_t paddr, size_t len) = 0;

--- a/src/crimson/os/seastore/random_block_manager/block_rb_manager.cc
+++ b/src/crimson/os/seastore/random_block_manager/block_rb_manager.cc
@@ -57,6 +57,11 @@ paddr_t BlockRBManager::alloc_extent(size_t size, data_category_t category)
           ? metadata_allocator.get()
           : data_allocator.get();
   auto alloc = a->alloc_extent(size);
+  if (!alloc && a == metadata_allocator.get()) {
+    INFO("metadata_allocator exhausted, falling back to data_allocator");
+    a = data_allocator.get();
+    alloc = a->alloc_extent(size);
+  }
   if (!alloc) {
     return P_ADDR_NULL;
   }
@@ -81,6 +86,11 @@ BlockRBManager::alloc_extents(size_t size, data_category_t category)
           ? metadata_allocator.get()
           : data_allocator.get();
   auto alloc = a->alloc_extents(size);
+  if (!alloc && a == metadata_allocator.get()) {
+    INFO("metadata_allocator exhausted, falling back to data_allocator");
+    a = data_allocator.get();
+    alloc = a->alloc_extents(size);
+  }
   if (!alloc) {
     return {};
   }

--- a/src/crimson/os/seastore/random_block_manager/block_rb_manager.cc
+++ b/src/crimson/os/seastore/random_block_manager/block_rb_manager.cc
@@ -46,11 +46,17 @@ device_config_t get_rbm_ephemeral_device_config(
           secondary_devices};
 }
 
-paddr_t BlockRBManager::alloc_extent(size_t size)
+paddr_t BlockRBManager::alloc_extent(size_t size, data_category_t category)
 {
   LOG_PREFIX(BlockRBManager::alloc_extent);
-  assert(allocator);
-  auto alloc = allocator->alloc_extent(size);
+  // Route to metadata pool only when it exists and the caller is asking
+  // for metadata. Everything else (including data on v1 single-pool
+  // devices) goes to data_allocator.
+  ExtentAllocator *a =
+      (metadata_allocator && category == data_category_t::METADATA)
+          ? metadata_allocator.get()
+          : data_allocator.get();
+  auto alloc = a->alloc_extent(size);
   if (!alloc) {
     return P_ADDR_NULL;
   }
@@ -60,17 +66,21 @@ paddr_t BlockRBManager::alloc_extent(size_t size)
   paddr_t paddr = convert_abs_addr_to_paddr(
     extent.get_start(),
     device->get_device_id());
-  DEBUG("allocated addr: {}, size: {}, requested size: {}",
-	paddr, extent.get_len(), size);
+  DEBUG("allocated addr: {}, size: {}, requested size: {}, pool: {}",
+	paddr, extent.get_len(), size,
+	(a == metadata_allocator.get()) ? "metadata" : "data");
   return paddr;
 }
 
 BlockRBManager::allocate_ret_bare
-BlockRBManager::alloc_extents(size_t size)
+BlockRBManager::alloc_extents(size_t size, data_category_t category)
 {
   LOG_PREFIX(BlockRBManager::alloc_extents);
-  assert(allocator);
-  auto alloc = allocator->alloc_extents(size);
+  ExtentAllocator *a =
+      (metadata_allocator && category == data_category_t::METADATA)
+          ? metadata_allocator.get()
+          : data_allocator.get();
+  auto alloc = a->alloc_extents(size);
   if (!alloc) {
     return {};
   }
@@ -83,8 +93,9 @@ BlockRBManager::alloc_extents(size_t size)
     paddr_t paddr = convert_abs_addr_to_paddr(
       extent.get_start(),
       device->get_device_id());
-    DEBUG("allocated addr: {}, size: {}, requested size: {}",
-         paddr, extent.get_len(), size);
+    DEBUG("allocated addr: {}, size: {}, requested size: {}, pool: {}",
+         paddr, extent.get_len(), size,
+         (a == metadata_allocator.get()) ? "metadata" : "data");
     ret.push_back(
       {std::move(paddr),
       static_cast<extent_len_t>(extent.get_len())});
@@ -96,22 +107,39 @@ BlockRBManager::alloc_extents(size_t size)
 void BlockRBManager::complete_allocation(
     paddr_t paddr, size_t size)
 {
-  assert(allocator);
   rbm_abs_addr addr = convert_paddr_to_abs_addr(paddr);
-  allocator->complete_allocation(addr, size);
+  auto *a = allocator_for(addr);
+  assert(a);
+  a->complete_allocation(addr, size);
 }
 
 BlockRBManager::open_ertr::future<> BlockRBManager::open()
 {
+  LOG_PREFIX(BlockRBManager::open);
   assert(device);
   assert(device->get_available_size() > 0);
   assert(device->get_block_size() > 0);
-  auto ool_start = get_start_rbm_addr();
-  allocator->init(
-    ool_start,
-    device->get_shard_end() -
-    ool_start,
-    device->get_block_size());
+  auto pool_start = get_start_rbm_addr();
+  auto data_start = get_data_start_rbm_addr();
+  auto device_end = device->get_shard_end();
+  auto meta_size = device->get_metadata_size();
+  auto block_size = device->get_block_size();
+
+  if (meta_size > 0) {
+    // v2 pool-separated layout: carve [pool_start, data_start) for metadata
+    // and [data_start, device_end) for data.
+    ceph_assert(data_start > pool_start);
+    ceph_assert(device_end > data_start);
+    metadata_allocator.reset(new AvlAllocator(detailed));
+    metadata_allocator->init(pool_start, data_start - pool_start, block_size);
+    data_allocator->init(data_start, device_end - data_start, block_size);
+    INFO("v2 pool-separated: metadata [0x{:x},0x{:x}) data [0x{:x},0x{:x})",
+         pool_start, data_start, data_start, device_end);
+  } else {
+    // v1 single-pool layout: data_allocator covers everything.
+    data_allocator->init(pool_start, device_end - pool_start, block_size);
+    INFO("v1 single-pool: data [0x{:x},0x{:x})", pool_start, device_end);
+  }
   return open_ertr::now();
 }
 
@@ -162,7 +190,10 @@ BlockRBManager::read_ertr::future<> BlockRBManager::read(
 BlockRBManager::close_ertr::future<> BlockRBManager::close()
 {
   ceph_assert(device);
-  allocator->close();
+  data_allocator->close();
+  if (metadata_allocator) {
+    metadata_allocator->close();
+  }
   co_return co_await device->close();
 }
 
@@ -191,15 +222,18 @@ void BlockRBManager::prefill_fragmented_device()
 {
   LOG_PREFIX(BlockRBManager::prefill_fragmented_device);
   // the first 3 blocks must be allocated to lba root
-  // and backref root during mkfs
+  // and backref root during mkfs.
+  // This test helper only fragments the data allocator (the metadata
+  // allocator, if present, is not affected) since callers exercising the
+  // fragmented-device assertions don't currently use pool separation.
   for (size_t block = get_block_size() * 3;
       block <= get_size() - get_block_size() * 3;
       block += get_block_size() * 2) {
     DEBUG("marking {}~{} used",
-      get_start_rbm_addr() + block,
+      get_data_start_rbm_addr() + block,
       get_block_size());
-    allocator->mark_extent_used(
-      get_start_rbm_addr() + block,
+    data_allocator->mark_extent_used(
+      get_data_start_rbm_addr() + block,
       get_block_size());
   }
 }

--- a/src/crimson/os/seastore/random_block_manager/block_rb_manager.cc
+++ b/src/crimson/os/seastore/random_block_manager/block_rb_manager.cc
@@ -58,7 +58,7 @@ paddr_t BlockRBManager::alloc_extent(size_t size, data_category_t category)
           : data_allocator.get();
   auto alloc = a->alloc_extent(size);
   if (!alloc && a == metadata_allocator.get()) {
-    INFO("metadata_allocator exhausted, falling back to data_allocator");
+    DEBUG("metadata_allocator exhausted, falling back to data_allocator");
     a = data_allocator.get();
     alloc = a->alloc_extent(size);
   }
@@ -87,7 +87,7 @@ BlockRBManager::alloc_extents(size_t size, data_category_t category)
           : data_allocator.get();
   auto alloc = a->alloc_extents(size);
   if (!alloc && a == metadata_allocator.get()) {
-    INFO("metadata_allocator exhausted, falling back to data_allocator");
+    DEBUG("metadata_allocator exhausted, falling back to data_allocator");
     a = data_allocator.get();
     alloc = a->alloc_extents(size);
   }
@@ -237,7 +237,7 @@ void BlockRBManager::prefill_fragmented_device()
   // allocator, if present, is not affected) since callers exercising the
   // fragmented-device assertions don't currently use pool separation.
   for (size_t block = get_block_size() * 3;
-      block <= get_size() - get_block_size() * 3;
+      block <= get_data_size() - get_block_size() * 3;
       block += get_block_size() * 2) {
     DEBUG("marking {}~{} used",
       get_data_start_rbm_addr() + block,

--- a/src/crimson/os/seastore/random_block_manager/block_rb_manager.h
+++ b/src/crimson/os/seastore/random_block_manager/block_rb_manager.h
@@ -87,6 +87,15 @@ public:
   size_t get_data_size() const {
     return device->get_shard_end() - get_data_start_rbm_addr();
   }
+  size_t get_data_pool_available() const override {
+    return data_allocator->get_available_size();
+  }
+  size_t get_metadata_pool_size() const override {
+    return metadata_allocator ? get_metadata_size() : 0;
+  }
+  size_t get_metadata_pool_available() const override {
+    return metadata_allocator ? metadata_allocator->get_available_size() : 0;
+  }
   size_t get_metadata_size() const {
     return device->get_metadata_size();
   }

--- a/src/crimson/os/seastore/random_block_manager/block_rb_manager.h
+++ b/src/crimson/os/seastore/random_block_manager/block_rb_manager.h
@@ -55,24 +55,48 @@ public:
    * To do so, alloc_extent() looks into both in-memory allocator
    * and freebitmap blocks.
    *
+   * On v2 (pool-separated) devices, routes the request to the metadata or
+   * data allocator based on `category`. On v1 single-pool devices (or v2
+   * devices configured with metadata_size==0) the data allocator backs
+   * both categories.
    */
-  paddr_t alloc_extent(size_t size) override; // allocator, return blocks
+  paddr_t alloc_extent(
+      size_t size,
+      data_category_t category = data_category_t::DATA) override;
 
-  allocate_ret_bare alloc_extents(size_t size) override; // allocator, return blocks
+  allocate_ret_bare alloc_extents(
+      size_t size,
+      data_category_t category = data_category_t::DATA) override;
 
   void complete_allocation(paddr_t addr, size_t size) override;
 
+  // Address of the first byte past the journal — start of the metadata
+  // pool on v2 devices, or start of the (single) data pool on v1.
   size_t get_start_rbm_addr() const {
     return device->get_shard_journal_start() + device->get_journal_size();
   }
+  // Start of the data pool. On v1 (metadata_size==0) this equals
+  // get_start_rbm_addr(); on v2 it's after the metadata region.
+  size_t get_data_start_rbm_addr() const {
+    return get_start_rbm_addr() + device->get_metadata_size();
+  }
+  // Total size of the data + metadata region (excluding the journal).
   size_t get_size() const override {
     return device->get_shard_end() - get_start_rbm_addr();
   };
+  size_t get_data_size() const {
+    return device->get_shard_end() - get_data_start_rbm_addr();
+  }
+  size_t get_metadata_size() const {
+    return device->get_metadata_size();
+  }
   extent_len_t get_block_size() const override { return device->get_block_size(); }
 
   BlockRBManager(RBMDevice * device, std::string path, bool detailed)
-    : device(device), path(path) {
-    allocator.reset(new AvlAllocator(detailed));
+    : device(device), path(path), detailed(detailed) {
+    data_allocator.reset(new AvlAllocator(detailed));
+    // metadata_allocator is constructed lazily in open() iff the device
+    // has a non-zero metadata region (v2 layout). On v1 it stays null.
   }
 
   write_ertr::future<> write(rbm_abs_addr addr, bufferlist &bl);
@@ -94,20 +118,33 @@ public:
     return device;
   }
 
+  // Route a paddr to the allocator that owns the underlying physical
+  // range. On v2 devices, addresses below get_data_start_rbm_addr() belong
+  // to the metadata allocator; the rest to the data allocator. On v1
+  // (metadata_allocator == null) everything goes to the data allocator.
+  ExtentAllocator *allocator_for(rbm_abs_addr addr) const {
+    if (metadata_allocator && addr < get_data_start_rbm_addr()) {
+      return metadata_allocator.get();
+    }
+    return data_allocator.get();
+  }
+
   void mark_space_used(paddr_t paddr, size_t len) override {
-    assert(allocator);
     rbm_abs_addr addr = convert_paddr_to_abs_addr(paddr);
     assert(addr >= get_start_rbm_addr() &&
 	   addr + len <= device->get_shard_end());
-    allocator->mark_extent_used(addr, len);
+    auto *a = allocator_for(addr);
+    assert(a);
+    a->mark_extent_used(addr, len);
   }
 
   void mark_space_free(paddr_t paddr, size_t len) override {
-    assert(allocator);
     rbm_abs_addr addr = convert_paddr_to_abs_addr(paddr);
     assert(addr >= get_start_rbm_addr() &&
 	   addr + len <= device->get_shard_end());
-    allocator->free_extent(addr, len);
+    auto *a = allocator_for(addr);
+    assert(a);
+    a->free_extent(addr, len);
   }
 
   paddr_t get_start() override {
@@ -117,11 +154,12 @@ public:
   }
 
   rbm_extent_state_t get_extent_state(paddr_t paddr, size_t size) override {
-    assert(allocator);
     rbm_abs_addr addr = convert_paddr_to_abs_addr(paddr);
     assert(addr >= get_start_rbm_addr() &&
 	   addr + size <= device->get_shard_end());
-    return allocator->get_extent_state(addr, size);
+    auto *a = allocator_for(addr);
+    assert(a);
+    return a->get_extent_state(addr, size);
   }
 
   size_t get_journal_size() const override {
@@ -136,12 +174,17 @@ public:
 
 private:
   /*
-   * this contains the number of bitmap blocks, free blocks and
-   * rbm specific information
+   * Allocators. data_allocator covers the data pool (the trailing portion
+   * of the device past the journal and the metadata region). On v2 devices
+   * with a non-zero metadata region, metadata_allocator covers
+   * [get_start_rbm_addr(), get_data_start_rbm_addr()); on v1 devices it is
+   * null and the data_allocator covers the entire post-journal range.
    */
-  ExtentAllocatorRef allocator;
+  ExtentAllocatorRef data_allocator;
+  ExtentAllocatorRef metadata_allocator;
   RBMDevice * device;
   std::string path;
+  bool detailed;
   int stream_id; // for multi-stream
 };
 using BlockRBManagerRef = std::unique_ptr<BlockRBManager>;

--- a/src/crimson/os/seastore/random_block_manager/nvme_block_device.cc
+++ b/src/crimson/os/seastore/random_block_manager/nvme_block_device.cc
@@ -44,7 +44,8 @@ NVMeBlockDevice::mkfs_ret NVMeBlockDevice::mkfs(device_config_t config) {
   using crimson::common::get_conf;
   co_await shard_devices.local().mshard_devices[0]->do_primary_mkfs(config,
     seastar::smp::count,
-    get_conf<Option::size_t>("seastore_cbjournal_size") 
+    get_conf<Option::size_t>("seastore_cbjournal_size"),
+    get_conf<std::string>("seastore_rbm_metadata_size")
   );
 }
 

--- a/src/crimson/os/seastore/random_block_manager/rbm_device.cc
+++ b/src/crimson/os/seastore/random_block_manager/rbm_device.cc
@@ -5,6 +5,7 @@
 #include <string.h>
 
 #include <fcntl.h>
+#include <algorithm>
 
 #include "crimson/common/log.h"
 #include "crimson/common/errorator-utils.h"
@@ -19,8 +20,57 @@ SET_SUBSYS(seastore_device);
 
 namespace crimson::os::seastore::random_block_device {
 
+size_t RBMDevice::parse_rbm_metadata_size(std::string str, size_t base_size) {
+  str.erase(std::remove_if(str.begin(), str.end(), ::isspace), str.end());
+  if (str == "0" || str.empty()) {
+    return 0;
+  }
+  try {
+    if (str.back() == '%') {
+      str.pop_back();
+      size_t pos = 0;
+      double percent = std::stod(str, &pos);
+      if (pos != str.size()) {
+        throw std::invalid_argument("trailing characters after percentage");
+      }
+      return static_cast<size_t>((percent / 100.0) * base_size);
+    }
+    uint64_t multiplier = 1;
+    if (!str.empty() && (str.back() == 'B' || str.back() == 'b')) {
+      str.pop_back();
+    }
+    if (!str.empty() && (str.back() == 'i' || str.back() == 'I')) {
+      str.pop_back();
+    }
+    if (!str.empty()) {
+      char suffix = std::tolower(str.back());
+      if (suffix == 'k') {
+        multiplier = 1ULL << 10;
+        str.pop_back();
+      } else if (suffix == 'm') {
+        multiplier = 1ULL << 20;
+        str.pop_back();
+      } else if (suffix == 'g') {
+        multiplier = 1ULL << 30;
+        str.pop_back();
+      } else if (suffix == 't') {
+        multiplier = 1ULL << 40;
+        str.pop_back();
+      }
+    }
+    size_t pos = 0;
+    double val = std::stod(str, &pos);
+    if (pos != str.size()) {
+      throw std::invalid_argument("trailing characters");
+    }
+    return static_cast<size_t>(val * multiplier);
+  } catch (const std::exception& e) {
+    ceph_abort_msgf("Invalid seastore_rbm_metadata_size config value: %s", str.c_str());
+  }
+}
+
 RBMDevice::mkfs_ret RBMDevice::do_primary_mkfs(device_config_t config,
-  int shard_num, size_t journal_size) {
+  int shard_num, size_t journal_size, const std::string& metadata_size_str) {
   LOG_PREFIX(RBMDevice::do_primary_mkfs);
   check_create_device_ret maybe_create = check_create_device_ertr::now();
   using crimson::common::get_conf;
@@ -54,11 +104,18 @@ RBMDevice::mkfs_ret RBMDevice::do_primary_mkfs(device_config_t config,
     (cur_total_size / shard_num) -
     ((cur_total_size / shard_num) % cur_block_size);
 
+  // Align the metadata region to block_size so the allocator's block-aligned
+  // invariant holds for both the metadata and data pools.
+  size_t metadata_size = parse_rbm_metadata_size(metadata_size_str, aligned_size - journal_size);
+  size_t aligned_metadata_size =
+      (metadata_size / cur_block_size) * cur_block_size;
+  ceph_assert_always(aligned_size > journal_size + aligned_metadata_size);
+
   std::vector<device_shard_info_t> shard_infos(shard_num);
   for (int i = 0; i < shard_num; i++) {
     shard_infos[i].size = aligned_size;
     shard_infos[i].start_offset = i * aligned_size;
-    assert(shard_infos[i].size > journal_size);
+    assert(shard_infos[i].size > journal_size + aligned_metadata_size);
   }
   shard_info = shard_infos[seastar::this_shard_id()];
   super = device_superblock_t::make_rbm(
@@ -66,6 +123,7 @@ RBMDevice::mkfs_ret RBMDevice::do_primary_mkfs(device_config_t config,
     cur_block_size,
     cur_total_size,
     journal_size,
+    aligned_metadata_size,
     std::move(config),
     std::move(shard_infos));
   DEBUG("super {} ", super);
@@ -359,7 +417,10 @@ EphemeralRBMDevice::mount_ret EphemeralRBMDevice::mount() {
 }
 
 EphemeralRBMDevice::mkfs_ret EphemeralRBMDevice::mkfs(device_config_t config) {
-  return do_primary_mkfs(config, seastar::smp::count, DEFAULT_TEST_CBJOURNAL_SIZE);
+  using crimson::common::get_conf;
+  return do_primary_mkfs(config, seastar::smp::count,
+                         DEFAULT_TEST_CBJOURNAL_SIZE,
+                         get_conf<std::string>("seastore_rbm_metadata_size"));
 }
 
 }

--- a/src/crimson/os/seastore/random_block_manager/rbm_device.cc
+++ b/src/crimson/os/seastore/random_block_manager/rbm_device.cc
@@ -21,7 +21,8 @@ SET_SUBSYS(seastore_device);
 namespace crimson::os::seastore::random_block_device {
 
 size_t RBMDevice::parse_rbm_metadata_size(std::string str, size_t base_size) {
-  str.erase(std::remove_if(str.begin(), str.end(), ::isspace), str.end());
+  const std::string original_str = str;
+  str.erase(std::remove_if(str.begin(), str.end(), [](unsigned char c) { return std::isspace(c); }), str.end());
   if (str == "0" || str.empty()) {
     return 0;
   }
@@ -33,6 +34,9 @@ size_t RBMDevice::parse_rbm_metadata_size(std::string str, size_t base_size) {
       if (pos != str.size()) {
         throw std::invalid_argument("trailing characters after percentage");
       }
+      if (percent < 0.0 || !std::isfinite(percent)) {
+        throw std::invalid_argument("percentage must be a finite non-negative number");
+      }
       return static_cast<size_t>((percent / 100.0) * base_size);
     }
     uint64_t multiplier = 1;
@@ -43,7 +47,7 @@ size_t RBMDevice::parse_rbm_metadata_size(std::string str, size_t base_size) {
       str.pop_back();
     }
     if (!str.empty()) {
-      char suffix = std::tolower(str.back());
+      char suffix = std::tolower(static_cast<unsigned char>(str.back()));
       if (suffix == 'k') {
         multiplier = 1ULL << 10;
         str.pop_back();
@@ -63,9 +67,12 @@ size_t RBMDevice::parse_rbm_metadata_size(std::string str, size_t base_size) {
     if (pos != str.size()) {
       throw std::invalid_argument("trailing characters");
     }
+    if (val < 0.0 || !std::isfinite(val)) {
+      throw std::invalid_argument("value must be a finite non-negative number");
+    }
     return static_cast<size_t>(val * multiplier);
   } catch (const std::exception& e) {
-    ceph_abort_msgf("Invalid seastore_rbm_metadata_size config value: %s", str.c_str());
+    ceph_abort_msgf("Invalid seastore_rbm_metadata_size config value: %s (%s)", original_str.c_str(), e.what());
   }
 }
 
@@ -104,11 +111,15 @@ RBMDevice::mkfs_ret RBMDevice::do_primary_mkfs(device_config_t config,
     (cur_total_size / shard_num) -
     ((cur_total_size / shard_num) % cur_block_size);
 
+  if (aligned_size <= journal_size) {
+    ceph_abort_msgf("aligned shard size (%zu) must be greater than journal size (%zu)", aligned_size, journal_size);
+  }
+
   // Align the metadata region to block_size so the allocator's block-aligned
   // invariant holds for both the metadata and data pools.
   size_t metadata_size = parse_rbm_metadata_size(metadata_size_str, aligned_size - journal_size);
   size_t aligned_metadata_size =
-      (metadata_size / cur_block_size) * cur_block_size;
+      ((metadata_size + cur_block_size - 1) / cur_block_size) * cur_block_size;
   ceph_assert_always(aligned_size > journal_size + aligned_metadata_size);
 
   std::vector<device_shard_info_t> shard_infos(shard_num);

--- a/src/crimson/os/seastore/random_block_manager/rbm_device.h
+++ b/src/crimson/os/seastore/random_block_manager/rbm_device.h
@@ -170,8 +170,10 @@ public:
 
   mkfs_ret do_mkfs(device_config_t);
 
-  // shard 0 mkfs
-  mkfs_ret do_primary_mkfs(device_config_t, int shard_num, size_t journal_size);
+  mkfs_ret do_primary_mkfs(device_config_t, int shard_num,
+                           size_t journal_size, const std::string& metadata_size);
+
+  static size_t parse_rbm_metadata_size(std::string str, size_t base_size);
 
   mount_ret do_mount();
 
@@ -189,6 +191,10 @@ public:
 
   uint64_t get_journal_size() const {
     return super.journal_size;
+  }
+
+  uint64_t get_metadata_size() const {
+    return super.metadata_size;
   }
 
   static rbm_abs_addr get_shard_reserved_size() {

--- a/src/test/crimson/seastore/test_randomblock_manager.cc
+++ b/src/test/crimson/seastore/test_randomblock_manager.cc
@@ -180,3 +180,21 @@ TEST_F(rbm_test_t, open_read_write_test)
  });
 }
 
+TEST(rbm_device_test, parse_metadata_size)
+{
+  using namespace crimson::os::seastore::random_block_device;
+  size_t base = 100000000;
+  ASSERT_EQ(RBMDevice::parse_rbm_metadata_size("0", base), 0);
+  ASSERT_EQ(RBMDevice::parse_rbm_metadata_size("", base), 0);
+  ASSERT_EQ(RBMDevice::parse_rbm_metadata_size("1.5%", base), 1500000);
+  ASSERT_EQ(RBMDevice::parse_rbm_metadata_size("0%", base), 0);
+  ASSERT_EQ(RBMDevice::parse_rbm_metadata_size("10G", base), 10ULL << 30);
+  ASSERT_EQ(RBMDevice::parse_rbm_metadata_size("10GB", base), 10ULL << 30);
+  ASSERT_EQ(RBMDevice::parse_rbm_metadata_size("10GiB", base), 10ULL << 30);
+  ASSERT_EQ(RBMDevice::parse_rbm_metadata_size(" 10 g ", base), 10ULL << 30);
+  ASSERT_EQ(RBMDevice::parse_rbm_metadata_size("500M", base), 500ULL << 20);
+  ASSERT_EQ(RBMDevice::parse_rbm_metadata_size("256k", base), 256ULL << 10);
+  ASSERT_EQ(RBMDevice::parse_rbm_metadata_size("1T", base), 1ULL << 40);
+  ASSERT_EQ(RBMDevice::parse_rbm_metadata_size("4096", base), 4096);
+  ASSERT_EQ(RBMDevice::parse_rbm_metadata_size("4096B", base), 4096);
+}


### PR DESCRIPTION
> [!IMPORTANT]
> Frozen / draft. On hold pending a detailed design review and evaluating alternative approach. A rework as an adaptive metadata pool (grows on demand based on observed metadata pressure, starts at 0) is the more promising path forward. See the comments below for the test data.

---

> [!NOTE]
> Depends on PR #69153 (`crimson/os/seastore: enforce capacity in RBMCleaner::try_reserve_projected_usage`).
> To view only the changes unique to this PR, see the [fultheim/ceph comparison diff](https://github.com/fultheim/ceph/compare/rbm-capacity-enforcement...rbm-pool-separation).

## Description
Currently, Seastore's Random Block Manager (RBM) interleaves object data and metadata blocks (LBA tree, backref tree, onode tree, etc.) using the same allocator in the data area. This results in:
1. **Safety Issues**: Running the cleaner over a paddr range in the data area can race with concurrent updates to metadata trees, leading to checksum mismatches (e.g. `FixedKVBtree::get_leaf_node` crashes).
2. **Fragmentation**: Scattered 4 KiB metadata blocks split free space, preventing 1 MiB write allocations from finding contiguous space, which severely inflates WAF.

This PR implements **metadata/data pool separation (v2 layout)**:
- Carves a dedicated metadata region between the journal and the data area during `mkfs`:
  `[ Journal | Metadata Region | Data Region ]`
- Bumps the device superblock to v2 (backward compatible with v1 devices, which default to single-pool).
- Separates allocator routing: `alloc_extent`/`alloc_extents` propagate the `data_category_t` to route allocations to the `metadata_allocator` or `data_allocator`.
- Enables pool separation by default for RBM formats, sizing the metadata region at `1.5%` of the data area (worst-case requirement for all-4K user data workloads).
- Implements a fallback: if the metadata pool is exhausted, it falls back to allocating metadata extents from the data pool, and updates `RBMCleaner::should_block_io_on_clean` to check the combined space of both pools to prevent premature IO blocking.

In benchmarks (8-job 1 MiB random-write, 90 GiB RBM), adding pool separation reduced WAF from `1.696` to `1.118` and increased user throughput by 3.3x before stalling.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [ ] No tests