### PR TITLE
doc/rados/bluestore: Add documentation for the BlueFS spillover cleaner

### DIFF
--- a/doc/rados/bluestore/bluefs-spillover-cleaner.rst
+++ b/doc/rados/bluestore/bluefs-spillover-cleaner.rst
@@ -1,0 +1,111 @@
+=========================
+BlueFS Spillover Cleaner
+=========================
+
+Overview
+========
+
+BlueFS may place files on the slow device when the DB device
+runs out of free space. This condition is known as spillover.
+
+The BlueFS Spillover Cleaner is a background component that periodically
+scans for spillover files and attempts to migrate them back to
+the DB device when sufficient space becomes available.
+
+Spillover is most commonly observed when the DB device becomes full,
+for example large RocksDB compactions after OSD crashes, upgrades that change
+RocksDB behavior.
+
+The cleaner is disabled by default.
+
+Operation
+=========
+
+The cleaner operates in two phases:
+
+Active Phase:
+
+- Scan for files located on the slow device.
+- Migrate those files back to the DB device.
+- While migration is in progress, the cleaner throttles itself according to :confval:`bluefs_spillover_cleaner_work_ratio` to reduce interference with foreground IO.
+
+Idle Phase:
+
+- Entered when no spillover files are found
+- When no spillover files remain, the cleaner enters a longer sleep period controlled by :confval:`bluefs_spillover_idle_time` before performing the next scan.
+
+Configuration
+=============
+
+Enable cleaner
+--------------
+
+.. confval:: bluefs_spillover_cleaner
+
+Idle Time
+-------------
+
+.. confval:: bluefs_spillover_idle_time
+
+Work ratio
+----------
+
+.. confval:: bluefs_spillover_cleaner_work_ratio
+
+Higher values make migration more aggressive, while lower values reduce
+resource consumption.
+
+Migration behavior
+==================
+
+Files are migrated incrementally rather than moving an entire file at
+once. This helps limit memory consumption and reduce latency spikes.
+
+Migration is attempted only when sufficient free space exists on the
+DB device.
+
+Admin Commands
+==============
+
+Display spillover cleaner status:
+
+.. prompt:: bash #
+
+   ceph tell osd.N bluefs spillover cleaner stats
+
+Example output:
+
+.. code-block::
+
+   {
+    "Files Migrated": [
+        ...
+        "db.wal/000052.log size=0x24cd21 migrated=0x1200000 from dev=2->1 ts=2026-06-02T12:44:25.488250+0000",
+        "db.wal/000053.log size=0x3696ad migrated=0x1200000 from dev=2->1 ts=2026-06-02T12:44:25.833014+0000",
+        "db.wal/000054.log size=0x1571f61 migrated=0x2400000 from dev=2->1 ts=2026-06-02T12:44:26.134245+0000",
+        "db.wal/000055.log size=0x1b2b508 migrated=0x2400000 from dev=2->1 ts=2026-06-02T12:44:26.550633+0000"
+    ],
+    "pending_files": [
+        "db.wal/000056.log",
+        "db.wal/000057.log",
+        "db.wal/000058.log",
+        "db.wal/000059.log",
+        "db.wal/000060.log",
+        ...
+    ]
+   }
+
+Testing
+=======
+
+For testing purposes, allocations can be forced onto the slow device.
+
+.. confval:: bluefs_debug_force_slow
+
+Example:
+
+.. prompt:: bash #
+
+   ceph config set osd bluefs_debug_force_slow true
+
+This option is intended only for development and testing.

--- a/doc/rados/configuration/index.rst
+++ b/doc/rados/configuration/index.rst
@@ -21,6 +21,7 @@ For general object store configuration, refer to the following:
 
    Storage devices <storage-devices>
    BlueStore RocksDB cache <../bluestore/rocksdb-config>
+   BlueFS Spillover Cleaner <../bluestore/bluefs-spillover-cleaner>
    ceph-conf
 
 


### PR DESCRIPTION
Documentation for the BlueFS spillover cleaner #68430

Fixes: https://tracker.ceph.com/issues/74319
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
