### PR TITLE
mgr, osd, mon: remove pg_upmap_primary mappings for PG merge targets

### DIFF
--- a/doc/rados/operations/read-balancer.rst
+++ b/doc/rados/operations/read-balancer.rst
@@ -130,11 +130,12 @@ To remove a specific ``pg-upmap-primary`` mapping, use:
 
    ceph osd rm-pg-upmap-primary <pgid>
 
-If you need to clear **all** ``pg-upmap-primary`` mappings in your cluster, you may use:
+If you need to clear **all** ``pg-upmap-primary`` mappings in your cluster, you may use the
+following command to either remove all mappings or optionally remove mappings for a single pool:
 
 .. prompt:: bash $
 
-   ceph osd rm-pg-upmap-primary-all
+   ceph osd rm-pg-upmap-primary-all {pool name}
 
 Unable to Use Kernel Client
 ---------------------------

--- a/qa/suites/rados/singleton-nomsgr/all/read-balancer-operations.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/read-balancer-operations.yaml
@@ -1,0 +1,21 @@
+roles:
+- - mon.a
+  - mgr.x
+  - osd.0
+  - osd.1
+  - osd.2
+  - osd.3
+  - client.0
+openstack:
+  - volumes:
+      count: 4
+      size: 10 # GB
+tasks:
+- install:
+- ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr_pool false --force
+- workunit:
+    clients:
+      all:
+        - rados/test_read_balancer.sh

--- a/qa/suites/rados/singleton-nomsgr/all/read-balancer-operations.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/read-balancer-operations.yaml
@@ -15,6 +15,11 @@ tasks:
 - ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr_pool false --force
+    conf:
+      mgr:
+        mgr max pg num change: 32
+      osd:
+        osd op thread timeout: 60
 - workunit:
     clients:
       all:

--- a/qa/workunits/rados/test_read_balancer.sh
+++ b/qa/workunits/rados/test_read_balancer.sh
@@ -1,0 +1,330 @@
+#!/usr/bin/env bash
+# vim: expandtab shiftwidth=4 softtabstop=4
+set -ex
+
+# This workunit is to be used as a basis for testing read balancer functionality of both the 'online'
+# mgr module and the 'offline' CLI commands.
+
+# See https://docs.ceph.com/en/latest/rados/operations/read-balancer/ for more information.
+
+vstart=false
+ceph="ceph"
+
+function print_help {
+    cat <<EOM >&2
+
+Help:
+
+   test_read_balancer.sh --help
+
+Usage:
+   test_read_balancer.sh {-vstart}
+
+The test may be run as-is for teuthology tests, but you may add the --vstart
+flag to run the test on a vstart cluster.
+
+EOM
+}
+
+function start_vstart_cluster {
+    echo "Setting up a test cluster..."
+    cd ~/ceph/build
+    ninja -j$(nproc) vstart
+    OSD=4 ../src/vstart.sh --debug --new -x --localhost --bluestore
+}
+
+function shut_down_cluster {
+    if [[ "$vstart" == "true" ]]; then
+        echo "Shutting down test cluster..."
+        ../src/stop.sh
+    fi
+}
+
+function TEST_read_balancer_bulk_flag {
+    # Tests bug from https://tracker.ceph.com/issues/76731
+    echo "TEST 1: Read balancer interaction with pg_autoscaler 'bulk' flag"
+
+    # Enable the read balancer
+    "$ceph" osd set-require-min-compat-client reef || return 1
+    "$ceph" balancer mode upmap-read || return 1
+
+    # Restrict upmap_max_deviation (balancer will apply more mappings this way)
+    "$ceph" config set mgr mgr/balancer/upmap_max_deviation 1 || return 1
+
+    # Create a new, empty pool
+    "$ceph" osd pool create foo 32 32 || return 1
+    "$ceph" osd pool application enable foo test || return 1 
+    pool_id=$("$ceph" osd pool ls detail -f json | jq '.[] | select(.pool_name == "foo")'.pool_id)
+
+    # Turn autoscaler on for that pool
+    "$ceph" osd pool set foo pg_autoscale_mode on || return 1
+
+    # Give some pool time to scale up and stabilize after creation
+    orig_pg_num=$("$ceph" osd pool ls detail -f json | jq '.[] | select(.pool_name == "foo")'.pg_num)
+    time_elapsed_s=0
+    while (( time_elapsed_s <= 300 )); do
+        if (( orig_pg_num == 32)); then
+            break
+        fi
+
+        echo "Pool foo needs more time to scale up pgs (actual: $orig_pg_num pgs | expected: 32 pgs)..."
+        orig_pg_num=$("$ceph" osd pool ls detail -f json | jq '.[] | select(.pool_name == "foo")'.pg_num)
+
+        time_elapsed_s=$((time_elapsed_s + 5))
+        sleep 5
+        echo "Waited $time_elapsed_s s for pool foo to scale up..."
+    done
+
+    test "$orig_pg_num" -eq 32 || { echo "ERROR: Pool foo failed to scale up to desired pg_num after it was created." >&2; return 1; }
+
+    # Adjust dynamic threshold (necessary to allow the test pool to scale up; if threshold is
+    # too high, the variance between the current pg_num and recommended pg_num
+    # is not large enough to trigger the autoscaler.)
+    "$ceph" osd pool set threshold 1.0 || return 1
+
+    # Restrict the balancer to only pool "foo" (ensures it isn't unable to add mappings due to other
+    # pools scaling up or down)
+    "$ceph" config set mgr mgr/balancer/pool_ids $pool_id || return 1
+
+    # Add the bulk flag
+    "$ceph" osd pool set foo bulk true || return 1
+
+    # Wait for pg_num to scale up more with bulk flag
+    pg_num_expected=$("$ceph" osd pool autoscale-status -f json | jq '.[] | select(.pool_name == "foo")'.pg_num_final)
+    pg_num_actual=$("$ceph" osd pool ls detail -f json | jq '.[] | select(.pool_name == "foo")'.pg_num)
+    time_elapsed_s=0
+    while (( time_elapsed_s <= 300 )); do
+        if (( pg_num_expected <= orig_pg_num )); then
+            echo "Autoscaler status doesn't reflect bulked pool value yet..."
+            pg_num_expected=$("$ceph" osd pool autoscale-status -f json | jq '.[] | select(.pool_name == "foo")'.pg_num_final)
+        else
+            if (( pg_num_expected == pg_num_actual )); then
+                break
+            fi
+
+            next_pg_num_actual=$("$ceph" osd pool ls detail -f json | jq '.[] | select(.pool_name == "foo")'.pg_num)
+            if (( next_pg_num_actual > pg_num_actual )); then
+                echo "Making progress on scaling up..."
+            else
+                echo "Not making progress on scaling up..."
+            fi
+            pg_num_actual=$next_pg_num_actual
+            echo "actual: $pg_num_actual pgs | expected: $pg_num_expected pgs"
+        fi
+
+        time_elapsed_s=$((time_elapsed_s + 5))
+        sleep 5
+        echo "Waited $time_elapsed_s s for pool foo to scale up..."
+
+    done
+
+    [[ $pg_num_expected -gt $orig_pg_num ]] || { echo "ERROR: Autoscaler never set higher pg value." >&2; return 1; }
+    [[ $pg_num_expected -eq $pg_num_actual ]] || { echo "ERROR: Pool foo failed to scale up in time." >&2; return 1; }
+
+
+    # Confirm that pool foo has pg_upmap_primary mappings
+    time_elapsed_s=0
+    primary_mappings=""
+
+    while (( time_elapsed_s <= 300 )); do
+        primary_mappings=$("$ceph" osd dump | grep 'pg_upmap_primary' | grep "${pool_id}\." || true)
+
+        # Run the balancer if there are no primary mappings
+        if [[ -z "$primary_mappings" ]]; then
+            "$ceph" balancer on || return 1
+        fi
+
+        # Exit early if we do have mappings
+        if [[ -n "$primary_mappings" ]]; then
+            break
+        fi
+
+        time_elapsed_s=$((time_elapsed_s + 5))
+        sleep 5
+        echo "Waited $time_elapsed_s s for the balancer to apply pg_upmap_primary mappings..."
+    done
+
+    test -n "$primary_mappings" || { echo "ERROR: No pg_upmap_primary mappings were created for pool foo." >&2; return 1; }
+
+    # Turn balancer off to control variables (we don't want it to add mappings back just yet)
+    "$ceph" balancer off || return 1
+
+    # Remove the bulk flag
+    "$ceph" osd pool set foo bulk false || return 1
+
+    # Wait for pg_num to scale down (allow a generous 2 hrs)
+    pg_num_expected=$("$ceph" osd pool autoscale-status -f json | jq '.[] | select(.pool_name == "foo")'.pg_num_final)
+    pg_num_actual=$("$ceph" osd pool ls detail -f json | jq '.[] | select(.pool_name == "foo")'.pg_num)
+    time_elapsed_s=0
+    while (( time_elapsed_s <= 7200 )); do
+        if (( pg_num_expected != orig_pg_num )); then
+            echo "Autoscaler status doesn't reflect lower (no bulk) pool value yet..."
+            pg_num_expected=$("$ceph" osd pool autoscale-status -f json | jq '.[] | select(.pool_name == "foo")'.pg_num_final)
+        else
+            if (( pg_num_expected == pg_num_actual )); then
+                break
+            fi
+
+            next_pg_num_actual=$("$ceph" osd pool ls detail -f json | jq '.[] | select(.pool_name == "foo")'.pg_num)
+            echo "pg_num went from $pg_num_actual to $next_pg_num_actual ..."
+            if (( next_pg_num_actual < pg_num_actual )); then
+                echo "Making progress on scaling down..."
+            else
+                echo "Not making progress on scaling down..."
+            fi
+            pg_num_actual=$next_pg_num_actual
+            echo "actual: $pg_num_actual pgs | expected: $pg_num_expected pgs"
+        fi
+
+        time_elapsed_s=$((time_elapsed_s + 5))
+        sleep 5
+        echo "Waited $time_elapsed_s s for pool foo to scale down..."
+
+    done
+
+    [[ $pg_num_expected -eq $orig_pg_num ]] || { echo "ERROR: Autoscaler never reverted to original pg value." >&2; return 1; }
+    [[ $pg_num_expected -eq $pg_num_actual ]] || { echo "ERROR: Pool foo failed to scale down in time." >&2; return 1; }
+
+    # Confirm that pg_upmap_primary mappings are cleared for pool foo
+    time_elapsed_s=0
+    primary_mappings=""
+
+    while (( time_elapsed_s <= 300 )); do
+        primary_mappings=$("$ceph" osd dump | grep 'pg_upmap_primary' | grep "${pool_id}\." || true)
+
+        # Exit early if the mappings are gone
+        if [[ -z "$primary_mappings" ]]; then
+            break
+        fi
+
+        time_elapsed_s=$((time_elapsed_s + 5))
+        sleep 5
+        echo "Waited $time_elapsed_s s for the pg_upmap_primary mappings to clear..."
+    done
+
+    test -z "$primary_mappings" || { echo "ERROR: The pg_upmap_primary mappings for pool foo were not cleared in time." >&2; return 1; }
+}
+
+function TEST_read_balancer_cli {
+    echo "TEST 2: Verify 'ceph osd rm-pg-upmap-primary-all'"
+
+    # Make sure the read balance is enabled
+    "$ceph" osd set-require-min-compat-client reef || return 1
+    "$ceph" balancer mode upmap-read || return 1
+
+    # Turn balancer back on for every pool
+    "$ceph" balancer on || return 1
+    "$ceph" config set mgr mgr/balancer/pool_ids "" || return 1
+
+    # Create more pools
+    "$ceph" osd pool create foo_2 32 32 || return 1
+    "$ceph" osd pool application enable foo_2 test || return 1
+
+    "$ceph" osd pool create foo_3 32 32 || return 1
+    "$ceph" osd pool application enable foo_3 test || return 1
+
+    echo "Let new pools settle..."
+    sleep 30
+
+    # Confirm that multiple pools have pg_upmap_primary mappings
+    time_elapsed_s=0
+    prim_pools=""
+    num_prim_pools=0
+    while (( time_elapsed_s <= 300 )); do
+        prim_pools="$(
+            "$ceph" osd dump -f json |
+            jq -r '.pg_upmap_primaries[]?.pgid | split(".")[0]' |
+            sort -u || true
+        )"
+        num_prim_pools=$(echo "$prim_pools" | grep -c .) || true
+
+        # Break if at least two pools have pg_upmap_primary mappings
+        if [[ $num_prim_pools -ge 2 ]]; then
+            echo "2 or more pools have pg_upmap_primary mappings."
+            break
+        fi
+
+        echo "Not enough pools have mappings. Running the balancer..."
+        "$ceph" balancer on || return 1
+
+        time_elapsed_s=$((time_elapsed_s + 5))
+        sleep 5
+        echo "Waited $time_elapsed_s s for the balancer to apply pg_upmap_primary mappings..."
+    done
+
+    test "$num_prim_pools" -ge 2 || { echo "Not enough pools have pg_upmap_primary mappings." >&2; return 1; }
+
+    # Turn balancer off to freeze mapping state
+    "$ceph" balancer off || return 1 
+
+    # Choose random pool
+    rand_pool_id=$(
+        echo "$prim_pools" |
+        shuf -n 1
+    )
+    [[ "$rand_pool_id" -ge 1 ]] || { echo "ERROR: Invalid pool id $rand_pool_id." >&2; return 1; }
+
+    rand_pool_name="$(
+        "$ceph" osd lspools -f json |
+        jq -r --argjson poolid "$rand_pool_id" '.[] | select(.poolnum == $poolid) | .poolname'
+    )"
+    [[ -n "$rand_pool_name" ]] || { echo "ERROR: Unable to extract pool name." >&2; return 1; }
+
+    # Remove prims for random pool only
+    "$ceph" osd rm-pg-upmap-primary-all "$rand_pool_name" || return 1
+    sleep 10 # shouldn't take longer than this to clear mappings
+
+    # Check each pool for existance of prim mappings
+    for pool_id in $prim_pools; do
+        primary_mappings=$("$ceph" osd dump | grep 'pg_upmap_primary' | grep "${pool_id}\." || true)
+
+        if [[ $pool_id -eq $rand_pool_id ]]; then
+            [[ -z "$primary_mappings" ]] || { echo "ERROR: Pool $pool_id (random pool) should not have any pg_upmap_primary mappings: $primary_mappings" >&2; return 1; }
+        else
+            [[ -n "$primary_mappings" ]] || { echo "ERROR: Pool $pool_id should have pg_upmap_primary_mappings." >&2; return 1; }
+        fi    
+    done
+
+    echo "Pool $rand_pool_id was properly cleared of mappings, and all other pools were preserved."
+
+    # Now remove all mappings
+    "$ceph" osd rm-pg-upmap-primary-all || return 1
+    sleep 10
+
+    # Verify all mappings are gone
+    primary_mappings=$("$ceph" osd dump | grep 'pg_upmap_primary' || true)
+    test -z "$primary_mappings" || { echo "ERROR: Not all pg_upmap_primary mappings were cleared: $primary_mappings" >&2; return 1; }
+}
+
+
+#-------------- END -------------
+
+
+main() {
+    if [ "$1" == "--help" ]; then
+        print_help
+        exit
+    fi
+
+    if [ "$1" == "--vstart" ]; then
+        vstart=true
+        ceph="./bin/ceph"
+    fi
+
+    if $vstart; then
+        start_vstart_cluster
+    fi
+
+    # ---- RUN TESTS ----
+    TEST_read_balancer_bulk_flag
+    TEST_read_balancer_cli
+    # -------------------
+
+    if $vstart; then
+        shut_down_cluster
+    fi
+
+    echo "PASS"
+}
+
+main "$@"

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -3302,6 +3302,7 @@ void DaemonServer::adjust_pgs()
   std::map<string,unsigned> pg_num_to_set;
   std::map<string,unsigned> pgp_num_to_set;
   std::set<pg_t> upmaps_to_clear;
+  std::map<uint64_t,string> current_pools; // pid -> pool_name
   cluster_state.with_osdmap_and_pgmap([&](const OSDMap& osdmap, const PGMap& pg_map) {
       unsigned creating_or_unknown = 0;
       for (auto& i : pg_map.num_pg_by_state) {
@@ -3336,7 +3337,8 @@ void DaemonServer::adjust_pgs()
 
       for (auto& i : osdmap.get_pools()) {
 	const pg_pool_t& p = i.second;
-
+        const auto& pool_name = osdmap.get_pool_name(i.first);
+        current_pools[i.first] = pool_name;
 	// adjust pg_num?
 	if (p.get_pg_num_target() != p.get_pg_num()) {
 	  dout(20) << "pool " << i.first
@@ -3593,7 +3595,9 @@ void DaemonServer::adjust_pgs()
       "}";
     monc->start_mon_command({cmd}, {}, nullptr, nullptr, nullptr);
   }
+  std::set<uint64_t> affected_pools;
   for (auto pg : upmaps_to_clear) {
+    affected_pools.emplace(pg.pool());
     const string cmd =
       "{"
       "\"prefix\": \"osd rm-pg-upmap\", "
@@ -3606,6 +3610,20 @@ void DaemonServer::adjust_pgs()
       "\"pgid\": \"" + stringify(pg) + "\"" +
       "}";
     monc->start_mon_command({cmd2}, {}, nullptr, nullptr, nullptr);
+   }
+  // remove all pg_upmap_primary mappings from any pool where pg_num was changed.
+  for (auto pool_id : affected_pools) {
+   std::string pool_name;
+   auto it = current_pools.find(pool_id);
+   if (it != current_pools.end()) {
+     pool_name = it->second;
+     const string cmd =
+       "{"
+       "\"prefix\": \"osd rm-pg-upmap-primary-all\", "
+       "\"pool\": \"" + pool_name + "\"" +
+       "}";
+     monc->start_mon_command({cmd}, {}, nullptr, nullptr, nullptr);
+   }
   }
 }
 

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1029,14 +1029,15 @@ COMMAND("osd rm-pg-upmap-items "
 COMMAND("osd pg-upmap-primary "
 	"name=pgid,type=CephPgid "
 	"name=id,type=CephOsdName ",
-	"set pg primary osd <pgid>:<id> (id (osd) must be part of pgid)",
+	"set pg_upmap_primary osd <pgid>:<id> (id (osd) must be part of pgid)",
         "osd", "rw")
 COMMAND("osd rm-pg-upmap-primary "
 	"name=pgid,type=CephPgid ",
-	"clear pg primary setting for <pgid>",
+	"clear pg_upmap_primary setting for <pgid>",
         "osd", "rw")
-COMMAND("osd rm-pg-upmap-primary-all ",
-        "clear all pg primary entries (developers only)",
+COMMAND("osd rm-pg-upmap-primary-all "
+        "name=pool,type=CephPoolname,req=false",
+        "clear all pg_upmap_primary entries, or all entries for pool <pool> (developers only)",
         "osd", "rw")
 COMMAND("osd primary-temp "
 	"name=pgid,type=CephPgid "

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -13308,8 +13308,20 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
 
     case OP_RM_PG_UPMAP_PRIMARY_ALL:
       {
-	osdmap.rm_all_upmap_prims(cct, &pending_inc);
-	ss << "cleared all pg_upmap_primary mappings";
+        string pool_name;
+        if (cmd_getval(cmdmap, "pool", pool_name)) {
+          auto pool_id = osdmap.lookup_pg_pool_name(pool_name);
+          if (pool_id < 0) {
+            err = -EINVAL;
+            ss << "unrecognized pool name '" << pool_name << "'";
+            goto reply_no_propose;
+          }
+          osdmap.rm_all_upmap_prims(cct, &pending_inc, pool_id);
+          ss << "cleared all pg_upmap_primary mappings for pool '" << pool_name << "'";
+        } else {
+          osdmap.rm_all_upmap_prims(cct, &pending_inc);
+          ss << "cleared all pg_upmap_primary mappings";
+        }
       }
       break;
 

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1766,7 +1766,7 @@ public:
 
   bool have_pg_upmaps(pg_t pg) const {
     return pg_upmap.count(pg) ||
-      pg_upmap_items.count(pg);
+      pg_upmap_items.count(pg) || pg_upmap_primaries.count(pg);
   }
 
   bool check_full(const std::set<pg_shard_t> &missing_on) const {


### PR DESCRIPTION
`OSDMap::check_pg_upmaps` already takes care of removing pg_upmap_primary
mappings for:

1. PGs that were “merge sources” (PGs that merged into another PG and thus
   no longer exist in the pool)
2. PGs that are “pending merge” (these PGs will end up becoming merge sources)

But there is a third scenario that was missing for pg_upmap_primary: “merge targets”.

The DaemonServer identifies PGs as “merge targets”, or the PGs that a “merge source”
will merge into. If there is a pg_upmap, pg_upmap_items, or pg_upmap_primary mapping
associated with a “merge target”, the DaemonServer issues this message:

```
2026-05-14T21:16:56.700+0000 7f745e33d640 10 mgr.server operator() pool 5 pg_num_target
32 pg_num 33 - merge target 5.0 acting does not match (source [3,2,1] != target [3,1,2])
```

Until the acting set of the “merge target” matches the “merge source”, the merging process
will stall. One way the PG merging process is triggered is by removing the “bulk” flag from a pool.

Removing upmap mappings for “merge target” PGs is not handled in the OSDMap code, but rather, the
DaemonServer code. This patch adds in that missing logic.

--------------------

This patch also improves the `ceph osd rm-pg-upmap-primary-all` command so all upmap_primary mappings can be removed on a per-pool basis.

The syntax is:
```
ceph osd rm-pg-upmap-primary-all <pool name>
```

This command can be used in a developer or advanced user setting,
but was mainly developed to be used in the DaemonServer code when we remove
mappings on pools where pg_num was adjusted.

Fixes: https://tracker.ceph.com/issues/76731
Signed-off-by: Laura Flores <lflores@ibm.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
