### PR TITLE
tentacle: qa: install nvme-cli only if distro remains rocky10

### DIFF
--- a/qa/distros/all/rocky_10.yaml
+++ b/qa/distros/all/rocky_10.yaml
@@ -1,25 +1,31 @@
+install_rocky_packages:
+  sequential:
+    - print: "Install additional rocky10 dependencies"
+    # postmerge appends to this
 os_type: rocky
 os_version: "10.1"
 overrides:
   selinux:
     allowlist:
       - 'comm="systemd".*denied.*\{ prog_run \}.*tclass=bpf.*permissive=1'
+tasks:
+  # This is appended to the tasks: list here so that we can edit the task list
+  # before e.g. ceph is installed.
+  - sequential:
+      - install_rocky_packages
 teuthology:
   postmerge:
     - |
+      log.debug("os is %s", yaml.os_type)
       if yaml.os_type == 'rocky' then
         local pexec_tasks = yaml_load([[
-        - pexec:
-            all:
-            # for https://tracker.ceph.com/issues/73823
-            - sudo dnf remove nvme-cli -y
-            - sudo dnf install nvmetcli nvme-cli -y
+        sequential:
+          - pexec:
+              all:
+                # for https://tracker.ceph.com/issues/73823
+                # Cannot use install.extra_system_packages because we also remove a package.
+                - sudo dnf remove nvme-cli -y
+                - sudo dnf install nvmetcli nvme-cli -y
         ]])
-        
-        -- Ensure the tasks array exists before attempting to merge
-        if yaml.tasks == nil then
-          yaml.tasks = py_list()
-        end
-        
-        deep_merge(yaml.tasks, pexec_tasks)
+        deep_merge(yaml.install_rocky_packages, pexec_tasks)
       end

--- a/qa/suites/fs/32bits/distro
+++ b/qa/suites/fs/32bits/distro
@@ -1,1 +1,0 @@
-.qa/distros/supported-random-distro$

--- a/qa/suites/fs/full/distro
+++ b/qa/suites/fs/full/distro
@@ -1,1 +1,0 @@
-.qa/distros/supported-random-distro$

--- a/qa/suites/fs/functional/distro
+++ b/qa/suites/fs/functional/distro
@@ -1,1 +1,0 @@
-.qa/distros/supported-random-distro$

--- a/qa/suites/fs/libcephfs/distro
+++ b/qa/suites/fs/libcephfs/distro
@@ -1,1 +1,0 @@
-.qa/distros/supported-random-distro$

--- a/qa/suites/fs/mirror-ha/supported-random-distro$
+++ b/qa/suites/fs/mirror-ha/supported-random-distro$
@@ -1,1 +1,0 @@
-.qa/distros/supported-random-distro$

--- a/qa/suites/fs/multifs/distro
+++ b/qa/suites/fs/multifs/distro
@@ -1,1 +1,0 @@
-.qa/distros/supported-random-distro$

--- a/qa/suites/fs/nfs/supported-random-distros$
+++ b/qa/suites/fs/nfs/supported-random-distros$
@@ -1,1 +1,0 @@
-.qa/distros/supported-random-distro$

--- a/qa/suites/fs/permission/distro
+++ b/qa/suites/fs/permission/distro
@@ -1,1 +1,0 @@
-.qa/distros/supported-random-distro$

--- a/qa/suites/fs/snaps/distro
+++ b/qa/suites/fs/snaps/distro
@@ -1,1 +1,0 @@
-.qa/distros/supported-random-distro$

--- a/qa/suites/fs/thrash/multifs/distro
+++ b/qa/suites/fs/thrash/multifs/distro
@@ -1,1 +1,0 @@
-.qa/distros/supported-random-distro$

--- a/qa/suites/fs/thrash/workloads/distro
+++ b/qa/suites/fs/thrash/workloads/distro
@@ -1,1 +1,0 @@
-.qa/distros/supported-random-distro$

--- a/qa/suites/fs/top/supported-random-distros$
+++ b/qa/suites/fs/top/supported-random-distros$
@@ -1,1 +1,0 @@
-.qa/distros/supported-random-distro$

--- a/qa/suites/fs/volumes/distro
+++ b/qa/suites/fs/volumes/distro
@@ -1,1 +1,0 @@
-.qa/distros/supported-random-distro$


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
