### PR TITLE
rgw: match CORS rules like Amazon S3

### DIFF
--- a/src/rgw/rgw_cors.cc
+++ b/src/rgw/rgw_cors.cc
@@ -245,6 +245,10 @@ bool RGWCORSRule::matches_method(const char *req_meth)
     dout(5) << "matches_method: req_meth is null or empty" << dendl;
     return false;
   }
+  if (allowed_methods == RGW_CORS_ALL) {
+    dout(10) << "matches_method: AllowedMethod * allows " << req_meth << dendl;
+    return true;
+  }
   const uint8_t flags = get_multi_cors_method_flags(req_meth);
   return flags != 0 && (allowed_methods & flags);
 }
@@ -252,6 +256,8 @@ bool RGWCORSRule::matches_method(const char *req_meth)
 bool RGWCORSRule::matches_preflight_headers(const char *req_hdrs)
 {
   if (!req_hdrs || !*req_hdrs) {
+    dout(20) << "matches_preflight_headers: no Access-Control-Request-Headers, "
+             << "passing per CORS spec 6.2.4" << dendl;
     return true;
   }
   vector<string> hdrs;

--- a/src/rgw/rgw_cors.cc
+++ b/src/rgw/rgw_cors.cc
@@ -17,6 +17,7 @@
 
 #include <iostream>
 #include <map>
+#include <vector>
 
 #include <boost/algorithm/string.hpp>
 
@@ -236,6 +237,56 @@ void RGWCORSRule::format_exp_headers(string& s) {
     // response header, so we escape '\n' to avoid header injection
     boost::replace_all_copy(std::back_inserter(s), header, "\n", "\\n");
   }
+}
+
+bool RGWCORSRule::matches_method(const char *req_meth)
+{
+  if (!req_meth || !*req_meth) {
+    return true;
+  }
+  const uint8_t flags = get_multi_cors_method_flags(req_meth);
+  return flags != 0 && (allowed_methods & flags);
+}
+
+bool RGWCORSRule::matches_preflight_headers(const char *req_hdrs)
+{
+  if (!req_hdrs || !*req_hdrs) {
+    return true;
+  }
+  vector<string> hdrs;
+  get_str_vec(req_hdrs, hdrs);
+  for (const auto& hdr : hdrs) {
+    if (!is_header_allowed(hdr.c_str(), hdr.length())) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool RGWCORSRule::matches(const char *origin,
+                          const char *req_meth,
+                          const char *req_hdrs)
+{
+  if (!origin || !*origin) {
+    return false;
+  }
+  return is_origin_present(origin)
+      && matches_method(req_meth)
+      && matches_preflight_headers(req_hdrs);
+}
+
+RGWCORSRule * RGWCORSConfiguration::match_rule(const char *origin,
+                                               const char *req_meth,
+                                               const char *req_hdrs)
+{
+  for (list<RGWCORSRule>::iterator it_r = rules.begin();
+       it_r != rules.end(); ++it_r) {
+    RGWCORSRule& r = (*it_r);
+    if (r.matches(origin, req_meth, req_hdrs)) {
+      return &r;
+    }
+  }
+  return NULL;
 }
 
 RGWCORSRule * RGWCORSConfiguration::host_name_rule(const char *origin) {

--- a/src/rgw/rgw_cors.cc
+++ b/src/rgw/rgw_cors.cc
@@ -264,6 +264,7 @@ bool RGWCORSRule::matches_preflight_headers(const char *req_hdrs)
   get_str_vec(req_hdrs, hdrs);
   for (const auto& hdr : hdrs) {
     if (!is_header_allowed(hdr.c_str(), hdr.length())) {
+      dout(5) << "Header " << hdr << " is not registered in this rule" << dendl;
       return false;
     }
   }

--- a/src/rgw/rgw_cors.cc
+++ b/src/rgw/rgw_cors.cc
@@ -242,7 +242,8 @@ void RGWCORSRule::format_exp_headers(string& s) {
 bool RGWCORSRule::matches_method(const char *req_meth)
 {
   if (!req_meth || !*req_meth) {
-    return true;
+    dout(5) << "matches_method: req_meth is null or empty" << dendl;
+    return false;
   }
   const uint8_t flags = get_multi_cors_method_flags(req_meth);
   return flags != 0 && (allowed_methods & flags);

--- a/src/rgw/rgw_cors.h
+++ b/src/rgw/rgw_cors.h
@@ -91,6 +91,11 @@ public:
   void dump_origins();
   void dump(Formatter *f) const;
   bool is_header_allowed(const char *hdr, size_t len);
+  bool matches_method(const char *req_meth);
+  bool matches_preflight_headers(const char *req_hdrs);
+  bool matches(const char *origin,
+               const char *req_meth,
+               const char *req_hdrs);
 };
 WRITE_CLASS_ENCODER(RGWCORSRule)
 
@@ -121,6 +126,9 @@ class RGWCORSConfiguration
   }
   void get_origins_list(const char *origin, std::list<std::string>& origins);
   RGWCORSRule * host_name_rule(const char *origin);
+  RGWCORSRule * match_rule(const char *origin,
+                           const char *req_meth,
+                           const char *req_hdrs);
   void erase_host_name_rule(std::string& origin);
   void dump();
   void stack_rule(RGWCORSRule& r) {

--- a/src/rgw/rgw_cors.h
+++ b/src/rgw/rgw_cors.h
@@ -18,6 +18,7 @@
 #include <map>
 #include <string>
 #include <include/types.h>
+#include "include/str_list.h"
 
 #define RGW_CORS_GET    0x1
 #define RGW_CORS_PUT    0x2
@@ -169,7 +170,7 @@ static inline uint8_t get_multi_cors_method_flags(const char *req_meth) {
     else if (method == "HEAD") flags |= RGW_CORS_HEAD;
     else if (method == "COPY") flags |= RGW_CORS_COPY;
   };
-  for_each_substr(allowed_methods, ";,= \t", apply_flag);
+  ceph::for_each_substr(allowed_methods, ";,= \t", apply_flag);
 
   return flags;
 }

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2000,8 +2000,14 @@ bool RGWOp::generate_cors_headers(string& origin, string& method, string& header
     return false;
   }
 
-  /* CORS 6.2.2. */
-  RGWCORSRule *rule = bucket_cors.host_name_rule(orig);
+  /* CORS 6.2.2–6.2.5: first rule matching origin, method, and preflight headers. */
+  const char *req_meth = s->info.env->get("HTTP_ACCESS_CONTROL_REQUEST_METHOD");
+  if (!req_meth) {
+    req_meth = s->info.method;
+  }
+  const char *req_hdrs = s->info.env->get("HTTP_ACCESS_CONTROL_REQUEST_HEADERS");
+
+  RGWCORSRule *rule = bucket_cors.match_rule(orig, req_meth, req_hdrs);
   auto is_allowed_to_generate_rule_cors_header = [this, &origin, &method, &headers, &exp_headers, &max_age] (RGWCORSRule *rule) {
     if (!rule)
       return false;
@@ -2019,24 +2025,20 @@ bool RGWOp::generate_cors_headers(string& origin, string& method, string& header
       origin = "*";
 
     /* CORS 6.2.3. */
-    const char *req_meth = s->info.env->get("HTTP_ACCESS_CONTROL_REQUEST_METHOD");
-    if (!req_meth) {
-      req_meth = s->info.method;
+    const char *req_meth_inner = s->info.env->get("HTTP_ACCESS_CONTROL_REQUEST_METHOD");
+    if (!req_meth_inner) {
+      req_meth_inner = s->info.method;
     }
 
-    if (req_meth) {
-      method = req_meth;
-      /* CORS 6.2.5. */
-      if (!validate_cors_rule_method(this, rule, req_meth)) {
-        return false;
-      }
+    if (req_meth_inner) {
+      method = req_meth_inner;
     }
 
     /* CORS 6.2.4. */
-    const char *req_hdrs = s->info.env->get("HTTP_ACCESS_CONTROL_REQUEST_HEADERS");
+    const char *req_hdrs_inner = s->info.env->get("HTTP_ACCESS_CONTROL_REQUEST_HEADERS");
 
     /* CORS 6.2.6. */
-    get_cors_response_headers(this, rule, req_hdrs, headers, exp_headers, max_age);
+    get_cors_response_headers(this, rule, req_hdrs_inner, headers, exp_headers, max_age);
 
     return true;
   };
@@ -2045,7 +2047,9 @@ bool RGWOp::generate_cors_headers(string& origin, string& method, string& header
     return true;
   }
 
-  if (optional_global_cors.has_value() && is_allowed_to_generate_rule_cors_header(&(*optional_global_cors))) {
+  if (optional_global_cors.has_value() &&
+      optional_global_cors->matches(orig, req_meth, req_hdrs) &&
+      is_allowed_to_generate_rule_cors_header(&(*optional_global_cors))) {
     return true;
   }
 
@@ -7253,17 +7257,10 @@ void RGWOptionsCORS::get_response_params(string& hdrs, string& exp_hdrs, unsigne
 }
 
 int RGWOptionsCORS::validate_cors_request(RGWCORSConfiguration *cc) {
-  rule = cc->host_name_rule(origin);
+  rule = cc->match_rule(origin, req_meth, req_hdrs);
   if (!rule) {
-    ldpp_dout(this, 10) << "There is no cors rule present for " << origin << dendl;
-    return -ENOENT;
-  }
-
-  if (!validate_cors_rule_method(this, rule, req_meth)) {
-    return -ENOENT;
-  }
-
-  if (!validate_cors_rule_header(this, rule, req_hdrs)) {
+    ldpp_dout(this, 10) << "no CORS rule matching origin=" << origin
+                        << " method=" << req_meth << dendl;
     return -ENOENT;
   }
 
@@ -7273,21 +7270,9 @@ int RGWOptionsCORS::validate_cors_request(RGWCORSConfiguration *cc) {
 int RGWOptionsCORS::validate_global_cors_request(RGWCORSRule *global_cors_rule) {
   ldpp_dout(this, 20) << "Validating request with global CORS" << dendl;
   rule = global_cors_rule;
-  if (!rule) {
-    ldpp_dout(this, 10) << "There is no global cors rule present" << dendl;
-    return -ENOENT;
-  }
-
-  if (!rule->is_origin_present(origin)) {
-    ldpp_dout(this, 10) << "There is no cors rule present for " << origin << dendl;
-    return -ENOENT;
-  }
-
-  if (!validate_cors_rule_method(this, rule, req_meth)) {
-    return -ENOENT;
-  }
-
-  if (!validate_cors_rule_header(this, rule, req_hdrs)) {
+  if (!rule || !rule->matches(origin, req_meth, req_hdrs)) {
+    ldpp_dout(this, 10) << "no global CORS rule matching origin=" << origin
+                        << " method=" << req_meth << dendl;
     return -ENOENT;
   }
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1856,38 +1856,6 @@ int RGWOp::init_quota()
   return 0;
 }
 
-static bool validate_cors_rule_method(const DoutPrefixProvider *dpp, RGWCORSRule *rule, const char *req_meth) {
-  if (!req_meth) {
-    ldpp_dout(dpp, 5) << "req_meth is null" << dendl;
-    return false;
-  }
-
-  uint8_t flags = get_multi_cors_method_flags(req_meth);
-
-  if (rule->get_allowed_methods() & flags) {
-    ldpp_dout(dpp, 10) << "Method " << req_meth << " is supported" << dendl;
-  } else {
-    ldpp_dout(dpp, 5) << "Method " << req_meth << " is not supported" << dendl;
-    return false;
-  }
-
-  return true;
-}
-
-static bool validate_cors_rule_header(const DoutPrefixProvider *dpp, RGWCORSRule *rule, const char *req_hdrs) {
-  if (req_hdrs) {
-    vector<string> hdrs;
-    get_str_vec(req_hdrs, hdrs);
-    for (const auto& hdr : hdrs) {
-      if (!rule->is_header_allowed(hdr.c_str(), hdr.length())) {
-        ldpp_dout(dpp, 5) << "Header " << hdr << " is not registered in this rule" << dendl;
-        return false;
-      }
-    }
-  }
-  return true;
-}
-
 int RGWOp::read_bucket_cors()
 {
   bufferlist bl;
@@ -2008,7 +1976,7 @@ bool RGWOp::generate_cors_headers(string& origin, string& method, string& header
   const char *req_hdrs = s->info.env->get("HTTP_ACCESS_CONTROL_REQUEST_HEADERS");
 
   RGWCORSRule *rule = bucket_cors.match_rule(orig, req_meth, req_hdrs);
-  auto is_allowed_to_generate_rule_cors_header = [this, &origin, &method, &headers, &exp_headers, &max_age] (RGWCORSRule *rule) {
+  auto is_allowed_to_generate_rule_cors_header = [this, &origin, &method, &headers, &exp_headers, &max_age, req_meth, req_hdrs] (RGWCORSRule *rule) {
     if (!rule)
       return false;
 
@@ -2025,20 +1993,12 @@ bool RGWOp::generate_cors_headers(string& origin, string& method, string& header
       origin = "*";
 
     /* CORS 6.2.3. */
-    const char *req_meth_inner = s->info.env->get("HTTP_ACCESS_CONTROL_REQUEST_METHOD");
-    if (!req_meth_inner) {
-      req_meth_inner = s->info.method;
+    if (req_meth) {
+      method = req_meth;
     }
-
-    if (req_meth_inner) {
-      method = req_meth_inner;
-    }
-
-    /* CORS 6.2.4. */
-    const char *req_hdrs_inner = s->info.env->get("HTTP_ACCESS_CONTROL_REQUEST_HEADERS");
 
     /* CORS 6.2.6. */
-    get_cors_response_headers(this, rule, req_hdrs_inner, headers, exp_headers, max_age);
+    get_cors_response_headers(this, rule, req_hdrs, headers, exp_headers, max_age);
 
     return true;
   };

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -102,6 +102,12 @@ add_executable(unittest_rgw_bencode test_rgw_bencode.cc)
 add_ceph_unittest(unittest_rgw_bencode)
 target_link_libraries(unittest_rgw_bencode ${rgw_libs})
 
+# unittest_rgw_cors
+add_executable(unittest_rgw_cors test_rgw_cors.cc)
+add_ceph_unittest(unittest_rgw_cors)
+target_link_libraries(unittest_rgw_cors ${rgw_libs})
+
+
 # unittest_rgw_bucket_sync_cache
 add_executable(unittest_rgw_bucket_sync_cache test_rgw_bucket_sync_cache.cc)
 add_ceph_unittest(unittest_rgw_bucket_sync_cache)

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -103,7 +103,9 @@ add_ceph_unittest(unittest_rgw_bencode)
 target_link_libraries(unittest_rgw_bencode ${rgw_libs})
 
 # unittest_rgw_cors
-add_executable(unittest_rgw_cors test_rgw_cors.cc)
+add_executable(unittest_rgw_cors
+  test_rgw_cors.cc
+  $<TARGET_OBJECTS:unit-main>)
 add_ceph_unittest(unittest_rgw_cors)
 target_link_libraries(unittest_rgw_cors ${rgw_libs})
 

--- a/src/test/rgw/test_rgw_cors.cc
+++ b/src/test/rgw/test_rgw_cors.cc
@@ -1,0 +1,73 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#include "gtest/gtest.h"
+
+#include "rgw_cors.h"
+
+using namespace std;
+
+static RGWCORSRule make_rule(const char *origin, uint8_t methods,
+                             const char *allowed_hdr = nullptr)
+{
+  set<string> origins;
+  origins.insert(origin);
+  set<string> hdrs;
+  if (allowed_hdr) {
+    hdrs.insert(allowed_hdr);
+  }
+  list<string> expose;
+  return RGWCORSRule(origins, hdrs, expose, methods, 3000);
+}
+
+TEST(RGWCORS, MatchRuleSameOriginDifferentMethods)
+{
+  RGWCORSConfiguration cfg;
+  cfg.get_rules().push_back(make_rule("https://app.example", RGW_CORS_GET));
+  cfg.get_rules().push_back(make_rule("https://app.example", RGW_CORS_PUT));
+
+  auto it_get = cfg.get_rules().begin();
+  auto it_put = std::next(it_get);
+
+  EXPECT_EQ(cfg.match_rule("https://app.example", "GET", nullptr), &(*it_get));
+  EXPECT_EQ(cfg.match_rule("https://app.example", "PUT", nullptr), &(*it_put));
+  EXPECT_EQ(cfg.match_rule("https://app.example", "DELETE", nullptr), nullptr);
+}
+
+TEST(RGWCORS, MatchRuleSkipsOriginOnlyMatch)
+{
+  RGWCORSConfiguration cfg;
+  cfg.get_rules().push_back(make_rule("https://app.example", RGW_CORS_GET));
+  cfg.get_rules().push_back(make_rule("https://app.example", RGW_CORS_PUT));
+
+  EXPECT_NE(nullptr, cfg.match_rule("https://app.example", "PUT", nullptr));
+}
+
+TEST(RGWCORS, MatchRulePreflightHeaders)
+{
+  RGWCORSConfiguration cfg;
+  cfg.get_rules().push_back(
+      make_rule("https://app.example", RGW_CORS_GET, "content-type"));
+  cfg.get_rules().push_back(
+      make_rule("https://app.example", RGW_CORS_GET, "*"));
+
+  auto it_strict = cfg.get_rules().begin();
+  auto it_wild = std::next(it_strict);
+
+  EXPECT_EQ(cfg.match_rule("https://app.example", "GET",
+                           "content-type"),
+            &(*it_strict));
+  EXPECT_EQ(cfg.match_rule("https://app.example", "GET",
+                           "authorization"),
+            &(*it_wild));
+}
+
+TEST(RGWCORS, HostNameRuleStillOriginOnly)
+{
+  RGWCORSConfiguration cfg;
+  cfg.get_rules().push_back(make_rule("https://app.example", RGW_CORS_GET));
+  cfg.get_rules().push_back(make_rule("https://other.example", RGW_CORS_PUT));
+
+  auto it_first = cfg.get_rules().begin();
+  EXPECT_EQ(cfg.host_name_rule("https://app.example"), &(*it_first));
+}


### PR DESCRIPTION
Amazon S3 evaluates bucket CORS configuration by selecting the **first**
`CORSRule` for which **all** of the following match the incoming request:

- the request `Origin` matches an `AllowedOrigin` in the rule;
- the request HTTP method (or `Access-Control-Request-Method` on preflight
  `OPTIONS`) matches an `AllowedMethod` in the rule;
- on preflight, every header in `Access-Control-Request-Headers` matches an
  `AllowedHeader` in the rule.

RGW previously called `host_name_rule()`, which matched **origin only**, then
validated method and headers on that single rule. If two `<CORSRule>` elements
shared the same origin but allowed different methods (e.g. rule 1: GET, rule 2:
PUT), only the first rule was ever considered; a `PUT` preflight could fail
even when a later rule allowed it.

This change adds `RGWCORSRule::matches()` and
`RGWCORSConfiguration::match_rule()` to walk rules in configuration order and
return the first fully matching rule. `generate_cors_headers()` and
`RGWOptionsCORS` use `match_rule()` for bucket CORS; global CORS
(`optional_global_cors`) uses `RGWCORSRule::matches()` before applying
headers. `host_name_rule()` is unchanged for origin-only paths such as
`erase_host_name_rule()`.

Unit tests in `unittest_rgw_cors` cover same-origin rules with different
methods and preflight header selection.

## Testing

- `unittest_rgw_cors` (new)
- Manual: `PutBucketCors` with two rules, same `AllowedOrigin`, different
  `AllowedMethod`; verify `OPTIONS` preflight for the second method succeeds.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>