### PR TITLE
monitoring/ceph-mixin: bump jsonnet-bundler to v0.6.0

### DIFF
--- a/monitoring/ceph-mixin/jsonnet-bundler-build.sh
+++ b/monitoring/ceph-mixin/jsonnet-bundler-build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -ex
 
-JSONNET_VERSION="v0.4.0"
+JSONNET_VERSION="v0.6.0"
 OUTPUT_DIR=${1:-$(pwd)}
 
 git clone -b ${JSONNET_VERSION} --depth 1 https://github.com/jsonnet-bundler/jsonnet-bundler

--- a/monitoring/ceph-mixin/jsonnet-bundler-build.sh
+++ b/monitoring/ceph-mixin/jsonnet-bundler-build.sh
@@ -3,6 +3,8 @@
 JSONNET_VERSION="v0.6.0"
 OUTPUT_DIR=${1:-$(pwd)}
 
+# clean up leftovers from an aborted run so the clone stays idempotent
+rm -rf jsonnet-bundler
 git clone -b ${JSONNET_VERSION} --depth 1 https://github.com/jsonnet-bundler/jsonnet-bundler
 make -C jsonnet-bundler  build
 mv jsonnet-bundler/_output/jb ${OUTPUT_DIR}


### PR DESCRIPTION
Bump jsonnet-bundler from v0.4.0 (2020) to the latest release v0.6.0 (2024).
changes in between:

- Dependency updates and various bug fixes (Windows paths, nested local dependencies)

This also fixes the build on riscv64: v0.4.0 pins a 2019 `golang.org/x/sys`
that predates riscv64 support for the standard Go compiler, failing with
`golang.org/x/sys/unix: missing function body`. Fixed since v0.5.1 by the
dependency refresh

Built and tested on a riscv64 machine (sg2044).

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests