### PR TITLE
seastore: add latency distribution (p95/p99) support

### DIFF
--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1023,6 +1023,9 @@ void Cache::mark_transaction_conflicted(
   SUBTRACET(seastore_t, "", t);
   assert(!t.conflicted);
   t.conflicted = true;
+  // count is only *sampled* for the user-MUTATE do_transaction path,
+  // where the transaction is reused across retries
+  ++t.num_replays;
 
   auto& efforts = get_by_src(stats.invalidated_efforts_by_src,
                              t.get_src());

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -178,6 +178,14 @@ void SeaStore::Shard::register_metrics(store_index_t store_index)
     {op_type_t::OMAP_ITERATE,     sm::label_instance("latency", "OMAP_ITERATE")},
   };
 
+  for (auto& hist : stats.op_lat) {
+    hist.buckets.resize(lat_hist_bounds_us.size());
+    for (std::size_t i = 0; i < lat_hist_bounds_us.size(); ++i) {
+      hist.buckets[i].upper_bound = lat_hist_bounds_us[i];
+      hist.buckets[i].count = 0;
+    }
+  }
+
   for (auto& [op_type, label] : labels_by_op_type) {
     auto desc = fmt::format("latency of seastore operation (optype={})",
                             op_type);

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -226,10 +226,16 @@ void SeaStore::Shard::register_metrics(store_index_t store_index)
   );
 
   std::pair<txn_stage_t, sm::label_instance> labels_by_stage[] = {
-    {txn_stage_t::COLLOCK_WAIT,   sm::label_instance("stage", "collock_wait")},
-    {txn_stage_t::THROTTLER_WAIT, sm::label_instance("stage", "throttler_wait")},
-    {txn_stage_t::BUILD,          sm::label_instance("stage", "build")},
-    {txn_stage_t::SUBMIT,         sm::label_instance("stage", "submit")},
+    {txn_stage_t::COLLOCK_WAIT,          sm::label_instance("stage", "collock_wait")},
+    {txn_stage_t::THROTTLER_WAIT,        sm::label_instance("stage", "throttler_wait")},
+    {txn_stage_t::BUILD,                 sm::label_instance("stage", "build")},
+    {txn_stage_t::SUBMIT_TOTAL,          sm::label_instance("stage", "submit_total")},
+    {txn_stage_t::SUBMIT_RESERVE,        sm::label_instance("stage", "submit_reserve")},
+    {txn_stage_t::SUBMIT_OOL_WRITE,      sm::label_instance("stage", "submit_ool_write")},
+    {txn_stage_t::SUBMIT_LBA_UPDATE,     sm::label_instance("stage", "submit_lba_update")},
+    {txn_stage_t::SUBMIT_PREPARE_ENTER,  sm::label_instance("stage", "submit_prepare_enter")},
+    {txn_stage_t::SUBMIT_PREPARE_RECORD, sm::label_instance("stage", "submit_prepare_record")},
+    {txn_stage_t::SUBMIT_JOURNAL,        sm::label_instance("stage", "submit_journal")},
   };
   for (auto& [stage, label] : labels_by_stage) {
     auto idx = static_cast<std::size_t>(stage);
@@ -1774,7 +1780,16 @@ seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
   add_stage_latency_sample(txn_stage_t::COLLOCK_WAIT, collock_wait);
   add_stage_latency_sample(txn_stage_t::THROTTLER_WAIT, throttler_wait);
   add_stage_latency_sample(txn_stage_t::BUILD, ctx.build_time);
-  add_stage_latency_sample(txn_stage_t::SUBMIT, ctx.submit_time);
+  add_stage_latency_sample(txn_stage_t::SUBMIT_TOTAL, ctx.submit_time);
+  {
+    auto& pd = ctx.transaction->get_phase_durations();
+    add_stage_latency_sample(txn_stage_t::SUBMIT_RESERVE, pd.reserve);
+    add_stage_latency_sample(txn_stage_t::SUBMIT_OOL_WRITE, pd.ool_write);
+    add_stage_latency_sample(txn_stage_t::SUBMIT_LBA_UPDATE, pd.lba_update);
+    add_stage_latency_sample(txn_stage_t::SUBMIT_PREPARE_ENTER, pd.prepare_enter);
+    add_stage_latency_sample(txn_stage_t::SUBMIT_PREPARE_RECORD, pd.prepare_record);
+    add_stage_latency_sample(txn_stage_t::SUBMIT_JOURNAL, pd.journal);
+  }
   add_latency_sample(
     op_type_t::DO_TRANSACTION,
     std::chrono::steady_clock::now() - ctx.begin_timestamp);

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -203,6 +203,28 @@ void SeaStore::Shard::register_metrics(store_index_t store_index)
     );
   }
 
+  stats.conflict_replays.buckets.resize(REPLAY_BUCKETS);
+  for (std::size_t i = 0; i < REPLAY_BUCKETS; ++i) {
+    stats.conflict_replays.buckets[i].upper_bound = i;
+    stats.conflict_replays.buckets[i].count = 0;
+  }
+  metrics.add_group(
+    "seastore",
+    {
+      sm::make_histogram(
+        "conflict_replay_distribution",
+        [this]() -> seastar::metrics::histogram& {
+          return stats.conflict_replays;
+        },
+        sm::description("distribution of per-transaction conflict/replay counts "
+                        "before commit, for user transactions submitted via "
+                        "do_transaction (the reused-transaction / "
+                        "with_repeat_trans_intr path); not all MUTATE transactions"),
+        {sm::label_instance("shard_store_index", std::to_string(store_index))}
+      )
+    }
+  );
+
   metrics.add_group(
     "seastore",
     {
@@ -1711,6 +1733,7 @@ seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
   );
 
   DEBUGT("done", *ctx.transaction);
+  add_conflict_replay_sample(ctx.transaction->get_num_replays());
   add_latency_sample(
     op_type_t::DO_TRANSACTION,
     std::chrono::steady_clock::now() - ctx.begin_timestamp);

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -229,6 +229,7 @@ void SeaStore::Shard::register_metrics(store_index_t store_index)
     {txn_stage_t::COLLOCK_WAIT,          sm::label_instance("stage", "collock_wait")},
     {txn_stage_t::THROTTLER_WAIT,        sm::label_instance("stage", "throttler_wait")},
     {txn_stage_t::BUILD,                 sm::label_instance("stage", "build")},
+    {txn_stage_t::BUILD_GET_ONODE,       sm::label_instance("stage", "build_get_onode")},
     {txn_stage_t::SUBMIT_TOTAL,          sm::label_instance("stage", "submit_total")},
     {txn_stage_t::SUBMIT_RESERVE,        sm::label_instance("stage", "submit_reserve")},
     {txn_stage_t::SUBMIT_OOL_WRITE,      sm::label_instance("stage", "submit_ool_write")},
@@ -1780,6 +1781,7 @@ seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
   add_stage_latency_sample(txn_stage_t::COLLOCK_WAIT, collock_wait);
   add_stage_latency_sample(txn_stage_t::THROTTLER_WAIT, throttler_wait);
   add_stage_latency_sample(txn_stage_t::BUILD, ctx.build_time);
+  add_stage_latency_sample(txn_stage_t::BUILD_GET_ONODE, ctx.get_onode_time);
   add_stage_latency_sample(txn_stage_t::SUBMIT_TOTAL, ctx.submit_time);
   {
     auto& pd = ctx.transaction->get_phase_durations();
@@ -1893,6 +1895,7 @@ SeaStore::Shard::_do_transaction_step(
   }
   if (!onodes[op->oid]) {
     const ghobject_t& oid = i.get_oid(op->oid);
+    auto t0 = std::chrono::steady_clock::now();
     if (!create) {
       DEBUGT("op {}, get oid={} ...",
              *ctx.transaction, (uint32_t)op->op, oid);
@@ -1902,6 +1905,10 @@ SeaStore::Shard::_do_transaction_step(
              *ctx.transaction, (uint32_t)op->op, oid);
       fut = onode_manager->get_or_create_onode(*ctx.transaction, oid);
     }
+    fut = std::move(fut).si_then([&ctx, t0](auto onode) {
+      ctx.get_onode_time += std::chrono::steady_clock::now() - t0;
+      return onode_iertr::make_ready_future<OnodeRef>(std::move(onode));
+    });
   }
   return fut.si_then([&, op, this, FNAME](auto get_onode)
                       -> OnodeManager::get_or_create_onode_iertr::future<> {

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -225,6 +225,35 @@ void SeaStore::Shard::register_metrics(store_index_t store_index)
     }
   );
 
+  std::pair<txn_stage_t, sm::label_instance> labels_by_stage[] = {
+    {txn_stage_t::COLLOCK_WAIT,   sm::label_instance("stage", "collock_wait")},
+    {txn_stage_t::THROTTLER_WAIT, sm::label_instance("stage", "throttler_wait")},
+    {txn_stage_t::BUILD,          sm::label_instance("stage", "build")},
+    {txn_stage_t::SUBMIT,         sm::label_instance("stage", "submit")},
+  };
+  for (auto& [stage, label] : labels_by_stage) {
+    auto idx = static_cast<std::size_t>(stage);
+    auto& hist = stats.stage_lat[idx];
+    hist.buckets.resize(STAGE_LAT_BUCKETS_US.size());
+    for (std::size_t i = 0; i < STAGE_LAT_BUCKETS_US.size(); ++i) {
+      hist.buckets[i].upper_bound = STAGE_LAT_BUCKETS_US[i];
+      hist.buckets[i].count = 0;
+    }
+    metrics.add_group(
+      "seastore",
+      {
+        sm::make_histogram(
+          "do_transaction_stage_lat",
+          [this, idx]() -> seastar::metrics::histogram& {
+            return stats.stage_lat[idx];
+          },
+          sm::description("per-stage latency (microseconds) of do_transaction"),
+          {label, sm::label_instance("shard_store_index", std::to_string(store_index))}
+        )
+      }
+    );
+  }
+
   metrics.add_group(
     "seastore",
     {
@@ -1667,15 +1696,19 @@ seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
   --(shard_stats.starting_io_num);
   ++(shard_stats.waiting_collock_io_num);
 
+  auto t_pre_collock = std::chrono::steady_clock::now();
   co_await ctx.transaction->get_handle().take_collection_lock(
     static_cast<SeastoreCollection&>(*(ctx.ch)).ordering_lock
   );
+  auto collock_wait = std::chrono::steady_clock::now() - t_pre_collock;
 
   assert(shard_stats.waiting_collock_io_num);
   --(shard_stats.waiting_collock_io_num);
   ++(shard_stats.waiting_throttler_io_num);
 
+  auto t_pre_throttler = std::chrono::steady_clock::now();
   co_await throttler.get(1);
+  auto throttler_wait = std::chrono::steady_clock::now() - t_pre_throttler;
 
   assert(shard_stats.waiting_throttler_io_num);
   --(shard_stats.waiting_throttler_io_num);
@@ -1711,6 +1744,7 @@ seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
       const size_t total_ops = ctx.ext_transaction.get_num_ops();
       size_t current_op = 0;
 
+      auto build_start = std::chrono::steady_clock::now();
       while (ctx.iter.have_op()) {
         current_op++;
 
@@ -1719,10 +1753,13 @@ seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
 	co_await _do_transaction_step(
 	  ctx, ctx.ch, onodes, ctx.iter);
       }
+      ctx.build_time += std::chrono::steady_clock::now() - build_start;
 
       DEBUGT("completed all {} ops for cid={}",
              t, total_ops, ctx.ch->get_cid());
+      auto submit_start = std::chrono::steady_clock::now();
       co_await transaction_manager->submit_transaction(*ctx.transaction);
+      ctx.submit_time += std::chrono::steady_clock::now() - submit_start;
     })
   ).handle_error(
     crimson::ct_error::all_same_way([FNAME, &ctx](auto e) {
@@ -1734,6 +1771,10 @@ seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
 
   DEBUGT("done", *ctx.transaction);
   add_conflict_replay_sample(ctx.transaction->get_num_replays());
+  add_stage_latency_sample(txn_stage_t::COLLOCK_WAIT, collock_wait);
+  add_stage_latency_sample(txn_stage_t::THROTTLER_WAIT, throttler_wait);
+  add_stage_latency_sample(txn_stage_t::BUILD, ctx.build_time);
+  add_stage_latency_sample(txn_stage_t::SUBMIT, ctx.submit_time);
   add_latency_sample(
     op_type_t::DO_TRANSACTION,
     std::chrono::steady_clock::now() - ctx.begin_timestamp);

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -437,9 +437,12 @@ public:
       100000
     };
 
+    // Buckets for the per-transaction conflict/replay distribution.
+    static constexpr std::size_t REPLAY_BUCKETS = 16;
 
     struct {
       std::array<seastar::metrics::histogram, LAT_MAX> op_lat;
+      seastar::metrics::histogram conflict_replays;
     } stats;
 
     seastar::metrics::histogram& get_latency(
@@ -465,6 +468,21 @@ public:
       if (!found && !lat.buckets.empty()) {
         ++lat.buckets.back().count;
       }
+    }
+
+    // Record how many times a just-completed transaction was conflicted/replayed.
+    // Called only from the do_transaction_no_callbacks() completion path.
+    void add_conflict_replay_sample(std::size_t num_replays) {
+      auto& hist = stats.conflict_replays;
+      if (hist.buckets.empty()) {
+        // register_metrics() did not run (store inactive); nothing to record.
+        return;
+      }
+      std::size_t idx = num_replays < REPLAY_BUCKETS ?
+        num_replays : REPLAY_BUCKETS - 1;
+      ++hist.buckets[idx].count;
+      ++hist.sample_count;
+      hist.sample_sum += num_replays;
     }
 
     /*

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -425,6 +425,19 @@ public:
 
     static constexpr auto LAT_MAX = static_cast<std::size_t>(op_type_t::MAX);
 
+    // Histogram bucket upper bounds in microseconds (0.25ms–20ms).
+    // Ops above 20ms land in the last bucket as overflow.
+    static constexpr std::array<double, 14> lat_hist_bounds_us = {
+      250, 500, 1000,
+      1500, 2000, 3000,
+      5000,
+      7500, 10000,
+      15000, 20000,
+      30000, 50000,
+      100000
+    };
+
+
     struct {
       std::array<seastar::metrics::histogram, LAT_MAX> op_lat;
     } stats;
@@ -440,6 +453,17 @@ public:
       seastar::metrics::histogram& lat = get_latency(op_type);
       lat.sample_count++;
       lat.sample_sum += std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
+      bool found = false;
+      for (auto& b : lat.buckets) {
+        if (static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(dur).count()) <= b.upper_bound) {
+          ++b.count;
+          found = true;
+          break;
+        }
+      }
+      if (!found && !lat.buckets.empty()) {
+        ++lat.buckets.back().count;
+      }
     }
 
     /*

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -51,7 +51,14 @@ enum class txn_stage_t : uint8_t {
     COLLOCK_WAIT = 0,  // waiting on the collection ordering_lock
     THROTTLER_WAIT,    // waiting for a throttler slot
     BUILD,             // building the transaction (_do_transaction_step loop)
-    SUBMIT,            // submit_transaction (pipeline + journal write)
+    SUBMIT_TOTAL,      // the whole submit_transaction (pipeline + journal write)
+    // Sub-phases of submit_transaction:
+    SUBMIT_RESERVE,        // enter(reserve_projected_usage) + epm reserve_projected_usage
+    SUBMIT_OOL_WRITE,      // write_delayed + write_preallocated OOL extents (device I/O)
+    SUBMIT_LBA_UPDATE,     // update_lba_mappings
+    SUBMIT_PREPARE_ENTER,  // enter(prepare) pipeline stage (global OrderedExclusive wait)
+    SUBMIT_PREPARE_RECORD, // prepare_record (record encoding)
+    SUBMIT_JOURNAL,        // journal->submit_record -- POST-lock (not part of the hold)
     MAX
 };
 

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -51,6 +51,7 @@ enum class txn_stage_t : uint8_t {
     COLLOCK_WAIT = 0,  // waiting on the collection ordering_lock
     THROTTLER_WAIT,    // waiting for a throttler slot
     BUILD,             // building the transaction (_do_transaction_step loop)
+    BUILD_GET_ONODE,   // onode_manager get/get_or_create calls within BUILD
     SUBMIT_TOTAL,      // the whole submit_transaction (pipeline + journal write)
     // Sub-phases of submit_transaction:
     SUBMIT_RESERVE,        // enter(reserve_projected_usage) + epm reserve_projected_usage
@@ -268,6 +269,7 @@ public:
       std::chrono::steady_clock::time_point begin_timestamp = std::chrono::steady_clock::now();
 
       std::chrono::steady_clock::duration build_time{0};
+      std::chrono::steady_clock::duration get_onode_time{0};
       std::chrono::steady_clock::duration submit_time{0};
 
       void reset_preserve_handle(TransactionManager &tm) {

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -47,6 +47,14 @@ enum class op_type_t : uint8_t {
     MAX
 };
 
+enum class txn_stage_t : uint8_t {
+    COLLOCK_WAIT = 0,  // waiting on the collection ordering_lock
+    THROTTLER_WAIT,    // waiting for a throttler slot
+    BUILD,             // building the transaction (_do_transaction_step loop)
+    SUBMIT,            // submit_transaction (pipeline + journal write)
+    MAX
+};
+
 class SeastoreCollection final : public FuturizedCollection {
 public:
   template <typename... T>
@@ -252,6 +260,9 @@ public:
       ceph::os::Transaction::iterator iter;
       std::chrono::steady_clock::time_point begin_timestamp = std::chrono::steady_clock::now();
 
+      std::chrono::steady_clock::duration build_time{0};
+      std::chrono::steady_clock::duration submit_time{0};
+
       void reset_preserve_handle(TransactionManager &tm) {
         tm.reset_transaction_preserve_handle(*transaction);
         iter = ext_transaction.begin();
@@ -440,9 +451,17 @@ public:
     // Buckets for the per-transaction conflict/replay distribution.
     static constexpr std::size_t REPLAY_BUCKETS = 16;
 
+    static constexpr auto STAGE_MAX = static_cast<std::size_t>(txn_stage_t::MAX);
+    // Upper bounds (microseconds) for the per-stage do_transaction latency histograms
+    static constexpr std::array<uint64_t, 14> STAGE_LAT_BUCKETS_US = {
+      250, 500, 1000, 1500, 2000, 3000, 5000, 7500,
+      10000, 15000, 20000, 30000, 50000, 100000
+    };
+
     struct {
       std::array<seastar::metrics::histogram, LAT_MAX> op_lat;
       seastar::metrics::histogram conflict_replays;
+      std::array<seastar::metrics::histogram, STAGE_MAX> stage_lat;
     } stats;
 
     seastar::metrics::histogram& get_latency(
@@ -483,6 +502,27 @@ public:
       ++hist.buckets[idx].count;
       ++hist.sample_count;
       hist.sample_sum += num_replays;
+    }
+
+    // Record the latency of one do_transaction stage (microseconds). Buckets are
+    // non-cumulative (bucket = first upper_bound >= value); values above the top
+    // bound aren't bucketed but still land in sample_count/sample_sum.
+    void add_stage_latency_sample(txn_stage_t stage,
+        std::chrono::steady_clock::duration dur) {
+      auto& hist = stats.stage_lat[static_cast<std::size_t>(stage)];
+      if (hist.buckets.empty()) {
+        // register_metrics() did not run (store inactive); nothing to record.
+        return;
+      }
+      auto us = std::chrono::duration_cast<std::chrono::microseconds>(dur).count();
+      for (auto& b : hist.buckets) {
+        if (static_cast<double>(us) <= b.upper_bound) {
+          ++b.count;
+          break;
+        }
+      }
+      ++hist.sample_count;
+      hist.sample_sum += us;
     }
 
     /*

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -451,11 +451,12 @@ public:
     void add_latency_sample(op_type_t op_type,
         std::chrono::steady_clock::duration dur) {
       seastar::metrics::histogram& lat = get_latency(op_type);
+      auto us = std::chrono::duration_cast<std::chrono::microseconds>(dur).count();
       lat.sample_count++;
-      lat.sample_sum += std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
+      lat.sample_sum += us;
       bool found = false;
       for (auto& b : lat.buckets) {
-        if (static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(dur).count()) <= b.upper_bound) {
+        if (static_cast<double>(us) <= b.upper_bound) {
           ++b.count;
           found = true;
           break;

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -464,6 +464,12 @@ public:
     return conflicted;
   }
 
+  // Number of times this transaction was conflicted and replayed before
+  // finally committing. do_transaction_no_callbacks() (user MUTATE writes)
+  std::size_t get_num_replays() const {
+    return num_replays;
+  }
+
   auto &get_handle() {
     return handle;
   }
@@ -881,6 +887,8 @@ private:
   rewrite_stats_t rewrite_stats;
 
   bool conflicted = false;
+
+  std::size_t num_replays = 0;
 
   bool has_reset = false;
 

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <iostream>
 
 #include <boost/intrusive/list.hpp>
@@ -470,6 +471,19 @@ public:
     return num_replays;
   }
 
+  // Time spent in each sub-phase of submit_transaction, accumulated across retries
+  struct phase_durations_t {
+    std::chrono::steady_clock::duration reserve{0};         // enter reserve + epm reserve
+    std::chrono::steady_clock::duration ool_write{0};       // delayed + preallocated OOL writes
+    std::chrono::steady_clock::duration lba_update{0};      // update_lba_mappings
+    std::chrono::steady_clock::duration prepare_enter{0};   // enter(prepare) pipeline stage
+    std::chrono::steady_clock::duration prepare_record{0};  // prepare_record
+    std::chrono::steady_clock::duration journal{0};         // journal->submit_record (post-lock)
+  };
+  phase_durations_t &get_phase_durations() {
+    return phase_durations;
+  }
+
   auto &get_handle() {
     return handle;
   }
@@ -889,6 +903,8 @@ private:
   bool conflicted = false;
 
   std::size_t num_replays = 0;
+
+  phase_durations_t phase_durations;
 
   bool has_reset = false;
 

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -471,6 +471,7 @@ TransactionManager::submit_transaction(
 {
   LOG_PREFIX(TransactionManager::submit_transaction);
   SUBDEBUGT(seastore_t, "start, entering reserve_projected_usage", t);
+  auto reserve_start = std::chrono::steady_clock::now();
   co_await trans_intr::make_interruptible(
     t.get_handle().enter(write_pipeline.reserve_projected_usage)
   );
@@ -483,6 +484,8 @@ TransactionManager::submit_transaction(
       projected_usage
     )
   );
+  t.get_phase_durations().reserve +=
+    std::chrono::steady_clock::now() - reserve_start;
   auto release_usage = seastar::defer([this, FNAME, projected_usage, &t] {
     SUBTRACET(seastore_t, "releasing projected_usage: {}", t, projected_usage);
     epm->release_projected_usage(projected_usage);
@@ -593,21 +596,33 @@ TransactionManager::do_submit_transaction(
   );
 
   SUBTRACET(seastore_t, "write delayed ool extents", tref);
+  auto ool_start = std::chrono::steady_clock::now();
   co_await epm->write_delayed_ool_extents(
     tref, dispatch_result.alloc_map
   );
+  tref.get_phase_durations().ool_write +=
+    std::chrono::steady_clock::now() - ool_start;
 
   auto allocated_extents = tref.get_valid_pre_alloc_list();
+  auto lba_start = std::chrono::steady_clock::now();
   co_await update_lba_mappings(tref, allocated_extents);
+  tref.get_phase_durations().lba_update +=
+    std::chrono::steady_clock::now() - lba_start;
 
   auto num_extents = allocated_extents.size();
   SUBTRACET(seastore_t, "process {} allocated extents", tref, num_extents);
+  ool_start = std::chrono::steady_clock::now();
   co_await epm->write_preallocated_ool_extents(tref, allocated_extents);
+  tref.get_phase_durations().ool_write +=
+    std::chrono::steady_clock::now() - ool_start;
 
   SUBTRACET(seastore_t, "entering prepare", tref);
+  auto prepare_enter_start = std::chrono::steady_clock::now();
   co_await trans_intr::make_interruptible(
     tref.get_handle().enter(write_pipeline.prepare)
   );
+  tref.get_phase_durations().prepare_enter +=
+    std::chrono::steady_clock::now() - prepare_enter_start;
 
   while (tref.need_wait_visibility) {
     co_await trans_intr::make_interruptible(seastar::yield());
@@ -617,10 +632,13 @@ TransactionManager::do_submit_transaction(
     cache->trim_backref_bufs(*trim_alloc_to);
   }
 
+  auto prepare_record_start = std::chrono::steady_clock::now();
   auto record = cache->prepare_record(
     tref,
     journal->get_trimmer().get_journal_head(),
     journal->get_trimmer().get_dirty_tail());
+  tref.get_phase_durations().prepare_record +=
+    std::chrono::steady_clock::now() - prepare_record_start;
 
   tref.get_handle().maybe_release_collection_lock();
   if (tref.get_src() == Transaction::src_t::MUTATE) {
@@ -629,6 +647,7 @@ TransactionManager::do_submit_transaction(
   }
 
   SUBTRACET(seastore_t, "submitting record", tref);
+  auto journal_start = std::chrono::steady_clock::now();
   co_await journal->submit_record(
     std::move(record),
     tref.get_handle(),
@@ -648,6 +667,8 @@ TransactionManager::do_submit_transaction(
       submit_transaction_iertr::pass_further{},
       crimson::ct_error::assert_all("Hit error submitting to journal")
     );
+  tref.get_phase_durations().journal +=
+    std::chrono::steady_clock::now() - journal_start;
 
   co_await trans_intr::make_interruptible(
     tref.get_handle().complete()


### PR DESCRIPTION
This is a follow up to the discussion from: https://github.com/ceph/ceph/pull/68691#issuecomment-4611631694

Commits: 
* Based on https://github.com/ceph/ceph/pull/69211
* add latency distribution (p95/p99) support (op_lat) [1]
* track per-transaction conflict/replay counts (omit long tail lat as an issue)
* Track do_transaction_stages to spot problematic phases.
* Track sub-phase (of submit phase) - we might hold collection lock too coarse.

---

[1] 
Previous work observed ~5–10% conflict rates with a clear correlation to average latency, but lacked visibility into latency distribution and tail behavior.

This change adds histogram buckets for `DO_TRANSACTION` latency, enabling p95/p99 analysis.
Initial results show higher-conflict shards have a heavier tail, not just higher averages (will share in the comments below).

Pre:
```
            "seastore_op_lat": {
                "latency": "DO_TRANSACTION",
                "shard": "0",
                "shard_store_index": "0",
                "value": {
                    "sum": 259383,
                    "count": 281545,
                    "buckets": [
                        {
                            "le": "+Inf",
                            "count": 281545
                        }
```

Post:
```
            "seastore_op_lat": {
                "latency": "DO_TRANSACTION",
                "shard": "0",
                "shard_store_index": "0",
                "value": {
                    "sum": 136694026,
                    "count": 128313,
                    "buckets": [
                        {
                            "le": 250,
                            "count": 11569
                        },
                        {
                            "le": 500,
                            "count": 35328
                        },
                        {
                            "le": 1000,
                            "count": 37047
                        },
                        {
                            "le": 1500,
                            "count": 17869
                        },
                        {
                            "le": 2000,
                            "count": 9890
                        },
                        {
                            "le": 3000,
                            "count": 9587
                        },
                        {
                            "le": 5000,
                            "count": 5139
                        },
                        {
                            "le": 7500,
                            "count": 1317
                        },
                        {
                            "le": 10000,
                            "count": 368
                        },
                        {
                            "le": 15000,
                            "count": 166
                        },
                        {
                            "le": 20000,
                            "count": 26
                        },
                        {
                            "le": 30000,
                            "count": 6
                        },
                        {
                            "le": 50000,
                            "count": 1
                        },
                        {
                            "le": 100000,
                            "count": 0
                        },
                        {
                            "le": "+Inf",
                            "count": 128313
                        }
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
