### PR TITLE
crimson/zns: make WITH_ZNS=ON the default for crimson builds

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1536,6 +1536,7 @@ cmake .. \
 %if 0%{with crimson}
     -DWITH_CRIMSON:BOOL=ON \
     -DWITH_JAEGER:BOOL=OFF \
+    -DWITH_ZNS:BOOL=ON \
 %endif
     -DWITH_GRAFANA:BOOL=ON \
 %if %{with sccache}

--- a/src/crimson/os/seastore/CMakeLists.txt
+++ b/src/crimson/os/seastore/CMakeLists.txt
@@ -59,7 +59,7 @@ set(crimson_seastore_srcs
   ${PROJECT_SOURCE_DIR}/src/os/Transaction.cc
 	)
 
-CMAKE_DEPENDENT_OPTION(WITH_ZNS "enable Linux ZNS support" OFF
+CMAKE_DEPENDENT_OPTION(WITH_ZNS "enable Linux ZNS support" ON
   "CMAKE_SYSTEM_NAME STREQUAL Linux" OFF)
 if(WITH_ZNS)
   find_package(LinuxZNS REQUIRED)


### PR DESCRIPTION
Mainly - to guarantee that no changes that break the WITH_ZNS build, are merged.

unstaling