### PR TITLE
cephsqlite: support concurrent readers

### DIFF
--- a/debian/libsqlite3-mod-ceph.symbols
+++ b/debian/libsqlite3-mod-ceph.symbols
@@ -1,37 +1,3 @@
 libcephsqlite.so libsqlite3-mod-ceph #MINVER#
- _ZGVN18SimpleRADOSStriper7biglockB5cxx11E@Base 15.2.0-1
- _ZGVN18SimpleRADOSStriper8lockdescB5cxx11E@Base 15.2.0-1
- _ZN18SimpleRADOSStriper10XATTR_EXCLE@Base 15.2.0-1
- _ZN18SimpleRADOSStriper10XATTR_SIZEE@Base 15.2.0-1
- _ZN18SimpleRADOSStriper12recover_lockEv@Base 15.2.0-1
- _ZN18SimpleRADOSStriper12set_metadataEmb@Base 15.2.0-1
- _ZN18SimpleRADOSStriper12shrink_allocEm@Base 15.2.0-1
- _ZN18SimpleRADOSStriper13XATTR_VERSIONE@Base 15.2.0-1
- _ZN18SimpleRADOSStriper13config_loggerEPN4ceph6common11CephContextESt17basic_string_viewIcSt11char_traitsIcEEPSt10shared_ptrINS1_12PerfCountersEE@Base 15.2.0-1
- _ZN18SimpleRADOSStriper13print_lockersERSo@Base 15.2.0-1
- _ZN18SimpleRADOSStriper13wait_for_aiosEb@Base 15.2.0-1
- _ZN18SimpleRADOSStriper15XATTR_ALLOCATEDE@Base 15.2.0-1
- _ZN18SimpleRADOSStriper16lock_keeper_mainEv@Base 15.2.0-1
- _ZN18SimpleRADOSStriper18maybe_shrink_allocEv@Base 15.2.0-1
- _ZN18SimpleRADOSStriper24XATTR_LAYOUT_OBJECT_SIZEE@Base 15.2.0-1
- _ZN18SimpleRADOSStriper24XATTR_LAYOUT_STRIPE_UNITE@Base 15.2.0-1
- _ZN18SimpleRADOSStriper25XATTR_LAYOUT_STRIPE_COUNTE@Base 15.2.0-1
- _ZN18SimpleRADOSStriper4lockEm@Base 15.2.0-1
- _ZN18SimpleRADOSStriper4openEv@Base 15.2.0-1
- _ZN18SimpleRADOSStriper4readEPvmm@Base 15.2.0-1
- _ZN18SimpleRADOSStriper4statEPm@Base 15.2.0-1
- _ZN18SimpleRADOSStriper5flushEv@Base 15.2.0-1
- _ZN18SimpleRADOSStriper5writeEPKvmm@Base 15.2.0-1
- _ZN18SimpleRADOSStriper6createEv@Base 15.2.0-1
- _ZN18SimpleRADOSStriper6removeEv@Base 15.2.0-1
- _ZN18SimpleRADOSStriper6str2blESt17basic_string_viewIcSt11char_traitsIcEE@Base 15.2.0-1
- _ZN18SimpleRADOSStriper6unlockEv@Base 15.2.0-1
- _ZN18SimpleRADOSStriper7biglockB5cxx11E@Base 15.2.0-1
- _ZN18SimpleRADOSStriper7uint2blEm@Base 15.2.0-1
- _ZN18SimpleRADOSStriper8lockdescB5cxx11E@Base 15.2.0-1
- _ZN18SimpleRADOSStriper8truncateEm@Base 15.2.0-1
- _ZN18SimpleRADOSStriperD1Ev@Base 15.2.0-1
- _ZN18SimpleRADOSStriperD2Ev@Base 15.2.0-1
- _ZNK18SimpleRADOSStriper15get_next_extentEmm@Base 15.2.0-1
  cephsqlite_setcct@Base 15.2.0-1
  sqlite3_cephsqlite_init@Base 15.2.0-1

--- a/qa/suites/upgrade/tentacle-x/parallel/1-tasks.yaml
+++ b/qa/suites/upgrade/tentacle-x/parallel/1-tasks.yaml
@@ -16,6 +16,9 @@ tasks:
     image: quay.ceph.io/ceph-ci/ceph:tentacle
     compiled_cephadm_branch: tentacle
     conf:
+      mgr:
+        debug_cephsqlite: 20
+        debug_rados: 20
       osd:
         #set config option for which cls modules are allowed to be loaded / used
         osd_class_load_list: "*"

--- a/qa/suites/upgrade/tentacle-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/tentacle-x/stress-split/1-start.yaml
@@ -48,6 +48,9 @@ tasks:
     image: quay.ceph.io/ceph-ci/ceph:tentacle
     compiled_cephadm_branch: tentacle
     conf:
+      mgr:
+        debug_cephsqlite: 20
+        debug_rados: 20
       osd:
         #set config option for which cls modules are allowed to be loaded / used
         osd_class_load_list: "*"

--- a/qa/suites/upgrade/tentacle-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/tentacle-x/stress-split/1-start.yaml
@@ -52,6 +52,9 @@ tasks:
     image: quay.ceph.io/ceph-ci/ceph:tentacle
     compiled_cephadm_branch: tentacle
     conf:
+      mgr:
+        debug_cephsqlite: 20
+        debug_rados: 20
       osd:
         #set config option for which cls modules are allowed to be loaded / used
         osd_class_load_list: "*"

--- a/qa/workunits/rados/test_libcephsqlite.sh
+++ b/qa/workunits/rados/test_libcephsqlite.sh
@@ -20,7 +20,15 @@ function sqlite {
   # We're doing job control gymnastics here to make sure that sqlite3 is the
   # main process (i.e. the process group leader) in the background, not a bash
   # function or job pipeline.
-  sqlite3 -cmd '.bail on' -cmd '.output /dev/null' -cmd '.load libcephsqlite.so' -cmd 'pragma journal_mode = PERSIST' -cmd ".open file:///$pool:$ns/baz.db?vfs=ceph" -cmd '.output stdout' <<<"$a" &
+  sqlite3 \
+      -cmd '.bail on' \
+      -cmd '.output /dev/null' \
+      -cmd '.load libcephsqlite.so' \
+      -cmd 'PRAGMA journal_mode = PERSIST' \
+      -cmd ".open file:///$pool:$ns/baz.db?vfs=ceph" \
+      -cmd 'PRAGMA busy_timeout = 300000;' \
+      -cmd '.output stdout' \
+      <<<"$a" &
   if [ "$background" != b ]; then
     wait
   fi

--- a/src/SimpleRADOSStriper.cc
+++ b/src/SimpleRADOSStriper.cc
@@ -49,7 +49,7 @@ using ceph::bufferlist;
 
 #define dout_subsys ceph_subsys_cephsqlite
 #undef dout_prefix
-#define dout_prefix *_dout << "client." << ioctx.get_instance_id() << ": SimpleRADOSStriper: " << __func__ << ": " << oid << ": "
+#define dout_prefix *_dout << "client." << ioctx.get_instance_id() << ": SimpleRADOSStriper(" << cookie_dstr << "): " << __func__ << ": " << oid << ": "
 #define d(lvl) ldout((CephContext*)ioctx.cct(), (lvl))
 
 enum {

--- a/src/SimpleRADOSStriper.cc
+++ b/src/SimpleRADOSStriper.cc
@@ -65,6 +65,23 @@ enum {
   P_LAST,
 };
 
+int SimpleRADOSStriper::check_reservation(bool* is_reserved)
+{
+  bufferlist bl_state;
+  auto ext = get_first_extent();
+  if (int rc = ioctx.getxattr(ext.soid, XATTR_STATE, bl_state); rc < 0) {
+    if (rc == -ENOENT || rc == -ENODATA) {
+      *is_reserved = false;
+      return 0;
+    }
+    d(-1) << " getxattr failed: " << cpp_strerror(rc) << dendl;
+    return rc;
+  }
+  auto state = bl_state.to_str();
+  *is_reserved = (state >= state2bl(LockLevel::Reserved).to_str());
+  return 0;
+}
+
 int SimpleRADOSStriper::config_logger(CephContext* cct, std::string_view name, std::shared_ptr<PerfCounters>* l)
 {
   PerfCountersBuilder plb(cct, name.data(), P_FIRST, P_LAST);
@@ -97,7 +114,7 @@ SimpleRADOSStriper::~SimpleRADOSStriper()
     d(5) << dendl;
 
     if (is_locked()) {
-      unlock();
+      unlock(LockLevel::None);
     }
   }
 }
@@ -141,7 +158,7 @@ int SimpleRADOSStriper::remove()
     return rc;
   }
 
-  locked = false;
+  locked = LockLevel::None;
 
   return 0;
 }
@@ -232,19 +249,217 @@ int SimpleRADOSStriper::create()
   }
 
   auto ext = get_first_extent();
-  auto op = librados::ObjectWriteOperation();
-  /* exclusive create ensures we do none of these setxattrs happen if it fails */
-  op.create(1);
-  op.setxattr(XATTR_VERSION, uint2bl(0));
-  op.setxattr(XATTR_EXCL, bufferlist());
-  op.setxattr(XATTR_SIZE, uint2bl(0));
-  op.setxattr(XATTR_ALLOCATED, uint2bl(0));
-  op.setxattr(XATTR_LAYOUT_STRIPE_UNIT, uint2bl(1));
-  op.setxattr(XATTR_LAYOUT_STRIPE_COUNT, uint2bl(1));
-  op.setxattr(XATTR_LAYOUT_OBJECT_SIZE, uint2bl(1<<object_size));
-  if (int rc = ioctx.operate(ext.soid, &op); rc < 0) {
-    return rc; /* including EEXIST */
+  /* create and init if not exists: */
+  {
+    auto op = librados::ObjectWriteOperation();
+    /* exclusive create ensures we do none of these setxattrs happen if it fails */
+    op.create(1);
+    op.setxattr(XATTR_VERSION, uint2bl(0));
+    op.setxattr(XATTR_EXCL, bufferlist());
+    op.setxattr(XATTR_STATE, state2bl(LockLevel::Shared));
+    op.setxattr(XATTR_WRITE_EPOCH, uint2bl(0));
+    op.setxattr(XATTR_SIZE, uint2bl(0));
+    op.setxattr(XATTR_ALLOCATED, uint2bl(0));
+    op.setxattr(XATTR_LAYOUT_STRIPE_UNIT, uint2bl(1));
+    op.setxattr(XATTR_LAYOUT_STRIPE_COUNT, uint2bl(1));
+    op.setxattr(XATTR_LAYOUT_OBJECT_SIZE, uint2bl(1<<object_size));
+    if (int rc = ioctx.operate(ext.soid, &op); rc != -EEXIST) {
+      return rc;
+    }
   }
+
+  // EEXIST
+
+  while (true) {
+    // Batch check all xattrs to optimize connection latency for existing databases
+    librados::ObjectReadOperation batch_op;
+    int rval_version = 0, rval_excl = 0, rval_state = 0, rval_epoch = 0;
+    int rval_size = 0, rval_alloc = 0, rval_su = 0, rval_sc = 0, rval_os = 0;
+
+    batch_op.getxattr(XATTR_VERSION, nullptr, &rval_version);
+    batch_op.set_op_flags2(librados::OP_FAILOK);
+    batch_op.getxattr(XATTR_EXCL, nullptr, &rval_excl);
+    batch_op.set_op_flags2(librados::OP_FAILOK);
+    batch_op.getxattr(XATTR_STATE, nullptr, &rval_state);
+    batch_op.set_op_flags2(librados::OP_FAILOK);
+    batch_op.getxattr(XATTR_WRITE_EPOCH, nullptr, &rval_epoch);
+    batch_op.set_op_flags2(librados::OP_FAILOK);
+    batch_op.getxattr(XATTR_SIZE, nullptr, &rval_size);
+    batch_op.set_op_flags2(librados::OP_FAILOK);
+    batch_op.getxattr(XATTR_ALLOCATED, nullptr, &rval_alloc);
+    batch_op.set_op_flags2(librados::OP_FAILOK);
+    batch_op.getxattr(XATTR_LAYOUT_STRIPE_UNIT, nullptr, &rval_su);
+    batch_op.set_op_flags2(librados::OP_FAILOK);
+    batch_op.getxattr(XATTR_LAYOUT_STRIPE_COUNT, nullptr, &rval_sc);
+    batch_op.set_op_flags2(librados::OP_FAILOK);
+    batch_op.getxattr(XATTR_LAYOUT_OBJECT_SIZE, nullptr, &rval_os);
+    batch_op.set_op_flags2(librados::OP_FAILOK);
+
+    bufferlist out_bl;
+    int batch_rc = ioctx.operate(ext.soid, &batch_op, &out_bl);
+    if (batch_rc < 0 && batch_rc != -ENODATA) {
+      return batch_rc;
+    }
+
+    // Fallback: at least one xattr is missing (upgrade path).
+    // Initialize missing ones individually.
+    if (rval_version == -ENODATA) {
+      d(-1) << "backing database exists but there is no " << XATTR_VERSION << dendl;
+      return -EINVAL;
+    }
+
+    librados::ObjectWriteOperation write_op;
+    bool need_write = false;
+
+    if (rval_excl == -ENODATA) { write_op.setxattr(XATTR_EXCL, bufferlist()); need_write = true; }
+    if (rval_state == -ENODATA) { write_op.setxattr(XATTR_STATE, state2bl(LockLevel::Shared)); need_write = true; }
+    if (rval_epoch == -ENODATA) { write_op.setxattr(XATTR_WRITE_EPOCH, uint2bl(0)); need_write = true; }
+    if (rval_size == -ENODATA) { write_op.setxattr(XATTR_SIZE, uint2bl(0)); need_write = true; }
+    if (rval_alloc == -ENODATA) { write_op.setxattr(XATTR_ALLOCATED, uint2bl(0)); need_write = true; }
+    if (rval_su == -ENODATA) { write_op.setxattr(XATTR_LAYOUT_STRIPE_UNIT, uint2bl(1)); need_write = true; }
+    if (rval_sc == -ENODATA) { write_op.setxattr(XATTR_LAYOUT_STRIPE_COUNT, uint2bl(1)); need_write = true; }
+    if (rval_os == -ENODATA) { write_op.setxattr(XATTR_LAYOUT_OBJECT_SIZE, uint2bl(1<<object_size)); need_write = true; }
+
+    if (need_write) {
+      uint64_t obj_ver = ioctx.get_last_version();
+      write_op.assert_version(obj_ver);
+      if (int rc = ioctx.operate(ext.soid, &write_op); rc < 0) {
+        if (rc == -ERANGE || rc == -EOVERFLOW) {
+          continue;
+        }
+        return rc;
+      }
+    }
+    
+    return 0;
+  }
+}
+
+void SimpleRADOSStriper::print(std::ostream& os) const
+{
+  os << "SimpleRADOSStriper"
+     << "(oid: " << oid
+     << " self_state: " << std::to_underlying(locked)
+     << " disk_state: " << std::to_underlying(disk_state)
+     << " size: " << size
+     << " allocated: " << allocated
+     << " version: " << version
+     << " write_epoch: " << write_epoch
+     << " cookie: " << cookie_dstr << "..."
+     << ")";
+}
+
+int SimpleRADOSStriper::get_metadata()
+{
+  d(5) << oid << dendl;
+
+  if (blocklisted.load()) {
+    return -EBLOCKLISTED;
+  }
+
+  auto ext = get_first_extent();
+  auto op = librados::ObjectReadOperation();
+  bufferlist bl_excl, bl_epoch, bl_size, bl_alloc, bl_version, bl_state, pbl;
+  bufferlist bl_layout_su, bl_layout_sc, bl_layout_os;
+  int prval_excl, prval_epoch, prval_size, prval_alloc, prval_version, prval_state;
+  int prval_layout_su, prval_layout_sc, prval_layout_os;
+
+  op.getxattr(XATTR_ALLOCATED, &bl_alloc, &prval_alloc);
+  op.getxattr(XATTR_EXCL, &bl_excl, &prval_excl);
+  op.getxattr(XATTR_LAYOUT_OBJECT_SIZE, &bl_layout_os, &prval_layout_os);
+  op.getxattr(XATTR_LAYOUT_STRIPE_COUNT, &bl_layout_sc, &prval_layout_sc);
+  op.getxattr(XATTR_LAYOUT_STRIPE_UNIT, &bl_layout_su, &prval_layout_su);
+  op.getxattr(XATTR_SIZE, &bl_size, &prval_size);
+  op.getxattr(XATTR_STATE, &bl_state, &prval_state);
+  op.getxattr(XATTR_VERSION, &bl_version, &prval_version);
+  op.getxattr(XATTR_WRITE_EPOCH, &bl_epoch, &prval_epoch);
+
+  if (int rc = ioctx.operate(ext.soid, &op, &pbl); rc < 0) {
+    d(1) << " getxattr failed: " << cpp_strerror(rc) << dendl;
+    return rc;
+  }
+
+  if (prval_alloc >= 0 && bl_alloc.length() > 0) {
+    auto sstr = bl_alloc.to_str();
+    std::string err;
+    allocated = strict_strtoll(sstr.c_str(), 10, &err);
+    ceph_assert(err.empty());
+    d(20) << XATTR_ALLOCATED << "=" << sstr << " (rval=" << prval_alloc << ")" << dendl;
+  } else {
+    d(20) << XATTR_ALLOCATED << " is missing or empty (rval=" << prval_alloc << ")" << dendl;
+  }
+  if (prval_excl >= 0) {
+    exclusive_holder = bl_excl.to_str();
+    d(20) << XATTR_EXCL << "=" << exclusive_holder << " (rval=" << prval_excl << ")" << dendl;
+  } else {
+    exclusive_holder.clear();
+    d(20) << XATTR_EXCL << " is missing (rval=" << prval_excl << ")" << dendl;
+  }
+  if (prval_layout_os >= 0 && bl_layout_os.length() > 0) {
+    auto sstr = bl_layout_os.to_str();
+    std::string err;
+    layout_object_size = strict_strtoll(sstr.c_str(), 10, &err);
+    ceph_assert(err.empty());
+    d(20) << XATTR_LAYOUT_OBJECT_SIZE << "=" << sstr << " (rval=" << prval_layout_os << ")" << dendl;
+  } else {
+    d(20) << XATTR_LAYOUT_OBJECT_SIZE << " is missing or empty (rval=" << prval_layout_os << ")" << dendl;
+  }
+  if (prval_layout_sc >= 0 && bl_layout_sc.length() > 0) {
+    auto sstr = bl_layout_sc.to_str();
+    std::string err;
+    layout_stripe_count = strict_strtoll(sstr.c_str(), 10, &err);
+    ceph_assert(err.empty());
+    d(20) << XATTR_LAYOUT_STRIPE_COUNT << "=" << sstr << " (rval=" << prval_layout_sc << ")" << dendl;
+  } else {
+    d(20) << XATTR_LAYOUT_STRIPE_COUNT << " is missing or empty (rval=" << prval_layout_sc << ")" << dendl;
+  }
+  if (prval_layout_su >= 0 && bl_layout_su.length() > 0) {
+    auto sstr = bl_layout_su.to_str();
+    std::string err;
+    layout_stripe_unit = strict_strtoll(sstr.c_str(), 10, &err);
+    ceph_assert(err.empty());
+    d(20) << XATTR_LAYOUT_STRIPE_UNIT << "=" << sstr << " (rval=" << prval_layout_su << ")" << dendl;
+  } else {
+    d(20) << XATTR_LAYOUT_STRIPE_UNIT << " is missing or empty (rval=" << prval_layout_su << ")" << dendl;
+  }
+  if (prval_size >= 0 && bl_size.length() > 0) {
+    auto sstr = bl_size.to_str();
+    std::string err;
+    size = strict_strtoll(sstr.c_str(), 10, &err);
+    ceph_assert(err.empty());
+    d(20) << XATTR_SIZE << "=" << sstr << " (rval=" << prval_size << ")" << dendl;
+  } else {
+    d(20) << XATTR_SIZE << " is missing or empty (rval=" << prval_size << ")" << dendl;
+  }
+  if (prval_state >= 0 && bl_state.length() > 0) {
+    auto sstr = bl_state.to_str();
+    std::string err;
+    disk_state = static_cast<LockLevel>(strict_strtoll(sstr.c_str(), 10, &err));
+    ceph_assert(err.empty());
+    d(20) << XATTR_STATE << "=" << sstr << " (rval=" << prval_state << ")" << dendl;
+  } else {
+    d(20) << XATTR_STATE << " is missing or empty (rval=" << prval_state << ")" << dendl;
+  }
+  if (prval_version >= 0 && bl_version.length() > 0) {
+    auto sstr = bl_version.to_str();
+    std::string err;
+    version = strict_strtoll(sstr.c_str(), 10, &err);
+    ceph_assert(err.empty());
+    d(20) << XATTR_VERSION << "=" << sstr << " (rval=" << prval_version << ")" << dendl;
+  } else {
+    d(20) << XATTR_VERSION << " is missing or empty (rval=" << prval_version << ")" << dendl;
+  }
+  if (prval_epoch >= 0 && bl_epoch.length() > 0) {
+    auto sstr = bl_epoch.to_str();
+    std::string err;
+    write_epoch = strict_strtoll(sstr.c_str(), 10, &err);
+    ceph_assert(err.empty());
+    d(20) << XATTR_WRITE_EPOCH << "=" << sstr << " (rval=" << prval_epoch << ")" << dendl;
+  } else {
+    d(20) << XATTR_WRITE_EPOCH << " is missing or empty (rval=" << prval_epoch << ")" << dendl;
+  }
+
+  d(10) << *this << dendl;
   return 0;
 }
 
@@ -256,39 +471,7 @@ int SimpleRADOSStriper::open()
     return -EBLOCKLISTED;
   }
 
-  auto ext = get_first_extent();
-  auto op = librados::ObjectReadOperation();
-  bufferlist bl_excl, bl_size, bl_alloc, bl_version, pbl;
-  int prval_excl, prval_size, prval_alloc, prval_version;
-  op.getxattr(XATTR_EXCL, &bl_excl, &prval_excl);
-  op.getxattr(XATTR_SIZE, &bl_size, &prval_size);
-  op.getxattr(XATTR_ALLOCATED, &bl_alloc, &prval_alloc);
-  op.getxattr(XATTR_VERSION, &bl_version, &prval_version);
-  if (int rc = ioctx.operate(ext.soid, &op, &pbl); rc < 0) {
-    d(1) << " getxattr failed: " << cpp_strerror(rc) << dendl;
-    return rc;
-  }
-  exclusive_holder = bl_excl.to_str();
-  {
-    auto sstr = bl_size.to_str();
-    std::string err;
-    size = strict_strtoll(sstr.c_str(), 10, &err);
-    ceph_assert(err.empty());
-  }
-  {
-    auto sstr = bl_alloc.to_str();
-    std::string err;
-    allocated = strict_strtoll(sstr.c_str(), 10, &err);
-    ceph_assert(err.empty());
-  }
-  {
-    auto sstr = bl_version.to_str();
-    std::string err;
-    version = strict_strtoll(sstr.c_str(), 10, &err);
-    ceph_assert(err.empty());
-  }
-  d(15) << " size: " << size << " allocated: " << allocated << " version: " << version << dendl;
-  return 0;
+  return get_metadata();
 }
 
 int SimpleRADOSStriper::shrink_alloc(uint64_t a)
@@ -384,6 +567,15 @@ bufferlist SimpleRADOSStriper::uint2bl(uint64_t v)
 {
   CachedStackStringStream css;
   *css << std::dec << std::setw(16) << std::setfill('0') << v;
+  bufferlist bl;
+  bl.append(css->strv());
+  return bl;
+}
+
+bufferlist SimpleRADOSStriper::state2bl(LockLevel l)
+{
+  CachedStackStringStream css;
+  *css << std::dec << std::setw(8) << std::setfill('0') << std::to_underlying(l);
   bufferlist bl;
   bl.append(css->strv());
   return bl;
@@ -531,14 +723,14 @@ int SimpleRADOSStriper::print_lockers(std::ostream& out)
   std::string tag;
   std::list<librados::locker_t> lockers;
   auto ext = get_first_extent();
-  if (int rc = ioctx.list_lockers(ext.soid, biglock, &exclusive, &tag, &lockers); rc < 0) {
+  if (int rc = ioctx.list_lockers(ext.soid, primary, &exclusive, &tag, &lockers); rc < 0) {
     d(1) << " list_lockers failure: " << cpp_strerror(rc) << dendl;
     return rc;
   }
   if (lockers.empty()) {
-    out << " lockers none";
+    out << " primary: none";
   } else {
-    out << " lockers exclusive=" << exclusive  << " tag=" << tag << " lockers=[";
+    out << " primary: exclusive=" << exclusive  << " tag=" << tag << " lockers=[";
     bool first = true;
     for (const auto& l : lockers) {
       if (!first) out << ",";
@@ -546,6 +738,13 @@ int SimpleRADOSStriper::print_lockers(std::ostream& out)
     }
     out << "]";
   }
+
+  if (int rc = get_metadata(); rc < 0) {
+    return rc;
+  }
+
+  out << " " << *this;
+
   return 0;
 }
 
@@ -565,10 +764,15 @@ void SimpleRADOSStriper::lock_keeper_main(void)
     auto now = clock::now();
     auto since = now-last_renewal;
 
-    if (since >= lock_keeper_interval && locked) {
+    if (since >= lock_keeper_interval && locked > LockLevel::None) {
       d(10) << "renewing lock" << dendl;
       auto tv = ceph::to_timeval(lock_keeper_timeout);
-      int rc = ioctx.lock_exclusive(ext.soid, biglock, cookie.to_string(), lockdesc, &tv, LIBRADOS_LOCK_FLAG_MUST_RENEW);
+      int rc = 0;
+      if (locked >= LockLevel::Exclusive) {
+        rc = ioctx.lock_exclusive(ext.soid, primary, cookie.to_string(), lockdesc, &tv, LIBRADOS_LOCK_FLAG_MUST_RENEW);
+      } else if (locked >= LockLevel::Shared) {
+        rc = ioctx.lock_shared(ext.soid, primary, cookie.to_string(), "", lockdesc, &tv, LIBRADOS_LOCK_FLAG_MUST_RENEW);
+      }
       if (rc) {
         /* If lock renewal fails, we cannot continue the application. Return
          * -EBLOCKLISTED for all calls into the striper for this instance, even
@@ -589,45 +793,50 @@ int SimpleRADOSStriper::recover_lock()
 {
   d(5) << "attempting to recover lock" << dendl;
 
-  std::string addrs;
   const auto ext = get_first_extent();
 
-  {
-    auto tv = ceph::to_timeval(lock_keeper_timeout);
-    if (int rc = ioctx.lock_exclusive(ext.soid, biglock, cookie.to_string(), lockdesc, &tv, 0); rc < 0) {
-      return rc;
+  if (int rc = get_metadata(); rc < 0) {
+    if (rc == -ENOENT || rc == -ENODATA) {
+      d(20) << "someone else cleaned up?" << dendl;
+      return -EBUSY; /* someone else cleaned up, wait our turn */
+    } else {
+      d(-1) << "could not recover exclusive locker" << dendl;
+      return -EIO;
     }
-    locked = true;
-    last_renewal = clock::now();
   }
 
-  d(5) << "acquired lock, fetching last owner" << dendl;
-
-  {
-    bufferlist bl_excl;
-    if (int rc = ioctx.getxattr(ext.soid, XATTR_EXCL, bl_excl); rc < 0) {
-      if (rc == -ENOENT) {
-        /* someone removed it? ok... */
-        goto setowner;
-      } else {
-        d(-1) << "could not recover exclusive locker" << dendl;
-        locked = false; /* it will drop eventually */
-        return -EIO;
-      }
-    }
-    addrs = bl_excl.to_str();
-  }
-
-  if (addrs.empty()) {
+  if (exclusive_holder.empty()) {
     d(5) << "someone else cleaned up" << dendl;
-    goto setowner;
+    return -EBUSY;
+  }
+
+  int exclusive;
+  std::string tag;
+  std::list<librados::locker_t> lockers;
+  if (int rc = ioctx.list_lockers(ext.soid, primary, &exclusive, &tag, &lockers); rc < 0) {
+    return rc;
+  }
+
+  bool active = false;
+  for (const auto& l : lockers) {
+    d(20) << "locker: " << l.address << dendl;
+    if (exclusive_holder.find(l.address) != std::string::npos || l.address.find(exclusive_holder) != std::string::npos) {
+      d(15) << "  found locker: " << l.address << dendl;
+      active = true;
+      break;
+    }
+  }
+
+  if (active) {
+    d(5) << "exclusive lock holder " << exclusive_holder << " is still active" << dendl;
+    return -EBUSY;
   } else {
-    d(5) << "exclusive lock holder was " << addrs << dendl;
+    d(5) << "exclusive lock holder " << exclusive_holder << " is dead, recovering" << dendl;
   }
 
   if (blocklist_the_dead) {
     entity_addrvec_t addrv;
-    addrv.parse(addrs.c_str());
+    addrv.parse(exclusive_holder.c_str());
     auto R = librados::Rados(ioctx);
     std::string_view b = "blocklist";
 retry:
@@ -646,7 +855,6 @@ retry:
           goto retry;
         }
         d(-1) << "Cannot proceed with recovery because I have failed to blocklist the old client: " << cpp_strerror(rc) << ", out = " << out << dendl;
-        locked = false; /* it will drop eventually */
         return -EIO;
       }
     }
@@ -654,130 +862,218 @@ retry:
     R.wait_for_latest_osdmap();
   }
 
-setowner:
-  d(5) << "setting new owner to myself, " << myaddrs << dendl;
   {
-    auto myaddrbl = str2bl(myaddrs);
-    if (int rc = ioctx.setxattr(ext.soid, XATTR_EXCL, myaddrbl); rc < 0) {
-      d(-1) << "could not set lock owner" << dendl;
-      locked = false; /* it will drop eventually */
-      return -EIO;
+    auto tv = ceph::to_timeval(lock_keeper_timeout);
+    if (int rc = ioctx.lock_shared(ext.soid, primary, cookie.to_string(), "", lockdesc, &tv, LIBRADOS_LOCK_FLAG_MAY_RENEW); rc < 0) {
+      return rc;
+    }
+    last_renewal = clock::now();
+    d(5) << "acquired Shared lock" << dendl;
+  }
+
+  d(5) << "cleaning up the lock state" << dendl;
+  {
+    auto op = librados::ObjectWriteOperation();
+    op.cmpxattr(XATTR_EXCL, LIBRADOS_CMPXATTR_OP_EQ, str2bl(exclusive_holder));
+    op.setxattr(XATTR_EXCL, bufferlist());
+    op.setxattr(XATTR_STATE, state2bl(LockLevel::Shared));
+    if (int rc = ioctx.operate(ext.soid, &op); rc < 0) {
+      if (rc == -ECANCELED) {
+        d(5) << "another client recovered the lock concurrently" << dendl;
+        return -ECANCELED;
+      } else {
+        d(-1) << "could not set lock owner: " << cpp_strerror(rc) << dendl;
+        return -EIO;
+      }
     }
   }
+
   return 0;
 }
 
-int SimpleRADOSStriper::lock(uint64_t timeoutms)
+int SimpleRADOSStriper::lock(LockLevel ilock)
 {
-  /* XXX: timeoutms is unused */
-  d(5) << "timeout=" << timeoutms << dendl;
+  using enum LockLevel;
 
-  if (blocklisted.load()) {
-    return -EBLOCKLISTED;
+  d(5) << "locked=" << std::to_underlying(locked) << " ilock=" << std::to_underlying(ilock) << dendl;
+
+  LockLevel initial_lock = locked;
+
+  auto start_time = std::chrono::steady_clock::now();
+  auto last_print_time = start_time;
+  bool first_print = true;
+  auto ext = get_first_extent();
+  auto tv = ceph::to_timeval(lock_keeper_timeout);
+  utime_t duration; duration.set_from_timeval(&tv);
+
+  if (locked == None) {
+    get_metadata();
   }
 
-  std::scoped_lock lock(lock_keeper_mutex);
+  while (locked < ilock) {
+    if (blocklisted.load()) {
+      return -EBLOCKLISTED;
+    }
 
-  ceph_assert(!is_locked());
-
-  /* We're going to be very lazy here in implementation: only exclusive locks
-   * are allowed. That even ensures a single reader.
-   */
-  uint64_t slept = 0;
-
-  auto ext = get_first_extent();
-  while (true) {
-    /* The general fast path in one compound operation: obtain the lock,
-     * confirm the past locker cleaned up after themselves (set XATTR_EXCL to
-     * ""), then finally set XATTR_EXCL to our address vector as the new
-     * exclusive locker.
-     */
+    std::unique_lock l(lock_keeper_mutex);
 
     auto op = librados::ObjectWriteOperation();
-    auto tv = ceph::to_timeval(lock_keeper_timeout);
-    utime_t duration;
-    duration.set_from_timeval(&tv);
-    rados::cls::lock::lock(&op, biglock, ClsLockType::EXCLUSIVE, cookie.to_string(), "", lockdesc, duration, 0);
-    op.cmpxattr(XATTR_EXCL, LIBRADOS_CMPXATTR_OP_EQ, bufferlist());
-    op.setxattr(XATTR_EXCL, str2bl(myaddrs));
-    int rc = ioctx.operate(ext.soid, &op);
-    if (rc == 0) {
-      locked = true;
+    int flags = LOCK_FLAG_MAY_RENEW;
+
+    /* XXX N.B.: CMPXATTR is weird. It is read as:
+     *    <arg> OP <ondisk>
+     */
+
+    if (ilock == Shared) {
+      d(10) << "escalating to Shared" << dendl;
+      /* allow Shared lock if lock state < Pending */
+      rados::cls::lock::lock(&op, primary, ClsLockType::SHARED, cookie.to_string(), "", lockdesc, duration, flags);
+      op.cmpxattr(XATTR_STATE, LIBRADOS_CMPXATTR_OP_GT, state2bl(LockLevel::Pending));
+    } else if (ilock == Reserved) {
+      d(10) << "escalating to Reserved" << dendl;
+      /* allow Reserve lock if lock state < Reserved */
+      rados::cls::lock::lock(&op, primary, ClsLockType::SHARED, cookie.to_string(), "", lockdesc, duration, flags);
+      op.cmpxattr(XATTR_STATE, LIBRADOS_CMPXATTR_OP_GT, state2bl(LockLevel::Reserved));
+      op.setxattr(XATTR_STATE, state2bl(LockLevel::Reserved));
+    } else if (ilock == Pending) {
+      d(10) << "escalating to Pending" << dendl;
+      /* allow Pending lock if lock state == Reserved */
+      rados::cls::lock::lock(&op, primary, ClsLockType::SHARED, cookie.to_string(), "", lockdesc, duration, flags);
+      op.cmpxattr(XATTR_STATE, LIBRADOS_CMPXATTR_OP_EQ, state2bl(LockLevel::Reserved));
+      op.setxattr(XATTR_STATE, state2bl(LockLevel::Pending));
+    } else if (ilock == Exclusive) {
+      d(10) << "escalating to Exclusive" << dendl;
+      /* allow Exclusive lock if Shared <= lock state <= Pending */
+      rados::cls::lock::lock(&op, primary, ClsLockType::EXCLUSIVE, cookie.to_string(), "", lockdesc, duration, flags);
+      op.cmpxattr(XATTR_STATE, LIBRADOS_CMPXATTR_OP_LTE, state2bl(LockLevel::Shared));
+      op.cmpxattr(XATTR_STATE, LIBRADOS_CMPXATTR_OP_GTE, state2bl(LockLevel::Pending));
+      op.cmpxattr(XATTR_WRITE_EPOCH, LIBRADOS_CMPXATTR_OP_EQ, uint2bl(write_epoch));
+      op.setxattr(XATTR_STATE, state2bl(LockLevel::Exclusive));
+      op.setxattr(XATTR_WRITE_EPOCH, uint2bl(write_epoch + 1));
+    }
+
+    if (locked < Reserved && ilock >= Reserved) {
+      op.cmpxattr(XATTR_EXCL, LIBRADOS_CMPXATTR_OP_EQ, bufferlist());
+      op.setxattr(XATTR_EXCL, str2bl(myaddrs));
+    } else if (locked >= Reserved) {
+      op.cmpxattr(XATTR_EXCL, LIBRADOS_CMPXATTR_OP_EQ, str2bl(myaddrs));
+    }
+
+    if (int rc = ioctx.operate(ext.soid, &op); rc == 0) {
+      locked = ilock;
       last_renewal = clock::now();
-      break;
-    } else if (rc == -EBUSY) {
-      if ((slept % 500000) == 0) {
-        d(-1) << "waiting for locks: ";
-        print_lockers(*_dout);
-        *_dout << dendl;
+      if (ilock >= Exclusive) {
+        write_epoch++;
       }
-      usleep(5000);
-      slept += 5000;
-      continue;
     } else if (rc == -ECANCELED) {
-      /* CMPXATTR failed, a locker didn't cleanup. Try to recover! */
-      if (rc = recover_lock(); rc < 0) {
-        if (rc == -EBUSY) {
-          continue; /* try again */
-        }
+      if (locked >= Reserved) {
+        blocklisted = true;
+        return -EBLOCKLISTED; /* We lost our reservation */
+      }
+      if (int rc = recover_lock(); rc < 0 && rc != -ECANCELED) {
         return rc;
       }
-      break;
+    } else if (rc == -EBUSY) {
+      auto now = std::chrono::steady_clock::now();
+      auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - start_time);
+
+      if (elapsed >= acquire_timeout) {
+        d(10) << "acquire_timeout exceeded" << dendl;
+        return -EBUSY;
+      }
+
+      if (first_print || std::chrono::duration_cast<std::chrono::milliseconds>(now - last_print_time).count() >= 500) {
+        d(10) << "waiting for locks: ";
+        print_lockers(*_dout);
+        *_dout << dendl;
+        last_print_time = now;
+        first_print = false;
+      }
+
+      l.unlock();
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+      if (int rc = get_metadata(); rc < 0) {
+        return rc;
+      }
     } else {
       d(-1) << " lock failed: " << cpp_strerror(rc) << dendl;
+      if (locked > initial_lock) {
+        _unlock(initial_lock);
+      }
       return rc;
     }
   }
 
-  if (!lock_keeper.joinable()) {
+  if (int rc = get_metadata(); rc < 0) {
+    return rc;
+  }
+
+  if (!lock_keeper.joinable() && locked > None) {
     lock_keeper = std::thread(&SimpleRADOSStriper::lock_keeper_main, this);
   }
 
-  if (int rc = open(); rc < 0) {
-    d(1) << " open failed: " << cpp_strerror(rc) << dendl;
-    return rc;
-  }
-
   d(5) << " = 0" << dendl;
-  if (logger) {
-    logger->inc(P_LOCK);
-  }
-
+  if (logger) logger->inc(P_LOCK);
   return 0;
 }
 
-int SimpleRADOSStriper::unlock()
+int SimpleRADOSStriper::unlock(LockLevel ilock)
 {
-  d(5) << dendl;
+  using enum LockLevel;
 
-  if (blocklisted.load()) {
-    return -EBLOCKLISTED;
+  d(5) << "ilock=" << std::to_underlying(ilock) << dendl;
+  if (blocklisted.load()) return -EBLOCKLISTED;
+
+  std::scoped_lock l(lock_keeper_mutex);
+  return _unlock(ilock);
+}
+
+int SimpleRADOSStriper::_unlock(LockLevel ilock)
+{
+  using enum LockLevel;
+
+  if (locked >= Exclusive && ilock < Exclusive) {
+    if (int rc = flush(); rc < 0) {
+      return rc;
+    }
   }
 
-  std::scoped_lock lock(lock_keeper_mutex);
+  auto ext = get_first_extent();
+  auto tv = ceph::to_timeval(lock_keeper_timeout);
+  utime_t duration; duration.set_from_timeval(&tv);
 
-  ceph_assert(is_locked());
-
-  /* wait for flush of metadata */
-  if (int rc = flush(); rc < 0) {
-    return rc;
-  }
-
-  const auto ext = get_first_extent();
   auto op = librados::ObjectWriteOperation();
-  op.cmpxattr(XATTR_EXCL, LIBRADOS_CMPXATTR_OP_EQ, str2bl(myaddrs));
-  op.setxattr(XATTR_EXCL, bufferlist());
-  rados::cls::lock::unlock(&op, biglock, cookie.to_string());
+
+  if (locked >= Reserved) {
+    op.cmpxattr(XATTR_EXCL, LIBRADOS_CMPXATTR_OP_EQ, str2bl(myaddrs));
+    if (ilock < Reserved) {
+      op.setxattr(XATTR_EXCL, bufferlist());
+      op.setxattr(XATTR_STATE, state2bl(LockLevel::Shared));
+    } else if (ilock == Reserved) {
+      op.setxattr(XATTR_STATE, state2bl(LockLevel::Reserved));
+    } else if (ilock == Pending) {
+      op.setxattr(XATTR_STATE, state2bl(LockLevel::Pending));
+    }
+  }
+
+  if (ilock >= Shared) {
+    rados::cls::lock::lock(&op, primary, ClsLockType::SHARED, cookie.to_string(), "", lockdesc, duration, LOCK_FLAG_MAY_RENEW);
+  } else {
+    rados::cls::lock::unlock(&op, primary, cookie.to_string());
+  }
+
   if (int rc = ioctx.operate(ext.soid, &op); rc < 0) {
-    d(-1) << " unlock failed: " << cpp_strerror(rc) << dendl;
-    return rc;
+    if (rc == -ENOENT) {
+      blocklisted = true;
+      return -EBLOCKLISTED;
+    } else {
+      return rc;
+    }
   }
-  locked = false;
 
+  locked = ilock;
   d(5) << " = 0" << dendl;
-  if (logger) {
-    logger->inc(P_UNLOCK);
-  }
-
+  if (logger) logger->inc(P_UNLOCK);
   return 0;
 }

--- a/src/SimpleRADOSStriper.cc
+++ b/src/SimpleRADOSStriper.cc
@@ -218,6 +218,8 @@ int SimpleRADOSStriper::stat(uint64_t* s)
   }
 
   *s = size;
+
+  d(5) << " = " << size << dendl;
   return 0;
 }
 

--- a/src/SimpleRADOSStriper.cc
+++ b/src/SimpleRADOSStriper.cc
@@ -82,8 +82,13 @@ int SimpleRADOSStriper::config_logger(CephContext* cct, std::string_view name, s
 
 SimpleRADOSStriper::~SimpleRADOSStriper()
 {
+  wait_for_aios(true);
+
   if (lock_keeper.joinable()) {
-    shutdown = true;
+    {
+      std::scoped_lock l(lock_keeper_mutex);
+      shutdown = true;
+    }
     lock_keeper_cvar.notify_all();
     lock_keeper.join();
   }

--- a/src/SimpleRADOSStriper.h
+++ b/src/SimpleRADOSStriper.h
@@ -44,6 +44,7 @@ public:
     , oid(std::move(_oid))
   {
     cookie.generate_random();
+    cookie_dstr = cookie.to_string().substr(0, 8);
     auto r = librados::Rados(ioctx);
     myaddrs = r.get_addrs();
   }
@@ -128,6 +129,7 @@ private:
   uint64_t size = 0;
   uint64_t allocated = 0;
   uuid_d cookie{};
+  std::string cookie_dstr;
   bool locked = false;
   bool size_dirty = false;
   bool blocklist_the_dead = true;

--- a/src/SimpleRADOSStriper.h
+++ b/src/SimpleRADOSStriper.h
@@ -28,7 +28,7 @@
 #include <chrono>
 #include "common/perf_counters.h"
 
-class [[gnu::visibility("default")]] SimpleRADOSStriper
+class [[gnu::visibility("hidden")]] SimpleRADOSStriper
 {
 public:
   enum class LockLevel : int {

--- a/src/SimpleRADOSStriper.h
+++ b/src/SimpleRADOSStriper.h
@@ -18,21 +18,30 @@
 #include <queue>
 #include <string_view>
 #include <thread>
+#include <utility>
 
 #include "include/buffer.h"
 #include "include/rados/librados.hpp"
 #include "include/uuid.h"
 #include "include/types.h"
 
-#include "common/ceph_time.h"
+#include <chrono>
 #include "common/perf_counters.h"
 
 class [[gnu::visibility("default")]] SimpleRADOSStriper
 {
 public:
+  enum class LockLevel : int {
+    None = 0,
+    Shared = 1,
+    Reserved = 2,
+    Pending = 3,
+    Exclusive = 4
+  };
+
   using aiocompletionptr = std::unique_ptr<librados::AioCompletion>;
-  using clock = ceph::coarse_mono_clock;
-  using time = ceph::coarse_mono_time;
+  using clock = std::chrono::steady_clock;
+  using time = std::chrono::time_point<std::chrono::steady_clock>;
 
   static inline const uint64_t object_size = 22; /* power of 2 */
   static inline const uint64_t min_growth = (1<<27); /* 128 MB */
@@ -54,25 +63,35 @@ public:
   SimpleRADOSStriper(SimpleRADOSStriper&&) = delete;
   ~SimpleRADOSStriper();
 
+  void print(std::ostream&) const;
+
   int create();
   int open();
+  int get_metadata();
   int remove();
   int stat(uint64_t* size);
   ssize_t write(const void* data, size_t len, uint64_t off);
   ssize_t read(void* data, size_t len, uint64_t off);
   int truncate(size_t size);
   int flush();
-  int lock(uint64_t timeoutms);
-  int unlock();
-  int is_locked() const {
-    return locked;
+  int lock(LockLevel ilock);
+  int unlock(LockLevel ilock);
+  bool is_locked() const {
+    return locked > LockLevel::None;
   }
+  int check_reservation(bool* is_reserved);
   int print_lockers(std::ostream& out);
   void set_logger(std::shared_ptr<PerfCounters> l) {
     logger = std::move(l);
   }
   void set_lock_interval(std::chrono::milliseconds t) {
     lock_keeper_interval = t;
+  }
+  void set_acquire_timeout(std::chrono::milliseconds t) {
+    acquire_timeout = t;
+  }
+  std::chrono::milliseconds get_acquire_timeout() const {
+    return acquire_timeout;
   }
   void set_lock_timeout(std::chrono::milliseconds t) {
     lock_keeper_timeout = t;
@@ -90,11 +109,13 @@ protected:
 
   ceph::bufferlist str2bl(std::string_view sv);
   ceph::bufferlist uint2bl(uint64_t v);
+  ceph::bufferlist state2bl(LockLevel l);
   int set_metadata(uint64_t new_size, bool update_size);
   int shrink_alloc(uint64_t a);
   int maybe_shrink_alloc();
   int wait_for_aios(bool block);
   int recover_lock();
+  int _unlock(LockLevel ilock);
   extent get_next_extent(uint64_t off, size_t len) const;
   extent get_first_extent() const {
     return get_next_extent(0, 0);
@@ -108,7 +129,9 @@ private:
   static inline const char XATTR_LAYOUT_STRIPE_UNIT[] = "striper.layout.stripe_unit";
   static inline const char XATTR_LAYOUT_STRIPE_COUNT[] = "striper.layout.stripe_count";
   static inline const char XATTR_LAYOUT_OBJECT_SIZE[] = "striper.layout.object_size";
-  static inline const std::string biglock = "striper.lock";
+  static inline const char XATTR_STATE[] = "striper.state";
+  static inline const char XATTR_WRITE_EPOCH[] = "striper.write_epoch";
+  static inline const std::string primary = "striper.lock";
   static inline const std::string lockdesc = "SimpleRADOSStriper";
 
   void lock_keeper_main();
@@ -119,18 +142,36 @@ private:
   std::thread lock_keeper;
   std::condition_variable lock_keeper_cvar;
   std::mutex lock_keeper_mutex;
-  time last_renewal = clock::zero();
+  time last_renewal = time::min();
   std::chrono::milliseconds lock_keeper_interval{2000};
   std::chrono::milliseconds lock_keeper_timeout{30000};
+  std::chrono::milliseconds acquire_timeout{0};
   std::atomic<bool> blocklisted = false;
   bool shutdown = false;
   version_t version = 0;
   std::string exclusive_holder;
+  uint64_t write_epoch = 0;
   uint64_t size = 0;
   uint64_t allocated = 0;
   uuid_d cookie{};
   std::string cookie_dstr;
-  bool locked = false;
+  LockLevel disk_state = LockLevel::None;
+
+  uint64_t layout_stripe_unit = 0;
+  uint64_t layout_stripe_count = 0;
+  uint64_t layout_object_size = 0;
+
+  /*
+   * Tracks the current lock state as a logical escalation level:
+   * None: No locks held.
+   * Shared: A shared lock is held on the primary lock object. XATTR_STATE is "1".
+   * Reserved: A shared lock is held on the primary lock object. XATTR_STATE is "2". XATTR_EXCL is set.
+   * Pending: A shared lock is held on the primary lock object. XATTR_STATE is "3" (blocks new readers).
+   * Exclusive: An exclusive lock is held on the primary lock object. XATTR_STATE is "4".
+   * Ownership metadata is additionally written for dead-client recovery.
+   */
+  LockLevel locked = LockLevel::None;
+
   bool size_dirty = false;
   bool blocklist_the_dead = true;
   std::queue<aiocompletionptr> aios;

--- a/src/libcephsqlite.cc
+++ b/src/libcephsqlite.cc
@@ -73,6 +73,7 @@ enum {
   P_OP_ACCESS,
   P_OP_FULLPATHNAME,
   P_OP_CURRENTTIME,
+  P_OP_SLEEP,
   P_OPF_CLOSE,
   P_OPF_READ,
   P_OPF_WRITE,
@@ -114,6 +115,7 @@ struct cephsqlite_appdata {
     plb.add_time_avg(P_OP_ACCESS, "op_access", "Time average of Access operations");
     plb.add_time_avg(P_OP_FULLPATHNAME, "op_fullpathname", "Time average of FullPathname operations");
     plb.add_time_avg(P_OP_CURRENTTIME, "op_currenttime", "Time average of Currenttime operations");
+    plb.add_time_avg(P_OP_SLEEP, "op_sleep", "Time average of Sleep operations");
     plb.add_time_avg(P_OPF_CLOSE, "opf_close", "Time average of Close file operations");
     plb.add_time_avg(P_OPF_READ, "opf_read", "Time average of Read file operations");
     plb.add_time_avg(P_OPF_WRITE, "opf_write", "Time average of Write file operations");
@@ -832,6 +834,19 @@ static int CurrentTime(sqlite3_vfs* vfs, sqlite3_int64* time)
   return SQLITE_OK;
 }
 
+static int Sleep(sqlite3_vfs* vfs, int microseconds)
+{
+  auto start = ceph::coarse_mono_clock::now();
+  auto [cct, cluster] = getdata(vfs).get_cluster();
+  dv(5) << microseconds << dendl;
+
+  std::this_thread::sleep_for(std::chrono::microseconds(microseconds));
+
+  auto end = ceph::coarse_mono_clock::now();
+  getdata(vfs).logger->tinc(P_OP_SLEEP, end-start);
+  return SQLITE_OK;
+}
+
 LIBCEPHSQLITE_API int cephsqlite_setcct(CephContext* _cct, char** ident)
 {
   ldout(_cct, 1) << "cct: " << _cct << dendl;
@@ -972,6 +987,7 @@ LIBCEPHSQLITE_API int sqlite3_cephsqlite_init(sqlite3* db, char** err, const sql
     vfs->xOpen = Open;
     vfs->xDelete = Delete;
     vfs->xAccess = Access;
+    vfs->xSleep = Sleep;
     vfs->xFullPathname = FullPathname;
     vfs->xCurrentTimeInt64 = CurrentTime;
     if (int rc = sqlite3_vfs_register(vfs, 0); rc) {

--- a/src/libcephsqlite.cc
+++ b/src/libcephsqlite.cc
@@ -30,6 +30,7 @@
 
 #include <limits.h>
 #include <string.h>
+#include <utility>
 
 #include <sqlite3ext.h>
 SQLITE_EXTENSION_INIT1
@@ -261,7 +262,7 @@ struct cephsqlite_file {
   struct sqlite3_vfs* vfs = nullptr;
   int flags = 0;
   // There are 5 lock states: https://sqlite.org/c3ref/c_lock_exclusive.html
-  int lock = 0;
+  SimpleRADOSStriper::LockLevel lock = SimpleRADOSStriper::LockLevel::None;
   struct cephsqlite_fileloc loc{};
   struct cephsqlite_fileio io{};
 };
@@ -269,26 +270,41 @@ struct cephsqlite_file {
 
 #define getdata(vfs) (*((cephsqlite_appdata*)((vfs)->pAppData)))
 
+/*
+ * SQLite VFS lock states map directly to the SimpleRADOSStriper lock levels:
+ * SQLITE_LOCK_NONE (0)      -> Striper Level 0 (No locks)
+ * SQLITE_LOCK_SHARED (1)    -> Striper Level 1 (Primary shared)
+ * SQLITE_LOCK_RESERVED (2)  -> Striper Level 2 (Primary shared + XATTR_EXCL populated)
+ * SQLITE_LOCK_PENDING (3)   -> Striper Level 3 (Primary shared + XATTR_EXCL populated)
+ * SQLITE_LOCK_EXCLUSIVE (4) -> Striper Level 4 (Primary exclusive + XATTR_EXCL populated)
+ *
+ * The XATTR_EXCL attribute acts as a gatekeeper for writers to prevent upgrade deadlocks.
+ */
 static int Lock(sqlite3_file *file, int ilock)
 {
   auto f = (cephsqlite_file*)file;
+  auto target_lock = static_cast<SimpleRADOSStriper::LockLevel>(ilock);
   auto start = ceph::coarse_mono_clock::now();
-  df(5) << std::hex << ilock << dendl;
+  df(5) << std::hex << std::to_underlying(target_lock) << dendl;
 
   auto& lock = f->lock;
-  ceph_assert(!f->io.rs->is_locked() || lock > SQLITE_LOCK_NONE);
-  ceph_assert(lock <= ilock);
-  if (!f->io.rs->is_locked() && ilock > SQLITE_LOCK_NONE) {
-    if (int rc = f->io.rs->lock(0); rc < 0) {
+  ceph_assert(!f->io.rs->is_locked() || lock > SimpleRADOSStriper::LockLevel::None);
+  ceph_assert(lock <= target_lock);
+
+  if (lock < target_lock) {
+    if (int rc = f->io.rs->lock(target_lock); rc < 0) {
       df(5) << "failed: " << rc << dendl;
+      if (rc == -EBUSY) {
+        return SQLITE_BUSY;
+      }
       if (rc == -EBLOCKLISTED) {
         getdata(f->vfs).maybe_reconnect(f->io.cluster);
       }
-      return SQLITE_IOERR;
+      return SQLITE_IOERR_LOCK;
     }
   }
 
-  lock = ilock;
+  lock = target_lock;
   auto end = ceph::coarse_mono_clock::now();
   getdata(f->vfs).logger->tinc(P_OPF_LOCK, end-start);
   return SQLITE_OK;
@@ -297,14 +313,16 @@ static int Lock(sqlite3_file *file, int ilock)
 static int Unlock(sqlite3_file *file, int ilock)
 {
   auto f = (cephsqlite_file*)file;
+  auto target_lock = static_cast<SimpleRADOSStriper::LockLevel>(ilock);
   auto start = ceph::coarse_mono_clock::now();
-  df(5) << std::hex << ilock << dendl;
+  df(5) << std::hex << std::to_underlying(target_lock) << dendl;
 
   auto& lock = f->lock;
-  ceph_assert(lock == SQLITE_LOCK_NONE || (lock > SQLITE_LOCK_NONE && f->io.rs->is_locked()));
-  ceph_assert(lock >= ilock);
-  if (ilock <= SQLITE_LOCK_NONE && SQLITE_LOCK_NONE < lock) {
-    if (int rc = f->io.rs->unlock(); rc < 0) {
+  ceph_assert(lock == SimpleRADOSStriper::LockLevel::None || (lock > SimpleRADOSStriper::LockLevel::None && f->io.rs->is_locked()));
+  ceph_assert(lock >= target_lock);
+
+  if (lock > target_lock) {
+    if (int rc = f->io.rs->unlock(target_lock); rc < 0) {
       df(5) << "failed: " << rc << dendl;
       if (rc == -EBLOCKLISTED) {
         getdata(f->vfs).maybe_reconnect(f->io.cluster);
@@ -313,7 +331,7 @@ static int Unlock(sqlite3_file *file, int ilock)
     }
   }
 
-  lock = ilock;
+  lock = target_lock;
   auto end = ceph::coarse_mono_clock::now();
   getdata(f->vfs).logger->tinc(P_OPF_UNLOCK, end-start);
   return SQLITE_OK;
@@ -327,8 +345,17 @@ static int CheckReservedLock(sqlite3_file *file, int *result)
   *result = 0;
 
   auto& lock = f->lock;
-  if (lock > SQLITE_LOCK_SHARED) {
+  if (lock > SimpleRADOSStriper::LockLevel::Shared) {
     *result = 1;
+  } else {
+    bool is_reserved = false;
+    if (int rc = f->io.rs->check_reservation(&is_reserved); rc < 0) {
+      if (rc == -EBLOCKLISTED) {
+        getdata(f->vfs).maybe_reconnect(f->io.cluster);
+      }
+      return SQLITE_IOERR;
+    }
+    *result = is_reserved ? 1 : 0;
   }
 
   df(10);
@@ -543,9 +570,30 @@ static int FileControl(sqlite3_file* sf, int op, void *arg)
   auto f = (cephsqlite_file*)sf;
   auto start = ceph::coarse_mono_clock::now();
   df(5) << op << ", " << arg << dendl;
+
+  int rc = SQLITE_NOTFOUND;
+  if (op == SQLITE_FCNTL_LOCKSTATE) {
+    auto* state = static_cast<int32_t*>(arg);
+    *state = std::to_underlying(f->lock);
+    df(5) << "SQLITE_FCNTL_LOCKSTATE: " << *state << dendl;
+    rc = SQLITE_OK;
+  } else if (op == SQLITE_FCNTL_SIZE_HINT) {
+    auto* hint = static_cast<int64_t*>(arg);
+    df(5) << "SQLITE_FCNTL_SIZE_HINT: " << *hint << dendl;
+    rc = SQLITE_OK;
+  } else if (op == SQLITE_FCNTL_LOCK_TIMEOUT) {
+    auto* timeout_ptr = static_cast<int32_t*>(arg);
+    int prev_timeout = f->io.rs->get_acquire_timeout().count();
+    auto value = std::chrono::milliseconds(*timeout_ptr);
+    df(2) << "Updating SQLITE_FCNTL_LOCK_TIMEOUT to " << value << dendl;
+    f->io.rs->set_acquire_timeout(std::chrono::milliseconds(*timeout_ptr));
+    *timeout_ptr = prev_timeout;
+    rc = SQLITE_OK;
+  }
+
   auto end = ceph::coarse_mono_clock::now();
   getdata(f->vfs).logger->tinc(P_OPF_FILECONTROL, end-start);
-  return SQLITE_NOTFOUND;
+  return rc;
 }
 
 static int DeviceCharacteristics(sqlite3_file* sf)
@@ -676,7 +724,7 @@ static int Delete(sqlite3_vfs* vfs, const char* path, int dsync)
     return SQLITE_IOERR;
   }
 
-  if (int rc = io.rs->lock(0); rc < 0) {
+  if (int rc = io.rs->lock(SimpleRADOSStriper::LockLevel::Exclusive); rc < 0) {
     return SQLITE_IOERR;
   }
 

--- a/src/libcephsqlite.cc
+++ b/src/libcephsqlite.cc
@@ -73,6 +73,7 @@ enum {
   P_OP_ACCESS,
   P_OP_FULLPATHNAME,
   P_OP_CURRENTTIME,
+  P_OP_SLEEP,
   P_OPF_CLOSE,
   P_OPF_READ,
   P_OPF_WRITE,
@@ -114,6 +115,7 @@ struct cephsqlite_appdata {
     plb.add_time_avg(P_OP_ACCESS, "op_access", "Time average of Access operations");
     plb.add_time_avg(P_OP_FULLPATHNAME, "op_fullpathname", "Time average of FullPathname operations");
     plb.add_time_avg(P_OP_CURRENTTIME, "op_currenttime", "Time average of Currenttime operations");
+    plb.add_time_avg(P_OP_SLEEP, "op_sleep", "Time average of Sleep operations");
     plb.add_time_avg(P_OPF_CLOSE, "opf_close", "Time average of Close file operations");
     plb.add_time_avg(P_OPF_READ, "opf_read", "Time average of Read file operations");
     plb.add_time_avg(P_OPF_WRITE, "opf_write", "Time average of Write file operations");
@@ -846,6 +848,19 @@ static int CurrentTime(sqlite3_vfs* vfs, sqlite3_int64* time)
   return SQLITE_OK;
 }
 
+static int Sleep(sqlite3_vfs* vfs, int microseconds)
+{
+  auto start = ceph::coarse_mono_clock::now();
+  auto [cct, cluster] = getdata(vfs).get_cluster();
+  dv(5) << microseconds << dendl;
+
+  std::this_thread::sleep_for(std::chrono::microseconds(microseconds));
+
+  auto end = ceph::coarse_mono_clock::now();
+  getdata(vfs).logger->tinc(P_OP_SLEEP, end-start);
+  return SQLITE_OK;
+}
+
 LIBCEPHSQLITE_API int cephsqlite_setcct(CephContext* _cct, char** ident)
 {
   ldout(_cct, 1) << "cct: " << _cct << dendl;
@@ -986,6 +1001,7 @@ LIBCEPHSQLITE_API int sqlite3_cephsqlite_init(sqlite3* db, char** err, const sql
     vfs->xOpen = Open;
     vfs->xDelete = Delete;
     vfs->xAccess = Access;
+    vfs->xSleep = Sleep;
     vfs->xFullPathname = FullPathname;
     vfs->xCurrentTimeInt64 = CurrentTime;
     if (int rc = sqlite3_vfs_register(vfs, 0); rc) {

--- a/src/libcephsqlite.cc
+++ b/src/libcephsqlite.cc
@@ -30,6 +30,7 @@
 
 #include <limits.h>
 #include <string.h>
+#include <utility>
 
 #include <sqlite3ext.h>
 SQLITE_EXTENSION_INIT1
@@ -261,7 +262,7 @@ struct cephsqlite_file {
   struct sqlite3_vfs* vfs = nullptr;
   int flags = 0;
   // There are 5 lock states: https://sqlite.org/c3ref/c_lock_exclusive.html
-  int lock = 0;
+  SimpleRADOSStriper::LockLevel lock = SimpleRADOSStriper::LockLevel::None;
   struct cephsqlite_fileloc loc{};
   struct cephsqlite_fileio io{};
 };
@@ -269,26 +270,41 @@ struct cephsqlite_file {
 
 #define getdata(vfs) (*((cephsqlite_appdata*)((vfs)->pAppData)))
 
+/*
+ * SQLite VFS lock states map directly to the SimpleRADOSStriper lock levels:
+ * SQLITE_LOCK_NONE (0)      -> Striper Level 0 (No locks)
+ * SQLITE_LOCK_SHARED (1)    -> Striper Level 1 (Primary shared)
+ * SQLITE_LOCK_RESERVED (2)  -> Striper Level 2 (Primary shared + XATTR_EXCL populated)
+ * SQLITE_LOCK_PENDING (3)   -> Striper Level 3 (Primary shared + XATTR_EXCL populated)
+ * SQLITE_LOCK_EXCLUSIVE (4) -> Striper Level 4 (Primary exclusive + XATTR_EXCL populated)
+ *
+ * The XATTR_EXCL attribute acts as a gatekeeper for writers to prevent upgrade deadlocks.
+ */
 static int Lock(sqlite3_file *file, int ilock)
 {
   auto f = (cephsqlite_file*)file;
+  auto target_lock = static_cast<SimpleRADOSStriper::LockLevel>(ilock);
   auto start = ceph::coarse_mono_clock::now();
-  df(5) << std::hex << ilock << dendl;
+  df(5) << std::hex << std::to_underlying(target_lock) << dendl;
 
   auto& lock = f->lock;
-  ceph_assert(!f->io.rs->is_locked() || lock > SQLITE_LOCK_NONE);
-  ceph_assert(lock <= ilock);
-  if (!f->io.rs->is_locked() && ilock > SQLITE_LOCK_NONE) {
-    if (int rc = f->io.rs->lock(0); rc < 0) {
+  ceph_assert(!f->io.rs->is_locked() || lock > SimpleRADOSStriper::LockLevel::None);
+  ceph_assert(lock <= target_lock);
+
+  if (lock < target_lock) {
+    if (int rc = f->io.rs->lock(target_lock); rc < 0) {
       df(5) << "failed: " << rc << dendl;
+      if (rc == -EBUSY) {
+        return SQLITE_BUSY;
+      }
       if (rc == -EBLOCKLISTED) {
         getdata(f->vfs).maybe_reconnect(f->io.cluster);
       }
-      return SQLITE_IOERR;
+      return SQLITE_IOERR_LOCK;
     }
   }
 
-  lock = ilock;
+  lock = target_lock;
   auto end = ceph::coarse_mono_clock::now();
   getdata(f->vfs).logger->tinc(P_OPF_LOCK, end-start);
   return SQLITE_OK;
@@ -297,14 +313,16 @@ static int Lock(sqlite3_file *file, int ilock)
 static int Unlock(sqlite3_file *file, int ilock)
 {
   auto f = (cephsqlite_file*)file;
+  auto target_lock = static_cast<SimpleRADOSStriper::LockLevel>(ilock);
   auto start = ceph::coarse_mono_clock::now();
-  df(5) << std::hex << ilock << dendl;
+  df(5) << std::hex << std::to_underlying(target_lock) << dendl;
 
   auto& lock = f->lock;
-  ceph_assert(lock == SQLITE_LOCK_NONE || (lock > SQLITE_LOCK_NONE && f->io.rs->is_locked()));
-  ceph_assert(lock >= ilock);
-  if (ilock <= SQLITE_LOCK_NONE && SQLITE_LOCK_NONE < lock) {
-    if (int rc = f->io.rs->unlock(); rc < 0) {
+  ceph_assert(lock == SimpleRADOSStriper::LockLevel::None || (lock > SimpleRADOSStriper::LockLevel::None && f->io.rs->is_locked()));
+  ceph_assert(lock >= target_lock);
+
+  if (lock > target_lock) {
+    if (int rc = f->io.rs->unlock(target_lock); rc < 0) {
       df(5) << "failed: " << rc << dendl;
       if (rc == -EBLOCKLISTED) {
         getdata(f->vfs).maybe_reconnect(f->io.cluster);
@@ -313,7 +331,7 @@ static int Unlock(sqlite3_file *file, int ilock)
     }
   }
 
-  lock = ilock;
+  lock = target_lock;
   auto end = ceph::coarse_mono_clock::now();
   getdata(f->vfs).logger->tinc(P_OPF_UNLOCK, end-start);
   return SQLITE_OK;
@@ -327,8 +345,17 @@ static int CheckReservedLock(sqlite3_file *file, int *result)
   *result = 0;
 
   auto& lock = f->lock;
-  if (lock > SQLITE_LOCK_SHARED) {
+  if (lock > SimpleRADOSStriper::LockLevel::Shared) {
     *result = 1;
+  } else {
+    bool is_reserved = false;
+    if (int rc = f->io.rs->check_reservation(&is_reserved); rc < 0) {
+      if (rc == -EBLOCKLISTED) {
+        getdata(f->vfs).maybe_reconnect(f->io.cluster);
+      }
+      return SQLITE_IOERR;
+    }
+    *result = is_reserved ? 1 : 0;
   }
 
   df(10);
@@ -551,9 +578,30 @@ static int FileControl(sqlite3_file* sf, int op, void *arg)
   auto f = (cephsqlite_file*)sf;
   auto start = ceph::coarse_mono_clock::now();
   df(5) << op << ", " << arg << dendl;
+
+  int rc = SQLITE_NOTFOUND;
+  if (op == SQLITE_FCNTL_LOCKSTATE) {
+    auto* state = static_cast<int32_t*>(arg);
+    *state = std::to_underlying(f->lock);
+    df(5) << "SQLITE_FCNTL_LOCKSTATE: " << *state << dendl;
+    rc = SQLITE_OK;
+  } else if (op == SQLITE_FCNTL_SIZE_HINT) {
+    auto* hint = static_cast<int64_t*>(arg);
+    df(5) << "SQLITE_FCNTL_SIZE_HINT: " << *hint << dendl;
+    rc = SQLITE_OK;
+  } else if (op == SQLITE_FCNTL_LOCK_TIMEOUT) {
+    auto* timeout_ptr = static_cast<int32_t*>(arg);
+    int prev_timeout = f->io.rs->get_acquire_timeout().count();
+    auto value = std::chrono::milliseconds(*timeout_ptr);
+    df(2) << "Updating SQLITE_FCNTL_LOCK_TIMEOUT to " << value << dendl;
+    f->io.rs->set_acquire_timeout(std::chrono::milliseconds(*timeout_ptr));
+    *timeout_ptr = prev_timeout;
+    rc = SQLITE_OK;
+  }
+
   auto end = ceph::coarse_mono_clock::now();
   getdata(f->vfs).logger->tinc(P_OPF_FILECONTROL, end-start);
-  return SQLITE_NOTFOUND;
+  return rc;
 }
 
 static int DeviceCharacteristics(sqlite3_file* sf)
@@ -684,7 +732,7 @@ static int Delete(sqlite3_vfs* vfs, const char* path, int dsync)
     return SQLITE_IOERR;
   }
 
-  if (int rc = io.rs->lock(0); rc < 0) {
+  if (int rc = io.rs->lock(SimpleRADOSStriper::LockLevel::Exclusive); rc < 0) {
     return SQLITE_IOERR;
   }
 

--- a/src/test/libcephsqlite/CMakeLists.txt
+++ b/src/test/libcephsqlite/CMakeLists.txt
@@ -1,9 +1,11 @@
 if(WITH_LIBCEPHSQLITE)
   add_executable(ceph_test_libcephsqlite
     main.cc
+    ${CMAKE_SOURCE_DIR}/src/SimpleRADOSStriper.cc
   )
   target_link_libraries(ceph_test_libcephsqlite
     cephsqlite
+    cls_lock_client
     librados
     ceph-common
     SQLite3::SQLite3

--- a/src/test/libcephsqlite/main.cc
+++ b/src/test/libcephsqlite/main.cc
@@ -361,15 +361,16 @@ TEST_F(CephSQLiteTest, DatabaseShrink) {
   sqlcatchcode(sqlite3_step(stmt), SQLITE_DONE);
   sqlcatch(sqlite3_finalize(stmt); stmt = NULL);
 
-  ASSERT_EQ(0, rs->lock(1000));
+  ASSERT_EQ(0, rs->open());
+  ASSERT_EQ(0, rs->lock(SimpleRADOSStriper::LockLevel::Exclusive));
   ASSERT_EQ(0, rs->stat(&size1));
-  ASSERT_EQ(0, rs->unlock());
+  ASSERT_EQ(0, rs->unlock(SimpleRADOSStriper::LockLevel::None));
   sqlcatch(sqlite3_prepare_v2(db, current, -1, &stmt, &current));
   sqlcatchcode(sqlite3_step(stmt), SQLITE_DONE);
   sqlcatch(sqlite3_finalize(stmt); stmt = NULL);
-  ASSERT_EQ(0, rs->lock(1000));
+  ASSERT_EQ(0, rs->lock(SimpleRADOSStriper::LockLevel::Exclusive));
   ASSERT_EQ(0, rs->stat(&size2));
-  ASSERT_EQ(0, rs->unlock());
+  ASSERT_EQ(0, rs->unlock(SimpleRADOSStriper::LockLevel::None));
   ASSERT_LT(size2, size1/2);
 
   rc = 0;
@@ -661,7 +662,7 @@ TEST_F(CephSQLiteTest, InsertExclusiveLock) {
   sqlcatchcode(sqlite3_step(stmt), SQLITE_ROW);
   ASSERT_GT(sqlite3_column_int64(stmt, 0), 0);
   ASSERT_GT(sqlite3_column_int64(stmt, 1), 0);
-  ASSERT_EQ(sqlite3_column_int64(stmt, 2), 1); /* one actual lock on the striper */
+  ASSERT_EQ(sqlite3_column_int64(stmt, 2), 3); /* NONE -> SHARED -> RESERVED -> EXCLUSIVE */
   sqlcatch(sqlite3_finalize(stmt); stmt = NULL);
 
   rc = 0;
@@ -1080,6 +1081,277 @@ out:
   ASSERT_EQ(0, rc);
 }
 
+TEST_F(CephSQLiteTest, ConcurrentReaders) {
+  static const char SETUP_SQL[] = "CREATE TABLE foo (a INT); INSERT INTO foo (a) VALUES (1);";
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, SETUP_SQL, NULL, NULL, NULL));
+
+  sqlite3* db2 = nullptr;
+  ASSERT_EQ(SQLITE_OK, sqlite3_open_v2(get_uri().c_str(), &db2, SQLITE_OPEN_READWRITE | SQLITE_OPEN_URI, "ceph"));
+
+  sqlite3_stmt *stmt1 = NULL;
+  sqlite3_stmt *stmt2 = NULL;
+  const char *sql = "SELECT * FROM foo;";
+
+  ASSERT_EQ(SQLITE_OK, sqlite3_prepare_v2(db, sql, -1, &stmt1, NULL));
+  ASSERT_EQ(SQLITE_OK, sqlite3_prepare_v2(db2, sql, -1, &stmt2, NULL));
+
+  // Step both statements so they hold SHARED locks simultaneously without blocking
+  ASSERT_EQ(SQLITE_ROW, sqlite3_step(stmt1));
+  ASSERT_EQ(SQLITE_ROW, sqlite3_step(stmt2));
+
+  // Verify that both connections actually hold a SHARED lock
+  int lock_state1 = SQLITE_LOCK_NONE;
+  int lock_state2 = SQLITE_LOCK_NONE;
+  ASSERT_EQ(SQLITE_OK, sqlite3_file_control(db, "main", SQLITE_FCNTL_LOCKSTATE, &lock_state1));
+  ASSERT_EQ(SQLITE_OK, sqlite3_file_control(db2, "main", SQLITE_FCNTL_LOCKSTATE, &lock_state2));
+  ASSERT_EQ(SQLITE_LOCK_SHARED, lock_state1);
+  ASSERT_EQ(SQLITE_LOCK_SHARED, lock_state2);
+
+  // Cleanup
+  ASSERT_EQ(SQLITE_OK, sqlite3_finalize(stmt1));
+  ASSERT_EQ(SQLITE_OK, sqlite3_finalize(stmt2));
+  sqlite3_close(db2);
+}
+
+TEST_F(CephSQLiteTest, ReservedLockConcurrency) {
+  static const char SETUP_SQL[] = "CREATE TABLE foo (a INT); INSERT INTO foo (a) VALUES (1);";
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, SETUP_SQL, NULL, NULL, NULL));
+
+  sqlite3* db2 = nullptr;
+  ASSERT_EQ(SQLITE_OK, sqlite3_open_v2(get_uri().c_str(), &db2, SQLITE_OPEN_READWRITE | SQLITE_OPEN_URI, "ceph"));
+
+  // Set timeout to 0 so blocked locks fail immediately with SQLITE_BUSY
+  sqlite3_busy_timeout(db2, 0);
+
+  // Explicitly tell the VFS to use a 0ms internal lock timeout
+  int vfs_timeout = 0;
+  ASSERT_EQ(SQLITE_OK, sqlite3_file_control(db2, "main", SQLITE_FCNTL_LOCK_TIMEOUT, &vfs_timeout));
+
+  // Connection 1 begins immediate transaction (acquires RESERVED lock)
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, "BEGIN IMMEDIATE TRANSACTION;", NULL, NULL, NULL));
+
+  int lock_state1 = SQLITE_LOCK_NONE;
+  ASSERT_EQ(SQLITE_OK, sqlite3_file_control(db, "main", SQLITE_FCNTL_LOCKSTATE, &lock_state1));
+  ASSERT_EQ(SQLITE_LOCK_RESERVED, lock_state1);
+
+  // Connection 2 can still read (acquires SHARED lock without conflicting with RESERVED)
+  sqlite3_stmt *stmt = NULL;
+  ASSERT_EQ(SQLITE_OK, sqlite3_prepare_v2(db2, "SELECT * FROM foo;", -1, &stmt, NULL));
+  ASSERT_EQ(SQLITE_ROW, sqlite3_step(stmt));
+
+  int lock_state2 = SQLITE_LOCK_NONE;
+  ASSERT_EQ(SQLITE_OK, sqlite3_file_control(db2, "main", SQLITE_FCNTL_LOCKSTATE, &lock_state2));
+  ASSERT_EQ(SQLITE_LOCK_SHARED, lock_state2);
+
+  ASSERT_EQ(SQLITE_OK, sqlite3_finalize(stmt));
+
+  // Connection 2 cannot begin immediate transaction (blocked by Connection 1's RESERVED lock)
+  int rc = sqlite3_exec(db2, "BEGIN IMMEDIATE TRANSACTION;", NULL, NULL, NULL);
+  ASSERT_EQ(SQLITE_BUSY, rc);
+
+  // Connection 1 commits (upgrades to EXCLUSIVE to write, then releases all locks)
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, "INSERT INTO foo (a) VALUES (2);", NULL, NULL, NULL));
+  ASSERT_EQ(SQLITE_OK, sqlite3_file_control(db, "main", SQLITE_FCNTL_LOCKSTATE, &lock_state1));
+  ASSERT_EQ(SQLITE_LOCK_RESERVED, lock_state1);
+
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, "COMMIT;", NULL, NULL, NULL));
+  ASSERT_EQ(SQLITE_OK, sqlite3_file_control(db, "main", SQLITE_FCNTL_LOCKSTATE, &lock_state1));
+  ASSERT_EQ(SQLITE_LOCK_NONE, lock_state1);
+
+  // Now Connection 2 can successfully begin an immediate transaction
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db2, "BEGIN IMMEDIATE TRANSACTION;", NULL, NULL, NULL));
+  ASSERT_EQ(SQLITE_OK, sqlite3_file_control(db2, "main", SQLITE_FCNTL_LOCKSTATE, &lock_state2));
+  ASSERT_EQ(SQLITE_LOCK_RESERVED, lock_state2);
+
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db2, "COMMIT;", NULL, NULL, NULL));
+
+  sqlite3_close(db2);
+}
+
+TEST_F(CephSQLiteTest, LockDowngrade) {
+  static const char SETUP_SQL[] = "CREATE TABLE foo (a INT); CREATE TABLE bar (b INT); INSERT INTO foo (a) VALUES (1);";
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, SETUP_SQL, NULL, NULL, NULL));
+
+  sqlite3_stmt *stmt = NULL;
+  // Step 1: Start a read query on foo to hold a SHARED lock
+  ASSERT_EQ(SQLITE_OK, sqlite3_prepare_v2(db, "SELECT * FROM foo;", -1, &stmt, NULL));
+  ASSERT_EQ(SQLITE_ROW, sqlite3_step(stmt));
+
+  int lock_state = SQLITE_LOCK_NONE;
+  ASSERT_EQ(SQLITE_OK, sqlite3_file_control(db, "main", SQLITE_FCNTL_LOCKSTATE, &lock_state));
+  ASSERT_EQ(SQLITE_LOCK_SHARED, lock_state);
+
+  // Step 2: Write to bar. This forces an upgrade to EXCLUSIVE, then an auto-commit.
+  // Because stmt is still open, the lock will automatically downgrade to SHARED, not NONE.
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, "INSERT INTO bar (b) VALUES (2);", NULL, NULL, NULL));
+
+  ASSERT_EQ(SQLITE_OK, sqlite3_file_control(db, "main", SQLITE_FCNTL_LOCKSTATE, &lock_state));
+  ASSERT_EQ(SQLITE_LOCK_SHARED, lock_state);
+
+  // Step 3: Finalize the read cursor to release the SHARED lock completely.
+  ASSERT_EQ(SQLITE_OK, sqlite3_finalize(stmt));
+
+  ASSERT_EQ(SQLITE_OK, sqlite3_file_control(db, "main", SQLITE_FCNTL_LOCKSTATE, &lock_state));
+  ASSERT_EQ(SQLITE_LOCK_NONE, lock_state);
+}
+
+TEST_F(CephSQLiteTest, ExclusiveLockConcurrency) {
+  static const char SETUP_SQL[] = "CREATE TABLE foo (a INT); INSERT INTO foo (a) VALUES (1);";
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, SETUP_SQL, NULL, NULL, NULL));
+
+  sqlite3* db2 = nullptr;
+  ASSERT_EQ(SQLITE_OK, sqlite3_open_v2(get_uri().c_str(), &db2, SQLITE_OPEN_READWRITE | SQLITE_OPEN_URI, "ceph"));
+  sqlite3_busy_timeout(db2, 0);
+
+  // Explicitly tell the VFS to use a 0ms internal lock timeout
+  int vfs_timeout = 0;
+  ASSERT_EQ(SQLITE_OK, sqlite3_file_control(db2, "main", SQLITE_FCNTL_LOCK_TIMEOUT, &vfs_timeout));
+
+  // Connection 1 acquires EXCLUSIVE lock directly
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, "BEGIN EXCLUSIVE TRANSACTION;", NULL, NULL, NULL));
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, "INSERT INTO foo (a) VALUES (2);", NULL, NULL, NULL));
+
+  int lock_state1 = SQLITE_LOCK_NONE;
+  ASSERT_EQ(SQLITE_OK, sqlite3_file_control(db, "main", SQLITE_FCNTL_LOCKSTATE, &lock_state1));
+  ASSERT_EQ(SQLITE_LOCK_EXCLUSIVE, lock_state1);
+
+  // Connection 2 cannot read (fails to acquire SHARED lock because of EXCLUSIVE lock)
+  int rc = sqlite3_exec(db2, "SELECT * FROM foo;", NULL, NULL, NULL);
+  ASSERT_EQ(SQLITE_BUSY, rc);
+
+  // Connection 1 commits and releases the lock
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, "COMMIT;", NULL, NULL, NULL));
+
+  // Connection 2 can now read successfully
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db2, "SELECT * FROM foo;", NULL, NULL, NULL));
+
+  sqlite3_close(db2);
+}
+
+
+TEST_F(CephSQLiteTest, DeadClientRecovery) {
+  static const char SETUP_SQL[] = "CREATE TABLE foo (a INT); INSERT INTO foo (a) VALUES (1);";
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, SETUP_SQL, NULL, NULL, NULL));
+
+  // 1. Manually inject a "dead client" by setting XATTR_EXCL.
+  // This simulates a client that crashed while holding a RESERVED/EXCLUSIVE lock,
+  // leaving the XATTR populated but the ephemeral RADOS locks released.
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, cluster.ioctx_create(pool.c_str(), ioctx));
+  std::string obj_name = fmt::format("{}.0000000000000000", get_name());
+
+  ceph::bufferlist bl;
+  bl.append("[v2:192.0.2.1:0/0,v1:192.0.2.1:0/0]");
+  ASSERT_EQ(0, ioctx.setxattr(obj_name, "striper.excl", bl));
+
+  // 2. Attempt to write. The VFS will attempt to upgrade to RESERVED,
+  // see the leftover XATTR_EXCL, fail the cmpxattr (-ECANCELED), and trigger recover_lock().
+  // recover_lock() will blocklist the mock IP and overwrite XATTR_EXCL to safely take ownership.
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, "BEGIN IMMEDIATE TRANSACTION;", NULL, NULL, NULL));
+
+  // Verify that the lock was stolen/recovered and striper.excl is updated to OUR address.
+  ceph::bufferlist current_bl;
+  ASSERT_LT(0, ioctx.getxattr(obj_name, "striper.excl", current_bl));
+  ASSERT_NE(bl.to_str(), current_bl.to_str());
+  ASSERT_FALSE(current_bl.to_str().empty());
+
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, "INSERT INTO foo (a) VALUES (2);", NULL, NULL, NULL));
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, "COMMIT;", NULL, NULL, NULL));
+
+  // 3. Verify the write succeeded and the lock state was restored.
+  sqlite3_stmt *stmt = NULL;
+  ASSERT_EQ(SQLITE_OK, sqlite3_prepare_v2(db, "SELECT SUM(a) FROM foo;", -1, &stmt, NULL));
+  ASSERT_EQ(SQLITE_ROW, sqlite3_step(stmt));
+  ASSERT_EQ(3, sqlite3_column_int64(stmt, 0));
+  ASSERT_EQ(SQLITE_OK, sqlite3_finalize(stmt));
+
+  int lock_state = SQLITE_LOCK_NONE;
+  ASSERT_EQ(SQLITE_OK, sqlite3_file_control(db, "main", SQLITE_FCNTL_LOCKSTATE, &lock_state));
+  ASSERT_EQ(SQLITE_LOCK_NONE, lock_state);
+}
+
+TEST_F(CephSQLiteTest, ContentionWaitLoop) {
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, cluster.ioctx_create(pool.c_str(), ioctx));
+  std::string db_name = fmt::format("{}.wait_test", get_name());
+
+  SimpleRADOSStriper rs1(ioctx, db_name);
+  ASSERT_EQ(0, rs1.create());
+  ASSERT_EQ(0, rs1.open());
+
+  SimpleRADOSStriper rs2(ioctx, db_name);
+  ASSERT_EQ(0, rs2.open());
+  rs2.set_acquire_timeout(std::chrono::milliseconds(2000));
+
+  // Client 1 acquires an Exclusive lock
+  ASSERT_EQ(0, rs1.lock(SimpleRADOSStriper::LockLevel::Exclusive));
+
+  std::atomic<int> rs2_rc = -1;
+  auto start = std::chrono::steady_clock::now();
+
+  // Client 2 attempts to acquire a Shared lock concurrently.
+  // This should trigger the `-EBUSY` wait loop instead of failing immediately.
+  std::thread t([&]() {
+    rs2_rc = rs2.lock(SimpleRADOSStriper::LockLevel::Shared);
+  });
+
+  // Client 1 holds the lock for ~300ms then releases
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+  ASSERT_EQ(0, rs1.unlock(SimpleRADOSStriper::LockLevel::None));
+
+  t.join();
+
+  auto end = std::chrono::steady_clock::now();
+  auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+
+  // Client 2 should have eventually succeeded and waited at least 300ms
+  ASSERT_EQ(0, rs2_rc.load());
+  ASSERT_GE(elapsed, 300);
+
+  ASSERT_EQ(0, rs2.unlock(SimpleRADOSStriper::LockLevel::None));
+  ASSERT_EQ(0, rs1.remove());
+}
+
+TEST_F(CephSQLiteTest, LockRenewal) {
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, cluster.ioctx_create(pool.c_str(), ioctx));
+  std::string db_name = fmt::format("{}.renewal_test", get_name());
+
+  SimpleRADOSStriper rs1(ioctx, db_name);
+  ASSERT_EQ(0, rs1.create());
+  ASSERT_EQ(0, rs1.open());
+
+  // Use very short timeouts to quickly test the lock keeper thread
+  rs1.set_lock_interval(std::chrono::milliseconds(200));
+  rs1.set_lock_timeout(std::chrono::milliseconds(500));
+
+  // --- 1. Test Shared lock renewal ---
+  ASSERT_EQ(0, rs1.lock(SimpleRADOSStriper::LockLevel::Shared));
+
+  // Sleep past the lock timeout (500ms). If the thread wasn't renewing, the lock would drop on the MDS.
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+  SimpleRADOSStriper rs2(ioctx, db_name);
+  ASSERT_EQ(0, rs2.open());
+  rs2.set_acquire_timeout(std::chrono::milliseconds(0));
+
+  // rs2 should fail to grab Exclusive because rs1's lock_keeper successfully kept the Shared lock alive
+  ASSERT_EQ(-EBUSY, rs2.lock(SimpleRADOSStriper::LockLevel::Exclusive));
+
+  // Release Shared lock
+  ASSERT_EQ(0, rs1.unlock(SimpleRADOSStriper::LockLevel::None));
+
+  // --- 2. Test Exclusive lock renewal ---
+  ASSERT_EQ(0, rs1.lock(SimpleRADOSStriper::LockLevel::Exclusive));
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+  // rs2 should fail to grab Shared because rs1's lock_keeper successfully kept the Exclusive lock alive
+  ASSERT_EQ(-EBUSY, rs2.lock(SimpleRADOSStriper::LockLevel::Shared));
+
+  ASSERT_EQ(0, rs1.unlock(SimpleRADOSStriper::LockLevel::None));
+  ASSERT_EQ(0, rs1.remove());
+}
 
 int main(int argc, char **argv) {
   auto args = argv_to_vec(argc, argv);

--- a/src/test/libcephsqlite/main.cc
+++ b/src/test/libcephsqlite/main.cc
@@ -361,15 +361,16 @@ TEST_F(CephSQLiteTest, DatabaseShrink) {
   sqlcatchcode(sqlite3_step(stmt), SQLITE_DONE);
   sqlcatch(sqlite3_finalize(stmt); stmt = NULL);
 
-  ASSERT_EQ(0, rs->lock(1000));
+  ASSERT_EQ(0, rs->open());
+  ASSERT_EQ(0, rs->lock(SimpleRADOSStriper::LockLevel::Exclusive));
   ASSERT_EQ(0, rs->stat(&size1));
-  ASSERT_EQ(0, rs->unlock());
+  ASSERT_EQ(0, rs->unlock(SimpleRADOSStriper::LockLevel::None));
   sqlcatch(sqlite3_prepare_v2(db, current, -1, &stmt, &current));
   sqlcatchcode(sqlite3_step(stmt), SQLITE_DONE);
   sqlcatch(sqlite3_finalize(stmt); stmt = NULL);
-  ASSERT_EQ(0, rs->lock(1000));
+  ASSERT_EQ(0, rs->lock(SimpleRADOSStriper::LockLevel::Exclusive));
   ASSERT_EQ(0, rs->stat(&size2));
-  ASSERT_EQ(0, rs->unlock());
+  ASSERT_EQ(0, rs->unlock(SimpleRADOSStriper::LockLevel::None));
   ASSERT_LT(size2, size1/2);
 
   rc = 0;
@@ -661,7 +662,7 @@ TEST_F(CephSQLiteTest, InsertExclusiveLock) {
   sqlcatchcode(sqlite3_step(stmt), SQLITE_ROW);
   ASSERT_GT(sqlite3_column_int64(stmt, 0), 0);
   ASSERT_GT(sqlite3_column_int64(stmt, 1), 0);
-  ASSERT_EQ(sqlite3_column_int64(stmt, 2), 1); /* one actual lock on the striper */
+  ASSERT_EQ(sqlite3_column_int64(stmt, 2), 3); /* NONE -> SHARED -> RESERVED -> EXCLUSIVE */
   sqlcatch(sqlite3_finalize(stmt); stmt = NULL);
 
   rc = 0;
@@ -1095,6 +1096,277 @@ TEST_F(CephSQLiteTest, FileSizeStatError) {
     << "sqlite3 error: " << rc << " `" << sqlite3_errstr(rc) << "': " << errmsg;
 }
 
+TEST_F(CephSQLiteTest, ConcurrentReaders) {
+  static const char SETUP_SQL[] = "CREATE TABLE foo (a INT); INSERT INTO foo (a) VALUES (1);";
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, SETUP_SQL, NULL, NULL, NULL));
+
+  sqlite3* db2 = nullptr;
+  ASSERT_EQ(SQLITE_OK, sqlite3_open_v2(get_uri().c_str(), &db2, SQLITE_OPEN_READWRITE | SQLITE_OPEN_URI, "ceph"));
+
+  sqlite3_stmt *stmt1 = NULL;
+  sqlite3_stmt *stmt2 = NULL;
+  const char *sql = "SELECT * FROM foo;";
+
+  ASSERT_EQ(SQLITE_OK, sqlite3_prepare_v2(db, sql, -1, &stmt1, NULL));
+  ASSERT_EQ(SQLITE_OK, sqlite3_prepare_v2(db2, sql, -1, &stmt2, NULL));
+
+  // Step both statements so they hold SHARED locks simultaneously without blocking
+  ASSERT_EQ(SQLITE_ROW, sqlite3_step(stmt1));
+  ASSERT_EQ(SQLITE_ROW, sqlite3_step(stmt2));
+
+  // Verify that both connections actually hold a SHARED lock
+  int lock_state1 = SQLITE_LOCK_NONE;
+  int lock_state2 = SQLITE_LOCK_NONE;
+  ASSERT_EQ(SQLITE_OK, sqlite3_file_control(db, "main", SQLITE_FCNTL_LOCKSTATE, &lock_state1));
+  ASSERT_EQ(SQLITE_OK, sqlite3_file_control(db2, "main", SQLITE_FCNTL_LOCKSTATE, &lock_state2));
+  ASSERT_EQ(SQLITE_LOCK_SHARED, lock_state1);
+  ASSERT_EQ(SQLITE_LOCK_SHARED, lock_state2);
+
+  // Cleanup
+  ASSERT_EQ(SQLITE_OK, sqlite3_finalize(stmt1));
+  ASSERT_EQ(SQLITE_OK, sqlite3_finalize(stmt2));
+  sqlite3_close(db2);
+}
+
+TEST_F(CephSQLiteTest, ReservedLockConcurrency) {
+  static const char SETUP_SQL[] = "CREATE TABLE foo (a INT); INSERT INTO foo (a) VALUES (1);";
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, SETUP_SQL, NULL, NULL, NULL));
+
+  sqlite3* db2 = nullptr;
+  ASSERT_EQ(SQLITE_OK, sqlite3_open_v2(get_uri().c_str(), &db2, SQLITE_OPEN_READWRITE | SQLITE_OPEN_URI, "ceph"));
+
+  // Set timeout to 0 so blocked locks fail immediately with SQLITE_BUSY
+  sqlite3_busy_timeout(db2, 0);
+
+  // Explicitly tell the VFS to use a 0ms internal lock timeout
+  int vfs_timeout = 0;
+  ASSERT_EQ(SQLITE_OK, sqlite3_file_control(db2, "main", SQLITE_FCNTL_LOCK_TIMEOUT, &vfs_timeout));
+
+  // Connection 1 begins immediate transaction (acquires RESERVED lock)
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, "BEGIN IMMEDIATE TRANSACTION;", NULL, NULL, NULL));
+
+  int lock_state1 = SQLITE_LOCK_NONE;
+  ASSERT_EQ(SQLITE_OK, sqlite3_file_control(db, "main", SQLITE_FCNTL_LOCKSTATE, &lock_state1));
+  ASSERT_EQ(SQLITE_LOCK_RESERVED, lock_state1);
+
+  // Connection 2 can still read (acquires SHARED lock without conflicting with RESERVED)
+  sqlite3_stmt *stmt = NULL;
+  ASSERT_EQ(SQLITE_OK, sqlite3_prepare_v2(db2, "SELECT * FROM foo;", -1, &stmt, NULL));
+  ASSERT_EQ(SQLITE_ROW, sqlite3_step(stmt));
+
+  int lock_state2 = SQLITE_LOCK_NONE;
+  ASSERT_EQ(SQLITE_OK, sqlite3_file_control(db2, "main", SQLITE_FCNTL_LOCKSTATE, &lock_state2));
+  ASSERT_EQ(SQLITE_LOCK_SHARED, lock_state2);
+
+  ASSERT_EQ(SQLITE_OK, sqlite3_finalize(stmt));
+
+  // Connection 2 cannot begin immediate transaction (blocked by Connection 1's RESERVED lock)
+  int rc = sqlite3_exec(db2, "BEGIN IMMEDIATE TRANSACTION;", NULL, NULL, NULL);
+  ASSERT_EQ(SQLITE_BUSY, rc);
+
+  // Connection 1 commits (upgrades to EXCLUSIVE to write, then releases all locks)
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, "INSERT INTO foo (a) VALUES (2);", NULL, NULL, NULL));
+  ASSERT_EQ(SQLITE_OK, sqlite3_file_control(db, "main", SQLITE_FCNTL_LOCKSTATE, &lock_state1));
+  ASSERT_EQ(SQLITE_LOCK_RESERVED, lock_state1);
+
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, "COMMIT;", NULL, NULL, NULL));
+  ASSERT_EQ(SQLITE_OK, sqlite3_file_control(db, "main", SQLITE_FCNTL_LOCKSTATE, &lock_state1));
+  ASSERT_EQ(SQLITE_LOCK_NONE, lock_state1);
+
+  // Now Connection 2 can successfully begin an immediate transaction
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db2, "BEGIN IMMEDIATE TRANSACTION;", NULL, NULL, NULL));
+  ASSERT_EQ(SQLITE_OK, sqlite3_file_control(db2, "main", SQLITE_FCNTL_LOCKSTATE, &lock_state2));
+  ASSERT_EQ(SQLITE_LOCK_RESERVED, lock_state2);
+
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db2, "COMMIT;", NULL, NULL, NULL));
+
+  sqlite3_close(db2);
+}
+
+TEST_F(CephSQLiteTest, LockDowngrade) {
+  static const char SETUP_SQL[] = "CREATE TABLE foo (a INT); CREATE TABLE bar (b INT); INSERT INTO foo (a) VALUES (1);";
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, SETUP_SQL, NULL, NULL, NULL));
+
+  sqlite3_stmt *stmt = NULL;
+  // Step 1: Start a read query on foo to hold a SHARED lock
+  ASSERT_EQ(SQLITE_OK, sqlite3_prepare_v2(db, "SELECT * FROM foo;", -1, &stmt, NULL));
+  ASSERT_EQ(SQLITE_ROW, sqlite3_step(stmt));
+
+  int lock_state = SQLITE_LOCK_NONE;
+  ASSERT_EQ(SQLITE_OK, sqlite3_file_control(db, "main", SQLITE_FCNTL_LOCKSTATE, &lock_state));
+  ASSERT_EQ(SQLITE_LOCK_SHARED, lock_state);
+
+  // Step 2: Write to bar. This forces an upgrade to EXCLUSIVE, then an auto-commit.
+  // Because stmt is still open, the lock will automatically downgrade to SHARED, not NONE.
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, "INSERT INTO bar (b) VALUES (2);", NULL, NULL, NULL));
+
+  ASSERT_EQ(SQLITE_OK, sqlite3_file_control(db, "main", SQLITE_FCNTL_LOCKSTATE, &lock_state));
+  ASSERT_EQ(SQLITE_LOCK_SHARED, lock_state);
+
+  // Step 3: Finalize the read cursor to release the SHARED lock completely.
+  ASSERT_EQ(SQLITE_OK, sqlite3_finalize(stmt));
+
+  ASSERT_EQ(SQLITE_OK, sqlite3_file_control(db, "main", SQLITE_FCNTL_LOCKSTATE, &lock_state));
+  ASSERT_EQ(SQLITE_LOCK_NONE, lock_state);
+}
+
+TEST_F(CephSQLiteTest, ExclusiveLockConcurrency) {
+  static const char SETUP_SQL[] = "CREATE TABLE foo (a INT); INSERT INTO foo (a) VALUES (1);";
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, SETUP_SQL, NULL, NULL, NULL));
+
+  sqlite3* db2 = nullptr;
+  ASSERT_EQ(SQLITE_OK, sqlite3_open_v2(get_uri().c_str(), &db2, SQLITE_OPEN_READWRITE | SQLITE_OPEN_URI, "ceph"));
+  sqlite3_busy_timeout(db2, 0);
+
+  // Explicitly tell the VFS to use a 0ms internal lock timeout
+  int vfs_timeout = 0;
+  ASSERT_EQ(SQLITE_OK, sqlite3_file_control(db2, "main", SQLITE_FCNTL_LOCK_TIMEOUT, &vfs_timeout));
+
+  // Connection 1 acquires EXCLUSIVE lock directly
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, "BEGIN EXCLUSIVE TRANSACTION;", NULL, NULL, NULL));
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, "INSERT INTO foo (a) VALUES (2);", NULL, NULL, NULL));
+
+  int lock_state1 = SQLITE_LOCK_NONE;
+  ASSERT_EQ(SQLITE_OK, sqlite3_file_control(db, "main", SQLITE_FCNTL_LOCKSTATE, &lock_state1));
+  ASSERT_EQ(SQLITE_LOCK_EXCLUSIVE, lock_state1);
+
+  // Connection 2 cannot read (fails to acquire SHARED lock because of EXCLUSIVE lock)
+  int rc = sqlite3_exec(db2, "SELECT * FROM foo;", NULL, NULL, NULL);
+  ASSERT_EQ(SQLITE_BUSY, rc);
+
+  // Connection 1 commits and releases the lock
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, "COMMIT;", NULL, NULL, NULL));
+
+  // Connection 2 can now read successfully
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db2, "SELECT * FROM foo;", NULL, NULL, NULL));
+
+  sqlite3_close(db2);
+}
+
+
+TEST_F(CephSQLiteTest, DeadClientRecovery) {
+  static const char SETUP_SQL[] = "CREATE TABLE foo (a INT); INSERT INTO foo (a) VALUES (1);";
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, SETUP_SQL, NULL, NULL, NULL));
+
+  // 1. Manually inject a "dead client" by setting XATTR_EXCL.
+  // This simulates a client that crashed while holding a RESERVED/EXCLUSIVE lock,
+  // leaving the XATTR populated but the ephemeral RADOS locks released.
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, cluster.ioctx_create(pool.c_str(), ioctx));
+  std::string obj_name = fmt::format("{}.0000000000000000", get_name());
+
+  ceph::bufferlist bl;
+  bl.append("[v2:192.0.2.1:0/0,v1:192.0.2.1:0/0]");
+  ASSERT_EQ(0, ioctx.setxattr(obj_name, "striper.excl", bl));
+
+  // 2. Attempt to write. The VFS will attempt to upgrade to RESERVED,
+  // see the leftover XATTR_EXCL, fail the cmpxattr (-ECANCELED), and trigger recover_lock().
+  // recover_lock() will blocklist the mock IP and overwrite XATTR_EXCL to safely take ownership.
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, "BEGIN IMMEDIATE TRANSACTION;", NULL, NULL, NULL));
+
+  // Verify that the lock was stolen/recovered and striper.excl is updated to OUR address.
+  ceph::bufferlist current_bl;
+  ASSERT_LT(0, ioctx.getxattr(obj_name, "striper.excl", current_bl));
+  ASSERT_NE(bl.to_str(), current_bl.to_str());
+  ASSERT_FALSE(current_bl.to_str().empty());
+
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, "INSERT INTO foo (a) VALUES (2);", NULL, NULL, NULL));
+  ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, "COMMIT;", NULL, NULL, NULL));
+
+  // 3. Verify the write succeeded and the lock state was restored.
+  sqlite3_stmt *stmt = NULL;
+  ASSERT_EQ(SQLITE_OK, sqlite3_prepare_v2(db, "SELECT SUM(a) FROM foo;", -1, &stmt, NULL));
+  ASSERT_EQ(SQLITE_ROW, sqlite3_step(stmt));
+  ASSERT_EQ(3, sqlite3_column_int64(stmt, 0));
+  ASSERT_EQ(SQLITE_OK, sqlite3_finalize(stmt));
+
+  int lock_state = SQLITE_LOCK_NONE;
+  ASSERT_EQ(SQLITE_OK, sqlite3_file_control(db, "main", SQLITE_FCNTL_LOCKSTATE, &lock_state));
+  ASSERT_EQ(SQLITE_LOCK_NONE, lock_state);
+}
+
+TEST_F(CephSQLiteTest, ContentionWaitLoop) {
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, cluster.ioctx_create(pool.c_str(), ioctx));
+  std::string db_name = fmt::format("{}.wait_test", get_name());
+
+  SimpleRADOSStriper rs1(ioctx, db_name);
+  ASSERT_EQ(0, rs1.create());
+  ASSERT_EQ(0, rs1.open());
+
+  SimpleRADOSStriper rs2(ioctx, db_name);
+  ASSERT_EQ(0, rs2.open());
+  rs2.set_acquire_timeout(std::chrono::milliseconds(2000));
+
+  // Client 1 acquires an Exclusive lock
+  ASSERT_EQ(0, rs1.lock(SimpleRADOSStriper::LockLevel::Exclusive));
+
+  std::atomic<int> rs2_rc = -1;
+  auto start = std::chrono::steady_clock::now();
+
+  // Client 2 attempts to acquire a Shared lock concurrently.
+  // This should trigger the `-EBUSY` wait loop instead of failing immediately.
+  std::thread t([&]() {
+    rs2_rc = rs2.lock(SimpleRADOSStriper::LockLevel::Shared);
+  });
+
+  // Client 1 holds the lock for ~300ms then releases
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+  ASSERT_EQ(0, rs1.unlock(SimpleRADOSStriper::LockLevel::None));
+
+  t.join();
+
+  auto end = std::chrono::steady_clock::now();
+  auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+
+  // Client 2 should have eventually succeeded and waited at least 300ms
+  ASSERT_EQ(0, rs2_rc.load());
+  ASSERT_GE(elapsed, 300);
+
+  ASSERT_EQ(0, rs2.unlock(SimpleRADOSStriper::LockLevel::None));
+  ASSERT_EQ(0, rs1.remove());
+}
+
+TEST_F(CephSQLiteTest, LockRenewal) {
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, cluster.ioctx_create(pool.c_str(), ioctx));
+  std::string db_name = fmt::format("{}.renewal_test", get_name());
+
+  SimpleRADOSStriper rs1(ioctx, db_name);
+  ASSERT_EQ(0, rs1.create());
+  ASSERT_EQ(0, rs1.open());
+
+  // Use very short timeouts to quickly test the lock keeper thread
+  rs1.set_lock_interval(std::chrono::milliseconds(200));
+  rs1.set_lock_timeout(std::chrono::milliseconds(500));
+
+  // --- 1. Test Shared lock renewal ---
+  ASSERT_EQ(0, rs1.lock(SimpleRADOSStriper::LockLevel::Shared));
+
+  // Sleep past the lock timeout (500ms). If the thread wasn't renewing, the lock would drop on the MDS.
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+  SimpleRADOSStriper rs2(ioctx, db_name);
+  ASSERT_EQ(0, rs2.open());
+  rs2.set_acquire_timeout(std::chrono::milliseconds(0));
+
+  // rs2 should fail to grab Exclusive because rs1's lock_keeper successfully kept the Shared lock alive
+  ASSERT_EQ(-EBUSY, rs2.lock(SimpleRADOSStriper::LockLevel::Exclusive));
+
+  // Release Shared lock
+  ASSERT_EQ(0, rs1.unlock(SimpleRADOSStriper::LockLevel::None));
+
+  // --- 2. Test Exclusive lock renewal ---
+  ASSERT_EQ(0, rs1.lock(SimpleRADOSStriper::LockLevel::Exclusive));
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+  // rs2 should fail to grab Shared because rs1's lock_keeper successfully kept the Exclusive lock alive
+  ASSERT_EQ(-EBUSY, rs2.lock(SimpleRADOSStriper::LockLevel::Shared));
+
+  ASSERT_EQ(0, rs1.unlock(SimpleRADOSStriper::LockLevel::None));
+  ASSERT_EQ(0, rs1.remove());
+}
 
 int main(int argc, char **argv) {
   auto args = argv_to_vec(argc, argv);


### PR DESCRIPTION
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
