### PR TITLE
osdc: deliver neorados completions to associated executor

### DIFF
--- a/qa/workunits/rados/test.sh
+++ b/qa/workunits/rados/test.sh
@@ -24,7 +24,7 @@ RADOS_TESTS=(
 )
 
 NEORADOS_TESTS=(
-    cls cmd handler_error io ec_io list ec_list misc pool
+    cls cmd completions handler_error io ec_io list ec_list misc pool
     read_operations snapshots watch_notify write_operations
 )
 

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -2072,8 +2072,9 @@ public:
 			      fu2::unique_function<OpSig>>) {
 		     std::move(arg)(ec);
                    } else {
-		     boost::asio::defer(e,
-					boost::asio::append(std::move(arg), ec));
+		     auto ex = boost::asio::get_associated_executor(arg, e);
+		     boost::asio::dispatch(ex,
+					   boost::asio::append(std::move(arg), ec));
 		   }
 		 }, std::move(f));
     }

--- a/src/test/neorados/CMakeLists.txt
+++ b/src/test/neorados/CMakeLists.txt
@@ -10,10 +10,6 @@ add_executable(ceph_test_neorados_start_stop start_stop.cc)
 target_link_libraries(ceph_test_neorados_start_stop global libneorados
   ${unittest_libs})
 
-add_executable(ceph_test_neorados_completions completions.cc)
-target_link_libraries(ceph_test_neorados_completions Boost::boost pthread
-  ${unittest_libs})
-
 add_executable(ceph_test_neorados_op_speed op_speed.cc)
 target_link_libraries(ceph_test_neorados_op_speed
   libneorados ${FMT_LIB} ${unittest_libs})
@@ -21,6 +17,10 @@ target_link_libraries(ceph_test_neorados_op_speed
 add_library(neoradostest-support STATIC common_tests.cc)
 target_link_libraries(neoradostest-support
   libneorados ${FMT_LIB} GTest::GTest)
+
+add_executable(ceph_test_neorados_completions completions.cc)
+target_link_libraries(ceph_test_neorados_completions
+  libneorados neoradostest-support GTest::Main)
 
 add_executable(ceph_test_neorados_list_pool list_pool.cc)
 target_link_libraries(ceph_test_neorados_list_pool

--- a/src/test/neorados/completions.cc
+++ b/src/test/neorados/completions.cc
@@ -1,19 +1,62 @@
-#include <boost/asio/io_context.hpp>
-#include <boost/asio/post.hpp>
+#include <optional>
+#include <boost/asio/bind_executor.hpp>
+#include "include/neorados/RADOS.hpp"
+#include "test/neorados/common_tests.h"
 
-constexpr int max_completions = 10'000'000;
-int completed = 0;
+TEST(NeoRadosCompletion, CrossExecutor)
+{
+  boost::asio::io_context rados_context;
+  std::optional<neorados::RADOS> rados;
+  std::optional<neorados::IOContext> pool;
 
-boost::asio::io_context c;
+  neorados::RADOS::Builder{}.build(rados_context,
+      [&rados, &pool] (boost::system::error_code ec, neorados::RADOS r) {
+        if (ec) {
+          throw boost::system::system_error(ec);
+        }
+        rados = std::move(r);
 
-void nested_cb() {
-  if (++completed < max_completions)
-    boost::asio::post(c, &nested_cb);
-}
+        const char* pool_name = "ceph_test_neorados_completions";
+        rados->lookup_pool(pool_name,
+            [&rados, &pool, pool_name] (boost::system::error_code ec, int64_t id) {
+              if (ec == boost::system::errc::no_such_file_or_directory) {
+                create_pool(*rados, pool_name,
+                    [&pool] (boost::system::error_code ec, int64_t id) {
+                      if (ec) {
+                        throw boost::system::system_error(ec);
+                      }
+                      pool.emplace(id);
+                    });
+              } else if (ec) {
+                throw boost::system::system_error(ec);
+              } else {
+                pool.emplace(id);
+              }
+            });
+      });
+  rados_context.run();
 
-int main(void) {
-  boost::asio::post(c, &nested_cb);
-  c.run();
-  assert(completed == max_completions);
-  return 0;
+  // expect ReadOp completion on a separate execution context
+  boost::asio::io_context completion_context;
+  std::optional<boost::system::error_code> ec;
+  uint64_t size;
+  ceph::real_time mtime;
+
+  rados->execute("nonexistent", *pool, neorados::ReadOp{}.stat(&size, &mtime), nullptr,
+      boost::asio::bind_executor(completion_context,
+          [&ec] (boost::system::error_code e) { ec = e; }));
+
+  rados_context.restart();
+  rados_context.run();
+
+  EXPECT_FALSE(ec); // completion does not run on rados_context
+
+  completion_context.run();
+
+  EXPECT_TRUE(ec);
+
+  rados->delete_pool(pool->get_pool(), boost::asio::detached);
+
+  rados_context.restart();
+  rados_context.run();
 }


### PR DESCRIPTION
while `Objecter` delivers librados completions directly by calling `Context::complete()`, neorados completions are passed in as `boost::asio::any_completion_handler` and delivered to an asio executor via `boost::asio::defer()` on completion

asio handlers may have an "associated executor" so callers can customize where these completions are delivered. for example, multithreaded applications often use strand executors to synchronize completion handlers and prevent data races between concurrent operations

however, applications like radosgw that depend on strands for thread-safety did not get it due to the fact that Objecter's `Op::complete()` delivered all neorados completions to the default io_context executor

use `boost::asio::get_associated_executor()` to respect the handler's executor affinity, if any

Fixes: https://tracker.ceph.com/issues/76725

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
