### PR TITLE
crimson/test: chain invoke_on_all() future instead of calling get()

### DIFF
--- a/src/test/crimson/seastar_runner.h
+++ b/src/test/crimson/seastar_runner.h
@@ -70,7 +70,7 @@ struct SeastarRunner {
   {
     auto ret = app.run(argc, argv, [this] {
       on_end.reset(new seastar::readable_eventfd);
-      return seastar::now().then([this] {
+      return seastar::now().then([] {
 // FIXME: The stall detector uses glibc backtrace function to
 // collect backtraces, this causes ASAN failures on ARM.
 // For now we just extend timeout duration to 10000h in order to
@@ -79,11 +79,14 @@ struct SeastarRunner {
 // Will remove once the ticket fixed.
 // Ceph ticket see: https://tracker.ceph.com/issues/65635
 #ifdef __aarch64__
-	seastar::smp::invoke_on_all([] {
+	return seastar::smp::invoke_on_all([] {
 	  using namespace std::chrono;
 	  seastar::engine().update_blocked_reactor_notify_ms(duration_cast<milliseconds>(10000h));
-	}).get();
+	});
+#else
+	return seastar::now();
 #endif
+      }).then([this] {
 	begin_signaled = true;
 	[[maybe_unused]] auto r = ::eventfd_write(begin_fd.get(), APP_RUNNING);
 	assert(r == 0);


### PR DESCRIPTION
reactor() blocking-calls invole_on_all() to set a configuration option for ARM runs. This PR removes the get() from that call,
in order to solve CI failures.
