### PR TITLE
mgr/dashboard: Fixing control flow on submit button for pool creation page

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
@@ -41,6 +41,7 @@ import { RbdMirroringService } from '~/app/shared/api/rbd-mirroring.service';
 import { MonitorService } from '~/app/shared/api/monitor.service';
 import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 import { Permissions } from '~/app/shared/models/permissions';
+import { FROM_STORAGE_CLASS } from './../../rgw/models/rgw-storage-class.model';
 
 interface FormFieldDescription {
   externalFieldName: string;
@@ -106,6 +107,8 @@ export class PoolFormComponent extends CdForm implements OnInit {
   isApplicationsSelected = true;
   msrCrush: boolean = false;
   isStretchMode: boolean = false;
+  private fromStorageClass: boolean = false;
+  private previousPath: string = '';
 
   readonly DEFAULT_REPLICATED_MIN_SIZE = 1;
   readonly DEFAULT_REPLICATED_MAX_SIZE = 3;
@@ -136,6 +139,9 @@ export class PoolFormComponent extends CdForm implements OnInit {
     this.resource = $localize`pool`;
     this.authenticate();
     this.createForm();
+    const nav = this.router.getCurrentNavigation();
+    this.fromStorageClass = nav?.extras?.state?.['from'] === FROM_STORAGE_CLASS;
+    this.previousPath = nav?.extras?.state?.['returnUrl'] || '/pool';
   }
 
   authenticate() {
@@ -1090,8 +1096,16 @@ export class PoolFormComponent extends CdForm implements OnInit {
           }
           this.form.setErrors({ cdSubmitButton: true });
         },
-        complete: () => this.router.navigate(['/pool'])
+        complete: () => this.navigateAfterPoolForm()
       });
+  }
+
+  navigateAfterPoolForm(): void {
+    if (this.fromStorageClass) {
+      this.router.navigate([this.previousPath]);
+    } else {
+      this.router.navigate(['/pool']);
+    }
   }
 
   appSelection(events: SelectOption[]) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/models/rgw-storage-class.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/models/rgw-storage-class.model.ts
@@ -350,3 +350,5 @@ export const AclHelperText: AclMaps = {
 export const POOL = {
   PATH: '/pool/create'
 };
+
+export const FROM_STORAGE_CLASS = 'from-storage-class';

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-form/rgw-storage-class-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-form/rgw-storage-class-form.component.html
@@ -131,7 +131,15 @@
             spacingClass="mb-2"
             (action)="navigateCreatePool()"
           >
-            <span i18n>To create a new pool click <a [routerLink]="[POOL.PATH]">here</a></span>
+            <span i18n
+              >To create a new pool click
+              <a
+                href="#"
+                (click)="navigateCreatePool()"
+              >
+                here
+              </a>
+            </span>
           </cd-alert-panel>
           <cds-select
             label="Pool"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-form/rgw-storage-class-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-form/rgw-storage-class-form.component.spec.ts
@@ -1,7 +1,8 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { Router } from '@angular/router';
 import { SharedModule } from '~/app/shared/shared.module';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 
@@ -15,10 +16,15 @@ import {
 import { CoreModule } from '~/app/core/core.module';
 import { RgwStorageClassFormComponent } from './rgw-storage-class-form.component';
 import { TIER_TYPE_DISPLAY } from '../models/rgw-storage-class.model';
+import { PoolFormComponent } from '../../pool/pool-form/pool-form.component';
+import { RgwZonegroupService } from '~/app/shared/api/rgw-zonegroup.service';
+import { PoolService } from '~/app/shared/api/pool.service';
+import { of } from 'rxjs';
 
 describe('RgwStorageClassFormComponent', () => {
   let component: RgwStorageClassFormComponent;
   let fixture: ComponentFixture<RgwStorageClassFormComponent>;
+  let router: Router;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -38,8 +44,14 @@ describe('RgwStorageClassFormComponent', () => {
       declarations: [RgwStorageClassFormComponent]
     }).compileComponents();
 
+    spyOn(TestBed.inject(RgwZonegroupService), 'getAllZonegroupsInfo').and.returnValue(
+      of({ zonegroups: [], default_zonegroup: '' })
+    );
+    spyOn(TestBed.inject(PoolService), 'getList').and.returnValue(of([]));
+
     fixture = TestBed.createComponent(RgwStorageClassFormComponent);
     component = fixture.componentInstance;
+    router = TestBed.inject(Router);
     fixture.detectChanges();
   });
 
@@ -193,6 +205,49 @@ describe('RgwStorageClassFormComponent', () => {
       control.setValue('');
       control.updateValueAndValidity();
       expect(component).toBeTruthy();
+    });
+  });
+
+  describe('pool form navigation from storage class form', () => {
+    const storageClassReturnUrl = '/rgw/storage-class/create';
+
+    const createPoolFormNavigationContext = (
+      fromStorageClass: boolean,
+      previousPath: string,
+      poolRouter: Router
+    ) => {
+      const poolForm = Object.create(PoolFormComponent.prototype) as PoolFormComponent;
+      (poolForm as any).fromStorageClass = fromStorageClass;
+      (poolForm as any).previousPath = previousPath;
+      (poolForm as any).router = poolRouter;
+      return poolForm;
+    };
+
+    it('should return to storage class form after pool creation when opened from storage class', () => {
+      const navigateSpy = spyOn(router, 'navigate');
+      const poolForm = createPoolFormNavigationContext(true, storageClassReturnUrl, router);
+
+      poolForm.navigateAfterPoolForm();
+
+      expect(navigateSpy).toHaveBeenCalledWith([storageClassReturnUrl]);
+    });
+
+    it('should return to pool list after pool creation when not opened from storage class', () => {
+      const navigateSpy = spyOn(router, 'navigate');
+      const poolForm = createPoolFormNavigationContext(false, '/pool', router);
+
+      poolForm.navigateAfterPoolForm();
+
+      expect(navigateSpy).toHaveBeenCalledWith(['/pool']);
+    });
+
+    it('should return to pool list when pool creation is cancelled outside storage class form', () => {
+      const navigateSpy = spyOn(router, 'navigate');
+      const poolForm = createPoolFormNavigationContext(false, '/pool', router);
+
+      poolForm.navigateAfterPoolForm();
+
+      expect(navigateSpy).toHaveBeenCalledWith(['/pool']);
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-form/rgw-storage-class-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-form/rgw-storage-class-form.component.ts
@@ -64,7 +64,8 @@ import {
   AclType,
   ZoneRequest,
   AllZonesResponse,
-  POOL
+  POOL,
+  FROM_STORAGE_CLASS
 } from '../models/rgw-storage-class.model';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
 import { NotificationService } from '~/app/shared/services/notification.service';
@@ -120,6 +121,7 @@ export class RgwStorageClassFormComponent extends CdForm implements OnInit {
   rgwPools: Pool[];
   zones: any[];
   POOL = POOL;
+  FROM_STORAGE_CLASS = FROM_STORAGE_CLASS;
 
   constructor(
     public actionLabels: ActionLabelsI18n,
@@ -631,6 +633,12 @@ export class RgwStorageClassFormComponent extends CdForm implements OnInit {
   }
   goToListView() {
     this.router.navigate([`rgw/storage-class`]);
+  }
+
+  navigateCreatePool(): void {
+    this.router.navigate([POOL.PATH], {
+      state: { from: FROM_STORAGE_CLASS, returnUrl: this.router.url }
+    });
   }
 
   getTierTargetByStorageClass(placementTargetInfo: PlacementTarget, storageClass: string) {


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/77030
Signed-off-by: Devika Babrekar <devika.babrekar@ibm.com>


https://github.com/user-attachments/assets/2fc747d9-35e7-4196-b909-a5200b6f4a56



Description:
When user access pools creation page from storage class page, after creating pool, the control now returns to storage class page instead of pools page.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
