### PR TITLE
squid: qa/suites/upgrade: ignore osd in unknown state

### DIFF
--- a/qa/suites/upgrade/quincy-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/quincy-x/stress-split/1-start.yaml
@@ -30,6 +30,7 @@ overrides:
       - with fewer MDS than max_mds
       - CEPHADM_FAILED_DAEMON
       - failed cephadm daemon
+      - osd.* is in unknown state
 tasks:
 - install:
     branch: quincy

--- a/qa/suites/upgrade/reef-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/reef-x/stress-split/1-start.yaml
@@ -30,6 +30,7 @@ overrides:
       - with fewer MDS than max_mds
       - CEPHADM_FAILED_DAEMON
       - failed cephadm daemon
+      - osd.* is in unknown state
 tasks:
 - install:
     branch: reef


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76972

---

backport of https://github.com/ceph/ceph/pull/69055
parent tracker: https://tracker.ceph.com/issues/76747

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh