### PR TITLE
crimson/os/seastore: wake blocked IO on BackgroundProcess wakeup

### DIFF
--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -841,6 +841,12 @@ ExtentPlacementManager::BackgroundProcess::run()
       assert(!blocking_background);
       blocking_background = seastar::promise<>();
       co_await blocking_background->get_future();
+      // After waking (typically because arm_blocking_io_and_wake() kicked us),
+      // give any blocked user IO a chance to proceed. Without this call the
+      // loop would go straight back to sleep if background_should_run() is
+      // still false, but the space condition (should_block_io) may already be
+      // satisfied, leaving blocked IO stuck with no future trigger to re-check.
+      maybe_wake_blocked_io();
     }
   }
   log_state("run(exit)");


### PR DESCRIPTION
## Summary

Closes a latent deadlock window in `ExtentPlacementManager::BackgroundProcess::run()`: when `background_should_run()` is false but the space-availability condition (`should_block_io`) has just become satisfied, the wake-up loop returns to sleep without re-checking blocked IO. The blocked IO stays stuck until some unrelated future wake-up happens to coincide, or never.

The fix is a single `maybe_wake_blocked_io()` call right after the wake, before the loop re-checks `background_should_run()`. It's a no-op when nothing is blocked.

## Why it matters

Observed in sustained random-write benches where IO stalled indefinitely while the cleaner sat idle. The bug only fires in a narrow race (cleaner work just ended at the same moment IO unblock was due) but the failure mode is permanent IO block — no further trigger ever re-checks.

## Test plan

- [x] Build clean against current `main`
- [x] No-op on workloads where nothing is blocked
- [ ] Targeted reproducer of the race (not included — the race is hard to trigger deterministically; happy to add a stress test if reviewers prefer)

## Contribution Guidelines
- Tracker (select at least one)
  - [x] Very recent bug; references commit where it was introduced — discovered during sustained-write benches against current `main`
  - [ ] References tracker ticket
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] No impact that needs to be tracked
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
- Documentation (select at least one)
  - [x] No doc update is appropriate
  - [ ] Updates relevant documentation
- Tests (select at least one)
  - [x] No tests
  - [ ] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Includes bug reproducer