### PR TITLE
cephadm: cephadm: omit --osd-type classic for older ceph-volume

### DIFF
--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -1169,7 +1169,7 @@ class TestCephadm(object):
             _run_cephadm.assert_any_call(
                 'test', 'osd', 'ceph-volume',
                 ['--config-json', '-', '--', 'lvm', 'batch',
-                    '--no-auto', '/dev/sdb', '--objectstore', 'bluestore', '--osd-type', 'classic',
+                    '--no-auto', '/dev/sdb', '--objectstore', 'bluestore',
                     '--yes', '--no-systemd'],
                 env_vars=['CEPH_VOLUME_OSDSPEC_AFFINITY=foo'], error_ok=True,
                 stdin='{"config": "", "keyring": ""}')
@@ -1216,7 +1216,7 @@ class TestCephadm(object):
                 'test', 'osd', 'ceph-volume',
                 ['--config-json', '-', '--', 'lvm', 'batch',
                     '--no-auto', '/dev/sdb', '--db-devices', '/dev/sdc',
-                    '--wal-devices', '/dev/sdd', '--objectstore', 'bluestore', '--osd-type', 'classic',
+                    '--wal-devices', '/dev/sdd', '--objectstore', 'bluestore',
                     '--yes', '--no-systemd'],
                 env_vars=['CEPH_VOLUME_OSDSPEC_AFFINITY=noncollocated'],
                 error_ok=True, stdin='{"config": "", "keyring": ""}',
@@ -1416,15 +1416,15 @@ class TestCephadm(object):
         "devices, preview, exp_commands",
         [
             # no preview and only one disk, prepare is used due the hack that is in place.
-            (['/dev/sda'], False, ["lvm batch --no-auto /dev/sda --objectstore bluestore --osd-type classic --yes --no-systemd"]),
+            (['/dev/sda'], False, ["lvm batch --no-auto /dev/sda --objectstore bluestore --yes --no-systemd"]),
             # no preview and multiple disks, uses batch
             (['/dev/sda', '/dev/sdb'], False,
-             ["CEPH_VOLUME_OSDSPEC_AFFINITY=test.spec lvm batch --no-auto /dev/sda /dev/sdb --objectstore bluestore --osd-type classic --yes --no-systemd"]),
+             ["CEPH_VOLUME_OSDSPEC_AFFINITY=test.spec lvm batch --no-auto /dev/sda /dev/sdb --objectstore bluestore --yes --no-systemd"]),
             # preview and only one disk needs to use batch again to generate the preview
-            (['/dev/sda'], True, ["lvm batch --no-auto /dev/sda --objectstore bluestore --osd-type classic --yes --no-systemd --report --format json"]),
+            (['/dev/sda'], True, ["lvm batch --no-auto /dev/sda --objectstore bluestore --yes --no-systemd --report --format json"]),
             # preview and multiple disks work the same
             (['/dev/sda', '/dev/sdb'], True,
-             ["CEPH_VOLUME_OSDSPEC_AFFINITY=test.spec lvm batch --no-auto /dev/sda /dev/sdb --objectstore bluestore --osd-type classic --yes --no-systemd --report --format json"]),
+             ["CEPH_VOLUME_OSDSPEC_AFFINITY=test.spec lvm batch --no-auto /dev/sda /dev/sdb --objectstore bluestore --yes --no-systemd --report --format json"]),
         ]
     )
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
@@ -1484,15 +1484,15 @@ class TestCephadm(object):
         "devices, preview, exp_commands",
         [
             # one data device, no preview
-            (['/dev/sda'], False, ["raw prepare --bluestore --data /dev/sda --osd-type classic"]),
+            (['/dev/sda'], False, ["raw prepare --bluestore --data /dev/sda"]),
             # multiple data devices, no preview
             (['/dev/sda', '/dev/sdb'], False,
-             ["raw prepare --bluestore --data /dev/sda --osd-type classic", "raw prepare --bluestore --data /dev/sdb --osd-type classic"]),
+             ["raw prepare --bluestore --data /dev/sda", "raw prepare --bluestore --data /dev/sdb"]),
             # one data device, preview
-            (['/dev/sda'], True, ["raw prepare --bluestore --data /dev/sda --osd-type classic --report --format json"]),
+            (['/dev/sda'], True, ["raw prepare --bluestore --data /dev/sda --report --format json"]),
             # multiple data devices, preview
             (['/dev/sda', '/dev/sdb'], True,
-             ["raw prepare --bluestore --data /dev/sda --osd-type classic --report --format json", "raw prepare --bluestore --data /dev/sdb --osd-type classic --report --format json"]),
+             ["raw prepare --bluestore --data /dev/sda --report --format json", "raw prepare --bluestore --data /dev/sdb --report --format json"]),
         ]
     )
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))

--- a/src/python-common/ceph/deployment/translate.py
+++ b/src/python-common/ceph/deployment/translate.py
@@ -140,7 +140,8 @@ class to_ceph_volume(object):
         for i in range(len(cmds)):
             if self.spec.osd_type:
                 osd_type_str = getattr(self.spec.osd_type, 'value', self.spec.osd_type)
-                cmds[i] += " --osd-type {}".format(osd_type_str)
+                if osd_type_str != 'classic':
+                    cmds[i] += " --osd-type {}".format(osd_type_str)
 
             if self.spec.encrypted:
                 cmds[i] += " --dmcrypt"

--- a/src/python-common/ceph/tests/test_drive_group.py
+++ b/src/python-common/ceph/tests/test_drive_group.py
@@ -163,7 +163,7 @@ def test_ceph_volume_command_0():
     inventory = _mk_inventory(_mk_device()*2)
     sel = drive_selection.DriveSelection(spec, inventory)
     cmds = translate.to_ceph_volume(sel, []).run()
-    assert all(cmd == 'lvm batch --no-auto /dev/sda /dev/sdb --objectstore bluestore --osd-type classic --yes --no-systemd' for cmd in cmds), f'Expected {cmd} in {cmds}'
+    assert all(cmd == 'lvm batch --no-auto /dev/sda /dev/sdb --objectstore bluestore --yes --no-systemd' for cmd in cmds), f'Expected {cmd} in {cmds}'
 
 
 def test_ceph_volume_command_1():
@@ -177,7 +177,7 @@ def test_ceph_volume_command_1():
     sel = drive_selection.DriveSelection(spec, inventory)
     cmds = translate.to_ceph_volume(sel, []).run()
     assert all(cmd == ('lvm batch --no-auto /dev/sda /dev/sdb '
-                   '--db-devices /dev/sdc /dev/sdd --objectstore bluestore --osd-type classic --yes --no-systemd') for cmd in cmds), f'Expected {cmd} in {cmds}'
+                   '--db-devices /dev/sdc /dev/sdd --objectstore bluestore --yes --no-systemd') for cmd in cmds), f'Expected {cmd} in {cmds}'
 
 
 def test_ceph_volume_command_2():
@@ -196,7 +196,7 @@ def test_ceph_volume_command_2():
     cmds = translate.to_ceph_volume(sel, []).run()
     assert all(cmd == ('lvm batch --no-auto /dev/sda /dev/sdb '
                    '--db-devices /dev/sdc /dev/sdd --wal-devices /dev/sde /dev/sdf --objectstore bluestore '
-                   '--osd-type classic --yes --no-systemd') for cmd in cmds), f'Expected {cmd} in {cmds}'
+                   '--yes --no-systemd') for cmd in cmds), f'Expected {cmd} in {cmds}'
 
 
 def test_ceph_volume_command_3():
@@ -216,7 +216,7 @@ def test_ceph_volume_command_3():
     cmds = translate.to_ceph_volume(sel, []).run()
     assert all(cmd == ('lvm batch --no-auto /dev/sda /dev/sdb '
                    '--db-devices /dev/sdc /dev/sdd '
-                   '--wal-devices /dev/sde /dev/sdf --objectstore bluestore --osd-type classic --dmcrypt '
+                   '--wal-devices /dev/sde /dev/sdf --objectstore bluestore --dmcrypt '
                    '--yes --no-systemd') for cmd in cmds), f'Expected {cmd} in {cmds}'
 
 
@@ -240,7 +240,7 @@ def test_ceph_volume_command_4():
     cmds = translate.to_ceph_volume(sel, []).run()
     assert all(cmd == ('lvm batch --no-auto /dev/sda /dev/sdb '
                    '--db-devices /dev/sdc /dev/sdd --wal-devices /dev/sde /dev/sdf '
-                   '--block-wal-size 500M --block-db-size 500M --objectstore bluestore --osd-type classic --dmcrypt '
+                   '--block-wal-size 500M --block-db-size 500M --objectstore bluestore --dmcrypt '
                    '--osds-per-device 3 --yes --no-systemd') for cmd in cmds), f'Expected {cmd} in {cmds}'
 
 
@@ -286,7 +286,7 @@ def test_ceph_volume_command_7():
     inventory = _mk_inventory(_mk_device(rotational=True)*2)
     sel = drive_selection.DriveSelection(spec, inventory)
     cmds = translate.to_ceph_volume(sel, ['0', '1']).run()
-    assert all(cmd == 'lvm batch --no-auto /dev/sda /dev/sdb --objectstore bluestore --osd-type classic --osd-ids 0 1 --yes --no-systemd' for cmd in cmds), f'Expected {cmd} in {cmds}'
+    assert all(cmd == 'lvm batch --no-auto /dev/sda /dev/sdb --objectstore bluestore --osd-ids 0 1 --yes --no-systemd' for cmd in cmds), f'Expected {cmd} in {cmds}'
 
 
 def test_ceph_volume_command_8():
@@ -304,7 +304,7 @@ def test_ceph_volume_command_8():
                               )
     sel = drive_selection.DriveSelection(spec, inventory)
     cmds = translate.to_ceph_volume(sel, []).run()
-    assert all(cmd == 'lvm batch --no-auto /dev/sda /dev/sdb --db-devices /dev/sdc --objectstore bluestore --osd-type classic --yes --no-systemd' for cmd in cmds), f'Expected {cmd} in {cmds}'
+    assert all(cmd == 'lvm batch --no-auto /dev/sda /dev/sdb --db-devices /dev/sdc --objectstore bluestore --yes --no-systemd' for cmd in cmds), f'Expected {cmd} in {cmds}'
 
 
 def test_ceph_volume_command_9():
@@ -317,7 +317,7 @@ def test_ceph_volume_command_9():
     inventory = _mk_inventory(_mk_device()*2)
     sel = drive_selection.DriveSelection(spec, inventory)
     cmds = translate.to_ceph_volume(sel, []).run()
-    assert all(cmd == 'lvm batch --no-auto /dev/sda /dev/sdb --objectstore bluestore --osd-type classic --data-allocate-fraction 0.8 --yes --no-systemd' for cmd in cmds), f'Expected {cmd} in {cmds}'
+    assert all(cmd == 'lvm batch --no-auto /dev/sda /dev/sdb --objectstore bluestore --data-allocate-fraction 0.8 --yes --no-systemd' for cmd in cmds), f'Expected {cmd} in {cmds}'
 
 
 @pytest.mark.parametrize("test_input_base",
@@ -340,7 +340,7 @@ def test_ceph_volume_command_10(test_input_base):
     drive = drive_selection.DriveSelection(spec, spec.data_devices.paths)
     cmds = translate.to_ceph_volume(drive, []).run()
 
-    assert all(cmd == 'lvm batch --no-auto /dev/sda --crush-device-class ssd --objectstore bluestore --osd-type classic --yes --no-systemd' for cmd in cmds), f'Expected {cmd} in {cmds}'
+    assert all(cmd == 'lvm batch --no-auto /dev/sda --crush-device-class ssd --objectstore bluestore --yes --no-systemd' for cmd in cmds), f'Expected {cmd} in {cmds}'
 
 
 @pytest.mark.parametrize("test_input1",
@@ -365,7 +365,7 @@ def test_ceph_volume_command_11(test_input1):
     spec.validate()
     drive = drive_selection.DriveSelection(spec, spec.data_devices.paths)
     cmds = translate.to_ceph_volume(drive, []).run()
-    assert all(cmd == 'lvm batch --no-auto /dev/sda /dev/sdb --crush-device-class hdd --objectstore bluestore --osd-type classic --yes --no-systemd' for cmd in cmds), f'Expected {cmd} in {cmds}'
+    assert all(cmd == 'lvm batch --no-auto /dev/sda /dev/sdb --crush-device-class hdd --objectstore bluestore --yes --no-systemd' for cmd in cmds), f'Expected {cmd} in {cmds}'
 
 
 @pytest.mark.parametrize("test_input2",
@@ -392,8 +392,8 @@ def test_ceph_volume_command_12(test_input2):
     cmds = translate.to_ceph_volume(drive, []).run()
 
     expected_cmds = [
-        'lvm batch --no-auto /dev/sdb --crush-device-class ssd --objectstore bluestore --osd-type classic --yes --no-systemd',
-        'lvm batch --no-auto /dev/sda --crush-device-class hdd --objectstore bluestore --osd-type classic --yes --no-systemd',
+        'lvm batch --no-auto /dev/sdb --crush-device-class ssd --objectstore bluestore --yes --no-systemd',
+        'lvm batch --no-auto /dev/sda --crush-device-class hdd --objectstore bluestore --yes --no-systemd',
     ]
     assert len(cmds) == len(expected_cmds), f"Expected {expected_cmds} got {cmds}"
     assert all(cmd in cmds for cmd in expected_cmds), f'Expected {expected_cmds} got {cmds}'
@@ -422,8 +422,8 @@ def test_ceph_volume_command_13(test_input3):
     cmds = translate.to_ceph_volume(drive, []).run()
 
     expected_cmds = [
-        'lvm batch --no-auto /dev/sdb --objectstore bluestore --osd-type classic --yes --no-systemd',
-        'lvm batch --no-auto /dev/sda --crush-device-class hdd --objectstore bluestore --osd-type classic --yes --no-systemd',
+        'lvm batch --no-auto /dev/sdb --objectstore bluestore --yes --no-systemd',
+        'lvm batch --no-auto /dev/sda --crush-device-class hdd --objectstore bluestore --yes --no-systemd',
     ]
     assert len(cmds) == len(expected_cmds), f"Expected {expected_cmds} got {cmds}"
     assert all(cmd in cmds for cmd in expected_cmds), f'Expected {expected_cmds} got {cmds}'
@@ -475,7 +475,7 @@ def test_raw_ceph_volume_command_0():
                               _mk_device(rotational=False) +  # db
                               _mk_device(rotational=False)  # db
                               )
-    exp_cmds = ['raw prepare --bluestore --data /dev/sda --block.db /dev/sdc --osd-type classic', 'raw prepare --bluestore --data /dev/sdb --block.db /dev/sdd --osd-type classic']
+    exp_cmds = ['raw prepare --bluestore --data /dev/sda --block.db /dev/sdc', 'raw prepare --bluestore --data /dev/sdb --block.db /dev/sdd']
     sel = drive_selection.DriveSelection(spec, inventory)
     cmds = translate.to_ceph_volume(sel, []).run()
     assert all(cmd in exp_cmds for cmd in cmds), f'Expected {exp_cmds} to match {cmds}'
@@ -528,9 +528,9 @@ def test_raw_ceph_volume_command_2(test_input5):
     drive = drive_selection.DriveSelection(spec, spec.data_devices.paths)
     cmds = translate.to_ceph_volume(drive, []).run()
 
-    assert cmds[0] == 'raw prepare --bluestore --data /dev/sda --block.db /dev/sdd --crush-device-class hdd --osd-type classic'
-    assert cmds[1] == 'raw prepare --bluestore --data /dev/sdb --block.db /dev/sde --crush-device-class hdd --osd-type classic'
-    assert cmds[2] == 'raw prepare --bluestore --data /dev/sdc --block.db /dev/sdf --crush-device-class hdd --osd-type classic'
+    assert cmds[0] == 'raw prepare --bluestore --data /dev/sda --block.db /dev/sdd --crush-device-class hdd'
+    assert cmds[1] == 'raw prepare --bluestore --data /dev/sdb --block.db /dev/sde --crush-device-class hdd'
+    assert cmds[2] == 'raw prepare --bluestore --data /dev/sdc --block.db /dev/sdf --crush-device-class hdd'
 
 
 @pytest.mark.parametrize("test_input6",
@@ -565,9 +565,9 @@ def test_raw_ceph_volume_command_3(test_input6):
     drive = drive_selection.DriveSelection(spec, spec.data_devices.paths)
     cmds = translate.to_ceph_volume(drive, []).run()
 
-    assert cmds[0] == 'raw prepare --bluestore --data /dev/sda --block.db /dev/sdd --crush-device-class hdd --osd-type classic'
-    assert cmds[1] == 'raw prepare --bluestore --data /dev/sdb --block.db /dev/sde --crush-device-class hdd --osd-type classic'
-    assert cmds[2] == 'raw prepare --bluestore --data /dev/sdc --block.db /dev/sdf --crush-device-class ssd --osd-type classic'
+    assert cmds[0] == 'raw prepare --bluestore --data /dev/sda --block.db /dev/sdd --crush-device-class hdd'
+    assert cmds[1] == 'raw prepare --bluestore --data /dev/sdb --block.db /dev/sde --crush-device-class hdd'
+    assert cmds[2] == 'raw prepare --bluestore --data /dev/sdc --block.db /dev/sdf --crush-device-class ssd'
 
 
 @pytest.mark.parametrize("test_input7",
@@ -607,9 +607,9 @@ def test_raw_ceph_volume_command_4(test_input7):
     drive = drive_selection.DriveSelection(spec, spec.data_devices.paths)
     cmds = translate.to_ceph_volume(drive, []).run()
 
-    assert cmds[0] == 'raw prepare --bluestore --data /dev/sda --block.db /dev/sdd --block.wal /dev/sdg --crush-device-class hdd --osd-type classic'
-    assert cmds[1] == 'raw prepare --bluestore --data /dev/sdb --block.db /dev/sdf --block.wal /dev/sdi --crush-device-class nvme --osd-type classic'
-    assert cmds[2] == 'raw prepare --bluestore --data /dev/sdc --block.db /dev/sde --block.wal /dev/sdh --crush-device-class ssd --osd-type classic'
+    assert cmds[0] == 'raw prepare --bluestore --data /dev/sda --block.db /dev/sdd --block.wal /dev/sdg --crush-device-class hdd'
+    assert cmds[1] == 'raw prepare --bluestore --data /dev/sdb --block.db /dev/sdf --block.wal /dev/sdi --crush-device-class nvme'
+    assert cmds[2] == 'raw prepare --bluestore --data /dev/sdc --block.db /dev/sde --block.wal /dev/sdh --crush-device-class ssd'
 
 
 def test_raw_ceph_volume_command_5():
@@ -625,8 +625,8 @@ def test_raw_ceph_volume_command_5():
                               )
     sel = drive_selection.DriveSelection(spec, inventory)
     cmds = translate.to_ceph_volume(sel, ['0', '1']).run()
-    assert cmds[0] == 'raw prepare --bluestore --data /dev/sda --osd-type classic --osd-id 0'
-    assert cmds[1] == 'raw prepare --bluestore --data /dev/sdb --osd-type classic --osd-id 1'
+    assert cmds[0] == 'raw prepare --bluestore --data /dev/sda --osd-id 0'
+    assert cmds[1] == 'raw prepare --bluestore --data /dev/sdb --osd-id 1'
 
 
 def test_raw_ceph_volume_command_6():
@@ -642,8 +642,8 @@ def test_raw_ceph_volume_command_6():
                               )
     sel = drive_selection.DriveSelection(spec, inventory)
     cmds = translate.to_ceph_volume(sel, ['0']).run()
-    assert cmds[0] == 'raw prepare --bluestore --data /dev/sda --osd-type classic --osd-id 0'
-    assert cmds[1] == 'raw prepare --bluestore --data /dev/sdb --osd-type classic'
+    assert cmds[0] == 'raw prepare --bluestore --data /dev/sda --osd-id 0'
+    assert cmds[1] == 'raw prepare --bluestore --data /dev/sdb'
 
 
 def test_ceph_volume_command_seastore():


### PR DESCRIPTION
tentacle doesn't know that flag yet.
During an upgrade, teuthology tests can break.
With this fix, we only add the flag when osd_type isn't classic.

Fixes: https://tracker.ceph.com/issues/76968


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
