### PR TITLE
test/qa: Allow ceph_test_rados to test omap operations in EC pools

### DIFF
--- a/qa/tasks/rados.py
+++ b/qa/tasks/rados.py
@@ -187,7 +187,6 @@ def task(ctx, config):
         'kill', 
         'ceph_test_rados']
     if config.get('ec_pool', False):
-        args.extend(['--no-omap'])
         if not config.get('erasure_code_use_overwrites', False):
             args.extend(['--ec-pool'])
     if config.get('write_fadvise_dontneed', False):

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -191,7 +191,7 @@ public:
   const uint64_t min_stride_size;
   const uint64_t max_stride_size;
   AttrGenerator attr_gen;
-  const bool no_omap;
+  bool no_omap;
   const bool no_sparse;
   bool pool_snaps;
   bool write_fadvise_dontneed;
@@ -328,6 +328,11 @@ public:
     if (initialized) {
       rados.shutdown();
     }
+  }
+
+  void set_no_omap(bool value)
+  {
+    no_omap = value;
   }
 
   void loop(TestOpGenerator *gen)

--- a/src/test/osd/RadosTestHelpers.h
+++ b/src/test/osd/RadosTestHelpers.h
@@ -1,0 +1,99 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2026 IBM
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <cerrno>
+#include <expected>
+#include <sstream>
+#include <string>
+#include "include/rados/librados.hpp"
+#include "include/buffer.h"
+#include "json_spirit/json_spirit.h"
+
+/**
+ * query_pool_flag - query a named boolean pool flag via the monitor.
+ *
+ * Sends an "osd pool get" mon_command for the given pool and flag variable
+ * name, parses the JSON response, and returns the flag value on success or a
+ * negative errno on failure via std::expected<bool, int>.
+ *
+ * This function is limited to boolean pool variables.
+ * The full set of supported flag_var names is:
+ *   supports_omap, allow_ec_overwrites, allow_ec_optimizations,
+ *   hashpspool, eio, nodelete, bulk, nopgchange, nosizechange,
+ *   write_fadvise_dontneed, noscrub, nodeep-scrub, use_gmt_hitset.
+ * Passing a non-boolean variable (e.g. "pg_num", "crush_rule") will cause
+ * the monitor to return an integer or string value; this function will
+ * detect the type mismatch and return std::unexpected(-EINVAL).
+ *
+ * @param pool_name  Name of the pool to query.
+ * @param flag_var   The boolean pool variable name to query
+ *                   (e.g. "supports_omap").
+ * @param rados      An initialised and connected Rados handle.
+ *
+ * @return std::expected<bool, int> containing:
+ *           - the flag value (true/false) on success, or
+ *           - a negative errno on failure:
+ *               - the RADOS error code when mon_command itself fails,
+ *               - -ENODATA when the response is empty or the key is absent,
+ *               - -EINVAL  when the response cannot be parsed or the value is
+ *                          not a boolean.
+ */
+inline std::expected<bool, int> query_pool_flag(
+    const std::string& pool_name,
+    const std::string& flag_var,
+    librados::Rados& rados)
+{
+  ceph::bufferlist inbl, outbl;
+  std::ostringstream cmd;
+  cmd << "{\"prefix\": \"osd pool get\", "
+      << "\"pool\": \"" << pool_name << "\", "
+      << "\"var\": \"" << flag_var << "\", "
+      << "\"format\": \"json\"}";
+
+  int ret = rados.mon_command(cmd.str(), std::move(inbl), &outbl, nullptr);
+  if (ret < 0) {
+    return std::unexpected(ret);
+  }
+
+  std::string outstr = outbl.to_str();
+  if (outstr.empty()) {
+    return std::unexpected(-ENODATA);
+  }
+
+  try {
+    json_spirit::Value v;
+    if (!json_spirit::read(outstr, v)) {
+      return std::unexpected(-EINVAL);
+    }
+    if (v.type() != json_spirit::obj_type) {
+      return std::unexpected(-EINVAL);
+    }
+    const json_spirit::Object& obj = v.get_obj();
+    for (json_spirit::Object::size_type i = 0; i < obj.size(); i++) {
+      const json_spirit::Pair& pair = obj[i];
+      if (pair.name_ == flag_var) {
+        if (pair.value_.type() == json_spirit::bool_type) {
+          return pair.value_.get_bool();
+        }
+        return std::unexpected(-EINVAL);
+      }
+    }
+    return std::unexpected(-ENODATA);
+  } catch (const std::exception&) {
+    return std::unexpected(-EINVAL);
+  }
+}

--- a/src/test/osd/TestRados.cc
+++ b/src/test/osd/TestRados.cc
@@ -15,6 +15,7 @@
 #include <unistd.h>
 
 #include "test/osd/RadosModel.h"
+#include "test/osd/RadosTestHelpers.h"
 
 using namespace std;
 
@@ -618,7 +619,6 @@ int main(int argc, char **argv)
 	exit(1);
       }
       ec_pool = true;
-      no_omap = true;
       no_sparse = true;
     } else if (strcmp(argv[i], "--op") == 0) {
       i++;
@@ -778,6 +778,21 @@ int main(int argc, char **argv)
 	 << cpp_strerror(r) << std::endl;
     exit(1);
   }
+
+  // Query pool's supports_omap flag for EC pools if user didn't explicitly set --no-omap
+  // Replicated pools always support omap, so we only need to check EC pools
+  if (ec_pool && !no_omap) {
+    auto result = query_pool_flag(pool_name, "supports_omap", context.rados);
+    if (!result) {
+      cerr << "Warning: failed to query supports_omap for pool " << pool_name
+           << ": " << cpp_strerror(result.error()) << std::endl;
+    } else if (!result.value()) {
+      cout << "EC pool " << pool_name << " does not support omap, setting no_omap=true" << std::endl;
+      no_omap = true;
+      context.set_no_omap(true);
+    }
+  }
+
   context.loop(&gen);
   if (enable_dedup) {
     if (!context.check_chunks_refcount(context.low_tier_io_ctx, context.io_ctx)) {

--- a/src/test/osd/TestRados.cc
+++ b/src/test/osd/TestRados.cc
@@ -15,6 +15,7 @@
 #include <unistd.h>
 
 #include "test/osd/RadosModel.h"
+#include "test/osd/RadosTestHelpers.h"
 
 using namespace std;
 
@@ -618,7 +619,6 @@ int main(int argc, char **argv)
 	exit(1);
       }
       ec_pool = true;
-      no_omap = true;
       no_sparse = true;
     } else if (strcmp(argv[i], "--op") == 0) {
       i++;
@@ -778,6 +778,20 @@ int main(int argc, char **argv)
 	 << cpp_strerror(r) << std::endl;
     exit(1);
   }
+
+  // Query pool's supports_omap flag if user didn't explicitly set --no-omap
+  if (!no_omap) {
+    auto result = query_pool_flag(pool_name, "supports_omap", context.rados);
+    if (!result) {
+      cerr << "Warning: failed to query supports_omap for pool " << pool_name
+           << ": " << cpp_strerror(result.error()) << std::endl;
+    } else if (!result.value()) {
+      cout << "Pool " << pool_name << " does not support omap, setting no_omap=true" << std::endl;
+      no_omap = true;
+      context.set_no_omap(true);
+    }
+  }
+
   context.loop(&gen);
   if (enable_dedup) {
     if (!context.check_chunks_refcount(context.low_tier_io_ctx, context.io_ctx)) {


### PR DESCRIPTION
Allow ceph_test_rados to test omap operations in EC pools

If the user gave the "--no-omap" flag, listen to that.
Otherwise, check if the EC pool supports omap, and use the response to determine whether no_omap should be true or false.

Fixes: https://tracker.ceph.com/issues/75055


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
