### PR TITLE
mgr/telemetry: add dashboard protocol usage metrics

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/ui_metrics.py
+++ b/src/pybind/mgr/dashboard/controllers/ui_metrics.py
@@ -1,87 +1,31 @@
 # -*- coding: utf-8 -*-
 """
-Dashboard UI Metrics controller.
+Dashboard Metrics controller.
 
-Tracks anonymous UI usage:
-  - Page visit counts per page (incremented by server-side API hooks)
-  - Session login count and last-login timestamp (posted by Angular on login)
-  - Storage protocol detection via pool application_metadata
-
-KV keys (all under shared mgr store, readable by telemetry + prometheus modules):
-  ui_metrics/page_visits/<page>           int
-  ui_metrics/sessions/login_count         int
-  ui_metrics/sessions/last_login_epoch    int (unix epoch)
-  ui_metrics/protocols_enabled            json str
+Provides REST API endpoints for dashboard telemetry metrics.
+Business logic is in services/telemetry.py
 """
-
-import json
-import logging
 
 from typing import Any, Dict
 
-from .. import mgr
 from . import APIDoc, APIRouter, Endpoint, EndpointDoc, RESTController
-
-logger = logging.getLogger('controllers.ui_metrics')
-
-
-KV_PROTOCOLS = 'ui_metrics/protocols_enabled'
-
-
-def collect_metrics() -> Dict[str, Any]:
-    """Returns protocol telemetry metrics."""
-    prot_raw = mgr.get_store(KV_PROTOCOLS)
-
-    if prot_raw:
-        protocols = json.loads(prot_raw)
-    else:
-        protocols = _detect_and_cache_protocols()
-
-    return {
-        'protocols_enabled': protocols,
-    }
-
-
-def _detect_and_cache_protocols() -> Dict[str, Any]:
-    """
-    Inspect osd_map pool application_metadata to determine which protocols
-    are in use:
-        'rbd'    → Block  (RBD)
-        'cephfs' → File   (CephFS)
-        'rgw'    → Object (RGW / S3)
-    Result is cached in KV store so telemetry and prometheus can read it
-    without re-inspecting osd_map every scrape.
-    """
-    try:
-        osd_map = mgr.get('osd_map') or {}
-        pools = osd_map.get('pools', [])
-    except Exception as e:  # pylint: disable=broad-except
-        logger.error('ui_metrics: failed to read osd_map: %s', e)
-        return {'block': False, 'file': False, 'object': False}
-
-    result: Dict[str, Any] = {
-        'block':  any('rbd'    in (p.get('application_metadata') or {}) for p in pools),
-        'file':   any('cephfs' in (p.get('application_metadata') or {}) for p in pools),
-        'object': any('rgw'    in (p.get('application_metadata') or {}) for p in pools),
-        'pools_checked': len(pools),
-    }
-    mgr.set_store(KV_PROTOCOLS, json.dumps(result))
-    return result
+from ..services.telemetry import DashboardTelemetryService, ProtocolsEnabled
 
 # ---------------------------------------------------------------------------
 # REST Controller
 # ---------------------------------------------------------------------------
 
-@APIRouter('/ui_metrics')
-@APIDoc('Dashboard UI usage metrics (anonymous, aggregated)', 'UIMetrics')
-class UIMetrics(RESTController):
+@APIRouter('/telemetry/metrics')
+@APIDoc('Dashboard usage metrics (anonymous, aggregated)', 'TelemetryMetrics')
+class TelemetryMetrics(RESTController):
+    """Thin controller - delegates to DashboardTelemetryService"""
 
-    def list(self) -> Dict[str, Any]:
-        return collect_metrics()
+    def list(self):
+        """Get all telemetry metrics"""
+        return DashboardTelemetryService.get_metrics()
 
     @Endpoint()
-    @EndpointDoc(
-        'Detect enabled storage protocols from pool application tags'
-    )
-    def protocols(self) -> Dict[str, Any]:
-        return _detect_and_cache_protocols()
+    @EndpointDoc('Detect enabled storage protocols from pool application tags')
+    def protocols(self) -> ProtocolsEnabled:
+        """Force re-detection of protocols (bypasses cache)"""
+        return DashboardTelemetryService.refresh_protocols()

--- a/src/pybind/mgr/dashboard/controllers/ui_metrics.py
+++ b/src/pybind/mgr/dashboard/controllers/ui_metrics.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+"""
+Dashboard UI Metrics controller.
+
+Tracks anonymous UI usage:
+  - Page visit counts per page (incremented by server-side API hooks)
+  - Session login count and last-login timestamp (posted by Angular on login)
+  - Storage protocol detection via pool application_metadata
+
+KV keys (all under shared mgr store, readable by telemetry + prometheus modules):
+  ui_metrics/page_visits/<page>           int
+  ui_metrics/sessions/login_count         int
+  ui_metrics/sessions/last_login_epoch    int (unix epoch)
+  ui_metrics/protocols_enabled            json str
+"""
+
+import json
+import logging
+
+from typing import Any, Dict
+
+from .. import mgr
+from . import APIDoc, APIRouter, Endpoint, EndpointDoc, RESTController
+
+logger = logging.getLogger('controllers.ui_metrics')
+
+
+KV_PROTOCOLS = 'ui_metrics/protocols_enabled'
+
+
+def collect_metrics() -> Dict[str, Any]:
+    """Returns protocol telemetry metrics."""
+    prot_raw = mgr.get_store(KV_PROTOCOLS)
+
+    if prot_raw:
+        protocols = json.loads(prot_raw)
+    else:
+        protocols = _detect_and_cache_protocols()
+
+    return {
+        'protocols_enabled': protocols,
+    }
+
+
+def _detect_and_cache_protocols() -> Dict[str, Any]:
+    """
+    Inspect osd_map pool application_metadata to determine which protocols
+    are in use:
+        'rbd'    → Block  (RBD)
+        'cephfs' → File   (CephFS)
+        'rgw'    → Object (RGW / S3)
+    Result is cached in KV store so telemetry and prometheus can read it
+    without re-inspecting osd_map every scrape.
+    """
+    try:
+        osd_map = mgr.get('osd_map') or {}
+        pools = osd_map.get('pools', [])
+    except Exception as e:  # pylint: disable=broad-except
+        logger.error('ui_metrics: failed to read osd_map: %s', e)
+        return {'block': False, 'file': False, 'object': False}
+
+    result: Dict[str, Any] = {
+        'block':  any('rbd'    in (p.get('application_metadata') or {}) for p in pools),
+        'file':   any('cephfs' in (p.get('application_metadata') or {}) for p in pools),
+        'object': any('rgw'    in (p.get('application_metadata') or {}) for p in pools),
+        'pools_checked': len(pools),
+    }
+    mgr.set_store(KV_PROTOCOLS, json.dumps(result))
+    return result
+
+# ---------------------------------------------------------------------------
+# REST Controller
+# ---------------------------------------------------------------------------
+
+@APIRouter('/ui_metrics')
+@APIDoc('Dashboard UI usage metrics (anonymous, aggregated)', 'UIMetrics')
+class UIMetrics(RESTController):
+
+    def list(self) -> Dict[str, Any]:
+        return collect_metrics()
+
+    @Endpoint()
+    @EndpointDoc(
+        'Detect enabled storage protocols from pool application tags'
+    )
+    def protocols(self) -> Dict[str, Any]:
+        return _detect_and_cache_protocols()

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -35,7 +35,6 @@ from mgr_util import ServerConfigException, build_url, \
 from . import mgr
 from .cli import DBCLICommand
 from .controllers import Router, json_error_page, nvmeof  # noqa # pylint: disable=unused-import
-from .controllers import ui_metrics  # noqa # pylint: disable=unused-import
 from .grafana import push_local_dashboards
 from .services import nvmeof_cli, nvmeof_top_cli  # noqa # pylint: disable=unused-import
 from .services.auth import AuthManager, AuthManagerTool, AuthType, JwtManager

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -35,6 +35,7 @@ from mgr_util import ServerConfigException, build_url, \
 from . import mgr
 from .cli import DBCLICommand
 from .controllers import Router, json_error_page, nvmeof  # noqa # pylint: disable=unused-import
+from .controllers import ui_metrics  # noqa # pylint: disable=unused-import
 from .grafana import push_local_dashboards
 from .services import nvmeof_cli, nvmeof_top_cli  # noqa # pylint: disable=unused-import
 from .services.auth import AuthManager, AuthManagerTool, AuthType, JwtManager

--- a/src/pybind/mgr/dashboard/services/telemetry.py
+++ b/src/pybind/mgr/dashboard/services/telemetry.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+import json
+import logging
+from typing import TypedDict
+
+from .. import mgr
+from ..plugins.ttl_cache import ttl_cache
+
+logger = logging.getLogger('services.telemetry')
+
+# TypedDicts for proper typing
+class ProtocolsEnabled(TypedDict):  # pylint: disable=inherit-non-class
+    block: bool
+    file: bool
+    object: bool
+
+class TelemetryMetrics(TypedDict):  # pylint: disable=inherit-non-class
+    protocols_enabled: ProtocolsEnabled
+
+# Service class
+class DashboardTelemetryService:
+    KV_PROTOCOLS = 'telemetry/metrics/protocols_enabled'
+    
+    @classmethod
+    @ttl_cache(300, label='protocols_enabled')  # 5 min cache
+    def get_protocols_enabled(cls) -> ProtocolsEnabled:
+        """Get cached or detect enabled protocols"""
+        prot_raw = mgr.get_store(cls.KV_PROTOCOLS)
+        if prot_raw:
+            return json.loads(prot_raw)
+        return cls._detect_and_cache_protocols()
+    
+    @classmethod
+    def _detect_and_cache_protocols(cls) -> ProtocolsEnabled:
+        """
+        Inspect osd_map pool application_metadata to determine which protocols
+        are in use:
+            'rbd'    → Block  (RBD)
+            'cephfs' → File   (CephFS)
+            'rgw'    → Object (RGW / S3)
+        Result is cached in KV store so telemetry and prometheus can read it
+        without re-inspecting osd_map every scrape.
+        """
+        try:
+            osd_map = mgr.get('osd_map') or {}
+            pools = osd_map.get('pools', [])
+        except Exception as e:  # pylint: disable=broad-except
+            logger.error('telemetry: failed to read osd_map: %s', e)
+            return {'block': False, 'file': False, 'object': False}
+
+        # Single-pass detection with early exit 
+        protocols_found = {'rbd': False, 'cephfs': False, 'rgw': False}
+        
+        for pool in pools:
+            app_meta = pool.get('application_metadata') or {}
+            
+            for protocol in protocols_found:
+                if not protocols_found[protocol] and protocol in app_meta:
+                    protocols_found[protocol] = True
+            
+            if all(protocols_found.values()):
+                break
+        
+        result: ProtocolsEnabled = {
+            'block': protocols_found['rbd'],
+            'file': protocols_found['cephfs'],
+            'object': protocols_found['rgw']
+        }
+        
+        mgr.set_store(cls.KV_PROTOCOLS, json.dumps(result))
+        return result
+
+    @classmethod
+    def refresh_protocols(cls) -> ProtocolsEnabled:
+        """Force refresh of protocol detection (bypasses cache)"""
+        return cls._detect_and_cache_protocols()
+        
+    @classmethod
+    def get_metrics(cls) -> TelemetryMetrics:
+        """Get all telemetry metrics"""
+        return {
+            'protocols_enabled': cls.get_protocols_enabled()
+        }

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -1371,6 +1371,32 @@ class Module(MgrModule):
 
         # NOTE: We do not include the 'device' channel in this report; it is
         # sent to a different endpoint.
+        # -- Dashboard UI metrics --
+        try:
+            import json as _json
+
+            def _read_key(key):
+                r, outb, outs = self.mon_command({
+                    'prefix': 'config-key get',
+                    'key': key
+                })
+                return outb.strip() if r == 0 and outb else None
+
+            report['dashboard'] = {
+                'protocols_enabled': _json.loads(
+                    _read_key(
+                        'mgr/dashboard/ui_metrics/protocols_enabled'
+                    ) or '{}'
+                ),
+            }
+
+        except Exception as e:  # pylint: disable=broad-except
+            self.log.warning(
+                'ui_metrics: failed to attach dashboard section: %s',
+                e
+            )
+
+        # -- End Dashboard UI metrics --
 
         return report
 

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -1371,32 +1371,26 @@ class Module(MgrModule):
 
         # NOTE: We do not include the 'device' channel in this report; it is
         # sent to a different endpoint.
-        # -- Dashboard UI metrics --
+        # -- Dashboard metrics --
         try:
-            import json as _json
+            r, outb, outs = self.mon_command({
+                'prefix': 'config-key get',
+                'key': 'mgr/dashboard/telemetry/metrics/protocols_enabled'
+            })
 
-            def _read_key(key):
-                r, outb, outs = self.mon_command({
-                    'prefix': 'config-key get',
-                    'key': key
-                })
-                return outb.strip() if r == 0 and outb else None
+            protocols_raw = outb.strip() if r == 0 and outb else None
 
             report['dashboard'] = {
-                'protocols_enabled': _json.loads(
-                    _read_key(
-                        'mgr/dashboard/ui_metrics/protocols_enabled'
-                    ) or '{}'
-                ),
+                'protocols_enabled': json.loads(protocols_raw or '{}'),
             }
 
         except Exception as e:  # pylint: disable=broad-except
             self.log.warning(
-                'ui_metrics: failed to attach dashboard section: %s',
+                'telemetry: failed to attach dashboard section: %s',
                 e
             )
 
-        # -- End Dashboard UI metrics --
+        # -- End Dashboard metrics --
 
         return report
 


### PR DESCRIPTION
## Problem Statement

The dashboard telemetry payload currently does not report which storage protocols are actively configured in a cluster. As a result, it is difficult to understand storage service adoption patterns through anonymous telemetry data.

This PR adds server-side detection of enabled storage protocols by inspecting pool `application_metadata`, caches the aggregated result in the mgr KV store, and includes it in the dashboard telemetry payload.

## Tracker

References: https://tracker.ceph.com/issues/76930

## What this PR does

* Adds a lightweight `ui_metrics` controller for dashboard telemetry aggregation.
* Detects active storage protocols from `osd_map` pool application tags:

  * `rbd` → Block
  * `cephfs` → File
  * `rgw` → Object
* Stores the aggregated result in the mgr KV store under:

```text
ui_metrics/protocols_enabled
```

* Exposes the cached data through the telemetry report.

Example telemetry output:

```json
"dashboard": {
  "protocols_enabled": {
    "block": true,
    "file": false,
    "object": false
  }
}
```

The implementation relies entirely on existing pool metadata and reports only aggregated protocol usage information. No user-identifiable data is collected.

## Local Validation

Validated on a local cluster containing an RBD-enabled pool.

Verified that the cluster contains an RBD application pool using:

```bash
ceph osd pool ls detail
```

Verified that the telemetry report correctly includes:

```bash
ceph telemetry show | grep -A8 '"protocols_enabled"'
```

Output:

```json
"protocols_enabled": {
    "block": true,
    "file": false,
    "object": false
}
```

The reported values correctly reflect the storage protocols configured in the cluster.
> Note: This is part of a broader Dashboard telemetry POC (tracker #76930). 
> Subsequent PRs will cover page visits, session metrics, and user personas.

---

## Contribution Guidelines

To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/main/SubmittingPatches-backports.rst) for the proper workflow.

When filling out the checklist below, you may click boxes directly in the GitHub web UI. When entering or editing the entire PR message, you may also select a checklist item by adding an `x` between the brackets: `[x]`. Spaces and capitalization matter when checking off items this way.
## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests