### PR TITLE
debian: enable crimson packages

### DIFF
--- a/make-debs.sh
+++ b/make-debs.sh
@@ -53,9 +53,9 @@ tar -C $releasedir --no-same-owner -jxf $releasedir/ceph_$vers.orig.tar.bz2
 #
 cp -a debian $releasedir/ceph-$vers/debian
 cd $releasedir
-if [[ -n "$SKIP_DEBUG_PACKAGES" ]] ; then
-	perl -ni -e 'print if(!(/^Package: .*-dbg$/../^$/))' ceph-$vers/debian/control
-	perl -pi -e 's/--dbg-package.*//' ceph-$vers/debian/rules
+if [[ -n "$SKIP_DEBUG_PACKAGES" ]]; then
+    perl -ni -e 'print if(!(/^Package: .*-dbg$/../^$/))' ceph-$vers/debian/control
+    perl -pi -e 's/--dbg-package.*//' ceph-$vers/debian/rules
 fi
 
 # For cache hit consistency, allow CI builds to use a build directory whose name
@@ -72,7 +72,7 @@ fi
 #
 chvers=$(head -1 debian/changelog | perl -ne 's/.*\(//; s/\).*//; print')
 if [ "$chvers" != "$dvers" ]; then
-   DEBEMAIL="contact@ceph.com" dch -D $VERSION_CODENAME --force-distribution -b -v "$dvers" "new version"
+    DEBEMAIL="contact@ceph.com" dch -D $VERSION_CODENAME --force-distribution -b -v "$dvers" "new version"
 fi
 #
 # create the packages
@@ -92,13 +92,52 @@ if test "$NPROC" -gt "$MAX_JOBS"; then
 else
     JOBS_FLAG="-j${NPROC}"
 fi
-if [ "$SCCACHE" != "true" ] ; then
+if [ "$SCCACHE" != "true" ]; then
     PATH=/usr/lib/ccache:$PATH
+fi
+# Crimson/seastar needs GCC >= 13 (C++20 coroutines).
+# WITH_CRIMSON: off forces disable; on/unset enable when the distro is new enough
+# (Ubuntu 24.04 (noble)+ or Debian 13 (trixie)+). Distro is a hard floor: setting
+# WITH_CRIMSON=on on an older distro is ignored (with a warning).
+distro_supports_crimson=no
+case "$ID" in
+ubuntu)
+    ubuntu_major=${VERSION_ID%%.*}
+    ubuntu_minor=${VERSION_ID#*.}
+    if [ "$ubuntu_major" -gt 24 ] ||
+        { [ "$ubuntu_major" -eq 24 ] && [ "$ubuntu_minor" -ge 4 ]; }; then
+        distro_supports_crimson=yes
+    fi
+    ;;
+debian)
+    if [ -z "$VERSION_ID" ] || [ "$VERSION_ID" -ge 13 ] 2>/dev/null; then
+        distro_supports_crimson=yes
+    fi
+    ;;
+esac
+
+enable_crimson=no
+case "${WITH_CRIMSON:-auto}" in
+OFF | off | 0 | false) ;;
+ON | on | 1 | true)
+    if [ "$distro_supports_crimson" = yes ]; then
+        enable_crimson=yes
+    else
+        echo "WITH_CRIMSON=$WITH_CRIMSON ignored: $ID $VERSION_ID lacks GCC >= 13" >&2
+    fi
+    ;;
+auto | "")
+    [ "$distro_supports_crimson" = yes ] && enable_crimson=yes
+    ;;
+esac
+
+if [ "$enable_crimson" = yes ]; then
+    export DEB_BUILD_PROFILES="${DEB_BUILD_PROFILES:+$DEB_BUILD_PROFILES }pkg.ceph.crimson"
 fi
 PATH=$PATH dpkg-buildpackage $JOBS_FLAG -uc -us
 cd ../..
 mkdir -p $VERSION_CODENAME/conf
-cat > $VERSION_CODENAME/conf/distributions <<EOF
+cat >$VERSION_CODENAME/conf/distributions <<EOF
 Codename: $VERSION_CODENAME
 Suite: stable
 Components: main
@@ -111,4 +150,4 @@ reprepro --basedir $(pwd) include $VERSION_CODENAME WORKDIR/*.changes
 #
 # teuthology needs the version in the version file
 #
-echo $dvers > $VERSION_CODENAME/version
+echo $dvers >$VERSION_CODENAME/version


### PR DESCRIPTION
## What
This PR enables ceph-osd-crimson and ceph-osd-crimson-dbg packages for debian builds, which have gcc version 13 and above. Before this PR, no crimson packages were in the ceph-osd builds. After this change, crimson and crimson debug deb packages will be in the ceph-osd binary by default. 

A more detailed explanation of the behavior: 

|WITH_CRIMSON|distro has gcc >= 13| result | 
|----------------|---------------------|-------|
|on|yes (eg - noble and above)|crimson packages are built|
|on|no (eg - jammy)|crimson packages are not built|
|off|yes|crimson packages are not built|
|off|no|crimson packages are not built|
 



## Why
Crimson wants to support debian distros as well. For the same, before we can start testing against debian, we need builds to work. This PR enables ceph OSD debian binaries to be packaged with both classic and crimson debs. 

## Testing 
The latest commit has been pushed against ceph-ci, build: https://shaman.ceph.com/builds/ceph/wip-shraddhaag-enable-debian-crimson-builds/e75cf185b22bb072cf6370846554f982fd35c8f3/. 

* Crimson packges exist for noble: https://3.chacra.ceph.com/r/ceph/wip-shraddhaag-enable-debian-crimson-builds/e75cf185b22bb072cf6370846554f982fd35c8f3/ubuntu/noble/flavors/default/pool/main/c/ceph/
* Crimson packages do not exist for jammy:  https://2.chacra.ceph.com/r/ceph/wip-shraddhaag-enable-debian-crimson-builds/e75cf185b22bb072cf6370846554f982fd35c8f3/ubuntu/jammy/flavors/default/pool/main/c/ceph/


Fixes: https://tracker.ceph.com/issues/77043


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
