### PR TITLE
tentacle: osd: Fix bug when calculating min_peer_features

### DIFF
--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -7427,7 +7427,10 @@ void PeeringState::GetInfo::get_infos()
       continue;
     }
     if (ps->peer_info.count(peer)) {
-      psdout(10) << " have osd." << peer << " info " << ps->peer_info[peer] << dendl;
+      uint64_t f = ps->get_osdmap()->get_xinfo(peer.osd).features;
+      psdout(10) << " have osd." << peer << " info " << ps->peer_info[peer]
+                 << " peer features: " << hex << f << dec << dendl;
+      ps->apply_peer_features(f);
       continue;
     }
     if (peer_info_requested.count(peer)) {


### PR DESCRIPTION
PeeringState calculates the minimum set of features for the set of OSDs within a PG. There is a bug when the peer info has already been cached where these peers features are not included in the calculation. This can lead to the min feature set including features that not all OSDs have.

Previously this just made some asserts less aggressive than they should have been. Pull request https://github.com/ceph/ceph/pull/57740 uses min_peer_features to decide how to encode messages to other OSDs.

Midway through an upgrade this bug can cause an OSD to send the wrong version of a message to a downlevel OSD causing it to abort.

---

backport tracker: https://tracker.ceph.com/issues/76987

---

backport of https://github.com/ceph/ceph/pull/68936
parent tracker: https://tracker.ceph.com/issues/76600

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh