### PR TITLE
compressor/zstd: include <zstd.h> instead of the bundled path

### DIFF
--- a/src/compressor/zstd/ZstdCompressor.h
+++ b/src/compressor/zstd/ZstdCompressor.h
@@ -17,7 +17,7 @@
 #define CEPH_ZSTDCOMPRESSOR_H
 
 #define ZSTD_STATIC_LINKING_ONLY
-#include "zstd/lib/zstd.h"
+#include <zstd.h>
 
 #include "include/buffer.h"
 #include "include/encoding.h"


### PR DESCRIPTION
ZstdCompressor.h hard-codes `#include "zstd/lib/zstd.h"`, which only
resolves because include_directories(src) puts the bundled submodule
on the search path. It thus silently depends on src/zstd being checked
out, and breaks with `-DWITH_SYSTEM_ZSTD=ON` where the submodule is absent.

ceph_zstd already links Zstd::Zstd, whose `INTERFACE_INCLUDE_DIRECTORIES`
points at the directory holding zstd.h in both modes: src/zstd/lib for
the bundled build, `${Zstd_INCLUDE_DIR}` for the system one. Use `<zstd.h>`
so the include resolves through that interface either way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests