### PR TITLE
tentacle: os/bluestore: BlueFS Spillover Cleaner Evolution

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4372,6 +4372,7 @@ options:
     sleep state for this duration. Once the idle period expires, it wakes up, scans
     for spillover files, and resumes migration if needed.
   default: 1200
+  min: 0
   see_also:
   - bluefs_spillover_cleaner
   flags:
@@ -4389,6 +4390,8 @@ options:
   default: 0.1
   flags:
   - runtime
+  min: 0.01
+  max: 1.0
   with_legacy: true
 - name: bluefs_debug_force_slow
   type: bool

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4390,6 +4390,16 @@ options:
   flags:
   - runtime
   with_legacy: true
+- name: bluefs_debug_force_slow
+  type: bool
+  level: dev
+  desc: For testing. Force BlueFS to allocate files on slow device.
+  long_desc: When enabled, the RocksDBBlueFSVolumeSelector will ignore normal
+    placement policy and redirect allocations to slow device.
+  default: false
+  flags:
+  - runtime
+  with_legacy: true
 - name: bluestore_bluefs
   type: bool
   level: dev

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4349,6 +4349,47 @@ options:
   flags:
   - startup
   with_legacy: true
+- name: bluefs_spillover_cleaner
+  type: bool
+  level: advanced
+  desc: Enable Background BlueFS Spillover cleaner thread
+  long_desc: Enables a background cleaner thread in BlueFS that periodically scans files
+    that spilled over to the slow device and attempts to migrate them back to the
+    BlueFS DB device
+  default: false
+  see_also:
+  - bluefs_spillover_idle_time
+  - bluefs_spillover_cleaner_work_ratio
+  flags:
+  - runtime
+  with_legacy: true
+- name: bluefs_spillover_idle_time
+  type: uint
+  level: advanced
+  desc: Idle time in seconds before the BlueFS spillover cleaner wakes
+    up for the next scan cycle.
+  long_desc: When no spillover files remain to migrate, the cleaner enters an idle
+    sleep state for this duration. Once the idle period expires, it wakes up, scans
+    for spillover files, and resumes migration if needed.
+  default: 1200
+  see_also:
+  - bluefs_spillover_cleaner
+  flags:
+  - runtime
+  with_legacy: true
+- name: bluefs_spillover_cleaner_work_ratio
+  type: float
+  level: advanced
+  desc: Fraction of time the BlueFS spillover cleaner spends performing work.
+  long_desc: Controls the rate of spillover migration work. After each migration
+    step, the cleaner targets to sleep proportionally to the time spent doing work
+    This reduces interference with foreground IO. For example, if a migration step
+    took 10 ms and the ratio is 0.1, the cleaner sleeps for ~90 ms before the next
+    step. This results in approximately 10% work time and 90% sleep time.
+  default: 0.1
+  flags:
+  - runtime
+  with_legacy: true
 - name: bluestore_bluefs
   type: bool
   level: dev

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2047,19 +2047,16 @@ int BlueFS::migrate_file(
 
   sync_metadata(false);
 
-  std::map<int, PExtentVector> releases;
+  std::vector<interval_set<uint64_t>> to_release(MAX_BDEV);
+
   for (const auto& old_ext : old_fnode_extents) {
     vselector->sub_usage(file_ref->vselector_hint, old_ext);
-    releases[old_ext.bdev].emplace_back(
+    to_release[old_ext.bdev].insert(
       old_ext.offset,
       old_ext.length);
-    if (is_shared_alloc(old_ext.bdev)) {
-      shared_alloc->bluefs_used -= old_ext.length;
-    }
   }
-  for (auto& [bdev, vec] : releases) {
-    alloc[bdev]->release(vec);
-  }
+
+  _release_pending_allocations(to_release);
 
   dout(10) << __func__
           << " done ino " << file_ref->fnode.ino

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -5529,7 +5529,9 @@ void *BlueFS::SpilloverCleanerThread::entry() {
 BlueFS::SpillOverCleanerAction BlueFS::RebalanceToDB::advance(BlueFS *fs)
 {
   if (idx >= pending.size()) {
+    last_scan_time = ceph_clock_now();
     pending.clear();
+    skipped.clear();
     idx = 0;
     std::unique_lock nl(fs->nodes.lock);
     for (auto& [dir, dir_ref] : fs->nodes.dir_map) {
@@ -5546,7 +5548,7 @@ BlueFS::SpillOverCleanerAction BlueFS::RebalanceToDB::advance(BlueFS *fs)
           });
 
         if (has_slow)
-          pending.push_back({dir + "/" + fname,file_ref});
+          pending.push_back({dir + "/" + fname, file_ref});
       }
     }
     if (pending.empty()) {
@@ -5554,6 +5556,13 @@ BlueFS::SpillOverCleanerAction BlueFS::RebalanceToDB::advance(BlueFS *fs)
     }
   }
   auto& [path, file] = pending[idx++];
+  int writers = file->num_writers.load(std::memory_order_relaxed);
+  // MANIFEST is excluded from this check because
+  // RocksDB keeps a writer open to it permanently.
+  if (writers > 0 && !path.ends_with("/MANIFEST")) {
+    skipped.push_back({path, writers});
+    return SpillOverCleanerAction::CONTINUE;
+  }
   int r = fs->migrate_file(
     fs->cct,
     file,
@@ -5618,6 +5627,15 @@ void BlueFS::RebalanceToDB::dump_plan(Formatter* f)
     f->dump_string("file", path);
   }
   f->close_section();
+  f->open_array_section("active_files");
+  for (const auto& [path, writers] : skipped) {
+    f->dump_string(
+      "file",
+      path + " num_writers=" + std::to_string(writers));
+  }
+  f->close_section();
+  f->dump_stream("last_scan_time")
+    << last_scan_time;
 }
 
 // ===============================================

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1955,7 +1955,7 @@ int BlueFS::migrate_file(
 {
   vector<byte> buf;
   bool buffered = cct->_conf->bluefs_buffered_io;
-  bufferlist bl;
+  constexpr uint64_t MIGRATION_CHUNK = 128ull << 20;
   mempool::bluefs::vector<bluefs_extent_t> old_fnode_extents;
   bluefs_fnode_t new_fnode;
 
@@ -1976,48 +1976,72 @@ int BlueFS::migrate_file(
 
   old_fnode_extents = file_ref->fnode.extents;
 
-  for (const auto &old_ext : old_fnode_extents) {
-    buf.resize(old_ext.length);
-    int r = _bdev_read_random(old_ext.bdev,
-      old_ext.offset,
-      old_ext.length,
-      (char*)&buf.at(0),
-      buffered);
-    if (r != 0) {
-      derr << __func__ << " failed to read 0x" << std::hex
-           << old_ext.offset << "~" << old_ext.length << std::dec
-           << " from " << (int)old_ext.bdev << dendl;
-      return -EIO;
+  dout(10) << __func__
+          << " start ino " << file_ref->fnode.ino
+          << " size 0x" << std::hex << file_ref->fnode.size
+          << std::dec
+          << " from_bdev " << from_bdev
+          << " to_bdev " << to_bdev
+          << dendl;
+
+  auto it = old_fnode_extents.begin();
+
+  while (it != old_fnode_extents.end()) {
+    bufferlist bl;
+    uint64_t batch = 0;
+    while (it != old_fnode_extents.end() &&
+      (batch == 0 || batch + it->length <= MIGRATION_CHUNK)) {
+
+      buf.resize(it->length);
+      int r = _bdev_read_random(it->bdev,
+        it->offset,
+        it->length,
+        (char*)&buf.at(0),
+        buffered);
+      if (r != 0) {
+        derr << __func__ << " failed to read 0x" << std::hex
+            << it->offset << "~" << it->length << std::dec
+            << " from " << (int)it->bdev << dendl;
+        return -EIO;
+      }
+      bl.append((char*)&buf[0], it->length);
+      batch += it->length;
+      ++it;
     }
-    bl.append((char*)&buf[0], old_ext.length);
-  }
+    bluefs_fnode_t chunk_fnode;
+    auto r = _allocate(to_bdev, bl.length(), 0,
+      &chunk_fnode, nullptr, 0, false);
+    if (r < 0) {
+      dout(10) << __func__ << " unable to allocate len 0x" << std::hex
+          << bl.length() << std::dec << " from " << (int)to_bdev
+          << ": " << cpp_strerror(r) << dendl;
+      return -ENOSPC;
+    }
 
-  auto r = _allocate(to_bdev, bl.length(), 0,
-    &new_fnode, nullptr, 0, false);
-  if (r < 0) {
-    dout(10) << __func__ << " unable to allocate len 0x" << std::hex
-        << bl.length() << std::dec << " from " << (int)to_bdev
-        << ": " << cpp_strerror(r) << dendl;
-    return -ENOSPC;
-  }
+    uint64_t off = 0;
+    for (auto& i : chunk_fnode.extents) {
+      bufferlist cur;
+      uint64_t cur_len = std::min<uint64_t>(i.length, bl.length() - off);
+      ceph_assert(cur_len > 0);
+      cur.substr_of(bl, off, cur_len);
+      int w = bdev[to_bdev]->write(i.offset, cur, buffered);
+      ceph_assert(w == 0);
+      off += cur_len;
+      vselector->add_usage(file_ref->vselector_hint, i);
+    }
 
-  uint64_t off = 0;
-  for (auto& i : new_fnode.extents) {
-    bufferlist cur;
-    uint64_t cur_len = std::min<uint64_t>(i.length, bl.length() - off);
-    ceph_assert(cur_len > 0);
-    cur.substr_of(bl, off, cur_len);
-    int w = bdev[to_bdev]->write(i.offset, cur, buffered);
-    ceph_assert(w == 0);
-    off += cur_len;
-    vselector->add_usage(file_ref->vselector_hint, i);
+    for (auto& ext : chunk_fnode.extents) {
+      new_fnode.append_extent(ext);
+    }
   }
+  new_fnode.recalc_allocated();
 
   file_ref->fnode.swap_extents(new_fnode);
   l.unlock();
 
   {
     std::lock_guard ll(log.lock);
+    std::lock_guard l(file_ref->lock);
     log.t.op_file_update(file_ref->fnode);
   }
 
@@ -2036,6 +2060,14 @@ int BlueFS::migrate_file(
   for (auto& [bdev, vec] : releases) {
     alloc[bdev]->release(vec);
   }
+
+  dout(10) << __func__
+          << " done ino " << file_ref->fnode.ino
+          << " migrated 0x" << std::hex << file_ref->fnode.allocated
+          << std::dec
+          << " from_bdev " << from_bdev
+          << " to_bdev " << to_bdev
+          << dendl;
 
   return 0;
 }

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -107,6 +107,9 @@ public:
 	r = admin_socket->register_command("bluefs debug_inject_read_zeros", hook,
 					   "Injects 8K zeros into next BlueFS read. Debug only.");
 	ceph_assert(r == 0);
+        r = admin_socket->register_command("bluefs spillover cleaner stats", hook,
+              "Show spillover cleaner thread stats");
+        ceph_assert(r == 0);
       }
     }
     return hook;
@@ -194,6 +197,8 @@ private:
       f->flush(out);
     } else if (command == "bluefs debug_inject_read_zeros") {
       bluefs->inject_read_zeros++;
+    } else if (command == "bluefs spillover cleaner stats") {
+      bluefs->dump_spillover_cleaner_stats(f);
     } else {
       errss << "Invalid command" << std::endl;
       return -ENOSYS;
@@ -208,7 +213,8 @@ BlueFS::BlueFS(CephContext* cct)
     ioc(MAX_BDEV),
     alloc(MAX_BDEV),
     alloc_size(MAX_BDEV, 0),
-    locked_alloc(MAX_BDEV)
+    locked_alloc(MAX_BDEV),
+    spillover_cleaner_thread(this)
 {
   dirty.pending_release.resize(MAX_BDEV);
   discard_cb[BDEV_WAL] = wal_discard_cb;
@@ -1939,6 +1945,99 @@ int BlueFS::log_dump()
   _shutdown_logger();
   super = bluefs_super_t();
   return r;
+}
+
+int BlueFS::migrate_file(
+  CephContext* cct,
+  FileRef file_ref,
+  int from_bdev,
+  int to_bdev)
+{
+  vector<byte> buf;
+  bool buffered = cct->_conf->bluefs_buffered_io;
+  bufferlist bl;
+  mempool::bluefs::vector<bluefs_extent_t> old_fnode_extents;
+  bluefs_fnode_t new_fnode;
+
+  std::unique_lock l(file_ref->lock);
+
+  if (file_ref->deleted)
+    return 0;
+
+  bool rewrite = std::any_of(
+    file_ref->fnode.extents.begin(),
+    file_ref->fnode.extents.end(),
+    [=](auto& ext) {
+      return ext.bdev != to_bdev;
+    });
+
+  if (!rewrite)
+    return 0;
+
+  old_fnode_extents = file_ref->fnode.extents;
+
+  for (const auto &old_ext : old_fnode_extents) {
+    buf.resize(old_ext.length);
+    int r = _bdev_read_random(old_ext.bdev,
+      old_ext.offset,
+      old_ext.length,
+      (char*)&buf.at(0),
+      buffered);
+    if (r != 0) {
+      derr << __func__ << " failed to read 0x" << std::hex
+           << old_ext.offset << "~" << old_ext.length << std::dec
+           << " from " << (int)old_ext.bdev << dendl;
+      return -EIO;
+    }
+    bl.append((char*)&buf[0], old_ext.length);
+  }
+
+  auto r = _allocate(to_bdev, bl.length(), 0,
+    &new_fnode, nullptr, 0, false);
+  if (r < 0) {
+    dout(10) << __func__ << " unable to allocate len 0x" << std::hex
+        << bl.length() << std::dec << " from " << (int)to_bdev
+        << ": " << cpp_strerror(r) << dendl;
+    return -ENOSPC;
+  }
+
+  uint64_t off = 0;
+  for (auto& i : new_fnode.extents) {
+    bufferlist cur;
+    uint64_t cur_len = std::min<uint64_t>(i.length, bl.length() - off);
+    ceph_assert(cur_len > 0);
+    cur.substr_of(bl, off, cur_len);
+    int w = bdev[to_bdev]->write(i.offset, cur, buffered);
+    ceph_assert(w == 0);
+    off += cur_len;
+    vselector->add_usage(file_ref->vselector_hint, i);
+  }
+
+  file_ref->fnode.swap_extents(new_fnode);
+  l.unlock();
+
+  {
+    std::lock_guard ll(log.lock);
+    log.t.op_file_update(file_ref->fnode);
+  }
+
+  sync_metadata(false);
+
+  std::map<int, PExtentVector> releases;
+  for (const auto& old_ext : old_fnode_extents) {
+    vselector->sub_usage(file_ref->vselector_hint, old_ext);
+    releases[old_ext.bdev].emplace_back(
+      old_ext.offset,
+      old_ext.length);
+    if (is_shared_alloc(old_ext.bdev)) {
+      shared_alloc->bluefs_used -= old_ext.length;
+    }
+  }
+  for (auto& [bdev, vec] : releases) {
+    alloc[bdev]->release(vec);
+  }
+
+  return 0;
 }
 
 int BlueFS::device_migrate_to_existing(
@@ -5328,6 +5427,170 @@ void BlueFS::trim_free_space(const string& type, std::ostream& outss)
     outss << "device " << type << " trim done";
   }
 }
+
+void *BlueFS::SpilloverCleanerThread::entry() {
+  auto cct = bluefs->cct;
+  dout(10) << __func__ << " starting" << dendl;
+  {
+    std::lock_guard l(lock);
+    start = true;
+    cond.notify_all();
+  }
+
+  while (true) {
+    {
+      std::lock_guard l(lock);
+      if (stop) {
+        dout(10) << __func__ << " stopping" << dendl;
+        break;
+      }
+    }
+
+    auto start = ceph::mono_clock::now();
+    SpillOverCleanerAction action = logic->advance(bluefs);
+    auto end = ceph::mono_clock::now();
+
+    auto run_time =
+      std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+
+    dout(20) << __func__
+         << " logic=" << logic->name
+         << " action=" << static_cast<int>(action)
+         << " runtime=" << run_time.count() << "ms"
+         << dendl;
+
+    if (action == SpillOverCleanerAction::DONE) {
+      break;
+    } else if (action == SpillOverCleanerAction::SLEEP) {
+      auto dur = std::chrono::seconds(
+        bluefs->cct->_conf->bluefs_spillover_idle_time);
+      dout(20) << __func__
+              << " entering sleep"
+              << " interval s=" << dur.count()
+              << dendl;
+      std::unique_lock l(lock);
+      cond.wait_for(l, dur);
+    } else if (action == SpillOverCleanerAction::CONTINUE) {
+      double work_ratio =
+        std::max(bluefs->cct->_conf->bluefs_spillover_cleaner_work_ratio, 0.01);
+      auto dur = std::chrono::duration_cast<std::chrono::milliseconds>(
+        run_time * (1.0 - work_ratio) / work_ratio);
+      dout(20) << __func__
+              << " entering wait"
+              << " work_ratio=" << work_ratio
+              << " runtime ms=" << run_time.count()
+              << " sleep ms=" << dur.count()
+              << dendl;
+      std::unique_lock l(lock);
+      cond.wait_for(l, dur);
+    }
+  }
+
+  {
+    std::lock_guard l(lock);
+    start = false;
+    created = false;
+  }
+
+  dout(10) << __func__ << " exiting" << dendl;
+
+  return nullptr;
+}
+
+BlueFS::SpillOverCleanerAction BlueFS::RebalanceToDB::advance(BlueFS *fs)
+{
+  if (idx >= pending.size()) {
+    pending.clear();
+    idx = 0;
+    std::unique_lock nl(fs->nodes.lock);
+    for (auto& [dir, dir_ref] : fs->nodes.dir_map) {
+      for (auto& [fname, file_ref] : dir_ref->file_map) {
+        if (file_ref->fnode.ino == 1) continue;
+
+        std::lock_guard fl(file_ref->lock);
+
+        bool has_slow = std::any_of(
+          file_ref->fnode.extents.begin(),
+          file_ref->fnode.extents.end(),
+          [](const auto& e) {
+            return e.bdev == BlueFS::BDEV_SLOW;
+          });
+
+        if (has_slow)
+          pending.push_back({dir + "/" + fname,file_ref});
+      }
+    }
+    if (pending.empty()) {
+      return SpillOverCleanerAction::SLEEP;
+    }
+  }
+  auto& [path, file] = pending[idx++];
+  int r = fs->migrate_file(
+    fs->cct,
+    file,
+    BlueFS::BDEV_SLOW,
+    BlueFS::BDEV_DB);
+
+  if (r == 0) {
+    uint64_t migrated;
+    uint64_t size;
+    {
+      std::lock_guard fl(file->lock);
+      migrated = file->fnode.allocated;
+      size = file->fnode.size;
+    }
+    append_entry(path,
+      size,
+      migrated,
+      BlueFS::BDEV_SLOW,
+      BlueFS::BDEV_DB);
+  }
+  return SpillOverCleanerAction::CONTINUE;
+}
+
+void BlueFS::RebalanceToDB::append_entry(
+    const std::string& path,
+    uint64_t size,
+    uint64_t migrated,
+    int from_bdev,
+    int to_bdev)
+{
+  std::ostringstream ss;
+  ss << path
+    << " size=0x" << std::hex << size
+    << " migrated=0x" << migrated
+    << std::dec
+    << " from dev=" << from_bdev
+    << "->" << to_bdev
+    << " ts="
+    << ceph_clock_now();
+
+  history.push_back(ss.str());
+
+  while (history.size() > max_history) {
+    history.pop_front();
+  }
+}
+
+void BlueFS::RebalanceToDB::dump_history(Formatter* f)
+{
+  f->open_array_section("Files Migrated");
+  for (const auto& entry : history) {
+    f->dump_string("File", entry);
+  }
+  f->close_section();
+}
+
+void BlueFS::RebalanceToDB::dump_plan(Formatter* f)
+{
+  f->open_array_section("pending_files");
+  for (size_t i = idx; i < pending.size(); i++) {
+    auto& [path, fileref] = pending[i];
+    f->dump_string("file", path);
+  }
+  f->close_section();
+}
+
 // ===============================================
 // OriginalVolumeSelector
 

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -5681,6 +5681,11 @@ void FitToFastVolumeSelector::get_paths(const std::string& base, paths& res) con
 uint8_t RocksDBBlueFSVolumeSelector::select_prefer_bdev(void* h) {
   ceph_assert(h != nullptr);
   uint64_t hint = reinterpret_cast<uint64_t>(h);
+  if (g_ceph_context->_conf->bluefs_debug_force_slow) {
+    if (hint != LEVEL_LOG) {
+      return BlueFS::BDEV_SLOW;
+    }
+  }
   uint8_t res;
   switch (hint) {
   case LEVEL_SLOW:

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -1020,6 +1020,8 @@ private:
 
   struct RebalanceToDB : public SpilloverCleanerLogic {
     std::vector<std::pair<std::string, FileRef>> pending;
+    std::vector<std::pair<std::string, int>> skipped;
+    utime_t last_scan_time;
     std::deque<std::string> history;
     static constexpr size_t max_history = 100;
     size_t idx = 0;

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -795,6 +795,12 @@ public:
   }
   int fsck();
 
+  int migrate_file(
+    CephContext *cct,
+    FileRef file_ref,
+    int from_bdev,
+    int to_bdev
+  );
   int device_migrate_to_new(
     CephContext *cct,
     const std::set<int>& devs_source,
@@ -939,6 +945,119 @@ private:
     const std::string& dir,
     const std::string& name
   );
+
+  enum class SpillOverCleanerAction {
+    CONTINUE,
+    SLEEP,
+    DONE
+  };
+
+  struct SpilloverCleanerLogic {
+    virtual ~SpilloverCleanerLogic() = default;
+    const char* const name;
+    explicit SpilloverCleanerLogic(const char* n) : name(n) {}
+    virtual SpillOverCleanerAction advance(
+      BlueFS* fs
+    ) = 0;
+    virtual void dump_history(Formatter* f) = 0;
+    virtual void dump_plan(Formatter* f) = 0;
+  };
+
+  struct SpilloverCleanerThread : public Thread {
+  public:
+    explicit SpilloverCleanerThread(BlueFS* fs)
+      : bluefs(fs) {}
+    void* entry() override;
+    void init() {
+      std::lock_guard l(lock);
+      if (created) {
+        return;
+      }
+      stop = false;
+      logic = std::make_shared<RebalanceToDB>();
+      create("bluefs_splctr");
+      created = true;
+    }
+    void shutdown() {
+      {
+        std::unique_lock l(lock);
+        if (!created) {
+          return;
+        }
+        while (!start) {
+          cond.wait(l);
+        }
+        stop = true;
+        cond.notify_all();
+      }
+      join();
+    }
+
+    void update_logic(std::shared_ptr<SpilloverCleanerLogic> logic_)
+    {
+      std::lock_guard l(lock);
+      logic = std::move(logic_);
+      cond.notify_all();
+    }
+    void dump(Formatter* f) {
+      std::lock_guard l(lock);
+      if (logic) {
+        logic->dump_history(f);
+        logic->dump_plan(f);
+      }
+    }
+  private:
+    BlueFS* bluefs;
+    ceph::mutex lock = ceph::make_mutex("SpilloverCleanerThread::lock");
+    ceph::condition_variable cond;
+
+    bool stop = false;
+    bool start = false;
+    bool created = false;
+
+    std::shared_ptr<SpilloverCleanerLogic> logic;
+  } spillover_cleaner_thread;
+
+  struct RebalanceToDB : public SpilloverCleanerLogic {
+    std::vector<std::pair<std::string, FileRef>> pending;
+    std::deque<std::string> history;
+    static constexpr size_t max_history = 100;
+    size_t idx = 0;
+    RebalanceToDB()
+      : SpilloverCleanerLogic("RebalanceToDB") {}
+    SpillOverCleanerAction advance(
+      BlueFS* fs
+    ) override;
+    void dump_history(Formatter* f) override;
+    void dump_plan(Formatter* f) override;
+    void append_entry(const std::string& path,
+      uint64_t size,
+      uint64_t migrated,
+      int from_bdev,
+      int to_bdev);
+  };
+public:
+  void spillover_cleaner_start()
+  {
+    spillover_cleaner_thread.init();
+  }
+  void spillover_cleaner_stop()
+  {
+    spillover_cleaner_thread.shutdown();
+  }
+  void update_spillover_cleaner_from_config()
+  {
+    if(cct->_conf->bluefs_spillover_cleaner) {
+      spillover_cleaner_start();
+    } else {
+      spillover_cleaner_stop();
+    }
+  }
+  void dump_spillover_cleaner_stats(Formatter* f) {
+    f->open_object_section("spillover_cleaner_stats");
+    spillover_cleaner_thread.dump(f);
+    f->close_section();
+  }
 };
 
 class OriginalVolumeSelector : public BlueFSVolumeSelector {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5829,7 +5829,8 @@ std::vector<std::string> BlueStore::get_tracked_keys() const noexcept
     "bluestore_warn_on_no_per_pg_omap"s,
     "bluestore_max_defer_interval"s,
     "bluestore_onode_segment_size"s,
-    "bluestore_allocator_lookup_policy"s
+    "bluestore_allocator_lookup_policy"s,
+    "bluefs_spillover_cleaner"s
   };
 }
 
@@ -5907,6 +5908,11 @@ void BlueStore::handle_conf_change(const ConfigProxy& conf,
   }
   if (changed.count("bluestore_allocator_lookup_policy")) {
     _update_allocator_lookup_policy();
+  }
+  if (changed.count("bluefs_spillover_cleaner")) {
+    if (bluefs) {
+      bluefs->update_spillover_cleaner_from_config();
+    }
   }
 }
 
@@ -9532,6 +9538,10 @@ int BlueStore::_mount()
     }
   }
 
+  if (bluefs && cct->_conf.get_val<bool>("bluefs_spillover_cleaner")) {
+    bluefs->spillover_cleaner_start();
+  }
+
   mounted = true;
   return 0;
 }
@@ -9541,6 +9551,10 @@ int BlueStore::umount()
   dout(5) << __func__ << dendl;
   ceph_assert(_kv_only || mounted);
   _osr_drain_all();
+
+  if (bluefs) {
+    bluefs->spillover_cleaner_stop();
+  }
 
   mounted = false;
 


### PR DESCRIPTION
This PR introduces a background spillover cleaner thread in BlueFS that periodically scans files that have spilled over to the slow device and attempts to migrate them back to the DB device.

Consists

Backport of: #68430
Backport of : #70217
Backport of : #70391

Fixes: https://tracker.ceph.com/issues/77077
Fixes : https://tracker.ceph.com/issues/78469
Fixes : https://tracker.ceph.com/issues/78541

Parent Tracker: https://tracker.ceph.com/issues/74319


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
