### PR TITLE
squid: osd: unregister admin socket commands in fast shutdown

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -14112,6 +14112,9 @@ uint64_t BlueStore::_assign_blobid(TransContext *txc)
 
 void BlueStore::get_db_statistics(Formatter *f)
 {
+  if (db == nullptr) {
+    return;
+  }
   db->get_statistics(f);
 }
 
@@ -18719,6 +18722,10 @@ const string prefix_other = "Z";
 //Itrerates through the db and collects the stats
 void BlueStore::generate_db_histogram(Formatter *f)
 {
+  if (db == nullptr) {
+    return;
+  }
+
   //globals
   uint64_t num_onodes = 0;
   uint64_t num_shards = 0;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2408,7 +2408,7 @@ OSD::OSD(CephContext *cct_,
   dev_path(dev), journal_path(jdev),
   store_is_rotational(store->is_rotational()),
   trace_endpoint("0.0.0.0", 0, "osd"),
-  asok_hook(NULL),
+  asok_hook(nullptr),
   m_osd_pg_epoch_max_lag_factor(cct->_conf.get_val<double>(
 				  "osd_pg_epoch_max_lag_factor")),
   osd_compat(get_osd_compat_set()),
@@ -2425,7 +2425,7 @@ OSD::OSD(CephContext *cct_,
   heartbeat_dispatcher(this),
   op_tracker(cct, cct->_conf->osd_enable_op_tracker,
                   cct->_conf->osd_num_op_tracker_shard),
-  test_ops_hook(NULL),
+  test_ops_hook(nullptr),
   op_shardedwq(
     this,
     ceph::make_timespan(cct->_conf->osd_op_thread_timeout),
@@ -4578,6 +4578,15 @@ int OSD::shutdown()
       tick_timer_without_osd_lock.shutdown();
     }
 
+    // unregister commands
+    cct->get_admin_socket()->unregister_commands(asok_hook);
+    delete asok_hook;
+    asok_hook = nullptr;
+
+    cct->get_admin_socket()->unregister_commands(test_ops_hook);
+    delete test_ops_hook;
+    test_ops_hook = nullptr;
+
     osd_lock.unlock();
     utime_t  start_time_osd_drain = ceph_clock_now();
 
@@ -4629,11 +4638,11 @@ int OSD::shutdown()
   // unregister commands
   cct->get_admin_socket()->unregister_commands(asok_hook);
   delete asok_hook;
-  asok_hook = NULL;
+  asok_hook = nullptr;
 
   cct->get_admin_socket()->unregister_commands(test_ops_hook);
   delete test_ops_hook;
-  test_ops_hook = NULL;
+  test_ops_hook = nullptr;
 
   osd_lock.unlock();
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77050

---

backport of https://github.com/ceph/ceph/pull/69061
parent tracker: https://tracker.ceph.com/issues/70346

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh