### PR TITLE
rgw/posix: fix leaks in error paths

### DIFF
--- a/src/rgw/driver/posix/bucket_cache.h
+++ b/src/rgw/driver/posix/bucket_cache.h
@@ -17,6 +17,7 @@
 #include <boost/intrusive/avl_set.hpp>
 #include "include/function2.hpp"
 #include "common/cohort_lru.h"
+#include "include/scope_guard.h"
 #include "lmdb-safe.hh"
 #include "zpp_bits.h"
 #include "notify.h"
@@ -286,8 +287,10 @@ public:
      * Drain the AVL cache and unref each entry to trigger deletion.
      *
      * Entries should have refcount=1 (sentinel state) after normal use
-     * because list_bucket() calls lru.unref() on all code paths. When
-     * we call unref here, the refcount goes to 0 and the entry is deleted.
+     * because every public method that calls get_bucket() uses a scope_guard
+     * to pair lru.unref() with the get_bucket() ref on all paths (including
+     * exceptions). When we call unref here, the refcount goes to 0 and the
+     * entry is deleted.
      *
      * The drain() method safely removes all entries
      * from the AVL cache partitions and calls the supplied lambda on each,
@@ -426,12 +429,14 @@ public:
 		 BucketCache<D, B>::FLAG_LOCK | BucketCache<D, B>::FLAG_CREATE);
     auto [b /* BucketCacheEntry */, flags] = gbr;
     if (b /* XXX again, can this fail? */) {
+      auto unref_guard = make_scope_guard([this, b]{ lru.unref(b, cohort::lru::FLAG_NONE); });
+      unique_lock ulk{b->mtx, std::adopt_lock};
       if (! (b->flags & BucketCacheEntry<D, B>::FLAG_FILLED)) {
 	/* bulk load into lmdb cache */
 	rc = fill(dpp, b, sal_bucket, FLAG_NONE, y);
       }
       /* display them */
-      b->mtx.unlock();
+      ulk.unlock();
       /*! LOCKED */
 
       auto txn = b->env->getROTransaction();
@@ -467,7 +472,6 @@ public:
 	auto rc = cursor.lower_bound(k, key, data);
 	if (rc == MDB_NOTFOUND) {
 	  /* no key sorts after k/marker, so there is nothing to do */
-	  lru.unref(b, cohort::lru::FLAG_NONE);
 	  return 0;
 	}
 	proc_result();
@@ -476,7 +480,6 @@ public:
 	auto rc = cursor.get(key, data, MDB_FIRST);
 	if (rc == MDB_NOTFOUND) {
 	  /* no initial key */
-	  lru.unref(b, cohort::lru::FLAG_NONE);
 	  return 0;
 	}
 	if (rc == MDB_SUCCESS) {
@@ -485,12 +488,10 @@ public:
       }
       while(cursor.get(key, data, MDB_NEXT) == MDB_SUCCESS) {
 	if (!again) {
-	  lru.unref(b, cohort::lru::FLAG_NONE);
 	  return 0;
 	}
 	proc_result();
       }
-      lru.unref(b, cohort::lru::FLAG_NONE);
     } /* b */
 
     return 0;
@@ -505,6 +506,7 @@ public:
     GetBucketResult gbr = get_bucket(nullptr, bname, BucketCache<D, B>::FLAG_LOCK);
     auto [b /* BucketCacheEntry */, flags] = gbr;
     if (b) {
+      auto unref_guard = make_scope_guard([this, b]{ lru.unref(b, cohort::lru::FLAG_NONE); });
       unique_lock ulk{b->mtx, std::adopt_lock};
       if ((b->name != bname) ||
 	  (opaque && (b != opaque)) ||
@@ -560,6 +562,7 @@ public:
 	  mdb_drop(*txn, b->dbi, 0);
 	  txn->commit();
 	  b->flags &= ~BucketCacheEntry<D, B>::FLAG_FILLED;
+	  ulk.unlock();
 	  return 0; /* don't process any more events in this batch */
 	}
 	  break;
@@ -569,7 +572,6 @@ public:
 	}
       } /* all events */
       txn->commit();
-      lru.unref(b, cohort::lru::FLAG_NONE);
     } /* b */
     return rc;
   } /* notify */
@@ -580,6 +582,7 @@ public:
     GetBucketResult gbr = get_bucket(dpp, bname, BucketCache<D, B>::FLAG_LOCK);
     auto [b /* BucketCacheEntry */, flags] = gbr;
     if (b) {
+      auto unref_guard = make_scope_guard([this, b]{ lru.unref(b, cohort::lru::FLAG_NONE); });
       unique_lock ulk{b->mtx, std::adopt_lock};
       ulk.unlock();
 
@@ -602,7 +605,6 @@ public:
       txn->put(b->dbi, concat_k, ser_data);
 
       txn->commit();
-      lru.unref(b, cohort::lru::FLAG_NONE);
     } /* b */
 
     return 0;
@@ -614,6 +616,7 @@ public:
     GetBucketResult gbr = get_bucket(dpp, bname, BucketCache<D, B>::FLAG_LOCK);
     auto [b /* BucketCacheEntry */, flags] = gbr;
     if (b) {
+      auto unref_guard = make_scope_guard([this, b]{ lru.unref(b, cohort::lru::FLAG_NONE); });
       unique_lock ulk{b->mtx, std::adopt_lock};
       ulk.unlock();
 
@@ -621,8 +624,6 @@ public:
       auto concat_k = concat_key(key);
       txn->del(b->dbi, concat_k);
       txn->commit();
-
-      lru.unref(b, cohort::lru::FLAG_NONE);
     } /* b */
 
     return 0;
@@ -634,6 +635,7 @@ public:
     GetBucketResult gbr = get_bucket(dpp, bname, BucketCache<D, B>::FLAG_LOCK);
     auto [b /* BucketCacheEntry */, flags] = gbr;
     if (b) {
+      auto unref_guard = make_scope_guard([this, b]{ lru.unref(b, cohort::lru::FLAG_NONE); });
       unique_lock ulk{b->mtx, std::adopt_lock};
 
       auto txn = b->env->getRWTransaction();

--- a/src/rgw/driver/posix/notify.h
+++ b/src/rgw/driver/posix/notify.h
@@ -204,6 +204,7 @@ namespace file::listing {
 	    } /* !overflow */
 	    if (evec.size() > 0) {
 	      n->notify(watch_name, watch_opaque, evec);
+	      evec.clear();
 	    }
 	  } /* events */
 	} /* n > 0 */


### PR DESCRIPTION
these leaks were identified when investigating https://tracker.ceph.com/issues/75601. but they are not likely the root cause of the timeout. but the leaked entries in cache hurts the hit rate of the cache. 


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
