### PR TITLE
tentacle: osd/scrub: 'repairing' scrubs allowed at all times

### DIFF
--- a/src/osd/scrubber/scrub_job.cc
+++ b/src/osd/scrubber/scrub_job.cc
@@ -371,7 +371,7 @@ bool ScrubJob::observes_noscrub_flags(urgency_t urgency)
 
 bool ScrubJob::observes_allowed_hours(urgency_t urgency)
 {
-  return urgency < urgency_t::operator_requested;
+  return urgency < urgency_t::repairing;
 }
 
 bool ScrubJob::observes_extended_sleep(urgency_t urgency)

--- a/src/osd/scrubber/scrub_job.h
+++ b/src/osd/scrubber/scrub_job.h
@@ -307,8 +307,6 @@ class ScrubJob {
  * Some types of scrubs are exempt from some or all of the preconditions and
  * limitations that apply to regular scrubs. The following table
  * details the specific set of exemptions per 'urgency' level:
- * (note: regular scrubs that are overdue are also allowed a specific
- * set of exemptions. Those will be covered elsewhere).
  *
  * The relevant limitations are:
  * - reservation: the scrub must reserve replicas;

--- a/src/osd/scrubber/scrub_job.h
+++ b/src/osd/scrubber/scrub_job.h
@@ -336,8 +336,8 @@ class ScrubJob {
  *  | limitation |  must-  | after-repair |repairing| operator | must-repair |
  *  |            |  scrub  |(aft recovery)|(errors) | request  |             |
  *  +------------+---------+--------------+---------+----------+-------------+
- *  | reservation|    yes! |      no      |    no?  |     no   |      no     |
- *  | dow/time   |    yes  |     yes      |    no   |     no   |      no     |
+ *  | reservation|    yes  |      no      |    no   |     no   |      no     |
+ *  | dow/time   |    yes  |      yes     |    no   |     no   |      no     |
  *  | ext-sleep  |    no   |      no      |    no   |     no   |      no     |
  *  | load       |    yes  |      no      |    no   |     no   |      no     |
  *  | noscrub    |    yes  |      no      |    Yes  |     no   |      no     |


### PR DESCRIPTION
Fix ScrubJob::observes_allowed_hours() to not block 'repairing' scrubs outside of the allowed hours. This allows repair scrubs to run at any time or day-of-week.
The fixed behaviour matches the documented requirements.

Backport of https://github.com/ceph/ceph/pull/69110;
Fixes: xxx
Original tracker: https://tracker.ceph.com/issues/76811