### PR TITLE
mgr/cephadm: Upgrade CephFS filesystems one at a time during MDS upgrade

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,3 +1,11 @@
+* cephadm: During ``ceph orch upgrade``, CephFS filesystems are now prepared
+  and restored one at a time during the MDS phase, so at most one filesystem
+  is offline (``fail_fs = true``) or degraded (scaled down to ``max_mds 1``)
+  at any moment, instead of all filesystems simultaneously. Total upgrade
+  duration is unchanged, as MDS daemons were already redeployed serially.
+  The previous behaviour can be restored with
+  ``ceph config set mgr mgr/cephadm/upgrade_fs_one_at_a_time false``.
+
 * CephFS: The ``client_force_lazyio`` configuration option is now correctly marked
   as not supporting runtime updates. Previously, the configuration schema indicated
   this option could be changed at runtime, but changes had no effect on opened file

--- a/doc/cephadm/upgrade.rst
+++ b/doc/cephadm/upgrade.rst
@@ -88,6 +88,19 @@ Starting the Upgrade
    #. Bring CephFS filesystems back up, bringing the state of active
       MDS daemon(s) from ``up:standby`` to ``up:active``.
 
+   When a cluster has more than one CephFS filesystem, cephadm upgrades the
+   MDS daemons one filesystem at a time by default: it prepares (fails, or
+   scales down to ``max_mds 1``) a single filesystem, upgrades its MDS
+   daemons, restores that filesystem, and only then proceeds to the next one.
+   Because MDS daemons are upgraded serially in any case, this does not slow
+   the upgrade down; it only narrows the disruption to one filesystem at a
+   time instead of taking every filesystem offline simultaneously. To restore
+   the previous behavior of preparing all filesystems at once, set:
+
+   .. prompt:: bash #
+
+      ceph config set mgr mgr/cephadm/upgrade_fs_one_at_a_time false
+
 Before you use cephadm to upgrade Ceph, verify that all hosts are currently
 online and that your cluster is healthy by running the following command:
 

--- a/doc/cephadm/upgrade.rst
+++ b/doc/cephadm/upgrade.rst
@@ -89,7 +89,7 @@ Starting the Upgrade
       MDS daemon(s) from ``up:standby`` to ``up:active``.
 
    When a cluster has more than one CephFS filesystem, cephadm upgrades the
-   MDS daemons one filesystem at a time by default: it prepares (fails, or
+   MDS daemons one filesystem at a time by default. It prepares (fails, or
    scales down to ``max_mds 1``) a single filesystem, upgrades its MDS
    daemons, restores that filesystem, and only then proceeds to the next one.
    Because MDS daemons are upgraded serially in any case, this does not slow

--- a/doc/cephadm/upgrade.rst
+++ b/doc/cephadm/upgrade.rst
@@ -88,6 +88,23 @@ Starting the Upgrade
    #. Bring CephFS filesystems back up, bringing the state of active
       MDS daemon(s) from ``up:standby`` to ``up:active``.
 
+   When a cluster has more than one CephFS filesystem, cephadm upgrades the
+   MDS daemons one filesystem at a time by default: it prepares (fails, or
+   scales down to ``max_mds 1``) a single filesystem, upgrades its MDS
+   daemons, restores that filesystem, and only then proceeds to the next one.
+   Because MDS daemons are upgraded serially in any case, this does not slow
+   the upgrade down; it only narrows the disruption to one filesystem at a
+   time instead of taking every filesystem offline simultaneously. One
+   exception: if an MDS daemon is found to be actively serving a filesystem
+   other than its own service's (a standby takeover), both filesystems are
+   prepared together, as restarting an active MDS of an unprepared
+   filesystem would be unsafe. To restore the previous behavior of preparing
+   all filesystems at once, set:
+
+   .. prompt:: bash #
+
+      ceph config set mgr mgr/cephadm/upgrade_fs_one_at_a_time false
+
 Before you use cephadm to upgrade Ceph, verify that all hosts are currently
 online and that your cluster is healthy by running the following command:
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -353,6 +353,15 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             desc='Automatically convert image tags to image digest to ensure that all daemons use the same image'
         ),
         Option(
+            'upgrade_fs_one_at_a_time',
+            type='bool',
+            default=True,
+            desc='During upgrade, prepare (fail or scale down) and restore one '
+                 'CephFS filesystem at a time when upgrading its MDS, instead of '
+                 'disrupting every filesystem simultaneously. MDS are upgraded '
+                 'serially regardless, so this only narrows the disruption window.'
+        ),
+        Option(
             'config_checks_enabled',
             type='bool',
             default=False,
@@ -627,6 +636,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             self.registry_password: Optional[str] = None
             self.registry_insecure: bool = False
             self.use_repo_digest = True
+            self.upgrade_fs_one_at_a_time = True
             self.config_checks_enabled = False
             self.default_registry = ''
             self.autotune_memory_target_ratio = 0.0

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -359,6 +359,15 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             desc='Automatically convert image tags to image digest to ensure that all daemons use the same image'
         ),
         Option(
+            'upgrade_fs_one_at_a_time',
+            type='bool',
+            default=True,
+            desc='During upgrade, prepare (fail or scale down) and restore one '
+                 'CephFS filesystem at a time when upgrading its MDS, instead of '
+                 'disrupting every filesystem simultaneously. MDS are upgraded '
+                 'serially regardless, so this only narrows the disruption window.'
+        ),
+        Option(
             'config_checks_enabled',
             type='bool',
             default=False,
@@ -644,6 +653,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             self.registry_password: Optional[str] = None
             self.registry_insecure: bool = False
             self.use_repo_digest = True
+            self.upgrade_fs_one_at_a_time = True
             self.config_checks_enabled = False
             self.default_registry = ''
             self.autotune_memory_target_ratio = 0.0

--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -870,6 +870,50 @@ def test_prepare_for_mds_upgrade_all_mds_touches_all_filesystems(
     assert 'cephfs2' in failed
 
 
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+@mock.patch("cephadm.module.CephadmOrchestrator.check_mon_command")
+@mock.patch("cephadm.CephadmOrchestrator.get")
+def test_complete_mds_upgrade_rejoins_only_fs_failed_by_upgrade(
+        get, check_mon_command, cephadm_module: CephadmOrchestrator):
+    # Only filesystems the upgrade itself failed (recorded in
+    # fs_failed_for_upgrade) must be set joinable again. A filesystem an admin
+    # set NOT_JOINABLE for another reason (here 'cephfs') must be left alone.
+    check_mon_command.return_value = (0, '', '')
+    get.side_effect = lambda what: _fsmap_two_filesystems() if what == "fs_map" else None
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'target_image', 0, fail_fs=True, fs_failed_for_upgrade=['cephfs2'])
+
+    cephadm_module.upgrade._complete_mds_upgrade()
+
+    rejoined = [c.args[0]['fs_name'] for c in check_mon_command.call_args_list
+                if c.args and c.args[0].get('prefix') == 'fs set'
+                and c.args[0].get('var') == 'joinable']
+    assert 'cephfs2' in rejoined
+    assert 'cephfs' not in rejoined
+    # the tracking list is cleared once completion has run
+    assert cephadm_module.upgrade.upgrade_state.fs_failed_for_upgrade == []
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+@mock.patch("cephadm.module.CephadmOrchestrator.check_mon_command")
+@mock.patch("cephadm.CephadmOrchestrator.get")
+def test_complete_mds_upgrade_rejoins_nothing_when_upgrade_failed_no_fs(
+        get, check_mon_command, cephadm_module: CephadmOrchestrator):
+    # If the upgrade did not fail any filesystem (empty fs_failed_for_upgrade),
+    # completion must not set any filesystem joinable.
+    check_mon_command.return_value = (0, '', '')
+    get.side_effect = lambda what: _fsmap_two_filesystems() if what == "fs_map" else None
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'target_image', 0, fail_fs=True, fs_failed_for_upgrade=[])
+
+    cephadm_module.upgrade._complete_mds_upgrade()
+
+    rejoined = [c.args[0]['fs_name'] for c in check_mon_command.call_args_list
+                if c.args and c.args[0].get('prefix') == 'fs set'
+                and c.args[0].get('var') == 'joinable']
+    assert rejoined == []
+
+
 @pytest.mark.parametrize("current_version, use_tags, show_all_versions, tags, result",
                          [
                              # several candidate versions (from different major versions)

--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -789,6 +789,87 @@ def test_enough_mds_for_ok_to_stop(get, get_daemons_by_service, cephadm_module: 
         DaemonDescription(daemon_type='mds', daemon_id='myfs.test.host1.gfknd', service_name='mds.myfs.test'))
 
 
+def _fsmap_two_filesystems():
+    # Two multi-rank filesystems. 'up' is non-empty so the fail_fs branch logs
+    # and issues 'fs fail'; max_mds > 1 so the max_mds branch issues 'fs set'.
+    return {'filesystems': [
+        {'id': 1, 'mdsmap': {'fs_name': 'cephfs', 'max_mds': 2, 'flags': 0,
+                             'up': {'mds_0': 1}, 'in': [0, 1], 'info': {}}},
+        {'id': 2, 'mdsmap': {'fs_name': 'cephfs2', 'max_mds': 2, 'flags': 0,
+                             'up': {'mds_0': 2}, 'in': [0, 1], 'info': {}}},
+    ]}
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+@mock.patch("cephadm.module.CephadmOrchestrator.check_mon_command")
+@mock.patch("cephadm.CephadmOrchestrator.get")
+def test_prepare_for_mds_upgrade_fail_fs_scopes_to_targeted_fs(
+        get, check_mon_command, cephadm_module: CephadmOrchestrator):
+    # With fail_fs=true and the upgrade scoped to a single filesystem
+    # (need_upgrade only contains cephfs2's MDS), only cephfs2 must be failed.
+    check_mon_command.return_value = (0, '', '')
+    get.side_effect = lambda what: _fsmap_two_filesystems() if what == "fs_map" else None
+    cephadm_module.upgrade.upgrade_state = UpgradeState('target_image', 0, fail_fs=True)
+
+    need_upgrade = [DaemonDescription(daemon_type='mds',
+                                      daemon_id='cephfs2.host1.abcde',
+                                      service_name='mds.cephfs2')]
+    cephadm_module.upgrade._prepare_for_mds_upgrade('18', need_upgrade)
+
+    failed = [c.args[0]['fs_name'] for c in check_mon_command.call_args_list
+              if c.args and c.args[0].get('prefix') == 'fs fail']
+    assert 'cephfs2' in failed
+    assert 'cephfs' not in failed
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+@mock.patch("cephadm.module.CephadmOrchestrator.check_mon_command")
+@mock.patch("cephadm.CephadmOrchestrator.get")
+def test_prepare_for_mds_upgrade_max_mds_scopes_to_targeted_fs(
+        get, check_mon_command, cephadm_module: CephadmOrchestrator):
+    # With fail_fs=false the targeted filesystem is scaled to max_mds 1, and
+    # only the targeted filesystem (cephfs2) must be touched.
+    check_mon_command.return_value = (0, '', '')
+    get.side_effect = lambda what: _fsmap_two_filesystems() if what == "fs_map" else None
+    cephadm_module.upgrade.upgrade_state = UpgradeState('target_image', 0, fail_fs=False)
+
+    need_upgrade = [DaemonDescription(daemon_type='mds',
+                                      daemon_id='cephfs2.host1.abcde',
+                                      service_name='mds.cephfs2')]
+    cephadm_module.upgrade._prepare_for_mds_upgrade('18', need_upgrade)
+
+    scaled = [c.args[0]['fs_name'] for c in check_mon_command.call_args_list
+              if c.args and c.args[0].get('prefix') == 'fs set'
+              and c.args[0].get('var') == 'max_mds']
+    assert 'cephfs2' in scaled
+    assert 'cephfs' not in scaled
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+@mock.patch("cephadm.module.CephadmOrchestrator.check_mon_command")
+@mock.patch("cephadm.CephadmOrchestrator.get")
+def test_prepare_for_mds_upgrade_all_mds_touches_all_filesystems(
+        get, check_mon_command, cephadm_module: CephadmOrchestrator):
+    # With --daemon-types mds (or no filter), need_upgrade contains MDS from
+    # every filesystem, so all filesystems must still be prepared.
+    check_mon_command.return_value = (0, '', '')
+    get.side_effect = lambda what: _fsmap_two_filesystems() if what == "fs_map" else None
+    cephadm_module.upgrade.upgrade_state = UpgradeState('target_image', 0, fail_fs=True)
+
+    need_upgrade = [
+        DaemonDescription(daemon_type='mds', daemon_id='cephfs.host1.aaaaa',
+                          service_name='mds.cephfs'),
+        DaemonDescription(daemon_type='mds', daemon_id='cephfs2.host1.bbbbb',
+                          service_name='mds.cephfs2'),
+    ]
+    cephadm_module.upgrade._prepare_for_mds_upgrade('18', need_upgrade)
+
+    failed = [c.args[0]['fs_name'] for c in check_mon_command.call_args_list
+              if c.args and c.args[0].get('prefix') == 'fs fail']
+    assert 'cephfs' in failed
+    assert 'cephfs2' in failed
+
+
 @pytest.mark.parametrize("current_version, use_tags, show_all_versions, tags, result",
                          [
                              # several candidate versions (from different major versions)

--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -1295,3 +1295,67 @@ def test_do_upgrade_limit_exhausted_marks_complete_without_scope_check(
 
     mark_complete.assert_called_once()
     filtered_scope.assert_not_called()
+
+
+def _mds_need_upgrade_entries(*service_names):
+    # Build (DaemonDescription, bool) entries like _detect_need_upgrade returns,
+    # one MDS per given service name (service_name is 'mds.<fs>').
+    entries = []
+    for i, svc in enumerate(service_names):
+        fs = svc[len('mds.'):]
+        entries.append(
+            (DaemonDescription(daemon_type='mds',
+                               daemon_id=f'{fs}.host{i}.aaaaa',
+                               service_name=svc), False))
+    return entries
+
+
+def test_restrict_mds_need_upgrade_to_one_fs_picks_single_fs(
+        cephadm_module: CephadmOrchestrator):
+    # MDS from three filesystems -> only one filesystem's MDS are kept.
+    need_upgrade = _mds_need_upgrade_entries(
+        'mds.cephfs2', 'mds.cephfs', 'mds.cephfs', 'mds.cephfs3')
+    restricted = cephadm_module.upgrade._restrict_mds_need_upgrade_to_one_fs(need_upgrade)
+    fs_names = {d.service_name() for d, _ in restricted}
+    assert fs_names == {'mds.cephfs'}, fs_names
+
+
+def test_restrict_mds_need_upgrade_to_one_fs_is_deterministic(
+        cephadm_module: CephadmOrchestrator):
+    # Selection is the lowest (sorted) service name, regardless of input order.
+    a = cephadm_module.upgrade._restrict_mds_need_upgrade_to_one_fs(
+        _mds_need_upgrade_entries('mds.b', 'mds.a', 'mds.c'))
+    b = cephadm_module.upgrade._restrict_mds_need_upgrade_to_one_fs(
+        _mds_need_upgrade_entries('mds.c', 'mds.b', 'mds.a'))
+    assert {d.service_name() for d, _ in a} == {'mds.a'}
+    assert {d.service_name() for d, _ in b} == {'mds.a'}
+
+
+def test_restrict_mds_need_upgrade_to_one_fs_sequences_across_passes(
+        cephadm_module: CephadmOrchestrator):
+    # Simulate successive serve() passes: once a filesystem's MDS are upgraded
+    # they drop out of need_upgrade and the next filesystem is selected.
+    selected = []
+    remaining = ['mds.cephfs', 'mds.cephfs2', 'mds.cephfs3']
+    # one MDS per fs for simplicity
+    while remaining:
+        entries = _mds_need_upgrade_entries(*remaining)
+        restricted = cephadm_module.upgrade._restrict_mds_need_upgrade_to_one_fs(entries)
+        fs_names = {d.service_name() for d, _ in restricted}
+        assert len(fs_names) == 1
+        picked = fs_names.pop()
+        selected.append(picked)
+        remaining.remove(picked)
+    assert selected == ['mds.cephfs', 'mds.cephfs2', 'mds.cephfs3']
+
+
+def test_restrict_mds_need_upgrade_to_one_fs_handles_multi_part_fs_names(
+        cephadm_module: CephadmOrchestrator):
+    # Filesystem names may themselves contain dots (service 'mds.my.fs');
+    # everything after the 'mds.' prefix is the filesystem grouping key.
+    need_upgrade = _mds_need_upgrade_entries('mds.my.fs', 'mds.my.fs', 'mds.other')
+    restricted = cephadm_module.upgrade._restrict_mds_need_upgrade_to_one_fs(need_upgrade)
+    fs_names = {d.service_name() for d, _ in restricted}
+    # 'mds.my.fs' sorts before 'mds.other'
+    assert fs_names == {'mds.my.fs'}, fs_names
+    assert len(restricted) == 2

--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -938,6 +938,50 @@ def test_prepare_for_mds_upgrade_all_mds_touches_all_filesystems(
     assert 'cephfs2' in failed
 
 
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+@mock.patch("cephadm.module.CephadmOrchestrator.check_mon_command")
+@mock.patch("cephadm.CephadmOrchestrator.get")
+def test_complete_mds_upgrade_rejoins_only_fs_failed_by_upgrade(
+        get, check_mon_command, cephadm_module: CephadmOrchestrator):
+    # Only filesystems the upgrade itself failed (recorded in
+    # fs_failed_for_upgrade) must be set joinable again. A filesystem an admin
+    # set NOT_JOINABLE for another reason (here 'cephfs') must be left alone.
+    check_mon_command.return_value = (0, '', '')
+    get.side_effect = lambda what: _fsmap_two_filesystems() if what == "fs_map" else None
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'target_image', 0, fail_fs=True, fs_failed_for_upgrade=[2])
+
+    cephadm_module.upgrade._complete_mds_upgrade()
+
+    rejoined = [c.args[0]['fs_name'] for c in check_mon_command.call_args_list
+                if c.args and c.args[0].get('prefix') == 'fs set'
+                and c.args[0].get('var') == 'joinable']
+    assert 'cephfs2' in rejoined
+    assert 'cephfs' not in rejoined
+    # the tracking list is cleared once completion has run
+    assert cephadm_module.upgrade.upgrade_state.fs_failed_for_upgrade == []
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+@mock.patch("cephadm.module.CephadmOrchestrator.check_mon_command")
+@mock.patch("cephadm.CephadmOrchestrator.get")
+def test_complete_mds_upgrade_rejoins_nothing_when_upgrade_failed_no_fs(
+        get, check_mon_command, cephadm_module: CephadmOrchestrator):
+    # If the upgrade did not fail any filesystem (empty fs_failed_for_upgrade),
+    # completion must not set any filesystem joinable.
+    check_mon_command.return_value = (0, '', '')
+    get.side_effect = lambda what: _fsmap_two_filesystems() if what == "fs_map" else None
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'target_image', 0, fail_fs=True, fs_failed_for_upgrade=[])
+
+    cephadm_module.upgrade._complete_mds_upgrade()
+
+    rejoined = [c.args[0]['fs_name'] for c in check_mon_command.call_args_list
+                if c.args and c.args[0].get('prefix') == 'fs set'
+                and c.args[0].get('var') == 'joinable']
+    assert rejoined == []
+
+
 @pytest.mark.parametrize("current_version, use_tags, show_all_versions, tags, result",
                          [
                              # several candidate versions (from different major versions)

--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -982,6 +982,32 @@ def test_complete_mds_upgrade_rejoins_nothing_when_upgrade_failed_no_fs(
     assert rejoined == []
 
 
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+@mock.patch("cephadm.module.CephadmOrchestrator.check_mon_command")
+@mock.patch("cephadm.CephadmOrchestrator.get")
+def test_complete_mds_upgrade_scales_up_only_finished_fs(
+        get, check_mon_command, cephadm_module: CephadmOrchestrator):
+    # With fail_fs=false, filesystems are scaled down to max_mds 1 during the
+    # upgrade (recorded in fs_original_max_mds by fscid). When completion is
+    # invoked for a single finished filesystem (fs_names given), only that
+    # filesystem must be scaled back up; the other entries must be retained
+    # for later restoration.
+    check_mon_command.return_value = (0, '', '')
+    get.side_effect = lambda what: _fsmap_two_filesystems() if what == "fs_map" else None
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'target_image', 0, fail_fs=False,
+        fs_original_max_mds={1: 2, 2: 2})
+
+    cephadm_module.upgrade._complete_mds_upgrade(fs_names=['cephfs'])
+
+    scaled = [c.args[0]['fs_name'] for c in check_mon_command.call_args_list
+              if c.args and c.args[0].get('prefix') == 'fs set'
+              and c.args[0].get('var') == 'max_mds']
+    assert scaled == ['cephfs']
+    # cephfs2 (fscid 2) is still being upgraded: its entry must remain
+    assert cephadm_module.upgrade.upgrade_state.fs_original_max_mds == {2: 2}
+
+
 @pytest.mark.parametrize("current_version, use_tags, show_all_versions, tags, result",
                          [
                              # several candidate versions (from different major versions)
@@ -1363,3 +1389,67 @@ def test_do_upgrade_limit_exhausted_marks_complete_without_scope_check(
 
     mark_complete.assert_called_once()
     filtered_scope.assert_not_called()
+
+
+def _mds_need_upgrade_entries(*service_names):
+    # Build (DaemonDescription, bool) entries like _detect_need_upgrade returns,
+    # one MDS per given service name (service_name is 'mds.<fs>').
+    entries = []
+    for i, svc in enumerate(service_names):
+        fs = svc[len('mds.'):]
+        entries.append(
+            (DaemonDescription(daemon_type='mds',
+                               daemon_id=f'{fs}.host{i}.aaaaa',
+                               service_name=svc), False))
+    return entries
+
+
+def test_restrict_mds_need_upgrade_to_one_fs_picks_single_fs(
+        cephadm_module: CephadmOrchestrator):
+    # MDS from three filesystems -> only one filesystem's MDS are kept.
+    need_upgrade = _mds_need_upgrade_entries(
+        'mds.cephfs2', 'mds.cephfs', 'mds.cephfs', 'mds.cephfs3')
+    restricted = cephadm_module.upgrade._restrict_mds_need_upgrade_to_one_fs(need_upgrade)
+    fs_names = {d.service_name() for d, _ in restricted}
+    assert fs_names == {'mds.cephfs'}, fs_names
+
+
+def test_restrict_mds_need_upgrade_to_one_fs_is_deterministic(
+        cephadm_module: CephadmOrchestrator):
+    # Selection is the lowest (sorted) service name, regardless of input order.
+    a = cephadm_module.upgrade._restrict_mds_need_upgrade_to_one_fs(
+        _mds_need_upgrade_entries('mds.b', 'mds.a', 'mds.c'))
+    b = cephadm_module.upgrade._restrict_mds_need_upgrade_to_one_fs(
+        _mds_need_upgrade_entries('mds.c', 'mds.b', 'mds.a'))
+    assert {d.service_name() for d, _ in a} == {'mds.a'}
+    assert {d.service_name() for d, _ in b} == {'mds.a'}
+
+
+def test_restrict_mds_need_upgrade_to_one_fs_sequences_across_passes(
+        cephadm_module: CephadmOrchestrator):
+    # Simulate successive serve() passes: once a filesystem's MDS are upgraded
+    # they drop out of need_upgrade and the next filesystem is selected.
+    selected = []
+    remaining = ['mds.cephfs', 'mds.cephfs2', 'mds.cephfs3']
+    # one MDS per fs for simplicity
+    while remaining:
+        entries = _mds_need_upgrade_entries(*remaining)
+        restricted = cephadm_module.upgrade._restrict_mds_need_upgrade_to_one_fs(entries)
+        fs_names = {d.service_name() for d, _ in restricted}
+        assert len(fs_names) == 1
+        picked = fs_names.pop()
+        selected.append(picked)
+        remaining.remove(picked)
+    assert selected == ['mds.cephfs', 'mds.cephfs2', 'mds.cephfs3']
+
+
+def test_restrict_mds_need_upgrade_to_one_fs_handles_multi_part_fs_names(
+        cephadm_module: CephadmOrchestrator):
+    # Filesystem names may themselves contain dots (service 'mds.my.fs');
+    # everything after the 'mds.' prefix is the filesystem grouping key.
+    need_upgrade = _mds_need_upgrade_entries('mds.my.fs', 'mds.my.fs', 'mds.other')
+    restricted = cephadm_module.upgrade._restrict_mds_need_upgrade_to_one_fs(need_upgrade)
+    fs_names = {d.service_name() for d, _ in restricted}
+    # 'mds.my.fs' sorts before 'mds.other'
+    assert fs_names == {'mds.my.fs'}, fs_names
+    assert len(restricted) == 2

--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -828,6 +828,116 @@ def test_to_upgrade_batches_mds_when_fail_fs(
     assert to_upgrade[0][0].name() == need_upgrade[0][0].name()
 
 
+def _fsmap_two_filesystems():
+    # Two multi-rank filesystems. 'up' is non-empty so the fail_fs branch logs
+    # and issues 'fs fail'; max_mds > 1 so the max_mds branch issues 'fs set'.
+    return {'filesystems': [
+        {'id': 1, 'mdsmap': {'fs_name': 'cephfs', 'max_mds': 2, 'flags': 0,
+                             'up': {'mds_0': 1, 'mds_1': 2}, 'in': [0, 1],
+                             'info': {'gid_1': {'name': 'a', 'state': 'up:active'},
+                                      'gid_2': {'name': 'b', 'state': 'up:active'}}}},
+        {'id': 2, 'mdsmap': {'fs_name': 'cephfs2', 'max_mds': 2, 'flags': 0,
+                             'up': {'mds_0': 3, 'mds_1': 4}, 'in': [0, 1],
+                             'info': {'gid_3': {'name': 'c', 'state': 'up:active'},
+                                      'gid_4': {'name': 'd', 'state': 'up:active'}}}},
+    ]}
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+@mock.patch("cephadm.module.CephadmOrchestrator.check_mon_command")
+@mock.patch("cephadm.CephadmOrchestrator.get")
+def test_prepare_for_mds_upgrade_fail_fs_scopes_to_targeted_fs(
+        get, check_mon_command, cephadm_module: CephadmOrchestrator):
+    # With fail_fs=true and the upgrade scoped to a single filesystem
+    # (need_upgrade only contains cephfs2's MDS), only cephfs2 must be failed.
+    check_mon_command.return_value = (0, '', '')
+    get.side_effect = lambda what: _fsmap_two_filesystems() if what == "fs_map" else None
+    cephadm_module.upgrade.upgrade_state = UpgradeState('target_image', 0, fail_fs=True)
+
+    need_upgrade = [DaemonDescription(daemon_type='mds',
+                                      daemon_id='cephfs2.host1.abcde',
+                                      service_name='mds.cephfs2')]
+    cephadm_module.upgrade._prepare_for_mds_upgrade('18', need_upgrade)
+
+    failed = [c.args[0]['fs_name'] for c in check_mon_command.call_args_list
+              if c.args and c.args[0].get('prefix') == 'fs fail']
+    assert 'cephfs2' in failed
+    assert 'cephfs' not in failed
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+@mock.patch("cephadm.module.CephadmOrchestrator.check_mon_command")
+@mock.patch("cephadm.CephadmOrchestrator.get")
+def test_prepare_for_mds_upgrade_includes_fs_actually_served(
+        get, check_mon_command, cephadm_module: CephadmOrchestrator):
+    # A daemon from service mds.cephfs2 currently holds a rank in cephfs
+    # (standby takeover: mds_join_fs is only a preference). The filesystem
+    # it actually serves must be prepared too, not only its service's.
+    fsmap = _fsmap_two_filesystems()
+    fsmap['filesystems'][0]['mdsmap']['info']['gid_1']['name'] = 'cephfs2.host1.abcde'
+    check_mon_command.return_value = (0, '', '')
+    get.side_effect = lambda what: fsmap if what == "fs_map" else None
+    cephadm_module.upgrade.upgrade_state = UpgradeState('target_image', 0, fail_fs=True)
+
+    need_upgrade = [DaemonDescription(daemon_type='mds',
+                                      daemon_id='cephfs2.host1.abcde',
+                                      service_name='mds.cephfs2')]
+    cephadm_module.upgrade._prepare_for_mds_upgrade('18', need_upgrade)
+
+    failed = [c.args[0]['fs_name'] for c in check_mon_command.call_args_list
+              if c.args and c.args[0].get('prefix') == 'fs fail']
+    assert 'cephfs' in failed
+    assert 'cephfs2' in failed
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+@mock.patch("cephadm.module.CephadmOrchestrator.check_mon_command")
+@mock.patch("cephadm.CephadmOrchestrator.get")
+def test_prepare_for_mds_upgrade_max_mds_scopes_to_targeted_fs(
+        get, check_mon_command, cephadm_module: CephadmOrchestrator):
+    # With fail_fs=false the targeted filesystem is scaled to max_mds 1, and
+    # only the targeted filesystem (cephfs2) must be touched.
+    check_mon_command.return_value = (0, '', '')
+    get.side_effect = lambda what: _fsmap_two_filesystems() if what == "fs_map" else None
+    cephadm_module.upgrade.upgrade_state = UpgradeState('target_image', 0, fail_fs=False)
+
+    need_upgrade = [DaemonDescription(daemon_type='mds',
+                                      daemon_id='cephfs2.host1.abcde',
+                                      service_name='mds.cephfs2')]
+    cephadm_module.upgrade._prepare_for_mds_upgrade('18', need_upgrade)
+
+    scaled = [c.args[0]['fs_name'] for c in check_mon_command.call_args_list
+              if c.args and c.args[0].get('prefix') == 'fs set'
+              and c.args[0].get('var') == 'max_mds']
+    assert 'cephfs2' in scaled
+    assert 'cephfs' not in scaled
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+@mock.patch("cephadm.module.CephadmOrchestrator.check_mon_command")
+@mock.patch("cephadm.CephadmOrchestrator.get")
+def test_prepare_for_mds_upgrade_all_mds_touches_all_filesystems(
+        get, check_mon_command, cephadm_module: CephadmOrchestrator):
+    # With --daemon-types mds (or no filter), need_upgrade contains MDS from
+    # every filesystem, so all filesystems must still be prepared.
+    check_mon_command.return_value = (0, '', '')
+    get.side_effect = lambda what: _fsmap_two_filesystems() if what == "fs_map" else None
+    cephadm_module.upgrade.upgrade_state = UpgradeState('target_image', 0, fail_fs=True)
+
+    need_upgrade = [
+        DaemonDescription(daemon_type='mds', daemon_id='cephfs.host1.aaaaa',
+                          service_name='mds.cephfs'),
+        DaemonDescription(daemon_type='mds', daemon_id='cephfs2.host1.bbbbb',
+                          service_name='mds.cephfs2'),
+    ]
+    cephadm_module.upgrade._prepare_for_mds_upgrade('18', need_upgrade)
+
+    failed = [c.args[0]['fs_name'] for c in check_mon_command.call_args_list
+              if c.args and c.args[0].get('prefix') == 'fs fail']
+    assert 'cephfs' in failed
+    assert 'cephfs2' in failed
+
+
 @pytest.mark.parametrize("current_version, use_tags, show_all_versions, tags, result",
                          [
                              # several candidate versions (from different major versions)

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -1187,7 +1187,19 @@ class CephadmUpgrade:
         target_major: str,
         need_upgrade: List[DaemonDescription]
     ) -> bool:
-        # scale down all filesystems to 1 MDS
+        # Only prepare the filesystem(s) whose MDS daemons are actually being
+        # upgraded. When the upgrade is scoped with --services mds.<fs> or
+        # --daemon-types mds, need_upgrade only contains the relevant MDS
+        # daemons, so unrelated filesystems must be left untouched. When no
+        # filter is set, need_upgrade contains every MDS daemon and all
+        # filesystems are prepared, preserving the previous behavior.
+        target_fs_names = {
+            d.service_name()[len('mds.'):]
+            for d in need_upgrade
+            if d.service_name() and d.service_name().startswith('mds.')
+        }
+
+        # scale down the targeted filesystems to 1 MDS
         assert self.upgrade_state
         if not self.upgrade_state.fs_original_max_mds:
             self.upgrade_state.fs_original_max_mds = {}
@@ -1199,6 +1211,10 @@ class CephadmUpgrade:
             fscid = fs["id"]
             mdsmap = fs["mdsmap"]
             fs_name = mdsmap["fs_name"]
+
+            # skip filesystems that have no MDS daemon in this upgrade scope
+            if target_fs_names and fs_name not in target_fs_names:
+                continue
 
             # disable allow_standby_replay?
             if mdsmap['flags'] & CEPH_MDSMAP_ALLOW_STANDBY_REPLAY:

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -195,6 +195,7 @@ class UpgradeState:
                  fail_fs: bool = False,
                  fs_original_max_mds: Optional[Dict[str, int]] = None,
                  fs_original_allow_standby_replay: Optional[Dict[str, bool]] = None,
+                 fs_failed_for_upgrade: Optional[List[str]] = None,
                  daemon_types: Optional[List[str]] = None,
                  hosts: Optional[List[str]] = None,
                  services: Optional[List[str]] = None,
@@ -216,6 +217,10 @@ class UpgradeState:
         self.fs_original_max_mds: Optional[Dict[str, int]] = fs_original_max_mds
         self.fs_original_allow_standby_replay: Optional[Dict[str,
                                                              bool]] = fs_original_allow_standby_replay
+        # filesystems that THIS upgrade put into 'fs fail' state, so completion
+        # only re-joins those (and not filesystems an admin failed for other
+        # reasons). Stored by fs_name.
+        self.fs_failed_for_upgrade: Optional[List[str]] = fs_failed_for_upgrade
         self.fail_fs = fail_fs
         self.daemon_types = daemon_types
         self.hosts = hosts
@@ -235,6 +240,7 @@ class UpgradeState:
             'target_digests': self.target_digests,
             'target_version': self.target_version,
             'fail_fs': self.fail_fs,
+            'fs_failed_for_upgrade': self.fs_failed_for_upgrade,
             'fs_original_max_mds': self.fs_original_max_mds,
             'fs_original_allow_standby_replay': self.fs_original_allow_standby_replay,
             'error': self.error,
@@ -1194,7 +1200,7 @@ class CephadmUpgrade:
         # filter is set, need_upgrade contains every MDS daemon and all
         # filesystems are prepared, preserving the previous behavior.
         target_fs_names = {
-            d.service_name()[len('mds.'):]
+            d.service_name().removeprefix('mds.')
             for d in need_upgrade
             if d.service_name() and d.service_name().startswith('mds.')
         }
@@ -1203,6 +1209,8 @@ class CephadmUpgrade:
         assert self.upgrade_state
         if not self.upgrade_state.fs_original_max_mds:
             self.upgrade_state.fs_original_max_mds = {}
+        if not self.upgrade_state.fs_failed_for_upgrade:
+            self.upgrade_state.fs_failed_for_upgrade = []
         if not self.upgrade_state.fs_original_allow_standby_replay:
             self.upgrade_state.fs_original_allow_standby_replay = {}
         fsmap = self.mgr.get("fs_map")
@@ -1249,6 +1257,11 @@ class CephadmUpgrade:
                                 'Upgrade: fs fail for %s failed: %s', fs_name, err)
                             continue_upgrade = False
                             continue
+                        # remember that WE failed this fs, so completion only
+                        # re-joins filesystems failed by the upgrade itself.
+                        if fs_name not in self.upgrade_state.fs_failed_for_upgrade:
+                            self.upgrade_state.fs_failed_for_upgrade.append(fs_name)
+                            self._save_upgrade_state()
                         continue_upgrade = False
                         continue
                     # fs already failed: fall through to wait for in-rank active
@@ -1698,27 +1711,37 @@ class CephadmUpgrade:
     def _complete_mds_upgrade(self) -> None:
         assert self.upgrade_state is not None
         if self.upgrade_state.fail_fs:
-            for fs in self.mgr.get("fs_map")['filesystems']:
-                fs_name = fs['mdsmap']['fs_name']
-                self.mgr.log.info('Upgrade: Setting filesystem '
-                                  f'{fs_name} Joinable')
-                try:
-                    ret, _, err = self.mgr.check_mon_command({
-                        'prefix': 'fs set',
-                        'fs_name': fs_name,
-                        'var': 'joinable',
-                        'val': 'true',
-                    })
-                except Exception as e:
-                    logger.error("Failed to set fs joinable "
-                                 f"true due to {e}")
-                    raise OrchestratorError("Failed to set"
-                                            "fs joinable true"
-                                            f"due to {e}")
-                if not self._wait_for_fs_mdss_active(fs_name):
-                    raise OrchestratorError(
-                        f'MDS daemons for filesystem {fs_name} did not become '
-                        f'up:active after fail_fs upgrade')
+            # Only re-join filesystems that THIS upgrade failed, leaving any
+            # filesystem an admin set NOT_JOINABLE for other reasons untouched.
+            # When the list is empty (e.g. _complete_mds_upgrade re-invoked
+            # during final cleanup) there is nothing to do and nothing to save.
+            failed = self.upgrade_state.fs_failed_for_upgrade or []
+            if failed:
+                for fs in self.mgr.get("fs_map")['filesystems']:
+                    fs_name = fs['mdsmap']['fs_name']
+                    if fs_name not in failed:
+                        continue
+                    self.mgr.log.info('Upgrade: Setting filesystem '
+                                      f'{fs_name} Joinable')
+                    try:
+                        ret, _, err = self.mgr.check_mon_command({
+                            'prefix': 'fs set',
+                            'fs_name': fs_name,
+                            'var': 'joinable',
+                            'val': 'true',
+                        })
+                    except Exception as e:
+                        logger.error("Failed to set fs joinable "
+                                     f"true due to {e}")
+                        raise OrchestratorError("Failed to set"
+                                                "fs joinable true"
+                                                f"due to {e}")
+                    if not self._wait_for_fs_mdss_active(fs_name):
+                        raise OrchestratorError(
+                            f'MDS daemons for filesystem {fs_name} did not become '
+                            f'up:active after fail_fs upgrade')
+                self.upgrade_state.fs_failed_for_upgrade = []
+                self._save_upgrade_state()
         elif self.upgrade_state.fs_original_max_mds:
             for fs in self.mgr.get("fs_map")['filesystems']:
                 fscid = fs["id"]
@@ -2051,6 +2074,12 @@ class CephadmUpgrade:
                 'name': 'container_image',
                 'who': name_to_config_section(daemon_type),
             })
+
+        # Ensure any filesystem that was failed for the MDS upgrade is restored,
+        # even when the upgrade was scoped (e.g. --services mds.<fs>) and the
+        # per-daemon-type completion hook was not reached in the final serve()
+        # cycle. _complete_mds_upgrade is idempotent.
+        self._complete_mds_upgrade()
 
         # Limited (--limit) upgrades end when the batch quota is exhausted,
         # even if other daemons in the filter still need the target image.

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -1188,6 +1188,28 @@ class CephadmUpgrade:
             elapsed += 10
         return False
 
+    def _restrict_mds_need_upgrade_to_one_fs(
+        self,
+        need_upgrade: List[Tuple[DaemonDescription, bool]]
+    ) -> List[Tuple[DaemonDescription, bool]]:
+        # Keep only the MDS daemons of a single filesystem (lowest service name)
+        # so we disrupt one filesystem at a time. _do_upgrade is re-entered each
+        # serve() cycle, so later filesystems are handled on subsequent passes.
+        by_fs: Dict[str, List[Tuple[DaemonDescription, bool]]] = {}
+        passthrough: List[Tuple[DaemonDescription, bool]] = []
+        for d_entry in need_upgrade:
+            svc = d_entry[0].service_name()
+            if svc and svc.startswith('mds.'):
+                by_fs.setdefault(svc.removeprefix('mds.'), []).append(d_entry)
+            else:
+                passthrough.append(d_entry)
+        if not by_fs:
+            return need_upgrade
+        first_fs = sorted(by_fs.keys())[0]
+        logger.info('Upgrade: handling MDS of filesystem %s this pass '
+                    '(one filesystem at a time)' % first_fs)
+        return by_fs[first_fs] + passthrough
+
     def _prepare_for_mds_upgrade(
         self,
         target_major: str,
@@ -1708,18 +1730,24 @@ class CephadmUpgrade:
                 else:
                     raise
 
-    def _complete_mds_upgrade(self) -> None:
+    def _complete_mds_upgrade(self, fs_names: Optional[List[str]] = None) -> None:
         assert self.upgrade_state is not None
         if self.upgrade_state.fail_fs:
             # Only re-join filesystems that THIS upgrade failed, leaving any
             # filesystem an admin set NOT_JOINABLE for other reasons untouched.
             # When the list is empty (e.g. _complete_mds_upgrade re-invoked
             # during final cleanup) there is nothing to do and nothing to save.
+            # If fs_names is given, restore only those filesystems (used to
+            # re-join one filesystem at a time); if None, restore all of them.
             failed = self.upgrade_state.fs_failed_for_upgrade or []
-            if failed:
+            if fs_names is None:
+                to_rejoin = list(failed)
+            else:
+                to_rejoin = [fs for fs in failed if fs in fs_names]
+            if to_rejoin:
                 for fs in self.mgr.get("fs_map")['filesystems']:
                     fs_name = fs['mdsmap']['fs_name']
-                    if fs_name not in failed:
+                    if fs_name not in to_rejoin:
                         continue
                     self.mgr.log.info('Upgrade: Setting filesystem '
                                       f'{fs_name} Joinable')
@@ -1740,7 +1768,8 @@ class CephadmUpgrade:
                         raise OrchestratorError(
                             f'MDS daemons for filesystem {fs_name} did not become '
                             f'up:active after fail_fs upgrade')
-                self.upgrade_state.fs_failed_for_upgrade = []
+                self.upgrade_state.fs_failed_for_upgrade = [
+                    fs for fs in failed if fs not in to_rejoin]
                 self._save_upgrade_state()
         elif self.upgrade_state.fs_original_max_mds:
             for fs in self.mgr.get("fs_map")['filesystems']:
@@ -1998,6 +2027,27 @@ class CephadmUpgrade:
                 # only after the mgr itself is upgraded can we expect daemons to have
                 # deployed_by == target_digests
                 need_upgrade += need_upgrade_deployer
+
+            # Disrupt one filesystem at a time.
+            if daemon_type == 'mds' and need_upgrade and \
+                    self.mgr.upgrade_fs_one_at_a_time:
+                # Re-join any filesystem we already finished upgrading before
+                # failing the next one, so at most one filesystem is disrupted
+                # at a time. A filesystem is finished when this upgrade failed it
+                # but it no longer has an MDS in need_upgrade.
+                still_upgrading = {
+                    d_entry[0].service_name().removeprefix('mds.')
+                    for d_entry in need_upgrade
+                    if d_entry[0].service_name()
+                    and d_entry[0].service_name().startswith('mds.')
+                }
+                finished_fs = [
+                    fs for fs in (self.upgrade_state.fs_failed_for_upgrade or [])
+                    if fs not in still_upgrading
+                ]
+                if finished_fs:
+                    self._complete_mds_upgrade(fs_names=finished_fs)
+                need_upgrade = self._restrict_mds_need_upgrade_to_one_fs(need_upgrade)
 
             # prepare filesystems for daemon upgrades?
             if (

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -1325,6 +1325,28 @@ class CephadmUpgrade:
                 fs_names.add(mdsmap['fs_name'])
         return fs_names
 
+    def _restrict_mds_need_upgrade_to_one_fs(
+        self,
+        need_upgrade: List[Tuple[DaemonDescription, bool]]
+    ) -> List[Tuple[DaemonDescription, bool]]:
+        # Keep only the MDS daemons of a single filesystem (lowest service name)
+        # so we disrupt one filesystem at a time. _do_upgrade is re-entered each
+        # serve() cycle, so later filesystems are handled on subsequent passes.
+        by_fs: Dict[str, List[Tuple[DaemonDescription, bool]]] = {}
+        passthrough: List[Tuple[DaemonDescription, bool]] = []
+        for d_entry in need_upgrade:
+            svc = d_entry[0].service_name()
+            if svc and svc.startswith('mds.'):
+                by_fs.setdefault(svc.removeprefix('mds.'), []).append(d_entry)
+            else:
+                passthrough.append(d_entry)
+        if not by_fs:
+            return need_upgrade
+        first_fs = sorted(by_fs.keys())[0]
+        logger.info('Upgrade: handling MDS of filesystem %s this pass '
+                    '(one filesystem at a time)' % first_fs)
+        return by_fs[first_fs] + passthrough
+
     def _prepare_for_mds_upgrade(
         self,
         target_major: str,
@@ -2052,19 +2074,27 @@ class CephadmUpgrade:
                 else:
                     raise
 
-    def _complete_mds_upgrade(self) -> None:
+    def _complete_mds_upgrade(self, fs_names: Optional[List[str]] = None) -> None:
         assert self.upgrade_state is not None
         if self.upgrade_state.fail_fs:
-            # Only re-join filesystems that THIS upgrade failed, leaving any
-            # filesystem an admin set NOT_JOINABLE for other reasons untouched.
-            # When the list is empty (e.g. _complete_mds_upgrade re-invoked
-            # during final cleanup) there is nothing to do and nothing to save.
+            # Only re-join filesystems that THIS upgrade failed (tracked by
+            # fscid), leaving any filesystem an admin set NOT_JOINABLE for
+            # other reasons untouched. When the list is empty (e.g.
+            # _complete_mds_upgrade re-invoked during final cleanup) there is
+            # nothing to do and nothing to save. If fs_names is given (current
+            # filesystem names), restore only those filesystems (used to
+            # re-join one filesystem at a time); if None, restore all of them.
             failed = self.upgrade_state.fs_failed_for_upgrade or []
             if failed:
+                rejoined: List[int] = []
                 for fs in self.mgr.get("fs_map")['filesystems']:
-                    if fs["id"] not in failed:
+                    fscid = fs["id"]
+                    if fscid not in failed:
                         continue
                     fs_name = fs['mdsmap']['fs_name']
+                    if fs_names is not None and fs_name not in fs_names:
+                        continue
+                    rejoined.append(fscid)
                     self.mgr.log.info('Upgrade: Setting filesystem '
                                       f'{fs_name} Joinable')
                     try:
@@ -2084,12 +2114,20 @@ class CephadmUpgrade:
                         raise OrchestratorError(
                             f'MDS daemons for filesystem {fs_name} did not become '
                             f'up:active after fail_fs upgrade')
-                self.upgrade_state.fs_failed_for_upgrade = []
+                if fs_names is None:
+                    self.upgrade_state.fs_failed_for_upgrade = []
+                else:
+                    self.upgrade_state.fs_failed_for_upgrade = [
+                        f for f in failed if f not in rejoined]
                 self._save_upgrade_state()
         elif self.upgrade_state.fs_original_max_mds:
+            # If fs_names is given, restore only those filesystems (used to
+            # scale one filesystem back up at a time); if None, restore all.
             for fs in self.mgr.get("fs_map")['filesystems']:
                 fscid = fs["id"]
                 fs_name = fs['mdsmap']['fs_name']
+                if fs_names is not None and fs_name not in fs_names:
+                    continue
                 new_max = self.upgrade_state.fs_original_max_mds.get(fscid, 1)
                 if new_max > 1:
                     self.mgr.log.info('Upgrade: Scaling up filesystem %s max_mds to %d' % (
@@ -2101,13 +2139,17 @@ class CephadmUpgrade:
                         'var': 'max_mds',
                         'val': str(new_max),
                     })
+                self.upgrade_state.fs_original_max_mds.pop(fscid, None)
 
-            self.upgrade_state.fs_original_max_mds = {}
+            if fs_names is None:
+                self.upgrade_state.fs_original_max_mds = {}
             self._save_upgrade_state()
         if self.upgrade_state.fs_original_allow_standby_replay:
             for fs in self.mgr.get("fs_map")['filesystems']:
                 fscid = fs["id"]
                 fs_name = fs['mdsmap']['fs_name']
+                if fs_names is not None and fs_name not in fs_names:
+                    continue
                 asr = self.upgrade_state.fs_original_allow_standby_replay.get(fscid, False)
                 if asr:
                     self.mgr.log.info('Upgrade: Enabling allow_standby_replay on filesystem %s' % (
@@ -2119,8 +2161,10 @@ class CephadmUpgrade:
                         'var': 'allow_standby_replay',
                         'val': '1'
                     })
+                self.upgrade_state.fs_original_allow_standby_replay.pop(fscid, None)
 
-            self.upgrade_state.fs_original_allow_standby_replay = {}
+            if fs_names is None:
+                self.upgrade_state.fs_original_allow_standby_replay = {}
             self._save_upgrade_state()
 
     def _filtered_scope_up_to_date(
@@ -2375,6 +2419,36 @@ class CephadmUpgrade:
                 # only after the mgr itself is upgraded can we expect daemons to have
                 # deployed_by == target_digests
                 need_upgrade += need_upgrade_deployer
+
+            # Disrupt one filesystem at a time.
+            if daemon_type == 'mds' and need_upgrade and \
+                    self.mgr.upgrade_fs_one_at_a_time:
+                # Restore any filesystem we already finished upgrading before
+                # preparing the next one, so at most one filesystem is
+                # disrupted at a time. A filesystem is finished when this
+                # upgrade put it in maintenance (failed it with fail_fs=true,
+                # or scaled it down / disabled standby-replay otherwise) but
+                # it no longer has an MDS in need_upgrade.
+                still_upgrading = self._fs_names_of_mds_daemons(
+                    [d_entry[0] for d_entry in need_upgrade])
+                recorded_fscids = set(
+                    self.upgrade_state.fs_failed_for_upgrade or []
+                ) | set(
+                    (self.upgrade_state.fs_original_max_mds or {}).keys()
+                ) | set(
+                    (self.upgrade_state.fs_original_allow_standby_replay or {}).keys()
+                )
+                recorded_fs: Set[str] = set()
+                if recorded_fscids:
+                    for fs in self.mgr.get("fs_map").get('filesystems', []):
+                        if fs["id"] in recorded_fscids:
+                            recorded_fs.add(fs['mdsmap']['fs_name'])
+                finished_fs = [
+                    fs for fs in recorded_fs if fs not in still_upgrading
+                ]
+                if finished_fs:
+                    self._complete_mds_upgrade(fs_names=finished_fs)
+                need_upgrade = self._restrict_mds_need_upgrade_to_one_fs(need_upgrade)
 
             # prepare filesystems for daemon upgrades?
             if (

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -223,6 +223,7 @@ class UpgradeState:
                  fail_fs: bool = False,
                  fs_original_max_mds: Optional[Dict[str, int]] = None,
                  fs_original_allow_standby_replay: Optional[Dict[str, bool]] = None,
+                 fs_failed_for_upgrade: Optional[List[int]] = None,
                  daemon_types: Optional[List[str]] = None,
                  hosts: Optional[List[str]] = None,
                  services: Optional[List[str]] = None,
@@ -248,6 +249,12 @@ class UpgradeState:
         self.fs_original_max_mds: Optional[Dict[str, int]] = fs_original_max_mds
         self.fs_original_allow_standby_replay: Optional[Dict[str,
                                                              bool]] = fs_original_allow_standby_replay
+        # filesystems that THIS upgrade put into 'fs fail' state, so completion
+        # only re-joins those (and not filesystems an admin failed for other
+        # reasons). Stored by fscid: 'fs rename' is only permitted while a
+        # filesystem is offline (the state created here), so tracking by name
+        # could lose the restoration target across a rename.
+        self.fs_failed_for_upgrade: Optional[List[int]] = fs_failed_for_upgrade
         self.fail_fs = fail_fs
         self.daemon_types = daemon_types
         self.hosts = hosts
@@ -271,6 +278,7 @@ class UpgradeState:
             'target_digests': self.target_digests,
             'target_version': self.target_version,
             'fail_fs': self.fail_fs,
+            'fs_failed_for_upgrade': self.fs_failed_for_upgrade,
             'fs_original_max_mds': self.fs_original_max_mds,
             'fs_original_allow_standby_replay': self.fs_original_allow_standby_replay,
             'error': self.error,
@@ -1334,6 +1342,8 @@ class CephadmUpgrade:
         assert self.upgrade_state
         if not self.upgrade_state.fs_original_max_mds:
             self.upgrade_state.fs_original_max_mds = {}
+        if not self.upgrade_state.fs_failed_for_upgrade:
+            self.upgrade_state.fs_failed_for_upgrade = []
         if not self.upgrade_state.fs_original_allow_standby_replay:
             self.upgrade_state.fs_original_allow_standby_replay = {}
         fsmap = self.mgr.get("fs_map")
@@ -1371,6 +1381,16 @@ class CephadmUpgrade:
                             len(mdsmap['up']) > 0:
                         self.mgr.log.info(f'Upgrade: failing fs {fs_name} for '
                                           f'rapid multi-rank mds upgrade')
+                        # remember that WE are failing this fs, so completion
+                        # only re-joins filesystems failed by the upgrade
+                        # itself. Saved before issuing 'fs fail' so a mgr
+                        # failover in between does not lose track of the
+                        # filesystem to re-join. Worst case, if 'fs fail'
+                        # fails below, setting a joinable fs joinable again
+                        # on completion is a no-op.
+                        if fscid not in self.upgrade_state.fs_failed_for_upgrade:
+                            self.upgrade_state.fs_failed_for_upgrade.append(fscid)
+                            self._save_upgrade_state()
                         ret, out, err = self.mgr.check_mon_command({
                             'prefix': 'fs fail',
                             'fs_name': fs_name
@@ -2035,27 +2055,37 @@ class CephadmUpgrade:
     def _complete_mds_upgrade(self) -> None:
         assert self.upgrade_state is not None
         if self.upgrade_state.fail_fs:
-            for fs in self.mgr.get("fs_map")['filesystems']:
-                fs_name = fs['mdsmap']['fs_name']
-                self.mgr.log.info('Upgrade: Setting filesystem '
-                                  f'{fs_name} Joinable')
-                try:
-                    ret, _, err = self.mgr.check_mon_command({
-                        'prefix': 'fs set',
-                        'fs_name': fs_name,
-                        'var': 'joinable',
-                        'val': 'true',
-                    })
-                except Exception as e:
-                    logger.error("Failed to set fs joinable "
-                                 f"true due to {e}")
-                    raise OrchestratorError("Failed to set"
-                                            "fs joinable true"
-                                            f"due to {e}")
-                if not self._wait_for_fs_mdss_active(fs_name):
-                    raise OrchestratorError(
-                        f'MDS daemons for filesystem {fs_name} did not become '
-                        f'up:active after fail_fs upgrade')
+            # Only re-join filesystems that THIS upgrade failed, leaving any
+            # filesystem an admin set NOT_JOINABLE for other reasons untouched.
+            # When the list is empty (e.g. _complete_mds_upgrade re-invoked
+            # during final cleanup) there is nothing to do and nothing to save.
+            failed = self.upgrade_state.fs_failed_for_upgrade or []
+            if failed:
+                for fs in self.mgr.get("fs_map")['filesystems']:
+                    if fs["id"] not in failed:
+                        continue
+                    fs_name = fs['mdsmap']['fs_name']
+                    self.mgr.log.info('Upgrade: Setting filesystem '
+                                      f'{fs_name} Joinable')
+                    try:
+                        ret, _, err = self.mgr.check_mon_command({
+                            'prefix': 'fs set',
+                            'fs_name': fs_name,
+                            'var': 'joinable',
+                            'val': 'true',
+                        })
+                    except Exception as e:
+                        logger.error("Failed to set fs joinable "
+                                     f"true due to {e}")
+                        raise OrchestratorError("Failed to set"
+                                                "fs joinable true"
+                                                f"due to {e}")
+                    if not self._wait_for_fs_mdss_active(fs_name):
+                        raise OrchestratorError(
+                            f'MDS daemons for filesystem {fs_name} did not become '
+                            f'up:active after fail_fs upgrade')
+                self.upgrade_state.fs_failed_for_upgrade = []
+                self._save_upgrade_state()
         elif self.upgrade_state.fs_original_max_mds:
             for fs in self.mgr.get("fs_map")['filesystems']:
                 fscid = fs["id"]
@@ -2410,6 +2440,15 @@ class CephadmUpgrade:
                 return
 
             logger.debug('Upgrade: Upgraded %s daemon(s).' % daemon_type)
+
+        # Ensure any filesystem that was failed for the MDS upgrade is restored,
+        # even when the upgrade was scoped (e.g. --services mds.<fs>) and the
+        # per-daemon-type completion hook was not reached in the final serve()
+        # cycle (its need-upgrade check is cluster-wide). Done before the
+        # key-rotation handler, which can return early for many cycles and
+        # would otherwise leave the filesystem down until rotation completes.
+        # _complete_mds_upgrade is idempotent.
+        self._complete_mds_upgrade()
 
         if not self.handle_osd_mds_key_rotation(target_image, target_digests):
             return

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -1289,12 +1289,48 @@ class CephadmUpgrade:
             elapsed += 10
         return False
 
+    def _fs_names_of_mds_daemons(
+        self,
+        daemons: List[DaemonDescription],
+    ) -> Set[str]:
+        """
+        Names of the filesystems targeted by the given MDS daemons.
+
+        Combines the cephadm naming convention that service mds.<fs_name>
+        serves <fs_name> (MdsService sets mds_join_fs accordingly) with
+        actual membership from the fsmap: mds_join_fs is only a preference,
+        so a daemon can hold a rank in a filesystem short on MDS other than
+        its service's. Standby daemons not present in any mdsmap only map
+        through their service name.
+        """
+        fs_names = {
+            d.service_name().removeprefix('mds.')
+            for d in daemons
+            if d.service_name() and d.service_name().startswith('mds.')
+        }
+        daemon_ids = {d.daemon_id for d in daemons if d.daemon_id}
+        fsmap = self.mgr.get("fs_map")
+        for fs in fsmap.get('filesystems', []):
+            mdsmap = fs.get('mdsmap', {})
+            if any(info.get('name') in daemon_ids
+                   for info in (mdsmap.get('info') or {}).values()):
+                fs_names.add(mdsmap['fs_name'])
+        return fs_names
+
     def _prepare_for_mds_upgrade(
         self,
         target_major: str,
         need_upgrade: List[DaemonDescription]
     ) -> bool:
-        # scale down all filesystems to 1 MDS
+        # Only prepare the filesystem(s) whose MDS daemons are actually being
+        # upgraded. When the upgrade is scoped with --services mds.<fs> or
+        # --daemon-types mds, need_upgrade only contains the relevant MDS
+        # daemons, so unrelated filesystems must be left untouched. When no
+        # filter is set, need_upgrade contains every MDS daemon and all
+        # filesystems are prepared, preserving the previous behavior.
+        target_fs_names = self._fs_names_of_mds_daemons(need_upgrade)
+
+        # scale down the targeted filesystems to 1 MDS
         assert self.upgrade_state
         if not self.upgrade_state.fs_original_max_mds:
             self.upgrade_state.fs_original_max_mds = {}
@@ -1306,6 +1342,10 @@ class CephadmUpgrade:
             fscid = fs["id"]
             mdsmap = fs["mdsmap"]
             fs_name = mdsmap["fs_name"]
+
+            # skip filesystems that have no MDS daemon in this upgrade scope
+            if target_fs_names and fs_name not in target_fs_names:
+                continue
 
             # disable allow_standby_replay?
             if mdsmap['flags'] & CEPH_MDSMAP_ALLOW_STANDBY_REPLAY:


### PR DESCRIPTION
During a **non-scoped** upgrade, when cephadm reaches the MDS phase it currently prepares every CephFS filesystem at once: with fail_fs=true it fails all filesystems, and with fail_fs=false it scales every filesystem down to max_mds 1. All filesystems therefore stay offline (or degraded) for the entire duration of the MDS redeployment. **On clusters with many filesystems this is a large, simultaneous disruption.**

Because MDS daemons are redeployed serially regardless (batched, respecting ok-to-stop), failing every filesystem up front provides no time benefit — it only widens the window during which all filesystems are disrupted at the same time.

This PR makes cephadm prepare and restore filesystems one at a time during the MDS phase:

- Each MDS preparation pass is restricted to a single filesystem (chosen deterministically), so only that filesystem is failed / scaled down.

- As soon as a filesystem's MDS are all upgraded, it is brought back out of maintenance before the next filesystem is touched, instead of waiting until the end of the whole MDS phase.

- To support this, `_complete_mds_upgrade()` now takes an optional fs_names argument: when given, it re-joins only those filesystems; when None (the existing call sites), it restores all the filesystems this upgrade failed, preserving the previous behaviour.

The net effect is that **at most one filesystem is disrupted at any moment**, without slowing the upgrade down, since the MDS redeployment was already serial. This applies to both methods (fail_fs and max_mds) and to every upgrade that touches MDS (non-staggered as well as staggered/scoped).

Controlled by a new `mgr/cephadm/upgrade_fs_one_at_a_time` option, defaulting to **true**. Set it to false to restore the previous "all filesystems at once" behaviour.

Validated on a multi-filesystem test cluster (3 filesystems, Reef 18.2.8): filesystems are failed, upgraded, and re-joined strictly one at a time, with only a single filesystem non-joinable at any point during the MDS phase.

This PR is based on / depends on #69260. Until PR #69260 merges, this PR's diff also includes its commits; once it lands I'll rebase onto main and the diff will shrink to this change only.

Fixes: https://tracker.ceph.com/issues/77235

Assisted-by: Claude Opus 4.8 High

Expected behavior successfully validated in the lab on a live Ceph cluster.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
