### PR TITLE
tentacle: rgw/sns: ListTopics uses account root arn for policy evaluation

### DIFF
--- a/src/rgw/rgw_account.cc
+++ b/src/rgw/rgw_account.cc
@@ -21,6 +21,7 @@
 #include "common/random_string.h"
 #include "common/utf8.h"
 
+#include "rgw_arn.h"
 #include "rgw_oidc_provider.h"
 #include "rgw_quota.h"
 #include "rgw_role.h"
@@ -99,6 +100,12 @@ bool validate_name(std::string_view name, std::string* err_msg)
     return false;
   }
   return true;
+}
+
+ARN root_arn(std::string id)
+{
+  const std::string region; // empty
+  return {Partition::aws, Service::iam, region, std::move(id), "root"};
 }
 
 

--- a/src/rgw/rgw_account.h
+++ b/src/rgw/rgw_account.h
@@ -27,6 +27,8 @@ class DoutPrefixProvider;
 class RGWFormatterFlusher;
 class optional_yield;
 
+namespace rgw { class ARN; }
+
 namespace rgw::account {
 
 /// generate a randomized account id in a specific format
@@ -37,6 +39,9 @@ bool validate_id(std::string_view id, std::string* err_msg = nullptr);
 
 /// check an account name for any invalid characters
 bool validate_name(std::string_view name, std::string* err_msg = nullptr);
+
+/// construct the account root arn
+ARN root_arn(std::string account_id);
 
 
 struct AdminOpState {

--- a/src/rgw/rgw_rest_pubsub.cc
+++ b/src/rgw/rgw_rest_pubsub.cc
@@ -6,6 +6,7 @@
 #include <optional>
 #include <regex>
 #include "include/function2.hpp"
+#include "rgw_account.h"
 #include "rgw_iam_policy.h"
 #include "rgw_rest_pubsub.h"
 #include "rgw_pubsub_push.h"
@@ -451,9 +452,13 @@ private:
 
 public:
   int verify_permission(optional_yield) override {
-    // check account permissions up front
-    if (s->auth.identity->get_account() &&
-        !verify_user_permission(this, s, {}, rgw::IAM::snsListTopics)) {
+    // account permissions are checked up front. for non-account users,
+    // execute() instead checks permissions against each topic
+    if (!s->auth.identity->get_account()) {
+      return 0;
+    }
+    const auto arn = rgw::account::root_arn(s->auth.identity->get_account()->id);
+    if (!verify_user_permission(this, s, arn, rgw::IAM::snsListTopics)) {
       return -ERR_AUTHORIZATION;
     }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76277

---

backport of https://github.com/ceph/ceph/pull/68429
parent tracker: https://tracker.ceph.com/issues/74595

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh