### PR TITLE
crimson/os/seastore: Add Seastore phase latency scaffolding

### DIFF
--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -1128,10 +1128,12 @@ RandomBlockOolWriter::do_write(
   DEBUGT("start with {} allocated extents",
          t, extents.size());
   std::vector<write_info_t> writes;
+  auto phase_latency =
+    t.record_phase_latency(phase_latency_bucket_t::write_packing);
   for (auto& ex : extents) {
     auto paddr = ex->get_paddr();
     assert(paddr.is_absolute());
-    RandomBlockManager * rbm = rb_cleaner->get_rbm(paddr); 
+    RandomBlockManager * rbm = rb_cleaner->get_rbm(paddr);
     assert(rbm);
     TRACE("write extent {}, paddr {} ...",
           fmt::ptr(ex.get()), paddr);
@@ -1147,7 +1149,7 @@ RandomBlockOolWriter::do_write(
       ceph_assert(r.has_value());
       extent_len_t offset = p2align(r->offset, rbm->get_block_size());
       extent_len_t len =
-	p2roundup(r->offset + r->len, rbm->get_block_size()) - offset;
+        p2roundup(r->offset + r->len, rbm->get_block_size()) - offset;
       bp = ceph::bufferptr(ex->get_bptr(), offset, len);
       paddr = ex->get_paddr() + offset;
     } else {
@@ -1169,11 +1171,11 @@ RandomBlockOolWriter::do_write(
 
     // TODO : allocate a consecutive address based on a transaction
     if (writes.size() != 0 &&
-	writes.back().offset + writes.back().get_mergeable_length() == paddr) {
+      writes.back().offset + writes.back().get_mergeable_length() == paddr) {
       // We can write both the currrent extent and the previous one at once
       // if the extents are located in a row
       if (writes.back().mergeable_bps.size() == 0) {
-	 writes.back().mergeable_bps.push_back(writes.back().bp);
+        writes.back().mergeable_bps.push_back(writes.back().bp);
       }
       writes.back().mergeable_bps.push_back(ex->get_bptr());
     } else {
@@ -1185,21 +1187,21 @@ RandomBlockOolWriter::do_write(
       writes.push_back(w_info);
     }
     TRACE("current extent: {}~0x{:x},\
-      maybe-merged current extent: {}~0x{:x}",
-      paddr, ex->get_length(), writes.back().offset, writes.back().bp.length());
+          maybe-merged current extent: {}~0x{:x}",
+          paddr, ex->get_length(), writes.back().offset, writes.back().bp.length());
   }
 
   for (auto &w : writes) {
     if (w.mergeable_bps.size() > 0) {
       extent_len_t len = 0;
       for (auto &b : w.mergeable_bps) {
-	len += b.length();
+        len += b.length();
       }
       w.bp = ceph::bufferptr(ceph::buffer::create_page_aligned(len));
       extent_len_t cursor = 0;
       for (auto &b : w.mergeable_bps) {
-	w.bp.copy_in(cursor, b.length(), b.c_str());
-	cursor += b.length();
+        w.bp.copy_in(cursor, b.length(), b.c_str());
+        cursor += b.length();
       }
       w.mergeable_bps.clear();
     }

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -177,19 +177,19 @@ void SeaStore::Shard::register_metrics(store_index_t store_index)
 
   for (auto& [op_type, label] : labels_by_op_type) {
     auto desc = fmt::format("latency of seastore operation (optype={})",
-                            op_type);
+        op_type);
     metrics.add_group(
-      "seastore",
-      {
+        "seastore",
+        {
         sm::make_histogram(
-          "op_lat", [this, op_type=op_type] {
+            "op_lat", [this, op_type=op_type] {
             return get_latency(op_type);
-          },
-          sm::description(desc),
-          {label, sm::label_instance("shard_store_index", std::to_string(store_index))}
-        ),
-      }
-    );
+            },
+            sm::description(desc),
+            {label, sm::label_instance("shard_store_index", std::to_string(store_index))}
+            ),
+        }
+        );
   }
 
   stats.conflict_replays.buckets.resize(REPLAY_BUCKETS);
@@ -198,21 +198,21 @@ void SeaStore::Shard::register_metrics(store_index_t store_index)
     stats.conflict_replays.buckets[i].count = 0;
   }
   metrics.add_group(
-    "seastore",
-    {
+      "seastore",
+      {
       sm::make_histogram(
-        "conflict_replay_distribution",
-        [this]() -> seastar::metrics::histogram& {
+          "conflict_replay_distribution",
+          [this]() -> seastar::metrics::histogram& {
           return stats.conflict_replays;
-        },
-        sm::description("distribution of per-transaction conflict/replay counts "
-                        "before commit, for user transactions submitted via "
-                        "do_transaction (the reused-transaction / "
-                        "with_repeat_trans_intr path); not all MUTATE transactions"),
-        {sm::label_instance("shard_store_index", std::to_string(store_index))}
-      )
-    }
-  );
+          },
+          sm::description("distribution of per-transaction conflict/replay counts "
+            "before commit, for user transactions submitted via "
+            "do_transaction (the reused-transaction / "
+            "with_repeat_trans_intr path); not all MUTATE transactions"),
+          {sm::label_instance("shard_store_index", std::to_string(store_index))}
+          )
+      }
+      );
 
   std::pair<txn_stage_t, sm::label_instance> labels_by_stage[] = {
     {txn_stage_t::THROTTLER_WAIT,        sm::label_instance("stage", "throttler_wait")},
@@ -258,6 +258,27 @@ void SeaStore::Shard::register_metrics(store_index_t store_index)
         }
       );
     }
+  for (auto& [stage, label] : labels_by_stage) {
+    auto idx = static_cast<std::size_t>(stage);
+    auto& hist = stats.stage_lat[idx];
+    hist.buckets.resize(STAGE_LAT_BUCKETS_US.size());
+    for (std::size_t i = 0; i < STAGE_LAT_BUCKETS_US.size(); ++i) {
+      hist.buckets[i].upper_bound = STAGE_LAT_BUCKETS_US[i];
+      hist.buckets[i].count = 0;
+    }
+    metrics.add_group(
+      "seastore",
+      {
+        sm::make_histogram(
+          "do_transaction_stage_lat",
+          [this, idx]() -> seastar::metrics::histogram& {
+            return stats.stage_lat[idx];
+          },
+          sm::description("per-stage latency (microseconds) of do_transaction"),
+          {label, sm::label_instance("shard_store_index", std::to_string(store_index))}
+        )
+      }
+    );
   }
 
   metrics.add_group(
@@ -312,24 +333,79 @@ void SeaStore::Shard::register_metrics(store_index_t store_index)
     "seastore",
     {
       sm::make_gauge(
-	"concurrent_transactions",
-	[this] {
-	  return throttler.get_current();
-	},
-  sm::description("transactions that are running inside seastore"),
-  {sm::label_instance("shard_store_index", std::to_string(store_index))}
-      ),
+          "concurrent_transactions",
+          [this] {
+          return throttler.get_current();
+          },
+          sm::description("transactions that are running inside seastore"),
+          {sm::label_instance("shard_store_index", std::to_string(store_index))}
+          ),
       sm::make_gauge(
-	"pending_transactions",
-	[this] {
-	  return throttler.get_pending();
-	},
-  sm::description("transactions waiting to get "
-		        "through seastore's throttler"),
-  {sm::label_instance("shard_store_index", std::to_string(store_index))}
-      )
-    }
+          "pending_transactions",
+          [this] {
+          return throttler.get_pending();
+          },
+          sm::description("transactions waiting to get "
+            "through seastore's throttler"),
+          {sm::label_instance("shard_store_index", std::to_string(store_index))}
+          )
+      }
   );
+
+  // seastore: Add Seastore phase latency scaffolding
+  std::pair<phase_latency_bucket_t, sm::label_instance> labels_by_phase[] = {
+    {phase_latency_bucket_t::metadata_lookup,
+      sm::label_instance("phase", std::string(phase_latency_bucket_name(
+              phase_latency_bucket_t::metadata_lookup)))},
+      {phase_latency_bucket_t::mapping_management,
+        sm::label_instance("phase", std::string(phase_latency_bucket_name(
+                phase_latency_bucket_t::mapping_management)))},
+        {phase_latency_bucket_t::cache_mutation,
+          sm::label_instance("phase", std::string(phase_latency_bucket_name(
+                  phase_latency_bucket_t::cache_mutation)))},
+          {phase_latency_bucket_t::transaction_commit,
+            sm::label_instance("phase", std::string(phase_latency_bucket_name(
+                    phase_latency_bucket_t::transaction_commit)))},
+            {phase_latency_bucket_t::write_packing,
+              sm::label_instance("phase", std::string(phase_latency_bucket_name(
+                      phase_latency_bucket_t::write_packing)))},
+              {phase_latency_bucket_t::durability,
+                sm::label_instance("phase", std::string(phase_latency_bucket_name(
+                        phase_latency_bucket_t::durability)))},
+  };
+
+  for (auto& [bucket, label] : labels_by_phase) {
+    auto desc = fmt::format("aggregated latency of seastore write phase ({})",
+        phase_latency_bucket_name(bucket));
+    metrics.add_group(
+        "seastore",
+        {
+        sm::make_histogram(
+            "phase_lat", [this, bucket] {
+            return get_phase_latency(bucket);
+            },
+            sm::description(desc),
+            {label, sm::label_instance("shard_store_index", std::to_string(store_index))}
+            ),
+        sm::make_counter(
+            "phase_lat_ns",
+            stats.phase_lat_ns[static_cast<std::size_t>(bucket)],
+            sm::description(fmt::format(
+                "cumulative nanoseconds spent in seastore write phase ({})",
+                phase_latency_bucket_name(bucket))),
+            {label, sm::label_instance("shard_store_index", std::to_string(store_index))}
+            ),
+        sm::make_counter(
+            "phase_lat_samples",
+            stats.phase_lat_samples[static_cast<std::size_t>(bucket)],
+            sm::description(fmt::format(
+                "number of timed scopes accumulated for seastore write phase ({})",
+                phase_latency_bucket_name(bucket))),
+            {label, sm::label_instance("shard_store_index", std::to_string(store_index))}
+            ),
+        }
+    );
+  }
 }
 
 seastar::future<> SeaStore::get_shard_nums()
@@ -1894,6 +1970,9 @@ seastar::future<> SeaStore::Shard::run_one_batch(
       DEBUGT("completed all {} ops for cid={}",
              t, total_ops, ctx.ch->get_cid());
       auto submit_start = seastar::lowres_clock::now();
+      //auto submit_start = std::chrono::steady_clock::now();
+      auto phase_latency =
+          t.record_phase_latency(phase_latency_bucket_t::transaction_commit);
       co_await transaction_manager->submit_transaction(*ctx.transaction);
       ctx.submit_time += seastar::lowres_clock::now() - submit_start;
     })
@@ -1941,6 +2020,7 @@ seastar::future<> SeaStore::Shard::run_one_batch(
   }
 
   add_onode_tree_sample(ctx.transaction->get_onode_tree_stats());
+  publish_phase_latency_samples(ctx.transaction->get_phase_latency_stats());
 
   throttler.put();
 
@@ -2038,9 +2118,14 @@ SeaStore::Shard::_do_transaction_step(
       op->op == Transaction::OP_ZERO) {
     create = true;
   }
+  /* onode is not already in the onodes vector, we need to fetch it from the OnodeManager. */
   if (!onodes[op->oid]) {
     const ghobject_t& oid = i.get_oid(op->oid);
     auto t0 = seastar::lowres_clock::now();
+    //auto t0 = std::chrono::steady_clock::now();
+    auto phase_latency =
+        ctx.transaction->record_phase_latency(
+          phase_latency_bucket_t::metadata_lookup);
     if (!create) {
       DEBUGT("op {}, get oid={} ...",
              *ctx.transaction, (uint32_t)op->op, oid);
@@ -2050,6 +2135,23 @@ SeaStore::Shard::_do_transaction_step(
              *ctx.transaction, (uint32_t)op->op, oid);
       fut = onode_manager->get_or_create_onode(*ctx.transaction, oid);
     }
+    /* TODO: coroutines
+      fut = seastar::coroutine::lambda(
+      [&, this, op, create, oid, FNAME]() -> onode_iertr::future<OnodeRef> {
+      auto phase_latency =
+        ctx.transaction->record_phase_latency(
+          phase_latency_bucket_t::metadata_lookup);
+      if (!create) {
+        DEBUGT("op {}, get oid={} ...",
+               *ctx.transaction, (uint32_t)op->op, oid);
+        co_return co_await onode_manager->get_onode(*ctx.transaction, oid);
+      } else {
+        DEBUGT("op {}, get_or_create oid={} ...",
+               *ctx.transaction, (uint32_t)op->op, oid);
+        co_return co_await onode_manager->get_or_create_onode(
+          *ctx.transaction, oid);
+      }
+    })(); */
     fut = std::move(fut).si_then([&ctx, t0](auto onode) {
       ctx.get_onode_time += seastar::lowres_clock::now() - t0;
       return onode_iertr::make_ready_future<OnodeRef>(std::move(onode));
@@ -2070,23 +2172,56 @@ SeaStore::Shard::_do_transaction_step(
       const ghobject_t& dest_oid = i.get_oid(op->dest_oid);
       DEBUGT("op {}, get_or_create dest oid={} ...",
              *ctx.transaction, (uint32_t)op->op, dest_oid);
+      auto phase_latency =
+          ctx.transaction->record_phase_latency(
+            phase_latency_bucket_t::metadata_lookup);
       //TODO: use when_all_succeed after making onode tree
       //      support parallel extents loading
       return onode_manager->get_or_create_onode(*ctx.transaction, dest_oid
       ).si_then([&d_onode](auto dest_onode) {
-	assert(dest_onode);
-	assert(!d_onode);
-	d_onode = dest_onode;
-	return seastar::now();
+       assert(dest_onode);
+       assert(!d_onode);
+       d_onode = dest_onode;
+       return seastar::now();
       });
+      /* TODO: parallelize the above with the below, but need to make sure that
+         the onode tree supports parallel loading of extents
+      return seastar::coroutine::lambda(
+        [this, &ctx, &d_onode, dest_oid]()
+        -> OnodeManager::get_or_create_onode_iertr::future<> {
+        auto phase_latency =
+          ctx.transaction->record_phase_latency(
+            phase_latency_bucket_t::metadata_lookup);
+        auto dest_onode = co_await onode_manager->get_or_create_onode(
+          *ctx.transaction, dest_oid);
+        assert(dest_onode);
+        assert(!d_onode);
+        d_onode = dest_onode;
+        co_return;
+      })(); */
     } else if (op->op == Transaction::OP_TOUCH_TEMP && !d_onode) {
       const ghobject_t& dest_oid = i.get_oid(op->dest_oid);
       DEBUGT("op {}, get_onode dest oid={} ...",
              *ctx.transaction, (uint32_t)op->op, dest_oid);
+      auto phase_latency =
+          ctx.transaction->record_phase_latency(
+            phase_latency_bucket_t::metadata_lookup);
       return onode_manager->get_or_create_onode(*ctx.transaction, dest_oid
       ).si_then([&d_onode](auto target_onode) {
         d_onode = target_onode;
       });
+      /* TODO: use coroutines:
+      return seastar::coroutine::lambda(
+        [this, &ctx, &d_onode, dest_oid]()
+        -> OnodeManager::get_or_create_onode_iertr::future<> {
+        auto phase_latency =
+          ctx.transaction->record_phase_latency(
+            phase_latency_bucket_t::metadata_lookup);
+        d_onode = co_await onode_manager->get_or_create_onode(
+          *ctx.transaction, dest_oid);
+        co_return;
+      })();
+      */
     } else {
       return OnodeManager::get_or_create_onode_iertr::now();
     }

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -495,6 +495,10 @@ public:
       // same metrics collected two more times for high tail txns.
       std::array<seastar::metrics::histogram, STAGE_MAX> stage_lat_slow;
       std::array<seastar::metrics::histogram, STAGE_MAX> stage_lat_very_slow;
+      // Seastore phase latency scaffolding
+      std::array<seastar::metrics::histogram, PHASE_LATENCY_BUCKET_MAX> phase_lat;
+      std::array<uint64_t, PHASE_LATENCY_BUCKET_MAX> phase_lat_ns = {};
+      std::array<uint64_t, PHASE_LATENCY_BUCKET_MAX> phase_lat_samples = {};
     } stats;
 
     void add_onode_tree_sample(const Transaction::tree_stats_t& ts) {
@@ -511,6 +515,11 @@ public:
       op_type_t op_type) {
       assert(static_cast<std::size_t>(op_type) < stats.op_lat.size());
       return stats.op_lat[static_cast<std::size_t>(op_type)];
+    }
+
+    static double duration_to_milliseconds(
+      std::chrono::steady_clock::duration dur) {
+      return std::chrono::duration<double, std::milli>(dur).count();
     }
 
     void add_latency_sample(op_type_t op_type,
@@ -570,6 +579,33 @@ public:
       }
       ++hist.sample_count;
       hist.sample_sum += ms;
+    }
+
+
+    // seastore: Add Seastore phase latency scaffolding
+    seastar::metrics::histogram& get_phase_latency(
+      phase_latency_bucket_t bucket) {
+      auto idx = static_cast<std::size_t>(bucket);
+      assert(idx < stats.phase_lat.size());
+      return stats.phase_lat[idx];
+    }
+
+    void publish_phase_latency_samples(const phase_latency_stats_t &phase_stats) {
+      for (std::size_t idx = 0; idx < PHASE_LATENCY_BUCKET_MAX; ++idx) {
+        const auto bucket = static_cast<phase_latency_bucket_t>(idx);
+        auto total_ns = phase_stats.get_total_ns(bucket);
+        if (total_ns == 0) {
+          continue;
+        }
+        auto samples = phase_stats.get_sample_count(bucket);
+        ceph_assert(samples > 0);
+        stats.phase_lat_ns[idx] += total_ns;
+        stats.phase_lat_samples[idx] += samples;
+        auto &lat = get_phase_latency(bucket);
+        lat.sample_count += samples;
+        lat.sample_sum += duration_to_milliseconds(
+          phase_stats.get_total_duration(bucket));
+      }
     }
 
     /*

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -3,8 +3,11 @@
 
 #pragma once
 
+#include <algorithm>
+#include <array>
 #include <chrono>
 #include <iostream>
+#include <string_view>
 
 #include <boost/intrusive/list.hpp>
 
@@ -99,6 +102,102 @@ struct btree_cursor_stats_t {
   }
 };
 
+enum class phase_latency_bucket_t : uint8_t {
+  metadata_lookup = 0,
+  mapping_management,
+  cache_mutation,
+  transaction_commit,
+  write_packing,
+  durability,
+  MAX
+};
+
+static constexpr auto PHASE_LATENCY_BUCKET_MAX =
+  static_cast<std::size_t>(phase_latency_bucket_t::MAX);
+
+constexpr std::string_view phase_latency_bucket_name(
+  phase_latency_bucket_t bucket)
+{
+  switch (bucket) {
+  case phase_latency_bucket_t::metadata_lookup:
+    return "metadata_lookup";
+  case phase_latency_bucket_t::mapping_management:
+    return "mapping_management";
+  case phase_latency_bucket_t::cache_mutation:
+    return "cache_mutation";
+  case phase_latency_bucket_t::transaction_commit:
+    return "transaction_commit";
+  case phase_latency_bucket_t::write_packing:
+    return "write_packing";
+  case phase_latency_bucket_t::durability:
+    return "durability";
+  case phase_latency_bucket_t::MAX:
+    break;
+  }
+  return "unknown";
+}
+
+struct phase_latency_stats_t {
+  using clock = std::chrono::steady_clock;
+  using duration_t = clock::duration;
+
+  std::array<uint64_t, PHASE_LATENCY_BUCKET_MAX> total_ns = {};
+  std::array<uint64_t, PHASE_LATENCY_BUCKET_MAX> sample_counts = {};
+  std::array<uint8_t, PHASE_LATENCY_BUCKET_MAX> active_depth = {};
+  std::array<clock::time_point, PHASE_LATENCY_BUCKET_MAX> active_start = {};
+
+  static uint64_t to_ns(duration_t dur) {
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(dur).count();
+  }
+
+  bool is_clear() const {
+    return std::all_of(
+      total_ns.begin(), total_ns.end(),
+      [](auto total) { return total == 0; });
+  }
+
+  void add(phase_latency_bucket_t bucket, duration_t dur) {
+    auto idx = static_cast<std::size_t>(bucket);
+    // Assert to ensure bucket enum values are within bounds of the arrays is too harsh, consider whether to raise a log error instead and ignore out-of-bounds buckets.
+    ceph_assert(idx < total_ns.size());
+    ++sample_counts[idx];
+    total_ns[idx] += to_ns(dur);
+  }
+
+  void enter(phase_latency_bucket_t bucket, clock::time_point now) {
+    auto idx = static_cast<std::size_t>(bucket);
+    ceph_assert(idx < active_depth.size());
+    if (active_depth[idx]++ == 0) {
+      active_start[idx] = now;
+    }
+  }
+
+  void exit(phase_latency_bucket_t bucket, clock::time_point now) {
+    auto idx = static_cast<std::size_t>(bucket);
+    ceph_assert(idx < active_depth.size());
+    ceph_assert(active_depth[idx] > 0);
+    if (--active_depth[idx] == 0) {
+      add(bucket, now - active_start[idx]);
+    }
+  }
+
+  uint64_t get_total_ns(phase_latency_bucket_t bucket) const {
+    auto idx = static_cast<std::size_t>(bucket);
+    ceph_assert(idx < total_ns.size());
+    return total_ns[idx];
+  }
+
+  uint64_t get_sample_count(phase_latency_bucket_t bucket) const {
+    auto idx = static_cast<std::size_t>(bucket);
+    ceph_assert(idx < sample_counts.size());
+    return sample_counts[idx];
+  }
+
+  duration_t get_total_duration(phase_latency_bucket_t bucket) const {
+    return std::chrono::nanoseconds(get_total_ns(bucket));
+  }
+};
+
 struct rbm_pending_ool_t {
   bool is_conflicted = false;
   std::list<CachedExtentRef> pending_extents;
@@ -120,6 +219,30 @@ class Transaction : public boost::intrusive_ref_counter<
 public:
   using Ref = boost::intrusive_ptr<Transaction>;
   using on_destruct_func_t = std::function<void(Transaction&)>;
+  class phase_latency_timer_t {
+  public:
+    phase_latency_timer_t(Transaction &t, phase_latency_bucket_t bucket)
+      : stats(&t.phase_latency_stats),
+        bucket(bucket) {
+      stats->enter(bucket, phase_latency_stats_t::clock::now());
+    }
+    phase_latency_timer_t(const phase_latency_timer_t&) = delete;
+    phase_latency_timer_t& operator=(const phase_latency_timer_t&) = delete;
+    phase_latency_timer_t(phase_latency_timer_t&& other) noexcept
+      : stats(other.stats),
+        bucket(other.bucket) {
+      other.stats = nullptr;
+    }
+    phase_latency_timer_t& operator=(phase_latency_timer_t&&) = delete;
+    ~phase_latency_timer_t() {
+      if (stats != nullptr) {
+        stats->exit(bucket, phase_latency_stats_t::clock::now());
+      }
+    }
+  private:
+    phase_latency_stats_t *stats = nullptr;
+    phase_latency_bucket_t bucket;
+  };
   enum class get_extent_ret {
     PRESENT,
     ABSENT,
@@ -566,6 +689,7 @@ public:
     backref_tree_stats = {};
     ool_write_stats = {};
     rewrite_stats = {};
+    phase_latency_stats = {};
     conflicted = false;
     force_rewrite_conflict = false;
     assert(backref_entries.empty());
@@ -636,6 +760,16 @@ public:
   }
   rewrite_stats_t& get_rewrite_stats() {
     return rewrite_stats;
+  }
+  phase_latency_stats_t& get_phase_latency_stats() {
+    return phase_latency_stats;
+  }
+  const phase_latency_stats_t& get_phase_latency_stats() const {
+    return phase_latency_stats;
+  }
+  phase_latency_timer_t record_phase_latency(
+    phase_latency_bucket_t bucket) {
+    return phase_latency_timer_t(*this, bucket);
   }
 
   struct existing_block_stats_t {
@@ -925,6 +1059,7 @@ private:
   tree_stats_t backref_tree_stats;
   ool_write_stats_t ool_write_stats;
   rewrite_stats_t rewrite_stats;
+  phase_latency_stats_t phase_latency_stats;
 
   bool conflicted = false;
 

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -521,6 +521,8 @@ TransactionManager::update_lba_mappings(
   std::list<CachedExtentRef> &pre_allocated_extents)
 {
   LOG_PREFIX(TransactionManager::update_lba_mappings);
+  auto phase_latency =
+    t.record_phase_latency(phase_latency_bucket_t::mapping_management);
   SUBTRACET(seastore_t, "update extent lba mappings", t);
   return seastar::do_with(
     std::list<LogicalChildNodeRef>(),
@@ -710,6 +712,8 @@ TransactionManager::do_submit_transaction(
 
   SUBTRACET(seastore_t, "submitting record", tref);
   auto journal_start = std::chrono::steady_clock::now();
+  auto phase_latency =
+      tref.record_phase_latency(phase_latency_bucket_t::durability);
   co_await journal->submit_record(
     std::move(record),
     tref.get_handle(),

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -127,6 +127,8 @@ public:
     laddr_t offset) {
     LOG_PREFIX(TransactionManager::get_pin);
     SUBDEBUGT(seastore_tm, "{} ...", t, offset);
+    auto phase_latency =
+      t.record_phase_latency(phase_latency_bucket_t::mapping_management);
     auto cursor = co_await lba_manager->get_cursor(t, offset, false);
     auto pin = co_await resolve_cursor_to_mapping(t, std::move(cursor));
     SUBDEBUGT(seastore_tm, "got {}", t, pin);
@@ -143,6 +145,8 @@ public:
     laddr_t laddr) {
     LOG_PREFIX(TransactionManager::get_containing_pin);
     SUBDEBUGT(seastore_tm, "{} ...", t, laddr);
+    auto phase_latency =
+      t.record_phase_latency(phase_latency_bucket_t::mapping_management);
     auto cursor = co_await lba_manager->get_cursor(t, laddr, true);
     auto pin = co_await resolve_cursor_to_mapping(t, std::move(cursor));
     SUBDEBUGT(seastore_tm, "got {}", t, pin);
@@ -152,6 +156,8 @@ public:
   get_pin_ret get_pin(Transaction &t, LogicalChildNode &extent) {
     LOG_PREFIX(TransactionManager::get_pin);
     SUBDEBUGT(seastore_tm, "{} ...", t, extent);
+    auto phase_latency =
+      t.record_phase_latency(phase_latency_bucket_t::mapping_management);
     auto cursor = co_await lba_manager->get_cursor(t, extent);
     ceph_assert(cursor->is_direct());
     auto ret = LBAMapping::create_direct(std::move(cursor));
@@ -172,6 +178,8 @@ public:
     extent_len_t length) {
     LOG_PREFIX(TransactionManager::get_pins);
     SUBDEBUGT(seastore_tm, "{}~0x{:x} ...", t, offset, length);
+    auto phase_latency =
+      t.record_phase_latency(phase_latency_bucket_t::mapping_management);
     auto cursors = co_await lba_manager->get_cursors(t, offset, length);
     std::list<LBAMapping> ret;
     for (auto &cursor: cursors) {
@@ -547,24 +555,30 @@ public:
     LOG_PREFIX(TransactionManager::alloc_non_data_extent);
     SUBDEBUGT(seastore_tm, "{} hint {}~0x{:x} phint={} ...",
               t, T::TYPE, laddr_hint, len, placement_hint);
-    auto ext = cache->alloc_new_non_data_extent<T>(
-      t,
-      len,
-      placement_hint,
-      INIT_GENERATION);
+    auto ext = [&]() {
+      auto phase_latency =
+        t.record_phase_latency(phase_latency_bucket_t::cache_mutation);
+      return cache->alloc_new_non_data_extent<T>(
+        t,
+        len,
+        placement_hint,
+        INIT_GENERATION);
+    }();
     // user must initialize the logical extent themselves.
     assert(is_user_transaction(t.get_src()));
     ext->set_seen_by_users();
-    return lba_manager->alloc_extent(
-      t,
-      laddr_hint,
-      *ext,
-      EXTENT_DEFAULT_REF_COUNT
-    ).si_then([ext=std::move(ext), &t, FNAME](auto &&) mutable {
-      SUBDEBUGT(seastore_tm, "allocated {}", t, *ext);
-      return alloc_extent_iertr::make_ready_future<TCachedExtentRef<T>>(
-	std::move(ext));
-    });
+    {
+      auto phase_latency =
+        t.record_phase_latency(phase_latency_bucket_t::mapping_management);
+      co_await lba_manager->alloc_extent(
+        t,
+        laddr_hint,
+        *ext,
+        EXTENT_DEFAULT_REF_COUNT
+      );
+    }
+    SUBDEBUGT(seastore_tm, "allocated {}", t, *ext);
+    co_return std::move(ext);
   }
 
   /**
@@ -588,11 +602,15 @@ public:
     LOG_PREFIX(TransactionManager::alloc_data_extents);
     SUBDEBUGT(seastore_tm, "{} hint {}~0x{:x} phint={} ...",
               t, T::TYPE, laddr_hint, len, placement_hint);
-    auto exts = cache->alloc_new_data_extents<T>(
-      t,
-      len,
-      placement_hint,
-      INIT_GENERATION);
+    auto exts = [&]() {
+      auto phase_latency =
+        t.record_phase_latency(phase_latency_bucket_t::cache_mutation);
+      return cache->alloc_new_data_extents<T>(
+        t,
+        len,
+        placement_hint,
+        INIT_GENERATION);
+    }();
     // user must initialize the logical extent themselves
     assert(is_user_transaction(t.get_src()));
     for (auto& ext : exts) {
@@ -607,20 +625,24 @@ public:
 	off = (off + extent->get_length()).checked_to_laddr();
       }
     }
-    if (pos) {
-      auto npos = co_await pos->refresh();
-      co_await lba_manager->alloc_extents(
-	t,
-	npos.get_effective_cursor_ref(),
-	std::vector<LogicalChildNodeRef>(
-	  exts.begin(), exts.end()));
-    } else {
-      co_await lba_manager->alloc_extents(
-	t,
-	laddr_hint,
-	std::vector<LogicalChildNodeRef>(
-	  exts.begin(), exts.end()),
-	EXTENT_DEFAULT_REF_COUNT);
+    {
+      auto phase_latency =
+        t.record_phase_latency(phase_latency_bucket_t::mapping_management);
+      if (pos) {
+        auto npos = co_await pos->refresh();
+        co_await lba_manager->alloc_extents(
+	  t,
+	  npos.get_effective_cursor_ref(),
+	  std::vector<LogicalChildNodeRef>(
+	    exts.begin(), exts.end()));
+      } else {
+        co_await lba_manager->alloc_extents(
+	  t,
+	  laddr_hint,
+	  std::vector<LogicalChildNodeRef>(
+	    exts.begin(), exts.end()),
+	  EXTENT_DEFAULT_REF_COUNT);
+      }
     }
     for (auto &ext : exts) {
       SUBDEBUGT(seastore_tm, "allocated {}", t, *ext);
@@ -662,6 +684,8 @@ public:
     extent_types_t type) {
     LOG_PREFIX(TransactionManager::reserve_region);
     SUBDEBUGT(seastore_tm, "hint {}~0x{:x} {} ...", t, hint, len, type);
+    auto phase_latency =
+      t.record_phase_latency(phase_latency_bucket_t::mapping_management);
     auto pin = co_await lba_manager->reserve_region(
       t,
       hint,
@@ -680,6 +704,8 @@ public:
     extent_types_t type) {
     LOG_PREFIX(TransactionManager::reserve_region);
     SUBDEBUGT(seastore_tm, "hint {}~0x{:x} {} ...", t, hint, len, type);
+    auto phase_latency =
+      t.record_phase_latency(phase_latency_bucket_t::mapping_management);
     pos = co_await pos.refresh();
     auto pin = co_await lba_manager->reserve_region(
       t,
@@ -714,8 +740,10 @@ public:
     extent_len_t len,
     bool updateref) {
     LOG_PREFIX(TransactionManager::clone_pin);
-    SUBDEBUGT(seastore_tm, "{} clone to hint {} ... pos={}, updateref={}",
-      t, mapping, hint, pos, updateref);
+      auto phase_latency =
+        t.record_phase_latency(phase_latency_bucket_t::mapping_management);
+      SUBDEBUGT(seastore_tm, "{} clone to hint {} ... pos={}, updateref={}",
+        t, mapping, hint, pos, updateref);
     pos = co_await pos.refresh();
     mapping = co_await complete_mapping(t, mapping);
     laddr_t inter_key = mapping.is_indirect() ?
@@ -760,6 +788,8 @@ public:
     bool updateref)
   {
     LOG_PREFIX(TransactionManager::clone_range);
+    auto phase_latency =
+      t.record_phase_latency(phase_latency_bucket_t::mapping_management);
     co_await pos.co_refresh();
     mapping = co_await mapping.refresh();
     SUBDEBUGT(seastore_tm,
@@ -1203,6 +1233,8 @@ public:
     bool keep_left)
   {
     LOG_PREFIX(TransactionManager::cut_mapping);
+    auto phase_latency =
+      t.record_phase_latency(phase_latency_bucket_t::mapping_management);
     SUBDEBUGT(seastore_tm, "{} {} {}",
       t, pivot, mapping, keep_left ? "LEFT" : "RIGHT");
     assert(mapping.is_indirect() || mapping.is_data_stable());
@@ -1245,6 +1277,8 @@ public:
     remove_mappings_param_t params)
   {
     LOG_PREFIX(TransactionManager::remove_mappings_in_range);
+    auto phase_latency =
+      t.record_phase_latency(phase_latency_bucket_t::mapping_management);
     auto mapping = co_await first_mapping.refresh();
     SUBDEBUGT(seastore_tm, "{}~{}, first_mapping: {}",
       t, start, unaligned_len, mapping);
@@ -1524,6 +1558,8 @@ private:
       if (extent) {
         SUBTRACET(seastore_tm, "retire extent...", t);
         assert(extent->is_seen_by_users());
+        auto phase_latency =
+          t.record_phase_latency(phase_latency_bucket_t::cache_mutation);
         cache->retire_extent(t, extent);
       }
       for (auto &remap : remaps) {
@@ -1538,41 +1574,50 @@ private:
         ceph_assert(remap_len != 0);
         ceph_assert(remap_offset % cache->get_block_size() == 0);
         ceph_assert(remap_len % cache->get_block_size() == 0);
-        auto remapped_extent = cache->alloc_remapped_extent<T>(
-          t,
-          remap_laddr,
-          remap_paddr,
-          remap_offset,
-          remap_len,
-          original_bptr);
+        auto remapped_extent = [&]() {
+          auto phase_latency =
+            t.record_phase_latency(phase_latency_bucket_t::cache_mutation);
+          return cache->alloc_remapped_extent<T>(
+            t,
+            remap_laddr,
+            remap_paddr,
+            remap_offset,
+            remap_len,
+            original_bptr);
+        }();
         // user must initialize the logical extent themselves.
         remapped_extent->set_seen_by_users();
         remap.extent = remapped_extent.get();
       }
     }
 
-    auto cursors = co_await lba_manager->remap_mappings(
-      t,
-      pin.get_effective_cursor_ref(),
-      std::vector<remap_entry_t>(remaps.begin(), remaps.end())
-    ).handle_error_interruptible(
-      remap_pin_iertr::pass_further{},
-      crimson::ct_error::assert_all(
-	"TransactionManager::remap_pin hit invalid error"
-      )
-    );
+    std::vector<LBACursorRef> remapped_cursors;
+    {
+      auto phase_latency =
+        t.record_phase_latency(phase_latency_bucket_t::mapping_management);
+      remapped_cursors = co_await lba_manager->remap_mappings(
+        t,
+        pin.get_effective_cursor_ref(),
+        std::vector<remap_entry_t>(remaps.begin(), remaps.end())
+      ).handle_error_interruptible(
+        remap_pin_iertr::pass_further{},
+        crimson::ct_error::assert_all(
+	  "TransactionManager::remap_pin hit invalid error"
+        )
+      );
+    }
 
     std::vector<LBAMapping> ret;
     if (pin.is_indirect()) {
       co_await pin.direct_cursor->refresh();
-      for (auto &cursor : cursors) {
+      for (auto &cursor : remapped_cursors) {
 	ret.push_back(
 	  LBAMapping::create_indirect(
 	    pin.direct_cursor,
 	    cursor));
       }
     } else {
-      for (auto &cursor : cursors) {
+      for (auto &cursor : remapped_cursors) {
 	ret.push_back(
 	  LBAMapping::create_direct(
 	    cursor));
@@ -1580,6 +1625,8 @@ private:
     }
     if (remaps.size() > 1 && pin.is_indirect()) {
       assert(pin.direct_cursor->is_viewable());
+      auto phase_latency =
+        t.record_phase_latency(phase_latency_bucket_t::mapping_management);
       co_await lba_manager->update_mapping_refcount(
 	t, pin.direct_cursor, 1);
     }


### PR DESCRIPTION
Implement a light-weight instrumentation for the write path in Seastore:

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

Seastore currently exposes end-to-end operation latency, but not enough write-path attribution to separate metadata, mapping, cache, packing, commit, and durability costs. This change adds low-overhead per-transaction accumulation with per-shard aggregated export for the requested write buckets.

- **Transaction-local phase accounting**
  - adds `phase_latency_bucket_t` and `phase_latency_stats_t` in `src/crimson/os/seastore/transaction.h`
  - adds a small scoped timer helper on `Transaction`
  - resets phase data on transaction reuse/retry paths

- **Per-shard exported metrics**
  - extends `SeaStore::Shard` metrics with phase latency histograms and cumulative counters
  - publishes collected phase samples once per completed transaction
  - keeps the export style aligned with existing Seastar Seastore metrics

- **Write-path instrumentation**
  - `metadata_lookup`: onode lookup/create paths in `_do_transaction_step()`
  - `transaction_commit`: around `submit_transaction()` from `do_transaction_no_callbacks()`
  - `mapping_management`: key LBA/mapping helpers in `transaction_manager.h/.cc`
  - `cache_mutation`: extent allocation/remap/retire paths where cache work is distinct
  - `write_packing`: RBM OOL prepare/merge/copy path in `extent_placement_manager.cc`
  - `durability`: journal submit/commit wait path in `transaction_manager.cc`

- **Bucket model**
  ```c++
  enum class phase_latency_bucket_t : uint8_t {
    metadata_lookup,
    mapping_management,
    cache_mutation,
    transaction_commit,
    write_packing,
    durability,
    MAX
  };
  ```

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
