### PR TITLE
crimson/os/seastore/linked_tree_node: get_child_sync should also get transactional views of the extent

### DIFF
--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -546,7 +546,7 @@ public:
       iter.leaf.node = root_node->template cast<leaf_node_t>();
       auto &root_entry = iter.leaf;
       auto riter = root_entry.node->lower_bound(addr);
-      SUBTRACET(
+      SUBDEBUGT(
         seastore_fixedkv_tree,
         "leaf addr {}, got ret offset {}, size {}, end {}",
         c.trans,
@@ -579,7 +579,7 @@ public:
     }
     auto it = iter.leaf.node->lower_bound(addr);
     iter.leaf.pos = it->get_offset();
-    SUBTRACET(
+    SUBDEBUGT(
       seastore_fixedkv_tree,
       "leaf addr {}, got ret offset {}, size {}, end {}",
       c.trans,

--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -577,7 +577,7 @@ public:
         iter.leaf.node = child;
       }
     }
-    auto it = iter.leaf.node->upper_bound(addr);
+    auto it = iter.leaf.node->lower_bound(addr);
     iter.leaf.pos = it->get_offset();
     SUBTRACET(
       seastore_fixedkv_tree,

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -573,6 +573,41 @@ public:
     }
   }
 
+  CachedExtentRef get_extent_viewable_by_trans_sync(
+    Transaction &t,
+    CachedExtentRef extent) final {
+    assert(extent->is_valid());
+
+    CachedExtent* p_extent = nullptr;
+    if (extent->is_stable()) {
+      p_extent = extent->maybe_get_transactional_view(t);
+      ceph_assert(p_extent);
+      if (p_extent != extent.get()) {
+        assert(p_extent->is_pending_in_trans(t.get_trans_id()));
+        assert(!p_extent->is_pending_io());
+        if (p_extent->is_mutable()) {
+          assert(p_extent->is_fully_loaded());
+          assert(!p_extent->is_pending_io());
+        } else {
+          assert(p_extent->is_exist_clean());
+        }
+      } else {
+        // stable from trans-view
+        assert(!p_extent->is_pending_in_trans(t.get_trans_id()));
+      }
+    } else {
+      assert(!extent->is_pending_io() || extent->is_exist_clean());
+      assert(extent->is_pending_in_trans(t.get_trans_id()));
+      if (extent->is_mutable()) {
+        assert(extent->is_fully_loaded());
+      } else {
+        assert(extent->is_exist_clean());
+      }
+      p_extent = extent.get();
+    }
+    return p_extent;
+  }
+
   get_extent_iertr::future<CachedExtentRef>
   get_extent_viewable_by_trans(
     Transaction &t,

--- a/src/crimson/os/seastore/lba/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.cc
@@ -1137,6 +1137,7 @@ void BtreeLBAManager::update_paddr_sync(
   auto c = get_context(t);
   auto btree = get_btree_sync<LBABtree>(c);
   auto iter = btree.lower_bound_sync(c, laddr);
+  assert(iter.get_leaf_node()->is_pending());
   auto cursor = iter.get_cursor(c);
   btree.update(
     c,

--- a/src/crimson/os/seastore/lba/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.cc
@@ -1132,7 +1132,7 @@ void BtreeLBAManager::update_paddr_sync(
   laddr_t laddr,
   paddr_t paddr)
 {
-  LOG_PREFIX(BtreeLBAManager::update_mapping);
+  LOG_PREFIX(BtreeLBAManager::update_paddr_sync);
   DEBUGT("laddr={}, paddr={}", t, laddr, paddr);
   auto c = get_context(t);
   auto btree = get_btree_sync<LBABtree>(c);
@@ -1168,7 +1168,7 @@ BtreeLBAManager::_copy_mapping(
   assert(!src->is_end());
   assert(src->get_refcount() == EXTENT_DEFAULT_REF_COUNT);
   assert(!src->is_indirect() == (bool)extent);
-  DEBUGT("src={} dest={}", c.trans, *src, *dest);
+  DEBUGT("src={} dest={} dest_laddr={}", c.trans, *src, *dest, dest_laddr);
   move_mapping_ret_t ret{std::move(src), std::move(dest)};
   auto &cursor = *ret.dest;
   auto iter = btree.make_partial_iter(c, cursor);

--- a/src/crimson/os/seastore/lba/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.cc
@@ -1139,6 +1139,7 @@ void BtreeLBAManager::update_paddr_sync(
   auto iter = btree.lower_bound_sync(c, laddr);
   assert(iter.get_leaf_node()->is_pending());
   auto cursor = iter.get_cursor(c);
+  assert(cursor->get_laddr() == laddr);
   btree.update(
     c,
     std::move(iter),

--- a/src/crimson/os/seastore/linked_tree_node.h
+++ b/src/crimson/os/seastore/linked_tree_node.h
@@ -260,6 +260,9 @@ public:
       return ext->template cast<T>();
     });
   }
+  virtual CachedExtentRef get_extent_viewable_by_trans_sync(
+    Transaction &t,
+    CachedExtentRef extent) = 0;
   virtual get_child_iertr::future<> maybe_wait_accessible(
     Transaction &, CachedExtent&) = 0;
   virtual CachedExtentRef peek_extent_viewable_by_trans(
@@ -333,12 +336,25 @@ public:
     btreenode_pos_t pos,
     node_key_t key)
   {
+    auto &me = down_cast();
     assert(children.capacity());
     assert(key == down_cast().iter_idx(pos).get_key());
     auto child = children[pos];
     ceph_assert(!is_reserved_ptr(child));
-    assert(is_valid_child_ptr(child));
-    return static_cast<ChildT*>(child);
+    if (is_valid_child_ptr(child)) {
+      auto ret = etvr.get_extent_viewable_by_trans_sync(
+        t, static_cast<ChildT*>(child));
+      return ret->template cast<ChildT>();
+    } else {
+      assert(me.is_pending());
+      auto &sparent = me.get_stable_for_key(key);
+      auto spos = sparent.lower_bound(key).get_offset();
+      child = sparent.children[spos];
+      assert(is_valid_child_ptr(child));
+      auto ret = etvr.get_extent_viewable_by_trans_sync(
+        t, static_cast<ChildT*>(child));
+      return ret->template cast<ChildT>();
+    }
   }
 
   template <typename ChildT>


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/76945
Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
