### PR TITLE
mgr/cephadm:Fixed NFS Ganesha QoS configuration updates not triggering automatic service restart when applied via ceph orch apply.

### DIFF
--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -142,6 +142,11 @@ class NFSService(CephService):
         deps.append(f'tls_ciphers: {nfs_spec.tls_ciphers}')
         deps.append(f'enable_rdma: {nfs_spec.enable_rdma}')
         deps.append(f'rdma_port: {nfs_spec.rdma_port}')
+        # added dependency for cluster QoS configuration
+        if nfs_spec.cluster_qos_config:
+            import json
+            qos_hash = utils.config_hash(json.dumps(nfs_spec.cluster_qos_config, sort_keys=True))
+            deps.append(f'cluster_qos_config: {qos_hash}')
         return sorted(deps)
 
     def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:


### PR DESCRIPTION
Fixed NFS Ganesha QoS configuration updates not triggering automatic service restart when applied via ceph orch apply.

Signed-off-by: Pooja Dwivedi pooja.dwivedi@ibm.com
Resolves: IBMCEPH-11821
Fixes: https://tracker.ceph.com/issues/77095

### Description 

When reapplying the NFS Ganesha spec file with updated QoS parameters, the changes are correctly reflected in cephadm (`ceph nfs cluster qos get`), but the updated QoS values are NOT enforced from the NFS client perspective. The client continues to observe the old QoS limits until the NFS Ganesha service is manually restarted.

To solve this issue added cluster_qos_config to the dependency tracking in the get_dependencies() method. When QoS parameters change, a new hash is generated and cephadm automatically triggers a service restart to apply the new configuration.

### Testing Steps

Prerequisites:-
- Ceph cluster with cephadm orchestrator
- NFS Ganesha cluster deployed
- QoS enabled in the spec file

### Testing Logs
```
Deploy NFS with Initial QoS

Create spec file `nfs.yaml`:
```
```yaml
service_type: nfs
service_id: nfsganesha1
placement:
  count: 1
cluster_qos_config:
  enable_qos: true
  enable_bw_control: true
  enable_iops_control: false
  combined_rw_bw_control: false
  qos_type: "PerShare"
  max_export_write_bw: "10MB"
  max_export_read_bw: "10MB"
```
```
[ceph: root@ceph-node-0 /]# vi nfs.yaml                         
[ceph: root@ceph-node-0 /]# ceph orch apply -i nfs.yaml
[ceph: root@ceph-node-0 /]# ceph orch ps --daemon-type nfs
NAME                                    HOST         PORTS              STATUS         REFRESHED  AGE  MEM USE  MEM LIM  VERSION  IMAGE ID      CONTAINER ID  
nfs.nfsganesha1.0.0.ceph-node-0.aqsvqn  ceph-node-0  *:2049,9587,31311  running (47s)    43s ago   8m    11.4M        -  7.0      a2e69cfaef9b  2db92fcd3737  

[ceph: root@ceph-node-0 /]# ceph nfs cluster qos get nfsganesha1
{
  "combined_rw_bw_control": false,
  "enable_bw_control": true,
  "enable_iops_control": false,
  "enable_qos": true,
  "max_export_read_bw": "9.5MiB",
  "max_export_write_bw": "9.5MiB",
  "qos_type": "PerShare"
}
[ceph: root@ceph-node-0 /]# ceph nfs export create cephfs nfsganesha1 /ganesha1 myfs --path=/                                  
{
  "bind": "/ganesha1",
  "cluster": "nfsganesha1",
  "fs": "myfs",
  "mode": "RW",
  "path": "/"
}

On Client node 

[root@ceph-node-1 ~]# mount -t nfs 192.168.100.100:/ganesha1 temp
[root@ceph-node-1 ~]# cd temp
[root@ceph-node-1 temp]# dd if=/dev/urandom of=file1 bs=1G count=1
1+0 records in
1+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 115.515 s, 9.3 MB/s
```
Update spec file `nfs.yaml`:

```yaml
service_type: nfs
service_id: nfsganesha1
placement:
  count: 1
cluster_qos_config:
  enable_qos: true
  enable_bw_control: true
  enable_iops_control: false
  combined_rw_bw_control: false
  qos_type: "PerShare"
  max_export_write_bw: "15MB"  # ← Changed from 10MB
  max_export_read_bw: "15MB"   # ← Changed from 10MB
```
```
[ceph: root@ceph-node-0 /]# ceph orch apply -i nfs.yaml
Scheduled nfs.nfsganesha1 update...
[ceph: root@ceph-node-0 /]# ceph orch ps --daemon-type nfs
NAME                                    HOST         PORTS              STATUS        REFRESHED  AGE  MEM USE  MEM LIM  VERSION  IMAGE ID      CONTAINER ID  
nfs.nfsganesha1.0.0.ceph-node-0.aqsvqn  ceph-node-0  *:2049,9587,31311  running (9s)     6s ago  27m    58.1M        -  7.0      a2e69cfaef9b  bb0438f3740d  

QOS bandwidth updated On Client Node :

[root@ceph-node-1 temp]# dd if=/dev/urandom of=file1 bs=1G count=1
1+0 records in
1+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 76.7565 s, 14.0 MB/s
```




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
