### PR TITLE
cmake/modules/Builduadk.cmake: add uadk as submodule, remove in-build git fetch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -85,6 +85,6 @@
 [submodule "src/lss"]
 	path = src/lss
 	url = https://chromium.googlesource.com/linux-syscall-support
-[submodule "src/librdkafka"]
-	path = src/librdkafka
-	url = https://github.com/confluentinc/librdkafka.git
+[submodule "src/uadk"]
+	path = src/uadk
+	url = https://github.com/ceph/uadk.git

--- a/cmake/modules/Builduadk.cmake
+++ b/cmake/modules/Builduadk.cmake
@@ -18,9 +18,6 @@ function(build_uadk)
     include(ExternalProject)
     ExternalProject_Add(uadk_ext
         UPDATE_COMMAND "" # this disables rebuild on each run
-        GIT_REPOSITORY "https://github.com/ceph/uadk.git"
-        GIT_CONFIG advice.detachedHead=false
-        GIT_TAG 267cf34617cc5d6af63191464db40eefcfb78448
         SOURCE_DIR "${PROJECT_SOURCE_DIR}/src/uadk"
         BUILD_IN_SOURCE 1
         CMAKE_ARGS -DCMAKE_CXX_COMPILER=which g++


### PR DESCRIPTION
add uadk as a git submodule under src/uadk

## Problem

`cmake/modules/Builduadk.cmake` currently uses a git fetch inside `ExternalProject_Add`:

```cmake
GIT_REPOSITORY "https://github.com/ceph/uadk.git"
GIT_CONFIG advice.detachedHead=false
GIT_TAG 267cf34617cc5d6af63191464db40eefcfb78448
```

This prevents offline builds.

## Proposed Fix

Add `uadk` as a proper git submodule at `src/uadk` (pinned to the same SHA `267cf34617cc5d6af63191464db40eefcfb78448`), then remove the in-build git fetch from `Builduadk.cmake`. `ExternalProject_Add` will then use the existing `SOURCE_DIR` without attempting a network clone.

This matches how Ceph already manages other bundled dependencies (e.g., `src/zstd`, `src/arrow`, `src/spdk`).

## Files Changed

### 1. `.gitmodules` — new entry

```diff
+[submodule "src/uadk"]
+	path = src/uadk
+	url = https://github.com/ceph/uadk.git
```

### 2. `src/uadk` — new submodule (at commit `267cf34617cc5d6af63191464db40eefcfb78448`)

The submodule pointer will be at the exact same commit that `Builduadk.cmake` currently clones:

```
Subproject commit 267cf34617cc5d6af63191464db40eefcfb78448
```

### 3. `cmake/modules/Builduadk.cmake` — remove git fetch

```diff
     include(ExternalProject)
     ExternalProject_Add(uadk_ext
         UPDATE_COMMAND "" # this disables rebuild on each run
-        GIT_REPOSITORY "https://github.com/ceph/uadk.git"
-        GIT_CONFIG advice.detachedHead=false
-        GIT_TAG 267cf34617cc5d6af63191464db40eefcfb78448
         SOURCE_DIR "${PROJECT_SOURCE_DIR}/src/uadk"
         BUILD_IN_SOURCE 1
         CMAKE_ARGS -DCMAKE_CXX_COMPILER=which g++
```