### PR TITLE
crimson/tests: emit success message in unittest-seastar-alienstore-thread-pool

### DIFF
--- a/src/test/crimson/test_alienstore_thread_pool.cc
+++ b/src/test/crimson/test_alienstore_thread_pool.cc
@@ -61,6 +61,8 @@ int main(int argc, char** argv)
           return tp->stop();
         });
       });
+    }).then([] {
+      std::cout << "All tests succeeded" << std::endl;
     }).finally([] {
       return crimson::common::sharded_conf().stop();
     }).handle_exception([](auto e) {


### PR DESCRIPTION


... avoiding the need to guess the results.

