### PR TITLE
librados: optionally retry the mon handshake on transient connect failure

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -8,6 +8,10 @@
   to optionally retry the monmap/config bootstrap and authentication steps when
   ``connect()`` fails transiently, for example a cephx EPERM returned by a monitor
   that is mid-election. The default of 0 preserves the previous fail-immediately
+  behaviour for every other caller. ceph-mgr defaults ``rados_connect_retries``
+  to 5 for itself, so a transient connect failure during a mgr failover no
+  longer leaves an always-on module stuck in HEALTH_ERR until a manual
+  ``ceph mgr fail``; setting the option back to 0 for the mgr restores the old
   behaviour.
 
 * RGW: S3 ListObjects and ListObjectVersions now support the

--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -4,6 +4,12 @@
   developers must update their method calls to use these new structs, which ensure
   read/write semantics are correctly applied.
 
+* librados: Added ``rados_connect_retries`` (and ``rados_connect_retry_interval``)
+  to optionally retry the monmap/config bootstrap and authentication steps when
+  ``connect()`` fails transiently, for example a cephx EPERM returned by a monitor
+  that is mid-election. The default of 0 preserves the previous fail-immediately
+  behaviour.
+
 * RGW: S3 ListObjects and ListObjectVersions now support the
   ``x-amz-optional-object-attributes: RestoreStatus`` request header to include
   restore status in listing responses. Restore status is stored in the bucket

--- a/src/ceph_mgr.cc
+++ b/src/ceph_mgr.cc
@@ -55,7 +55,14 @@ int main(int argc, const char **argv)
   }
 
   std::map<std::string,std::string> defaults = {
-    { "keyring", "$mgr_data/keyring" }
+    { "keyring", "$mgr_data/keyring" },
+    // Modules open their librados handle while the mgr is coming up, which is
+    // exactly when the monitors may still be (re)forming quorum. A module that
+    // throws out of __init__ is never reconstructed, so let connect() ride out
+    // a transient failure instead of leaving the module permanently failed.
+    // This is only a default, so an operator who wants the historical
+    // fail-immediately behaviour can still set rados_connect_retries = 0.
+    { "rados_connect_retries", "5" }
   };
   auto cct = global_init(&defaults, args, CEPH_ENTITY_TYPE_MGR,
 			 CODE_ENVIRONMENT_DAEMON, 0);

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -6682,6 +6682,37 @@ options:
   min: 0
   flags:
   - runtime
+- name: rados_connect_retries
+  type: uint
+  level: advanced
+  desc: Number of times to retry the mon handshake when librados connect() fails
+  long_desc: The monmap/config bootstrap and authentication steps of connect() can
+    fail transiently while the monitors are (re)forming quorum, for example a cephx
+    EPERM returned by a monitor that is mid-election. A client that opens its librados
+    handle during such a window would otherwise fail permanently. When set above 0,
+    connect() retries each of those steps this many times (with a linear backoff of
+    rados_connect_retry_interval) before giving up. Retries are only cheap while
+    the monitors are actively rejecting the client. If they are unreachable
+    instead, a single attempt already blocks for client_mount_timeout or longer,
+    since the bootstrap step retries internally, so raising this multiplies the
+    time connect() can take in the worst case. The default of 0 preserves the
+    historical fail-immediately behaviour.
+  default: 0
+  min: 0
+  flags:
+  - runtime
+- name: rados_connect_retry_interval
+  type: float
+  level: advanced
+  desc: Base backoff in seconds between librados connect() authentication retries
+  long_desc: When rados_connect_retries is above 0, connect() waits this many seconds
+    before the first retry and scales the wait linearly with each further attempt
+    (attempt N waits N times this value). Has no effect when rados_connect_retries
+    is 0.
+  default: 1.0
+  min: 0
+  flags:
+  - runtime
 - name: rados_replica_read_policy
   type: str
   level: advanced

--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -233,8 +233,13 @@ int librados::RadosClient::connect()
   {
     MonClient mc_bootstrap(cct, poolctx);
     err = mc_bootstrap.get_monmap_and_config();
-    if (err < 0)
+    if (err < 0) {
+      // nothing has been set up yet, so this early return cannot go through the
+      // out: label, but the handle still has to leave CONNECTING behind or every
+      // later connect() on it returns -EINPROGRESS
+      state = DISCONNECTED;
       return err;
+    }
   }
 
   common_init_finish(cct);

--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -17,9 +17,11 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 
+#include <chrono>
 #include <iostream>
 #include <string>
 #include <sstream>
+#include <thread>
 #include <pthread.h>
 #include <errno.h>
 
@@ -230,16 +232,45 @@ int librados::RadosClient::connect()
     cct->_log->start();
   }
 
-  {
-    MonClient mc_bootstrap(cct, poolctx);
-    err = mc_bootstrap.get_monmap_and_config();
-    if (err < 0) {
-      // nothing has been set up yet, so this early return cannot go through the
-      // out: label, but the handle still has to leave CONNECTING behind or every
-      // later connect() on it returns -EINPROGRESS
-      state = DISCONNECTED;
-      return err;
+  // Connecting can fail transiently while the monitors are (re)forming quorum,
+  // e.g. a cephx EPERM returned by a monitor that is mid-election. Both the
+  // initial monmap/config bootstrap and authentication can hit this. Optionally
+  // retry those steps a bounded number of times with a linear backoff before
+  // giving up, so a caller started during an election window (a mgr module
+  // opening its librados handle right after a failover is the motivating case)
+  // does not fail permanently. This is opt-in: rados_connect_retries defaults to
+  // 0, which preserves the historical fail-immediately behaviour. Each step is
+  // safe to reattempt: get_monmap_and_config() runs on a throwaway MonClient,
+  // and authenticate() drops whatever a failed attempt left behind and hunts
+  // the monitors again.
+  const uint64_t connect_retries =
+    conf.get_val<uint64_t>("rados_connect_retries");
+  const double connect_retry_interval =
+    conf.get_val<double>("rados_connect_retry_interval");
+  auto with_retries = [&](const char *what, auto step) {
+    int r;
+    for (uint64_t attempt = 0; ; ++attempt) {
+      r = step();
+      if (r >= 0 || attempt >= connect_retries)
+        return r;
+      ldout(cct, 1) << conf->name << " " << what << " attempt " << (attempt + 1)
+                    << " failed (" << cpp_strerror(-r) << "), retrying in "
+                    << connect_retry_interval * (attempt + 1) << "s" << dendl;
+      std::this_thread::sleep_for(std::chrono::duration<double>(
+        connect_retry_interval * (attempt + 1)));
     }
+  };
+
+  err = with_retries("monmap/config bootstrap", [&] {
+    MonClient mc_bootstrap(cct, poolctx);
+    return mc_bootstrap.get_monmap_and_config();
+  });
+  if (err < 0) {
+    // nothing has been set up yet, so this early return cannot go through the
+    // out: label, but the handle still has to leave CONNECTING behind or every
+    // later connect() on it returns -EINPROGRESS
+    state = DISCONNECTED;
+    return err;
   }
 
   common_init_finish(cct);
@@ -291,9 +322,13 @@ int librados::RadosClient::connect()
     goto out;
   }
 
-  err = monclient.authenticate(std::chrono::duration<double>(conf.get_val<std::chrono::seconds>("client_mount_timeout")).count());
+  err = with_retries("authentication", [&] {
+    return monclient.authenticate(std::chrono::duration<double>(
+      conf.get_val<std::chrono::seconds>("client_mount_timeout")).count());
+  });
   if (err) {
-    ldout(cct, 0) << conf->name << " authentication error " << cpp_strerror(-err) << dendl;
+    ldout(cct, 0) << conf->name << " authentication error "
+                  << cpp_strerror(-err) << dendl;
     shutdown();
     goto out;
   }

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -588,7 +588,14 @@ int MonClient::authenticate(double timeout)
   }
   sub.want("monmap", monmap.get_epoch() ? monmap.get_epoch() + 1 : 0, 0);
   sub.want("config", 0, 0);
-  if (!_opened())
+  // A previous attempt may have left a failure behind: either it gave up on
+  // the last pending connection (nothing is open, the usual case) or it timed
+  // out while the connections were still hunting, in which case they are still
+  // around along with the error they recorded. Start a fresh hunt in both
+  // cases, otherwise a caller retrying authenticate() is handed the stale
+  // authenticate_err straight back without the monitors ever being contacted
+  // again.
+  if (!_opened() || authenticate_err < 0)
     _reopen_session();
 
   auto until = ceph::mono_clock::now();

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -2579,8 +2579,21 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
             return self._rados
 
         ctx_capsule = self.get_context()
-        self._rados = rados.Rados(context=ctx_capsule)
-        self._rados.connect()
+        rados_inst = rados.Rados(context=ctx_capsule)
+
+        # The monitors may be briefly unreachable when a module first opens
+        # its librados handle, e.g. right after a mgr failover while the mons
+        # are still (re)forming quorum. connect() retries such a failure on
+        # its own because ceph-mgr defaults rados_connect_retries above 0; an
+        # error surfacing here is one that outlived those retries.
+        rados_inst.connect()
+
+        # Only cache the handle once it is actually connected, so a failed
+        # connect does not leave a poisoned, unconnected instance behind. The
+        # mgr does not retry a module that throws in __init__, but a module
+        # that catches the error and asks for the handle again gets a fresh
+        # connect attempt rather than a dead instance.
+        self._rados = rados_inst
         self._ceph_register_client(None, self._rados.get_addrs(), False)
         return self._rados
 

--- a/src/pybind/mgr/tests/test_mgr_module.py
+++ b/src/pybind/mgr/tests/test_mgr_module.py
@@ -1,0 +1,86 @@
+# type: ignore
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import rados
+import mgr_module
+
+
+def _make_handle(connect_side_effect=None):
+    handle = MagicMock()
+    handle.connect.side_effect = connect_side_effect
+    handle.get_addrs.return_value = '1.2.3.4:0/0'
+    return handle
+
+
+def test_rados_connects_and_caches_the_handle():
+    inst = MagicMock()
+    inst._rados = None
+    handle = _make_handle()
+    with patch.object(mgr_module.rados, 'Rados', return_value=handle):
+        result = mgr_module.MgrModule.rados.fget(inst)
+
+    handle.connect.assert_called_once()
+    assert result is handle
+    assert inst._rados is handle
+    inst._ceph_register_client.assert_called_once()
+
+
+def test_rados_leaves_the_shared_config_alone():
+    # The handle shares the mgr's CephContext, so setting a config value on it
+    # would change that value for every other module in the process and
+    # override whatever the operator configured. Retry behaviour comes from
+    # ceph-mgr's own default for rados_connect_retries instead.
+    inst = MagicMock()
+    inst._rados = None
+    handle = _make_handle()
+    with patch.object(mgr_module.rados, 'Rados', return_value=handle):
+        mgr_module.MgrModule.rados.fget(inst)
+
+    handle.conf_set.assert_not_called()
+
+
+def test_rados_does_not_cache_handle_on_persistent_failure():
+    # If the bounded retries inside connect() exhaust, the error propagates
+    # and no unconnected handle is left cached on self._rados.
+    err = rados.Error('cluster unreachable', errno=1)
+    inst = MagicMock()
+    inst._rados = None
+    handle = _make_handle(connect_side_effect=err)
+    with patch.object(mgr_module.rados, 'Rados', return_value=handle):
+        with pytest.raises(rados.Error):
+            mgr_module.MgrModule.rados.fget(inst)
+
+    assert inst._rados is None
+    inst._ceph_register_client.assert_not_called()
+
+
+def test_rados_reconnects_after_a_failed_connect():
+    # A failed connect must not poison the property: the next access builds a
+    # new handle and tries again.
+    err = rados.Error('cluster unreachable', errno=1)
+    inst = MagicMock()
+    inst._rados = None
+    failing = _make_handle(connect_side_effect=err)
+    working = _make_handle()
+    with patch.object(mgr_module.rados, 'Rados',
+                      side_effect=[failing, working]):
+        with pytest.raises(rados.Error):
+            mgr_module.MgrModule.rados.fget(inst)
+        result = mgr_module.MgrModule.rados.fget(inst)
+
+    assert result is working
+    assert inst._rados is working
+
+
+def test_rados_returns_cached_handle_without_reconnecting():
+    cached = MagicMock()
+    inst = MagicMock()
+    inst._rados = cached
+    with patch.object(mgr_module.rados, 'Rados') as ctor:
+        result = mgr_module.MgrModule.rados.fget(inst)
+
+    assert result is cached
+    ctor.assert_not_called()
+    inst._ceph_register_client.assert_not_called()

--- a/src/test/librados/librados.cc
+++ b/src/test/librados/librados.cc
@@ -1,6 +1,7 @@
 //#include "common/config.h"
 #include "include/rados/librados.h"
 
+#include <chrono>
 #include <errno.h>
 
 #include "gtest/gtest.h"
@@ -24,6 +25,43 @@ static rados_t make_unconnectable_cluster()
   EXPECT_EQ(0, rados_conf_set(cluster, "mon_host", ""));
   EXPECT_EQ(0, rados_conf_set(cluster, "monmap", "/nonexistent/monmap.bin"));
   return cluster;
+}
+
+static double time_connect(rados_t cluster, int *err)
+{
+  auto start = std::chrono::steady_clock::now();
+  *err = rados_connect(cluster);
+  std::chrono::duration<double> elapsed =
+    std::chrono::steady_clock::now() - start;
+  return elapsed.count();
+}
+
+TEST(Librados, ConnectDoesNotRetryByDefault) {
+  rados_t cluster = make_unconnectable_cluster();
+  // long enough that a single retry could not be mistaken for none
+  ASSERT_EQ(0, rados_conf_set(cluster, "rados_connect_retry_interval", "10"));
+
+  int err = 0;
+  double elapsed = time_connect(cluster, &err);
+  ASSERT_EQ(-ENOENT, err);
+  ASSERT_LT(elapsed, 5.0);
+
+  rados_shutdown(cluster);
+}
+
+TEST(Librados, ConnectRetriesAreBounded) {
+  rados_t cluster = make_unconnectable_cluster();
+  ASSERT_EQ(0, rados_conf_set(cluster, "rados_connect_retries", "3"));
+  ASSERT_EQ(0, rados_conf_set(cluster, "rados_connect_retry_interval", "0.05"));
+
+  int err = 0;
+  double elapsed = time_connect(cluster, &err);
+  // three retries with a linear backoff, so at least 1+2+3 intervals, and the
+  // original error once the budget is spent rather than an endless retry
+  ASSERT_EQ(-ENOENT, err);
+  ASSERT_GE(elapsed, 6 * 0.05);
+
+  rados_shutdown(cluster);
 }
 
 TEST(Librados, ConnectFailureLeavesHandleUsable) {

--- a/src/test/librados/librados.cc
+++ b/src/test/librados/librados.cc
@@ -1,6 +1,8 @@
 //#include "common/config.h"
 #include "include/rados/librados.h"
 
+#include <errno.h>
+
 #include "gtest/gtest.h"
 
 TEST(Librados, CreateShutdown) {
@@ -8,6 +10,29 @@ TEST(Librados, CreateShutdown) {
   int err;
   err = rados_create(&cluster, "someid");
   EXPECT_EQ(err, 0);
+
+  rados_shutdown(cluster);
+}
+
+// A handle pointed at a monmap file that does not exist fails in the
+// monmap/config bootstrap, the first of the two mon-contact steps of
+// connect(), locally and without touching the network.
+static rados_t make_unconnectable_cluster()
+{
+  rados_t cluster = nullptr;
+  EXPECT_EQ(0, rados_create(&cluster, "someid"));
+  EXPECT_EQ(0, rados_conf_set(cluster, "mon_host", ""));
+  EXPECT_EQ(0, rados_conf_set(cluster, "monmap", "/nonexistent/monmap.bin"));
+  return cluster;
+}
+
+TEST(Librados, ConnectFailureLeavesHandleUsable) {
+  rados_t cluster = make_unconnectable_cluster();
+
+  ASSERT_EQ(-ENOENT, rados_connect(cluster));
+  // the failed attempt must not leave the handle stuck in CONNECTING, which
+  // would turn every later attempt into -EINPROGRESS
+  ASSERT_EQ(-ENOENT, rados_connect(cluster));
 
   rados_shutdown(cluster);
 }

--- a/src/test/mon/CMakeLists.txt
+++ b/src/test/mon/CMakeLists.txt
@@ -18,6 +18,13 @@ add_executable(ceph_test_mon_msg
   )
 target_link_libraries(ceph_test_mon_msg os osdc global ${UNITTEST_LIBS})
 
+# unittest_monclient_retry
+add_executable(unittest_monclient_retry
+  test_monclient_retry.cc
+  )
+add_ceph_unittest(unittest_monclient_retry)
+target_link_libraries(unittest_monclient_retry mon global ${UNITTEST_LIBS})
+
 # unittest_config_map
 add_executable(unittest_config_map
   test_config_map.cc

--- a/src/test/mon/test_monclient_retry.cc
+++ b/src/test/mon/test_monclient_retry.cc
@@ -1,0 +1,100 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <chrono>
+
+#include "common/async/context_pool.h"
+#include "common/ceph_argparse.h"
+#include "global/global_context.h"
+#include "global/global_init.h"
+#include "include/scope_guard.h"
+#include "mon/MonClient.h"
+#include "msg/Messenger.h"
+
+#include "gtest/gtest.h"
+
+using namespace std::chrono;
+
+// A socket that accepts connections but never speaks the messenger protocol,
+// so a hunt started against it stays pending: authenticate() gives up on the
+// timeout with the connection still in pending_cons, which is the state a
+// retried authenticate() has to recover from.
+class silent_mon {
+  int fd = -1;
+  int port = 0;
+public:
+  silent_mon() {
+    fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    ceph_assert(fd >= 0);
+    struct sockaddr_in addr = {};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0;
+    ceph_assert(::bind(fd, (struct sockaddr *)&addr, sizeof(addr)) == 0);
+    ceph_assert(::listen(fd, 5) == 0);
+    socklen_t len = sizeof(addr);
+    ceph_assert(::getsockname(fd, (struct sockaddr *)&addr, &len) == 0);
+    port = ntohs(addr.sin_port);
+  }
+  ~silent_mon() {
+    if (fd >= 0)
+      ::close(fd);
+  }
+  std::string get_addr() const {
+    return "v1:127.0.0.1:" + std::to_string(port);
+  }
+};
+
+TEST(MonClient, AuthenticateRetriedAfterTimeout) {
+  ceph::async::io_context_pool poolctx(1);
+  MonClient monc(g_ceph_context, poolctx);
+  ASSERT_EQ(0, monc.build_initial_monmap());
+
+  Messenger *msgr = Messenger::create_client_messenger(g_ceph_context,
+						       "monclient-test");
+  ASSERT_NE(nullptr, msgr);
+  msgr->start();
+  monc.set_messenger(msgr);
+  monc.set_want_keys(CEPH_ENTITY_TYPE_MON);
+  ASSERT_EQ(0, monc.init());
+  auto shutdown = make_scope_guard([&] {
+    monc.shutdown();
+    msgr->shutdown();
+    msgr->wait();
+    delete msgr;
+  });
+
+  const double timeout = 0.5;
+  ASSERT_GT(0, monc.authenticate(timeout));
+
+  // the second call has to hunt the monitors again rather than hand back what
+  // the first one recorded, so it can only return once it has waited too
+  auto start = steady_clock::now();
+  ASSERT_GT(0, monc.authenticate(timeout));
+  duration<double> elapsed = steady_clock::now() - start;
+  ASSERT_GE(elapsed.count(), timeout * 0.8);
+}
+
+int main(int argc, char **argv)
+{
+  // mon_host is a startup option, so the monitor the client hunts has to be
+  // in place before the config is assembled
+  silent_mon mon;
+  std::string mon_host = "--mon-host=" + mon.get_addr();
+
+  auto args = argv_to_vec(argc, argv);
+  args.push_back(mon_host.c_str());
+  args.push_back("--auth-client-required=none");
+  auto cct = global_init(nullptr, args,
+			 CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY,
+			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE|
+			 CINIT_FLAG_NO_MON_CONFIG);
+  common_init_finish(g_ceph_context);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Description

A librados client that opens its handle while the monitors are (re)forming
quorum can hit a transient failure during `connect()`, for example a cephx
EPERM from a monitor that is mid-election, and fail even though the condition
clears moments later. `connect()` contacts the mons twice (the monmap/config
bootstrap and authentication) and either can be affected.

The motivating case is a mgr always-on module (`volumes`, `rbd_support`) that
opens the shared librados handle during construction right after a mgr
failover. The mgr does not retry a module that throws in `__init__`, so a
single transient failure drops the module and the cluster sits in `HEALTH_ERR`
("Module 'X' has failed: Not found or unloadable") until an operator runs
`ceph mgr fail`, long after the condition cleared. Seen on a production
cluster after a mon election.

## Fix

Four commits, each standing on its own:

**`mon/MonClient`: start a fresh hunt when `authenticate()` is retried.**
`authenticate()` gives up in two ways. When the monitors reject the client the
last pending connection is erased before the error is recorded, so a later
call hunts again. When it times out instead, the connections are still hunting
and `authenticate_err` still holds the timeout, so a later call finds
`_opened()` true, skips the reopen and returns the previous call's error
without contacting a monitor. It now reopens the session whenever a previous
attempt left an error behind.

**`librados`: leave CONNECTING behind when `connect()` fails at the
bootstrap.** Every failure path clears the state through the `out:` label
except the bootstrap early return, so a handle whose connect failed there
returned `-EINPROGRESS` on every later attempt. Pre-existing, and a
prerequisite for retrying at all.

**`librados`: the retry itself.** A bounded, opt-in retry around both
mon-contact steps in `RadosClient::connect()`, controlled by two new options:

- `rados_connect_retries` (default `0`)
- `rados_connect_retry_interval` (default `1.0`s, linear backoff)

The default of `0` keeps the current fail-immediately behaviour for every
existing librados caller. Since the retry lives in the C++ connect path it
covers both the C (`rados_connect`) and C++ APIs. This replaces the earlier
mgr-only Python retry, per @NitzanMordhai's review, so any client started
during an election window benefits.

**`mgr`: opt in.** ceph-mgr defaults `rados_connect_retries` to 5 through its
`global_init` defaults map. Being a default it is scoped to the mgr process
and an operator can still set the option to 0; setting it from the module
would instead rewrite the config shared by the whole mgr. The handle is also
kept out of the property cache until `connect()` succeeds, so a failed connect
no longer leaves a dead instance behind.

The retries are bounded twice, by `rados_connect_retries` and by
`client_mount_timeout` of wall-clock time per step. An attempt that has
already spent that long hunting for unreachable monitors is not repeated, so a
`connect()` against unreachable monitors gives up after about the same time as
before. The retries only add time while the monitors are reachable but
rejecting the client, where every attempt fails within milliseconds and the
whole budget is the backoff, 15s at the mgr default.

## Testing

- `unittest_monclient_retry` (new): authenticates twice against a socket that
  accepts connections but never answers, and checks the second call waits out
  its own timeout instead of returning the first call's error. Returns in
  about 9us without the `MonClient` change, 0.5s with it.
- `unittest_librados`: the default of 0 does not retry, retries are bounded
  and back off linearly, retries stop once `client_mount_timeout` has elapsed
  even when the count would allow more, and a handle stays usable after a
  failed connect (the last one fails without the state fix).
- 5 mgr unit tests, including one asserting the module never writes to the
  shared config.
- Validated on vstart: a forced mid-hunt timeout on the first attempt is
  recovered by the retry, while the old code burned all three retries in
  microseconds against a healthy monitor and failed the connect. Also checked
  the mgr reports 5 while mons and plain clients report 0, and that
  `ceph config set mgr rados_connect_retries 0` wins over the default.

Tracker: https://tracker.ceph.com/issues/77151

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
- Component impact
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
- Tests (select at least one)
  - [x] Includes unit test(s)

