### PR TITLE
crimson/os/seastore: refresh cursor before make_partial_iter in reserve_region/alloc_extents

### DIFF
--- a/src/crimson/os/seastore/lba/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.cc
@@ -280,6 +280,7 @@ BtreeLBAManager::reserve_region(
   assert(cursor->is_viewable());
   auto c = get_context(t);
   auto btree = co_await get_btree<LBABtree>(cache, c);
+  co_await cursor->refresh();
   auto iter = btree.make_partial_iter(c, *cursor);
   lba_map_val_t val{
     len,
@@ -306,6 +307,7 @@ BtreeLBAManager::alloc_extents(
   DEBUGT("{}", t, *cursor);
   auto c = get_context(t);
   auto btree = co_await get_btree<LBABtree>(cache, c);
+  co_await cursor->refresh();
   auto iter = btree.make_partial_iter(c, *cursor);
   std::vector<LBACursorRef> ret;
   for (auto eiter = extents.rbegin(); eiter != extents.rend(); ++eiter) {


### PR DESCRIPTION
## Problem

`reserve_region()` and `alloc_extents()` both assert `is_viewable()` on
the cursor at function entry, then `co_await get_btree<LBABtree>()`, and
immediately call `make_partial_iter(c, *cursor)` without re-validating
the cursor.

Because `co_await get_btree()` is a coroutine suspension point, other
coroutines may run during the suspension and modify or invalidate the
cursor's parent leaf node (e.g. through a concurrent node split, merge,
or rewrite in another transaction).  When execution resumes, the partial
iterator constructed from the stale cursor either:

- triggers the `assert(leaf->is_viewable_by_trans(c.trans).first)` inside
  `make_partial_iter` (debug builds), or
- causes `btree.insert()` to fail because the logical address is already
  occupied or the leaf position is wrong, making `ceph_assert(p.second)`
  (i.e. `ceph_assert(inserted)`) fire.

This has been observed in CI as a recurring `ceph_assert(inserted)` crash:

```
backtrace:
  FixedKVBtree::make_partial_iter(op_context_t, LBALeafNode*, laddr_t, unsigned short)
  FixedKVBtree::make_partial_iter(op_context_t, LBACursor&)
  BtreeLBAManager::reserve_region(...)   <-- btree_lba_manager.cc
```

Tracker: https://tracker.ceph.com/issues/75533

## Fix

Add `co_await cursor->refresh()` immediately after `co_await get_btree()`
in both `reserve_region()` and `alloc_extents()`, before constructing the
partial iterator.

This matches the existing pattern in `clone_mapping()`, which already
calls `co_await pos->refresh()` after `co_await get_btree()` for the
same reason (lines 364–365 in the same file).

## Testing

The fix is consistent with the established `refresh()` pattern used
elsewhere in `btree_lba_manager.cc`.  The `crimson-rados` CI suite that
reproduces the crash should be used to verify the fix.