### PR TITLE
tentacle: rgw/beast: add ssl_ciphersuites option for tls 1.3

### DIFF
--- a/doc/radosgw/frontends.rst
+++ b/doc/radosgw/frontends.rst
@@ -87,11 +87,13 @@ Options
 :Type: String
 :Default: ``no_sslv2:no_sslv3:no_tlsv1:no_tlsv1_1``
 
-``ssl_ciphers``
+``ssl_ciphers`` and ``ssl_ciphersuites``
 
 :Description: Optional list of one or more cipher strings separated by colons.
-              The format of the string is described in openssl's ciphers(1)
-              manual.
+              The format of the string is described in OpenSSL's ciphers(1)
+              manual. The ``ssl_ciphers`` option only applies to connections
+              using TLS v1.2 and below, while ``ssl_ciphersuites`` only applies
+              to TLS v1.3.
 
 :Type: String
 :Default: None

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -1005,6 +1005,21 @@ int AsioFrontend::init_ssl()
     }
   }
 
+  std::optional<string> ciphersuites = conf->get_val("ssl_ciphersuites");
+  if (ciphersuites) {
+    if (!cert) {
+      lderr(ctx()) << "no ssl_certificate configured for ssl_ciphersuites" << dendl;
+      return -EINVAL;
+    }
+
+    int r = SSL_CTX_set_ciphersuites(ssl_context->native_handle(), ciphersuites->c_str());
+    if (r == 0) {
+      lderr(ctx()) << "no cipher could be selected from ssl_ciphersuites: "
+                   << *ciphersuites << dendl;
+      return -EINVAL;
+    }
+  }
+
   auto ports = config.equal_range("ssl_port");
   auto endpoints = config.equal_range("ssl_endpoint");
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77002

---

backport of https://github.com/ceph/ceph/pull/68934
parent tracker: https://tracker.ceph.com/issues/76578

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh