### PR TITLE
rgw: serialize send_partial_response in multi-object delete

### DIFF
--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <cstdint>
+#include <mutex>
 #include <limits.h>
 
 #include <array>
@@ -2274,6 +2275,8 @@ class RGWDeleteMultiObj : public RGWOp {
 
 protected:
   std::vector<delete_multi_obj_entry> ops_log_entries;
+  std::mutex mtx_partial_response;
+
   bufferlist data;
   rgw::sal::Bucket* bucket;
   bool quiet;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -4961,23 +4961,9 @@ void RGWDeleteMultiObj_ObjStore_S3::send_partial_response(const rgw_obj_key& key
       if (delete_marker) {
         ops_log_entry.marker_version_id = marker_version_id;
       }
-      if (!quiet) {
-        s->formatter->open_object_section("Deleted");
-        s->formatter->dump_string("Key", key.name);
-        if (!key.instance.empty()) {
-            s->formatter->dump_string("VersionId", key.instance);
-        }
-        if (delete_marker) {
-            s->formatter->dump_bool("DeleteMarker", true);
-            s->formatter->dump_string("DeleteMarkerVersionId", marker_version_id);
-        }
-        s->formatter->close_section();
-      }
     } else if (ret < 0) {
       struct rgw_http_error r;
       int err_no;
-
-      s->formatter->open_object_section("Error");
 
       err_no = -ret;
       rgw_get_errno_s3(&r, err_no);
@@ -4985,15 +4971,35 @@ void RGWDeleteMultiObj_ObjStore_S3::send_partial_response(const rgw_obj_key& key
       ops_log_entry.error = true;
       ops_log_entry.http_status = r.http_ret;
       ops_log_entry.error_message = r.s3_code;
-
-      s->formatter->dump_string("Key", key.name);
-      s->formatter->dump_string("VersionId", key.instance);
-      s->formatter->dump_string("Code", r.s3_code);
-      s->formatter->dump_string("Message", r.s3_code);
-      s->formatter->close_section();
     }
 
-    ops_log_entries.push_back(std::move(ops_log_entry));
+    {
+      std::lock_guard<std::mutex> lck(mtx_partial_response);
+
+      if (ret == 0) {
+        if (!quiet) {
+          s->formatter->open_object_section("Deleted");
+          s->formatter->dump_string("Key", key.name);
+          if (!key.instance.empty()) {
+              s->formatter->dump_string("VersionId", key.instance);
+          }
+          if (delete_marker) {
+              s->formatter->dump_bool("DeleteMarker", true);
+              s->formatter->dump_string("DeleteMarkerVersionId", marker_version_id);
+          }
+          s->formatter->close_section();
+        }
+      } else if (ret < 0) {
+        s->formatter->open_object_section("Error");
+        s->formatter->dump_string("Key", key.name);
+        s->formatter->dump_string("VersionId", key.instance);
+        s->formatter->dump_string("Code", ops_log_entry.error_message);
+        s->formatter->dump_string("Message", ops_log_entry.error_message);
+        s->formatter->close_section();
+      }
+
+      ops_log_entries.push_back(std::move(ops_log_entry));
+    }
   }
 }
 


### PR DESCRIPTION
concurrent Multi Objects Delete request can run on different io_context pool threads, causing concurrent access to the shared formatter and ops_log_entries vector in send_partial_response().
this data race can lead to use-after-free during vector reallocation (detected by ASAN)

add a mutex to serialize the formatter writes and ops_log_entries push_back.

Fixes: https://tracker.ceph.com/issues/76725





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
