### PR TITLE
crimson/os/seastore: fix roll_segment continuation-inline race

### DIFF
--- a/src/crimson/os/seastore/journal/record_submitter.cc
+++ b/src/crimson/os/seastore/journal/record_submitter.cc
@@ -258,6 +258,9 @@ RecordSubmitter::roll_segment()
       wait_available_promise.reset();
       return roll_segment_ertr::now();
     } else {
+      // roll() can resolve inline and reset wait_available_promise before the
+      // next line runs, so grab the future while the promise is still set.
+      auto wait_fut = wait_available();
       // start rolling in background
       std::ignore = journal_allocator.roll(
       ).safe_then([FNAME, this] {
@@ -281,7 +284,7 @@ RecordSubmitter::roll_segment()
         wait_available_promise.reset();
       });
       // wait for background rolling
-      return wait_available();
+      return wait_fut;
     }
   });
 }


### PR DESCRIPTION
roll_segment() starts journal_allocator.roll() in the background and
then calls wait_available(), which does
wait_available_promise->get_shared_future(). In the circular journal
path roll() is all in-memory and returns an already-ready future, so
its safe_then continuation can run inline and reset the promise before
wait_available() gets to it -- get_shared_future() then derefs an empty
optional and aborts.

Take the future before starting the roll. It owns the shared state, so
the later set_value()/reset() are fine whether the continuation runs
inline or later.

On riscv64 (sg2044) it runs inline, and unittest-seastore-cbjournal
aborts 100% of the time ~10s in, right after the first "rolling done,
available" message, with

```
  optional<shared_promise<>>::operator->(): Assertion
  'this->_M_is_engaged()' failed.
```

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests