### PR TITLE
osd: clear stale pending_inc entries in pack_upmap_results

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -6308,6 +6308,10 @@ int OSDMap::pack_upmap_results(
     ceph_assert(tmp_osd_map.pg_upmap_items.count(i));
     tmp_osd_map.pg_upmap_items.erase(i);
     pending_inc->old_pg_upmap_items.insert(i);
+    // Drop any pending new_pg_upmap_items entry left from an earlier
+    // iteration of calc_pg_upmaps, otherwise the incremental ends up with
+    // both an old and a new entry for the same pg.
+    pending_inc->new_pg_upmap_items.erase(i);
     ++num_changed;
   }
   for (auto& [pg, um_items] : to_upmap) {
@@ -6316,10 +6320,13 @@ int OSDMap::pack_upmap_results(
                    << dendl;
     tmp_osd_map.pg_upmap_items[pg] = um_items;
     pending_inc->new_pg_upmap_items[pg] = um_items;
+    // Symmetric to the to_unmap loop: drop a stale old_pg_upmap_items
+    // entry so this iteration's add isn't undone on apply.
+    pending_inc->old_pg_upmap_items.erase(pg);
     ++num_changed;
   }
 
-  return num_changed; 
+  return num_changed;
 }
 
 std::default_random_engine OSDMap::get_random_engine(

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -684,6 +684,7 @@ private:
   uint32_t crush_version = 1;
 
   friend class OSDMonitor;
+  friend class OSDMapTest;
 
  public:
   OSDMap() : epoch(0), 

--- a/src/test/osd/TestOSDMap.cc
+++ b/src/test/osd/TestOSDMap.cc
@@ -185,6 +185,24 @@ public:
     return pool_id;
   }
 
+  // OSDMapTest is a friend of OSDMap, but TEST_F generates subclasses that
+  // do not inherit that friendship. Expose pack_upmap_results and direct
+  // pg_upmap_items writes through the fixture so individual tests can use
+  // them without needing per-test friend declarations.
+  int call_pack_upmap_results(
+      const std::set<pg_t>& to_unmap,
+      const std::map<pg_t, mempool::osdmap::vector<std::pair<int, int>>>& to_upmap,
+      OSDMap& tmp_osd_map,
+      OSDMap::Incremental& pending_inc) {
+    return osdmap.pack_upmap_results(g_ceph_context, to_unmap, to_upmap,
+                                     tmp_osd_map, &pending_inc);
+  }
+  void set_pg_upmap_items(
+      OSDMap& target, pg_t pg,
+      const mempool::osdmap::vector<std::pair<int32_t,int32_t>>& items) {
+    target.pg_upmap_items[pg] = items;
+  }
+
   void balance_capacity(int64_t pid) {
     set<int64_t> only_pools;
     only_pools.insert(pid);
@@ -1923,6 +1941,66 @@ TEST_F(OSDMapTest, TryDropRemapOverfullBothOverfull) {
     int up_primary;
     newmap.pg_to_up_acting_osds(pg6, &up, &up_primary, nullptr, nullptr);
     ASSERT_EQ(up[0], 1);
+  }
+}
+
+TEST_F(OSDMapTest, BUG_77013_pack_upmap_results_dedup) {
+  // https://tracker.ceph.com/issues/77013
+  //
+  // pack_upmap_results is called once per accepted calc_pg_upmaps iteration
+  // and accumulates into pending_inc.  A pg that is partially dropped in one
+  // iteration (new_pg_upmap_items[pg] = smaller set) and then fully dropped
+  // in a later iteration (old_pg_upmap_items.insert(pg)) used to leave both
+  // entries set, producing duplicate osdmaptool output and silently undoing
+  // a later add via apply_incremental's new-then-old ordering.
+  //
+  // This test pre-seeds pending_inc with a stale entry in one map and calls
+  // pack_upmap_results to drive the opposite map, asserting the stale entry
+  // is cleared.  Setup uses a single fake pg and a minimal tmp_osd_map to
+  // avoid coupling to the balancer's pg_upmap_items math.
+  set_up_map(3, true);
+
+  pg_t pg(0, 99);
+  mempool::osdmap::vector<pair<int32_t,int32_t>> stale_items{{0, 1}};
+  mempool::osdmap::vector<pair<int32_t,int32_t>> fresh_items{{0, 2}};
+
+  // Direction 1: pending_inc has stale new_pg_upmap_items[pg] from a prior
+  // partial drop.  A subsequent full drop must clear it.
+  {
+    OSDMap tmp_osd_map;
+    tmp_osd_map.deepish_copy_from(osdmap);
+    OSDMap::Incremental pending_inc(osdmap.get_epoch() + 1);
+    pending_inc.new_pg_upmap_items[pg] = stale_items;
+    // Mirror real flow: pg_upmap_items must exist in tmp before unmap.
+    set_pg_upmap_items(tmp_osd_map, pg, stale_items);
+
+    set<pg_t> to_unmap{pg};
+    map<pg_t, mempool::osdmap::vector<pair<int32_t,int32_t>>> to_upmap;
+    call_pack_upmap_results(to_unmap, to_upmap, tmp_osd_map, pending_inc);
+
+    EXPECT_TRUE(pending_inc.old_pg_upmap_items.count(pg));
+    EXPECT_FALSE(pending_inc.new_pg_upmap_items.count(pg))
+        << "stale new_pg_upmap_items survived a later unmap";
+  }
+
+  // Direction 2: pending_inc has stale old_pg_upmap_items[pg] from a prior
+  // full drop.  A subsequent fresh add must clear it, otherwise apply's
+  // "new first, then old" ordering would erase the add.
+  {
+    OSDMap tmp_osd_map;
+    tmp_osd_map.deepish_copy_from(osdmap);
+    OSDMap::Incremental pending_inc(osdmap.get_epoch() + 1);
+    pending_inc.old_pg_upmap_items.insert(pg);
+
+    set<pg_t> to_unmap;
+    map<pg_t, mempool::osdmap::vector<pair<int32_t,int32_t>>> to_upmap;
+    to_upmap[pg] = fresh_items;
+    call_pack_upmap_results(to_unmap, to_upmap, tmp_osd_map, pending_inc);
+
+    EXPECT_TRUE(pending_inc.new_pg_upmap_items.count(pg));
+    EXPECT_EQ(pending_inc.new_pg_upmap_items[pg], fresh_items);
+    EXPECT_FALSE(pending_inc.old_pg_upmap_items.count(pg))
+        << "stale old_pg_upmap_items survived a later upmap add";
   }
 }
 


### PR DESCRIPTION
## Summary
- pack_upmap_results accumulates per-iteration drops and adds into pending_inc, but never clears the opposite map's stale entry. When a pg is partially dropped in one calc_pg_upmaps iteration and fully dropped later (or vice versa), pending_inc ends up with both new_pg_upmap_items[pg] and old_pg_upmap_items[pg] set.
- Symptoms: osdmaptool prints the same pg twice (one remove, one add); and since apply_incremental walks new before old, a "full drop then fresh add" sequence silently undoes the later add.
- Fix mirrors the existing cancel pattern in OSDMap::clean_pg_upmaps.

## Test plan
- `unittest_osdmap` 42/42 pass, including the new `BUG_77013_pack_upmap_results_dedup` that covers both directions (stale `new_pg_upmap_items` cleared on a later unmap; stale `old_pg_upmap_items` cleared on a later upmap add).
- vstart smoke on a 6-OSD replicated cluster with reweight-driven imbalance: `osdmaptool --upmap` produced a multi-iteration plan with no duplicate pg in its output, and the mgr `balancer` module ran calc_pg_upmaps cleanly through the Python path.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [x] Includes bug reproducer
  - [ ] No tests

Tracker: https://tracker.ceph.com/issues/77013
