### PR TITLE
tools/cephfs: add header recover command in cephfs-journal-tool

### DIFF
--- a/doc/cephfs/cephfs-journal-tool.rst
+++ b/doc/cephfs/cephfs-journal-tool.rst
@@ -25,6 +25,7 @@ Syntax
 
     cephfs-journal-tool [:ref:`options<cephfs_journal_tool_options>`] journal <inspect|import|export|reset>
     cephfs-journal-tool [:ref:`options<cephfs_journal_tool_options>`] header <get|set> <trimmed_pos|expire_pos|write_pos|pool_id> <value>
+    cephfs-journal-tool [:ref:`options<cephfs_journal_tool_options>`] header recover [--force]
     cephfs-journal-tool [:ref:`options<cephfs_journal_tool_options>`] event <get|splice|recover_dentries> [filter] <list|json|summary|binary>
 
 
@@ -97,8 +98,38 @@ Header mode
 * ``set`` modifies an attribute of the header.  Allowed attributes are
   ``trimmed_pos``, ``expire_pos``,  ``write_pos`` and ``pool_id``.
 
-Example: header get/set
-~~~~~~~~~~~~~~~~~~~~~~~
+* ``recover``  recover corrupted journal pointers within the ``mdlog``.
+  It enumerates the journal events and determines safe fallback offsets:
+
+  * ``trimmed_pos``: Set to the first event discovered in the log segment.
+  * ``expire_pos``: Set to the first major segment event.
+  * ``read_pos``: Set to the first major segment event.
+  * ``write_pos``: Set to the first position immediately following the last valid event.
+
+.. note::
+
+   The scope of this command is limited to scenarios where it is reasonably certain that the
+   journal's starting position (``expire_pos``) is sane. It trusts this starting anchor to
+   determine the beginning of the scan and recalculate the remaining boundary pointers.
+   Before using this command, administrators should manually inspect the journal header
+   to verify that this pointer makes logical sense. For catastrophic scenarios where the
+   header object is completely lost or the starting pointers are irreparably damaged,
+   this tool may not be able to recover uncommitted metadata.
+
+   This command requires the journal header to be present and have a valid magic number.
+   If the header is missing or entirely unrecognized, the tool will abort.
+
+By default, running this command performs a **dry run**. It emits a log to the
+console listing the proposed changes to the header offsets but does not modify the
+disk.
+
+.. warning::
+
+   The proposed header fields will only be committed to disk if the ``--force``
+   argument is explicitly passed. Use this flag with caution on corrupted file systems.
+
+Example: header get/set/recover
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ::
 
@@ -118,6 +149,23 @@ Example: header get/set
     Updating trimmed_pos 0x400000 -> 0x3fffff
     Successfully updated header.
 
+    # cephfs-journal-tool --rank a:0 header recover
+    Proposed Journal Header Updates:
+      trimmed_pos: 0x400000 -> 0x400000
+      expire_pos:  0x415f74 -> 0x415f74
+      read_pos:    0x415f74 -> 0x415f74
+      write_pos:   0x41576c -> 0x41676c
+      Target event type at proposed read_pos: EVENT_SUBTREEMAP
+    Dry-run mode enabled. Header modifications skipped.
+
+    # cephfs-journal-tool --rank a:0 header recover --force
+    Proposed Journal Header Updates:
+      trimmed_pos: 0x400000 -> 0x400000
+      expire_pos:  0x415f74 -> 0x415f74
+      read_pos:    0x415f74 -> 0x415f74
+      write_pos:   0x41576c -> 0x41676c
+      Target event type at proposed read_pos: EVENT_SUBTREEMAP
+    Successfully recovered journal header.
 
 Event mode
 ----------

--- a/qa/suites/fs/functional/tasks/journal-repair.yaml
+++ b/qa/suites/fs/functional/tasks/journal-repair.yaml
@@ -7,6 +7,7 @@ overrides:
       - slow requests are blocked
       - Behind on trimming
       - error reading sessionmap
+      - Error recovering journal
 tasks:
   - cephfs_test_runner:
       modules:

--- a/qa/tasks/cephfs/test_journal_repair.py
+++ b/qa/tasks/cephfs/test_journal_repair.py
@@ -639,3 +639,112 @@ wait
             raise RuntimeError("Expected journal import to fail")
         finally:
             self.mount_a.run_shell(["sudo", "rm", fname], omit_sudo=False)
+
+    def test_recover_header(self):
+        """
+        Validates the discovery of segment boundaries, dry-run reporting,
+        and header field modification (trimmed_pos, expire_pos, write_pos) via --force.
+        after a deliberate journal corruption that breaks MDS replay.
+        """
+        # Generate metadata events in the journal
+        log.info("Creating file system activity to populate the journal...")
+        test_dir = "header_recover_test_dir"
+        self.mount_a.run_shell(["mkdir", "-p", test_dir])
+        for i in range(20):
+            self.mount_a.run_shell(["touch", f"{test_dir}/file_{i}"])
+
+        # Force a deep metadata log flush from the MDS to RADOS layers
+        log.info("Forcing absolute metadata flush to RADOS storage...")
+        self.mount_a.run_shell(["sync"])
+        # Follow the file's native multi-rank flush pattern to ensure write_pos > 0
+        self.fs.rank_asok(["flush", "journal"], rank=0)
+
+        # Fail the filesystem to run journal operations.
+        log.info("Fail the filesystem to run offline journal operations...")
+        self.fs.fail()
+
+        # Fetch the real header first to avoid breaking trimmed_pos constraints
+        log.info("Fetching healthy header to calculate dynamic corruption offset...")
+        header_raw = self.fs.journal_tool(["header", "get"], 0)
+        if "{" in header_raw:
+            header_raw = header_raw[header_raw.index("{"):]
+        header_json = json.loads(header_raw)
+
+        # Calculate a corrupt write position relative to the valid active stream position
+        real_write_pos = header_json["write_pos"]
+        corrupt_write_pos = real_write_pos - 4096 if real_write_pos > 4096 else real_write_pos + 4096
+
+        log.info(f"Corrupting the journal header by shifting write_pos from {real_write_pos} to {corrupt_write_pos}...")
+        self.fs.journal_tool(["header", "set", "write_pos", str(corrupt_write_pos)], 0)
+
+        log.info("Verifying that MDS daemon fails to replay the corrupted journal...")
+        self.fs.set_joinable()
+
+        # Capture the status profile while the FS is active/joinable
+        # so that the rank dictionary definitions exist.
+        time.sleep(10)
+        status = self.fs.status()
+        try:
+            info = status.get_rank(self.fs.id, 0)
+            current_state = info.get('state')
+            log.info(f"MDS daemon is in state: {current_state} after corruption.")
+            self.assertNotEqual(current_state, "up:active", "MDS reached active despite header corruption!")
+        except Exception as e:
+            log.info(f"MDS rank missing or failed as expected during replay: {e}")
+
+        # Fail the filesystem again to regain exclusive access to the journal
+        log.info("Regaining exclusive offline access...")
+        self.fs.fail()
+
+        # Test Dry-Run Mode on the corrupted journal
+        log.info("Executing recover_header in dry-run mode (without --force)...")
+        dry_run_output = self.fs.journal_tool(["header", "recover"], 0)
+        log.info(f"Dry-run output:\n{dry_run_output}")
+
+        # Assert against outputs printed in JournalTool::recover_header
+        self.assertIn("Proposed Journal Header Updates:", dry_run_output)
+        self.assertIn("trimmed_pos:", dry_run_output)
+        self.assertIn("expire_pos:", dry_run_output)
+        self.assertIn("read_pos:", dry_run_output)
+        self.assertIn("write_pos:", dry_run_output)
+        self.assertIn("Target event type at proposed read_pos:", dry_run_output)
+        self.assertIn("Dry-run mode enabled. Header modifications skipped.", dry_run_output)
+
+        # Test Mutation Mode (--force)
+        log.info("Executing recover_header with --force to commit changes to RADOS...")
+        mutation_output = self.fs.journal_tool(["header", "recover", "--force"], 0)
+        log.info(f"Mutation output:\n{mutation_output}")
+
+        # Verify the success indicators printed upon successful RADOS synchronization
+        self.assertIn("Proposed Journal Header Updates:", mutation_output)
+        self.assertIn("trimmed_pos:", mutation_output)
+        self.assertIn("expire_pos:", mutation_output)
+        self.assertIn("read_pos:", mutation_output)
+        self.assertIn("write_pos:", mutation_output)
+        self.assertIn("Successfully recovered journal header.", mutation_output)
+        self.assertNotIn("Dry-run mode enabled", mutation_output)
+
+        log.info("Resetting session and inode allocation tables to prevent boot loops...")
+        target_rank = f"{self.fs.name}:0"
+        self.fs.table_tool([target_rank, "reset", "session"])
+        self.fs.table_tool([target_rank, "reset", "inode"])
+
+        # Bring the filesystem back up and confirm MDS can now replay successfully
+        log.info("Verify file system stability post-recovery...")
+        self.fs.set_joinable()
+
+        # Explicitly tell the Monitor to clear the "damaged" state record for Rank 0.
+        log.info("Clearing damaged rank flag from monitor status...")
+        self.fs.mon_manager.raw_cluster_cmd("mds", "repaired", f"{self.fs.name}:0")
+
+        # Wait for the daemons report healthy and active. This should succeed now.
+        try:
+            self.fs.wait_for_daemons(timeout=60)
+            log.info("MDS successfully booted up after journal recovery")
+        except Exception as e:
+            raise RuntimeError(f"MDS failed to start after journal recovery: {e}")
+
+        # Ensure data can still be read without MDS crashing
+        log.info("Verifying that directory contents are readable...")
+        dir_list = self.mount_a.run_shell(["ls", test_dir])
+        self.assertIn("file_19", dir_list.stdout.getvalue().strip())

--- a/qa/workunits/suites/cephfs_journal_tool_smoke.sh
+++ b/qa/workunits/suites/cephfs_journal_tool_smoke.sh
@@ -89,3 +89,5 @@ $BIN event splice summary
 $BIN journal reset --yes-i-really-really-mean-it
 cephfs-table-tool all reset session
 
+$BIN header recover 2>/dev/null #dry-run
+$BIN header recover --force 2>/dev/null #mutation

--- a/src/tools/cephfs/JournalTool.cc
+++ b/src/tools/cephfs/JournalTool.cc
@@ -51,7 +51,7 @@ void JournalTool::usage()
     << "      import <path> [--force]\n"
     << "      export <path>\n"
     << "      reset [--force] <--yes-i-really-really-mean-it>\n"
-    << "  cephfs-journal-tool [options] header <get|set> <field> <value>\n"
+    << "  cephfs-journal-tool [options] header {<get|set> <field> <value> | <recover> [--force]}\n"
     << "    <field>: [trimmed_pos|expire_pos|write_pos|pool_id]\n"
     << "  cephfs-journal-tool [options] event <effect> <selector> <output> [special options]\n"
     << "    <selector>:\n"
@@ -329,7 +329,7 @@ int JournalTool::main_header(std::vector<const char*> &argv)
   }
 
   if (argv.empty()) {
-    derr << "Missing header command, must be [get|set]" << dendl;
+    derr << "Missing header command, must be [get|set|recover]" << dendl;
     return -EINVAL;
   }
   std::vector<const char *>::iterator arg = argv.begin();
@@ -386,6 +386,22 @@ int JournalTool::main_header(std::vector<const char*> &argv)
     output.write_full(js.obj_name(0), header_bl);
     dout(4) << "Write complete." << dendl;
     std::cout << "Successfully updated header." << std::endl;
+  } else if (command == std::string("recover")) {
+    bool dry_run = true;
+    if (arg != argv.end()) {
+      if (std::string_view(*arg) == "--force") {
+        dry_run = false;
+        ++arg;
+      } else {
+        std::cerr << "Unknown argument trailing recover: " << *arg << std::endl;
+        return -EINVAL;
+      }
+    }
+    if (arg != argv.end()) {
+      std::cerr << "Too many arguments passed to recover command." << std::endl;
+      return -EINVAL;
+    }
+    return recover_header(dry_run);
   } else {
     derr << "Bad header command '" << command << "'" << dendl;
     return -EINVAL;
@@ -1372,3 +1388,167 @@ int JournalTool::consume_inos(const std::set<inodeno_t> &inos)
   return r;
 }
 
+/**
+ * Returns a string view representation of journal events
+ * @param event_type the type of journal event
+ * @returns a string view of event_type
+ */
+std::string_view JournalTool::get_event_name_str(uint32_t event_type)
+{
+  switch (event_type) {
+    case EVENT_SUBTREEMAP:      return "EVENT_SUBTREEMAP";
+    case EVENT_SUBTREEMAP_TEST: return "EVENT_SUBTREEMAP_TEST";
+    case EVENT_LID:             return "EVENT_LID";
+    case EVENT_RESETJOURNAL:    return "EVENT_RESETJOURNAL";
+    default:                    return "EVENT_UNKNOWN";
+  }
+}
+
+/**
+ * Analyzes journal corruptions and repositions header markers (write_pos, expire_pos)
+ * safely to resolve broken log segments.
+ * @params dry_run only displays the Proposed Journal Header Updates.
+ * @returns 0 if success, error code otherwise.
+ */
+int JournalTool::recover_header(bool dry_run)
+{
+  std::cerr << "WARNING: 'header recover' performs a best-effort recovery assuming the "
+            << "existing journal starting pointer (expire_pos) is sane. It is highly "
+            << "recommended to manually inspect this position relative to the object "
+            << "layout before relying on this tool." << std::endl;
+
+  dout(4) << "Starting journal header recover analysis (dry_run="
+          << std::boolalpha << dry_run << ")" << dendl;
+
+  JournalFilter filter("mdlog");
+  JournalScanner js(input, rank, type, filter);
+
+  // First do a header scan (full=false), so that we could do error reporting
+  int r = js.scan(false);
+  if (r < 0) {
+    derr << "Failed to parse initial journal status: " << cpp_strerror(r) << dendl;
+    return -EIO;
+  }
+
+  if (!js.header_present) {
+    derr << "Journal header object is missing entirely, cannot execute recovery" << dendl;
+    return -EIO;
+  }
+
+  if (!js.header_valid) {
+    // Check if the invalidity is due to a completely unrecognized/corrupt header
+    if (js.header->magic != CEPH_FS_ONDISK_MAGIC) {
+      derr << "Critical failure: Invalid journal magic number ('"
+           << js.header->magic << "'). This does not appear to be a valid CephFS journal."
+           << dendl;
+      return -EINVAL;
+    }
+    // If magic is correct, the invalidity is just offset inconsistency
+    dout(1) << "Journal header is present but marked invalid due to offset inconsistencies. "
+            << "Attempting analytical recovery from stream base..." << dendl;
+  }
+
+  uint64_t first_pos = std::numeric_limits<uint64_t>::max();
+  uint64_t last_pos = 0;
+  uint64_t last_raw_size = 0;
+  uint64_t expected_next_pos = 0;
+  bool is_first = true;
+  BoundaryMatch boundary_match;
+
+  // Events scan: execute events dynamically via the new callback interface.
+  r = js.scan_events([&](uint64_t pos, JournalScanner::EventRecord& er) {
+    if (is_first) {
+      first_pos = pos;
+    } else if (expected_next_pos != pos) {
+      // Alert the user
+      std::cerr << "warning: Discontinuity detected in journal offsets. Expected: 0x"
+                << std::hex << expected_next_pos << ", Found: 0x" << pos << std::dec
+                << ". Attempting to skip gap and continue recovery..." << std::endl;
+      // Log it
+      dout(1) << "warning: Discontinuity detected in journal offsets. Expected: 0x"
+              << std::hex << expected_next_pos << ", Found: 0x" << pos << std::dec << dendl;
+    }
+    is_first = false;
+    expected_next_pos = pos + er.raw_size;
+
+    // Tracks the absolute last element seen in log timeline stream
+    last_pos = pos;
+    last_raw_size = er.raw_size;
+
+    // Check for the earliest major alignment boundary block
+    if (boundary_match.pos == std::numeric_limits<uint64_t>::max()) {
+      if (er.log_event) {
+        const uint32_t type = er.log_event->get_type();
+        if (type == EVENT_SUBTREEMAP ||
+            type == EVENT_SUBTREEMAP_TEST ||
+            type == EVENT_LID        ||
+            type == EVENT_RESETJOURNAL) {
+          boundary_match.event_type = type;
+          boundary_match.pos = pos;
+        }
+      }
+    }
+  });
+
+  if (r < 0) {
+    derr << "Failed streaming scan over journal objects: " << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  if (is_first) {
+    derr << "No events discovered in scanned journal stream. Nothing to recover." << dendl;
+    return -ENOENT;
+  }
+
+  if (boundary_match.pos == std::numeric_limits<uint64_t>::max()) {
+    derr << "Critical failure: No valid major segment boundary event found in logs." << dendl;
+    return -EIO;
+  }
+
+  // Save the current values for the logs
+  const auto old_trimmed_pos = js.header->trimmed_pos;
+  const auto old_expire_pos  = js.header->expire_pos;
+  const auto old_write_pos   = js.header->write_pos;
+  const auto old_read_pos    = js.header->unused_field;
+
+  // Calculate new parameters
+  uint64_t obj_size = js.header->layout.object_size;
+  if (obj_size == 0) {
+    obj_size = 4194304; // 4MB fallback
+  }
+  if (js.header_present && old_trimmed_pos <= first_pos) {
+    js.header->trimmed_pos = old_trimmed_pos; // Safest: keep the known good boundary
+  } else {
+    js.header->trimmed_pos = first_pos - (first_pos % obj_size); // Fallback: force alignment
+  }
+  js.header->expire_pos   = boundary_match.pos;
+  js.header->write_pos    = last_pos + last_raw_size;
+  js.header->unused_field = boundary_match.pos;
+
+  // Output
+  std::cout << "Proposed Journal Header Updates:" << std::endl << std::hex
+            << "  trimmed_pos: 0x" << old_trimmed_pos << " -> 0x" << js.header->trimmed_pos << std::endl
+            << "  expire_pos:  0x" << old_expire_pos  << " -> 0x" << js.header->expire_pos  << std::endl
+            << "  read_pos:    0x" << old_read_pos    << " -> 0x" << js.header->unused_field << std::endl
+            << "  write_pos:   0x" << old_write_pos   << " -> 0x" << js.header->write_pos   << std::endl << std::dec
+            << "  Target event type at proposed read_pos: " << get_event_name_str(boundary_match.event_type) << std::endl;
+
+  if (dry_run) {
+    std::cout << "Dry-run mode enabled. Header modifications skipped." << std::endl;
+    return 0;
+  }
+
+  // Save changes to RADOS
+  dout(4) << "Serializing modified header to pool layer..." << dendl;
+  bufferlist header_bl;
+  encode(*(js.header), header_bl);
+  r = output.write_full(js.obj_name(0), header_bl);
+  if (r < 0) {
+    derr << "Failed writing updated journal header object: " << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  dout(4) << "RADOS header mutation finalized successfully." << dendl;
+  std::cout << "Successfully recovered journal header." << std::endl;
+  return 0;
+}

--- a/src/tools/cephfs/JournalTool.h
+++ b/src/tools/cephfs/JournalTool.h
@@ -74,6 +74,11 @@ class JournalTool : public MDSUtility
         bool const dry_run,
         std::set<inodeno_t> *consumed_inos);
 
+    struct BoundaryMatch {
+      uint64_t pos = std::numeric_limits<uint64_t>::max();
+      uint32_t event_type = 0;
+    };
+
     // Splicing
     int erase_region(JournalScanner const &jp, uint64_t const pos, uint64_t const length);
 
@@ -93,8 +98,12 @@ class JournalTool : public MDSUtility
     // executed on all ranks.
     bool can_execute_for_all_ranks(const std::string &mode,
                                    const std::string &command);
+
+  std::string_view get_event_name_str(uint32_t event_type);
+
   public:
     static void usage();
+    int recover_header(bool dry_run);
 
     JournalTool() :
       rank(0), other_pool(false)


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/64101
(Please Note: This PR resolves [#64101](https://tracker.ceph.com/issues/64101) only. Recovering a completely missing journal header, as requested in tracker issue [#77284](https://tracker.ceph.com/issues/77284), remains out of scope for this task).

* **Automated Recovery:** 

     - Introduces the `cephfs-journal-tool header recover` command to automatically repair corrupted CephFS journal headers, resolving tracker issue [#64101](https://tracker.ceph.com/issues/64101). *(Note: Recovering a completely missing journal header, as requested in  tracker issue [#77284](https://tracker.ceph.com/issues/77284), remains out of scope for this task).*
     - Scans the `mdlog` to identify valid segment boundaries and dynamically calculates safe fallback markers for `trimmed_pos`, `expire_pos`, `read_pos`, and `write_pos`.
     - Defaults to a dry-run mode that prints proposed changes to the console, requiring the explicit `--force` flag to actually commit mutations to RADOS.

* **Documentation:** Updates `cephfs-journal-tool.rst` with the command syntax, offset calculation details, safety warnings, and clear output examples for both modes.
* **QA Validation:** Adds the `test_recover_header` functional test to simulate a corruption, validate MDS crash behavior, and prove successful offline repair and cluster recovery, alongside smoke tests.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
