### PR TITLE
tentacle: qa/suites/nvmeof: set beacon grace and connect panic

### DIFF
--- a/qa/suites/nvmeof/basic/clusters/4-gateways-2-initiator.yaml
+++ b/qa/suites/nvmeof/basic/clusters/4-gateways-2-initiator.yaml
@@ -28,6 +28,8 @@ overrides:
       mon:
         # cephadm can take up to 5 minutes to bring up remaining mons
         mon down mkfs grace: 300
+        mon nvmeofgw beacon grace: 10
+        nvmeof mon client connect panic: 60
     log-ignorelist:
       - OSD_DOWN
       - OSD_HOST_DOWN

--- a/qa/suites/nvmeof/basic/clusters/4-gateways-2-initiator.yaml
+++ b/qa/suites/nvmeof/basic/clusters/4-gateways-2-initiator.yaml
@@ -36,4 +36,6 @@ overrides:
       - OSD_ROOT_DOWN
       - PG_DEGRADED
       - NVMEOF_SINGLE_GATEWAY
+      - have only 1 nvmeof gateway
+      - has 1 gateway
       - CEPHADM_FAILED_DAEMON

--- a/qa/suites/nvmeof/thrash/clusters/4-gateways-1-initiator.yaml
+++ b/qa/suites/nvmeof/thrash/clusters/4-gateways-1-initiator.yaml
@@ -32,3 +32,5 @@ overrides:
       mon:
         # cephadm can take up to 5 minutes to bring up remaining mons
         mon down mkfs grace: 300
+        mon nvmeofgw beacon grace: 10
+        nvmeof mon client connect panic: 60

--- a/qa/suites/nvmeof/thrash/thrashers/nvmeof_mon_thrash.yaml
+++ b/qa/suites/nvmeof/thrash/thrashers/nvmeof_mon_thrash.yaml
@@ -15,6 +15,8 @@ overrides:
       # nvmeof daemon thrashing
       - CEPHADM_FAILED_DAEMON
       - NVMEOF_SINGLE_GATEWAY
+      - have only 1 nvmeof gateway
+      - has 1 gateway
       - NVMEOF_GATEWAY_DOWN
       - are in unavailable state
       - is unavailable

--- a/qa/suites/nvmeof/thrash/thrashers/nvmeof_thrash.yaml
+++ b/qa/suites/nvmeof/thrash/thrashers/nvmeof_thrash.yaml
@@ -10,6 +10,8 @@ overrides:
       # nvmeof daemon thrashing
       - CEPHADM_FAILED_DAEMON
       - NVMEOF_SINGLE_GATEWAY
+      - have only 1 nvmeof gateway
+      - has 1 gateway
       - NVMEOF_GATEWAY_DOWN
       - are in unavailable state
       - is unavailable

--- a/qa/suites/nvmeof/upgrade/0-clusters/4-gateways-1-initiator.yaml
+++ b/qa/suites/nvmeof/upgrade/0-clusters/4-gateways-1-initiator.yaml
@@ -26,3 +26,11 @@ roles:
   - client.4
   - ceph.nvmeof.nvmeof.d
 
+overrides:
+  ceph:
+    conf:
+      mon:
+        # cephadm can take up to 5 minutes to bring up remaining mons
+        mon down mkfs grace: 300
+        mon nvmeofgw beacon grace: 10
+        nvmeof mon client connect panic: 60


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77031

---

backport of https://github.com/ceph/ceph/pull/69135
parent tracker: https://tracker.ceph.com/issues/74660

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh