### PR TITLE
tentacle: qa: ignore cephadm failed daemon warnings during thrashing

### DIFF
--- a/qa/suites/upgrade/reef-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/reef-x/stress-split/1-start.yaml
@@ -6,6 +6,8 @@ overrides:
       - or freeform for custom applications
       - POOL_APP_NOT_ENABLED
       - is down
+      - CEPHADM_FAILED_DAEMON
+      - failed cephadm daemon
       - OSD_DOWN
       - mons down
       - mon down

--- a/qa/suites/upgrade/squid-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/squid-x/stress-split/1-start.yaml
@@ -6,6 +6,8 @@ overrides:
       - or freeform for custom applications
       - POOL_APP_NOT_ENABLED
       - is down
+      - CEPHADM_FAILED_DAEMON
+      - failed cephadm daemon
       - OSD_DOWN
       - mons down
       - mon down


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76742

---

backport of https://github.com/ceph/ceph/pull/68896
parent tracker: https://tracker.ceph.com/issues/73079

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh