### PR TITLE
SimpleRADOSStriper: retrieve AIO return values with get_return_value()

### DIFF
--- a/src/SimpleRADOSStriper.cc
+++ b/src/SimpleRADOSStriper.cc
@@ -163,7 +163,8 @@ int SimpleRADOSStriper::wait_for_aios(bool block)
     auto& aiocp = aios.front();
     int rc;
     if (block) {
-      rc = aiocp->wait_for_complete();
+      aiocp->wait_for_complete();
+      rc = aiocp->get_return_value();
     } else {
       if (aiocp->is_complete()) {
         rc = aiocp->get_return_value();
@@ -307,7 +308,8 @@ int SimpleRADOSStriper::shrink_alloc(uint64_t a)
   }
 
   for (auto& aiocp : removes) {
-    if (int rc = aiocp->wait_for_complete(); rc < 0 && rc != -ENOENT) {
+    aiocp->wait_for_complete();
+    if (int rc = aiocp->get_return_value(); rc < 0 && rc != -ENOENT) {
       d(1) << " aio_remove failed: " << cpp_strerror(rc) << dendl;
       return rc;
     }
@@ -326,7 +328,8 @@ int SimpleRADOSStriper::shrink_alloc(uint64_t a)
   }
   /* we need to wait so we don't have dangling extents */
   d(10) << " waiting for allocated update" << dendl;
-  if (int rc = aiocp->wait_for_complete(); rc < 0) {
+  aiocp->wait_for_complete();
+  if (int rc = aiocp->get_return_value(); rc < 0) {
     d(1) << " update failure: " << cpp_strerror(rc) << dendl;
     return rc;
   }
@@ -423,7 +426,8 @@ int SimpleRADOSStriper::set_metadata(uint64_t new_size, bool update_size)
     if (allocated != new_allocated) {
       /* we need to wait so we don't have dangling extents */
       d(10) << "waiting for allocated update" << dendl;
-      if (int rc = aiocp->wait_for_complete(); rc < 0) {
+      aiocp->wait_for_complete();
+      if (int rc = aiocp->get_return_value(); rc < 0) {
         d(1) << " update failure: " << cpp_strerror(rc) << dendl;
         return rc;
       }
@@ -506,7 +510,8 @@ ssize_t SimpleRADOSStriper::read(void* data, size_t len, uint64_t off)
 
   r = 0;
   for (auto& [bl, aiocp] : reads) {
-    if (int rc = aiocp->wait_for_complete(); rc < 0) {
+    aiocp->wait_for_complete();
+    if (int rc = aiocp->get_return_value(); rc < 0) {
       d(1) << " read failure: " << cpp_strerror(rc) << dendl;
       return rc;
     }


### PR DESCRIPTION
Previously, the AIO wait logic mistakenly assumed wait_for_complete() returned the operation's status code. This caused asynchronous I/O errors to be silently ignored. This change explicitly calls get_return_value() after the wait completes to ensure I/O failures are correctly captured and propagated back to the caller.

Fixes: https://tracker.ceph.com/issues/77010





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
