### PR TITLE
crimson/os/seastore: avoid merging ool persisted txns

### DIFF
--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -982,20 +982,24 @@ void Cache::commit_replace_extent(
 
 }
 
-void Cache::invalidate_extent(
-    Transaction& t,
-    CachedExtent& extent)
+void Cache::invalidate_extent_readers(
+  Transaction &t,
+  CachedExtent &extent,
+  bool ool_written_only)
 {
-  if (!extent.may_conflict()) {
-    assert(extent.read_transactions.empty());
-    extent.set_invalid(t);
-    return;
-  }
-
-  LOG_PREFIX(Cache::invalidate_extent);
+  LOG_PREFIX(Cache::invalidate_extent_readers);
   bool do_conflict_log = true;
   std::vector<Transaction*> invalidated_trans;
   for (auto &&i: extent.read_transactions) {
+    // For no_conflict_publish txns: only invalidate transactions that have
+    // already written their OOL extents to disk. These cannot be safely
+    // merged in-memory, as their persisted state would override the rewritten
+    // result and cause lost updates.
+    bool should_invalidate = !ool_written_only ||
+                             i.t->ool_written;
+    if (likely(!should_invalidate)) {
+      continue;
+    }
     if (!i.t->conflicted) {
       if (do_conflict_log) {
         SUBDEBUGT(seastore_t, "conflict begin -- {}", t, extent);
@@ -1013,6 +1017,20 @@ void Cache::invalidate_extent(
     trans->retired_set.clear();
     trans->views.clear();
   }
+}
+
+void Cache::invalidate_extent(
+    Transaction& t,
+    CachedExtent& extent)
+{
+  if (!extent.may_conflict()) {
+    assert(extent.read_transactions.empty());
+    extent.set_invalid(t);
+    return;
+  }
+
+  invalidate_extent_readers(t, extent, false);
+
   extent.set_invalid(t);
 }
 
@@ -1392,6 +1410,7 @@ record_t Cache::prepare_record(
     if (should_use_no_conflict_publish(t, i->get_type())) {
       i->new_committer(t);
       i->committer->block_trans(t);
+      invalidate_extent_readers(t, *i->prior_instance, true);
     }
     assert(i->is_exist_mutation_pending() ||
 	   i->prior_instance);
@@ -1674,6 +1693,7 @@ record_t Cache::prepare_record(
       assert(i->committer);
       auto &committer = *i->committer;
       committer.block_trans(t);
+      invalidate_extent_readers(t, *i->prior_instance, true);
       i->get_prior_instance()->set_io_wait(
         CachedExtent::extent_state_t::CLEAN,
         should_use_no_conflict_publish(t, i->get_type()));
@@ -1710,6 +1730,7 @@ record_t Cache::prepare_record(
       i->get_prior_instance()->committer = i->committer;
       auto &committer = *i->committer;
       committer.block_trans(t);
+      invalidate_extent_readers(t, *i->prior_instance, true);
       i->get_prior_instance()->set_io_wait(
         CachedExtent::extent_state_t::CLEAN, true);
     }
@@ -2039,6 +2060,7 @@ void Cache::complete_commit(
       committer.commit_state();
       committer.sync_checksum();
       committer.commit_and_share_paddr();
+      invalidate_extent_readers(t, prior, true);
       if (is_lba_backref_node(i->get_type())) {
         committer.commit_data();
       }
@@ -2132,6 +2154,7 @@ void Cache::complete_commit(
       auto &prior = *i->prior_instance;
       prior.pending_for_transaction = TRANS_ID_NULL;
       ceph_assert(prior.is_valid());
+      invalidate_extent_readers(t, prior, true);
       if (is_lba_backref_node(i->get_type())) {
         committer.commit_data();
       }

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1989,6 +1989,10 @@ private:
 void stage_visibility_handoff(Transaction& t,
                               CachedExtentRef next,
                               CachedExtentRef prev);
+  void invalidate_extent_readers(
+    Transaction &t,
+    CachedExtent &extent,
+    bool backref_lba_written_only);
 
   /// Invalidate extent and mark affected transactions
   void invalidate_extent(Transaction& t, CachedExtent& extent);

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -549,6 +549,7 @@ public:
     conflicted = false;
     need_wait_visibility = false;
     force_rewrite_conflict = false;
+    ool_written = false;
     assert(backref_entries.empty());
     if (!has_reset) {
       has_reset = true;
@@ -669,6 +670,7 @@ public:
 
   bool need_wait_visibility = false;
   bool force_rewrite_conflict = false;
+  bool ool_written = false;
 
   using update_copied_lba_key_func_t =
     std::function<void (Transaction&, laddr_t, paddr_t)>;

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -612,6 +612,19 @@ TransactionManager::do_submit_transaction(
   auto num_extents = allocated_extents.size();
   SUBTRACET(seastore_t, "process {} allocated extents", tref, num_extents);
   ool_start = std::chrono::steady_clock::now();
+  if (!allocated_extents.empty()) {
+    // TODO: for now, this is only effective for rbm backends, which is
+    // enough. Because:
+    // 1. no_conflict_publish doesn't affect the logical extents for now.
+    // 2. in the case of segmented backends, backref/lba nodes are always
+    //    inline written, which means all of its backref/lba nodes are
+    //    written after the contents have already been merged.
+    //
+    // This should be made effective for all kinds of backends if any of
+    // the above condition doesn't hold anymore.
+    tref.ool_written = true;
+  }
+
   co_await epm->write_preallocated_ool_extents(tref, allocated_extents);
   tref.get_phase_durations().ool_write +=
     std::chrono::steady_clock::now() - ool_start;


### PR DESCRIPTION
Invalidate transactions that have already written their OOL extents to disk when committing no_conflict_publish transactions if their read_set intersects.

Such transactions cannot be safely merged in memory: their persisted state would override the rewritten result - leading to lost updates.

The issue was introduced since https://github.com/ceph/ceph/commit/bd0ce704f24afbe11830d31b46d8b22771f54456

Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
