### PR TITLE
test/mds: don't drop await_idle_v under NDEBUG

### DIFF
--- a/src/test/mds/TestQuiesceAgent.cc
+++ b/src/test/mds/TestQuiesceAgent.cc
@@ -192,7 +192,7 @@ class QuiesceAgentTest : public testing::Test {
       if (WaitForAgent::No == wait) {
         return std::nullopt;
       } else {
-        assert(await_idle_v(v.set_version));
+        EXPECT_TRUE(await_idle_v(v.set_version));
         return async_ack;
       }
     }


### PR DESCRIPTION
await_idle_v() is wrapped in assert(), so with NDEBUG it is never
called and the test reads a default-constructed ack, racing the agent
thread. Use EXPECT_TRUE() like the rest of the file.

On riscv64 (sg2044) this fails deterministically: 4 of 7 sub-tests
(DbUpdates / QuiesceProtocol / DuplicateQuiesceRequest /
TimeoutBeforeComplete) report ack->db_version == (0:0). On faster x86
the agent thread probably usually wins the race, so it goes unnoticed there.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests