### PR TITLE
crimson/os/seastore/journal/circular_bounded_journal: find the real journal tail on startup

### DIFF
--- a/src/crimson/os/seastore/journal/circular_bounded_journal.cc
+++ b/src/crimson/os/seastore/journal/circular_bounded_journal.cc
@@ -332,94 +332,80 @@ Journal::replay_ret CircularBoundedJournal::replay(
   /*
    * read records from last applied record prior to written_to, and replay
    */
+  auto d_handler = std::move(delta_handler);
   LOG_PREFIX(CircularBoundedJournal::replay);
-  return cjs.read_header(
-  ).handle_error(
+  auto p = co_await cjs.read_header().handle_error(
     open_for_mount_ertr::pass_further{},
-    crimson::ct_error::assert_all(
-      "Invalid error read_header"
-  )).safe_then([this, FNAME, delta_handler=std::move(delta_handler)](auto p)
-    mutable {
-    auto &[head, bl] = *p;
-    cjs.set_cbj_header(head);
-    DEBUG("header : {}", cjs.get_cbj_header());
-    cjs.set_initialized(true);
-    return seastar::do_with(
-      std::move(delta_handler),
-      std::map<paddr_t, journal_seq_t>(),
-      std::map<paddr_t, std::pair<CachedExtentRef, uint32_t>>(),
-      [this](auto &d_handler, auto &map, auto &crc_info) {
-      auto build_paddr_seq_map = [&map](
-        const auto &offsets,
-        const auto &e,
-	sea_time_point modify_time)
-      {
-	if (e.type == extent_types_t::ALLOC_INFO) {
-	  alloc_delta_t alloc_delta;
-	  decode(alloc_delta, e.bl);
-	  if (alloc_delta.op == alloc_delta_t::op_types_t::CLEAR) {
-	    for (auto &alloc_blk : alloc_delta.alloc_blk_ranges) {
-	      map[alloc_blk.paddr] = offsets.write_result.start_seq;
-	    }
-	  }
-	}
-	return replay_ertr::make_ready_future<bool>(true);
-      };
-      auto tail = get_dirty_tail() <= get_alloc_tail() ?
-	get_dirty_tail() : get_alloc_tail();
-      set_written_to(tail);
-      // The first pass to build the paddr->journal_seq_t map 
-      // from extent allocations
-      return scan_valid_record_delta(std::move(build_paddr_seq_map), tail
-      ).safe_then([this, &map, &d_handler, tail, &crc_info]() {
-	auto call_d_handler_if_valid = [this, &map, &d_handler, &crc_info](
-	  const auto &offsets,
-	  const auto &e,
-	  sea_time_point modify_time)
-	{
-	  if (map.find(e.paddr) == map.end() ||
-	      map[e.paddr] <= offsets.write_result.start_seq) {
-	    return d_handler(
-	      offsets,
-	      e,
-	      get_dirty_tail(),
-	      get_alloc_tail(),
-	      modify_time
-	    ).safe_then([&e, &crc_info](auto ret) {
-	      auto [applied, ext] = ret;
-	      if (applied && ext && can_inplace_rewrite(
-		  ext->get_type())) {
-		crc_info[ext->get_paddr()] =
-		  std::make_pair(ext, e.final_crc);
-	      }
-	      return replay_ertr::make_ready_future<bool>(applied);
-	    });
-	  }
-	  return replay_ertr::make_ready_future<bool>(true);
-	};
-	// The second pass to replay deltas
-	return scan_valid_record_delta(std::move(call_d_handler_if_valid), tail
-	).safe_then([&crc_info]() {
-	  for (auto p : crc_info) {
-	    ceph_assert_always(p.second.first->get_last_committed_crc() == p.second.second);	
-	  }
-	  crc_info.clear();
-	  return replay_ertr::now();
-	});
-      });
-    }).safe_then([this]() {
-      // make sure that committed_to is JOURNAL_SEQ_NULL if jounal is the initial state
-      if (get_written_to() != 
-	  journal_seq_t{0,
-	    convert_abs_addr_to_paddr(get_records_start(),
-	    get_device_id())}) {
-	record_submitter.update_committed_to(get_written_to());
+    crimson::ct_error::assert_all("Invalid error read_header"));
+  auto &[head, bl] = *p;
+  cjs.set_cbj_header(head);
+  DEBUG("header : {}", cjs.get_cbj_header());
+  cjs.set_initialized(true);
+  std::map<paddr_t, journal_seq_t> map;
+  std::map<paddr_t, std::pair<CachedExtentRef, uint32_t>> crc_info;
+  auto build_paddr_seq_map = [&map](
+    const auto &offsets,
+    const auto &e,
+    sea_time_point modify_time)
+  {
+    if (e.type == extent_types_t::ALLOC_INFO) {
+      alloc_delta_t alloc_delta;
+      decode(alloc_delta, e.bl);
+      if (alloc_delta.op == alloc_delta_t::op_types_t::CLEAR) {
+        for (auto &alloc_blk : alloc_delta.alloc_blk_ranges) {
+          map[alloc_blk.paddr] = offsets.write_result.start_seq;
+        }
       }
-      trimmer.update_journal_tails(
-	get_dirty_tail(),
-	get_alloc_tail());
-    });
-  });
+    }
+    return replay_ertr::make_ready_future<bool>(true);
+  };
+  auto tail = get_dirty_tail() <= get_alloc_tail() ?
+    get_dirty_tail() : get_alloc_tail();
+  set_written_to(tail);
+  // The first pass to build the paddr->journal_seq_t map 
+  // from extent allocations
+  co_await scan_valid_record_delta(std::move(build_paddr_seq_map), tail);
+  auto call_d_handler_if_valid = [this, &map, &d_handler, &crc_info](
+    const auto &offsets,
+    const auto &e,
+    sea_time_point modify_time)
+  {
+    if (map.find(e.paddr) == map.end() ||
+        map[e.paddr] <= offsets.write_result.start_seq) {
+      return d_handler(
+        offsets,
+        e,
+        get_dirty_tail(),
+        get_alloc_tail(),
+        modify_time
+      ).safe_then([&e, &crc_info](auto ret) {
+        auto [applied, ext] = ret;
+        if (applied && ext && can_inplace_rewrite(
+            ext->get_type())) {
+          crc_info[ext->get_paddr()] =
+            std::make_pair(ext, e.final_crc);
+        }
+        return replay_ertr::make_ready_future<bool>(applied);
+      });
+    }
+    return replay_ertr::make_ready_future<bool>(true);
+  };
+  // The second pass to replay deltas
+  co_await scan_valid_record_delta(std::move(call_d_handler_if_valid), tail);
+  for (auto p : crc_info) {
+    ceph_assert_always(p.second.first->get_last_committed_crc() == p.second.second);	
+  }
+  crc_info.clear();
+  // make sure that committed_to is JOURNAL_SEQ_NULL if jounal is the initial state
+  if (get_written_to() != 
+      journal_seq_t{0,
+        convert_abs_addr_to_paddr(get_records_start(),
+        get_device_id())}) {
+    record_submitter.update_committed_to(get_written_to());
+  }
+  trimmer.update_journal_tails(
+    get_dirty_tail(),
+    get_alloc_tail());
 }
 
 void CircularBoundedJournal::register_metrics()

--- a/src/crimson/os/seastore/journal/circular_bounded_journal.cc
+++ b/src/crimson/os/seastore/journal/circular_bounded_journal.cc
@@ -343,6 +343,25 @@ Journal::replay_ret CircularBoundedJournal::replay(
   cjs.set_initialized(true);
   std::map<paddr_t, journal_seq_t> map;
   std::map<paddr_t, std::pair<CachedExtentRef, uint32_t>> crc_info;
+  auto tail = get_dirty_tail() <= get_alloc_tail() ?
+    get_dirty_tail() : get_alloc_tail();
+  set_written_to(tail);
+  // the first pass to find the real journal tail.
+  auto find_tail = [this](
+    const auto&,
+    const auto &e,
+    sea_time_point) {
+    if (e.type == extent_types_t::JOURNAL_TAIL) {
+      journal_tail_delta_t tails;
+      decode(tails, e.bl);
+      cjs.update_journal_tail_on_startup(
+        tails.dirty_tail, tails.alloc_tail);
+    }
+    return replay_ertr::make_ready_future<bool>(true);
+  };
+  co_await scan_valid_record_delta(std::move(find_tail), tail);
+  tail = get_dirty_tail() <= get_alloc_tail() ?
+    get_dirty_tail() : get_alloc_tail();
   auto build_paddr_seq_map = [&map](
     const auto &offsets,
     const auto &e,
@@ -359,10 +378,7 @@ Journal::replay_ret CircularBoundedJournal::replay(
     }
     return replay_ertr::make_ready_future<bool>(true);
   };
-  auto tail = get_dirty_tail() <= get_alloc_tail() ?
-    get_dirty_tail() : get_alloc_tail();
-  set_written_to(tail);
-  // The first pass to build the paddr->journal_seq_t map 
+  // The second pass to build the paddr->journal_seq_t map
   // from extent allocations
   co_await scan_valid_record_delta(std::move(build_paddr_seq_map), tail);
   auto call_d_handler_if_valid = [this, &map, &d_handler, &crc_info](
@@ -390,7 +406,7 @@ Journal::replay_ret CircularBoundedJournal::replay(
     }
     return replay_ertr::make_ready_future<bool>(true);
   };
-  // The second pass to replay deltas
+  // The third pass to replay deltas
   co_await scan_valid_record_delta(std::move(call_d_handler_if_valid), tail);
   for (auto p : crc_info) {
     ceph_assert_always(p.second.first->get_last_committed_crc() == p.second.second);	

--- a/src/crimson/os/seastore/journal/circular_journal_space.h
+++ b/src/crimson/os/seastore/journal/circular_journal_space.h
@@ -220,6 +220,23 @@ class CircularJournalSpace : public JournalAllocator {
     return device->read(offset, bptr);
   }
 
+  void update_journal_tail_on_startup(
+    journal_seq_t dirty,
+    journal_seq_t alloc) {
+    LOG_PREFIX(CircularJournalSpace);
+    SUBDEBUG(seastore_journal,
+      "update tail during replay: dirty={} alloc={}",
+      dirty, alloc);
+    if (dirty > header.dirty_tail ||
+        header.dirty_tail == JOURNAL_SEQ_NULL) {
+      header.dirty_tail = dirty;
+    }
+    if (alloc >= header.alloc_tail ||
+        header.alloc_tail == JOURNAL_SEQ_NULL) {
+      header.alloc_tail = alloc;
+    }
+  }
+
   seastar::future<> update_journal_tail(
     journal_seq_t dirty,
     journal_seq_t alloc) {


### PR DESCRIPTION
Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
