### PR TITLE
tentacle: qa/suites/upgrade: ignore undersized PG during stress splits

### DIFF
--- a/qa/suites/upgrade/reef-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/reef-x/stress-split/1-start.yaml
@@ -16,6 +16,7 @@ overrides:
       - Reduced data availability
       - Degraded data redundancy
       - pg .* is stuck inactive
+      - pg .* is stuck undersized
       - pg .* is stuck peering
       - pg .* is .*degraded
       - FS_DEGRADED

--- a/qa/suites/upgrade/squid-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/squid-x/stress-split/1-start.yaml
@@ -16,6 +16,7 @@ overrides:
       - Reduced data availability
       - Degraded data redundancy
       - pg .* is stuck inactive
+      - pg .* is stuck undersized
       - pg .* is .*degraded
       - FS_DEGRADED
       - OSDMAP_FLAGS


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76739

---

backport of https://github.com/ceph/ceph/pull/68897
parent tracker: https://tracker.ceph.com/issues/76585

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh