### PR TITLE
cephadm/tests: mock find_program in test_container_engine

### DIFF
--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -2282,10 +2282,11 @@ exec /usr/bin/docker run --rm --ipc=host --stop-signal=SIGTERM --ulimit nofile=1
 
 class TestCheckHost:
 
+    @mock.patch('cephadm.find_program', return_value='foo')
     @mock.patch('cephadm.find_executable', return_value='foo')
     @mock.patch('cephadm.check_time_sync', return_value=True)
     @mock.patch('cephadm.logger')
-    def test_container_engine(self, _logger, _find_executable, _check_time_sync):
+    def test_container_engine(self, _logger, _find_executable, _check_time_sync, _find_program):
         ctx = _cephadm.CephadmContext()
 
         ctx.container_engine = None


### PR DESCRIPTION
test_container_engine mocks find_executable to keep command_check_host
off the real host, but command_check_host looks up 'lvcreate' (and
'systemctl') through find_program, which isn't mocked. So the test
actually needs lvcreate installed and only passes where it is.

Mock find_program too so the test doesn't depend on host binaries.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests