### PR TITLE
tentacle: qa/suites/upgrade: ignore osd in unknown state

### DIFF
--- a/qa/suites/upgrade/reef-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/reef-x/stress-split/1-start.yaml
@@ -27,6 +27,7 @@ overrides:
       - filesystem is offline
       - with fewer MDS than max_mds
       - CEPHADM_FAILED_DAEMON
+      - osd.* is in unknown state
       - pg .* is stuck undersized
       - HEALTH_WARN .* osds down
       - MDS_INSUFFICIENT_STANDBY

--- a/qa/suites/upgrade/squid-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/squid-x/stress-split/1-start.yaml
@@ -26,6 +26,7 @@ overrides:
       - filesystem is offline
       - with fewer MDS than max_mds
       - CEPHADM_FAILED_DAEMON
+      - osd.* is in unknown state
       - pg .* is stuck undersized
       - HEALTH_WARN .* osds down
       - MDS_INSUFFICIENT_STANDBY


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76973

---

backport of https://github.com/ceph/ceph/pull/69055
parent tracker: https://tracker.ceph.com/issues/76747

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh