### PR TITLE
squid: mds: persist session auth_name in ESession journal event

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -775,7 +775,8 @@ void Server::handle_client_session(const cref_t<MClientSession> &m)
         ceph_assert(r == 0);
         log_session_status("ACCEPTED", "");
       });
-      mdlog->submit_entry(new ESession(m->get_source_inst(), true, pv, client_metadata),
+      mdlog->submit_entry(new ESession(m->get_source_inst(), true, pv,
+      client_metadata, session->info.auth_name),
 				new C_MDS_session_finish(this, session, sseq, true, pv, fin));
       mdlog->flush();
     }
@@ -1485,7 +1486,8 @@ void Server::journal_close_session(Session *session, int state, Context *on_safe
   } else
     piv = 0;
   
-  auto le = new ESession(session->info.inst, false, pv, inos_to_free, piv, session->delegated_inos);
+  auto le = new ESession(session->info.inst, false, pv, inos_to_free, piv,
+    session->delegated_inos, session->info.auth_name);
   auto fin = new C_MDS_session_finish(this, session, sseq, false, pv, inos_to_free, piv,
 				      session->delegated_inos, mdlog->get_current_segment(), on_safe);
   mdlog->submit_entry(le, fin);

--- a/src/mds/events/ESession.h
+++ b/src/mds/events/ESession.h
@@ -34,18 +34,22 @@ class ESession : public LogEvent {
   // Client metadata stored during open
   client_metadata_t client_metadata;
 
+  // persist auth_name to allow journal recreated session to be reclaimed
+  EntityName auth_name;
+
  public:
   ESession() : LogEvent(EVENT_SESSION), open(false) { }
   ESession(const entity_inst_t& inst, bool o, version_t v,
-	   const client_metadata_t& cm) :
+	   const client_metadata_t& cm, EntityName auth_name_) :
     LogEvent(EVENT_SESSION),
     client_inst(inst), open(o), cmapv(v), inotablev(0),
-    client_metadata(cm) { }
+    client_metadata(cm), auth_name(auth_name_) { }
   ESession(const entity_inst_t& inst, bool o, version_t v,
 	   const interval_set<inodeno_t>& to_free, version_t iv,
-	   const interval_set<inodeno_t>& to_purge) :
+	   const interval_set<inodeno_t>& to_purge, EntityName auth_name_) :
     LogEvent(EVENT_SESSION), client_inst(inst), open(o), cmapv(v),
-    inos_to_free(to_free), inotablev(iv), inos_to_purge(to_purge) {}
+    inos_to_free(to_free), inotablev(iv), inos_to_purge(to_purge),
+    auth_name(auth_name_) {}
 
   void encode(bufferlist& bl, uint64_t features) const override;
   void decode(bufferlist::const_iterator& bl) override;

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -1853,6 +1853,9 @@ void ESession::replay(MDSRank *mds)
       session = mds->sessionmap.get_or_add_session(client_inst);
       mds->sessionmap.set_state(session, Session::STATE_OPEN);
       session->set_client_metadata(client_metadata);
+      if (session->info.auth_name.to_str().empty()) {
+        session->info.auth_name = auth_name;
+      }
       dout(10) << " opened session " << session->info.inst << dendl;
     } else {
       session = mds->sessionmap.get_session(client_inst.name);
@@ -1902,7 +1905,7 @@ void ESession::replay(MDSRank *mds)
 
 void ESession::encode(bufferlist &bl, uint64_t features) const
 {
-  ENCODE_START(6, 5, bl);
+  ENCODE_START(7, 5, bl);
   encode(stamp, bl);
   encode(client_inst, bl, features);
   encode(open, bl);
@@ -1911,12 +1914,13 @@ void ESession::encode(bufferlist &bl, uint64_t features) const
   encode(inotablev, bl);
   encode(client_metadata, bl);
   encode(inos_to_purge, bl);
+  encode(auth_name, bl);
   ENCODE_FINISH(bl);
 }
 
 void ESession::decode(bufferlist::const_iterator &bl)
 {
-  DECODE_START_LEGACY_COMPAT_LEN(6, 3, 3, bl);
+  DECODE_START_LEGACY_COMPAT_LEN(7, 3, 3, bl);
   if (struct_v >= 2)
     decode(stamp, bl);
   decode(client_inst, bl);
@@ -1931,6 +1935,9 @@ void ESession::decode(bufferlist::const_iterator &bl)
   }
   if (struct_v >= 6){
     decode(inos_to_purge, bl);
+  }
+  if (struct_v >= 7) {
+    decode(auth_name, bl);
   }
     
   DECODE_FINISH(bl);

--- a/src/test/libcephfs/reclaim.cc
+++ b/src/test/libcephfs/reclaim.cc
@@ -15,28 +15,29 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <sys/types.h>
+#include <sys/wait.h>
 #include <sys/stat.h>
 #include <dirent.h>
 #include <sys/uio.h>
 #include <libgen.h>
 #include <stdlib.h>
+#include <cstring>
 
 #ifdef __linux__
 #include <sys/xattr.h>
 #include <limits.h>
 #endif
 
-#ifdef __FreeBSD__
-#include <sys/wait.h>
-#endif
-
-
 #include <map>
+#include <string>
 #include <vector>
 #include <thread>
 #include <atomic>
 
 #define	CEPHFS_RECLAIM_TIMEOUT		60
+
+/* execl argv[1] for ReclaimResetAfterMDSFailover child */
+static const char DYING_FAILOVER[] = "--failover";
 
 static int dying_client(int argc, char **argv)
 {
@@ -80,6 +81,58 @@ static int dying_client(int argc, char **argv)
 		      &file, &fh, &stx, 0, 0, perms) != 0)
     return 1;
 
+  return 0;
+}
+
+static int dying_client_failover(const char *uuid)
+{
+  struct ceph_mount_info *cmount;
+
+  if (ceph_create(&cmount, nullptr) != 0) {
+    return 1;
+  }
+  if (ceph_conf_read_file(cmount, nullptr) != 0) {
+    return 1;
+  }
+  if (ceph_conf_parse_env(cmount, nullptr) != 0) {
+    return 1;
+  }
+  if (ceph_init(cmount) != 0) {
+    return 1;
+  }
+
+  ceph_set_session_timeout(cmount, 300);
+
+  if (ceph_start_reclaim(cmount, uuid, CEPH_RECLAIM_RESET) != -ENOENT) {
+    return 1;
+  }
+
+  ceph_set_uuid(cmount, uuid);
+
+  if (ceph_mount(cmount, "/") != 0) {
+    return 1;
+  }
+
+  if (ceph_mkdir(cmount, "/reclaim_failover_test", 0755) != 0 && errno != EEXIST) {
+    return 1;
+  }
+
+  int fd = ceph_open(cmount, "/reclaim_failover_test/testfile",
+    O_RDWR|O_CREAT, 0644);
+  if (fd < 0) {
+    return 1;
+  }
+
+  if (ceph_write(cmount, fd, "hello", 5, 0) < 0) {
+    return 1;
+  }
+
+  if (ceph_fsync(cmount, fd, 0) != 0) {
+    return 1;
+  }
+
+  /*since this is called from the child inside an execl(), returning from here
+    without cloing fd would mimic client crash*/
   return 0;
 }
 
@@ -128,6 +181,78 @@ TEST(LibCephFS, ReclaimReset) {
   ceph_release(cmount);
 }
 
+TEST(LibCephFS, ReclaimResetAfterMDSFailover) {
+  char uuid[256];
+  const char *exe = "/proc/self/exe";
+
+  sprintf(uuid, "reclaim_failover:%x", getpid());
+
+  pid_t pid = fork();
+  ASSERT_GE(pid, 0);
+  if (pid == 0) {
+    errno = 0;
+    execl(exe, exe, DYING_FAILOVER, uuid, nullptr);
+    ASSERT_EQ(errno, 0);
+  }
+
+  int status = 0;
+  ASSERT_EQ(waitpid(pid, &status, 0), pid);
+  ASSERT_TRUE(WIFEXITED(status));
+  ASSERT_EQ(WEXITSTATUS(status), 0);
+
+  /* Get a separate client to kill mds because the same client cannot be used
+     to reclaim since it needs to be done before mounting. */
+  {
+    struct ceph_mount_info *admin;
+
+    ASSERT_EQ(ceph_create(&admin, nullptr), 0);
+    ASSERT_EQ(ceph_conf_read_file(admin, nullptr), 0);
+    ASSERT_EQ(ceph_conf_parse_env(admin, nullptr), 0);
+    ASSERT_EQ(ceph_init(admin), 0);
+    ASSERT_EQ(ceph_mount(admin, "/"), 0);
+
+    /* Respawn rank 0 so that once it boots up it replays the ESession events
+       in journal and recreates the old open session. */  
+    const char *cmd[1] = {"{\"prefix\": \"respawn\"}"};
+    char *outbuf = nullptr, *outs = nullptr;
+    size_t outbuf_len = 0, outs_len = 0;
+    int ret = ceph_mds_command(admin, "0", cmd, 1, nullptr, 0,
+                              &outbuf, &outbuf_len, &outs, &outs_len);
+
+    bool exiting = (ret == 0 && outbuf && outbuf_len > 0 &&
+                    std::string(outbuf, outbuf_len).find("Respawning") != std::string::npos &&
+                    outs_len == 0);
+    ASSERT_EQ(exiting, true);
+
+    if (outbuf) ceph_buffer_free(outbuf);
+    if (outs) ceph_buffer_free(outs);
+    ceph_unmount(admin);
+    ceph_release(admin);
+  }
+
+  sleep(60);
+
+  struct ceph_mount_info *cmount;
+  ASSERT_EQ(ceph_create(&cmount, nullptr), 0);
+  ASSERT_EQ(ceph_conf_read_file(cmount, nullptr), 0);
+  ASSERT_EQ(ceph_conf_parse_env(cmount, nullptr), 0);
+  ASSERT_EQ(ceph_init(cmount), 0);
+  ceph_set_session_timeout(cmount, 300);
+  /* Now reclaim the dead client's session. If auth_name was not preserved
+     across journal replay, this will fail with -EPERM. */
+  ASSERT_EQ(ceph_start_reclaim(cmount, uuid, CEPH_RECLAIM_RESET), 0);
+  ceph_finish_reclaim(cmount);
+  ceph_set_uuid(cmount, uuid);
+  ASSERT_EQ(ceph_mount(cmount, "/"), 0);
+
+  /* Verify we can still see the file the dead client had created */
+  struct ceph_statx stx;
+  ASSERT_EQ(ceph_statx(cmount, "/reclaim_failover_test/testfile", &stx, 0, 0), 0);
+
+  ceph_unmount(cmount);
+  ceph_release(cmount);
+}
+
 static int update_root_mode()
 {
   struct ceph_mount_info *admin;
@@ -154,8 +279,17 @@ int main(int argc, char **argv)
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  if (argc > 1)
+  if (argc == 2)
     return dying_client(argc, argv);
+
+  if (argc == 3 && strcmp(argv[1], DYING_FAILOVER) == 0) {
+    r = dying_client_failover(argv[2]);
+    if (r == 0) {
+      return r;
+    } else {
+      exit(1);
+    }
+  }
 
   srand(getpid());
 


### PR DESCRIPTION
backport of https://github.com/ceph/ceph/pull/69037
backport tracker: https://tracker.ceph.com/issues/77061
parent tracker: https://tracker.ceph.com/issues/76728


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
