### PR TITLE
[Draft]: SSE-S3 for KMIP backend

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -55,8 +55,8 @@
 	url = https://github.com/ceph/s3select.git
 [submodule "src/libkmip"]
 	path = src/libkmip
-	url = https://github.com/ceph/libkmip
-	branch = ceph-master
+	url = https://github.com/supriti/libkmip.git
+	branch = wip-kmip-clean-for-review
 [submodule "src/arrow"]
 	path = src/arrow
 	url = https://github.com/apache/arrow.git

--- a/qa/suites/rgw/crypt/2-kms/pykmip-sse.yaml
+++ b/qa/suites/rgw/crypt/2-kms/pykmip-sse.yaml
@@ -1,0 +1,42 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        rgw crypt s3 kms backend: kmip
+        rgw crypt kmip ca path: /etc/ceph/kmiproot.crt
+        rgw crypt kmip client cert: /etc/ceph/kmip-client.crt
+        rgw crypt kmip client key: /etc/ceph/kmip-client.key
+        rgw crypt kmip kms key template: pykmip-$keyid
+        rgw crypt sse s3 backend: kmip
+        rgw crypt sse s3 key template: pykmip-sse-s3-key
+  rgw:
+    client.0:
+      use-pykmip-role: client.0
+  s3tests:
+    with-sse-s3: true
+
+tasks:
+- openssl_keys:
+    kmiproot:
+      client: client.0
+      cn: kmiproot
+      key-type: rsa:4096
+    kmip-server:
+      client: client.0
+      ca: kmiproot
+    kmip-client:
+      client: client.0
+      ca: kmiproot
+      cn: rgw-client
+- exec:
+    client.0:
+      - chmod 644 /home/ubuntu/cephtest/ca/kmip-client.key
+- pykmip:
+    client.0:
+      clientca: kmiproot
+      servercert: kmip-server
+      clientcert: kmip-client
+      secrets:
+      - name: pykmip-my-key-1
+      - name: pykmip-my-key-2
+      - name: pykmip-sse-s3-key

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3388,6 +3388,20 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_crypt_kmip_socket_io_timeout_sec
+  type: int
+  level: advanced
+  desc: KMIP TLS per-socket read/write timeout (SO_RCVTIMEO/SO_SNDTIMEO), seconds
+  long_desc: >
+    Applied after TCP+TLS connect on the BIO used for KMIP. Limits how long
+    each socket recv/send may block. Use 0 to disable (falls back to the
+    kernel TCP retransmit timeout). Does not bound total KMIP request time by itself.
+  default: 300
+  min: 0
+  max: 300
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_crypt_suppress_logs
   type: bool
   level: advanced

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3405,11 +3405,12 @@ options:
 - name: rgw_crypt_kmip_worker_threads
   type: int
   level: advanced
-  desc: parallel KMIP client worker threads for SSE-S3 (each runs its own connection pool)
+  desc: parallel KMIP client worker threads for SSE-S3
   long_desc: >
     Requests are queued and processed concurrently up to this many workers.
-    Each worker may open one or more TLS sessions to the KMIP server; size this
-    for KMIP server limits and RGW load. Minimum 1, maximum 32.
+    Each worker keeps at most one cached TLS sessions to the KMIP server,
+    reused across requests until idle longer than 5 seconds. Set this as per
+    KMIP server limits and RGW load. Minimum 1, maximum 32
   default: 1
   min: 1
   max: 32

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3402,6 +3402,19 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_crypt_kmip_worker_threads
+  type: int
+  level: advanced
+  desc: parallel KMIP client worker threads for SSE-S3 (each runs its own connection pool)
+  long_desc: >
+    Requests are queued and processed concurrently up to this many workers.
+    Each worker may open one or more TLS sessions to the KMIP server; size this
+    for KMIP server limits and RGW load. Minimum 1, maximum 32.
+  default: 1
+  min: 1
+  max: 32
+  services:
+  - rgw
 - name: rgw_crypt_suppress_logs
   type: bool
   level: advanced

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3125,10 +3125,10 @@ options:
   type: str
   level: advanced
   desc: Where the SSE-KMS encryption keys are stored. Supported KMS systems are OpenStack
-    Barbican ('barbican', the default) and HashiCorp Vault ('vault').
+    Barbican ('barbican', the default), HashiCorp Vault ('vault'), and KMIP ('kmip')
   fmt_desc: Where the SSE-KMS encryption keys are stored. Supported KMS
-    systems are OpenStack Barbican (``barbican``, the default) and
-    HashiCorp Vault (``vault``).
+    systems are OpenStack Barbican (``barbican``, the default),
+    HashiCorp Vault (``vault``), and KMIP (``kmip``).
   default: barbican
   services:
   - rgw
@@ -3415,6 +3415,7 @@ options:
   max: 32
   services:
   - rgw
+  with_legacy: true
 - name: rgw_crypt_suppress_logs
   type: bool
   level: advanced
@@ -3445,15 +3446,16 @@ options:
 - name: rgw_crypt_sse_s3_backend
   type: str
   level: advanced
-  desc: Where the SSE-S3 encryption keys are stored. The only valid choice here is
-    HashiCorp Vault ('vault').
-  fmt_desc: Where the SSE-S3 encryption keys are stored. The only valid
-    choice is HashiCorp Vault (``vault``).
+  desc: Where the SSE-S3 encryption keys are stored. Valid choices are HashiCorp
+    Vault ('vault') and KMIP ('kmip').
+  fmt_desc: Where the SSE-S3 encryption keys are stored. Valid choices are
+    HashiCorp Vault (``vault``) and KMIP (``kmip``).
   default: vault
   services:
   - rgw
   enum_values:
   - vault
+  - kmip
   with_legacy: true
 
 - name: rgw_crypt_sse_s3_vault_secret_engine

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3433,6 +3433,20 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_crypt_kmip_socket_io_timeout_sec
+  type: int
+  level: advanced
+  desc: KMIP TLS per-socket read/write timeout (SO_RCVTIMEO/SO_SNDTIMEO), seconds
+  long_desc: >
+    Applied after TCP+TLS connect on the BIO used for KMIP. Limits how long
+    each socket recv/send may block. Use 0 to disable (falls back to the
+    kernel TCP retransmit timeout). Does not bound total KMIP request time by itself.
+  default: 300
+  min: 0
+  max: 300
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_crypt_suppress_logs
   type: bool
   level: advanced

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3170,10 +3170,10 @@ options:
   type: str
   level: advanced
   desc: Where the SSE-KMS encryption keys are stored. Supported KMS systems are OpenStack
-    Barbican ('barbican', the default) and HashiCorp Vault ('vault').
+    Barbican ('barbican', the default), HashiCorp Vault ('vault'), and KMIP ('kmip')
   fmt_desc: Where the SSE-KMS encryption keys are stored. Supported KMS
-    systems are OpenStack Barbican (``barbican``, the default) and
-    HashiCorp Vault (``vault``).
+    systems are OpenStack Barbican (``barbican``, the default),
+    HashiCorp Vault (``vault``), and KMIP (``kmip``).
   default: barbican
   services:
   - rgw
@@ -3460,6 +3460,7 @@ options:
   max: 32
   services:
   - rgw
+  with_legacy: true
 - name: rgw_crypt_suppress_logs
   type: bool
   level: advanced
@@ -3490,15 +3491,16 @@ options:
 - name: rgw_crypt_sse_s3_backend
   type: str
   level: advanced
-  desc: Where the SSE-S3 encryption keys are stored. The only valid choice here is
-    HashiCorp Vault ('vault').
-  fmt_desc: Where the SSE-S3 encryption keys are stored. The only valid
-    choice is HashiCorp Vault (``vault``).
+  desc: Where the SSE-S3 encryption keys are stored. Valid choices are HashiCorp
+    Vault ('vault') and KMIP ('kmip').
+  fmt_desc: Where the SSE-S3 encryption keys are stored. Valid choices are
+    HashiCorp Vault (``vault``) and KMIP (``kmip``).
   default: vault
   services:
   - rgw
   enum_values:
   - vault
+  - kmip
   with_legacy: true
 
 - name: rgw_crypt_sse_s3_vault_secret_engine

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3447,6 +3447,19 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_crypt_kmip_worker_threads
+  type: int
+  level: advanced
+  desc: parallel KMIP client worker threads for SSE-S3 (each runs its own connection pool)
+  long_desc: >
+    Requests are queued and processed concurrently up to this many workers.
+    Each worker may open one or more TLS sessions to the KMIP server; size this
+    for KMIP server limits and RGW load. Minimum 1, maximum 32.
+  default: 1
+  min: 1
+  max: 32
+  services:
+  - rgw
 - name: rgw_crypt_suppress_logs
   type: bool
   level: advanced

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3450,11 +3450,12 @@ options:
 - name: rgw_crypt_kmip_worker_threads
   type: int
   level: advanced
-  desc: parallel KMIP client worker threads for SSE-S3 (each runs its own connection pool)
+  desc: parallel KMIP client worker threads for SSE-S3
   long_desc: >
     Requests are queued and processed concurrently up to this many workers.
-    Each worker may open one or more TLS sessions to the KMIP server; size this
-    for KMIP server limits and RGW load. Minimum 1, maximum 32.
+    Each worker keeps at most one cached TLS sessions to the KMIP server,
+    reused across requests until idle longer than 5 seconds. Set this as per
+    KMIP server limits and RGW load. Minimum 1, maximum 32
   default: 1
   min: 1
   max: 32

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -133,6 +133,8 @@ set(librgw_common_srcs
   rgw_kms.cc
   rgw_kms_cache.cc
   rgw_kmip_client.cc
+  rgw_kmip_client_impl.cc
+  rgw_kmip_sse_s3.cc
   rgw_url.cc
   rgw_oidc_provider.cc
   rgw_log.cc
@@ -326,12 +328,14 @@ target_link_libraries(rgw_common
     RapidJSON::RapidJSON
     Boost::context
     Boost::url
+    kmip
     ${FMT_LIB}
     OpenSSL::SSL
     BLAKE3::blake3)
 target_include_directories(rgw_common
   PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/services"
   PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
+  PUBLIC "${CMAKE_SOURCE_DIR}/src/libkmip/include"
   PUBLIC "${LUA_INCLUDE_DIR}")
 
 # work around https://github.com/Cyan4973/xxHash/issues/943 for debug builds
@@ -419,7 +423,6 @@ set(rgw_a_srcs
   rgw_file.cc
   rgw_frontend.cc
   rgw_http_client_curl.cc
-  rgw_kmip_client_impl.cc
   rgw_lib.cc
   rgw_loadgen.cc
   rgw_loadgen_process.cc
@@ -460,14 +463,13 @@ set_source_files_properties(rgw_iam_policy.cc PROPERTIES
 
 add_library(rgw_a STATIC
     ${rgw_a_srcs})
-
+target_include_directories(rgw_common PUBLIC "${CMAKE_SOURCE_DIR}/src/libkmip/include")
 target_compile_definitions(rgw_a PUBLIC "-DCLS_CLIENT_HIDE_IOCTX")
 
 target_include_directories(rgw_a
   PUBLIC "${CMAKE_SOURCE_DIR}/src/dmclock/support/src"
   PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
-  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/driver/rados"
-  PRIVATE "${CMAKE_SOURCE_DIR}/src/libkmip")
+  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/driver/rados")
 
 if(WITH_RADOSGW_AMQP_ENDPOINT)
   find_package(RabbitMQ REQUIRED)
@@ -527,7 +529,7 @@ endif(WITH_RADOSGW_ARROW_FLIGHT)
 target_compile_definitions(radosgw PUBLIC "-DCLS_CLIENT_HIDE_IOCTX")
 target_include_directories(radosgw
   PUBLIC "${CMAKE_SOURCE_DIR}/src/dmclock/support/src"
-  PRIVATE "${CMAKE_SOURCE_DIR}/src/libkmip"
+  PUBLIC "${CMAKE_SOURCE_DIR}/src/libkmip/include"
   PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
   PRIVATE "${LUA_INCLUDE_DIR}")
 
@@ -635,7 +637,7 @@ add_library(rgw SHARED ${librgw_srcs})
 target_compile_definitions(rgw PUBLIC "-DCLS_CLIENT_HIDE_IOCTX")
 target_include_directories(rgw
   PUBLIC "${CMAKE_SOURCE_DIR}/src/dmclock/support/src"
-  PRIVATE "${CMAKE_SOURCE_DIR}/src/libkmip"
+  PUBLIC "${CMAKE_SOURCE_DIR}/src/libkmip/include"
   PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
   PRIVATE "${LUA_INCLUDE_DIR}")
 

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -139,6 +139,8 @@ set(librgw_common_srcs
   rgw_kms.cc
   rgw_kms_cache.cc
   rgw_kmip_client.cc
+  rgw_kmip_client_impl.cc
+  rgw_kmip_sse_s3.cc
   rgw_url.cc
   rgw_oidc_provider.cc
   rgw_log.cc
@@ -375,12 +377,14 @@ target_link_libraries(rgw_common
     RapidJSON::RapidJSON
     Boost::context
     Boost::url
+    kmip
     ${FMT_LIB}
     OpenSSL::SSL
     BLAKE3::blake3)
 target_include_directories(rgw_common
   PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/services"
   PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
+  PUBLIC "${CMAKE_SOURCE_DIR}/src/libkmip/include"
   PUBLIC "${LUA_INCLUDE_DIR}")
 
 # work around https://github.com/Cyan4973/xxHash/issues/943 for debug builds
@@ -550,7 +554,6 @@ set(rgw_a_srcs
   rgw_file.cc
   rgw_frontend.cc
   rgw_http_client_curl.cc
-  rgw_kmip_client_impl.cc
   rgw_lib.cc
   rgw_loadgen.cc
   rgw_loadgen_process.cc
@@ -592,6 +595,7 @@ add_library(rgw_a STATIC
     ${rgw_a_srcs}
     ${rgw_a_rados_srcs})
 
+target_include_directories(rgw_common PUBLIC "${CMAKE_SOURCE_DIR}/src/libkmip/include")
 target_compile_definitions(rgw_a PUBLIC "-DCLS_CLIENT_HIDE_IOCTX")
 
 if(WITH_RADOSGW_RADOS)
@@ -602,8 +606,7 @@ endif()
 target_include_directories(rgw_a
   PUBLIC "${CMAKE_SOURCE_DIR}/src/dmclock/support/src"
   PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
-  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/driver/rados"
-  PRIVATE "${CMAKE_SOURCE_DIR}/src/libkmip")
+  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/driver/rados")
 
 if(WITH_RADOSGW_AMQP_ENDPOINT)
   find_package(RabbitMQ REQUIRED)
@@ -734,7 +737,7 @@ endif(WITH_RADOSGW_ARROW_FLIGHT)
 target_compile_definitions(radosgw PUBLIC "-DCLS_CLIENT_HIDE_IOCTX")
 target_include_directories(radosgw
   PUBLIC "${CMAKE_SOURCE_DIR}/src/dmclock/support/src"
-  PRIVATE "${CMAKE_SOURCE_DIR}/src/libkmip"
+  PUBLIC "${CMAKE_SOURCE_DIR}/src/libkmip/include"
   PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
   PUBLIC "${CMAKE_SOURCE_DIR}/src/s3select/rapidjson/include"
   PRIVATE "${LUA_INCLUDE_DIR}")
@@ -946,7 +949,7 @@ add_library(rgw SHARED ${librgw_srcs})
 target_compile_definitions(rgw PUBLIC "-DCLS_CLIENT_HIDE_IOCTX")
 target_include_directories(rgw
   PUBLIC "${CMAKE_SOURCE_DIR}/src/dmclock/support/src"
-  PRIVATE "${CMAKE_SOURCE_DIR}/src/libkmip"
+  PUBLIC "${CMAKE_SOURCE_DIR}/src/libkmip/include"
   PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
   PUBLIC "${CMAKE_SOURCE_DIR}/src/s3select/rapidjson/include"
   PRIVATE "${LUA_INCLUDE_DIR}")

--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -1873,13 +1873,16 @@ static int get_sse_s3_bucket_key(req_state *s, optional_yield y,
       // Someone else committed a KEK. Destroy our orphan, adopt theirs.
       std::string winner_id = it->second.to_str();
       if (winner_id != key_id) {
-        ldpp_dout(s, 5) << "Lost KEK race; destroying our orphan KEK "
+        int worker_id = -1;
+        int cleanup_res = remove_sse_s3_bucket_key(s, key_id, y, &worker_id);
+        ldpp_dout(s, 5) << "kmip_worker[" << worker_id << "] "
+                        << "Lost KEK race; destroying our orphan KEK "
                            "(id_len=" << key_id.length()
                         << ") and adopting winner (id_len="
                         << winner_id.length() << ")" << dendl;
-        int cleanup_res = remove_sse_s3_bucket_key(s, key_id, y);
         if (cleanup_res != 0) {
-          ldpp_dout(s, 0) << "WARN: failed to destroy orphan KEK after losing "
+          ldpp_dout(s, 0) << "kmip_worker[" << worker_id << "] "
+                          << "WARN: failed to destroy orphan KEK after losing "
                              "race (id_len=" << key_id.length()
                           << "); manual cleanup may be required" << dendl;
         }

--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -14,6 +14,7 @@
 #include <auth/Crypto.h>
 #include <rgw/rgw_b64.h>
 #include <rgw/rgw_rest_s3.h>
+#include "common/errno.h"
 #include "include/ceph_assert.h"
 #include "include/function2.hpp"
 #include "crypto/crypto_accel.h"
@@ -21,6 +22,7 @@
 #include "rgw/rgw_kms.h"
 #include "rgw_range_projection.h"
 #include "rgw/rgw_process_env.h"
+#include "rgw/rgw_kmip_sse_s3.h"
 #include "rapidjson/document.h"
 #include "rapidjson/writer.h"
 #include "rapidjson/error/error.h"
@@ -1803,48 +1805,109 @@ std::string expand_key_name(req_state *s, const std::string_view&t)
 static int get_sse_s3_bucket_key(req_state *s, optional_yield y,
                                  std::string &key_id)
 {
-  int res;
-  std::string saved_key;
+  int res = 0;
+  std::string saved_key = fetch_bucket_key_id(s);
 
-  key_id = expand_key_name(s, s->cct->_conf->rgw_crypt_sse_s3_key_template);
-
-  if (key_id == cant_expand_key) {
-    ldpp_dout(s, 5) << "ERROR: unable to expand key_id " <<
-      s->cct->_conf->rgw_crypt_sse_s3_key_template << " on bucket" << dendl;
-    s->err.message = "Server side error - unable to expand key_id";
-    return -EINVAL;
+  // Return existing key if metadata is already present
+  if (!saved_key.empty()) {
+    key_id = saved_key;
+    return 0;
   }
 
-  saved_key = fetch_bucket_key_id(s);
-  if (saved_key != "") {
-    ldpp_dout(s, 5) << "Found KEK ID: " << key_id << dendl;
-  }
-  if (saved_key != key_id) {
-    res = create_sse_s3_bucket_key(s, key_id, y);
-    if (res != 0) {
-      return res;
+  const std::string& backend = s->cct->_conf->rgw_crypt_sse_s3_backend;
+  // Expand key name for Vault
+  if (backend == RGW_SSE_KMS_BACKEND_VAULT) {
+    key_id = expand_key_name(s, s->cct->_conf->rgw_crypt_sse_s3_key_template);
+    if (key_id == cant_expand_key) {
+      ldpp_dout(s, 5) << "ERROR: unable to expand key_id template" << dendl;
+      s->err.message = "Server side error - unable to expand key_id";
+      return -EINVAL;
     }
-    bufferlist key_id_bl;
-    key_id_bl.append(key_id.c_str(), key_id.length());
-    for (int count = 0; count < 15; ++count) {
-      rgw::sal::Attrs attrs = s->bucket->get_attrs();
-      attrs[RGW_ATTR_BUCKET_ENCRYPTION_KEY_ID] = key_id_bl;
-      res = s->bucket->merge_and_store_attrs(s, attrs, s->yield);
-      if (res != -ECANCELED) {
-        break;
+  }
+
+  // Create the key on the KMIP/Vault backend
+  // Use bucket UUID to create unique bucket name to avoid bucket name collisions.
+  res = create_sse_s3_bucket_key(s, key_id, y, s->bucket->get_bucket_id());
+  if (res != 0) {
+    ldpp_dout(s, 0) << "ERROR: create_sse_s3_bucket_key failed, res=" << res << dendl;
+    return res;
+  }
+
+  //  Persist the ID to Bucket Attributes (The Link)
+  bufferlist bl;
+  bl.append(key_id);
+
+  // Retry loop for metadata synchronization
+  for (int count = 0; count < 15; ++count) {
+    rgw::sal::Attrs attrs = s->bucket->get_attrs();
+    attrs[RGW_ATTR_BUCKET_ENCRYPTION_KEY_ID] = bl;
+
+    res = s->bucket->merge_and_store_attrs(s, attrs, y);
+    if (res == 0) {
+      ldpp_dout(s, 10) << "Successfully linked KEK ID: " << key_id << dendl;
+      return 0;
+    }
+
+    if (res != -ECANCELED) {
+      ldpp_dout(s, 0) << "ERROR: failed to save bucket attr, res=" << res << dendl;
+      break;
+    }
+
+    // Conflict (ECANCELED): someone else may have committed a KEK while we
+    // were trying. Refresh and check.
+    int r = s->bucket->try_refresh_info(s, nullptr, y);
+    if (r < 0) {
+      ldpp_dout(s, 0) << "ERROR: try_refresh_info() failed: " << dendl;
+      //One quick try before giving up, blips mon/rados blips are usually momentary.
+      r = s->bucket->try_refresh_info(s, nullptr, y);
+    }
+    if (r < 0) {
+      ldpp_dout(s, 0) << "ERROR: try_refresh_info() failed: "
+                    << cpp_strerror(r) << dendl;
+      return r;
+    }
+
+    rgw::sal::Attrs refreshed = s->bucket->get_attrs();
+    auto it = refreshed.find(RGW_ATTR_BUCKET_ENCRYPTION_KEY_ID);
+    if (it != refreshed.end() && it->second.length() > 0) {
+      // Someone else committed a KEK. Destroy our orphan, adopt theirs.
+      std::string winner_id = it->second.to_str();
+      if (winner_id != key_id) {
+        ldpp_dout(s, 5) << "Lost KEK race; destroying our orphan KEK "
+                           "(id_len=" << key_id.length()
+                        << ") and adopting winner (id_len="
+                        << winner_id.length() << ")" << dendl;
+        int cleanup_res = remove_sse_s3_bucket_key(s, key_id, y);
+        if (cleanup_res != 0) {
+          ldpp_dout(s, 0) << "WARN: failed to destroy orphan KEK after losing "
+                             "race (id_len=" << key_id.length()
+                          << "); manual cleanup may be required" << dendl;
+        }
+        key_id = winner_id;
       }
-      res = s->bucket->try_refresh_info(s, nullptr, s->yield);
-      if (res != 0) {
-        break;
+      return 0;
+    }
+
+    // Bucket attr still empty — retry our commit
+    ldpp_dout(s, 5) << "Metadata conflict (ECANCELED), retrying..." << dendl;
+  }
+
+  if (res != 0) {
+    ldpp_dout(s, 0) << "ERROR: unable to save key_id on bucket metadata" << dendl;
+    s->err.message = "Server side error - unable to save key_id";
+    /* The key was created on the backend but we failed to persist its ID.
+     * Best-effort cleanup to avoid orphaning the key on the KMS server. */
+    if (!key_id.empty()) {
+      int cleanup_res = remove_sse_s3_bucket_key(s, key_id, y);
+      if (cleanup_res != 0) {
+        ldpp_dout(s, 0) << "ERROR: failed to clean up orphaned backend key after "
+                           "metadata save failure (id_len=" << key_id.size()
+                        << "); manual cleanup may be required" << dendl;
       }
     }
-    if (res != 0) {
-      ldpp_dout(s, 5) << "ERROR: unable to save new key_id on bucket" << dendl;
-      s->err.message = "Server side error - unable to save key_id";
-      return res;
-    }
   }
-  return 0;
+
+  return res;
 }
 
 
@@ -2012,7 +2075,6 @@ int rgw_s3_prepare_encrypt(req_state* s, optional_yield y,
   CryptAttributes crypt_attributes { s };
   const bool is_copy = (s->op_type == RGW_OP_COPY_OBJ);
   crypt_http_responses.clear();
-
   {
     std::string_view req_sse_ca =
         crypt_attributes.get(X_AMZ_SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM);
@@ -2272,7 +2334,8 @@ int rgw_s3_prepare_encrypt(req_state* s, optional_yield y,
         return -EINVAL;
       }
 
-      if (s->cct->_conf->rgw_crypt_sse_s3_backend != "vault") {
+      if (s->cct->_conf->rgw_crypt_sse_s3_backend != RGW_SSE_KMS_BACKEND_VAULT &&
+          s->cct->_conf->rgw_crypt_sse_s3_backend != RGW_SSE_KMS_BACKEND_KMIP) {
         s->err.message = "Request specifies Server Side Encryption "
             "but server configuration does not support this.";
         return -EINVAL;
@@ -2291,6 +2354,10 @@ int rgw_s3_prepare_encrypt(req_state* s, optional_yield y,
         return res;
       }
 
+      std::string key_selector = create_random_key_selector(s->cct);
+      set_attr(attrs, RGW_ATTR_CRYPT_KEYSEL, key_selector);
+      ldpp_dout(s, 10) << "SSE-S3: resolved bucket key id (len=" << key_id.size()
+                       << ")" << dendl;
       set_attr(attrs, RGW_ATTR_CRYPT_CONTEXT, cooked_context);
       set_attr(attrs, RGW_ATTR_CRYPT_KEYID, key_id);
       std::string actual_key;
@@ -2966,34 +3033,55 @@ int rgw_s3_prepare_decrypt(req_state* s, optional_yield y,
 int rgw_remove_sse_s3_bucket_key(req_state *s, optional_yield y)
 {
   int res;
-  auto key_id { expand_key_name(s, s->cct->_conf->rgw_crypt_sse_s3_key_template) };
+  const std::string& backend = s->cct->_conf->rgw_crypt_sse_s3_backend;
   auto saved_key { fetch_bucket_key_id(s) };
-  size_t i;
 
-  if (key_id == cant_expand_key) {
-    ldpp_dout(s, 5) << "ERROR: unable to expand key_id " <<
-      s->cct->_conf->rgw_crypt_sse_s3_key_template << " on bucket" << dendl;
-    s->err.message = "Server side error - unable to expand key_id";
-    return -EINVAL;
+  if (backend == RGW_SSE_KMS_BACKEND_KMIP) {
+    if (saved_key.empty()) {
+      return 0;
+    }
+    ldpp_dout(s, 5) << "KMIP: Removing bucket KEK: " << saved_key.length() << dendl;
+    res = remove_sse_s3_bucket_key(s, saved_key, y);
+    if (res != 0) {
+      ldpp_dout(s, 0) << "ERROR: KMIP failed to remove KEK id_len=" << saved_key.length()
+                      << dendl;
+    }
+    return res;
   }
 
-  if (saved_key == "") {
-    return 0;
-  } else if (saved_key != key_id) {
-    ldpp_dout(s, 5) << "Found but will not delete strange KEK ID: " << saved_key << dendl;
-    return 0;
+  if (backend == RGW_SSE_KMS_BACKEND_VAULT) {
+    size_t i;
+    auto key_id{expand_key_name(s, s->cct->_conf->rgw_crypt_sse_s3_key_template)};
+    if (key_id == cant_expand_key) {
+      ldpp_dout(s, 5) << "ERROR: unable to expand key_id "
+                      << s->cct->_conf->rgw_crypt_sse_s3_key_template
+                      << " on bucket" << dendl;
+      s->err.message = "Server side error - unable to expand key_id";
+      return -EINVAL;
+    }
+
+    if (saved_key == "") {
+      return 0;
+    } else if (saved_key != key_id) {
+      ldpp_dout(s, 5) << "Found but will not delete strange KEK id_len=" << saved_key.length()
+                      << dendl;
+      return 0;
+    }
+    i = s->cct->_conf->rgw_crypt_sse_s3_key_template.find("%bucket_id");
+    if (i == std::string_view::npos) {
+      ldpp_dout(s, 5) << "Kept valid KEK id_len=" << saved_key.length() << dendl;
+      return 0;
+    }
+    ldpp_dout(s, 5) << "Removing valid KEK id_len=" << saved_key.length() << dendl;
+    res = remove_sse_s3_bucket_key(s, saved_key, y);
+    if (res != 0) {
+      ldpp_dout(s, 0) << "ERROR: Unable to remove KEK id_len=" << saved_key.length()
+                      << " got " << res << dendl;
+    }
+    return res;
   }
-  i = s->cct->_conf->rgw_crypt_sse_s3_key_template.find("%bucket_id");
-  if (i == std::string_view::npos) {
-    ldpp_dout(s, 5) << "Kept valid KEK ID: " << saved_key << dendl;
-    return 0;
-  }
-  ldpp_dout(s, 5) << "Removing valid KEK ID: " << saved_key << dendl;
-  res = remove_sse_s3_bucket_key(s, saved_key, y);
-  if (res != 0) {
-    ldpp_dout(s, 0) << "ERROR: Unable to remove KEK ID: " << saved_key << " got " << res << dendl;
-  }
-  return res;
+
+  return 0;
 }
 
 /*********************************************************************

--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -14,6 +14,7 @@
 #include <auth/Crypto.h>
 #include <rgw/rgw_b64.h>
 #include <rgw/rgw_rest_s3.h>
+#include "common/errno.h"
 #include "include/ceph_assert.h"
 #include "include/function2.hpp"
 #include "crypto/crypto_accel.h"
@@ -21,6 +22,7 @@
 #include "rgw/rgw_kms.h"
 #include "rgw_range_projection.h"
 #include "rgw/rgw_process_env.h"
+#include "rgw/rgw_kmip_sse_s3.h"
 #include "rapidjson/document.h"
 #include "rapidjson/writer.h"
 #include "rapidjson/error/error.h"
@@ -1814,48 +1816,109 @@ std::string expand_key_name(req_state *s, const std::string_view&t)
 static int get_sse_s3_bucket_key(req_state *s, optional_yield y,
                                  std::string &key_id)
 {
-  int res;
-  std::string saved_key;
+  int res = 0;
+  std::string saved_key = fetch_bucket_key_id(s);
 
-  key_id = expand_key_name(s, s->cct->_conf->rgw_crypt_sse_s3_key_template);
-
-  if (key_id == cant_expand_key) {
-    ldpp_dout(s, 5) << "ERROR: unable to expand key_id " <<
-      s->cct->_conf->rgw_crypt_sse_s3_key_template << " on bucket" << dendl;
-    s->err.message = "Server side error - unable to expand key_id";
-    return -EINVAL;
+  // Return existing key if metadata is already present
+  if (!saved_key.empty()) {
+    key_id = saved_key;
+    return 0;
   }
 
-  saved_key = fetch_bucket_key_id(s);
-  if (saved_key != "") {
-    ldpp_dout(s, 5) << "Found KEK ID: " << key_id << dendl;
-  }
-  if (saved_key != key_id) {
-    res = create_sse_s3_bucket_key(s, key_id, y);
-    if (res != 0) {
-      return res;
+  const std::string& backend = s->cct->_conf->rgw_crypt_sse_s3_backend;
+  // Expand key name for Vault
+  if (backend == RGW_SSE_KMS_BACKEND_VAULT) {
+    key_id = expand_key_name(s, s->cct->_conf->rgw_crypt_sse_s3_key_template);
+    if (key_id == cant_expand_key) {
+      ldpp_dout(s, 5) << "ERROR: unable to expand key_id template" << dendl;
+      s->err.message = "Server side error - unable to expand key_id";
+      return -EINVAL;
     }
-    bufferlist key_id_bl;
-    key_id_bl.append(key_id.c_str(), key_id.length());
-    for (int count = 0; count < 15; ++count) {
-      rgw::sal::Attrs attrs = s->bucket->get_attrs();
-      attrs[RGW_ATTR_BUCKET_ENCRYPTION_KEY_ID] = key_id_bl;
-      res = s->bucket->merge_and_store_attrs(s, attrs, s->yield);
-      if (res != -ECANCELED) {
-        break;
+  }
+
+  // Create the key on the KMIP/Vault backend
+  // Use bucket UUID to create unique bucket name to avoid bucket name collisions.
+  res = create_sse_s3_bucket_key(s, key_id, y, s->bucket->get_bucket_id());
+  if (res != 0) {
+    ldpp_dout(s, 0) << "ERROR: create_sse_s3_bucket_key failed, res=" << res << dendl;
+    return res;
+  }
+
+  //  Persist the ID to Bucket Attributes (The Link)
+  bufferlist bl;
+  bl.append(key_id);
+
+  // Retry loop for metadata synchronization
+  for (int count = 0; count < 15; ++count) {
+    rgw::sal::Attrs attrs = s->bucket->get_attrs();
+    attrs[RGW_ATTR_BUCKET_ENCRYPTION_KEY_ID] = bl;
+
+    res = s->bucket->merge_and_store_attrs(s, attrs, y);
+    if (res == 0) {
+      ldpp_dout(s, 10) << "Successfully linked KEK ID: " << key_id << dendl;
+      return 0;
+    }
+
+    if (res != -ECANCELED) {
+      ldpp_dout(s, 0) << "ERROR: failed to save bucket attr, res=" << res << dendl;
+      break;
+    }
+
+    // Conflict (ECANCELED): someone else may have committed a KEK while we
+    // were trying. Refresh and check.
+    int r = s->bucket->try_refresh_info(s, nullptr, y);
+    if (r < 0) {
+      ldpp_dout(s, 0) << "ERROR: try_refresh_info() failed: " << dendl;
+      //One quick try before giving up, blips mon/rados blips are usually momentary.
+      r = s->bucket->try_refresh_info(s, nullptr, y);
+    }
+    if (r < 0) {
+      ldpp_dout(s, 0) << "ERROR: try_refresh_info() failed: "
+                    << cpp_strerror(r) << dendl;
+      return r;
+    }
+
+    rgw::sal::Attrs refreshed = s->bucket->get_attrs();
+    auto it = refreshed.find(RGW_ATTR_BUCKET_ENCRYPTION_KEY_ID);
+    if (it != refreshed.end() && it->second.length() > 0) {
+      // Someone else committed a KEK. Destroy our orphan, adopt theirs.
+      std::string winner_id = it->second.to_str();
+      if (winner_id != key_id) {
+        ldpp_dout(s, 5) << "Lost KEK race; destroying our orphan KEK "
+                           "(id_len=" << key_id.length()
+                        << ") and adopting winner (id_len="
+                        << winner_id.length() << ")" << dendl;
+        int cleanup_res = remove_sse_s3_bucket_key(s, key_id, y);
+        if (cleanup_res != 0) {
+          ldpp_dout(s, 0) << "WARN: failed to destroy orphan KEK after losing "
+                             "race (id_len=" << key_id.length()
+                          << "); manual cleanup may be required" << dendl;
+        }
+        key_id = winner_id;
       }
-      res = s->bucket->try_refresh_info(s, nullptr, s->yield);
-      if (res != 0) {
-        break;
+      return 0;
+    }
+
+    // Bucket attr still empty — retry our commit
+    ldpp_dout(s, 5) << "Metadata conflict (ECANCELED), retrying..." << dendl;
+  }
+
+  if (res != 0) {
+    ldpp_dout(s, 0) << "ERROR: unable to save key_id on bucket metadata" << dendl;
+    s->err.message = "Server side error - unable to save key_id";
+    /* The key was created on the backend but we failed to persist its ID.
+     * Best-effort cleanup to avoid orphaning the key on the KMS server. */
+    if (!key_id.empty()) {
+      int cleanup_res = remove_sse_s3_bucket_key(s, key_id, y);
+      if (cleanup_res != 0) {
+        ldpp_dout(s, 0) << "ERROR: failed to clean up orphaned backend key after "
+                           "metadata save failure (id_len=" << key_id.size()
+                        << "); manual cleanup may be required" << dendl;
       }
     }
-    if (res != 0) {
-      ldpp_dout(s, 5) << "ERROR: unable to save new key_id on bucket" << dendl;
-      s->err.message = "Server side error - unable to save key_id";
-      return res;
-    }
   }
-  return 0;
+
+  return res;
 }
 
 
@@ -2023,7 +2086,6 @@ int rgw_s3_prepare_encrypt(req_state* s, optional_yield y,
   CryptAttributes crypt_attributes { s };
   const bool is_copy = (s->op_type == RGW_OP_COPY_OBJ);
   crypt_http_responses.clear();
-
   {
     std::string_view req_sse_ca =
         crypt_attributes.get(X_AMZ_SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM);
@@ -2283,7 +2345,8 @@ int rgw_s3_prepare_encrypt(req_state* s, optional_yield y,
         return -EINVAL;
       }
 
-      if (s->cct->_conf->rgw_crypt_sse_s3_backend != "vault") {
+      if (s->cct->_conf->rgw_crypt_sse_s3_backend != RGW_SSE_KMS_BACKEND_VAULT &&
+          s->cct->_conf->rgw_crypt_sse_s3_backend != RGW_SSE_KMS_BACKEND_KMIP) {
         s->err.message = "Request specifies Server Side Encryption "
             "but server configuration does not support this.";
         return -EINVAL;
@@ -2302,6 +2365,10 @@ int rgw_s3_prepare_encrypt(req_state* s, optional_yield y,
         return res;
       }
 
+      std::string key_selector = create_random_key_selector(s->cct);
+      set_attr(attrs, RGW_ATTR_CRYPT_KEYSEL, key_selector);
+      ldpp_dout(s, 10) << "SSE-S3: resolved bucket key id (len=" << key_id.size()
+                       << ")" << dendl;
       set_attr(attrs, RGW_ATTR_CRYPT_CONTEXT, cooked_context);
       set_attr(attrs, RGW_ATTR_CRYPT_KEYID, key_id);
       std::string actual_key;
@@ -2977,34 +3044,55 @@ int rgw_s3_prepare_decrypt(req_state* s, optional_yield y,
 int rgw_remove_sse_s3_bucket_key(req_state *s, optional_yield y)
 {
   int res;
-  auto key_id { expand_key_name(s, s->cct->_conf->rgw_crypt_sse_s3_key_template) };
+  const std::string& backend = s->cct->_conf->rgw_crypt_sse_s3_backend;
   auto saved_key { fetch_bucket_key_id(s) };
-  size_t i;
 
-  if (key_id == cant_expand_key) {
-    ldpp_dout(s, 5) << "ERROR: unable to expand key_id " <<
-      s->cct->_conf->rgw_crypt_sse_s3_key_template << " on bucket" << dendl;
-    s->err.message = "Server side error - unable to expand key_id";
-    return -EINVAL;
+  if (backend == RGW_SSE_KMS_BACKEND_KMIP) {
+    if (saved_key.empty()) {
+      return 0;
+    }
+    ldpp_dout(s, 5) << "KMIP: Removing bucket KEK: " << saved_key.length() << dendl;
+    res = remove_sse_s3_bucket_key(s, saved_key, y);
+    if (res != 0) {
+      ldpp_dout(s, 0) << "ERROR: KMIP failed to remove KEK id_len=" << saved_key.length()
+                      << dendl;
+    }
+    return res;
   }
 
-  if (saved_key == "") {
-    return 0;
-  } else if (saved_key != key_id) {
-    ldpp_dout(s, 5) << "Found but will not delete strange KEK ID: " << saved_key << dendl;
-    return 0;
+  if (backend == RGW_SSE_KMS_BACKEND_VAULT) {
+    size_t i;
+    auto key_id{expand_key_name(s, s->cct->_conf->rgw_crypt_sse_s3_key_template)};
+    if (key_id == cant_expand_key) {
+      ldpp_dout(s, 5) << "ERROR: unable to expand key_id "
+                      << s->cct->_conf->rgw_crypt_sse_s3_key_template
+                      << " on bucket" << dendl;
+      s->err.message = "Server side error - unable to expand key_id";
+      return -EINVAL;
+    }
+
+    if (saved_key == "") {
+      return 0;
+    } else if (saved_key != key_id) {
+      ldpp_dout(s, 5) << "Found but will not delete strange KEK id_len=" << saved_key.length()
+                      << dendl;
+      return 0;
+    }
+    i = s->cct->_conf->rgw_crypt_sse_s3_key_template.find("%bucket_id");
+    if (i == std::string_view::npos) {
+      ldpp_dout(s, 5) << "Kept valid KEK id_len=" << saved_key.length() << dendl;
+      return 0;
+    }
+    ldpp_dout(s, 5) << "Removing valid KEK id_len=" << saved_key.length() << dendl;
+    res = remove_sse_s3_bucket_key(s, saved_key, y);
+    if (res != 0) {
+      ldpp_dout(s, 0) << "ERROR: Unable to remove KEK id_len=" << saved_key.length()
+                      << " got " << res << dendl;
+    }
+    return res;
   }
-  i = s->cct->_conf->rgw_crypt_sse_s3_key_template.find("%bucket_id");
-  if (i == std::string_view::npos) {
-    ldpp_dout(s, 5) << "Kept valid KEK ID: " << saved_key << dendl;
-    return 0;
-  }
-  ldpp_dout(s, 5) << "Removing valid KEK ID: " << saved_key << dendl;
-  res = remove_sse_s3_bucket_key(s, saved_key, y);
-  if (res != 0) {
-    ldpp_dout(s, 0) << "ERROR: Unable to remove KEK ID: " << saved_key << " got " << res << dendl;
-  }
-  return res;
+
+  return 0;
 }
 
 /*********************************************************************

--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -1884,13 +1884,16 @@ static int get_sse_s3_bucket_key(req_state *s, optional_yield y,
       // Someone else committed a KEK. Destroy our orphan, adopt theirs.
       std::string winner_id = it->second.to_str();
       if (winner_id != key_id) {
-        ldpp_dout(s, 5) << "Lost KEK race; destroying our orphan KEK "
+        int worker_id = -1;
+        int cleanup_res = remove_sse_s3_bucket_key(s, key_id, y, &worker_id);
+        ldpp_dout(s, 5) << "kmip_worker[" << worker_id << "] "
+                        << "Lost KEK race; destroying our orphan KEK "
                            "(id_len=" << key_id.length()
                         << ") and adopting winner (id_len="
                         << winner_id.length() << ")" << dendl;
-        int cleanup_res = remove_sse_s3_bucket_key(s, key_id, y);
         if (cleanup_res != 0) {
-          ldpp_dout(s, 0) << "WARN: failed to destroy orphan KEK after losing "
+          ldpp_dout(s, 0) << "kmip_worker[" << worker_id << "] "
+                          << "WARN: failed to destroy orphan KEK after losing "
                              "race (id_len=" << key_id.length()
                           << "); manual cleanup may be required" << dendl;
         }

--- a/src/rgw/rgw_kmip_client.cc
+++ b/src/rgw/rgw_kmip_client.cc
@@ -7,6 +7,7 @@
 #include "rgw_asio_thread.h"
 #include "rgw_common.h"
 #include "rgw_kmip_client.h"
+#include "rgw_kmip_sse_s3.h"
 
 #include <atomic>
 
@@ -32,7 +33,6 @@ RGWKMIPTransceiver::wait(const DoutPrefixProvider* dpp, optional_yield y)
 
   std::unique_lock l{lock};
   cond.wait(l, [this] { return done.load(std::memory_order_relaxed); });
-
   if (ret) {
     lderr(cct) << "kmip process failed, " << ret << dendl;
   }
@@ -78,6 +78,32 @@ RGWKMIPTransceiver::~RGWKMIPTransceiver()
   }
 }
 
+int
+RGWKMIPManager::execute_fn(const DoutPrefixProvider* dpp,
+                            optional_yield y,
+                            std::function<int(KMIP*, BIO*)> op_fn)
+{
+  /* Virtual-dispatch wrapper for transceivers that need ops more complex
+   * than the legacy fixed-schema path (LOCATE/GET/DESTROY). The op enum
+   * passed to the parent is a placeholder; do_one_entry routes by the
+   * non-zero return from execute(), not by the enum value. */
+  struct LambdaTransceiver : public RGWKMIPTransceiver {
+    std::function<int(KMIP*, BIO*)> op_fn;
+    LambdaTransceiver(CephContext* cct, std::function<int(KMIP*, BIO*)> op_fn)
+      : RGWKMIPTransceiver(cct, ENCRYPT /* placeholder, see comment above */),
+        op_fn(std::move(op_fn)) {}
+    int execute(KMIP* ctx, BIO* bio) override {
+      int r = op_fn(ctx, bio);
+      return (r == 0) ? 1 : r;  // map success (0) to non-zero so do_one_entry takes the custom path
+    }
+  };
+
+  LambdaTransceiver op(cct, std::move(op_fn));
+  int r = add_request(&op);
+  if (r < 0) return r;
+  return op.wait(dpp, y);
+}
+
 void
 rgw_kmip_client_init(RGWKMIPManager &m)
 {
@@ -88,6 +114,12 @@ rgw_kmip_client_init(RGWKMIPManager &m)
 void
 rgw_kmip_client_cleanup()
 {
-  rgw_kmip_manager->stop();
-  delete rgw_kmip_manager;
+  if (rgw_kmip_manager) {
+    rgw_kmip_manager->stop();
+  }
+  cleanup_kmip_sse_s3_backend();
+  if (rgw_kmip_manager) {
+    delete rgw_kmip_manager;
+    rgw_kmip_manager = nullptr;
+  }
 }

--- a/src/rgw/rgw_kmip_client.cc
+++ b/src/rgw/rgw_kmip_client.cc
@@ -81,7 +81,8 @@ RGWKMIPTransceiver::~RGWKMIPTransceiver()
 int
 RGWKMIPManager::execute_fn(const DoutPrefixProvider* dpp,
                             optional_yield y,
-                            std::function<int(KMIP*, BIO*)> op_fn)
+                            std::function<int(KMIP*, BIO*)> op_fn,
+                            int* worker_id_out)
 {
   /* Virtual-dispatch wrapper for transceivers that need ops more complex
    * than the legacy fixed-schema path (LOCATE/GET/DESTROY). The op enum
@@ -101,7 +102,9 @@ RGWKMIPManager::execute_fn(const DoutPrefixProvider* dpp,
   LambdaTransceiver op(cct, std::move(op_fn));
   int r = add_request(&op);
   if (r < 0) return r;
-  return op.wait(dpp, y);
+  int rc = op.wait(dpp, y);
+  if (worker_id_out) *worker_id_out = op.worker_id;
+  return rc;
 }
 
 void

--- a/src/rgw/rgw_kmip_client.cc
+++ b/src/rgw/rgw_kmip_client.cc
@@ -18,15 +18,21 @@ RGWKMIPManager *rgw_kmip_manager;
 int
 RGWKMIPTransceiver::wait(const DoutPrefixProvider* dpp, optional_yield y)
 {
-  if (done)
+  /* done is std::atomic<bool> so this load is safe without the lock.
+   * The worker sets done under the lock before notify_all(), so the acquire
+   * load here pairs with that release store. */
+  if (done.load(std::memory_order_acquire))
     return ret;
 
-  // TODO: when given a coroutine yield context, suspend instead of blocking
+  /* NOTE: optional_yield y is not yet used to yield the coroutine; the
+   * current implementation blocks the calling thread.  A future improvement
+   * should post the KMIP work to the asio executor and co_await the result
+   * via rgw::run_coro(), removing this blocking wait entirely. */
   maybe_warn_about_blocking(dpp);
 
   std::unique_lock l{lock};
-  if (!done)
-    cond.wait(l);
+  cond.wait(l, [this] { return done.load(std::memory_order_relaxed); });
+
   if (ret) {
     lderr(cct) << "kmip process failed, " << ret << dendl;
   }

--- a/src/rgw/rgw_kmip_client.h
+++ b/src/rgw/rgw_kmip_client.h
@@ -1,5 +1,6 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
-// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+#include<atomic>
 
 #pragma once
 
@@ -32,19 +33,18 @@ public:
   } outkey[1] = {0, 0};
   // end must free
   int ret;
-  bool done;
+  std::atomic<bool> done{false};
   ceph::mutex lock = ceph::make_mutex("rgw_kmip_req::lock");
   ceph::condition_variable cond;
 
   int wait(const DoutPrefixProvider* dpp, optional_yield y);
-  RGWKMIPTransceiver(CephContext * const cct,
-    kmip_operation operation)
+  RGWKMIPTransceiver(CephContext * const cct, kmip_operation operation)
   : cct(cct),
     operation(operation),
-    ret(-EDOM),
-    done(false)
+    ret(-EDOM)
   {}
-  ~RGWKMIPTransceiver();
+
+  virtual ~RGWKMIPTransceiver();
 
   int send();
   int process(const DoutPrefixProvider* dpp, optional_yield y);

--- a/src/rgw/rgw_kmip_client.h
+++ b/src/rgw/rgw_kmip_client.h
@@ -1,11 +1,17 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab ft=cpp
-#include<atomic>
 
 #pragma once
 
+#include <atomic>
+#include <functional>
+
 class DoutPrefixProvider;
 class RGWKMIPManager;
+extern "C" {
+#include "kmip.h"
+#include "kmip_bio.h"
+}
 
 class RGWKMIPTransceiver {
 public:
@@ -15,7 +21,9 @@ public:
     GET,
     GET_ATTRIBUTES,
     GET_ATTRIBUTE_LIST,
-    DESTROY
+    DESTROY,
+    ENCRYPT,
+    DECRYPT
   };
   CephContext *cct;
   kmip_operation operation;
@@ -38,16 +46,27 @@ public:
   ceph::condition_variable cond;
 
   int wait(const DoutPrefixProvider* dpp, optional_yield y);
-  RGWKMIPTransceiver(CephContext * const cct, kmip_operation operation)
+  RGWKMIPTransceiver(CephContext * const cct,
+    kmip_operation operation)
   : cct(cct),
     operation(operation),
     ret(-EDOM)
   {}
-
   virtual ~RGWKMIPTransceiver();
 
   int send();
   int process(const DoutPrefixProvider* dpp, optional_yield y);
+  /**
+   * Called by the worker thread with an active KMIP context and BIO.
+   * Return value tristate (checked by do_one_entry):
+   *   0        — not handled; fall through to the legacy batch-request path
+   *   positive — custom handler succeeded (mapped to errno 0 for the caller)
+   *   negative — custom handler failed; errno propagated directly
+   * The default implementation returns 0 (fall through).
+   */
+  virtual int execute(KMIP* ctx, BIO* bio) {
+    return 0;
+  }
 };
 
 class RGWKMIPManager {
@@ -60,7 +79,21 @@ public:
   virtual int start() = 0;
   virtual void stop() = 0;
   virtual int add_request(RGWKMIPTransceiver*) = 0;
+
+  /**
+   * Execute op_fn on a worker thread with a pooled KMIP connection.
+   * op_fn(ctx, bio) must return 0 on success or a negative errno on error.
+   * Blocks the caller until the worker completes (optional_yield is a
+   * hint for a future async implementation).
+   */
+  int execute_fn(const DoutPrefixProvider* dpp,
+                 optional_yield y,
+                 std::function<int(KMIP*, BIO*)> op_fn);
 };
 
+extern RGWKMIPManager *rgw_kmip_manager;
+
+/** Install global KMIP manager and start worker threads (see RGWKMIPManager::start). */
 void rgw_kmip_client_init(RGWKMIPManager &);
+
 void rgw_kmip_client_cleanup();

--- a/src/rgw/rgw_kmip_client.h
+++ b/src/rgw/rgw_kmip_client.h
@@ -41,6 +41,7 @@ public:
   } outkey[1] = {0, 0};
   // end must free
   int ret;
+  int worker_id = -1;  // set by worker that processed this request; -1 if unprocessed
   std::atomic<bool> done{false};
   ceph::mutex lock = ceph::make_mutex("rgw_kmip_req::lock");
   ceph::condition_variable cond;
@@ -88,7 +89,8 @@ public:
    */
   int execute_fn(const DoutPrefixProvider* dpp,
                  optional_yield y,
-                 std::function<int(KMIP*, BIO*)> op_fn);
+                 std::function<int(KMIP*, BIO*)> op_fn,
+                 int* worker_id_out = nullptr);
 };
 
 extern RGWKMIPManager *rgw_kmip_manager;

--- a/src/rgw/rgw_kmip_client_impl.cc
+++ b/src/rgw/rgw_kmip_client_impl.cc
@@ -29,7 +29,7 @@ extern "C" {
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
-static enum kmip_version protocol_version = KMIP_1_0;
+static enum kmip_version protocol_version = KMIP_1_4;
 
 static void kmip_bio_set_socket_io_timeout(BIO *bio, int seconds)
 {
@@ -74,13 +74,8 @@ struct RGWKmipHandle {
 struct RGWKmipWorker: public Thread {
   RGWKMIPManagerImpl &m;
   const int worker_id;
-  RGWKmipWorker(RGWKMIPManagerImpl& m, int wid)
-    : m(m), worker_id(wid) {}
+  RGWKmipWorker(RGWKMIPManagerImpl& m, int wid) : m(m), worker_id(wid) {}
   void *entry() override;
-  void signal() {
-    std::lock_guard l{m.lock};
-    m.cond.notify_all();
-  }
 };
 
 struct RGWKmipWorkerPool {
@@ -94,12 +89,12 @@ RGWKMIPManagerImpl::RGWKMIPManagerImpl(CephContext *cct)
 RGWKMIPManagerImpl::~RGWKMIPManagerImpl() = default;
 
 /*
- * Tear down KMIP + TLS in dependency order:
- * 1) release encode buffer and KMIP context
- * 2) SSL_shutdown (best-effort close_notify) while SSL is still wired to the BIO
- * 3) BIO_free_all frees SSL and closes the TCP fd
- * 4) SSL_CTX last
- */
+* Tear down KMIP + TLS in dependency order:
+* 1) release encode buffer and KMIP context
+* 2) SSL_shutdown (best-effort close_notify) while SSL is still wired to the BIO
+* 3) BIO_free_all frees SSL and closes the TCP fd
+* 4) SSL_CTX last
+*/
 static void
 kmip_free_handle_stuff(RGWKmipHandle *kmip)
 {
@@ -114,7 +109,7 @@ kmip_free_handle_stuff(RGWKmipHandle *kmip)
   if (kmip->ssl) {
     int rc = SSL_shutdown(kmip->ssl);
     if (rc == 0)
-    (void)SSL_shutdown(kmip->ssl);
+      (void)SSL_shutdown(kmip->ssl);
   }
   if (kmip->bio) {
     BIO_free_all(kmip->bio);
@@ -205,7 +200,7 @@ RGWKmipHandleBuilder::build() const
   int failed = 1;
   RGWKmipHandle *r = new RGWKmipHandle();
   TextString *up = 0;
-	size_t ns;
+  size_t ns;
 
   r->ctx = SSL_CTX_new(TLS_client_method());
   if (!r->ctx) {
@@ -240,6 +235,7 @@ RGWKmipHandleBuilder::build() const
     ERR_print_errors_ceph(cct);
     goto Done;
   }
+
   r->bio = BIO_new_ssl_connect(r->ctx);
   if (!r->bio) {
     lderr(cct) << "BIO_new_ssl_connect failed" << dendl;
@@ -259,7 +255,7 @@ RGWKmipHandleBuilder::build() const
 
   {
     int64_t sec = cct->_conf->rgw_crypt_kmip_socket_io_timeout_sec;
-    if (sec <= 0) {
+    if (sec < 0) {
       sec = 0;
     } else if (sec > 300) {
       sec = 300;
@@ -267,23 +263,23 @@ RGWKmipHandleBuilder::build() const
     kmip_bio_set_socket_io_timeout(r->bio, static_cast<int>(sec));
   }
 
-  // setup kmip
 
+  // setup kmip
   kmip_init(r->kmip_ctx, NULL, 0, protocol_version);
-	r->need_to_free_kmip = 1;
-	r->buffer_blocks = 1;
-	r->buffer_block_size = 1024;
-	r->encoding = static_cast<uint8*>(r->kmip_ctx->calloc_func(
+  r->need_to_free_kmip = 1;
+  r->buffer_blocks = 1;
+  r->buffer_block_size = 1024;
+  r->encoding = static_cast<uint8*>(r->kmip_ctx->calloc_func(
     r->kmip_ctx->state, r->buffer_blocks, r->buffer_block_size));
-	if (!r->encoding) {
-		lderr(cct) << "kmip buffer alloc failed: "
+  if (!r->encoding) {
+    lderr(cct) << "kmip buffer alloc failed: "
       << r->buffer_blocks <<
       " * " << r->buffer_block_size << dendl;
-		goto Done;
-	}
-	ns = r->buffer_blocks * r->buffer_block_size;
-	kmip_set_buffer(r->kmip_ctx, r->encoding, ns);
-	r->buffer_total_size = ns;
+    goto Done;
+  }
+  ns = r->buffer_blocks * r->buffer_block_size;
+  kmip_set_buffer(r->kmip_ctx, r->encoding, ns);
+  r->buffer_total_size = ns;
 
   up = r->textstrings;
   if (username) {
@@ -315,137 +311,108 @@ Done:
   return r;
 }
 
-struct RGWKmipHandles : public Thread {
+/*
+* Per-worker persistent KMIP connection.
+*
+* Each KMIP worker thread owns one RGWKmipHandles instance. It caches at most
+* one RGWKmipHandle (TLS connection + libkmip context) so subsequent ops on
+* the same worker can skip the TLS handshake.
+*
+* Since each RGWKmipHandles is only ever accessed by its owning worker
+* thread, no synchronization is required.
+*
+* If the cached connection has been idle longer than MAXIDLE seconds it is
+* dropped on the next get_kmip_handle() call (lazy eviction).
+*/
+struct RGWKmipHandles {
   CephContext *cct;
-  ceph::mutex cleaner_lock = ceph::make_mutex("RGWKmipHandles::cleaner_lock");
-  std::vector<RGWKmipHandle*> saved_kmip;
-  int cleaner_shutdown;
-  bool cleaner_active = false;
-  ceph::condition_variable cleaner_cond;
-  RGWKmipHandles(CephContext *cct) :
-    cct(cct), cleaner_shutdown{0} {
-  }
+  RGWKmipHandle* cached_kmip = nullptr;
+  RGWKmipHandles(CephContext *cct) : cct(cct) {}
+  ~RGWKmipHandles() { flush_kmip_handles(); }
   RGWKmipHandle* get_kmip_handle();
   void release_kmip_handle_now(RGWKmipHandle* kmip);
   void release_kmip_handle(RGWKmipHandle* kmip);
   void flush_kmip_handles();
+  /* Drop the cached connection if it's been idle ≥ MAXIDLE seconds.
+   * Called proactively from the worker's idle loop so the server doesn't
+   * see a half-dead long-lived connection. Lazy-equivalent of the same
+   * check at the top of get_kmip_handle(). */
+  void evict_if_stale();
   int do_one_entry(RGWKMIPTransceiver &element);
-  void* entry();
-  void start();
-  void stop();
 };
+
+#define MAXIDLE 5
+
+void
+RGWKmipHandles::evict_if_stale()
+{
+  if (cached_kmip &&
+    mono_clock::now() - cached_kmip->lastuse >= std::chrono::seconds(MAXIDLE)) {
+    kmip_free_handle_stuff(cached_kmip);
+    delete cached_kmip;
+    cached_kmip = nullptr;
+  }
+}
 
 RGWKmipHandle*
 RGWKmipHandles::get_kmip_handle()
 {
-  RGWKmipHandle* kmip = 0;
+  RGWKmipHandle* kmip = nullptr;
+
+  evict_if_stale();
+
+  if (cached_kmip) {
+    RGWKmipHandle* kmip = cached_kmip;
+    cached_kmip = nullptr;
+    return kmip;
+  }
+
   const char *hostaddr = cct->_conf->rgw_crypt_kmip_addr.c_str();
-  {
-    std::lock_guard lock{cleaner_lock};
-    if (!saved_kmip.empty()) {
-      kmip = *saved_kmip.begin();
-      saved_kmip.erase(saved_kmip.begin());
-    }
+  if (!hostaddr) {
+    return nullptr;
   }
-  if (!kmip && hostaddr) {
-    char *hosttemp = strdup(hostaddr);
-    char *port = strchr(hosttemp, ':');
-    if (port)
-      *port++ = 0;
-    kmip = RGWKmipHandleBuilder{cct}
-      .set_clientcert(cct->_conf->rgw_crypt_kmip_client_cert)
-      .set_clientkey(cct->_conf->rgw_crypt_kmip_client_key)
-      .set_capath(cct->_conf->rgw_crypt_kmip_ca_path)
-      .set_host(hosttemp)
-      .set_portstring(port ? port : "5696")
-      .set_username(cct->_conf->rgw_crypt_kmip_username)
-      .set_password(cct->_conf->rgw_crypt_kmip_password)
-      .build();
+
+  char *hosttemp = strdup(hostaddr);
+  char *port = strchr(hosttemp, ':');
+  if (port)
+    *port++ = 0;
+  kmip = RGWKmipHandleBuilder{cct}
+    .set_clientcert(cct->_conf->rgw_crypt_kmip_client_cert)
+    .set_clientkey(cct->_conf->rgw_crypt_kmip_client_key)
+    .set_capath(cct->_conf->rgw_crypt_kmip_ca_path)
+    .set_host(hosttemp)
+    .set_portstring(port ? port : "5696")
+    .set_username(cct->_conf->rgw_crypt_kmip_username)
+    .set_password(cct->_conf->rgw_crypt_kmip_password)
+    .build();
     free(hosttemp);
-  }
   return kmip;
 }
 
 void
 RGWKmipHandles::release_kmip_handle_now(RGWKmipHandle* kmip)
 {
+  if (!kmip) return;
   kmip_free_handle_stuff(kmip);
   delete kmip;
 }
 
-#define MAXIDLE 5
 void
 RGWKmipHandles::release_kmip_handle(RGWKmipHandle* kmip)
 {
-  if (cleaner_shutdown) {
-    release_kmip_handle_now(kmip);
-  } else {
-    std::lock_guard lock{cleaner_lock};
-    kmip->lastuse = mono_clock::now();
-    saved_kmip.insert(saved_kmip.begin(), 1, kmip);
-  }
-}
-
-void*
-RGWKmipHandles::entry()
-{
-  RGWKmipHandle* kmip;
-  std::unique_lock lock{cleaner_lock};
-
-  for (;;) {
-    if (cleaner_shutdown) {
-      if (saved_kmip.empty())
-	break;
-    } else {
-      cleaner_cond.wait_for(lock, std::chrono::seconds(MAXIDLE));
-    }
-    mono_time now = mono_clock::now();
-    while (!saved_kmip.empty()) {
-      auto cend = saved_kmip.end();
-      --cend;
-      kmip = *cend;
-      if (!cleaner_shutdown && now - kmip->lastuse
-	  < std::chrono::seconds(MAXIDLE))
-	break;
-      saved_kmip.erase(cend);
-      release_kmip_handle_now(kmip);
-    }
-  }
-  return nullptr;
-}
-
-void
-RGWKmipHandles::start()
-{
-  std::lock_guard lock{cleaner_lock};
-  if (!cleaner_active) {
-    cleaner_active = true;
-    this->create("KMIPcleaner");  // len<16!!!
-  }
-}
-
-void
-RGWKmipHandles::stop()
-{
-  std::unique_lock lock{cleaner_lock};
-  cleaner_shutdown = 1;
-  cleaner_cond.notify_all();
-  if (cleaner_active) {
-    lock.unlock();
-    this->join();
-    cleaner_active = false;
-  }
+  if (!kmip) return;
+  kmip->lastuse = mono_clock::now();
+  cached_kmip = kmip;
 }
 
 void
 RGWKmipHandles::flush_kmip_handles()
 {
-  stop();
-  join();
-  if (!saved_kmip.empty()) {
-    ldout(cct, 0) << "ERROR: " << __func__ << " failed final cleanup" << dendl;
+  if (cached_kmip) {
+    kmip_free_handle_stuff(cached_kmip);
+    delete cached_kmip;
+    cached_kmip = nullptr;
   }
-  saved_kmip.shrink_to_fit();
 }
 
 int
@@ -510,6 +477,33 @@ RGWKmipHandles::do_one_entry(RGWKMIPTransceiver &element)
 {
   auto h = get_kmip_handle();
   std::unique_lock l{element.lock};
+
+  if (!h) {
+    element.ret = -ERR_SERVICE_UNAVAILABLE;
+    element.done = true;
+    element.cond.notify_all();
+    return element.ret;
+  }
+
+  int custom = element.execute(h->kmip_ctx, h->bio);
+  if (custom != 0) {
+    // Positive = success, negative = error
+    // Convert positive to 0 for Ceph convention
+    element.ret = (custom > 0) ? 0 : custom;
+    element.done = true;
+    element.cond.notify_all();
+    /* kmip_bio_*_with_context functions allocate and free their own internal
+    * buffer, leaving ctx->buffer == NULL.  Restore the handle's encoding
+    * buffer before returning it to the pool so the next operation can reuse
+    * this TLS connection without a fresh handshake. */
+    kmip_set_buffer(h->kmip_ctx, h->encoding, h->buffer_total_size);
+    if (custom > 0)
+      release_kmip_handle(h);   // success: pool the connection for reuse
+    else
+      release_kmip_handle_now(h); // error: drop it (may be in bad state)
+    return element.ret;
+  }
+
   Attribute a[8], *ap;
   TextString nvalue[1], uvalue[1];
   Name nattr[1];
@@ -539,10 +533,6 @@ RGWKmipHandles::do_one_entry(RGWKMIPTransceiver &element)
   enum result_status rs;
   ResponseBatchItem *req;
 
-  if (!h) {
-    element.ret = -ERR_SERVICE_UNAVAILABLE;
-    return element.ret;
-  }
   memset(a, 0, sizeof *a);
   for (i = 0; i < (int)(sizeof a/sizeof *a); ++i)
     kmip_init_attribute(a+i);
@@ -593,6 +583,11 @@ RGWKmipHandles::do_one_entry(RGWKMIPTransceiver &element)
   kmip_init_request_batch_item(rbi);
   memset(u, 0, sizeof *u);
   rbi->request_payload = u;
+  if (element.operation == RGWKMIPTransceiver::LOCATE) {
+    ldout(cct, 10) << "LOCATE attributes: count=" << (ap - a)
+                  << " name_len="
+                  << (element.name ? strlen(element.name) : 0) << dendl;
+  }
   switch(element.operation) {
   case RGWKMIPTransceiver::CREATE:
     memset(ta, 0, sizeof *ta);
@@ -601,8 +596,18 @@ RGWKmipHandles::do_one_entry(RGWKMIPTransceiver &element)
     u->create_req->object_type = KMIP_OBJTYPE_SYMMETRIC_KEY;
     u->create_req->template_attribute = ta;
     rbi->operation = KMIP_OP_CREATE;
+    //rbi->request_payload = u->create_req;
     what = "create";
     break;
+
+  case RGWKMIPTransceiver::ENCRYPT:
+  case RGWKMIPTransceiver::DECRYPT:
+    /* Custom execute() already ran above; generic batch path is invalid. */
+    lderr(cct) << "KMIP ENCRYPT/DECRYPT reached generic batch path (internal error) op="
+              << element.operation << dendl;
+    element.ret = -EINVAL;
+    goto Done;
+
   case RGWKMIPTransceiver::GET:
     if (element.unique_id)
       u->get_req->unique_identifier = uvalue;
@@ -644,8 +649,8 @@ RGWKmipHandles::do_one_entry(RGWKMIPTransceiver &element)
     h->encoding = static_cast<uint8*>(h->kmip_ctx->calloc_func(h->kmip_ctx->state, h->buffer_blocks, h->buffer_block_size));
     if (!h->encoding) {
       lderr(cct) << "kmip buffer alloc failed: "
-	<< h->buffer_blocks
-	<< " * " << h->buffer_block_size << dendl;
+                << h->buffer_blocks
+                << " * " << h->buffer_block_size << dendl;
       element.ret = -ENOMEM;
       goto Done;
     }
@@ -710,9 +715,9 @@ RGWKmipHandles::do_one_entry(RGWKMIPTransceiver &element)
       LocateResponsePayload *pld = (LocateResponsePayload *)req->response_payload;
       char **list = static_cast<char **>(malloc(sizeof (char*) * (1 + pld->unique_identifiers_count)));
       for (i = 0; i < pld->unique_identifiers_count; ++i) {
-	list[i] = static_cast<char *>(malloc(pld->unique_identifiers[i].size+1));
-	memcpy(list[i], pld->unique_identifiers[i].value, pld->unique_identifiers[i].size);
-	list[i][pld->unique_identifiers[i].size] = 0;
+  list[i] = static_cast<char *>(malloc(pld->unique_identifiers[i].size+1));
+  memcpy(list[i], pld->unique_identifiers[i].value, pld->unique_identifiers[i].size);
+  list[i][pld->unique_identifiers[i].size] = 0;
       }
       list[i] = 0;
       element.outlist->strings = list;
@@ -724,16 +729,16 @@ RGWKmipHandles::do_one_entry(RGWKMIPTransceiver &element)
       memcpy(element.out, pld->unique_identifier->value, pld->unique_identifier->size);
       element.out[pld->unique_identifier->size] = 0;
       if (pld->object_type != KMIP_OBJTYPE_SYMMETRIC_KEY) {
-	lderr(cct) << "get: expected symmetric key got " << pld->object_type << dendl;
-	element.ret = -EINVAL;
-	goto Done;
+  lderr(cct) << "get: expected symmetric key got " << pld->object_type << dendl;
+  element.ret = -EINVAL;
+  goto Done;
       }
       KeyBlock *kp = static_cast<SymmetricKey *>(pld->object)->key_block;
       ByteString *bp;
       if (kp->key_format_type != KMIP_KEYFORMAT_RAW) {
-	lderr(cct) << "get: expected raw key format got  " << kp->key_format_type << dendl;
-	element.ret = -EINVAL;
-	goto Done;
+  lderr(cct) << "get: expected raw key format got  " << kp->key_format_type << dendl;
+  element.ret = -EINVAL;
+  goto Done;
       }
       KeyValue *kv = static_cast<KeyValue *>(kp->key_value);
       bp  = static_cast<ByteString*>(kv->key_material);
@@ -770,7 +775,7 @@ Done:
     kmip_free_response_message(h->kmip_ctx, resp_m);
   element.done = true;
   element.cond.notify_all();
-  release_kmip_handle(h);
+  release_kmip_handle_now(h);
   return element.ret;
 }
 
@@ -780,10 +785,16 @@ RGWKmipWorker::entry()
   std::unique_lock entry_lock{m.lock};
   ldout(m.cct, 10) << "kmip_worker[" << worker_id << "] start" << dendl;
   RGWKmipHandles handles{m.cct};
-  handles.start();
   while (!m.going_down) {
     if (m.requests.empty()) {
       m.cond.wait_for(entry_lock, std::chrono::seconds(MAXIDLE));
+      /* If we woke from the timeout (still no work), proactively drop a
+       * cached TLS connection that's been idle past MAXIDLE.  Lazy eviction
+       * in get_kmip_handle() alone wouldn't fire until a fresh request shows
+       * up, so possibly never, on idle workers. */
+      if (m.requests.empty()) {
+        handles.evict_if_stale();
+      }
       continue;
     }
     auto iter = m.requests.begin();
@@ -794,6 +805,7 @@ RGWKmipWorker::entry()
     entry_lock.unlock();
     (void) handles.do_one_entry(node->details);
     delete node;
+    entry_lock.lock();
   }
   for (;;) {
     if (m.requests.empty()) break;
@@ -807,7 +819,6 @@ RGWKmipWorker::entry()
     node->details.cond.notify_all();
     delete node;
   }
-  handles.stop();
   ldout(m.cct, 10) << "kmip_worker[" << worker_id << "] finish" << dendl;
   return nullptr;
 }

--- a/src/rgw/rgw_kmip_client_impl.cc
+++ b/src/rgw/rgw_kmip_client_impl.cc
@@ -802,6 +802,7 @@ RGWKmipWorker::entry()
     m.requests.erase(iter);
     ldout(m.cct, 10) << "kmip_worker[" << worker_id << "] remaining queue depth "
                     << m.requests.size() << dendl;
+    node->details.worker_id = worker_id;
     entry_lock.unlock();
     (void) handles.do_one_entry(node->details);
     delete node;

--- a/src/rgw/rgw_kmip_client_impl.cc
+++ b/src/rgw/rgw_kmip_client_impl.cc
@@ -3,6 +3,9 @@
 
 #include <boost/intrusive/list.hpp>
 #include <atomic>
+#include <cinttypes>
+#include <cstdio>
+#include <memory>
 #include <mutex>
 #include <string.h>
 
@@ -70,13 +73,25 @@ struct RGWKmipHandle {
 
 struct RGWKmipWorker: public Thread {
   RGWKMIPManagerImpl &m;
-  RGWKmipWorker(RGWKMIPManagerImpl& m) : m(m) {}
+  const int worker_id;
+  RGWKmipWorker(RGWKMIPManagerImpl& m, int wid)
+    : m(m), worker_id(wid) {}
   void *entry() override;
   void signal() {
     std::lock_guard l{m.lock};
     m.cond.notify_all();
   }
 };
+
+struct RGWKmipWorkerPool {
+  std::vector<std::unique_ptr<RGWKmipWorker>> workers;
+};
+
+RGWKMIPManagerImpl::RGWKMIPManagerImpl(CephContext *cct)
+  : RGWKMIPManager(cct),
+    worker_pool(std::make_unique<RGWKmipWorkerPool>()) {}
+
+RGWKMIPManagerImpl::~RGWKMIPManagerImpl() = default;
 
 /*
  * Tear down KMIP + TLS in dependency order:
@@ -244,7 +259,7 @@ RGWKmipHandleBuilder::build() const
 
   {
     int64_t sec = cct->_conf->rgw_crypt_kmip_socket_io_timeout_sec;
-    if (sec < 0) {
+    if (sec <= 0) {
       sec = 0;
     } else if (sec > 300) {
       sec = 300;
@@ -436,40 +451,57 @@ RGWKmipHandles::flush_kmip_handles()
 int
 RGWKMIPManagerImpl::start()
 {
-  if (worker) {
+  auto& workers = worker_pool->workers;
+  if (!workers.empty()) {
     lderr(cct) << "kmip worker already started" << dendl;
     return -1;
   }
-  worker = new RGWKmipWorker(*this);
-  worker->create("kmip worker");
+  int64_t n = cct->_conf->rgw_crypt_kmip_worker_threads;
+  if (n < 1) {
+    n = 1;
+  } else if (n > 32) {
+    n = 32;
+  }
+  workers.reserve(static_cast<size_t>(n));
+  for (int64_t i = 0; i < n; ++i) {
+    char name[16];
+    snprintf(name, sizeof(name), "rgwkmip%" PRId64, i);
+    auto w = std::make_unique<RGWKmipWorker>(*this, (int)i);
+    w->create(name);
+    workers.push_back(std::move(w));
+  }
   return 0;
 }
 
 void
 RGWKMIPManagerImpl::stop()
 {
-  going_down = true;
-  if (worker) {
-    worker->signal();
-    worker->join();
-    delete worker;
-    worker = 0;
+  {
+    std::lock_guard l{lock};
+    going_down = true;
+    cond.notify_all();
   }
+  auto& workers = worker_pool->workers;
+  for (auto& w : workers) {
+    w->join();
+  }
+  workers.clear();
 }
 
 int
 RGWKMIPManagerImpl::add_request(RGWKMIPTransceiver *req)
 {
   std::unique_lock l{lock};
-  if (going_down)
+  if (going_down) {
+    ldout(cct, 10) << "add_request(): going_down=true, rejecting" << dendl;
     return -ECANCELED;
+  }
   // requests is a boost::intrusive::list, which manages pointers and does not copy the instance
   // coverity[leaked_storage:SUPPRESS]
   // coverity[uninit_use_in_call:SUPPRESS]
   requests.push_back(*new Request{*req});
+  cond.notify_one();
   l.unlock();
-  if (worker)
-    worker->signal();
   return 0;
 }
 
@@ -746,7 +778,7 @@ void *
 RGWKmipWorker::entry()
 {
   std::unique_lock entry_lock{m.lock};
-  ldout(m.cct, 10) << __func__ << " start" << dendl;
+  ldout(m.cct, 10) << "kmip_worker[" << worker_id << "] start" << dendl;
   RGWKmipHandles handles{m.cct};
   handles.start();
   while (!m.going_down) {
@@ -755,22 +787,27 @@ RGWKmipWorker::entry()
       continue;
     }
     auto iter = m.requests.begin();
-    auto element = *iter;
+    RGWKMIPManagerImpl::Request *node = &*iter;
     m.requests.erase(iter);
+    ldout(m.cct, 10) << "kmip_worker[" << worker_id << "] remaining queue depth "
+                    << m.requests.size() << dendl;
     entry_lock.unlock();
-    (void) handles.do_one_entry(element.details);
-    entry_lock.lock();
+    (void) handles.do_one_entry(node->details);
+    delete node;
   }
   for (;;) {
     if (m.requests.empty()) break;
     auto iter = m.requests.begin();
-    auto element = std::move(*iter);
+    RGWKMIPManagerImpl::Request *node = &*iter;
+    ldout(m.cct, 10) << "kmip_worker[" << worker_id << "] dispatching op="
+                    << (int)node->details.operation << dendl;
     m.requests.erase(iter);
-    element.details.ret = -666;
-    element.details.done = true;
-    element.details.cond.notify_all();
+    node->details.ret = -ECANCELED;
+    node->details.done = true;
+    node->details.cond.notify_all();
+    delete node;
   }
   handles.stop();
-  ldout(m.cct, 10) << __func__ << " finish" << dendl;
+  ldout(m.cct, 10) << "kmip_worker[" << worker_id << "] finish" << dendl;
   return nullptr;
 }

--- a/src/rgw/rgw_kmip_client_impl.cc
+++ b/src/rgw/rgw_kmip_client_impl.cc
@@ -60,6 +60,13 @@ struct RGWKmipWorker: public Thread {
   }
 };
 
+/*
+ * Tear down KMIP + TLS in dependency order:
+ * 1) release encode buffer and KMIP context
+ * 2) SSL_shutdown (best-effort close_notify) while SSL is still wired to the BIO
+ * 3) BIO_free_all frees SSL and closes the TCP fd
+ * 4) SSL_CTX last
+ */
 static void
 kmip_free_handle_stuff(RGWKmipHandle *kmip)
 {
@@ -71,10 +78,20 @@ kmip_free_handle_stuff(RGWKmipHandle *kmip)
   }
   if (kmip->need_to_free_kmip)
     kmip_destroy(kmip->kmip_ctx);
-  if (kmip->bio)
+  if (kmip->ssl) {
+    int rc = SSL_shutdown(kmip->ssl);
+    if (rc == 0)
+    (void)SSL_shutdown(kmip->ssl);
+  }
+  if (kmip->bio) {
     BIO_free_all(kmip->bio);
-  if (kmip->ctx)
+    kmip->bio = nullptr;
+    kmip->ssl = nullptr;
+  }
+  if (kmip->ctx) {
     SSL_CTX_free(kmip->ctx);
+    kmip->ctx = nullptr;
+  }
 }
 
 class RGWKmipHandleBuilder {
@@ -158,6 +175,10 @@ RGWKmipHandleBuilder::build() const
 	size_t ns;
 
   r->ctx = SSL_CTX_new(TLS_client_method());
+  if (!r->ctx) {
+    lderr(cct) << "SSL_CTX_new failed" << dendl;
+    goto Done;
+  }
 
   if (!clientcert)
     ;
@@ -236,7 +257,7 @@ RGWKmipHandleBuilder::build() const
     r->credential->credential_value = r->upc;
     int i = kmip_add_credential(r->kmip_ctx, r->credential);
     if (i != KMIP_OK) {
-      fprintf(stderr,"failed to add credential to kmip\n");
+      lderr(cct) << "kmip_add_credential failed err=" << i << dendl;
       goto Done;
     }
   }

--- a/src/rgw/rgw_kmip_client_impl.cc
+++ b/src/rgw/rgw_kmip_client_impl.cc
@@ -6,6 +6,9 @@
 #include <mutex>
 #include <string.h>
 
+#include <sys/socket.h>
+#include <sys/time.h>
+
 #include "include/compat.h"
 #include "common/errno.h"
 #include "rgw_common.h"
@@ -24,6 +27,21 @@ extern "C" {
 #define dout_subsys ceph_subsys_rgw
 
 static enum kmip_version protocol_version = KMIP_1_0;
+
+static void kmip_bio_set_socket_io_timeout(BIO *bio, int seconds)
+{
+  if (!bio || seconds <= 0) {
+    return;
+  }
+  const int fd = BIO_get_fd(bio, nullptr);
+  if (fd < 0) {
+    return;
+  }
+  struct timeval tv = {};
+  tv.tv_sec = seconds;
+  (void)setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+  (void)setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+}
 
 struct RGWKmipHandle {
   int uses;
@@ -222,6 +240,16 @@ RGWKmipHandleBuilder::build() const
       << ":" << portstring << dendl;
     ERR_print_errors_ceph(cct);
     goto Done;
+  }
+
+  {
+    int64_t sec = cct->_conf->rgw_crypt_kmip_socket_io_timeout_sec;
+    if (sec < 0) {
+      sec = 0;
+    } else if (sec > 300) {
+      sec = 300;
+    }
+    kmip_bio_set_socket_io_timeout(r->bio, static_cast<int>(sec));
   }
 
   // setup kmip

--- a/src/rgw/rgw_kmip_client_impl.h
+++ b/src/rgw/rgw_kmip_client_impl.h
@@ -1,9 +1,13 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
-// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+#include <boost/intrusive/list.hpp>
+#include <memory>
+#include "common/ceph_mutex.h"
 
 #pragma once
 
 struct RGWKmipWorker;
+struct RGWKmipWorkerPool;
 class RGWKMIPManagerImpl: public RGWKMIPManager {
 protected:
   ceph::mutex lock = ceph::make_mutex("RGWKMIPManager");
@@ -17,10 +21,10 @@ protected:
   boost::intrusive::list<Request, boost::intrusive::member_hook< Request,
   boost::intrusive::list_member_hook<>, &Request::req_hook>> requests;
   bool going_down = false;
-  RGWKmipWorker *worker = 0;
+  std::unique_ptr<RGWKmipWorkerPool> worker_pool;
 public:
-  RGWKMIPManagerImpl(CephContext *cct) : RGWKMIPManager(cct) {};
-  int add_request(RGWKMIPTransceiver *);
+  RGWKMIPManagerImpl(CephContext *cct);
+  ~RGWKMIPManagerImpl() override;  int add_request(RGWKMIPTransceiver *);
   int start();
   void stop();
   friend RGWKmipWorker;

--- a/src/rgw/rgw_kmip_sse_s3.cc
+++ b/src/rgw/rgw_kmip_sse_s3.cc
@@ -196,7 +196,8 @@ int RGWKmipSSES3::create_bucket_key(const DoutPrefixProvider* dpp,
 
 int RGWKmipSSES3::destroy_bucket_key(const DoutPrefixProvider* dpp,
                                       const std::string& kek_id,
-                                      optional_yield y) {
+                                      optional_yield y,
+                                      int* worker_id_out) {
   const DoutPrefix dp(dpp->get_cct(), dout_subsys, "KMIP SSE-S3: ");
   if (!rgw_kmip_manager) {
     ldpp_dout(&dp, 0) << "ERROR: KMIP manager not available for destroy" << dendl;
@@ -227,7 +228,7 @@ int RGWKmipSSES3::destroy_bucket_key(const DoutPrefixProvider* dpp,
     return 0;
   };
 
-  int ret = rgw_kmip_manager->execute_fn(dpp, y, destroy_kek_op);
+  int ret = rgw_kmip_manager->execute_fn(dpp, y, destroy_kek_op, worker_id_out);
 
   if (ret < 0) {
     ldpp_dout(&dp, 0) << "ERROR: destroy KEK failed: " << cpp_strerror(ret) << dendl;

--- a/src/rgw/rgw_kmip_sse_s3.cc
+++ b/src/rgw/rgw_kmip_sse_s3.cc
@@ -1,0 +1,472 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+#include "rgw_kmip_sse_s3.h"
+#include "rgw_kmip_client_impl.h"
+#include "common/errno.h"
+#include "common/async/yield_context.h"
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+#include <openssl/rand.h>
+#include <new>
+
+extern "C" {
+#include "kmip.h"
+#include "kmip_bio.h"
+}
+
+#include "include/buffer.h"
+#include "include/encoding.h"
+
+#define dout_subsys ceph_subsys_rgw
+
+// AES-256 key: 32 bytes / 256 bits. DEKs and KEK-wrapped outputs must match.
+static constexpr int KMIP_DEK_SIZE = 32;
+static RGWKmipSSES3* g_kmip_sse_s3_backend = nullptr;
+static ceph::mutex g_kmip_sse_s3_lock = ceph::make_mutex("kmip_sse_s3");
+
+namespace {
+struct wrapped_dek {
+  ceph::buffer::list iv;
+  ceph::buffer::list tag;
+  ceph::buffer::list ciphertext;
+
+  void encode(ceph::buffer::list& bl) const {
+    ENCODE_START(1, 1, bl);
+    using ceph::encode;
+    encode(iv, bl);
+    encode(tag, bl);
+    encode(ciphertext, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(ceph::buffer::list::const_iterator& p) {
+    DECODE_START(1, p);
+    using ceph::decode;
+    decode(iv, p);
+    decode(tag, p);
+    decode(ciphertext, p);
+    DECODE_FINISH(p);
+  }
+};
+WRITE_CLASS_ENCODER(wrapped_dek)
+} // namespace
+
+RGWKmipSSES3::RGWKmipSSES3(CephContext* cct)
+  : cct(cct) {
+}
+
+int RGWKmipSSES3::initialize() {
+  const DoutPrefix dp(cct, dout_subsys, "KMIP SSE-S3: ");
+  if (rgw_kmip_manager) {
+    ldpp_dout(&dp, 10) << "reusing global KMIP manager" << dendl;
+    return 0;
+  }
+
+  rgw_kmip_manager = new (std::nothrow) RGWKMIPManagerImpl(cct);
+  if (!rgw_kmip_manager) {
+    ldpp_dout(&dp, 0) << "ERROR: failed to create KMIP manager (alloc)" << dendl;
+    return -ENOMEM;
+  }
+
+  int ret = rgw_kmip_manager->start();
+  if (ret < 0) {
+    ldpp_dout(&dp, 0) << "ERROR: failed to start KMIP manager: "
+                      << cpp_strerror(ret) << dendl;
+    delete rgw_kmip_manager;
+    rgw_kmip_manager = nullptr;
+    return ret;
+  }
+
+  ldpp_dout(&dp, 10) << "backend initialized standalone KMIP manager" << dendl;
+  return 0;
+}
+
+int RGWKmipSSES3::create_bucket_key(const DoutPrefixProvider* dpp,
+                                     const std::string& bucket_id,
+                                     std::string& kek_id_out,
+                                     optional_yield y) {
+  const DoutPrefix dp(dpp->get_cct(), dout_subsys, "KMIP SSE-S3: ");
+  if (!rgw_kmip_manager) {
+    ldpp_dout(&dp, 0) << "ERROR: KMIP manager not available" << dendl;
+    return -EINVAL;
+  }
+
+  const std::string key_template = "rgw-kek-" + bucket_id;
+
+  auto create_kek_op = [&](KMIP* ctx, BIO* bio) -> int {
+    ERR_clear_error();
+    /* Pooled KMIP ctx is owned by the handle; reset per op (kmip_init would tear down credentials). */
+    kmip_reset(ctx);
+
+    Attribute name_attr;
+    memset(&name_attr, 0, sizeof(name_attr));
+    name_attr.type = KMIP_ATTR_NAME;
+
+    // libkmip Name struct: heap-allocated so libkmip can reference them during encoding.
+    Name* name_val = (Name*)ctx->calloc_func(ctx->state, 1, sizeof(Name));
+    text_string* ts = (text_string*)ctx->calloc_func(ctx->state, 1, sizeof(text_string));
+    if (!name_val || !ts) {
+      if (ts)       ctx->free_func(ctx->state, ts);
+      if (name_val) ctx->free_func(ctx->state, name_val);
+      return -ENOMEM;
+    }
+    ts->value = const_cast<char*>(key_template.c_str());
+    ts->size = key_template.length();
+
+    name_val->value = ts;
+    name_val->type = KMIP_NAME_UNINTERPRETED_TEXT_STRING;
+    name_attr.value = name_val;
+
+    TemplateAttribute template_attr = {0};
+    Attribute attrs[4];
+    memset(attrs, 0, sizeof(attrs));
+
+    attrs[0] = name_attr;
+
+    attrs[1].type = KMIP_ATTR_CRYPTOGRAPHIC_ALGORITHM;
+    attrs[1].value = ctx->calloc_func(ctx->state, 1, sizeof(int32));
+    attrs[2].type = KMIP_ATTR_CRYPTOGRAPHIC_LENGTH;
+    attrs[2].value = ctx->calloc_func(ctx->state, 1, sizeof(int32));
+    attrs[3].type = KMIP_ATTR_CRYPTOGRAPHIC_USAGE_MASK;
+    attrs[3].value = ctx->calloc_func(ctx->state, 1, sizeof(int32));
+
+    if (!attrs[1].value || !attrs[2].value || !attrs[3].value) {
+      ctx->free_func(ctx->state, ts);
+      ctx->free_func(ctx->state, name_val);
+      for (int i = 1; i < 4; i++) {
+        if (attrs[i].value) ctx->free_func(ctx->state, attrs[i].value);
+      }
+      return -ENOMEM;
+    }
+    *(int32*)attrs[1].value = KMIP_CRYPTOALG_AES;
+    *(int32*)attrs[2].value = 256;
+    *(int32*)attrs[3].value = KMIP_CRYPTOMASK_ENCRYPT | KMIP_CRYPTOMASK_DECRYPT;
+
+    template_attr.attributes = attrs;
+    template_attr.attribute_count = 4;
+
+    char* key_id = nullptr;
+    int key_id_size = 0;
+    int r = kmip_bio_create_symmetric_key_with_context(ctx, bio, &template_attr, &key_id, &key_id_size);
+
+    // attrs[0].value (name_val, ts) freed separately; attrs[1-3] freed in loop.
+    ctx->free_func(ctx->state, ts);
+    ctx->free_func(ctx->state, name_val);
+    for (int i = 1; i < 4; i++) {
+      if (attrs[i].value) ctx->free_func(ctx->state, attrs[i].value);
+    }
+
+    if (r != KMIP_OK || !key_id) {
+      ldpp_dout(&dp, 5) << "create failed: " << r << dendl;
+      ERR_clear_error();
+      return -EIO;
+    }
+
+    kek_id_out = std::string(key_id, key_id_size);
+    ldpp_dout(&dp, 10) << "created key id_len=" << kek_id_out.length() << dendl;
+
+    r = kmip_bio_activate_with_context(ctx, bio, key_id);
+    if (r != KMIP_OK) {
+      ldpp_dout(&dp, 0) << "activate failed id_len=" << kek_id_out.length()
+                        << ", destroying orphaned key" << dendl;
+      kmip_bio_destroy_symmetric_key_with_context(ctx, bio,
+        const_cast<char*>(kek_id_out.c_str()), kek_id_out.length());
+      ctx->free_func(ctx->state, key_id);
+      ERR_clear_error();
+      kek_id_out.clear();
+      return -EIO;
+    }
+    ctx->free_func(ctx->state, key_id);
+    return 0;
+  };
+
+  int ret = rgw_kmip_manager->execute_fn(dpp, y, create_kek_op);
+
+  if (ret < 0) {
+    ldpp_dout(&dp, 0) << "ERROR: create KEK failed" << dendl;
+    return ret;
+  }
+
+  ldpp_dout(&dp, 10) << "created and activated KEK id_len=" << kek_id_out.length()
+                     << dendl;
+  return 0;
+}
+
+
+int RGWKmipSSES3::destroy_bucket_key(const DoutPrefixProvider* dpp,
+                                      const std::string& kek_id,
+                                      optional_yield y) {
+  const DoutPrefix dp(dpp->get_cct(), dout_subsys, "KMIP SSE-S3: ");
+  if (!rgw_kmip_manager) {
+    ldpp_dout(&dp, 0) << "ERROR: KMIP manager not available for destroy" << dendl;
+    return -EINVAL;
+  }
+
+  auto destroy_kek_op = [&](KMIP* ctx, BIO* bio) -> int {
+    char* id_ptr = const_cast<char*>(kek_id.c_str());
+    int id_len = kek_id.length();
+
+    kmip_reset(ctx);
+    ERR_clear_error();
+
+    int revoke_res = kmip_bio_revoke_with_context(
+        ctx, bio, id_ptr, id_len, KMIP_REVOCATION_CESSATION_OF_OPERATION);
+    if (revoke_res != 0) {
+      ldpp_dout(&dp, 0) << "revoke KEK id_len=" << kek_id.length()
+                        << " returned " << revoke_res
+                        << " (proceeding to destroy)" << dendl;
+      ERR_clear_error();
+    }
+    int destroy_res = kmip_bio_destroy_symmetric_key_with_context(ctx, bio, id_ptr, id_len);
+    if (destroy_res != 0) {
+      ldpp_dout(&dp, 0) << "ERROR: destroy failed: " << destroy_res << dendl;
+      ERR_clear_error();
+      return -EIO;
+    }
+    return 0;
+  };
+
+  int ret = rgw_kmip_manager->execute_fn(dpp, y, destroy_kek_op);
+
+  if (ret < 0) {
+    ldpp_dout(&dp, 0) << "ERROR: destroy KEK failed: " << cpp_strerror(ret) << dendl;
+  } else {
+    ldpp_dout(&dp, 10) << "successfully destroyed KEK id_len=" << kek_id.length()
+                       << dendl;
+  }
+  return ret;
+}
+
+
+int RGWKmipSSES3::generate_and_wrap_dek(const DoutPrefixProvider* dpp,
+                                         const std::string& kek_id,
+                                         const std::string& encryption_context,
+                                         bufferlist& plaintext_dek_out,
+                                         bufferlist& wrapped_dek_out,
+                                         optional_yield y) {
+  const DoutPrefix dp(dpp->get_cct(), dout_subsys, "KMIP SSE-S3: ");
+  if (!rgw_kmip_manager) {
+    ldpp_dout(&dp, 0) << "ERROR: KMIP manager not available for wrap" << dendl;
+    return -EINVAL;
+  }
+
+  // Generate random DEK
+  unsigned char dek[KMIP_DEK_SIZE];
+  if (RAND_bytes(dek, KMIP_DEK_SIZE) != 1) {
+    ldpp_dout(&dp, 0) << "ERROR: failed to generate DEK" << dendl;
+    return -EIO;
+  }
+
+  plaintext_dek_out.clear();
+
+  /* Strip trailing NULL if callers pass null-terminated strings as std::string.
+   * AAD must be identical at wrap and unwrap time; stripping here ensures
+   * consistent behaviour if the caller is inconsistent. */
+  std::string aad = encryption_context;
+  if (!aad.empty() && aad.back() == '\0') {
+    aad.pop_back();
+  }
+
+  auto wrap_dek_op = [&](KMIP* ctx, BIO* bio) -> int {
+    wrapped_dek_out.clear();
+    /* kmip_bio_encrypt_with_context resets ctx at entry */
+
+    /* Zeroize a KMIP-allocated buffer and free it back to the KMIP allocator. */
+    auto kmip_zeroize_free = [ctx](uint8_t* buf, int sz) {
+      if (buf) {
+        ::ceph::crypto::zeroize_for_security(buf, sz);
+        ctx->free_func(ctx->state, buf);
+      }
+    };
+
+    CryptographicParameters params;
+    memset(&params, 0, sizeof(params));
+    kmip_init_cryptographic_parameters(&params);
+    params.cryptographic_algorithm = KMIP_CRYPTOALG_AES;
+    params.block_cipher_mode = KMIP_BLOCK_GCM;
+    params.padding_method = KMIP_PAD_NONE;
+    params.random_iv = KMIP_TRUE;
+    params.tag_length = 16;
+    const uint8_t* aad_ptr = reinterpret_cast<const uint8_t*>(aad.c_str());
+    int aad_len = static_cast<int>(aad.length());
+
+    uint8_t* ciphertext = NULL;
+    int ciphertext_size = 0;
+    uint8_t* iv = NULL;
+    int iv_size = 0;
+    uint8_t* tag = NULL;
+    int tag_size = 0;
+
+    int r = kmip_bio_encrypt_with_context(
+        ctx, bio,
+        const_cast<char*>(kek_id.c_str()), (int)kek_id.length(),
+        const_cast<uint8_t*>(dek), KMIP_DEK_SIZE,
+        const_cast<uint8_t*>(aad_ptr), aad_len,
+        &params,
+        &ciphertext, &ciphertext_size,
+        &iv, &iv_size,
+        &tag, &tag_size
+    );
+
+    if (r != KMIP_OK) {
+      ldpp_dout(&dp, 0) << "ERROR: encrypt failed: " << r << dendl;
+      kmip_zeroize_free(ciphertext, ciphertext_size);
+      kmip_zeroize_free(iv, iv_size);
+      kmip_zeroize_free(tag, tag_size);
+      return -EIO;
+    }
+
+    wrapped_dek wd;
+    wd.iv.append((char*)iv, iv_size);
+    wd.tag.append((char*)tag, tag_size);
+    wd.ciphertext.append((char*)ciphertext, ciphertext_size);
+    using ceph::encode;
+    encode(wd, wrapped_dek_out);
+
+    kmip_zeroize_free(ciphertext, ciphertext_size);
+    kmip_zeroize_free(iv, iv_size);
+    kmip_zeroize_free(tag, tag_size);
+
+    ldpp_dout(&dp, 10) << "encrypt succeeded, wrapped_dek="
+                       << wrapped_dek_out.length() << " bytes" << dendl;
+    return 0;
+  };
+
+  int ret = rgw_kmip_manager->execute_fn(dpp, y, wrap_dek_op);
+
+  if (ret < 0) {
+    explicit_bzero(dek, KMIP_DEK_SIZE);
+    ldpp_dout(&dp, 0) << "ERROR: wrap DEK failed" << dendl;
+    return ret;
+  }
+
+  plaintext_dek_out.append((char*)dek, KMIP_DEK_SIZE);
+  explicit_bzero(dek, KMIP_DEK_SIZE);
+
+  ldpp_dout(&dp, 10) << "wrapped DEK, size=" << wrapped_dek_out.length() << dendl;
+  return 0;
+}
+
+int RGWKmipSSES3::unwrap_dek(const DoutPrefixProvider* dpp,
+                              const std::string& kek_id,
+                              const bufferlist& wrapped_dek,
+                              const std::string& encryption_context,
+                              bufferlist& plaintext_dek_out,
+                              optional_yield y) {
+  const DoutPrefix dp(dpp->get_cct(), dout_subsys, "KMIP SSE-S3: ");
+  if (!rgw_kmip_manager) {
+    ldpp_dout(&dp, 0) << "ERROR: KMIP manager not available for unwrap" << dendl;
+    return -EINVAL;
+  }
+
+  struct wrapped_dek wd;
+  try {
+    using ceph::decode;
+    auto p = wrapped_dek.cbegin();
+    decode(wd, p);
+  } catch (const ceph::buffer::error& e) {
+    ldpp_dout(&dp, 0) << "ERROR: failed to decode wrapped DEK: " << e.what()
+                      << dendl;
+    return -EINVAL;
+  }
+  if (wd.tag.length() != 16 || wd.iv.length() == 0 ||
+      wd.ciphertext.length() == 0) {
+    ldpp_dout(&dp, 0) << "ERROR: invalid wrapped DEK layout"
+                      << " iv=" << wd.iv.length()
+                      << " tag=" << wd.tag.length()
+                      << " ct=" << wd.ciphertext.length() << dendl;
+    return -EINVAL;
+  }
+
+  auto unwrap_dek_op = [&](KMIP* ctx, BIO* bio) -> int {
+    plaintext_dek_out.clear();
+
+    CryptographicParameters params;
+    memset(&params, 0, sizeof(params));
+    kmip_init_cryptographic_parameters(&params);
+    params.cryptographic_algorithm = KMIP_CRYPTOALG_AES;
+    params.block_cipher_mode = KMIP_BLOCK_GCM;
+    params.padding_method = KMIP_PAD_NONE;
+    params.tag_length = 16;
+    /* Strip trailing NUL — must match generate_and_wrap_dek's AAD exactly,
+     * otherwise AES-GCM authentication will fail on decrypt. */
+    std::string aad = encryption_context;
+    if (!aad.empty() && aad.back() == '\0') {
+      aad.pop_back();
+    }
+
+    uint8_t* plaintext = nullptr;
+    int32_t plaintext_size = 0;
+
+    int r = kmip_bio_decrypt_with_context(
+      ctx, bio,
+      const_cast<char*>(kek_id.c_str()), (int)kek_id.length(),
+      reinterpret_cast<uint8_t*>(wd.ciphertext.c_str()),
+      static_cast<int>(wd.ciphertext.length()),
+      reinterpret_cast<uint8_t*>(aad.data()),
+      static_cast<int>(aad.length()),
+      reinterpret_cast<uint8_t*>(wd.iv.c_str()),
+      static_cast<int>(wd.iv.length()),
+      reinterpret_cast<uint8_t*>(wd.tag.c_str()),
+      static_cast<int>(wd.tag.length()),
+      &params,
+      &plaintext, &plaintext_size
+    );
+
+    if (r != KMIP_OK || plaintext_size != KMIP_DEK_SIZE) {
+      ldpp_dout(&dp, 0) << "ERROR: decrypt failed: ret=" << r
+                        << " plaintext_size=" << plaintext_size << dendl;
+      if (plaintext) {
+        ::ceph::crypto::zeroize_for_security(plaintext, plaintext_size);
+        ctx->free_func(ctx->state, plaintext);
+      }
+      return -EIO;
+    }
+
+    plaintext_dek_out.append(reinterpret_cast<char*>(plaintext), KMIP_DEK_SIZE);
+    ::ceph::crypto::zeroize_for_security(plaintext, plaintext_size);
+    ctx->free_func(ctx->state, plaintext);
+    return 0;
+  };
+
+  int ret = rgw_kmip_manager->execute_fn(dpp, y, unwrap_dek_op);
+
+  if (ret < 0) {
+    ldpp_dout(&dp, 0) << "ERROR: unwrap DEK failed: " << cpp_strerror(ret) << dendl;
+    return ret;
+  }
+
+  ldpp_dout(&dp, 10) << "successfully unwrapped DEK ("
+                      << plaintext_dek_out.length() << " bytes)" << dendl;
+  return 0;
+}
+
+RGWKmipSSES3* get_kmip_sse_s3_backend(CephContext* cct) {
+  const DoutPrefix dp(cct, dout_subsys, "KMIP SSE-S3: ");
+  std::unique_lock l{g_kmip_sse_s3_lock};
+
+  if (!g_kmip_sse_s3_backend) {
+    g_kmip_sse_s3_backend = new (std::nothrow) RGWKmipSSES3(cct);
+    if (!g_kmip_sse_s3_backend) {
+      ldpp_dout(&dp, 0) << "ERROR: failed to allocate backend" << dendl;
+      return nullptr;
+    }
+    int ret = g_kmip_sse_s3_backend->initialize();
+    if (ret < 0) {
+      ldpp_dout(&dp, 0) << "ERROR: failed to initialize backend" << dendl;
+      delete g_kmip_sse_s3_backend;
+      g_kmip_sse_s3_backend = nullptr;
+    }
+  }
+  return g_kmip_sse_s3_backend;
+}
+
+void cleanup_kmip_sse_s3_backend()
+{
+  std::unique_lock l{g_kmip_sse_s3_lock};
+  if (g_kmip_sse_s3_backend) {
+    delete g_kmip_sse_s3_backend;
+    g_kmip_sse_s3_backend = nullptr;
+  }
+}

--- a/src/rgw/rgw_kmip_sse_s3.h
+++ b/src/rgw/rgw_kmip_sse_s3.h
@@ -36,7 +36,8 @@ public:
 
   int destroy_bucket_key(const DoutPrefixProvider* dpp,
                          const std::string& kek_id,
-                         optional_yield y);
+                         optional_yield y,
+                         int* worker_id_out = nullptr);
 
   int generate_and_wrap_dek(const DoutPrefixProvider* dpp,
                             const std::string& kek_id,

--- a/src/rgw/rgw_kmip_sse_s3.h
+++ b/src/rgw/rgw_kmip_sse_s3.h
@@ -1,0 +1,58 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+#pragma once
+
+#include "rgw_common.h"
+#include "rgw_kmip_client.h"
+#include "include/buffer.h"
+
+/**
+ * KMIP Backend for SSE-S3 Encryption
+ *
+ * Contract (RGW-facing, independent of transport threading):
+ * - Bucket-level KEK stored in KMIP; id returned to RGW for attrs / config.
+ * - Per-object DEK generated in RGW; wrap/unwrap via KMIP Encrypt/Decrypt.
+ *
+ * Implements KEK/DEK pattern:
+ * - Bucket-level KEK stored in KMIP server
+ * - Per-object DEK generated in RGW
+ * - DEK wrapped/unwrapped using KMIP Encrypt/Decrypt operations
+ */
+class RGWKmipSSES3 {
+private:
+  CephContext* cct;
+
+public:
+  RGWKmipSSES3(CephContext* cct);
+  ~RGWKmipSSES3() = default;
+
+  int initialize();
+
+  int create_bucket_key(const DoutPrefixProvider* dpp,
+                        const std::string& bucket_name,
+                        std::string& kek_id_out,
+                        optional_yield y);
+
+  int destroy_bucket_key(const DoutPrefixProvider* dpp,
+                         const std::string& kek_id,
+                         optional_yield y);
+
+  int generate_and_wrap_dek(const DoutPrefixProvider* dpp,
+                            const std::string& kek_id,
+                            const std::string& encryption_context,
+                            bufferlist& plaintext_dek_out,
+                            bufferlist& wrapped_dek_out,
+                            optional_yield y);
+
+  int unwrap_dek(const DoutPrefixProvider* dpp,
+                 const std::string& kek_id,
+                 const bufferlist& wrapped_dek,
+                 const std::string& encryption_context,
+                 bufferlist& plaintext_dek_out,
+                 optional_yield y);
+};
+
+RGWKmipSSES3* get_kmip_sse_s3_backend(CephContext* cct);
+
+void cleanup_kmip_sse_s3_backend();

--- a/src/rgw/rgw_kms.cc
+++ b/src/rgw/rgw_kms.cc
@@ -1430,12 +1430,13 @@ int create_sse_s3_bucket_key(const DoutPrefixProvider *dpp,
 
 int remove_sse_s3_bucket_key(const DoutPrefixProvider *dpp,
                              const std::string& bucket_key,
-                             optional_yield y)
+                             optional_yield y,
+                             int* worker_id_out)
 {
   CephContext* cct = dpp->get_cct();
   SseS3Context kctx { cct };
   const std::string kms_backend { kctx.backend() };
-  
+
   if (kms_backend == RGW_SSE_KMS_BACKEND_KMIP) {
     RGWKmipSSES3* kmip_backend = get_kmip_sse_s3_backend(cct);
     if (!kmip_backend) {
@@ -1443,7 +1444,7 @@ int remove_sse_s3_bucket_key(const DoutPrefixProvider *dpp,
       return -EIO;
     }
 
-    return kmip_backend->destroy_bucket_key(dpp, bucket_key, y);
+    return kmip_backend->destroy_bucket_key(dpp, bucket_key, y, worker_id_out);
   }
 
   if (kms_backend == RGW_SSE_KMS_BACKEND_VAULT) {

--- a/src/rgw/rgw_kms.cc
+++ b/src/rgw/rgw_kms.cc
@@ -22,6 +22,7 @@
 #include "rapidjson/error/error.h"
 #include "rapidjson/error/en.h"
 #include <regex>
+#include "rgw_kmip_sse_s3.h"
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
@@ -1075,6 +1076,34 @@ static int make_actual_key_from_vault(const DoutPrefixProvider *dpp,
   return get_actual_key_from_vault(dpp, kctx, attrs, y, actual_key, true);
 }
 
+static int make_actual_key_from_kmip(const DoutPrefixProvider *dpp,
+                                     SSEContext & kctx,
+                                     map<string, bufferlist>& attrs,
+                                     optional_yield y,
+                                     std::string& actual_key)
+{
+  CephContext* cct = dpp->get_cct();
+  RGWKmipSSES3* kmip_backend = get_kmip_sse_s3_backend(cct);
+  if (!kmip_backend) {
+    ldpp_dout(dpp, 0) << "ERROR: KMIP backend not available" << dendl;
+    return -EIO;
+  }
+
+  std::string kek_id = get_str_attribute(attrs, RGW_ATTR_CRYPT_KEYID);
+  bufferlist unwrapped_dek_bl;
+  bufferlist wrapped_dek_bl;
+  std::string encryption_context = get_str_attribute(attrs, RGW_ATTR_CRYPT_CONTEXT);
+
+  int r = kmip_backend->generate_and_wrap_dek(dpp, kek_id, encryption_context, unwrapped_dek_bl, wrapped_dek_bl, y);
+  if (r < 0) return r;
+
+  if (wrapped_dek_bl.length() == 0)
+    return -EIO;
+
+  attrs[RGW_ATTR_CRYPT_DATAKEY] = wrapped_dek_bl;
+  actual_key = unwrapped_dek_bl.to_str();
+  return 0;
+}
 
 static int reconstitute_actual_key_from_vault(const DoutPrefixProvider *dpp,
                                               SSEContext & kctx,
@@ -1085,22 +1114,46 @@ static int reconstitute_actual_key_from_vault(const DoutPrefixProvider *dpp,
   return get_actual_key_from_vault(dpp, kctx, attrs, y, actual_key, false);
 }
 
+static int reconstitute_actual_key_from_kmip(const DoutPrefixProvider *dpp,
+                                              SSEContext & kctx,
+                                              map<string, bufferlist>& attrs,
+                                              optional_yield y,
+                                              std::string& actual_key)
+{
+  CephContext* cct = dpp->get_cct();
+  RGWKmipSSES3* kmip_backend = get_kmip_sse_s3_backend(cct);
+
+  if (!kmip_backend) {
+    ldpp_dout(dpp, 0) << "ERROR: KMIP backend not available" << dendl;
+    return -EIO;
+  }
+
+  std::string kek_id = get_str_attribute(attrs, RGW_ATTR_CRYPT_KEYID);
+
+  auto it = attrs.find(RGW_ATTR_CRYPT_DATAKEY);
+  if (it == attrs.end() || it->second.length() == 0) {
+    ldpp_dout(dpp, 0) << "ERROR: missing or empty wrapped DEK" << dendl;
+    return -EIO;
+  }
+  const bufferlist& dek_bl = it->second;
+
+  std::string encryption_context = get_str_attribute(attrs, RGW_ATTR_CRYPT_CONTEXT);
+  bufferlist unwrapped_dek_bl;
+
+  int r = kmip_backend->unwrap_dek(dpp, kek_id, dek_bl, encryption_context, unwrapped_dek_bl, y);
+  if (r < 0) return r;
+
+  actual_key.assign(unwrapped_dek_bl.c_str(), unwrapped_dek_bl.length());
+  return 0;
+}
 
 static int get_actual_key_from_kmip(const DoutPrefixProvider *dpp,
                                     std::string_view key_id,
                                     optional_yield y,
                                     std::string& actual_key)
 {
-  std::string secret_engine = RGW_SSE_KMS_KMIP_SE_KV;
-
-  if (RGW_SSE_KMS_KMIP_SE_KV == secret_engine){
-    KmipSecretEngine engine(dpp->get_cct());
-    return engine.get_key(dpp, key_id, y, actual_key);
-  }
-  else{
-    ldpp_dout(dpp, 0) << "Missing or invalid secret engine" << dendl;
-    return -EINVAL;
-  }
+  KmipSecretEngine engine(dpp->get_cct());
+  return engine.get_key(dpp, key_id, y, actual_key);
 }
 class KMSContext : public SSEContext {
   CephContext *cct;
@@ -1294,6 +1347,9 @@ int reconstitute_actual_key_from_sse_s3(const DoutPrefixProvider *dpp,
   if (RGW_SSE_KMS_BACKEND_VAULT == kms_backend) {
     return reconstitute_actual_key_from_vault(dpp, kctx, attrs, y, actual_key);
   }
+  if (RGW_SSE_KMS_BACKEND_KMIP == kms_backend) {
+    return reconstitute_actual_key_from_kmip(dpp, kctx, attrs, y, actual_key);
+  }
 
   ldpp_dout(dpp, 0) << "ERROR: Invalid rgw_crypt_sse_s3_backend: " << kms_backend << dendl;
   return -EINVAL;
@@ -1305,41 +1361,71 @@ int make_actual_key_from_sse_s3(const DoutPrefixProvider *dpp,
                                 std::string& actual_key)
 {
   SseS3Context kctx { dpp->get_cct() };
-  const std::string kms_backend { kctx.backend() };
-  if (RGW_SSE_KMS_BACKEND_VAULT != kms_backend) {
-    ldpp_dout(dpp, 0) << "ERROR: Unsupported rgw_crypt_sse_s3_backend: " << kms_backend << dendl;
-    return -EINVAL;
+  const std::string &kms_backend { kctx.backend() };
+
+  if (RGW_SSE_KMS_BACKEND_VAULT == kms_backend) {
+    return make_actual_key_from_vault(dpp, kctx, attrs, y, actual_key);
   }
-  return make_actual_key_from_vault(dpp, kctx, attrs, y, actual_key);
+  if (RGW_SSE_KMS_BACKEND_KMIP == kms_backend) {
+    return make_actual_key_from_kmip(dpp, kctx, attrs, y, actual_key);
+  }
+  ldpp_dout(dpp, 0) << "ERROR: Unsupported rgw_crypt_sse_s3_backend: " << kms_backend << dendl;
+  return -EINVAL;
 }
 
 
 int create_sse_s3_bucket_key(const DoutPrefixProvider *dpp,
-                             const std::string& bucket_key,
-                             optional_yield y)
+                             std::string& bucket_key,
+                             optional_yield y,
+                             const std::string& sse_s3_bucket_id)
 {
   CephContext* cct = dpp->get_cct();
   SseS3Context kctx { cct };
 
   const std::string kms_backend { kctx.backend() };
-  if (RGW_SSE_KMS_BACKEND_VAULT != kms_backend) {
-    ldpp_dout(dpp, 0) << "ERROR: Unsupported rgw_crypt_sse_s3_backend: " << kms_backend << dendl;
-    return -EINVAL;
+  ldpp_dout(dpp, 10) << "create_sse_s3_bucket_key using backend: " << kms_backend << dendl;
+
+  if (kms_backend == RGW_SSE_KMS_BACKEND_KMIP) {
+    RGWKmipSSES3* kmip_backend = get_kmip_sse_s3_backend(cct);
+    if (!kmip_backend) {
+      ldpp_dout(dpp, 0) << "ERROR: KMIP SSE-S3 backend unavailable" << dendl;
+      return -EIO;
+    }
+    if (sse_s3_bucket_id.empty()) {
+      ldpp_dout(dpp, 0) << "ERROR: KMIP SSE-S3 key create requires S3 bucket name" << dendl;
+      return -EINVAL;
+    }
+    /* Do not pass the same string as both KMIP name input and kek_id output (aliasing). */
+    const std::string kmip_name_base(sse_s3_bucket_id);
+    std::string kek_id_from_kmip;
+    int r = kmip_backend->create_bucket_key(dpp, kmip_name_base, kek_id_from_kmip, y);
+    if (r < 0) {
+      return r;
+    }
+    bucket_key = std::move(kek_id_from_kmip);
+    return 0;
   }
 
-  std::string secret_engine_str = kctx.secret_engine();
-  EngineParmMap secret_engine_parms;
-  auto secret_engine { config_to_engine_and_parms(
-    cct, "rgw_crypt_sse_s3_vault_secret_engine",
-    secret_engine_str, secret_engine_parms) };
-  if (RGW_SSE_KMS_VAULT_SE_TRANSIT == secret_engine){
-    TransitSecretEngine engine(cct, kctx, std::move(secret_engine_parms));
-    return engine.create_bucket_key(dpp, bucket_key, y);
+  if (kms_backend == RGW_SSE_KMS_BACKEND_VAULT) {
+    std::string secret_engine_str = kctx.secret_engine();
+    EngineParmMap secret_engine_parms;
+    auto secret_engine { config_to_engine_and_parms(
+      cct, "rgw_crypt_sse_s3_vault_secret_engine",
+      secret_engine_str, secret_engine_parms) };
+
+    if (RGW_SSE_KMS_VAULT_SE_TRANSIT == secret_engine) {
+      TransitSecretEngine engine(cct, kctx, std::move(secret_engine_parms));
+      // For Vault, bucket_key is the name expanded from the template
+      return engine.create_bucket_key(dpp, bucket_key, y);
+    } else {
+      ldpp_dout(dpp, 0) << "Missing or invalid Vault secret engine: " << secret_engine_str << dendl;
+      return -EINVAL;
+    }
   }
-  else {
-    ldpp_dout(dpp, 0) << "Missing or invalid secret engine" << dendl;
-    return -EINVAL;
-  }
+
+  ldpp_dout(dpp, 0) << "ERROR: Unsupported rgw_crypt_sse_s3_backend: " << kms_backend << dendl;
+  return -EINVAL;
+
 }
 
 int remove_sse_s3_bucket_key(const DoutPrefixProvider *dpp,
@@ -1348,17 +1434,31 @@ int remove_sse_s3_bucket_key(const DoutPrefixProvider *dpp,
 {
   CephContext* cct = dpp->get_cct();
   SseS3Context kctx { cct };
-  std::string secret_engine_str = kctx.secret_engine();
-  EngineParmMap secret_engine_parms;
-  auto secret_engine { config_to_engine_and_parms(
-    cct, "rgw_crypt_sse_s3_vault_secret_engine",
-    secret_engine_str, secret_engine_parms) };
-  if (RGW_SSE_KMS_VAULT_SE_TRANSIT == secret_engine){
-    TransitSecretEngine engine(cct, kctx, std::move(secret_engine_parms));
-    return engine.delete_bucket_key(dpp, bucket_key, y);
+  const std::string kms_backend { kctx.backend() };
+  
+  if (kms_backend == RGW_SSE_KMS_BACKEND_KMIP) {
+    RGWKmipSSES3* kmip_backend = get_kmip_sse_s3_backend(cct);
+    if (!kmip_backend) {
+      ldpp_dout(dpp, 0) << "ERROR: KMIP SSE-S3 backend unavailable" << dendl;
+      return -EIO;
+    }
+
+    return kmip_backend->destroy_bucket_key(dpp, bucket_key, y);
   }
-  else {
-    ldpp_dout(dpp, 0) << "Missing or invalid secret engine" << dendl;
-    return -EINVAL;
+
+  if (kms_backend == RGW_SSE_KMS_BACKEND_VAULT) {
+    std::string secret_engine_str = kctx.secret_engine();
+    EngineParmMap secret_engine_parms;
+    auto secret_engine { config_to_engine_and_parms(
+      cct, "rgw_crypt_sse_s3_vault_secret_engine",
+      secret_engine_str, secret_engine_parms) };
+    if (RGW_SSE_KMS_VAULT_SE_TRANSIT == secret_engine) {
+      TransitSecretEngine engine(cct, kctx, std::move(secret_engine_parms));
+      return engine.delete_bucket_key(dpp, bucket_key, y);
+    } else {
+      ldpp_dout(dpp, 0) << "Missing or invalid secret engine" << dendl;
+      return -EINVAL;
+    }
   }
+  return 0;
 }

--- a/src/rgw/rgw_kms.cc
+++ b/src/rgw/rgw_kms.cc
@@ -1436,12 +1436,13 @@ int create_sse_s3_bucket_key(const DoutPrefixProvider *dpp,
 
 int remove_sse_s3_bucket_key(const DoutPrefixProvider *dpp,
                              const std::string& bucket_key,
-                             optional_yield y)
+                             optional_yield y,
+                             int* worker_id_out)
 {
   CephContext* cct = dpp->get_cct();
   SseS3Context kctx { cct };
   const std::string kms_backend { kctx.backend() };
-  
+
   if (kms_backend == RGW_SSE_KMS_BACKEND_KMIP) {
     RGWKmipSSES3* kmip_backend = get_kmip_sse_s3_backend(cct);
     if (!kmip_backend) {
@@ -1449,7 +1450,7 @@ int remove_sse_s3_bucket_key(const DoutPrefixProvider *dpp,
       return -EIO;
     }
 
-    return kmip_backend->destroy_bucket_key(dpp, bucket_key, y);
+    return kmip_backend->destroy_bucket_key(dpp, bucket_key, y, worker_id_out);
   }
 
   if (kms_backend == RGW_SSE_KMS_BACKEND_VAULT) {

--- a/src/rgw/rgw_kms.cc
+++ b/src/rgw/rgw_kms.cc
@@ -23,6 +23,7 @@
 #include "rapidjson/error/error.h"
 #include "rapidjson/error/en.h"
 #include <regex>
+#include "rgw_kmip_sse_s3.h"
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
@@ -1076,6 +1077,34 @@ static int make_actual_key_from_vault(const DoutPrefixProvider *dpp,
   return get_actual_key_from_vault(dpp, kctx, attrs, y, actual_key, true);
 }
 
+static int make_actual_key_from_kmip(const DoutPrefixProvider *dpp,
+                                     SSEContext & kctx,
+                                     map<string, bufferlist>& attrs,
+                                     optional_yield y,
+                                     std::string& actual_key)
+{
+  CephContext* cct = dpp->get_cct();
+  RGWKmipSSES3* kmip_backend = get_kmip_sse_s3_backend(cct);
+  if (!kmip_backend) {
+    ldpp_dout(dpp, 0) << "ERROR: KMIP backend not available" << dendl;
+    return -EIO;
+  }
+
+  std::string kek_id = get_str_attribute(attrs, RGW_ATTR_CRYPT_KEYID);
+  bufferlist unwrapped_dek_bl;
+  bufferlist wrapped_dek_bl;
+  std::string encryption_context = get_str_attribute(attrs, RGW_ATTR_CRYPT_CONTEXT);
+
+  int r = kmip_backend->generate_and_wrap_dek(dpp, kek_id, encryption_context, unwrapped_dek_bl, wrapped_dek_bl, y);
+  if (r < 0) return r;
+
+  if (wrapped_dek_bl.length() == 0)
+    return -EIO;
+
+  attrs[RGW_ATTR_CRYPT_DATAKEY] = wrapped_dek_bl;
+  actual_key = unwrapped_dek_bl.to_str();
+  return 0;
+}
 
 static int reconstitute_actual_key_from_vault(const DoutPrefixProvider *dpp,
                                               SSEContext & kctx,
@@ -1086,22 +1115,46 @@ static int reconstitute_actual_key_from_vault(const DoutPrefixProvider *dpp,
   return get_actual_key_from_vault(dpp, kctx, attrs, y, actual_key, false);
 }
 
+static int reconstitute_actual_key_from_kmip(const DoutPrefixProvider *dpp,
+                                              SSEContext & kctx,
+                                              map<string, bufferlist>& attrs,
+                                              optional_yield y,
+                                              std::string& actual_key)
+{
+  CephContext* cct = dpp->get_cct();
+  RGWKmipSSES3* kmip_backend = get_kmip_sse_s3_backend(cct);
+
+  if (!kmip_backend) {
+    ldpp_dout(dpp, 0) << "ERROR: KMIP backend not available" << dendl;
+    return -EIO;
+  }
+
+  std::string kek_id = get_str_attribute(attrs, RGW_ATTR_CRYPT_KEYID);
+
+  auto it = attrs.find(RGW_ATTR_CRYPT_DATAKEY);
+  if (it == attrs.end() || it->second.length() == 0) {
+    ldpp_dout(dpp, 0) << "ERROR: missing or empty wrapped DEK" << dendl;
+    return -EIO;
+  }
+  const bufferlist& dek_bl = it->second;
+
+  std::string encryption_context = get_str_attribute(attrs, RGW_ATTR_CRYPT_CONTEXT);
+  bufferlist unwrapped_dek_bl;
+
+  int r = kmip_backend->unwrap_dek(dpp, kek_id, dek_bl, encryption_context, unwrapped_dek_bl, y);
+  if (r < 0) return r;
+
+  actual_key.assign(unwrapped_dek_bl.c_str(), unwrapped_dek_bl.length());
+  return 0;
+}
 
 static int get_actual_key_from_kmip(const DoutPrefixProvider *dpp,
                                     std::string_view key_id,
                                     optional_yield y,
                                     std::string& actual_key)
 {
-  std::string secret_engine = RGW_SSE_KMS_KMIP_SE_KV;
-
-  if (RGW_SSE_KMS_KMIP_SE_KV == secret_engine){
-    KmipSecretEngine engine(dpp->get_cct());
-    return engine.get_key(dpp, key_id, y, actual_key);
-  }
-  else{
-    ldpp_dout(dpp, 0) << "Missing or invalid secret engine" << dendl;
-    return -EINVAL;
-  }
+  KmipSecretEngine engine(dpp->get_cct());
+  return engine.get_key(dpp, key_id, y, actual_key);
 }
 class KMSContext : public SSEContext {
   CephContext *cct;
@@ -1300,6 +1353,9 @@ int reconstitute_actual_key_from_sse_s3(const DoutPrefixProvider *dpp,
   if (RGW_SSE_KMS_BACKEND_VAULT == kms_backend) {
     return reconstitute_actual_key_from_vault(dpp, kctx, attrs, y, actual_key);
   }
+  if (RGW_SSE_KMS_BACKEND_KMIP == kms_backend) {
+    return reconstitute_actual_key_from_kmip(dpp, kctx, attrs, y, actual_key);
+  }
 
   ldpp_dout(dpp, 0) << "ERROR: Invalid rgw_crypt_sse_s3_backend: " << kms_backend << dendl;
   return -EINVAL;
@@ -1311,41 +1367,71 @@ int make_actual_key_from_sse_s3(const DoutPrefixProvider *dpp,
                                 std::string& actual_key)
 {
   SseS3Context kctx { dpp->get_cct() };
-  const std::string kms_backend { kctx.backend() };
-  if (RGW_SSE_KMS_BACKEND_VAULT != kms_backend) {
-    ldpp_dout(dpp, 0) << "ERROR: Unsupported rgw_crypt_sse_s3_backend: " << kms_backend << dendl;
-    return -EINVAL;
+  const std::string &kms_backend { kctx.backend() };
+
+  if (RGW_SSE_KMS_BACKEND_VAULT == kms_backend) {
+    return make_actual_key_from_vault(dpp, kctx, attrs, y, actual_key);
   }
-  return make_actual_key_from_vault(dpp, kctx, attrs, y, actual_key);
+  if (RGW_SSE_KMS_BACKEND_KMIP == kms_backend) {
+    return make_actual_key_from_kmip(dpp, kctx, attrs, y, actual_key);
+  }
+  ldpp_dout(dpp, 0) << "ERROR: Unsupported rgw_crypt_sse_s3_backend: " << kms_backend << dendl;
+  return -EINVAL;
 }
 
 
 int create_sse_s3_bucket_key(const DoutPrefixProvider *dpp,
-                             const std::string& bucket_key,
-                             optional_yield y)
+                             std::string& bucket_key,
+                             optional_yield y,
+                             const std::string& sse_s3_bucket_id)
 {
   CephContext* cct = dpp->get_cct();
   SseS3Context kctx { cct };
 
   const std::string kms_backend { kctx.backend() };
-  if (RGW_SSE_KMS_BACKEND_VAULT != kms_backend) {
-    ldpp_dout(dpp, 0) << "ERROR: Unsupported rgw_crypt_sse_s3_backend: " << kms_backend << dendl;
-    return -EINVAL;
+  ldpp_dout(dpp, 10) << "create_sse_s3_bucket_key using backend: " << kms_backend << dendl;
+
+  if (kms_backend == RGW_SSE_KMS_BACKEND_KMIP) {
+    RGWKmipSSES3* kmip_backend = get_kmip_sse_s3_backend(cct);
+    if (!kmip_backend) {
+      ldpp_dout(dpp, 0) << "ERROR: KMIP SSE-S3 backend unavailable" << dendl;
+      return -EIO;
+    }
+    if (sse_s3_bucket_id.empty()) {
+      ldpp_dout(dpp, 0) << "ERROR: KMIP SSE-S3 key create requires S3 bucket name" << dendl;
+      return -EINVAL;
+    }
+    /* Do not pass the same string as both KMIP name input and kek_id output (aliasing). */
+    const std::string kmip_name_base(sse_s3_bucket_id);
+    std::string kek_id_from_kmip;
+    int r = kmip_backend->create_bucket_key(dpp, kmip_name_base, kek_id_from_kmip, y);
+    if (r < 0) {
+      return r;
+    }
+    bucket_key = std::move(kek_id_from_kmip);
+    return 0;
   }
 
-  std::string secret_engine_str = kctx.secret_engine();
-  EngineParmMap secret_engine_parms;
-  auto secret_engine { config_to_engine_and_parms(
-    cct, "rgw_crypt_sse_s3_vault_secret_engine",
-    secret_engine_str, secret_engine_parms) };
-  if (RGW_SSE_KMS_VAULT_SE_TRANSIT == secret_engine){
-    TransitSecretEngine engine(cct, kctx, std::move(secret_engine_parms));
-    return engine.create_bucket_key(dpp, bucket_key, y);
+  if (kms_backend == RGW_SSE_KMS_BACKEND_VAULT) {
+    std::string secret_engine_str = kctx.secret_engine();
+    EngineParmMap secret_engine_parms;
+    auto secret_engine { config_to_engine_and_parms(
+      cct, "rgw_crypt_sse_s3_vault_secret_engine",
+      secret_engine_str, secret_engine_parms) };
+
+    if (RGW_SSE_KMS_VAULT_SE_TRANSIT == secret_engine) {
+      TransitSecretEngine engine(cct, kctx, std::move(secret_engine_parms));
+      // For Vault, bucket_key is the name expanded from the template
+      return engine.create_bucket_key(dpp, bucket_key, y);
+    } else {
+      ldpp_dout(dpp, 0) << "Missing or invalid Vault secret engine: " << secret_engine_str << dendl;
+      return -EINVAL;
+    }
   }
-  else {
-    ldpp_dout(dpp, 0) << "Missing or invalid secret engine" << dendl;
-    return -EINVAL;
-  }
+
+  ldpp_dout(dpp, 0) << "ERROR: Unsupported rgw_crypt_sse_s3_backend: " << kms_backend << dendl;
+  return -EINVAL;
+
 }
 
 int remove_sse_s3_bucket_key(const DoutPrefixProvider *dpp,
@@ -1354,17 +1440,31 @@ int remove_sse_s3_bucket_key(const DoutPrefixProvider *dpp,
 {
   CephContext* cct = dpp->get_cct();
   SseS3Context kctx { cct };
-  std::string secret_engine_str = kctx.secret_engine();
-  EngineParmMap secret_engine_parms;
-  auto secret_engine { config_to_engine_and_parms(
-    cct, "rgw_crypt_sse_s3_vault_secret_engine",
-    secret_engine_str, secret_engine_parms) };
-  if (RGW_SSE_KMS_VAULT_SE_TRANSIT == secret_engine){
-    TransitSecretEngine engine(cct, kctx, std::move(secret_engine_parms));
-    return engine.delete_bucket_key(dpp, bucket_key, y);
+  const std::string kms_backend { kctx.backend() };
+  
+  if (kms_backend == RGW_SSE_KMS_BACKEND_KMIP) {
+    RGWKmipSSES3* kmip_backend = get_kmip_sse_s3_backend(cct);
+    if (!kmip_backend) {
+      ldpp_dout(dpp, 0) << "ERROR: KMIP SSE-S3 backend unavailable" << dendl;
+      return -EIO;
+    }
+
+    return kmip_backend->destroy_bucket_key(dpp, bucket_key, y);
   }
-  else {
-    ldpp_dout(dpp, 0) << "Missing or invalid secret engine" << dendl;
-    return -EINVAL;
+
+  if (kms_backend == RGW_SSE_KMS_BACKEND_VAULT) {
+    std::string secret_engine_str = kctx.secret_engine();
+    EngineParmMap secret_engine_parms;
+    auto secret_engine { config_to_engine_and_parms(
+      cct, "rgw_crypt_sse_s3_vault_secret_engine",
+      secret_engine_str, secret_engine_parms) };
+    if (RGW_SSE_KMS_VAULT_SE_TRANSIT == secret_engine) {
+      TransitSecretEngine engine(cct, kctx, std::move(secret_engine_parms));
+      return engine.delete_bucket_key(dpp, bucket_key, y);
+    } else {
+      ldpp_dout(dpp, 0) << "Missing or invalid secret engine" << dendl;
+      return -EINVAL;
+    }
   }
+  return 0;
 }

--- a/src/rgw/rgw_kms.h
+++ b/src/rgw/rgw_kms.h
@@ -62,7 +62,8 @@ int create_sse_s3_bucket_key(const DoutPrefixProvider *dpp,
 
 int remove_sse_s3_bucket_key(const DoutPrefixProvider *dpp,
                              const std::string& actual_key,
-                             optional_yield y);
+                             optional_yield y,
+                             int* worker_id_out = nullptr);
 
 /**
  * SecretEngine Interface

--- a/src/rgw/rgw_kms.h
+++ b/src/rgw/rgw_kms.h
@@ -56,8 +56,9 @@ int reconstitute_actual_key_from_sse_s3(const DoutPrefixProvider *dpp,
                                         std::string& actual_key);
 
 int create_sse_s3_bucket_key(const DoutPrefixProvider *dpp,
-                             const std::string& actual_key,
-                             optional_yield y);
+                             std::string& actual_key,
+                             optional_yield y,
+                             const std::string& sse_s3_bucket_id = {});
 
 int remove_sse_s3_bucket_key(const DoutPrefixProvider *dpp,
                              const std::string& actual_key,


### PR DESCRIPTION
### Summary
This PR adds support for using KMIP as a backend for SSE-S3, alongside the existing Vault backend. Per-bucket KEKs (Key Encryption Keys) are provisioned on the KMIP server; per-object DEKs (Data Encryption Keys) are generated in RGW and wrapped via KMIP Encrypt/Decrypt using AES-256-GCM (AEAD).

### libkmip dependency
To support KMIP as backend we had to extend the libkmip. As [ceph/libkmip](https://github.com/ceph/libkmip) had diverged from [OpenKMIP](https://github.com/OpenKMIP/libkmip), we decided to base our work based on [OpenKMIP](https://github.com/OpenKMIP/libkmip). The changes can be found in my personal fork for now. [supriti/libkmip](https://github.com/supriti/libkmip/tree/wip-kmip-clean-for-review).  

How best to land the libkmip side in `ceph/libkmip` is an open question. The branches have diverged significantly, so a clean cherry-pick onto `ceph/libkmip:ceph-main` isn't straightforward. My preferred approach is to land the SSE-S3 work as a separate branch under `ceph/libkmip`. Happy to take direction from maintainers on the preferred approach.

This Ceph PR is otherwise self-contained and can be reviewed independently of how the libkmip side is structured. For now I am marking this as draft PR as we need libkmip to be merged and then Ceph changes.

### Changes in this PR

- Multi-threaded KMIP worker pool (the previous implementation was single-threaded on the client side; multi-threading improves throughput at SSE-S3 scale). 
- SSE-S3 KMIP backend: bucket-level KEK creation/destruction, per-object DEK wrap/unwrap, race-safe first-PUT handling with adopt-winner cleanup, wrapped DEK serialized via Ceph encoder (versioned for forward compatibility, so future algorithm or layout changes can land without breaking existing objects)
- Simplified per-worker TLS connection cache: each worker now keeps at most one cached connection (was a vector of connections, of which only one was ever used in practice).
- Enable teuthology testing for SSE-S3 using PyKMIP
- Fixed the TLS teardown sequence

## Configuration

Enable with:

rgw_crypt_sse_s3_backend       = kmip
rgw_crypt_kmip_addr            = [host:port]
rgw_crypt_kmip_ca_path         = <path>
rgw_crypt_kmip_client_cert     = <path>
rgw_crypt_kmip_client_key      = <path>

Two new options for tuning. Both have safe defaults; tuning is optional
and depends on KMIP server capacity and RGW load.

| Option | Default | Range | Purpose |
|---|---|---|---|
| `rgw_crypt_kmip_worker_threads` | 1 | 1–32 | Number of parallel KMIP client worker threads. |
| `rgw_crypt_kmip_socket_io_timeout_sec` | 300 | 0–300 | Per-socket `SO_RCVTIMEO`/`SO_SNDTIMEO` on KMIP TLS connections. |

## Testing

- The `rgw:crypt` teuthology suite passes (existing SSE-KMS coverage, plus the new SSE-S3 path added in this PR).
- libkmip changes tested against both SSE-KMS and SSE-S3.
- Long-running soak test (mixed PUT/GET/overwrite/delete/multipart
  workload with SHA-256 verification on every GET) executed against:
  - **PyKMIP** locally: ~25,000 ops, zero data-corruption events.
  - **OVH OKMS** over network: ~2,000 ops, zero data-corruption events.
- Audited the first-PUT KEK race path (RADOS CAS + adopt-winner) for
  correctness; no integrity issues observed at any worker thread count
  from 1 to 16.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [X] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [X] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
