### PR TITLE
cmake/AddCephTest: use namespaced Catch2 imported targets

### DIFF
--- a/cmake/modules/AddCephTest.cmake
+++ b/cmake/modules/AddCephTest.cmake
@@ -183,9 +183,9 @@ if(DEFINED catch2_opt_EXTRA_INCS)
 endif()
 
 if(${catch2_opt_NO_CATCH2_MAIN})
-  LIST(APPEND tl_libs Catch2)
+  LIST(APPEND tl_libs Catch2::Catch2)
 else()
-  LIST(APPEND tl_libs Catch2WithMain)
+  LIST(APPEND tl_libs Catch2::Catch2WithMain)
 endif()
 
 target_link_libraries(unittest_${test_name} 


### PR DESCRIPTION
AddCephTest.cmake links the bare target names Catch2 / Catch2WithMain.
With WITH_SYSTEM_CATCH2=ON, CPM resolves Catch2 via find_package(),
which only exports the namespaced IMPORTED targets Catch2::Catch2 /
Catch2::Catch2WithMain. CMake then treats the bare names as plain
library names and the link fails with -lCatch2WithMain, since the
physical library is named libCatch2Main (OUTPUT_NAME "Catch2Main").

Use the namespaced names. Catch2 exports them as ALIASes in the bundled
(CPM subproject) build too, so the default path keeps working.

Reproduced on openRuyi riscv64 (sg2044) building against the system
Catch2-devel (WITH_SYSTEM_CATCH2=ON): the link fails with
`/usr/bin/ld.bfd: cannot find -lCatch2WithMain`. 

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests