### PR TITLE
cmake: link legacy-option-headers from targets that use legacy options

### DIFF
--- a/src/compressor/zstd/CMakeLists.txt
+++ b/src/compressor/zstd/CMakeLists.txt
@@ -13,7 +13,9 @@ set(zstd_sources
   CompressionPluginZstd.cc)
 
 add_library(ceph_zstd SHARED ${zstd_sources})
-target_link_libraries(ceph_zstd PRIVATE Zstd::Zstd $<$<PLATFORM_ID:Windows>:ceph-common>)
+target_link_libraries(ceph_zstd PRIVATE
+  legacy-option-headers
+  Zstd::Zstd $<$<PLATFORM_ID:Windows>:ceph-common>)
 set_target_properties(ceph_zstd PROPERTIES
   VERSION 2.0.0
   SOVERSION 2

--- a/src/neorados/CMakeLists.txt
+++ b/src/neorados/CMakeLists.txt
@@ -2,10 +2,12 @@ add_library(neorados_objs OBJECT
   RADOSImpl.cc)
 target_compile_definitions(neorados_objs PRIVATE
   $<TARGET_PROPERTY:${FMT_LIB},INTERFACE_COMPILE_DEFINITIONS>)
+target_link_libraries(neorados_objs legacy-option-headers)
 add_library(neorados_api_obj OBJECT
   RADOS.cc)
 target_compile_definitions(neorados_api_obj PRIVATE
   $<TARGET_PROPERTY:${FMT_LIB},INTERFACE_COMPILE_DEFINITIONS>)
+target_link_libraries(neorados_api_obj legacy-option-headers)
 
 add_library(libneorados STATIC
   $<TARGET_OBJECTS:neorados_api_obj>

--- a/src/perfglue/CMakeLists.txt
+++ b/src/perfglue/CMakeLists.txt
@@ -2,6 +2,7 @@ if(ALLOCATOR STREQUAL "tcmalloc")
   add_library(heap_profiler STATIC
     heap_profiler.cc)
   target_link_libraries(heap_profiler
+    legacy-option-headers
     gperftools::tcmalloc)
 else()
   add_library(heap_profiler STATIC


### PR DESCRIPTION
The *_legacy_options.h headers that define the legacy ConfigValues
members are generated at build time by y2c.py. Linking the
legacy-option-headers INTERFACE library adds an order dependency on
that step. A few targets reference legacy members without linking it,
so under a parallel build they can be compiled before the headers
exist and fail with `class ConfigValues has no member ...`:

  neorados_objs, neorados_api_obj - objecter_inflight_ops,
      ms_die_on_unhandled_msg (via Objecter.h / Messenger.h)
  ceph_zstd - compressor_zstd_level
  heap_profiler - log_file

Link legacy-option-headers from them, as ceph_lz4, ceph_snappy and
jerasure_utils already do.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests