### PR TITLE
pybind/mgr: Implement Ceph Manager module to determine PG specific rebuild stats

### DIFF
--- a/src/pybind/mgr/rebuild_stats/__init__.py
+++ b/src/pybind/mgr/rebuild_stats/__init__.py
@@ -1,0 +1,2 @@
+# flake8: noqa
+from .module import RebuildStats

--- a/src/pybind/mgr/rebuild_stats/cli.py
+++ b/src/pybind/mgr/rebuild_stats/cli.py
@@ -1,0 +1,3 @@
+from mgr_module import CLICommandBase
+
+RebuildStatsCLICommand = CLICommandBase.make_registry_subtype("RebuildStatsCLICommand")

--- a/src/pybind/mgr/rebuild_stats/module.py
+++ b/src/pybind/mgr/rebuild_stats/module.py
@@ -1,0 +1,258 @@
+"""
+Show PG Rebuild Stats for each PG
+"""
+
+import json
+from datetime import datetime
+
+from .cli import RebuildStatsCLICommand
+
+from mgr_module import MgrModule
+
+
+class RebuildStats(MgrModule):
+    CLICommand = RebuildStatsCLICommand
+    COMMANDS = [
+        {
+            "cmd": "rebuild-stats ",
+            "desc": "Report of active/past PG rebuild times",
+            "perm": "r"
+        },
+    ]
+
+    def __init__(self, *args, **kwargs):
+        super(RebuildStats, self).__init__(*args, **kwargs)
+        # Caches the historical record of PG rebuild times (upto 10 per PG)
+        self.completed_history = {}
+        # Tracks clean timestamps and incident flags prior to failures.
+        self.healthy_baselines = {}
+        # Latches the exact time when an active failure occurs
+        self.active_recovery_starts = {}
+        # Captures current cumulative objects recovered and use it as a baseline
+        self.recovery_base_counters = {}
+
+    def _parse_ceph_timestamp(self, ts_val):
+        """
+        Converts variable string and number timestamp payloads returned by Ceph
+        subsystems into native Python datetime structures while preserving the
+        precision and timezone information.
+
+        Parameters:
+          - ts_val (str/float/int): Raw chronological metric streamed from
+            OSD map dumps.
+
+        Returns:
+          - datetime: Valid datetime object if parsing succeeded.
+          - None: If the input timestamp represents an uninitialized or
+            zero-state value ("0.000000").
+        """
+        if not ts_val or ts_val == "0.000000" or ts_val == 0:
+            return None
+        try:
+            ts_str = str(ts_val).strip().rstrip('Z')
+            if '+' in ts_str:
+                ts_base, offset = ts_str.split('+', 1)
+                if len(offset) == 4 and ':' not in offset:
+                    offset = f"{offset[:2]}:{offset[2:]}"
+                ts_str = f"{ts_base}+{offset}"
+            return datetime.fromisoformat(ts_str)
+        except Exception:
+            return None
+
+    def _process_live_stats(self):
+        """
+        Scans the active cluster-wide PG map in memory to statefully capture
+        transitions. This function handles baseline capture, latching the
+        failure timestamps, and recovery counters verification to safely
+        calculate rebuild times.
+
+        Workflow:
+          1. Evaluates live redundancy loss by scanning PG `state` transitions.
+          2. On failure: Freezes the healthy `last_clean` baseline and logs the
+             initial counter state.
+          3. On recovery completion: Pops the latched timestamps, executes a
+             calculation against cumulative rolling recovery metrics, and logs
+             verified entries to history.
+          4. De-duplicates records within a rolling 2-second timestamp delta.
+        """
+        pg_stats = self.get("pg_stats")
+        for pg in pg_stats.get('pg_stats', []):
+            pgid = pg['pgid']
+            state_str = pg.get('state', "")
+
+            stat_sum_dict = pg.get('stat_sum', {})
+            misplaced = stat_sum_dict.get('num_objects_misplaced', 0)
+            degraded = stat_sum_dict.get('num_objects_degraded', 0)
+            cumulative_recovered = stat_sum_dict.get('num_objects_recovered', 0)
+
+            is_vulnerable = "degraded" in state_str or "undersized" in state_str or misplaced > 0 or degraded > 0
+            clean_str = str(pg.get('last_clean', ""))
+
+            # The PG is undergoing a recovery event
+            if is_vulnerable:
+                raw_enter_time = str(pg.get('last_change', ""))
+
+                # If we are not already tracking this PG, create an entry.
+                if pgid not in self.active_recovery_starts and raw_enter_time:
+                    dt_enter = self._parse_ceph_timestamp(raw_enter_time)
+                    # Record & latch `last_clean` if this is a new entry
+                    baseline_clean = self.healthy_baselines.get(pgid, clean_str)
+                    dt_baseline = self._parse_ceph_timestamp(baseline_clean)
+
+                    should_latch = False
+                    if dt_enter and dt_baseline and dt_enter > dt_baseline:
+                        should_latch = True
+                    elif not dt_baseline:
+                        should_latch = True
+
+                    if should_latch:
+                        self.active_recovery_starts[pgid] = raw_enter_time
+                        self.recovery_base_counters[pgid] = cumulative_recovered
+
+                        # Track if this a genuine recovery event with non-zero
+                        # degraded or misplaced objects.
+                        had_redundancy_loss = (degraded > 0 or misplaced > 0)
+                        self.healthy_baselines[pgid] = (clean_str, had_redundancy_loss)
+
+                        self.log.info(f"[rebuild-stats] Latched failure start for PG {pgid} at {raw_enter_time}.")
+
+                # Initialize healthy baseline state tracking if empty
+                if pgid not in self.healthy_baselines and clean_str and not clean_str.startswith("0.000000"):
+                    self.healthy_baselines[pgid] = (clean_str, False)
+            else:
+                # PG is healthy. Process history if an active latch exists
+                if pgid in self.active_recovery_starts:
+                    event_start = self.active_recovery_starts.pop(pgid)
+                    base_recovered = self.recovery_base_counters.pop(pgid, 0)
+
+                    # Unpack baseline clean tuple data safely
+                    baseline_clean = None
+                    had_redundancy_loss = False
+                    if pgid in self.healthy_baselines:
+                        baseline_clean, had_redundancy_loss = self.healthy_baselines.pop(pgid)
+
+                    dt_start = self._parse_ceph_timestamp(event_start)
+                    dt_end = self._parse_ceph_timestamp(clean_str)
+
+                    if dt_start and dt_end:
+                        is_valid_recovery = True
+                        if baseline_clean:
+                            dt_baseline = self._parse_ceph_timestamp(baseline_clean)
+                            if dt_baseline and dt_end <= dt_baseline:
+                                is_valid_recovery = False
+
+                        if is_valid_recovery and dt_end > dt_start:
+                            duration_seconds = int((dt_end - dt_start).total_seconds())
+                            delta_recovered = cumulative_recovered - base_recovered
+
+                            # A record is valid if duration > 0 AND (it repaired objects OR it had
+                            # misplaced/degraded objects when it failed)
+                            if duration_seconds > 0 and (delta_recovered > 0 or had_redundancy_loss):
+                                # Don't consider the PG if the time drift
+                                # between the start and end times is less than
+                                # a threshold of 2 secs. This could happen when
+                                # multiple notifications are received resulting
+                                # in `last_clean` shifting by fractions of
+                                # seconds across the notifications.
+                                if pgid in self.completed_history:
+                                    is_duplicate = False
+                                    for r in self.completed_history[pgid]:
+                                        existing_end = self._parse_ceph_timestamp(r["end"])
+                                        existing_start = self._parse_ceph_timestamp(r["start"])
+
+                                        if existing_end and existing_start:
+                                            end_drift = abs((dt_end - existing_end).total_seconds())
+                                            start_drift = abs((dt_start - existing_start).total_seconds())
+                                            if end_drift <= 2.0 or start_drift <= 2.0:
+                                                is_duplicate = True
+                                                break
+                                    if is_duplicate:
+                                        continue
+
+                                record = {
+                                    "start": event_start,
+                                    "end": clean_str,
+                                    "duration": duration_seconds
+                                }
+
+                                if pgid not in self.completed_history:
+                                    self.completed_history[pgid] = []
+                                self.completed_history[pgid].append(record)
+                                if len(self.completed_history[pgid]) > 10:
+                                    self.completed_history[pgid].pop(0)
+
+                # Maintain continuous updates while healthy
+                if clean_str and not clean_str.startswith("0.000000"):
+                    self.healthy_baselines[pgid] = (clean_str, False)
+
+    def handle_command(self, _, cmd):
+        """
+        Handles the user executed command routed from the Ceph CLI engine.
+        Forces an immediate processing of the stats and formatting rebuild data
+        and historical timelines into a JSON payload.
+
+        Parameters:
+          - inbuf (str): Input buffer (unused for standard read command routing).
+          - cmd (dict): Structured array containing the CLI prefix validation tokens.
+
+        Returns:
+          - tuple (int, str, str): Returns standard Ceph return code (0 for success),
+            the formatted JSON report body string, and any applicable execution errors.
+        """
+        if cmd['prefix'] != 'rebuild-stats':
+            raise NotImplementedError(cmd['prefix'])
+
+        self._process_live_stats()
+
+        total_records = sum(len(v) for v in self.completed_history.values())
+        report = {
+            "summary": {
+                "total_historical_records_captured": total_records
+            },
+            "active_rebuilds": [],
+            "historical_rebuilds": []
+        }
+
+        pg_stats = self.get("pg_stats")
+        for pg in pg_stats.get('pg_stats', []):
+            pgid = pg['pgid']
+            state_str = pg.get('state', "")
+
+            stat_sum_dict = pg.get('stat_sum', {})
+            misplaced = stat_sum_dict.get('num_objects_misplaced', 0)
+            degraded = stat_sum_dict.get('num_objects_degraded', 0)
+
+            if "degraded" in state_str or "undersized" in state_str or misplaced > 0 or degraded > 0:
+                latched_start = self.active_recovery_starts.get(pgid, str(pg.get('last_change', "")))
+                report["active_rebuilds"].append({
+                    "pgid": pgid,
+                    "rebuild_start": latched_start,
+                    "objects_degraded": degraded,
+                    "objects_misplaced": misplaced
+                })
+
+        for pgid, records in self.completed_history.items():
+            for rec in records:
+                report["historical_rebuilds"].append({
+                    "pgid": pgid,
+                    "rebuild_start": rec["start"],
+                    "rebuild_end": rec["end"],
+                    "duration_seconds": rec["duration"]
+                })
+
+        return 0, json.dumps(report, indent=2), ""
+
+    def notify(self, notify_type, notify_id):
+        """
+        Pure push-based callback interface executed by the core C++ engine.
+        Listens exclusively for pg_stats notification events and streams the
+        data payload directly into a handler to capture dynamic transitions.
+
+        Parameters:
+        - notify_type (str): The subsystem type sending the event broadcast.
+        - notify_id (str): Specific entity ID reference (Unused).
+        """
+        if notify_type != "pg_stats":
+            return
+        self._process_live_stats()
+


### PR DESCRIPTION
This draft PR implements a Ceph Manager Plugin Module to statefully intercept high-frequency PG statistics, calculate data rebuild durations,  and provide an on-demand report via the following Ceph CLI command:

  `ceph rebuild-stats`

The module is off by default and can be enabled using:

 `ceph mgr module enable rebuild-stats`

Note that the AI assisted module is written only as a guide to enable replicating the logic in the Prometheus module. The requirement here is to use the existing data available in the `pg_stats` data pushed periodically to the Manager modules (and other listeners) and determine the PG specific rebuild times as accurately as possible. There is no plan to merge this into the Ceph tree at this point.

The module Scans the active cluster-wide PG map in memory to statefully capture  transitions. The module handles baseline capture, latches the  failure timestamps and performs recovery counters verification to safely  calculate rebuild times.

Workflow:
1. Evaluates live redundancy loss by scanning PG `state` transitions.
2. On failure: Freezes the healthy `last_clean` baseline and tracks the initial recovery counters state. The `last_change` timestamp is also latched/frozen at this point in order to mark the entry point of the redundancy loss.
4. On recovery completion: Pops the latched timestamps, executes a  calculation against cumulative rolling recovery metrics, and logs  verified entries to history.
5. De-duplicates records within a rolling 2-second timestamp delta when there are frequent updates under high load.

### Caveats, Contraints and other Observations:

**Errors Due to  Asynchronous Sampling**
The rebuild times recorded using this method can be considered as a close approximation. Because of the asynchronous batching and reporting, the latched failure start time (`last_change`) and the logged recovery completion time (`last_clean`) can lag behind the actual events by a few seconds.

For long-running rebuilds (e.g., hours or days), a 2-to-5 second sampling variance represents a negligible error margin. However, for rapid recoveries (e.g., 5 seconds), a 3-second delay can result in a significant percentage error, making the metric less precise for micro-events.

**Rebuild Time Inaccuracy Due to Timestamp Overwrites (Fixed)**
Pulling on-demand timestamps directly from raw fields resulted in severe data corruption. This happened because background operations like deep/shallow scrubbing continuously advanced `last_clean` on healthy PGs, leading to inaccurate recovery durations. 

By implementing a latch-and-hold architecture, this solution successfully freezes the pre-incident healthy baseline the moment an event begins. It safely ignores all subsequent background scrubbing timestamp adjustments until the PG returns to a fully healthy `active+clean` state.

**Cascading Failure Handling + Ceph Manager Failure Caveat**
 If a single PG suffers multiple sequential drive failures over a prolonged window (e.g., OSD.0 dies, followed by OSD.1 dying 5 minutes later), `last_change` updates itself to reflect the most recent state configuration modification. This can skew the rebuild metrics. The sticky latch logic fixes this issue by preserving the original failure time in memory.

But if the Ceph Manager restarts or crashes mid-flight, this volatile latch is wiped out. Upon reloading, the script will fall back to the newer cascading timestamp, missing the initial duration of the failure lifecycle. While the solution tracks standard, OSD failures reliably, it can underestimate the total vulnerability window during cascading failure events when combined with manager restarts.

I am not sure if the Prometheus module is affected by the same problem in case the service restarts. This is something to consider.


Signed-off-by: Sridhar Seshasayee <sridhar.seshasayee@ibm.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
