### PR TITLE
mgr/ClusterState: remove debug 30 memory spike

### DIFF
--- a/src/mgr/ClusterState.cc
+++ b/src/mgr/ClusterState.cc
@@ -142,16 +142,14 @@ void ClusterState::update_delta_stats()
   pending_inc.version = pg_map.version + 1; // to make apply_incremental happy
   dout(10) << " v" << pending_inc.version << dendl;
 
-  dout(30) << " pg_map before:\n";
-  JSONFormatter jf(true);
-  jf.dump_object("pg_map", pg_map);
-  jf.flush(*_dout);
-  *_dout << dendl;
-  dout(30) << " incremental:\n";
-  JSONFormatter jf(true);
-  jf.dump_object("pending_inc", pending_inc);
-  jf.flush(*_dout);
-  *_dout << dendl;
+  if (!pending_inc.empty()) {
+    dout(30) << " incremental:\n";
+    JSONFormatter jf(true);
+    jf.dump_object("pending_inc", pending_inc);
+    jf.flush(*_dout);
+    *_dout << dendl;
+  }
+
   pg_map.apply_incremental(g_ceph_context, pending_inc);
   pending_inc = PGMap::Incremental();
 }
@@ -179,16 +177,13 @@ void ClusterState::notify_osdmap(const OSDMap &osd_map)
   PGMapUpdater::check_down_pgs(osd_map, pg_map, true,
 			       need_check_down_pg_osds, &pending_inc);
 
-  dout(30) << " pg_map before:\n";
-  JSONFormatter jf(true);
-  jf.dump_object("pg_map", pg_map);
-  jf.flush(*_dout);
-  *_dout << dendl;
-  dout(30) << " incremental:\n";
-  JSONFormatter jf(true);
-  jf.dump_object("pending_inc", pending_inc);
-  jf.flush(*_dout);
-  *_dout << dendl;
+  if (!pending_inc.empty()) {
+    dout(30) << " incremental:\n";
+    JSONFormatter jf(true);
+    jf.dump_object("pending_inc", pending_inc);
+    jf.flush(*_dout);
+    *_dout << dendl;
+  }
 
   pg_map.apply_incremental(g_ceph_context, pending_inc);
   pending_inc = PGMap::Incremental();

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -326,6 +326,16 @@ public:
     static std::list<Incremental> generate_test_instances();
 
     Incremental() : version(0), osdmap_epoch(0), pg_scan(0) {}
+
+    bool empty() const {
+      return pg_stat_updates.empty() &&
+        osd_stat_updates.empty() &&
+        osd_stat_rm.empty() &&
+        pg_remove.empty() &&
+        pool_statfs_updates.empty() &&
+        osdmap_epoch == 0 &&
+        pg_scan == 0;
+    }
   };
 
 


### PR DESCRIPTION
Add early returns in update_delta_stats() and notify_osdmap() when pending_inc contains no actual updates. This avoids unnecessary calls to apply_incremental() and keeps pg_map.stamp current for delta calculations.

Remove the full pg_map JSON dump at dout(30) which was flooding the log queue with multi-MB entries on every tick. The much smaller incremental dump is retained for debugging.

Fixes: https://tracker.ceph.com/issues/64082





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
