### PR TITLE
tentacle: qa: ignore POOL_FULL for rbd tests exercising full pools

### DIFF
--- a/qa/suites/upgrade/reef-x/parallel/workload/test_rbd_api.yaml
+++ b/qa/suites/upgrade/reef-x/parallel/workload/test_rbd_api.yaml
@@ -1,6 +1,13 @@
 meta:
 - desc: |
    librbd C and C++ api tests
+overrides:
+  ceph:
+    log-ignorelist:
+      # TestLibRBD.RemoveFullTryDataPool
+      - POOL_FULL
+      - is full
+      - pool.*full
 workload:
   full_sequential:
     - print: "**** done start test_rbd_api.yaml"

--- a/qa/suites/upgrade/reef-x/stress-split/3-stress-tasks/rbd_api.yaml
+++ b/qa/suites/upgrade/reef-x/stress-split/3-stress-tasks/rbd_api.yaml
@@ -1,6 +1,13 @@
 meta:
 - desc: |
    librbd C and C++ api tests
+overrides:
+  ceph:
+    log-ignorelist:
+      # TestLibRBD.RemoveFullTryDataPool
+      - POOL_FULL
+      - pool.*full
+      - is full
 stress-tasks:
 - workunit:
      branch: reef

--- a/qa/suites/upgrade/squid-x/parallel/workload/test_rbd_api.yaml
+++ b/qa/suites/upgrade/squid-x/parallel/workload/test_rbd_api.yaml
@@ -1,6 +1,13 @@
 meta:
 - desc: |
    librbd C and C++ api tests
+overrides:
+  ceph:
+    log-ignorelist:
+      # TestLibRBD.RemoveFullTryDataPool
+      - POOL_FULL
+      - is full
+      - pool.*full
 workload:
   full_sequential:
     - print: "**** done start test_rbd_api.yaml"

--- a/qa/suites/upgrade/squid-x/stress-split/3-stress-tasks/rbd_api.yaml
+++ b/qa/suites/upgrade/squid-x/stress-split/3-stress-tasks/rbd_api.yaml
@@ -1,6 +1,13 @@
 meta:
 - desc: |
    librbd C and C++ api tests
+overrides:
+  ceph:
+    log-ignorelist:
+      # TestLibRBD.RemoveFullTryDataPool
+      - POOL_FULL
+      - is full
+      - pool.*full
 stress-tasks:
 - workunit:
      branch: squid


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77027

---

backport of https://github.com/ceph/ceph/pull/68899
parent tracker: https://tracker.ceph.com/issues/76586

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh