### PR TITLE
test: optionally run test venvs with system site-packages

### DIFF
--- a/qa/mypy.ini
+++ b/qa/mypy.ini
@@ -1,2 +1,6 @@
 [mypy]
 ignore_missing_imports = True
+
+[mypy-prettytable]
+ignore_missing_imports = True
+follow_imports = skip

--- a/src/mypy.ini
+++ b/src/mypy.ini
@@ -36,6 +36,7 @@ ignore_missing_imports = True
 
 [mypy-prettytable]
 ignore_missing_imports = True
+follow_imports = skip
 
 [mypy-jsonpatch]
 ignore_missing_imports = True

--- a/src/script/run_tox.sh
+++ b/src/script/run_tox.sh
@@ -125,6 +125,10 @@ function main() {
     export CEPH_BUILD_DIR=$build_dir
     # use the wheelhouse prepared by install-deps.sh
     export PIP_FIND_LINKS="$tox_path/wheelhouse"
+    # CEPH_PYTHON_SYSTEM_SITE (default off): let tox's venvs see system site-packages
+    if ${CEPH_PYTHON_SYSTEM_SITE:-false}; then
+        export VIRTUALENV_SYSTEM_SITE_PACKAGES=true
+    fi
     tox_cmd=(tox -c $tox_path/tox.ini)
     if [ "$tox_envs" != "__tox_defaults__" ]; then
         tox_cmd+=("-e" "$tox_envs")

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -684,10 +684,6 @@ add_ceph_test(run-cli-tests ${CMAKE_CURRENT_SOURCE_DIR}/run-cli-tests)
 
 add_ceph_test(smoke.sh ${CMAKE_CURRENT_SOURCE_DIR}/smoke.sh)
 
-set_property(
-  TEST ${tox_tests}
-  PROPERTY ENVIRONMENT ${env_vars_for_tox_tests})
-
 # unittest_admin_socket
 add_executable(unittest_admin_socket
   admin_socket.cc

--- a/src/tools/setup-virtualenv.sh
+++ b/src/tools/setup-virtualenv.sh
@@ -62,7 +62,12 @@ if [ -z "$DIR" ] ; then
 fi
 rm -fr $DIR
 mkdir -p $DIR
-$PYTHON -m venv $DIR
+# CEPH_PYTHON_SYSTEM_SITE (default off): build venv against system site-packages
+VENV_OPTS=
+if ${CEPH_PYTHON_SYSTEM_SITE:-false}; then
+    VENV_OPTS="--system-site-packages"
+fi
+$PYTHON -m venv $VENV_OPTS $DIR
 . $DIR/bin/activate
 
 if pip --help | grep -q disable-pip-version-check; then


### PR DESCRIPTION
Add a `CEPH_PYTHON_SYSTEM_SITE` switch (off by default). When set:

- `setup-virtualenv.sh` builds its venv with `--system-site-packages`;
- `run_tox.sh` exports `VIRTUALENV_SYSTEM_SITE_PACKAGES=true` for tox's venvs.

This lets installed distro packages satisfy test dependencies instead of pip
rebuilding them from sdist, which helps where prebuilt wheels are missing (e.g.
scipy and numpy on riscv64).

---

FWIW, I'm working on riscv64 CI for Ceph, where building scipy from source alone
can take over 30 minutes. Reusing the packages that are already installed saves
a lot of that rebuild time, and on machines with poor connectivity it also
avoids a lot of network trouble.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests