### PR TITLE
crimson/osd: add debug logs for snaptrim and scrub background_process_lock

### DIFF
--- a/src/crimson/osd/osd_operations/scrub_events.cc
+++ b/src/crimson/osd/osd_operations/scrub_events.cc
@@ -109,6 +109,7 @@ ScrubReserveRange::ifut<> ScrubReserveRange::run(PG &pg)
 {
   LOG_PREFIX(ScrubReserveRange::run);
   DEBUGDPP("", pg);
+  DEBUGDPP("waiting for pg background_process_lock", pg);
   return pg.background_process_lock.lock(
   ).then_interruptible([FNAME, this, &pg] {
     DEBUGDPP("pg_background_io_mutex locked", pg);
@@ -130,8 +131,9 @@ ScrubReserveRange::ifut<> ScrubReserveRange::run(PG &pg)
       return scrubber.machine.process_event(
 	scrub::ScrubContext::reserve_range_complete_t{p->version});
     }
-  }).finally([&pg, this] {
+  }).finally([FNAME, &pg, this] {
     if (!blocked_set) {
+      DEBUGDPP("releasing pg background_process_lock (reserve not set)", pg);
       pg.background_process_lock.unlock();
     }
   });

--- a/src/crimson/osd/osd_operations/snaptrim_event.cc
+++ b/src/crimson/osd/osd_operations/snaptrim_event.cc
@@ -78,8 +78,11 @@ SnapTrimEvent::start()
    * pipeline stages. https://tracker.ceph.com/issues/66473 */
   ShardServices &shard_services = pg->get_shard_services();
   {
+    logger().debug("{}: waiting for pg background_process_lock", *this);
     co_await pg->background_process_lock.lock_with_op(*this);
+    logger().debug("{}: acquired pg background_process_lock", *this);
     auto unlocker = seastar::defer([this] {
+      logger().debug("{}: releasing pg background_process_lock", *this);
       pg->background_process_lock.unlock();
     });
 
@@ -100,6 +103,8 @@ SnapTrimEvent::start()
     });
     auto to_trim = co_await std::move(to_trim_fut);
 
+    logger().debug("{}: snap_mapper returned {} object(s) for this batch",
+                   *this, to_trim.size());
     if (to_trim.empty()) {
       // the legit ENOENT -> done
       logger().debug("{}: to_trim is empty! Stopping iteration", *this);
@@ -115,8 +120,9 @@ SnapTrimEvent::start()
 	  snapid));
     }
 
-    logger().debug("{}: awaiting completion", *this);
+    logger().debug("{}: awaiting completion ({} subevent(s))", *this, to_trim.size());
     co_await subop_blocker.interruptible_wait_completion();
+    logger().debug("{}: all subevents completed this round", *this);
   }
 
   if (needs_pause) {
@@ -405,6 +411,7 @@ SnapTrimObjSubEvent::start()
     std::ignore = handle.complete().then([opref = std::move(opref)] {});
   });
 
+  logger().debug("{}: entering obc pipeline process", *this);
   co_await enter_stage<interruptor>(
     obc_orderer->obc_pp().process);
 
@@ -428,11 +435,14 @@ SnapTrimObjSubEvent::start()
   auto all_completed = interruptor::now();
   {
     auto unlocker = seastar::defer([this] {
+      logger().debug("{}: releasing submit_lock", *this);
       pg->submit_lock.unlock();
     });
     // as with PG::submit_executer, we need to build the pg log entries
     // and submit the transaction atomically
+    logger().debug("{}: acquiring submit_lock", *this);
     co_await interruptor::make_interruptible(pg->submit_lock.lock());
+    logger().debug("{}: submit_lock held", *this);
 
     logger().debug("{}: calling remove_or_update obc={}",
 		   *this, obc_manager.get_obc()->get_oid());
@@ -448,11 +458,14 @@ SnapTrimObjSubEvent::start()
       std::move(osd_op_p),
       std::move(log_entries)
     );
+    logger().debug("{}: transaction submitted, waiting local apply", *this);
     co_await std::move(submitted);
   }
 
+  logger().debug("{}: entering wait_repop", *this);
   co_await enter_stage<interruptor>(obc_orderer->obc_pp().wait_repop);
 
+  logger().debug("{}: waiting repop completion future", *this);
   co_await std::move(all_completed);
 
   logger().debug("{}: completed", *this);

--- a/src/crimson/osd/scrub/pg_scrubber.cc
+++ b/src/crimson/osd/scrub/pg_scrubber.cc
@@ -188,7 +188,8 @@ void PGScrubber::release_range()
     DEBUGDPP("range not reserved, skipping", pg);
     return;
   }
-  DEBUGDPP("blocked: {}", pg, *blocked);
+  DEBUGDPP("blocked: {}, releasing pg background_process_lock (range {} .. {})",
+	   pg, *blocked, blocked->begin, blocked->end);
   pg.background_process_lock.unlock();
   blocked->p.set_value();
   blocked = std::nullopt;


### PR DESCRIPTION
Add targeted debug logs to help diagnose snaptrim stalls under thrash/pggrow





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
