### PR TITLE
tentacle: qa: install nvme-cli only if distro remains rocky10

### DIFF
--- a/qa/distros/all/rocky_10.yaml
+++ b/qa/distros/all/rocky_10.yaml
@@ -1,25 +1,31 @@
+install_rocky_packages:
+  sequential:
+    - print: "Install additional rocky10 dependencies"
+    # postmerge appends to this
 os_type: rocky
 os_version: "10.1"
 overrides:
   selinux:
     allowlist:
       - 'comm="systemd".*denied.*\{ prog_run \}.*tclass=bpf.*permissive=1'
+tasks:
+  # This is appended to the tasks: list here so that we can edit the task list
+  # before e.g. ceph is installed.
+  - sequential:
+      - install_rocky_packages
 teuthology:
   postmerge:
     - |
+      log.debug("os is %s", yaml.os_type)
       if yaml.os_type == 'rocky' then
         local pexec_tasks = yaml_load([[
-        - pexec:
-            all:
-            # for https://tracker.ceph.com/issues/73823
-            - sudo dnf remove nvme-cli -y
-            - sudo dnf install nvmetcli nvme-cli -y
+        sequential:
+          - pexec:
+              all:
+                # for https://tracker.ceph.com/issues/73823
+                # Cannot use install.extra_system_packages because we also remove a package.
+                - sudo dnf remove nvme-cli -y
+                - sudo dnf install nvmetcli nvme-cli -y
         ]])
-        
-        -- Ensure the tasks array exists before attempting to merge
-        if yaml.tasks == nil then
-          yaml.tasks = py_list()
-        end
-        
-        deep_merge(yaml.tasks, pexec_tasks)
+        deep_merge(yaml.install_rocky_packages, pexec_tasks)
       end


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77084

---

backport of https://github.com/ceph/ceph/pull/69222
parent tracker: https://tracker.ceph.com/issues/77037

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh