### PR TITLE
cephadm: start rpcbind before NFS-Ganesha for NFSv3 TCP

### DIFF
--- a/src/cephadm/cephadmlib/daemons/nfs.py
+++ b/src/cephadm/cephadmlib/daemons/nfs.py
@@ -28,7 +28,9 @@ class NFSGanesha(ContainerDaemonForm):
     """Defines a NFS-Ganesha container"""
 
     daemon_type = 'nfs'
-    entrypoint = '/usr/bin/ganesha.nfsd'
+    entrypoint = '/usr/local/scripts/ganesha-entrypoint.sh'
+    ganesha_binary = '/usr/bin/ganesha.nfsd'
+    entrypoint_script_name = 'ganesha-entrypoint.sh'
     daemon_args = ['-F', '-L', 'STDERR']
 
     required_files = ['ganesha.conf', 'idmap.conf']
@@ -88,6 +90,9 @@ class NFSGanesha(ContainerDaemonForm):
         mounts[os.path.join(data_dir, 'config')] = '/etc/ceph/ceph.conf:z'
         mounts[os.path.join(data_dir, 'keyring')] = '/etc/ceph/keyring:z'
         mounts[os.path.join(data_dir, 'etc/ganesha')] = '/etc/ganesha:z'
+        mounts[
+            os.path.join(data_dir, self.entrypoint_script_name)
+        ] = self.entrypoint
         if self.rgw:
             cluster = self.rgw.get('cluster', 'ceph')
             rgw_user = self.rgw.get('user', 'admin')
@@ -118,7 +123,7 @@ class NFSGanesha(ContainerDaemonForm):
                 ctx.container_engine.path,
                 'exec',
                 container_id,
-                NFSGanesha.entrypoint,
+                NFSGanesha.ganesha_binary,
                 '-v',
             ],
             verbosity=CallVerbosity.QUIET,
@@ -168,6 +173,42 @@ class NFSGanesha(ContainerDaemonForm):
         # type: () -> List[str]
         return self.daemon_args + self.extra_args
 
+    @staticmethod
+    def ganesha_conf_text(conf: Union[str, List[str]]) -> str:
+        if isinstance(conf, list):
+            return '\n'.join(conf)
+        return conf
+
+    @staticmethod
+    def nfsv3_enabled_in_ganesha_conf(conf: Union[str, List[str]]) -> bool:
+        """Return True when ganesha.conf enables NFSv3 (Protocols includes 3)."""
+        text = NFSGanesha.ganesha_conf_text(conf)
+        match = re.search(r'Protocols\s*=\s*([^;]+)', text, re.MULTILINE)
+        if not match:
+            # No Protocols line (e.g. minimal test stubs): keep legacy behavior.
+            return True
+        protocols = match.group(1)
+        return bool(re.search(r'(?:^|[,\s])3(?:[,\s]|$)', protocols))
+
+    @staticmethod
+    def ganesha_entrypoint_script(nfsv3: bool = True) -> str:
+        # NFSv3 registration with SunRPC requires a running portmapper.
+        # The image installs rpcbind but cephadm previously started only
+        # ganesha.nfsd, which fails on Rocky 10 / Ganesha 9.x with
+        # "Cannot register NFS V3 on TCP" when rpcbind is not up.
+        rpcbind_block = ''
+        if nfsv3:
+            rpcbind_block = """if command -v rpcbind >/dev/null 2>&1; then
+    if ! rpcinfo -p >/dev/null 2>&1; then
+        rpcbind
+    fi
+fi
+"""
+        return f"""#!/bin/bash
+set -e
+{rpcbind_block}exec /usr/bin/ganesha.nfsd "$@"
+"""
+
     def create_daemon_dirs(self, data_dir, uid, gid):
         # type: (str, int, int) -> None
         """Create files under the container data dir"""
@@ -195,6 +236,13 @@ class NFSGanesha(ContainerDaemonForm):
         # populate files from the config-json
         populate_files(config_dir, config_files, uid, gid)
         populate_files(tls_dir, tls_files, uid, gid)
+
+        ganesha_conf = self.files.get('ganesha.conf', '')
+        nfsv3 = self.nfsv3_enabled_in_ganesha_conf(ganesha_conf)
+        entrypoint_path = os.path.join(data_dir, self.entrypoint_script_name)
+        with write_new(entrypoint_path, owner=(uid, gid)) as f:
+            f.write(self.ganesha_entrypoint_script(nfsv3=nfsv3))
+        os.chmod(entrypoint_path, 0o700)
 
         # write the RGW keyring
         if self.rgw:

--- a/src/cephadm/tests/test_nfs.py
+++ b/src/cephadm/tests/test_nfs.py
@@ -119,10 +119,14 @@ def test_nfsganesha_container_mounts():
             good_nfs_json(),
         )
         cmounts = nfsg._get_container_mounts("/var/tmp")
-        assert len(cmounts) == 3
+        assert len(cmounts) == 4
         assert cmounts["/var/tmp/config"] == "/etc/ceph/ceph.conf:z"
         assert cmounts["/var/tmp/keyring"] == "/etc/ceph/keyring:z"
         assert cmounts["/var/tmp/etc/ganesha"] == "/etc/ganesha:z"
+        assert (
+            cmounts["/var/tmp/ganesha-entrypoint.sh"]
+            == "/usr/local/scripts/ganesha-entrypoint.sh"
+        )
 
     with with_cephadm_ctx([]) as ctx:
         nfsg = _cephadm.NFSGanesha(
@@ -132,7 +136,7 @@ def test_nfsganesha_container_mounts():
             nfs_json(pool=True, files=True, rgw=True),
         )
         cmounts = nfsg._get_container_mounts("/var/tmp")
-        assert len(cmounts) == 4
+        assert len(cmounts) == 5
         assert cmounts["/var/tmp/config"] == "/etc/ceph/ceph.conf:z"
         assert cmounts["/var/tmp/keyring"] == "/etc/ceph/keyring:z"
         assert cmounts["/var/tmp/etc/ganesha"] == "/etc/ganesha:z"
@@ -212,6 +216,52 @@ def test_nfsganesha_get_daemon_args():
         assert args == ["-F", "-L", "STDERR"]
 
 
+@pytest.mark.parametrize(
+    'conf,expected',
+    [
+        ('Protocols = 3, 4;', True),
+        ('Protocols = 4, 3;', True),
+        ('Protocols = 4;', False),
+        ('Protocols = 4, nfsrdma, rpcrdma;', False),
+        ('', True),
+    ],
+)
+def test_nfsv3_enabled_in_ganesha_conf(conf, expected):
+    assert _cephadm.NFSGanesha.nfsv3_enabled_in_ganesha_conf(conf) is expected
+
+
+def test_nfsganesha_entrypoint_script_nfsv3():
+    script = _cephadm.NFSGanesha.ganesha_entrypoint_script(nfsv3=True)
+    assert 'rpcbind' in script
+    assert 'exec /usr/bin/ganesha.nfsd "$@"' in script
+
+
+def test_nfsganesha_entrypoint_script_v4_only():
+    script = _cephadm.NFSGanesha.ganesha_entrypoint_script(nfsv3=False)
+    assert 'rpcbind' not in script
+    assert 'exec /usr/bin/ganesha.nfsd "$@"' in script
+
+
+def test_nfsganesha_entrypoint_script_from_conf():
+    conf_v3 = '\n'.join(
+        [
+            'NFS_CORE_PARAM {',
+            '        Protocols = 3, 4;',
+            '}',
+        ]
+    )
+    script = _cephadm.NFSGanesha.ganesha_entrypoint_script(
+        nfsv3=_cephadm.NFSGanesha.nfsv3_enabled_in_ganesha_conf(conf_v3),
+    )
+    assert 'rpcbind' in script
+
+    conf_v4 = 'NFS_CORE_PARAM { Protocols = 4; }'
+    script = _cephadm.NFSGanesha.ganesha_entrypoint_script(
+        nfsv3=_cephadm.NFSGanesha.nfsv3_enabled_in_ganesha_conf(conf_v4),
+    )
+    assert 'rpcbind' not in script
+
+
 @mock.patch("cephadm.logger")
 def test_nfsganesha_create_daemon_dirs(_logger, cephadm_fs):
     with with_cephadm_ctx([]) as ctx:
@@ -225,7 +275,24 @@ def test_nfsganesha_create_daemon_dirs(_logger, cephadm_fs):
             nfsg.create_daemon_dirs("/var/tmp", 45, 54)
         cephadm_fs.create_dir("/var/tmp")
         nfsg.create_daemon_dirs("/var/tmp", 45, 54)
-        # TODO: make assertions about the dirs created
+        with open("/var/tmp/ganesha-entrypoint.sh") as f:
+            assert 'rpcbind' in f.read()
+
+        nfsg_v4 = _cephadm.NFSGanesha(
+            ctx,
+            SAMPLE_UUID,
+            "fred",
+            {
+                'pool': 'party',
+                'files': {
+                    'ganesha.conf': 'NFS_CORE_PARAM { Protocols = 4; }',
+                    'idmap.conf': '',
+                },
+            },
+        )
+        nfsg_v4.create_daemon_dirs("/var/tmp", 45, 54)
+        with open("/var/tmp/ganesha-entrypoint.sh") as f:
+            assert 'rpcbind' not in f.read()
 
 
 @mock.patch("cephadm.logger")


### PR DESCRIPTION
With Protocols = 3, 4 and Enable_UDP = false, Ganesha 9.x on Rocky 10 needs a running portmapper to register NFSv3 on TCP. The container image installs rpcbind but cephadm only started ganesha.nfsd.

Fixes: https://tracker.ceph.com/issues/76981
Signed-off-by: Kobi Ginon <kginon@redhat.com>

Reproduction (prove the bug — without this PR)
Goal: show that the same config as QA fails when rpcbind is not running, and succeeds when it is.

A. Environment
```
Rocky Linux 10.x (e.g. Rocky Linux release 10.2)
Image: quay.ceph.io/ceph-ci/ceph:main (same as teuthology)
Ganesha config matching the sample after #68976:
mkdir -p /tmp/ganesha-repro-76981
cat > /tmp/ganesha-repro-76981/ganesha.conf <<'EOF'
NFS_CORE_PARAM {
    Protocols = 3, 4;
    Enable_UDP = false;
    allow_set_io_flusher_fail = true;
}
EOF

```
B. Confirm rpcbind is not running (typical on Rocky 10)
```
systemctl status rpcbind
# Expected: inactive (dead), disabled
rpcinfo -p

# Expected: fails or no programs (portmapper not usable)
This matches the container/host state where NFSv3 TCP registration fails.
```

C. Run Ganesha like cephadm did before the fix (direct binary, no entrypoint)
```
podman rm -f ganesha-repro 2>/dev/null
podman run -d --name ganesha-repro \
  --net=host \
  -v /tmp/ganesha-repro-76981/ganesha.conf:/etc/ganesha/ganesha.conf:Z \
  quay.ceph.io/ceph-ci/ceph:main \
  ganesha.nfsd -F -L STDERR -f /etc/ganesha/ganesha.conf
sleep 3
podman logs ganesha-repro 2>&1 | tee /tmp/ganesha-broken.log
podman ps -a --filter name=ganesha-repro
Expected (bug):

Container exits or is not healthy
Log contains: Cannot register NFS V3 on TCP (same as [#76981](https://tracker.ceph.com/issues/76981))
No stable listener: ss -tlnp | grep ganesha / port 2049 missing
grep -i 'Cannot register NFS V3 on TCP' /tmp/ganesha-broken.log

**Verification after the Fix**

Inside cephadm shell / ceph shell:

ceph mgr module enable nfs

HOST=$(hostname -s)   # must match ceph orch host name
cat > /tmp/nfs.yaml <<EOF
service_type: nfs
service_id: test
placement:
  hosts:
    - ${HOST}
EOF
ceph orch apply -i /tmp/nfs.yaml
# Force fresh unit + entrypoint script (important after cephadm_path change)
ceph orch redeploy nfs.test

[ceph: root@ceph-node-0 /]# ceph orch ps --service-name nfs.test
NAME                             HOST         PORTS              STATUS        REFRESHED  AGE  MEM USE  MEM LIM  VERSION  IMAGE ID      CONTAINER ID
nfs.test.0.0.ceph-node-0.zcgihv  ceph-node-0  *:2049,9587,31311  running (3m)     3m ago   3m    15.0M        -  7.0      e197eb02a5eb  fbde8fc82551

[ceph: root@ceph-node-0 /]# ceph orch ls --service-name nfs.test
NAME      PORTS              RUNNING  REFRESHED  AGE  PLACEMENT
nfs.test  ?:2049,9587,31311      1/1  3m ago     4m   ceph-node-0

On the host (not inside shell):
[root@ceph-node-0 ~]# FSID=$(cephadm shell ceph fsid)
Inferring fsid 95773a66-5d25-11f1-bc57-525400991f34
Inferring config /var/lib/ceph/95773a66-5d25-11f1-bc57-525400991f34/mon.ceph-node-0/config
[root@ceph-node-0 ~]# echo $FSID
95773a66-5d25-11f1-bc57-525400991f34


DATA=$(ls -d /var/lib/ceph/$FSID/nfs.test.* 2>/dev/null | head -1)
echo "DATA=$DATA"

DATA=/var/lib/ceph/95773a66-5d25-11f1-bc57-525400991f34/nfs.test.0.0.ceph-node-0.zcgihv

[root@ceph-node-0 ~]# test -f "$DATA/ganesha-entrypoint.sh" && echo "OK: entrypoint file exists"
OK: entrypoint file exists
[root@ceph-node-0 ~]# cat "$DATA/ganesha-entrypoint.sh"
#!/bin/bash
set -e
if command -v rpcbind >/dev/null 2>&1; then
    if ! rpcinfo -p >/dev/null 2>&1; then
        rpcbind
    fi
fi
exec /usr/bin/ganesha.nfsd "$@"

[root@ceph-node-0 ~]# # 3) Host rpcbind still off
systemctl is-active rpcbind.service || echo "host rpcbind still off (good)"
inactive
host rpcbind still off (good)

[root@ceph-node-0 ~]# # 4) No V3 TCP registration error
journalctl -u "ceph-${FSID}@nfs.test*" --no-pager -n 80 | grep -i 'Cannot register' \
  && echo "FAIL" || echo "OK: no Cannot register"
OK: no Cannot register

[root@ceph-node-0 ~]# # 5) Ganesha listening
ss -tlnp | grep -E '2049|ganesha'
LISTEN 0      3                    *:9587             *:*    users:(("ganesha.nfsd",pid=19633,fd=4))
LISTEN 0      4096                 *:50051            *:*    users:(("ganesha.nfsd",pid=19633,fd=28))
LISTEN 0      4096                 *:37055            *:*    users:(("ganesha.nfsd",pid=19633,fd=36))
LISTEN 0      4096                 *:2049             *:*    users:(("ganesha.nfsd",pid=19633,fd=35))

[root@ceph-node-0 ~]# # 6) Config sanity
grep -E 'Protocols|Enable_UDP' "$DATA/etc/ganesha/ganesha.conf"
        Protocols = 3, 4;
        Enable_UDP = false;
```



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
