### PR TITLE
mgr/dashboard: honor MDS count when creating a CephFS volume

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -85,15 +85,15 @@ class CephFS(RESTController):
         data_pool: Optional[str] = None,
         metadata_pool: Optional[str] = None
     ):
-        service_spec_str = '1 '
-        if 'labels' in service_spec['placement']:
-            for label in service_spec['placement']['labels']:
-                service_spec_str += f'label:{label},'
-            service_spec_str = service_spec_str[:-1]
-        if 'hosts' in service_spec['placement']:
-            for host in service_spec['placement']['hosts']:
-                service_spec_str += f'{host} '
-            service_spec_str = service_spec_str[:-1]
+        placement = service_spec['placement']
+        parts = []
+        if 'count' in placement:
+            parts.append(str(placement['count']))
+        if 'labels' in placement:
+            parts.append(','.join(f'label:{label}' for label in placement['labels']))
+        if 'hosts' in placement:
+            parts.append(' '.join(placement['hosts']))
+        service_spec_str = ' '.join(parts)
 
         error_code, _, err = mgr.remote(
             'volumes',

--- a/src/pybind/mgr/dashboard/tests/test_cephfs.py
+++ b/src/pybind/mgr/dashboard/tests/test_cephfs.py
@@ -44,6 +44,28 @@ class CephFsTest(ControllerTestCase):
         self.assertEqual(mds_versions['bar'], ['foo'])
 
 
+class CephFSCreateTest(ControllerTestCase):
+    cephFs = CephFS()
+
+    def _placement(self, placement):
+        mgr.remote = Mock(return_value=(0, '', ''))
+        self.cephFs.create('test_fs', {'placement': placement})
+        return mgr.remote.call_args[0][3]['placement']
+
+    def test_empty_placement_inherits_orchestrator_default(self):
+        # No count/labels/hosts must produce an empty placement so the
+        # orchestrator applies its default (active + standby), matching the CLI.
+        self.assertEqual(self._placement({}), '')
+
+    def test_count_is_honored(self):
+        self.assertEqual(self._placement({'count': 2}), '2')
+
+    def test_labels_and_hosts(self):
+        self.assertEqual(self._placement({'labels': ['mds']}), 'label:mds')
+        self.assertEqual(self._placement({'count': 2, 'hosts': ['host-a', 'host-b']}),
+                         '2 host-a host-b')
+
+
 class CephFSMirrorTest(ControllerTestCase):
 
     @classmethod


### PR DESCRIPTION
Creating a CephFS volume from the dashboard (`POST /api/cephfs`) always deploys a
single MDS and no standby, so the new file system is not highly available. The same
operation on the CLI (`ceph fs volume create <name>`) gives an active + standby pair.

`CephFS.create()` seeds the orchestrator placement string with a hardcoded `'1 '` and
never reads `placement['count']`, so the count is pinned to one and any count in the
request body is dropped. The CLI forwards an empty placement and lets the orchestrator
apply its default layout.

Build the placement from the requested count/labels/hosts and fall back to an empty
string when nothing is given, so the dashboard inherits the same orchestrator default
as the CLI. When a count is supplied it is now honored.

Exposing an MDS count field in the create form is left as a follow-up.

Tracker: https://tracker.ceph.com/issues/77236





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>

