### PR TITLE
rgw/restore: process shards on a coroutine and trim as we go

### DIFF
--- a/doc/radosgw/cloud-restore.rst
+++ b/doc/radosgw/cloud-restore.rst
@@ -302,6 +302,34 @@ updated with the downloaded data, and its ``HEAD`` object will be modified accor
 
 
 
+Restore Processor Tunables
+--------------------------
+
+Cloud restores are carried out asynchronously by a background processor that
+walks per-shard work queues. Its behavior is governed by the following
+configuration options:
+
+.. confval:: rgw_restore_processor_period
+
+.. confval:: rgw_restore_lock_max_time
+
+.. confval:: rgw_restore_max_objs
+
+.. confval:: rgw_restore_max_concurrent_io
+
+.. confval:: rgw_restore_batch_size
+
+The processor renews the per-shard lock in the background for as long as it is
+draining a shard. Each run attempts every shard once; if a shard still has
+backlog after ``rgw_restore_lock_max_time``, the processor stops it after the
+current batch is safely requeued and trimmed, then unlocks it and moves on to
+the next shard. ``rgw_restore_max_concurrent_io`` overlaps several cloud fetches
+to drain a backlog faster -- keep it modest to avoid overloading or being
+rate-limited by the cloud endpoint -- and larger ``rgw_restore_batch_size``
+values trim (and update FIFO metadata) less often.
+
+
+
 Future Work
 -----------
 

--- a/src/common/async/completion.h
+++ b/src/common/async/completion.h
@@ -198,12 +198,13 @@ class CompletionImpl final : public Completion<void(Args...), T> {
 
   void destroy_defer(std::tuple<Args...>&& args) override {
     auto w = std::move(work);
+    auto ex1 = w.first.get_executor();
     auto ex2 = w.second.get_executor();
     RebindAlloc2 alloc2 = boost::asio::get_associated_allocator(handler, DefaultAlloc{});
     auto f = bind_and_forward(ex2, std::move(handler), std::move(args));
     RebindTraits2::destroy(alloc2, this);
     RebindTraits2::deallocate(alloc2, this, 1);
-    boost::asio::defer(std::move(f));
+    boost::asio::defer(ex1, std::move(f));
   }
   void destroy_dispatch(std::tuple<Args...>&& args) override {
     auto w = std::move(work);
@@ -216,12 +217,13 @@ class CompletionImpl final : public Completion<void(Args...), T> {
   }
   void destroy_post(std::tuple<Args...>&& args) override {
     auto w = std::move(work);
+    auto ex1 = w.first.get_executor();
     auto ex2 = w.second.get_executor();
     RebindAlloc2 alloc2 = boost::asio::get_associated_allocator(handler, DefaultAlloc{});
     auto f = bind_and_forward(ex2, std::move(handler), std::move(args));
     RebindTraits2::destroy(alloc2, this);
     RebindTraits2::deallocate(alloc2, this, 1);
-    boost::asio::post(std::move(f));
+    boost::asio::post(ex1, std::move(f));
   }
   void destroy() override {
     RebindAlloc2 alloc2 = boost::asio::get_associated_allocator(handler, DefaultAlloc{});

--- a/src/common/async/detail/lease_state.h
+++ b/src/common/async/detail/lease_state.h
@@ -1,0 +1,143 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <optional>
+#include <utility>
+#include <boost/asio/append.hpp>
+#include <boost/asio/basic_waitable_timer.hpp>
+#include <boost/asio/bind_cancellation_slot.hpp>
+#include <boost/asio/cancellation_signal.hpp>
+#include <boost/intrusive_ptr.hpp>
+#include <boost/smart_ptr/intrusive_ref_counter.hpp>
+#include "common/ceph_time.h"
+
+namespace ceph::async::detail {
+
+using lease_clock = ceph::coarse_mono_clock;
+using lease_timer = boost::asio::basic_waitable_timer<lease_clock>;
+
+// base class for the lease completion state. this contains everything that
+// doesn't depend on the coroutine's return type
+class lease_state {
+  lease_timer timer;
+  boost::asio::cancellation_signal signal;
+  std::exception_ptr eptr;
+
+ public:
+  lease_state(boost::asio::any_io_executor ex) : timer(ex) {}
+
+  lease_timer& get_timer() { return timer; }
+
+  boost::asio::any_io_executor get_executor() { return timer.get_executor(); }
+  boost::asio::cancellation_slot get_cancellation_slot() { return signal.slot(); }
+
+  void complete()
+  {
+    timer.cancel(); // wake the renewal loop
+  }
+
+  void abort(std::exception_ptr e)
+  {
+    if (!eptr) { // only the first exception is reported
+      eptr = e;
+      cancel();
+    }
+  }
+
+  void rethrow()
+  {
+    if (eptr) {
+      std::rethrow_exception(eptr);
+    }
+  }
+
+  void cancel()
+  {
+    signal.emit(boost::asio::cancellation_type::terminal);
+    timer.cancel();
+  }
+};
+
+// capture and return the arguments to cr's completion handler
+template <typename T>
+class lease_completion_state : public lease_state,
+    public boost::intrusive_ref_counter<lease_completion_state<T>,
+        boost::thread_unsafe_counter>
+{
+  using result_type = std::pair<std::exception_ptr, T>;
+  std::optional<result_type> result;
+ public:
+  lease_completion_state(boost::asio::any_io_executor ex) : lease_state(ex) {}
+
+  bool completed() const { return result.has_value(); }
+
+  auto completion_handler()
+  {
+    return bind_cancellation_slot(get_cancellation_slot(),
+                                  bind_executor(get_executor(),
+        [self = boost::intrusive_ptr{this}] (std::exception_ptr eptr, T val) {
+          self->result.emplace(eptr, std::move(val));
+          self->complete();
+        }));
+  }
+
+  T get() // precondition: completed()
+  {
+    rethrow(); // rethrow exceptions from renewal
+    if (auto eptr = std::get<0>(*result); eptr) {
+      std::rethrow_exception(eptr);
+    }
+    return std::get<1>(std::move(*result));
+  }
+};
+
+// specialization for void return type
+template<>
+class lease_completion_state<void> : public lease_state,
+    public boost::intrusive_ref_counter<lease_completion_state<void>,
+        boost::thread_unsafe_counter>
+{
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+ public:
+  lease_completion_state(boost::asio::any_io_executor ex) : lease_state(ex) {}
+
+  bool completed() const { return result.has_value(); }
+
+  auto completion_handler()
+  {
+    return bind_cancellation_slot(get_cancellation_slot(),
+                                  bind_executor(get_executor(),
+        [self = boost::intrusive_ptr{this}] (std::exception_ptr eptr) {
+          self->result = eptr;
+          self->complete();
+        }));
+  }
+
+  void get() // precondition: completed()
+  {
+    rethrow(); // rethrow exceptions from renewal
+    if (*result) {
+      std::rethrow_exception(*result);
+    }
+  }
+};
+
+template <typename T>
+auto make_lease_completion_state(boost::asio::any_io_executor ex)
+{
+  return boost::intrusive_ptr{new lease_completion_state<T>(ex)};
+}
+
+} // namespace ceph::async::detail

--- a/src/common/async/detail/spawn_throttle_impl.h
+++ b/src/common/async/detail/spawn_throttle_impl.h
@@ -195,7 +195,8 @@ class spawn_throttle_impl :
   size_t wait_for_count = 0;
 
   struct op_cancellation {
-    spawn_throttle_impl* self;
+    // hold a ref: a cancellation can fire after the throttle is destroyed
+    boost::intrusive_ptr<spawn_throttle_impl> self;
     explicit op_cancellation(spawn_throttle_impl* self) noexcept
       : self(self) {}
     void operator()(boost::asio::cancellation_type type) {

--- a/src/common/async/lease.h
+++ b/src/common/async/lease.h
@@ -1,0 +1,257 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <exception>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/redirect_error.hpp>
+#include <boost/asio/spawn.hpp>
+#include <boost/asio/use_awaitable.hpp>
+#include <boost/system.hpp>
+#include "include/scope_guard.h"
+#include "common/ceph_time.h"
+#include "lock_client.h"
+#include "detail/lease_state.h"
+
+namespace ceph::async {
+
+/// Exception thrown by with_lease() whenever the wrapped coroutine is
+/// canceled due to a renewal failure.
+class lease_aborted : public std::runtime_error {
+  boost::system::error_code ec;
+ public:
+  lease_aborted(boost::system::error_code ec)
+    : runtime_error("lease aborted"), ec(ec)
+  {}
+
+  /// Return the original error that triggered the cancellation.
+  boost::system::error_code code() const { return ec; }
+};
+
+
+/// \brief Call a coroutine under the protection of a continuous lease.
+///
+/// Acquires exclusive access to a timed lock, then spawns the given coroutine
+/// \ref cr. The lock is renewed at intervals of \ref duration / 2, and released
+/// after the coroutine's completion.
+///
+/// Exceptions from acquire() propagate directly to the caller. Exceptions from
+/// release() are ignored in favor of the result of \ref cr.
+///
+/// If renew() is delayed long enough for the timed lock to expire, that results
+/// in an error code matching boost::system::errc::timed_out. That error, along
+/// with any error from renew() itself, gets wrapped in a lease_aborted
+/// exception when reported to the caller. Any failure to renew the lock will
+/// also result in the cancellation of \ref cr.
+///
+/// Cancellation of the parent coroutine also cancels the child coroutine
+/// without releasing the lock.
+///
+/// Otherwise, the result of \ref cr is returned to the caller, whether by
+/// exception or return value.
+///
+/// \relates LockClient
+///
+/// \param lock A client that can send lock requests
+/// \param duration Duration of the lock
+/// \param cr The coroutine to call under lease
+///
+/// \tparam T The return type of the coroutine \ref cr
+template <typename T>
+auto with_lease(LockClient& lock,
+                ceph::timespan duration,
+                boost::asio::awaitable<T> cr)
+    -> boost::asio::awaitable<T>
+{
+  auto ex = co_await boost::asio::this_coro::executor;
+
+  // acquire the lock. exceptions propagate directly to the caller
+  co_await lock.async_acquire(duration, boost::asio::use_awaitable);
+  auto expires_at = detail::lease_clock::now() + duration;
+
+  // the LockClient may not support cancellation, so check after it returns
+  if (auto cs = co_await boost::asio::this_coro::cancellation_state;
+      cs.cancelled() != boost::asio::cancellation_type::none) {
+    throw boost::system::system_error(boost::asio::error::operation_aborted);
+  }
+
+  // allocate the lease state with scoped cancellation so that with_lease()'s
+  // cancellation triggers cancellation of the spawned coroutine
+  auto state = detail::make_lease_completion_state<T>(ex);
+  const auto state_guard = make_scope_guard([&state] { state->cancel(); });
+
+  // spawn the coroutine with a waitable/cancelable completion handler
+  boost::asio::co_spawn(ex, std::move(cr), state->completion_handler());
+
+  // lock renewal loop
+  auto& timer = state->get_timer();
+  const ceph::timespan interval = duration / 2;
+  boost::system::error_code ec;
+
+  while (!state->completed()) {
+    // sleep until the next lock interval
+    timer.expires_after(interval);
+    co_await timer.async_wait(boost::asio::redirect_error(
+            boost::asio::use_awaitable, ec));
+    if (ec) {
+      if (auto cs = co_await boost::asio::this_coro::cancellation_state;
+          cs.cancelled() != boost::asio::cancellation_type::none) {
+        // if cancellation was requested by the caller, let the timer's
+        // operation_aborted exception propagate. state_guard will cancel the
+        // wrapped coroutine immediately on unwind
+        throw boost::system::system_error(ec);
+      }
+      break; // timer canceled by cr's completion
+    }
+
+    // arm a timeout for the renew request
+    timer.expires_at(expires_at);
+    timer.async_wait([state] (boost::system::error_code ec) {
+          if (!ec) {
+            state->abort(std::make_exception_ptr(lease_aborted{
+                make_error_code(std::errc::timed_out)}));
+          }
+        });
+
+    co_await lock.async_renew(duration, boost::asio::redirect_error(
+            boost::asio::use_awaitable, ec));
+    timer.cancel();
+    if (auto cs = co_await boost::asio::this_coro::cancellation_state;
+        cs.cancelled() != boost::asio::cancellation_type::none) {
+      ec = boost::asio::error::operation_aborted;
+    }
+    if (ec) {
+      state->rethrow(); // may already have a timeout error to return
+      throw lease_aborted{ec};
+    }
+    expires_at = detail::lease_clock::now() + duration;
+  }
+
+  // release the lock, ignoring errors
+  co_await lock.async_release(boost::asio::redirect_error(
+          boost::asio::use_awaitable, ec));
+
+  // return the spawned coroutine's result
+  co_return state->get();
+}
+
+namespace detail {
+
+template <typename T>
+void renew(LockClient& lock,
+           lease_clock::time_point expires_at,
+           ceph::timespan duration,
+           boost::asio::yield_context yield,
+           boost::intrusive_ptr<lease_completion_state<T>>& state);
+
+} // namespace detail
+
+/// \overload
+///
+/// \param lock A client that can send lock requests
+/// \param duration Duration of the lock
+/// \param yield The calling coroutine's yield context
+/// \param cr The coroutine to call under lease, taking a newly-spawned
+///           yield context as its only argument.
+template <std::invocable<boost::asio::yield_context> Func>
+auto with_lease(LockClient& lock,
+                ceph::timespan duration,
+                boost::asio::yield_context yield,
+                Func&& cr)
+    -> std::invoke_result_t<Func, boost::asio::yield_context>
+{
+  auto ex = yield.get_executor();
+
+  // acquire the lock. exceptions propagate directly to the caller
+  lock.async_acquire(duration, yield);
+  auto expires_at = detail::lease_clock::now() + duration;
+
+  // the LockClient may not support cancellation, so check after it returns
+  if (yield.cancelled() != boost::asio::cancellation_type::none) {
+    throw boost::system::system_error(boost::asio::error::operation_aborted);
+  }
+
+  // allocate the lease state with scoped cancellation so that with_lease()'s
+  // cancellation triggers cancellation of the spawned coroutine
+  using T = std::invoke_result_t<Func, boost::asio::yield_context>;
+  auto state = detail::make_lease_completion_state<T>(ex);
+  const auto state_guard = make_scope_guard([&state] { state->cancel(); });
+
+  // spawn the coroutine with a waitable/cancelable completion handler
+  boost::asio::spawn(ex, std::forward<Func>(cr), state->completion_handler());
+
+  detail::renew(lock, expires_at, duration, yield, state);
+
+  // release the lock, ignoring errors
+  boost::system::error_code ec;
+  lock.async_release(yield[ec]);
+
+  // return the spawned coroutine's result
+  return state->get();
+}
+
+namespace detail {
+
+// the renewal loop only depends on the coroutine's return type T, so doesn't
+// need to be reinstantiated for every Func
+template <typename T>
+void renew(LockClient& lock,
+           lease_clock::time_point expires_at,
+           ceph::timespan duration,
+           boost::asio::yield_context yield,
+           boost::intrusive_ptr<lease_completion_state<T>>& state)
+{
+  // lock renewal loop
+  auto& timer = state->get_timer();
+  const ceph::timespan interval = duration / 2;
+  boost::system::error_code ec;
+
+  while (!state->completed()) {
+    // sleep until the next lock interval
+    timer.expires_after(interval);
+    timer.async_wait(yield[ec]);
+    if (ec) {
+      if (yield.cancelled() != boost::asio::cancellation_type::none) {
+        // if cancellation was requested by the caller, let the timer's
+        // operation_aborted exception propagate. state_guard will cancel the
+        // wrapped coroutine immediately on unwind
+        throw boost::system::system_error(ec);
+      }
+      break; // timer canceled by cr's completion
+    }
+
+    // arm a timeout for the renew request
+    timer.expires_at(expires_at);
+    timer.async_wait([state] (boost::system::error_code ec) {
+          if (!ec) {
+            state->abort(std::make_exception_ptr(lease_aborted{
+                make_error_code(std::errc::timed_out)}));
+          }
+        });
+
+    lock.async_renew(duration, yield[ec]);
+    timer.cancel();
+    if (yield.cancelled() != boost::asio::cancellation_type::none) {
+      ec = boost::asio::error::operation_aborted;
+    }
+    if (ec) {
+      state->rethrow(); // may already have a timeout error to return
+      throw lease_aborted{ec};
+    }
+    expires_at = lease_clock::now() + duration;
+  }
+}
+
+} // namespace detail
+
+} // namespace ceph::async

--- a/src/common/async/lease.h
+++ b/src/common/async/lease.h
@@ -154,9 +154,31 @@ void renew(LockClient& lock,
            boost::asio::yield_context yield,
            boost::intrusive_ptr<lease_completion_state<T>>& state);
 
+// cancel the spawned coroutine and wait for its completion handler. the
+// join must suspend, so keep a pending cancellation from throwing until
+// it finishes
+template <typename T>
+void join(boost::intrusive_ptr<lease_completion_state<T>>& state,
+          boost::asio::yield_context yield)
+{
+  state->cancel();
+  const bool throw_on_cancel = yield.throw_if_cancelled();
+  yield.throw_if_cancelled(false);
+  auto& timer = state->get_timer();
+  boost::system::error_code ec;
+  while (!state->completed()) {
+    timer.expires_at(lease_clock::time_point::max());
+    timer.async_wait(yield[ec]);
+  }
+  yield.throw_if_cancelled(throw_on_cancel);
+}
+
 } // namespace detail
 
 /// \overload
+///
+/// On renewal failure or cancellation, waits for the spawned coroutine's
+/// completion before unwinding.
 ///
 /// \param lock A client that can send lock requests
 /// \param duration Duration of the lock
@@ -190,7 +212,18 @@ auto with_lease(LockClient& lock,
   // spawn the coroutine with a waitable/cancelable completion handler
   boost::asio::spawn(ex, std::forward<Func>(cr), state->completion_handler());
 
-  detail::renew(lock, expires_at, duration, yield, state);
+  // on failure, join the coroutine outside of the handler so the fiber's
+  // forced unwind on execution context shutdown passes through untouched
+  std::exception_ptr eptr;
+  try {
+    detail::renew(lock, expires_at, duration, yield, state);
+  } catch (const std::exception&) {
+    eptr = std::current_exception();
+  }
+  if (eptr) {
+    detail::join(state, yield);
+    std::rethrow_exception(eptr);
+  }
 
   // release the lock, ignoring errors
   boost::system::error_code ec;

--- a/src/common/async/lock_client.h
+++ b/src/common/async/lock_client.h
@@ -1,0 +1,56 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <boost/asio/any_completion_handler.hpp>
+#include <boost/asio/async_result.hpp>
+#include <boost/system.hpp>
+#include "common/ceph_time.h"
+
+namespace ceph::async {
+
+/// \brief Client interface for a specific timed exclusive lock.
+/// \see with_lease
+class LockClient {
+ protected:
+  using Signature = void(boost::system::error_code);
+  using Handler = boost::asio::any_completion_handler<Signature>;
+
+  virtual void acquire(ceph::timespan duration, Handler handler) = 0;
+  virtual void renew(ceph::timespan duration, Handler handler) = 0;
+  virtual void release(Handler handler) = 0;
+
+ public:
+  virtual ~LockClient() {}
+
+  /// Acquire a timed lock for the given duration.
+  template <boost::asio::completion_token_for<Signature> CompletionToken>
+  auto async_acquire(ceph::timespan duration, CompletionToken&& token) {
+    return boost::asio::async_initiate<CompletionToken, Signature>(
+        [this, duration] (auto h) { acquire(duration, std::move(h)); }, token);
+  }
+  /// Renew an acquired lock for the given duration.
+  template <boost::asio::completion_token_for<Signature> CompletionToken>
+  auto async_renew(ceph::timespan duration, CompletionToken&& token) {
+    return boost::asio::async_initiate<CompletionToken, Signature>(
+        [this, duration] (auto h) { renew(duration, std::move(h)); }, token);
+  }
+  /// Release an acquired lock.
+  template <boost::asio::completion_token_for<Signature> CompletionToken>
+  auto async_release(CompletionToken&& token) {
+    return boost::asio::async_initiate<CompletionToken, Signature>(
+        [this] (auto h) { release(std::move(h)); }, token);
+  }
+};
+
+} // namespace ceph::async

--- a/src/common/async/lock_rados.h
+++ b/src/common/async/lock_rados.h
@@ -1,0 +1,82 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <boost/asio/any_io_executor.hpp>
+#include "librados/librados_asio.h"
+#include "librados/redirect_version.h"
+#include "cls/lock/cls_lock_client.h"
+#include "lock_client.h"
+
+namespace ceph::async {
+
+/// A LockClient based on librados and cls_lock.
+/// \see with_lease
+class RadosLockClient : public LockClient {
+ public:
+  using executor_type = boost::asio::any_io_executor;
+  executor_type get_executor() const { return ex; }
+
+  RadosLockClient(executor_type ex,
+                  librados::IoCtx ioctx,
+                  std::string oid,
+                  rados::cls::lock::Lock lock,
+                  bool ephemeral)
+    : ex(std::move(ex)),
+      ioctx(std::move(ioctx)),
+      oid(std::move(oid)),
+      lock(std::move(lock)),
+      ephemeral(ephemeral)
+  {}
+
+ private:
+  executor_type ex;
+  librados::IoCtx ioctx;
+  std::string oid;
+  rados::cls::lock::Lock lock;
+  bool ephemeral = false;
+
+  void acquire(ceph::timespan dur, Handler h) override {
+    librados::ObjectWriteOperation op;
+    lock.set_duration(dur);
+    if (ephemeral) {
+      lock.lock_exclusive_ephemeral(&op);
+    } else {
+      lock.lock_exclusive(&op);
+    }
+    librados::async_operate(ex, ioctx, oid, std::move(op), 0, nullptr,
+                            librados::redirect_version(std::move(h)));
+  }
+  void renew(ceph::timespan dur, Handler h) override {
+    librados::ObjectWriteOperation op;
+    op.assert_exists();
+    lock.set_must_renew(true);
+    lock.set_duration(dur);
+    if (ephemeral) {
+      lock.lock_exclusive_ephemeral(&op);
+    } else {
+      lock.lock_exclusive(&op);
+    }
+    librados::async_operate(ex, ioctx, oid, std::move(op), 0, nullptr,
+                            librados::redirect_version(std::move(h)));
+  }
+  void release(Handler h) override {
+    librados::ObjectWriteOperation op;
+    op.assert_exists();
+    lock.unlock(&op);
+    librados::async_operate(ex, ioctx, oid, std::move(op), 0, nullptr,
+                            librados::redirect_version(std::move(h)));
+  }
+};
+
+} // namespace ceph::async

--- a/src/common/async/yield_context.h
+++ b/src/common/async/yield_context.h
@@ -19,6 +19,7 @@
 #include <boost/range/end.hpp>
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/spawn.hpp>
+#include <boost/asio/cancellation_type.hpp>
 
 #include "acconfig.h"
 
@@ -44,3 +45,14 @@ class optional_yield {
 
 // type tag object to construct an empty optional_yield
 static constexpr optional_yield::empty_t null_yield{};
+
+/// true if the optional_yield carries a yield_context whose cancellation was
+/// requested; false for an empty (null) yield
+inline bool yield_cancelled(optional_yield y)
+{
+  if (!y) {
+    return false;
+  }
+  return y.get_yield_context().cancelled() !=
+         boost::asio::cancellation_type::none;
+}

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -614,6 +614,35 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_restore_max_concurrent_io
+  type: int
+  level: advanced
+  desc: Max concurrent cloud-restore operations per shard
+  long_desc: The maximum number of restore operations (cloud object fetches) the restore
+    processor runs concurrently while draining a single shard, using a coroutine work
+    pool. Concurrent fetches overlap cloud-fetch latency and aggregate per-connection
+    download bandwidth, so higher values drain a backlog faster. The gains taper off once
+    local RADOS write throughput or the cloud endpoint's aggregate rate limit becomes the
+    bottleneck, and higher values put more load on the cloud-storage endpoint.
+  fmt_desc: The number of cloud-restore operations processed concurrently per restore shard.
+  default: 16
+  min: 1
+  services:
+  - rgw
+  with_legacy: true
+- name: rgw_restore_batch_size
+  type: int
+  level: advanced
+  desc: Max restore entries processed per batch while draining a shard
+  long_desc: The number of restore entries the restore processor lists, restores, and
+    trims as a single batch per shard. Larger batches trim (and update FIFO metadata)
+    less often.
+  fmt_desc: The number of restore entries processed as one batch per restore shard.
+  default: 100
+  min: 1
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_mp_lock_max_time
   type: int
   level: advanced

--- a/src/librados/redirect_version.h
+++ b/src/librados/redirect_version.h
@@ -1,0 +1,130 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#pragma once
+
+#include <boost/asio/associator.hpp>
+#include <boost/asio/async_result.hpp>
+#include <boost/system/error_code.hpp>
+#include "include/types.h"
+
+namespace librados {
+
+template <typename CompletionToken>
+struct redirect_version_t {
+  [[no_unique_address]] CompletionToken token;
+  version_t* ver = nullptr;
+};
+
+/// A completion token adapter that modifies the completion signature by
+/// removing the version_t argument, optionally redirecting its value into
+/// the given pointer.
+template <typename CompletionToken>
+auto redirect_version(CompletionToken&& token, version_t* ver = nullptr)
+    -> redirect_version_t<CompletionToken> {
+  return {std::forward<CompletionToken>(token), ver};
+}
+
+namespace detail {
+
+template <typename Handler>
+struct redirect_version_handler {
+  [[no_unique_address]] Handler handler;
+  version_t* ver = nullptr;
+
+  void operator()(boost::system::error_code ec, version_t v) {
+    if (ver) {
+      *ver = v;
+    }
+    std::move(handler)(ec);
+  }
+  void operator()(boost::system::error_code ec, version_t v, bufferlist bl) {
+    if (ver) {
+      *ver = v;
+    }
+    std::move(handler)(ec, std::move(bl));
+  }
+};
+
+template <typename Signature>
+struct redirect_version_signature {};
+template <>
+struct redirect_version_signature<void(boost::system::error_code, version_t)> {
+  using type = void(boost::system::error_code);
+};
+template <>
+struct redirect_version_signature<void(boost::system::error_code, version_t, bufferlist)> {
+  using type = void(boost::system::error_code, bufferlist);
+};
+template <typename Signature>
+using redirect_version_signature_t = typename redirect_version_signature<Signature>::type;
+
+} // namespace detail
+
+} // namespace librados
+
+namespace boost::asio {
+
+template <template <typename, typename> class Associator,
+    typename Handler, typename DefaultCandidate>
+struct associator<Associator,
+    librados::detail::redirect_version_handler<Handler>, DefaultCandidate>
+  : Associator<Handler, DefaultCandidate>
+{
+  static auto get(const librados::detail::redirect_version_handler<Handler>& h) noexcept {
+    return Associator<Handler, DefaultCandidate>::get(h.handler);
+  }
+  static auto get(const librados::detail::redirect_version_handler<Handler>& h,
+                  const DefaultCandidate& c) noexcept {
+    return Associator<Handler, DefaultCandidate>::get(h.handler, c);
+  }
+};
+
+template <typename CompletionToken, typename Signature>
+struct async_result<librados::redirect_version_t<CompletionToken>, Signature>
+  : async_result<CompletionToken,
+      librados::detail::redirect_version_signature_t<Signature>>
+{
+  template <typename Initiation>
+  struct init_wrapper {
+    [[no_unique_address]] Initiation init;
+
+    template <typename Handler, typename... Args>
+    void operator()(Handler&& handler, version_t* ver, Args&&... args) && {
+      std::move(init)(
+          librados::detail::redirect_version_handler<decay_t<Handler>>{
+              std::forward<Handler>(handler), ver},
+          std::forward<Args>(args)...);
+    }
+
+    template <typename Handler, typename... Args>
+    void operator()(Handler&& handler, version_t* ver, Args&&... args) const & {
+      init(
+          librados::detail::redirect_version_handler<decay_t<Handler>>{
+              std::forward<Handler>(handler), ver},
+          std::forward<Args>(args)...);
+    }
+  };
+
+  template <typename Initiation, typename RawCompletionToken, typename... Args>
+  static auto initiate(Initiation&& init,
+                       RawCompletionToken&& token,
+                       Args&&... args) {
+    return async_initiate<
+      conditional_t<is_const<remove_reference_t<RawCompletionToken>>::value,
+          const CompletionToken, CompletionToken>,
+      librados::detail::redirect_version_signature_t<Signature>>(
+        init_wrapper<decay_t<Initiation>>{std::forward<Initiation>(init)},
+        token.token, token.ver, std::forward<Args>(args)...);
+  }
+};
+
+} // namespace boost::asio

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -5678,7 +5678,13 @@ int RGWRados::restore_obj_from_cloud(RGWLCCloudTierCtx& tier_ctx,
   bufferlist t, t_tier;
   string tag;
   append_rand_alpha(cct, tag, tag, 32);
-  auto aio = rgw::make_throttle(cct->_conf->rgw_put_obj_min_window_size, y);
+  /*
+   * The cloud fetch delivers data on the libcurl reqs_thread, so put-object
+   * writes run there, not on the restore coroutine. null_yield gives a
+   * thread-safe BlockingAioThrottle; a yielding throttle would abort when
+   * driven from the curl thread.
+   */
+  auto aio = rgw::make_throttle(cct->_conf->rgw_put_obj_min_window_size, null_yield);
   using namespace rgw::putobj;
   jspan_context no_trace{false, false};
 
@@ -5691,7 +5697,7 @@ int RGWRados::restore_obj_from_cloud(RGWLCCloudTierCtx& tier_ctx,
 
   uint64_t olh_epoch = 0; // read it from attrs fetched from cloud below
   rgw::putobj::AtomicObjectProcessor processor(aio.get(), this, dest_bucket_info, nullptr,
-                                  owner, obj_ctx, dest_obj_bi, olh_epoch, tag, dpp, y, no_trace);
+                                  owner, obj_ctx, dest_obj_bi, olh_epoch, tag, dpp, null_yield, no_trace);
  
   void (*progress_cb)(off_t, void *) = NULL;
   void *progress_data = NULL;

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -24,7 +24,10 @@
 #include <fmt/core.h>
 
 #include "common/async/blocked_completion.h"
+#include "common/async/lock_rados.h"
+#include "common/async/yield_context.h"
 #include "neorados/cls/fifo.h"
+#include <boost/asio/deferred.hpp>
 
 #include "common/ceph_time.h"
 #include "common/Clock.h"
@@ -3232,6 +3235,13 @@ int RadosObject::restore_obj_from_cloud(Bucket* bucket,
                                 bucket->get_info(), get_obj(),
                                 tier_config, days, in_progress, size, dpp, y);
 
+  if (ret == -ECANCELED && yield_cancelled(y)) {
+    // cancellation leaves HEAD as-is; the restore worker will retry later
+    ldpp_dout(dpp, 10) << "Restore of object(" << get_key() << ") from the cloud endpoint("
+                       << endpoint << ") was canceled" << dendl;
+    return ret;
+  }
+
   if (ret < 0) { //failed to restore
     ldpp_dout(dpp, 0) << "Restoring object(" << get_key() << ") from the cloud endpoint(" << endpoint << ") failed, ret=" << ret << dendl;
 
@@ -4958,39 +4968,24 @@ std::unique_ptr<LCSerializer> RadosLifecycle::get_serializer(const std::string& 
   return std::make_unique<LCRadosSerializer>(store, oid, lock_name, cookie);
 }
 
-RadosRestoreSerializer::RadosRestoreSerializer(RadosStore* store, const std::string& _oid, const std::string& lock_name, const std::string& cookie) :
-  StoreRestoreSerializer(_oid),
-  ioctx(*store->getRados()->get_restore_pool_ctx()),
-  lock(lock_name)
-{
-  lock.set_cookie(cookie);
-}
-
-int RadosRestoreSerializer::try_lock(const DoutPrefixProvider *dpp, ceph::timespan dur, optional_yield y)
-{
-  lock.set_duration(dur);
-  return lock.lock_exclusive((librados::IoCtx*)(&ioctx), oid);
-}
-
-int RadosRestoreSerializer::unlock(const DoutPrefixProvider *dpp, optional_yield y)
-{
-  librados::ObjectWriteOperation op;
-  op.assert_exists();
-  lock.unlock(&op);
-  return rgw_rados_operate(dpp, ioctx, oid, std::move(op), y);
-}
-
 RadosRestore::RadosRestore(RadosStore* _st) : store(_st),
-       	ioctx(*store->getRados()->get_restore_pool_ctx()),
 	r(store->get_neorados()),
 	neo_ioctx(*store->getRados()->get_restore_pool_neo_ctx()) {}
 
-std::unique_ptr<RestoreSerializer> RadosRestore::get_serializer(
-							const std::string& lock_name,
-							const std::string& oid,
-							const std::string& cookie)
+std::unique_ptr<ceph::async::LockClient> RadosRestore::get_lock_client(
+    boost::asio::any_io_executor ex,
+    const std::string& lock_name,
+    const std::string& oid,
+    const std::string& cookie)
 {
-  return std::make_unique<RadosRestoreSerializer>(store, oid, lock_name, cookie);
+  rados::cls::lock::Lock lock(lock_name);
+  lock.set_cookie(cookie);
+  return std::make_unique<ceph::async::RadosLockClient>(
+      std::move(ex),
+      *store->getRados()->get_restore_pool_ctx(),
+      oid,
+      std::move(lock),
+      false);
 }
 
 int RadosRestore::initialize(const DoutPrefixProvider* dpp, optional_yield y,
@@ -5058,9 +5053,14 @@ int RadosRestore::push(const DoutPrefixProvider *dpp, optional_yield y,
 		int index, std::deque<ceph::buffer::list>&& items) {
   ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__
 		 << "Pushing entries to FIFO:" << obj_names[index] << dendl;
-  maybe_warn_about_blocking(dpp);
   try {
-    fifos[index]->push(dpp, items, ceph::async::use_blocked);
+    auto op = fifos[index]->push(dpp, items, boost::asio::deferred);
+    if (y) {
+      op(y.get_yield_context());
+    } else {
+      maybe_warn_about_blocking(dpp);
+      op(ceph::async::use_blocked);
+    }
   } catch (const sys::system_error& e) {
     ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
 		 << ": unable to push to FIFO: " << obj_names[index]
@@ -5075,9 +5075,14 @@ int RadosRestore::push(const DoutPrefixProvider *dpp, optional_yield y,
   ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__
 		 << "Pushing entry to FIFO:" << obj_names[index] << dendl;
 
-  maybe_warn_about_blocking(dpp);
   try {
-    fifos[index]->push(dpp, std::move(bl), ceph::async::use_blocked);
+    auto op = fifos[index]->push(dpp, std::move(bl), boost::asio::deferred);
+    if (y) {
+      op(y.get_yield_context());
+    } else {
+      maybe_warn_about_blocking(dpp);
+      op(ceph::async::use_blocked);
+    }
   } catch (const sys::system_error& e) {
     ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
 		 << ": unable to push to FIFO: " << obj_names[index]
@@ -5126,10 +5131,13 @@ int RadosRestore::list(const DoutPrefixProvider *dpp, optional_yield y,
   ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__
 		 << "Listing entries from FIFO:" << obj_names[index] << dendl;
 
-  maybe_warn_about_blocking(dpp);
+  if (!y) {
+    maybe_warn_about_blocking(dpp);
+  }
   try {
-    auto [lentries, lmark] = fifos[index]->list(dpp, marker,
-			  	 restore_entries, ceph::async::use_blocked);
+    auto [lentries, lmark] = y
+        ? fifos[index]->list(dpp, marker, restore_entries, y.get_yield_context())
+        : fifos[index]->list(dpp, marker, restore_entries, ceph::async::use_blocked);
     entries.clear();
 
     for (const auto& entry : lentries) {
@@ -5187,9 +5195,13 @@ int RadosRestore::trim(const DoutPrefixProvider *dpp, optional_yield y,
   ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__
 		 << "Trimming FIFO:" << obj_names[index] << " upto marker:" << marker << dendl;
 
-  maybe_warn_about_blocking(dpp);
   try {
-    fifos[index]->trim(dpp, std::string(marker), false, ceph::async::use_blocked);
+    if (y) {
+      fifos[index]->trim(dpp, std::string(marker), false, y.get_yield_context());
+    } else {
+      maybe_warn_about_blocking(dpp);
+      fifos[index]->trim(dpp, std::string(marker), false, ceph::async::use_blocked);
+    }
   } catch (const sys::system_error& e) {
     ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
 		 << ": unable to trim FIFO: " << obj_names[index]

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -973,20 +973,8 @@ public:
 						       const std::string& cookie) override;
 };
 
-class RadosRestoreSerializer : public StoreRestoreSerializer {
-  librados::IoCtx& ioctx;
-  ::rados::cls::lock::Lock lock;
-
-public:
-  RadosRestoreSerializer(RadosStore* store, const std::string& oid, const std::string& lock_name, const std::string& cookie);
-
-  virtual int try_lock(const DoutPrefixProvider *dpp, ceph::timespan dur, optional_yield y) override;
-  virtual int unlock(const DoutPrefixProvider* dpp, optional_yield y) override;
-};
-
 class RadosRestore : public StoreRestore {
   RadosStore* store;
-  librados::IoCtx& ioctx;
   neorados::RADOS& r;
   neorados::IOContext neo_ioctx;  
   std::vector<std::unique_ptr<fifo::FIFO>> fifos;  
@@ -1012,7 +1000,8 @@ public:
 		   bool* truncated) override;
   virtual int trim_entries(const DoutPrefixProvider *dpp, optional_yield y,
 		 	  int index, const std::string_view& marker) override;
-  virtual std::unique_ptr<RestoreSerializer> get_serializer(
+  virtual std::unique_ptr<ceph::async::LockClient> get_lock_client(
+                                boost::asio::any_io_executor ex,
 	  				       const std::string& lock_name,
 					       const std::string& oid,
 					       const std::string& cookie) override;

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -15,6 +15,9 @@
 #include "rgw_http_errors.h"
 #include "common/async/completion.h"
 #include "common/RefCountedObj.h"
+#include <boost/asio/associated_cancellation_slot.hpp>
+#include <boost/asio/cancellation_signal.hpp>
+#include <boost/asio/cancellation_type.hpp>
 
 #include "rgw_coroutine.h"
 
@@ -56,6 +59,7 @@ struct rgw_http_req_data : public RefCountedObject {
   using Signature = void(boost::system::error_code);
   using Completion = ceph::async::Completion<Signature>;
   std::unique_ptr<Completion> completion;
+  boost::asio::cancellation_slot cancel_slot;
 
   rgw_http_req_data() : id(-1) {
     // FIPS zeroization audit 20191115: this memset is not security related.
@@ -67,6 +71,24 @@ struct rgw_http_req_data : public RefCountedObject {
                   CompletionToken&& token) {
     return boost::asio::async_initiate<CompletionToken, Signature>(
         [this, &lock] (auto handler, auto ex) {
+          cancel_slot = boost::asio::get_associated_cancellation_slot(handler);
+          if (cancel_slot.is_connected()) {
+            cancel_slot.assign([this]
+                               (boost::asio::cancellation_type) {
+              /*
+               * No extra ref needed: wait()'s caller holds one for the op's
+               * lifetime, and cancel_slot.clear() in wait() drops this handler
+               * before wait() returns. Snapshot under the lock, then call
+               * remove_request() without it (reqs_lock is ordered before lock).
+               */
+              RGWHTTPManager* m = nullptr;
+              {
+                std::lock_guard l{this->lock};
+                if (!done) { m = mgr; }
+              }
+              if (m) { m->remove_request(this); }
+            });
+          }
           completion = Completion::create(ex, std::move(handler));
           lock.unlock(); // unlock before suspend
         }, token, ex);
@@ -81,6 +103,9 @@ struct rgw_http_req_data : public RefCountedObject {
       auto& yield = y.get_yield_context();
       boost::system::error_code ec;
       async_wait(yield.get_executor(), l, yield[ec]);
+      if (cancel_slot.is_connected()) {
+        cancel_slot.clear();   // back on the io thread; drop the handler on its own thread
+      }
       return -ec.value();
     }
     maybe_warn_about_blocking(dpp);
@@ -1006,8 +1031,11 @@ int RGWHTTPManager::add_request(RGWHTTPClient *client)
 
 int RGWHTTPManager::remove_request(RGWHTTPClient *client)
 {
-  rgw_http_req_data *req_data = client->get_req_data();
+  return remove_request(client->get_req_data());
+}
 
+int RGWHTTPManager::remove_request(rgw_http_req_data *req_data)
+{
   if (!is_started) {
     unlink_request(req_data);
     return 0;

--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -375,6 +375,8 @@ enum RGWHTTPRequestSetState {
 };
 
 class RGWHTTPManager {
+  friend struct rgw_http_req_data;
+
   struct set_state {
     rgw_http_req_data *req;
     int bitmask;
@@ -409,6 +411,7 @@ class RGWHTTPManager {
   void _finish_request(rgw_http_req_data *req_data, int r);
   void _set_req_state(set_state& ss);
   int link_request(rgw_http_req_data *req_data);
+  int remove_request(rgw_http_req_data *req_data);
 
   void manage_pending_requests();
 

--- a/src/rgw/rgw_restore.cc
+++ b/src/rgw/rgw_restore.cc
@@ -22,7 +22,9 @@
 #include "common/split.h"
 #include <common/errno.h>
 #include "include/random.h"
-#include "cls/lock/cls_lock_client.h"
+#include "common/async/lease.h"
+#include "common/async/yield_context.h"
+#include "common/error_code.h"
 #include "rgw_perf_counters.h"
 #include "rgw_common.h"
 #include "rgw_bucket.h"
@@ -42,6 +44,15 @@
 #include "services/svc_zone.h"
 #include "services/svc_tier_rados.h"
 #include "common/ceph_time.h"
+
+#include <unordered_set>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/spawn.hpp>
+#include <boost/asio/post.hpp>
+#include <boost/asio/bind_cancellation_slot.hpp>
+#include <boost/asio/cancellation_signal.hpp>
+#include "common/async/spawn_throttle.h"
+#include "rgw_asio_thread.h"
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw_restore
@@ -217,39 +228,49 @@ static inline std::ostream& operator<<(std::ostream &os, RestoreEntry& ent) {
   return os;
 }
 
-void Restore::RestoreWorker::stop()
-{
-  std::lock_guard l{lock};
-  cond.notify_all();
-}
-
-bool Restore::going_down()
-{
-  return down_flag;
-}
-
 void Restore::start_processor()
 {
-  worker = std::make_unique<Restore::RestoreWorker>(this, cct, this);
-  worker->create("rgw_restore");
+  // single thread: process_locked's spawn_throttle children share batch state
+  // without a lock, relying on a single-threaded executor
+  proc_pool.start(1, [] { is_asio_thread = true; });
+  proc_started = true;
+  boost::asio::spawn(proc_pool.get_executor(),
+      [this] (boost::asio::yield_context yield) { process_cycles(yield); },
+      boost::asio::bind_cancellation_slot(proc_signal.slot(),
+      [this] (std::exception_ptr eptr) {
+        if (!eptr)
+          return;
+        try {
+          std::rethrow_exception(eptr);
+        } catch (const boost::system::system_error& e) {
+          if (e.code() != boost::asio::error::operation_aborted)
+            ldpp_dout(this, -1) << "ERROR: restore processor coroutine exited: "
+                                << e.what() << dendl;
+        } catch (const std::exception& e) {
+          ldpp_dout(this, -1) << "ERROR: restore processor coroutine exited: "
+                              << e.what() << dendl;
+        }
+      }));
 }
 
 void Restore::stop_processor()
 {
-  down_flag = true;
-  if (worker) {
-    worker->stop();
-    worker->join();
+  if (proc_started) {
+    // cancellation_signal isn't thread-safe; emit it on a pool thread
+    boost::asio::post(proc_pool.get_executor(),
+        [this] { proc_signal.emit(boost::asio::cancellation_type::terminal); });
+    proc_pool.finish();   // unwinds the coroutine, then joins the pool thread
+    proc_started = false;
   }
-  worker.reset(nullptr);
 }
 
 void Restore::wake_worker()
 {
-  if (worker) {
-    std::lock_guard lock(worker->lock);
-    worker->cond.notify_one();
-  }
+  if (!proc_started)
+    return;
+  // the timer must be cancelled on its own io_context thread
+  boost::asio::post(proc_pool.get_executor(),
+      [this] { proc_timer.cancel(); });
 }
 
 unsigned Restore::get_subsys() const
@@ -270,58 +291,47 @@ int Restore::choose_oid(const RestoreEntry& e) {
   return static_cast<int>(index);
 }
 
-void *Restore::RestoreWorker::entry() {
-  do {
-    ceph_timespec start = ceph::real_clock::to_ceph_timespec(real_clock::now());
-    int r = 0;
-    r = restore->process(this, null_yield);
-    if (r < 0) {
-      ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ": ERROR: restore process() returned error r=" << r << dendl;	    
-    }
-    if (restore->going_down())
-      break;
-    ceph_timespec end = ceph::real_clock::to_ceph_timespec(real_clock::now());
-    auto d = end - start;
-    end = d;
+void Restore::process_cycles(boost::asio::yield_context yield)
+{
+  using Clock = ceph::coarse_mono_clock;
+  yield.throw_if_cancelled(true);
+  // spawn() reports completion by suspending one last time, so a pending
+  // cancellation would make throw_if_cancelled() throw past the coroutine
+  // frame and terminate the process. disarm it before the coroutine exits
+  auto disarm = make_scope_guard([&yield] { yield.throw_if_cancelled(false); });
+
+  while (!yield_cancelled(yield)) {
+    const auto start = Clock::now();
+
+    process(yield);   // errors are logged at the point of failure
+
     int secs = cct->_conf->rgw_restore_processor_period;
+    if (secs <= 0)
+      secs = secs_in_a_day;                         // avoid a busy-loop on misconfiguration
 
-    if (secs < d)
-      continue; // next round
-
-    std::unique_lock locker{lock};
-    cond.wait_for(locker, std::chrono::seconds(secs));
-  } while (!restore->going_down());
-
-  return NULL;
-
+    // start-to-start period: a deadline already in the past fires immediately
+    const auto next = start + std::chrono::seconds(secs);
+    proc_timer.expires_at(next);
+    boost::system::error_code ec;
+    proc_timer.async_wait(yield[ec]);   // cancellation -> ec, loop exits via yield_cancelled
+  }
 }
 
-int Restore::process(RestoreWorker* worker, optional_yield y)
+int Restore::process(boost::asio::yield_context yield)
 {
   int max_secs = cct->_conf->rgw_restore_lock_max_time;
 
   const int start = ceph::util::generate_random_number(0, max_objs - 1);
   for (int i = 0; i < max_objs; i++) {
     int index = (i + start) % max_objs;
-    int ret = process(index, max_secs, y);
+    int ret = process(index, max_secs, yield);
+    if (ret == -EBUSY)
+      continue;                        // another RGW holds this shard; try the next one
     if (ret < 0)
-      return ret;
+      return ret;                      // -ECANCELED (cancellation) or a real error: stop the cycle
   }
   return 0;
 }
-
-// unique_lock expects an unlock() taking no arguments, but
-// RadosRestoreSerializer::unlock() requires two. create an adapter that binds these
-// additional args
-struct RestoreLockAdapter {
-  rgw::sal::RestoreSerializer& serializer;
-  const DoutPrefixProvider* dpp = nullptr;
-  optional_yield y;
-
-  void unlock() {
-    serializer.unlock(dpp, y);
-  }
-};
 
 /* 
  * Given an index, fetch a list of restore entries to process. After each
@@ -330,117 +340,202 @@ struct RestoreLockAdapter {
  * While processing the entries, if any of their restore operation is still in
  * progress, such entries are added back to the list.
  */ 
-int Restore::process(int index, int max_secs, optional_yield y)
+int Restore::process(int index, int max_secs, boost::asio::yield_context yield)
 {
-  ldpp_dout(this, 20) << __PRETTY_FUNCTION__ << ": process entered index="	
-		      << index << ", max_secs=" << max_secs << dendl;
+  ldpp_dout(this, 20) << __PRETTY_FUNCTION__
+                      << ": process entered index=" << index << dendl;
 
-  /* list used to gather still IN_PROGRESS */
-  std::vector<RestoreEntry> r_entries;
-
-  std::unique_ptr<rgw::sal::RestoreSerializer> serializer =
-  			sal_restore->get_serializer(std::string(restore_index_lock_name),
-				       	std::string(obj_names[index]),
-					worker->thr_name());
-  utime_t end = ceph_clock_now();
-
-  /* max_secs should be greater than zero. We don't want a zero max_secs
-   * to be translated as no timeout, since we'd then need to break the
-   * lock and that would require a manual intervention. In this case
-   * we can just wait it out. */
-
-  if (max_secs <= 0)
+  if (max_secs <= 0) {
     return -EAGAIN;
-
-  end += max_secs;
-  const ceph::timespan time = std::chrono::seconds(max_secs);
-  int ret = serializer->try_lock(this, time, y);
-  if (ret == -EBUSY || ret == -EEXIST) {
-    /* already locked by another lc processor */
-    ldpp_dout(this, 0) << __PRETTY_FUNCTION__ << ": failed to acquire lock on "	 
-		       << obj_names[index] << dendl;
-    return -EBUSY;
   }
-  if (ret < 0)
-    return 0;
 
-  auto lock_adapter = RestoreLockAdapter{*serializer, this, y};
-  std::unique_lock<RestoreLockAdapter> lock(lock_adapter, std::adopt_lock);
+  const ceph::timespan lock_dur = std::chrono::seconds(max_secs);
+
+  /*
+   * Renewal shares this single worker io_context: a cloud restore's blocking
+   * put-drain (null_yield in restore_obj_from_cloud) can starve it, so a RADOS
+   * write stall past the lease TTL may lapse the shard lock mid-restore.
+   */
+  try {
+    auto lock = sal_restore->get_lock_client(
+        yield.get_executor(),
+        std::string(restore_index_lock_name),
+        std::string(obj_names[index]),
+        std::string(restore_lock_cookie));
+    return ceph::async::with_lease(*lock, lock_dur, yield,
+        [&] (boost::asio::yield_context ly) {
+          return process_locked(index, max_secs, ly);
+        });
+  } catch (const ceph::async::lease_aborted& e) {
+    // renewal failed, or the shard was cancelled after the body started
+    ldpp_dout(this, 0) << __PRETTY_FUNCTION__
+                       << ": lock lease aborted on " << obj_names[index]
+                       << ": " << e.code().message() << dendl;
+    return ceph::from_error_code(e.code());
+  } catch (const boost::system::system_error& e) {
+    // reported directly (not wrapped in lease_aborted) => lock acquisition
+    // failed and the body never ran
+    const int ret = ceph::from_error_code(e.code());
+    if (ret == -ECANCELED) {
+      throw;                             // propagate cancellation
+    }
+    if (ret == -EBUSY || ret == -EEXIST) {
+      ldpp_dout(this, 0) << __PRETTY_FUNCTION__
+                         << ": failed to acquire lock on "
+                         << obj_names[index] << dendl;
+      return -EBUSY;
+    }
+    ldpp_dout(this, 0) << __PRETTY_FUNCTION__
+                       << ": lock-acquire error on " << obj_names[index]
+                       << " (ret=" << ret << "); skipping shard" << dendl;
+    return 0;
+  } catch (const std::exception& e) {
+    // bad_alloc etc. would otherwise escape the worker thread and terminate the
+    // daemon; stop the cycle cleanly instead
+    ldpp_dout(this, 0) << __PRETTY_FUNCTION__ << ": unexpected exception on shard "
+                       << obj_names[index] << ": " << e.what() << dendl;
+    return -EIO;
+  }
+}
+
+// per-shard FIFO body, run under with_lease()
+int Restore::process_locked(int index, int max_secs, boost::asio::yield_context yield)
+{
+  yield.throw_if_cancelled(true);
+  // spawn() reports completion by suspending one last time, so a pending
+  // cancellation would make throw_if_cancelled() throw past the coroutine
+  // frame and terminate the process. disarm it before the coroutine exits
+  auto disarm = make_scope_guard([&yield] { yield.throw_if_cancelled(false); });
+  int ret = 0;
+
+  utime_t end = ceph_clock_now();
+  end += max_secs;
+
+  // clamp signed first: a negative value would wrap to a huge size_t (config min is 1)
+  const size_t io_limit = static_cast<size_t>(
+      std::max<int64_t>(1, cct->_conf->rgw_restore_max_concurrent_io));
+  const int max_entries = std::max<int>(1,
+      static_cast<int>(cct->_conf->rgw_restore_batch_size));
+
   std::string marker;
   std::string next_marker;
   bool truncated = false;
 
+  /*
+   * Keys re-queued this cycle; re-encountering one means we wrapped -> stop.
+   * Full identity needed because the shard hash ignores tenant/namespace.
+   */
+  std::unordered_set<std::string> requeued;
+  auto entry_key = [](const RestoreEntry& e) {
+    const auto& b = e.bucket; const auto& k = e.obj_key;
+    return b.tenant + '\0' + b.name + '\0' + b.bucket_id + '\0'
+         + k.ns + '\0' + k.name + '\0' + k.instance;
+  };
+
   do {
-    int max = 100;
     std::vector<RestoreEntry> entries;
 
-    ret = sal_restore->list(this, y, index, marker, &next_marker, max, entries, &truncated);
+    ret = sal_restore->list(this, yield, index, marker, &next_marker, max_entries, entries, &truncated);
     ldpp_dout(this, 20) << __PRETTY_FUNCTION__ <<
       ": list on shard:" << obj_names[index] << " returned:" << ret <<
       ", entries.size=" << entries.size() << ", truncated=" << truncated <<
-      ", marker='" << marker << "'" <<
-      ", next_marker='" << next_marker << "'" << dendl;
+      ", marker='" << marker << "'" << ", next_marker='" << next_marker << "'" << dendl;
+    if (ret < 0) {
+      ldpp_dout(this, -1) << __PRETTY_FUNCTION__ << ": ERROR: failed to list entries on "
+                          << obj_names[index] << " (ret=" << ret << ")" << dendl;
+      return ret;
+    }
+    if (entries.size() == 0)
+      break;                       // caught up
 
-    if (ret < 0)
-      goto done;
+    std::vector<RestoreEntry> batch_inprog;   // shared, no lock (single-threaded io_context)
+    int batch_err = 0;                        // first hard (non-ENOENT) error in the batch
+    bool wrapped = false;
 
-    if (entries.size() == 0) {
-      lock.unlock();
-      return 0;
+    {
+      ceph::async::spawn_throttle workpool{yield, io_limit};
+      std::unordered_set<std::string> seen_in_batch;
+      try {
+        for (auto iter = entries.begin(); iter != entries.end(); ++iter) {
+          const std::string k = entry_key(*iter);
+          if (requeued.count(k)) { wrapped = true; break; }
+          // coalesce dups: the FIFO can hold an object twice; running both would race it
+          if (!seen_in_batch.insert(k).second)
+            continue;
+
+          workpool.spawn(
+            [this, index, &batch_inprog, &batch_err, e = *iter]
+            (boost::asio::yield_context ey) mutable {
+              ey.throw_if_cancelled(true);
+              // spawn() reports completion by suspending one last time, so a
+              // pending cancellation would make throw_if_cancelled() throw past
+              // the coroutine frame and terminate the process. disarm it before
+              // the coroutine exits
+              auto disarm = make_scope_guard(
+                  [&ey] { ey.throw_if_cancelled(false); });
+              int r = process_restore_entry(e, ey);
+              if (!r && e.status == rgw::sal::RGWRestoreStatus::RestoreAlreadyInProgress) {
+                batch_inprog.push_back(e);
+                ldpp_dout(this, 20) << __PRETTY_FUNCTION__ << ": re-queueing entry: '"
+                                    << e << "' on shard:" << obj_names[index] << dendl;
+              } else if (r < 0 && r != -ENOENT && !batch_err) {
+                batch_err = r;     // tolerated -ENOENT (missing bucket/obj) is ignored
+              }
+            });
+        }
+        workpool.wait();           // join every child
+      } catch (...) {
+        // a cancelled child can still resume through the -ECANCELED return
+        // path and touch batch state; join every child before this frame
+        // unwinds
+        yield.throw_if_cancelled(false);
+        workpool.cancel();
+        try {
+          workpool.wait();
+        } catch (...) {}           // stragglers' aborts; the original error propagates
+        yield.throw_if_cancelled(true);
+        throw;
+      }
+    }
+
+    if (batch_err < 0)
+      return batch_err;            // hard error: do NOT trim
+    if (wrapped)
+      return ret;                  // wrapped batch: leave untrimmed for next cycle
+
+    /*
+     * Add-before-trim: re-queue in-progress entries before trimming, so a failure leaves
+     * the originals in the FIFO (no loss; at worst a benign dup). Re-queued markers sort
+     * beyond next_marker, so the inclusive trim won't remove them. The FIFO add/trim carry
+     * no cls lock; cross-RGW shard exclusivity rests on the advisory lease alone.
+     */
+    if (!batch_inprog.empty()) {
+      ret = sal_restore->add_entries(this, yield, index, batch_inprog);
+      if (ret < 0) {
+        ldpp_dout(this, -1) << __PRETTY_FUNCTION__ << ": ERROR: failed to re-queue "
+                            << batch_inprog.size() << " in-progress entries on "
+                            << obj_names[index] << dendl;
+        return ret;                // originals not trimmed -> no loss; surface error
+      }
+      for (auto& e : batch_inprog)
+        requeued.insert(entry_key(e));
     }
 
     marker = next_marker;
-    std::vector<RestoreEntry>::iterator iter;
-    for (iter = entries.begin(); iter != entries.end(); ++iter) {
-      RestoreEntry entry = *iter;
-
-      ret = process_restore_entry(entry, y);
-
-      if (!ret && entry.status == rgw::sal::RGWRestoreStatus::RestoreAlreadyInProgress) {
-      	 r_entries.push_back(entry);
-         ldpp_dout(this, 20) << __PRETTY_FUNCTION__ << ": re-pushing entry: '" << entry
-		 	 << "' on shard:"
-  	  	         << obj_names[index] << dendl;	 
-      }
-
-      // Skip the entry of object/bucket which no longer exists
-      if (ret < 0 && (ret != -ENOENT))
-        goto done;
-
-      ///process all entries, trim and re-add
-      utime_t now = ceph_clock_now();
-      if (now >= end) {
-        goto done;
-      }
-
-      if (going_down()) {
- 	// leave early, even if tag isn't removed, it's ok since it
-	// will be picked up next time around
-	goto done;
-      }
-    }
-  } while (truncated);
-
-  ldpp_dout(this, 20) << __PRETTY_FUNCTION__ << ": trimming till marker: '" << marker
-		 	 << "' on shard:"
-  	  	         << obj_names[index] << dendl;    
-  ret = sal_restore->trim_entries(this, y, index, marker);
-  if (ret < 0) {
-    ldpp_dout(this, -1) << __PRETTY_FUNCTION__ << ": ERROR: failed to trim entries on "	    	  	         << obj_names[index] << dendl;
-  }
-
-  if (!r_entries.empty()) {
-    ret = sal_restore->add_entries(this, y, index, r_entries);
+    ret = sal_restore->trim_entries(this, yield, index, marker);
     if (ret < 0) {
-      ldpp_dout(this, -1) << __PRETTY_FUNCTION__ << ": ERROR: failed to add entries on "    
-  	  	           << obj_names[index] << dendl;
+      ldpp_dout(this, -1) << __PRETTY_FUNCTION__ << ": ERROR: failed to trim entries on "
+                          << obj_names[index] << dendl;
+      return ret;
     }
-  }
+    ldpp_dout(this, 20) << __PRETTY_FUNCTION__ << ": trimmed till marker: '" << marker
+                        << "' on shard:" << obj_names[index] << dendl;
 
-  r_entries.clear();
-
-done:
-  lock.unlock();
+    // deadline checked only at the batch boundary, so a started batch always
+    // makes progress (worst-case overshoot: one batch of max_entries)
+    if (ceph_clock_now() >= end)
+      break;
+  } while (truncated);
 
   return ret;
 }
@@ -458,6 +553,21 @@ int Restore::process_restore_entry(RestoreEntry& entry, optional_yield y)
   // mark in_progress as false if the entry is being processed first time
   bool in_progress = ((entry.status == rgw::sal::RGWRestoreStatus::None) ? false : true);
 
+  // finalize a fully-attempted entry: record failure, then wake any GET waiters.
+  // a cancellation exception unwinds past this, leaving the entry queued, so it
+  // runs only on a real completion, never on shutdown.
+  auto finish = [&] (int r) -> int {
+    if (r < 0) {
+      ldpp_dout(this, -1) << __PRETTY_FUNCTION__ << ": Restore of entry:'" << entry
+                          << "' failed" << r << dendl;
+      entry.status = rgw::sal::RGWRestoreStatus::RestoreFailed;
+    }
+    if (waiter_registry && !in_progress) {
+      waiter_registry->notify_completion(entry.bucket, entry.obj_key, r >= 0, r);
+    }
+    return r;
+  };
+
   // Ensure its the same source zone processing temp entries as we do not
   // replicate temp restored copies
   if (days) { // temp copy
@@ -470,7 +580,7 @@ int Restore::process_restore_entry(RestoreEntry& entry, optional_yield y)
 
   // fill in the details from entry
   // bucket, obj, days, state=in_progress
-  ret = driver->load_bucket(this, entry.bucket, &bucket, null_yield);
+  ret = driver->load_bucket(this, entry.bucket, &bucket, y);
   if (ret < 0) {
     ldpp_dout(this, -1) << __PRETTY_FUNCTION__ << ": ERROR: get_bucket for "
 	   		<< bucket->get_name()	  
@@ -479,7 +589,7 @@ int Restore::process_restore_entry(RestoreEntry& entry, optional_yield y)
   }
   obj = bucket->get_object(entry.obj_key);
 
-  ret = obj->load_obj_state(this, null_yield, true);
+  ret = obj->load_obj_state(this, y, true);
 
   if (ret < 0) {
     ldpp_dout(this, -1) << __PRETTY_FUNCTION__ << ": ERROR: get_object for "
@@ -519,7 +629,7 @@ int Restore::process_restore_entry(RestoreEntry& entry, optional_yield y)
 
   if (ret < 0) {
     ldpp_dout(this, -1) << __PRETTY_FUNCTION__ << ": ERROR: failed to fetch tier placement handle, target_placement = " << target_placement << ", for zonegroup = " << driver->get_zone()->get_zonegroup().get_name() << ", ret = " << ret << dendl;
-    goto done;	  
+    return finish(ret);
   } else {
     ldpp_dout(this, 20) << __PRETTY_FUNCTION__ << ": getting tier placement handle"
 	   		 << " cloud tier for " <<	  
@@ -530,20 +640,24 @@ int Restore::process_restore_entry(RestoreEntry& entry, optional_yield y)
     ldpp_dout(this, -1) << __PRETTY_FUNCTION__ << ": ERROR: not s3 tier type - "
 	   		<< tier->get_tier_type() << 	  
                       " for storage class " << target_placement.storage_class << dendl;
-    goto done;
+    return finish(ret);
   }
 
   uint64_t size;
   // now go ahead with restoring object
   ret = obj->restore_obj_from_cloud(bucket.get(), tier.get(), cct, days, in_progress, size, 
 		  		      this, y);
+  if (ret == -ECANCELED && yield_cancelled(y)) {
+    // cancelled: HEAD left as-is, entry stays queued for retry
+    return ret;
+  }
   if (ret < 0) {
     ldpp_dout(this, -1) << __PRETTY_FUNCTION__ << ": Restore of object(" << obj->get_key() << ") failed" << ret << dendl;	  
     auto reset_ret = set_cloud_restore_status(this, obj.get(), y, rgw::sal::RGWRestoreStatus::RestoreFailed);
     if (reset_ret < 0) {
       ldpp_dout(this, -1) << __PRETTY_FUNCTION__ << ": Setting restore status ad RestoreFailed failed for object(" << obj->get_key() << ") " << reset_ret << dendl;	    
     }
-    goto done;
+    return finish(ret);
   }
 
   if (in_progress) {
@@ -565,24 +679,7 @@ int Restore::process_restore_entry(RestoreEntry& entry, optional_yield y)
                       {rgw::notify::ObjectRestoreCompleted}, y);
   }
 
-done:
-  if (ret < 0) {
-    ldpp_dout(this, -1) << __PRETTY_FUNCTION__ << ": Restore of entry:'" << entry << "' failed" << ret << dendl;	  
-    entry.status = rgw::sal::RGWRestoreStatus::RestoreFailed;
-  }
-
-  // Notify any waiting GET requests
-  if (waiter_registry && !in_progress) {
-    bool success = (ret >= 0);
-    waiter_registry->notify_completion(
-      entry.bucket,
-      entry.obj_key,
-      success,
-      ret
-    );
-  }
-
-  return ret;
+  return finish(ret);
 }
 
 time_t Restore::thread_stop_at()

--- a/src/rgw/rgw_restore.h
+++ b/src/rgw/rgw_restore.h
@@ -16,6 +16,7 @@
 #include "common/Cond.h"
 #include "common/iso_8601.h"
 #include "common/Thread.h"
+#include "common/async/context_pool.h"
 #include "rgw_common.h"
 #include "cls/rgw/cls_rgw_types.h"
 #include "rgw_sal.h"
@@ -25,10 +26,18 @@
 #include <atomic>
 #include <tuple>
 
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/cancellation_signal.hpp>
+#include <boost/asio/spawn.hpp>
+#include <boost/asio/basic_waitable_timer.hpp>
+
+#include "common/ceph_time.h"
+
 #define HASH_PRIME 7877
 #define MAX_ID_LEN 255
 static constexpr std::string_view restore_oid_prefix = "restore";
 static constexpr std::string_view restore_index_lock_name = "restore_process";
+static constexpr std::string_view restore_lock_cookie = "restore_thrd: ";
 
 namespace rgw::restore {
 
@@ -73,35 +82,13 @@ class Restore : public DoutPrefixProvider {
   std::unique_ptr<rgw::sal::Restore> sal_restore;
   int max_objs{0};
   std::vector<std::string> obj_names;
-  std::atomic<bool> down_flag = { false };
   std::shared_ptr<RestoreWaiterRegistry> waiter_registry;
 
-  class RestoreWorker : public Thread
-  {
-    const DoutPrefixProvider *dpp;
-    CephContext *cct;
-    rgw::restore::Restore *restore;
-    ceph::mutex lock = ceph::make_mutex("RestoreWorker");
-    ceph::condition_variable cond;
-
-  public:
-
-    using lock_guard = std::lock_guard<std::mutex>;
-    using unique_lock = std::unique_lock<std::mutex>;
-
-    RestoreWorker(const DoutPrefixProvider* _dpp, CephContext *_cct, rgw::restore::Restore *_restore) : dpp(_dpp), cct(_cct), restore(_restore) {}
-    rgw::restore::Restore* get_restore() { return restore; }
-    std::string thr_name() {
-      return std::string{"restore_thrd: "}; // + std::to_string(ix);
-    }
-    void *entry() override;
-    void stop();
-
-    friend class Restore;
-    friend class RGWRados;
-  }; // RestoreWorker
-
-  std::unique_ptr<Restore::RestoreWorker> worker;
+  ceph::async::io_context_pool proc_pool;
+  boost::asio::basic_waitable_timer<ceph::coarse_mono_clock>
+      proc_timer{proc_pool.get_executor()};
+  boost::asio::cancellation_signal proc_signal;
+  bool proc_started = false;
 
 public:
   ~Restore() {
@@ -116,7 +103,6 @@ public:
   int initialize(CephContext *_cct, rgw::sal::Driver* _driver);
   void finalize();
 
-  bool going_down();
   void start_processor();
   void stop_processor();
   void wake_worker();
@@ -128,9 +114,11 @@ public:
 
   std::ostream& gen_prefix(std::ostream& out) const;
 
-  int process(RestoreWorker* worker, optional_yield y);
+  int process(boost::asio::yield_context yield);
+  void process_cycles(boost::asio::yield_context yield);
   int choose_oid(const rgw::restore::RestoreEntry& e);
-  int process(int index, int max_secs, optional_yield y);
+  int process(int index, int max_secs, boost::asio::yield_context yield);
+  int process_locked(int index, int max_secs, boost::asio::yield_context yield);
   int process_restore_entry(rgw::restore::RestoreEntry& entry, optional_yield y);
   time_t thread_stop_at();
 
@@ -150,7 +138,7 @@ public:
 
   /** Given <bucket, obj>, restore the object from the cloud-tier. In case the
    * object cannot be restored immediately, save that restore state(/entry) 
-   * to be procesed later by RestoreWorker thread. */
+   * to be procesed later by the restore processor. */
   int restore_obj_from_cloud(rgw::sal::Bucket* pbucket, rgw::sal::Object* pobj,
 		  	     rgw::sal::PlacementTier* tier,
 			     std::optional<uint64_t> days,

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -19,6 +19,7 @@
 #include <optional>
 #include <boost/intrusive_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ref_counter.hpp>
+#include <boost/asio/any_io_executor.hpp>
 
 #include "common/tracer.h"
 #include "rgw_cksum.h"
@@ -64,6 +65,10 @@ namespace rgw {
 namespace rgw::restore {
   class Restore;
   struct RestoreEntry;
+}
+
+namespace ceph::async {
+  class LockClient;
 }
 
 namespace rgw::lua {
@@ -1716,14 +1721,6 @@ public:
 						       const std::string& cookie) = 0;
 };
 
-/** @brief Abstraction of a serializer for Restore
- */
-class RestoreSerializer : public Serializer {
-public:
-  RestoreSerializer() {}
-  virtual ~RestoreSerializer() = default;
-};
-
 /**
  * @brief Abstraction for restore processing
  *
@@ -1753,8 +1750,9 @@ public:
   virtual int trim_entries(const DoutPrefixProvider *dpp, optional_yield y,
 		 	  int index, const std::string_view& marker) = 0;
 
-  /** Get a serializer for restore processing */
-  virtual std::unique_ptr<RestoreSerializer> get_serializer(
+  /** Get a lock client for restore shard processing */
+  virtual std::unique_ptr<ceph::async::LockClient> get_lock_client(
+                                boost::asio::any_io_executor ex,
 		  				const std::string& lock_name,
 						const std::string& oid,
 						const std::string& cookie) = 0;

--- a/src/rgw/rgw_sal_filter.cc
+++ b/src/rgw/rgw_sal_filter.cc
@@ -14,6 +14,7 @@
  */
 
 #include "rgw_sal_filter.h"
+#include "common/async/lock_client.h"
 
 namespace rgw { namespace sal {
 
@@ -1463,18 +1464,13 @@ std::unique_ptr<LCSerializer> FilterLifecycle::get_serializer(
   return std::make_unique<FilterLCSerializer>(std::move(ns));
 }
 
-int FilterRestoreSerializer::try_lock(const DoutPrefixProvider *dpp, ceph::timespan dur,
-				 optional_yield y)
+std::unique_ptr<ceph::async::LockClient> FilterRestore::get_lock_client(
+    boost::asio::any_io_executor ex,
+    const std::string& lock_name,
+    const std::string& oid,
+    const std::string& cookie)
 {
-  return next->try_lock(dpp, dur, y);
-}
-
-std::unique_ptr<RestoreSerializer> FilterRestore::get_serializer(const std::string& lock_name,
-						       const std::string& oid,
-						       const std::string& cookie) {
-  std::unique_ptr<RestoreSerializer> ns;
-  ns = next->get_serializer(lock_name, oid, cookie);
-  return std::make_unique<FilterRestoreSerializer>(std::move(ns));
+  return next->get_lock_client(std::move(ex), lock_name, oid, cookie);
 }
 
 int FilterRestore::initialize(const DoutPrefixProvider* dpp, optional_yield y,

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -1066,20 +1066,6 @@ public:
 						       const std::string& cookie) override;
 };
 
-class FilterRestoreSerializer : public RestoreSerializer {
-
-protected:
-  std::unique_ptr<RestoreSerializer> next;
-
-public:
-  FilterRestoreSerializer(std::unique_ptr<RestoreSerializer> _next) : next(std::move(_next)) {}
-  virtual ~FilterRestoreSerializer() = default;
-  virtual int try_lock(const DoutPrefixProvider *dpp, ceph::timespan dur, optional_yield y) override;
-  virtual int unlock(const DoutPrefixProvider* dpp, optional_yield y) override
- 	{ return next->unlock(dpp, y); }
-  virtual void print(std::ostream& out) const override { return next->print(out); }
-};
-
 class FilterRestore : public Restore {
 
 protected:
@@ -1104,8 +1090,9 @@ public:
   virtual int trim_entries(const DoutPrefixProvider *dpp, optional_yield y,
 		 	  int index, const std::string_view& marker) override;
 
-  /** Get a serializer for lifecycle */
-  virtual std::unique_ptr<RestoreSerializer> get_serializer(
+  /** Get a lock client for restore shard processing */
+  virtual std::unique_ptr<ceph::async::LockClient> get_lock_client(
+                                boost::asio::any_io_executor ex,
 		  		const std::string& lock_name,
 				const std::string& oid,
 				const std::string& cookie) override;

--- a/src/rgw/rgw_sal_store.h
+++ b/src/rgw/rgw_sal_store.h
@@ -456,19 +456,6 @@ public:
   virtual void print(std::ostream& out) const override { out << oid; }
 };
 
-class StoreRestoreSerializer : public RestoreSerializer {
-
-protected:
-  std::string oid;
-
-public:
-  StoreRestoreSerializer() {}
-  StoreRestoreSerializer(std::string _oid) : oid(_oid) {}
-
-  virtual ~StoreRestoreSerializer() = default;
-  virtual void print(std::ostream& out) const override { out << oid; }
-};
-
 class StoreRestore : public Restore {
 
 public:

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -427,7 +427,7 @@ target_link_libraries(unittest_async_spawn_throttle ceph-common Boost::boost Boo
 
 add_executable(unittest_async_lease test_async_lease.cc)
 add_ceph_unittest(unittest_async_lease)
-target_link_libraries(unittest_async_lease ceph-common Boost::system Boost::context librados)
+target_link_libraries(unittest_async_lease ceph-common Boost::system Boost::context librados cls_lock_client)
 
 add_executable(unittest_async_yield_waiter test_async_yield_waiter.cc)
 add_ceph_unittest(unittest_async_yield_waiter)

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -427,7 +427,7 @@ target_link_libraries(unittest_async_spawn_throttle ceph-common Boost::boost Boo
 
 add_executable(unittest_async_lease test_async_lease.cc)
 add_ceph_unittest(unittest_async_lease)
-target_link_libraries(unittest_async_lease ceph-common Boost::system Boost::context)
+target_link_libraries(unittest_async_lease ceph-common Boost::system Boost::context librados)
 
 add_executable(unittest_async_yield_waiter test_async_yield_waiter.cc)
 add_ceph_unittest(unittest_async_yield_waiter)

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -425,6 +425,10 @@ add_executable(unittest_async_spawn_throttle test_async_spawn_throttle.cc)
 add_ceph_unittest(unittest_async_spawn_throttle)
 target_link_libraries(unittest_async_spawn_throttle ceph-common Boost::boost Boost::context)
 
+add_executable(unittest_async_lease test_async_lease.cc)
+add_ceph_unittest(unittest_async_lease)
+target_link_libraries(unittest_async_lease ceph-common Boost::system Boost::context)
+
 add_executable(unittest_async_yield_waiter test_async_yield_waiter.cc)
 add_ceph_unittest(unittest_async_yield_waiter)
 target_link_libraries(unittest_async_yield_waiter ceph-common Boost::boost Boost::context)

--- a/src/test/common/test_async_lease.cc
+++ b/src/test/common/test_async_lease.cc
@@ -1,0 +1,1730 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+//#define BOOST_ASIO_ENABLE_HANDLER_TRACKING
+#include "common/async/lease.h"
+
+#include <optional>
+#include <utility>
+#include <vector>
+#include <boost/asio/any_completion_executor.hpp>
+#include <boost/asio/append.hpp>
+#include <boost/asio/associated_cancellation_slot.hpp>
+#include <boost/asio/dispatch.hpp>
+#include <boost/asio/executor_work_guard.hpp>
+#include <gtest/gtest.h>
+#include "common/async/co_waiter.h"
+#include "common/async/yield_waiter.h"
+
+namespace ceph::async {
+
+namespace asio = boost::asio;
+using executor_type = asio::any_io_executor;
+
+using namespace std::chrono_literals;
+
+enum class event { acquire, renew, release };
+
+// a LockClient that logs events and injects delays and exceptions
+class MockClient : public LockClient {
+  Handler waiter;
+  using Work = asio::executor_work_guard<asio::any_completion_executor>;
+  std::optional<Work> work;
+ public:
+  std::vector<event> events; // tracks the sequence of LockClient calls
+
+  void acquire(ceph::timespan, Handler handler) override {
+    events.push_back(event::acquire);
+    work.emplace(asio::make_work_guard(handler));
+    waiter = std::move(handler);
+  }
+  void renew(ceph::timespan, Handler handler) override {
+    events.push_back(event::renew);
+    work.emplace(asio::make_work_guard(handler));
+    waiter = std::move(handler);
+  }
+  void release(Handler handler) override {
+    events.push_back(event::release);
+    work.emplace(asio::make_work_guard(handler));
+    waiter = std::move(handler);
+  }
+
+  void complete(boost::system::error_code ec = {}) {
+    auto w = std::move(*work);
+    work = std::nullopt;
+    asio::dispatch(asio::append(std::move(waiter), ec));
+  }
+};
+
+// a MockClient that supports per-op cancellation
+class CancelableMockClient : public MockClient {
+  struct op_cancellation {
+    MockClient* self;
+    op_cancellation(MockClient* self) : self(self) {}
+    void operator()(asio::cancellation_type_t type) {
+      if (type != asio::cancellation_type::none) {
+        self->complete(make_error_code(asio::error::operation_aborted));
+      }
+    }
+  };
+ public:
+  void acquire(ceph::timespan dur, Handler handler) override {
+    auto slot = get_associated_cancellation_slot(handler);
+    if (slot.is_connected()) {
+      slot.template emplace<op_cancellation>(this);
+    }
+    MockClient::acquire(dur, std::move(handler));
+  }
+  void renew(ceph::timespan dur, Handler handler) override {
+    auto slot = get_associated_cancellation_slot(handler);
+    if (slot.is_connected()) {
+      slot.template emplace<op_cancellation>(this);
+    }
+    MockClient::renew(dur, std::move(handler));
+  }
+  void release(Handler handler) override {
+    auto slot = get_associated_cancellation_slot(handler);
+    if (slot.is_connected()) {
+      slot.template emplace<op_cancellation>(this);
+    }
+    MockClient::release(std::move(handler));
+  }
+};
+
+template <typename T>
+auto capture(std::optional<T>& opt)
+{
+  return [&opt] (T value) {
+    opt = std::move(value);
+  };
+}
+
+template <typename T>
+auto capture(asio::cancellation_signal& signal, std::optional<T>& opt)
+{
+  return asio::bind_cancellation_slot(signal.slot(), capture(opt));
+}
+
+template <typename ...Args>
+auto capture(std::optional<std::tuple<Args...>>& opt)
+{
+  return [&opt] (Args ...args) {
+    opt = std::forward_as_tuple(std::forward<Args>(args)...);
+  };
+}
+
+
+TEST(co_spawn, return_void)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> { co_return; };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  locker.complete(); // unblock release
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+}
+
+TEST(spawn, return_void)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&locker] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, [] (asio::yield_context) {});
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  locker.complete(); // unblock release
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+}
+
+TEST(co_spawn, return_value)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  using ptr = std::unique_ptr<int>; // test a move-only return type
+  auto cr = [] () -> asio::awaitable<ptr> { co_return std::make_unique<int>(42); };
+
+  using result_type = std::tuple<std::exception_ptr, ptr>;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  EXPECT_FALSE(result);
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  locker.complete(); // unblock release
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(std::get<0>(*result));
+  ASSERT_TRUE(std::get<1>(*result));
+  EXPECT_EQ(42, *std::get<1>(*result));
+}
+
+TEST(spawn, return_value)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  /// using ptr = std::unique_ptr<int>;
+  // XXX: spawn() doesn't support move-only return values, see
+  // https://github.com/chriskohlhoff/asio/issues/1543
+  using ptr = std::shared_ptr<int>;
+  auto cr = [] (asio::yield_context) { return std::make_shared<int>(42); };
+
+  using result_type = std::tuple<std::exception_ptr, ptr>;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        return with_lease(locker, 30s, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  EXPECT_FALSE(result);
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  locker.complete(); // unblock release
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(std::get<0>(*result));
+  ASSERT_TRUE(std::get<1>(*result));
+  EXPECT_EQ(42, *std::get<1>(*result));
+}
+
+TEST(co_spawn, spawned_exception)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> {
+    throw std::domain_error{"oops"};
+    co_return;
+  };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  locker.complete(); // unblock release
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  EXPECT_THROW(std::rethrow_exception(*result), std::domain_error);
+}
+
+TEST(spawn, spawned_exception)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] (asio::yield_context) { throw std::domain_error{"oops"}; };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  locker.complete(); // unblock release
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  EXPECT_THROW(std::rethrow_exception(*result), std::domain_error);
+}
+
+TEST(co_spawn, acquire_exception)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> { co_return; };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(make_error_code(std::errc::invalid_argument));
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), std::errc::invalid_argument);
+  } catch (const std::exception& e) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(spawn, acquire_exception)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] (asio::yield_context) {};
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(make_error_code(std::errc::invalid_argument));
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), std::errc::invalid_argument);
+  } catch (const std::exception& e) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(co_spawn, acquire_shutdown)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> { co_return; };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+  // shut down before acquire completes
+}
+
+TEST(spawn, acquire_shutdown)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] (asio::yield_context) {};
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+  // shut down before acquire completes
+}
+
+TEST(co_spawn, acquire_cancel_supported)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = CancelableMockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> { co_return; };
+
+  asio::cancellation_signal signal;
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  // cancel before acquire completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result); // throws on cancellation
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception& e) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(spawn, acquire_cancel_supported)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = CancelableMockClient{};
+
+  auto cr = [] (asio::yield_context) {};
+
+  asio::cancellation_signal signal;
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, cr);
+      }, capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  // cancel before acquire completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result); // throws on cancellation
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception& e) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(co_spawn, acquire_cancel)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> { co_return; };
+
+  asio::cancellation_signal signal;
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  // cancel before acquire completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete();
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception& e) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(spawn, acquire_cancel)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] (asio::yield_context) {};
+
+  asio::cancellation_signal signal;
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, cr);
+      }, capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  // cancel before acquire completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete();
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result); // throws on cancellation
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception& e) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(co_spawn, acquired_shutdown)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::co_waiter<void, executor_type> waiter;
+  auto cr = waiter.get(); // cr is a wait that never completes
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 10ms, std::move(cr)), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // start cr and renewal timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  // shut down before renewal timer
+}
+
+TEST(spawn, acquired_shutdown)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::yield_waiter<void> waiter;
+  auto cr = [&waiter] (asio::yield_context yield) { waiter.async_wait(yield); };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 10ms, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // start cr and renewal timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  // shut down before renewal timer
+}
+
+TEST(co_spawn, acquired_cancel)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::co_waiter<void, executor_type> waiter;
+  auto cr = waiter.get(); // cr is a wait that never completes
+
+  asio::cancellation_signal signal;
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 10ms, std::move(cr)),
+                 capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // wait for acquire to finish
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  // cancel before renewal timer
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result); // throws on cancellation
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception& e) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(spawn, acquired_cancel)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::yield_waiter<void> waiter;
+  auto cr = [&waiter] (asio::yield_context yield) { waiter.async_wait(yield); };
+
+  asio::cancellation_signal signal;
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 10ms, yield, cr);
+      }, capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // wait for acquire to finish
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  // cancel before renewal timer
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result); // throws on cancellation
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception& e) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(co_spawn, renew_exception)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::co_waiter<void, executor_type> waiter;
+  auto cr = waiter.get(); // cr is a wait that never completes
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 10ms, std::move(cr)), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  // inject an exception on renew
+  locker.complete(make_error_code(std::errc::invalid_argument));
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), std::errc::invalid_argument);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(spawn, renew_exception)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::yield_waiter<void> waiter;
+  auto cr = [&waiter] (asio::yield_context yield) { waiter.async_wait(yield); };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 10ms, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  // inject an exception on renew
+  locker.complete(make_error_code(std::errc::invalid_argument));
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), std::errc::invalid_argument);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(co_spawn, renew_after_timeout)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::co_waiter<void, executor_type> waiter;
+  auto cr = waiter.get(); // cr is a wait that never completes
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 10ms, std::move(cr)), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  ctx.run_one(); // wait for renew timeout
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete(); // unblock renew
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(3, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  locker.complete(); // unblock release
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), boost::system::errc::timed_out);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(spawn, renew_after_timeout)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::yield_waiter<void> waiter;
+  auto cr = [&waiter] (asio::yield_context yield) { waiter.async_wait(yield); };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 10ms, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  ctx.run_one(); // wait for renew timeout
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete(); // unblock renew
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(3, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  locker.complete(); // unblock release
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), boost::system::errc::timed_out);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(co_spawn, renew_exception_after_timeout)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::co_waiter<void, executor_type> waiter;
+  auto cr = waiter.get(); // cr is a wait that never completes
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 10ms, std::move(cr)), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  ctx.run_one(); // wait for renew timeout
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  // inject an exception on renew
+  locker.complete(make_error_code(std::errc::invalid_argument));
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), boost::system::errc::timed_out);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(spawn, renew_exception_after_timeout)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::yield_waiter<void> waiter;
+  auto cr = [&waiter] (asio::yield_context yield) { waiter.async_wait(yield); };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 10ms, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  ctx.run_one(); // wait for renew timeout
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  // inject an exception on renew
+  locker.complete(make_error_code(std::errc::invalid_argument));
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), boost::system::errc::timed_out);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(co_spawn, renew_cancel_after_timeout_supported)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = CancelableMockClient{};
+
+  ceph::async::co_waiter<void, executor_type> waiter;
+  auto cr = waiter.get(); // cr is a wait that never completes
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::co_spawn(ex, with_lease(locker, 10ms, std::move(cr)),
+                 capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  ctx.run_one(); // wait for renew timeout
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  // cancel before renew completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size()); // no release
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), boost::system::errc::timed_out);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(spawn, renew_cancel_after_timeout_supported)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = CancelableMockClient{};
+
+  ceph::async::yield_waiter<void> waiter;
+  auto cr = [&waiter] (asio::yield_context yield) { waiter.async_wait(yield); };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 10ms, yield, cr);
+      }, capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  ctx.run_one(); // wait for renew timeout
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  // cancel before renew completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size()); // no release
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), boost::system::errc::timed_out);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(co_spawn, renew_cancel_after_timeout)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::co_waiter<void, executor_type> waiter;
+  auto cr = waiter.get(); // cr is a wait that never completes
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::co_spawn(ex, with_lease(locker, 10ms, std::move(cr)),
+                 capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  ctx.run_one(); // wait for renew timeout
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  // cancel before renew completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete();
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size()); // no release
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), boost::system::errc::timed_out);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(spawn, renew_cancel_after_timeout)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::yield_waiter<void> waiter;
+  auto cr = [&waiter] (asio::yield_context yield) { waiter.async_wait(yield); };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 10ms, yield, cr);
+      }, capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  ctx.run_one(); // wait for renew timeout
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  // cancel before renew completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete();
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size()); // no release
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), boost::system::errc::timed_out);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(co_spawn, renew_shutdown)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::co_waiter<void, executor_type> waiter;
+  auto cr = waiter.get(); // cr is a wait that never completes
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 10ms, std::move(cr)), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+  // shut down before renew completes
+}
+
+TEST(spawn, renew_shutdown)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::yield_waiter<void> waiter;
+  auto cr = [&waiter] (asio::yield_context yield) { waiter.async_wait(yield); };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 10ms, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+  // shut down before renew completes
+}
+
+TEST(co_spawn, renew_cancel)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::co_waiter<void, executor_type> waiter;
+  auto cr = waiter.get(); // cr is a wait that never completes
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::co_spawn(ex, with_lease(locker, 50ms, std::move(cr)),
+                 capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~25ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  // cancel before renew completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete();
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result); // throws on cancellation
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(spawn, renew_cancel)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::yield_waiter<void> waiter;
+  auto cr = [&waiter] (asio::yield_context yield) { waiter.async_wait(yield); };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 50ms, yield, cr);
+      }, capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~25ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  // cancel before renew completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete();
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result); // throws on cancellation
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(co_spawn, release_exception)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> { co_return; };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  // inject an exception on release
+  locker.complete(make_error_code(std::errc::invalid_argument));
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result); // release exceptions are ignored
+}
+
+TEST(spawn, release_exception)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] (asio::yield_context) {};
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  // inject an exception on release
+  locker.complete(make_error_code(std::errc::invalid_argument));
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result); // release exceptions are ignored
+}
+
+TEST(co_spawn, release_shutdown)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> { co_return; };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+  // shut down before release completes
+}
+
+TEST(spawn, release_shutdown)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] (asio::yield_context) {};
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+  // shut down before release completes
+}
+
+TEST(co_spawn, release_cancel_supported)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = CancelableMockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> { co_return; };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  // cancel before release completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_FALSE(*result); // exception is ignored
+}
+
+TEST(spawn, release_cancel_supported)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = CancelableMockClient{};
+
+  auto cr = [] (asio::yield_context) {};
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, cr);
+      }, capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  // cancel before release completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_FALSE(*result); // exception is ignored
+}
+
+TEST(co_spawn, release_cancel)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> { co_return; };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  // cancel before release completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete();
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_FALSE(*result); // exception is ignored
+}
+
+TEST(spawn, release_cancel)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] (asio::yield_context) {};
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, cr);
+      }, capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  // cancel before release completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete();
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_FALSE(*result); // exception is ignored
+}
+
+} // namespace ceph::async

--- a/src/test/common/test_async_lease.cc
+++ b/src/test/common/test_async_lease.cc
@@ -12,6 +12,7 @@
 
 //#define BOOST_ASIO_ENABLE_HANDLER_TRACKING
 #include "common/async/lease.h"
+#include "common/async/lock_rados.h"
 
 #include <optional>
 #include <utility>

--- a/src/test/common/test_async_yield_waiter.cc
+++ b/src/test/common/test_async_yield_waiter.cc
@@ -18,6 +18,8 @@
 #include <memory>
 #include <optional>
 #include <thread>
+#include <boost/asio/bind_cancellation_slot.hpp>
+#include <boost/asio/cancellation_signal.hpp>
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/spawn.hpp>
 #include <gtest/gtest.h>
@@ -35,6 +37,12 @@ void rethrow(std::exception_ptr eptr)
 auto capture(std::optional<std::exception_ptr>& eptr)
 {
   return [&eptr] (std::exception_ptr e) { eptr = e; };
+}
+
+auto capture(asio::cancellation_signal& signal,
+             std::optional<std::exception_ptr>& eptr)
+{
+  return bind_cancellation_slot(signal.slot(), capture(eptr));
 }
 
 
@@ -71,6 +79,36 @@ TEST(YieldWaiterVoid, wait_complete)
   EXPECT_TRUE(ctx.stopped());
 }
 
+TEST(YieldWaiterVoid, wait_cancel)
+{
+  asio::io_context ctx;
+  yield_waiter<void> waiter;
+  asio::cancellation_signal signal;
+  std::optional<std::exception_ptr> eptr;
+
+  asio::spawn(ctx, [&waiter] (asio::yield_context yield) {
+        waiter.async_wait(yield);
+      }, capture(signal, eptr));
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_TRUE(waiter);
+
+  signal.emit(asio::cancellation_type::all);
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(eptr);
+  ASSERT_TRUE(*eptr);
+  try {
+    std::rethrow_exception(*eptr);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
 TEST(YieldWaiterVoid, wait_error)
 {
   asio::io_context ctx;
@@ -85,7 +123,7 @@ TEST(YieldWaiterVoid, wait_error)
   ASSERT_FALSE(ctx.stopped());
 
   ASSERT_TRUE(waiter);
-  waiter.complete(make_error_code(asio::error::operation_aborted));
+  waiter.complete(make_error_code(std::errc::no_such_file_or_directory));
   EXPECT_FALSE(waiter);
 
   ctx.poll();
@@ -95,7 +133,7 @@ TEST(YieldWaiterVoid, wait_error)
   try {
     std::rethrow_exception(*eptr);
   } catch (const boost::system::system_error& e) {
-    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+    EXPECT_EQ(e.code(), std::errc::no_such_file_or_directory);
   } catch (const std::exception&) {
     EXPECT_THROW(throw, boost::system::system_error);
   }
@@ -203,6 +241,38 @@ TEST(YieldWaiterInt, wait_complete)
   EXPECT_EQ(42, *result);
 }
 
+TEST(YieldWaiterInt, wait_cancel)
+{
+  asio::io_context ctx;
+  yield_waiter<int> waiter;
+  asio::cancellation_signal signal;
+  std::optional<int> result;
+  std::optional<std::exception_ptr> eptr;
+
+  asio::spawn(ctx, [&waiter, &result] (asio::yield_context yield) {
+        result = waiter.async_wait(yield);
+      }, capture(signal, eptr));
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_TRUE(waiter);
+
+  signal.emit(asio::cancellation_type::all);
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_TRUE(eptr);
+  ASSERT_TRUE(*eptr);
+  try {
+    std::rethrow_exception(*eptr);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
 TEST(YieldWaiterInt, wait_error)
 {
   asio::io_context ctx;
@@ -272,6 +342,37 @@ TEST(YieldWaiterPtr, wait_complete)
   ASSERT_TRUE(result);
   ASSERT_TRUE(*result);
   EXPECT_EQ(42, **result);
+}
+
+TEST(YieldWaiterPtr, wait_cancel)
+{
+  asio::io_context ctx;
+  yield_waiter<std::unique_ptr<int>> waiter;
+  asio::cancellation_signal signal;
+  std::optional<std::unique_ptr<int>> result;
+  std::optional<std::exception_ptr> eptr;
+
+  asio::spawn(ctx, [&waiter, &result] (asio::yield_context yield) {
+        result = waiter.async_wait(yield);
+      }, capture(signal, eptr));
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+
+  signal.emit(asio::cancellation_type::all);
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_TRUE(eptr);
+  ASSERT_TRUE(*eptr);
+  try {
+    std::rethrow_exception(*eptr);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
 }
 
 TEST(YieldWaiterPtr, wait_error)

--- a/src/test/librados/asio.cc
+++ b/src/test/librados/asio.cc
@@ -13,6 +13,7 @@
  */
 
 #include "librados/librados_asio.h"
+#include "librados/redirect_version.h"
 
 #include <optional>
 #include <gtest/gtest.h>
@@ -106,6 +107,13 @@ TEST_F(AsioRados, AsyncReadCallback)
   };
   librados::async_read(ex, io, "exist", 256, 0, success_cb);
 
+  auto success_nover_cb = [&] (error_code ec, bufferlist bl) {
+    EXPECT_FALSE(ec);
+    EXPECT_EQ("hello", bl.to_str());
+  };
+  librados::async_read(ex, io, "exist", 256, 0,
+                       librados::redirect_version(success_nover_cb));
+
   auto failure_cb = [&] (error_code ec, version_t ver, bufferlist bl) {
     EXPECT_EQ(boost::system::errc::no_such_file_or_directory, ec);
     EXPECT_EQ(0, ver);
@@ -153,7 +161,11 @@ TEST_F(AsioRados, AsyncReadFuture)
 
   auto f1 = librados::async_read(ex, io, "exist", 256,
                                  0, boost::asio::use_future);
-  auto f2 = librados::async_read(ex, io, "noexist", 256,
+  version_t ver2 = 0;
+  auto f2 = librados::async_read(ex, io, "exist", 256, 0,
+                                 librados::redirect_version(
+                                     boost::asio::use_future, &ver2));
+  auto f3 = librados::async_read(ex, io, "noexist", 256,
                                  0, boost::asio::use_future);
 
   service.run();
@@ -162,7 +174,10 @@ TEST_F(AsioRados, AsyncReadFuture)
   EXPECT_LT(0, ver);
   EXPECT_EQ("hello", bl.to_str());
 
-  EXPECT_THROW(f2.get(), boost::system::system_error);
+  EXPECT_LT(0, ver2);
+  EXPECT_EQ("hello", f2.get().to_str());
+
+  EXPECT_THROW(f3.get(), boost::system::system_error);
 }
 
 TEST_F(AsioRados, AsyncReadYield)
@@ -179,6 +194,17 @@ TEST_F(AsioRados, AsyncReadYield)
     EXPECT_EQ("hello", bl.to_str());
   };
   boost::asio::spawn(ex, success_cr, rethrow);
+
+  auto success_nover_cr = [&] (boost::asio::yield_context yield) {
+    error_code ec;
+    version_t ver;
+    auto bl = librados::async_read(ex, io, "exist", 256, 0,
+                                   librados::redirect_version(yield[ec], &ver));
+    EXPECT_FALSE(ec);
+    EXPECT_LT(0, ver);
+    EXPECT_EQ("hello", bl.to_str());
+  };
+  boost::asio::spawn(service, success_nover_cr, rethrow);
 
   auto failure_cr = [&] (boost::asio::yield_context yield) {
     error_code ec;
@@ -259,6 +285,12 @@ TEST_F(AsioRados, AsyncWriteCallback)
   librados::async_write(ex, io, "exist", bl, bl.length(), 0,
                         success_cb);
 
+  auto success_nover_cb = [&] (error_code ec) {
+    EXPECT_FALSE(ec);
+  };
+  librados::async_write(ex, io, "exist", bl, bl.length(), 0,
+                        librados::redirect_version(success_nover_cb));
+
   auto failure_cb = [&] (error_code ec, version_t ver) {
     EXPECT_EQ(boost::system::errc::read_only_file_system, ec);
     EXPECT_EQ(0, ver);
@@ -313,13 +345,19 @@ TEST_F(AsioRados, AsyncWriteFuture)
 
   auto f1 = librados::async_write(ex, io, "exist", bl, bl.length(), 0,
                                   boost::asio::use_future);
-  auto f2 = librados::async_write(ex, snapio, "exist", bl, bl.length(), 0,
+  version_t ver2 = 0;
+  std::future<void> f2 = librados::async_write(
+      ex, io, "exist", bl, bl.length(), 0,
+      librados::redirect_version(boost::asio::use_future, &ver2));
+  auto f3 = librados::async_write(ex, snapio, "exist", bl, bl.length(), 0,
                                   boost::asio::use_future);
 
   service.run();
 
   EXPECT_LT(0, f1.get());
-  EXPECT_THROW(f2.get(), boost::system::system_error);
+  f2.get();
+  EXPECT_LT(0, ver2);
+  EXPECT_THROW(f3.get(), boost::system::system_error);
 }
 
 TEST_F(AsioRados, AsyncWriteYield)
@@ -339,6 +377,17 @@ TEST_F(AsioRados, AsyncWriteYield)
     EXPECT_EQ("hello", bl.to_str());
   };
   boost::asio::spawn(ex, success_cr, rethrow);
+
+  auto success_nover_cr = [&] (boost::asio::yield_context yield) {
+    error_code ec;
+    version_t ver;
+    librados::async_write(ex, io, "exist", bl, bl.length(), 0,
+                          librados::redirect_version(yield[ec], &ver));
+    EXPECT_FALSE(ec);
+    EXPECT_LT(0, ver);
+    EXPECT_EQ("hello", bl.to_str());
+  };
+  boost::asio::spawn(service, success_nover_cr, rethrow);
 
   auto failure_cr = [&] (boost::asio::yield_context yield) {
     error_code ec;
@@ -415,6 +464,16 @@ TEST_F(AsioRados, AsyncReadOperationCallback)
   {
     librados::ObjectReadOperation op;
     op.read(0, 0, nullptr, nullptr);
+    auto success_nover_cb = [&] (error_code ec, bufferlist bl) {
+      EXPECT_FALSE(ec);
+      EXPECT_EQ("hello", bl.to_str());
+    };
+    librados::async_operate(ex, io, "exist", std::move(op), 0, nullptr,
+                            librados::redirect_version(success_nover_cb));
+  }
+  {
+    librados::ObjectReadOperation op;
+    op.read(0, 0, nullptr, nullptr);
     auto failure_cb = [&] (error_code ec, version_t ver, bufferlist bl) {
       EXPECT_EQ(boost::system::errc::no_such_file_or_directory, ec);
       EXPECT_EQ(0, ver);
@@ -473,12 +532,21 @@ TEST_F(AsioRados, AsyncReadOperationFuture)
     f1 = librados::async_operate(ex, io, "exist", std::move(op),
                                  0, nullptr, boost::asio::use_future);
   }
-  std::future<read_result> f2;
+  std::future<bufferlist> f2;
+  version_t ver2 = 0;
   {
     librados::ObjectReadOperation op;
     op.read(0, 0, nullptr, nullptr);
-    f2 = librados::async_operate(ex, io, "noexist", std::move(op),
-                                 0, nullptr, boost::asio::use_future);
+    f2 = librados::async_operate(ex, io, "exist", std::move(op), 0, nullptr,
+                                 librados::redirect_version(
+                                     boost::asio::use_future, &ver2));
+  }
+  std::future<read_result> f3;
+  {
+    librados::ObjectReadOperation op;
+    op.read(0, 0, nullptr, nullptr);
+    f3 = librados::async_operate(ex, io, "noexist", std::move(op), 0, nullptr,
+                                 boost::asio::use_future);
   }
   service.run();
 
@@ -486,7 +554,10 @@ TEST_F(AsioRados, AsyncReadOperationFuture)
   EXPECT_LT(0, ver);
   EXPECT_EQ("hello", bl.to_str());
 
-  EXPECT_THROW(f2.get(), boost::system::system_error);
+  EXPECT_EQ("hello", f2.get().to_str());
+  EXPECT_LT(0, ver2);
+
+  EXPECT_THROW(f3.get(), boost::system::system_error);
 }
 
 TEST_F(AsioRados, AsyncReadOperationYield)
@@ -592,6 +663,15 @@ TEST_F(AsioRados, AsyncWriteOperationCallback)
   {
     librados::ObjectWriteOperation op;
     op.write_full(bl);
+    auto success_nover_cb = [&] (error_code ec) {
+      EXPECT_FALSE(ec);
+    };
+    librados::async_operate(ex, io, "exist", std::move(op), 0, nullptr,
+                            librados::redirect_version(success_nover_cb));
+  }
+  {
+    librados::ObjectWriteOperation op;
+    op.write_full(bl);
     auto failure_cb = [&] (error_code ec, version_t ver) {
       EXPECT_EQ(boost::system::errc::read_only_file_system, ec);
       EXPECT_EQ(0, ver);
@@ -655,17 +735,28 @@ TEST_F(AsioRados, AsyncWriteOperationFuture)
     f1 = librados::async_operate(ex, io, "exist", std::move(op),
                                  0, nullptr, boost::asio::use_future);
   }
-  std::future<version_t> f2;
+  std::future<void> f2;
+  version_t ver2 = 0;
   {
     librados::ObjectWriteOperation op;
     op.write_full(bl);
-    f2 = librados::async_operate(ex, snapio, "exist", std::move(op),
-                                 0, nullptr, boost::asio::use_future);
+    f2 = librados::async_operate(ex, io, "exist", std::move(op), 0, nullptr,
+                                 librados::redirect_version(
+                                     boost::asio::use_future, &ver2));
+  }
+  std::future<version_t> f3;
+  {
+    librados::ObjectWriteOperation op;
+    op.write_full(bl);
+    f3 = librados::async_operate(ex, snapio, "exist", std::move(op), 0, nullptr,
+                                 boost::asio::use_future);
   }
   service.run();
 
   EXPECT_LT(0, f1.get());
-  EXPECT_THROW(f2.get(), boost::system::system_error);
+  f2.get();
+  EXPECT_LT(0, ver2);
+  EXPECT_THROW(f3.get(), boost::system::system_error);
 }
 
 TEST_F(AsioRados, AsyncWriteOperationYield)
@@ -686,6 +777,18 @@ TEST_F(AsioRados, AsyncWriteOperationYield)
     EXPECT_LT(0, ver);
   };
   boost::asio::spawn(ex, success_cr, rethrow);
+
+  auto success_nover_cr = [&] (boost::asio::yield_context yield) {
+    librados::ObjectWriteOperation op;
+    op.write_full(bl);
+    error_code ec;
+    version_t ver;
+    librados::async_operate(ex, io, "exist", std::move(op), 0, nullptr,
+                            librados::redirect_version(yield[ec], &ver));
+    EXPECT_FALSE(ec);
+    EXPECT_LT(0, ver);
+  };
+  boost::asio::spawn(service, success_nover_cr, rethrow);
 
   auto failure_cr = [&] (boost::asio::yield_context yield) {
     librados::ObjectWriteOperation op;


### PR DESCRIPTION
The cloud-restore processor only trims a shard's work queue after walking the
whole shard, but the walk stops at `rgw_restore_lock_max_time` (90s), which is also
the un-renewed lock TTL. So any shard that can't drain inside one 90s window never
trims, and its FIFO just keeps growing. They drain serially too, since the worker
runs under `null_yield`.

Run each restore cycle on a `boost::asio::io_context` coroutine and rework
`Restore::process()` to drain a shard in batches:

- Incremental trim with no entry loss: each batch is trimmed from the queue as soon
  as it's processed (instead of only after the whole shard), so a cycle always makes
  durable progress
- Lock held for the whole shard: a background coroutine renews the `cls_lock` so a
  slow cloud fetch can't expire it mid-shard; `is_locked()` is re-checked after every
  FIFO mutation and nothing is trimmed once the lock is gone
- Bounded concurrency: objects are fetched several at a time per shard via
  `ceph::async::spawn_throttle`, capped by new `rgw_restore_max_concurrent_io` (16)
  and `rgw_restore_batch_size` (100) options
- Clean shutdown: in-flight fetches are cancelled, so anything unfinished stays
  queued for the next run

The cloud-fetch write path stays on `null_yield`, since the data comes back on the
libcurl reqs_thread.

The shutdown cancellation relies on a companion `RGWHTTPManager` fix (rgw/http:
cancel the in-flight request when the waiter is cancelled): the async request wait
now honors its cancellation slot and removes the request, finishing it with
`-ECANCELED`. Callers that don't cancel are unaffected.

Fixes: https://tracker.ceph.com/issues/77007
Requires: https://github.com/ceph/ceph/pull/69051

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [X] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
