### PR TITLE
mgr/rook: select InternalIP for HostSpec.addr instead of slash-joinin…

### DIFF
--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -40,6 +40,9 @@ log = logging.getLogger(__name__)
 
 
 def resolve_ip(hostname: str) -> str:
+    # Tolerate the legacy mgr/rook get_hosts() format ("<ip>/<hostname>"),
+    # which older Rook backends may still produce; take just the address.
+    hostname = hostname.split("/")[0]
     try:
         r = socket.getaddrinfo(hostname, None, flags=socket.AI_CANONNAME,
                                type=socket.SOCK_STREAM)

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -60,6 +60,9 @@ def _is_log_only_config(nfs_config: str) -> bool:
 
 
 def resolve_ip(hostname: str) -> str:
+    # Tolerate the legacy mgr/rook get_hosts() format ("<ip>/<hostname>"),
+    # which older Rook backends may still produce; take just the address.
+    hostname = hostname.split("/")[0]
     try:
         r = socket.getaddrinfo(hostname, None, flags=socket.AI_CANONNAME,
                                type=socket.SOCK_STREAM)

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -892,9 +892,17 @@ class RookCluster(object):
     def get_hosts(self) -> List[orchestrator.HostSpec]:
         ret = []
         for node in self.nodes.items:
+            addrs = node.status.addresses or []
+            # Prefer InternalIP; fall back to the first address. orchestrator
+            # consumers (mgr/nfs, mgr/dashboard, ...) treat HostSpec.addr as a
+            # single IP/hostname and call socket.getaddrinfo() on it. The old
+            # '/'.join(...) produced strings like "<ip>/<hostname>" that broke
+            # every such consumer.
+            internal = [a.address for a in addrs if a.type == "InternalIP"]
+            addr = internal[0] if internal else (addrs[0].address if addrs else "")
             spec = orchestrator.HostSpec(
                 node.metadata.name,
-                addr='/'.join([addr.address for addr in node.status.addresses]), 
+                addr=addr,
                 labels=[label.split('/')[1] for label in node.metadata.labels if label.startswith('ceph-label')],
             )
             ret.append(spec)

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -921,9 +921,17 @@ class RookCluster(object):
     def get_hosts(self) -> List[orchestrator.HostSpec]:
         ret = []
         for node in self.nodes.items:
+            addrs = node.status.addresses or []
+            # Prefer InternalIP; fall back to the first address. orchestrator
+            # consumers (mgr/nfs, mgr/dashboard, ...) treat HostSpec.addr as a
+            # single IP/hostname and call socket.getaddrinfo() on it. The old
+            # '/'.join(...) produced strings like "<ip>/<hostname>" that broke
+            # every such consumer.
+            internal = [a.address for a in addrs if a.type == "InternalIP"]
+            addr = internal[0] if internal else (addrs[0].address if addrs else "")
             spec = orchestrator.HostSpec(
                 node.metadata.name,
-                addr='/'.join([addr.address for addr in node.status.addresses]), 
+                addr=addr,
                 labels=[label.split('/')[1] for label in node.metadata.labels if label.startswith('ceph-label')],
             )
             ret.append(spec)

--- a/src/pybind/mgr/rook/tests/test_rook.py
+++ b/src/pybind/mgr/rook/tests/test_rook.py
@@ -1,6 +1,7 @@
 import orchestrator
 from .fixtures import wait
 import pytest
+from types import SimpleNamespace
 from unittest.mock import patch, PropertyMock
 
 from rook.module import RookOrchestrator
@@ -12,6 +13,20 @@ from rook.rook_cluster import RookCluster
 class FakeRookCluster(RookCluster):
     def __init__(self):
         pass
+
+
+def _fake_node(name, addresses, labels=None):
+    """Build a V1Node-like object for get_hosts() tests.
+
+    addresses is a list of (type, address) tuples, mirroring the
+    kubernetes client's V1NodeAddress entries.
+    """
+    return SimpleNamespace(
+        metadata=SimpleNamespace(name=name, labels=labels or {}),
+        status=SimpleNamespace(
+            addresses=[SimpleNamespace(type=t, address=a) for t, a in addresses]
+        ),
+    )
 
 
 class TestRook(object):
@@ -118,3 +133,31 @@ class TestRook(object):
                     assert dds[i].last_deployed == pods[i]['created']
                     assert dds[i].started == pods[i]['started']
                     assert dds[i].last_refresh == pods[i]['refreshed']
+
+    @pytest.mark.parametrize("addresses, expected_addr", [
+        # InternalIP is preferred over the Hostname entry.
+        ([("InternalIP", "10.0.0.1"), ("Hostname", "node-1")], "10.0.0.1"),
+        # InternalIP is preferred regardless of ordering.
+        ([("Hostname", "node-1"), ("InternalIP", "10.0.0.1")], "10.0.0.1"),
+        # No InternalIP: fall back to the first address.
+        ([("ExternalIP", "1.2.3.4"), ("Hostname", "node-1")], "1.2.3.4"),
+        # No addresses at all: get_hosts() passes "" and HostSpec falls
+        # back to the node name (addr = addr or name).
+        ([], "node-1"),
+    ])
+    def test_get_hosts(self, addresses, expected_addr):
+        fake_rook_cluster = FakeRookCluster()
+        node = _fake_node(
+            "node-1",
+            addresses,
+            labels={"ceph-label/mon": "", "kubernetes.io/os": "linux"},
+        )
+        fake_rook_cluster.nodes = SimpleNamespace(items=[node])
+
+        hosts = fake_rook_cluster.get_hosts()
+
+        assert len(hosts) == 1
+        assert hosts[0].hostname == "node-1"
+        assert hosts[0].addr == expected_addr
+        # only ceph-label labels are kept, with the prefix stripped
+        assert hosts[0].labels == ["mon"]

--- a/src/pybind/mgr/rook/tests/test_rook.py
+++ b/src/pybind/mgr/rook/tests/test_rook.py
@@ -1,6 +1,7 @@
 import orchestrator
 from .fixtures import wait
 import pytest
+from types import SimpleNamespace
 from unittest.mock import patch, PropertyMock
 
 from rook.module import RookOrchestrator
@@ -12,6 +13,20 @@ from rook.rook_cluster import RookCluster
 class FakeRookCluster(RookCluster):
     def __init__(self):
         pass
+
+
+def _fake_node(name, addresses, labels=None):
+    """Build a V1Node-like object for get_hosts() tests.
+
+    addresses is a list of (type, address) tuples, mirroring the
+    kubernetes client's V1NodeAddress entries.
+    """
+    return SimpleNamespace(
+        metadata=SimpleNamespace(name=name, labels=labels or {}),
+        status=SimpleNamespace(
+            addresses=[SimpleNamespace(type=t, address=a) for t, a in addresses]
+        ),
+    )
 
 
 class TestRook(object):
@@ -118,6 +133,34 @@ class TestRook(object):
                     assert dds[i].last_deployed == pods[i]['created']
                     assert dds[i].started == pods[i]['started']
                     assert dds[i].last_refresh == pods[i]['refreshed']
+
+    @pytest.mark.parametrize("addresses, expected_addr", [
+        # InternalIP is preferred over the Hostname entry.
+        ([("InternalIP", "10.0.0.1"), ("Hostname", "node-1")], "10.0.0.1"),
+        # InternalIP is preferred regardless of ordering.
+        ([("Hostname", "node-1"), ("InternalIP", "10.0.0.1")], "10.0.0.1"),
+        # No InternalIP: fall back to the first address.
+        ([("ExternalIP", "1.2.3.4"), ("Hostname", "node-1")], "1.2.3.4"),
+        # No addresses at all: get_hosts() passes "" and HostSpec falls
+        # back to the node name (addr = addr or name).
+        ([], "node-1"),
+    ])
+    def test_get_hosts(self, addresses, expected_addr):
+        fake_rook_cluster = FakeRookCluster()
+        node = _fake_node(
+            "node-1",
+            addresses,
+            labels={"ceph-label/mon": "", "kubernetes.io/os": "linux"},
+        )
+        fake_rook_cluster.nodes = SimpleNamespace(items=[node])
+
+        hosts = fake_rook_cluster.get_hosts()
+
+        assert len(hosts) == 1
+        assert hosts[0].hostname == "node-1"
+        assert hosts[0].addr == expected_addr
+        # only ceph-label labels are kept, with the prefix stripped
+        assert hosts[0].labels == ["mon"]
 
 
 class TestFetchK8sItems(object):


### PR DESCRIPTION
mgr/rook: select InternalIP for HostSpec.addr instead of slash-joining all node addresses

get_hosts() built HostSpec.addr with '/'.join() over every entry in node.status.addresses, producing strings like "10.248.0.3/np6b438a15bf1a4" (InternalIP + Hostname). The orchestrator interface documents addr as a single "dns name or IP", and consumers treat it as one resolvable address.

Concrete symptom: mgr/nfs resolve_ip() calls socket.getaddrinfo() on the joined string and fails with:

  Error EINVAL: Cannot resolve IP for host 10.248.0.3/np6b438a15bf1a4:
  [Errno -2] Name or service not known

(seen via Manila's CephFS driver calling `ceph nfs cluster info`). The malformed value is also visible directly in `ceph orch host ls`. Any consumer of HostSpec.addr that resolves it as an IP is affected.

Fix get_hosts() to pick a single address: prefer InternalIP (always present on managed nodes and routable cluster-internally), falling back to the first address. The hostname is already carried as HostSpec's name, so nothing is lost.

Also harden mgr/nfs resolve_ip() to strip the legacy "<ip>/<hostname>" format, so a newer mgr keeps working against older Rook backends still emitting it.

Add unit tests for get_hosts() covering InternalIP preference, the fallback path, and the empty-address case.

Fixes: https://tracker.ceph.com/issues/77100


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
