### PR TITLE
osd/scrub: clean up inconsistent_obj_wrapper and ScrubStore

### DIFF
--- a/src/common/scrub_types.h
+++ b/src/common/scrub_types.h
@@ -117,6 +117,7 @@ namespace librados {
 }
 
 struct inconsistent_obj_wrapper : librados::inconsistent_obj_t {
+  inconsistent_obj_wrapper() = default;
   explicit inconsistent_obj_wrapper(const hobject_t& hoid);
 
   void merge(obj_err_t other) {

--- a/src/osd/scrubber/ScrubStore.cc
+++ b/src/osd/scrubber/ScrubStore.cc
@@ -308,10 +308,9 @@ inline void decode(
 
 
 inconsistent_obj_wrapper decode_wrapper(
-    hobject_t obj,
     ceph::buffer::list::const_iterator bp)
 {
-  inconsistent_obj_wrapper iow{obj};
+  inconsistent_obj_wrapper iow;
   iow.decode(bp);
   return iow;
 }
@@ -342,13 +341,12 @@ void Store::collect_specific_store(
  *   structure.
  */
 bufferlist Store::merge_encoded_error_wrappers(
-    hobject_t obj,
     ExpCacherPosData& latest_sh,
     ExpCacherPosData& latest_dp) const
 {
   // decode both error wrappers
-  auto sh_wrap = decode_wrapper(obj, latest_sh->data.cbegin());
-  auto dp_wrap = decode_wrapper(obj, latest_dp->data.cbegin());
+  auto sh_wrap = decode_wrapper(latest_sh->data.cbegin());
+  auto dp_wrap = decode_wrapper(latest_dp->data.cbegin());
 
   // note: the '20' level is just until we're sure the merging works as
   // expected
@@ -414,6 +412,7 @@ bufferlist Store::merge_encoded_error_wrappers(
 	}
       }
     } else if (sh_wrap.version > dp_wrap.version) {
+        // RRR decide on the policy here.
 	if (false && dp_wrap.version == 0) {
 	  // there was a read error in the deep scrub. The deep version
 	  // shows as '0'. That's severe enough for us to ignore the shallow.
@@ -491,8 +490,7 @@ std::vector<bufferlist> Store::get_errors(
     // we have results from both stores. Select the one with a lower key.
     // If the keys are equal, combine the errors.
     if (latest_sh->last_key == latest_dp->last_key) {
-      auto bl = merge_encoded_error_wrappers(
-	  shallow_db->errors_hoid.hobj, latest_sh, latest_dp);
+      auto bl = merge_encoded_error_wrappers(latest_sh, latest_dp);
       errors.push_back(bl);
       latest_sh = shallow_db->backend.get_1st_after_key(latest_sh->last_key);
       latest_dp = deep_db->backend.get_1st_after_key(latest_dp->last_key);

--- a/src/osd/scrubber/ScrubStore.h
+++ b/src/osd/scrubber/ScrubStore.h
@@ -172,7 +172,6 @@ class Store {
    * entries.
    */
   bufferlist merge_encoded_error_wrappers(
-      hobject_t obj,
       ExpCacherPosData& latest_sh,
       ExpCacherPosData& latest_dp) const;
 };


### PR DESCRIPTION
Add a default constructor to inconsistent_obj_wrapper, allowing
decode_wrapper() to avoid requiring a bogus hobject_t that gets
immediately overwritten by decode(). Remove the now-unnecessary
hobject_t parameter from merge_encoded_error_wrappers().
