### PR TITLE
crimson/osd: avoid calling get_sharded_store() for obj size

### DIFF
--- a/src/crimson/os/futurized_store.h
+++ b/src/crimson/os/futurized_store.h
@@ -207,11 +207,6 @@ public:
       uint32_t op_flags = 0) = 0;
 
     virtual unsigned get_max_attr_name_length() const = 0;
-
-    /// Override to report a tighter per-object cap than osd_max_object_size.
-    virtual uint64_t get_max_object_size() const {
-      return crimson::common::local_conf()->osd_max_object_size;
-    }
   };
 
 public:
@@ -248,6 +243,11 @@ public:
   virtual seastar::future<> report_stats() { return seastar::now(); }
 
   virtual uuid_d get_fsid() const  = 0;
+
+  /// Override to report a tighter per-object cap than osd_max_object_size.
+  virtual uint64_t get_max_object_size() const {
+    return crimson::common::local_conf()->osd_max_object_size;
+  }
 
   virtual seastar::future<> write_meta(const std::string& key,
 				       const std::string& value) = 0;

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -185,12 +185,6 @@ public:
       return 256;
     }
 
-    uint64_t get_max_object_size() const override final {
-      return std::min<uint64_t>(
-        crimson::common::local_conf()->osd_max_object_size,
-        max_object_size);
-    }
-
     omap_root_t select_log_omap_root(Onode& onode) const;
 
   // only exposed to SeaStore
@@ -593,6 +587,12 @@ public:
     return shard_stores.local().mshard_stores[0]->get_fsid();
   }
 
+  uint64_t get_max_object_size() const override final {
+    return std::min<uint64_t>(
+      crimson::common::local_conf()->osd_max_object_size,
+      crimson::common::get_conf<uint64_t>("seastore_default_max_object_size"));
+  }
+
   seastar::future<> write_meta(const std::string& key, const std::string& value) override;
 
   seastar::future<std::tuple<int, std::string>> read_meta(const std::string& key) override;
@@ -624,6 +624,7 @@ public:
     assert(shard_store.get_status() == true);
     return shard_store;
   }
+
   static col_obj_ranges_t
   get_objs_range(CollectionRef ch, unsigned bits);
 

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -618,15 +618,14 @@ void PGBackend::truncate_update_size_and_usage(object_stat_sum_t& delta_stats,
 }
 
 bool PGBackend::is_offset_and_length_valid(
-  const std::uint64_t offset,
-  const std::uint64_t length) const
+    const std::uint64_t offset,
+    const std::uint64_t length) const
 {
-  if (const std::uint64_t max =
-        store.f_store.get_sharded_store(store.store_index).get_max_object_size();
+  if (const std::uint64_t max = store.f_store.get_max_object_size();
       offset >= max || length > max || offset + length > max) {
     logger().debug("{} max_object_size: {}, offset: {}, len: {}; "
-                   "Hard limit of object size is 4GB",
-                   __func__, max, offset, length);
+        "Hard limit of object size is 4GB",
+        __func__, max, offset, length);
     return false;
   } else {
     return true;


### PR DESCRIPTION
is_offset_and_length_valid() called get_sharded_store() locally to
obtain the store-specific max_object_size. On alien cores (where
smp::count > store_shard_nums), the local store is inactive and the
call hits assert(shard_store.get_status() == true).

As the max object size is a store-specific property and not a
store-shard one, there is no reason to acquire the
store shard to obtain it. Instead -
a get_max_object_size() method is added to the Store interface.

Fixes: https://tracker.ceph.com/issues/76946
