### PR TITLE
crimson/os/seastore/extent_pinboard: per-extent-type pinboard hit/miss metrics

### DIFF
--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -550,6 +550,30 @@ void Cache::register_metrics(store_index_t store_index)
           sm::description("extents not in pinboard when touched (newly added), by type"),
           {ext_label}
         ),
+        sm::make_counter(
+          "cache_hit",
+          [this, ext] {
+            uint64_t total = 0;
+            for (auto& per_src : stats.access_by_src_ext) {
+              total += get_by_ext(per_src, ext).get_cache_hit();
+            }
+            return total;
+          },
+          sm::description("read_extent hits in Cache::extents (no disk I/O) by extent type"),
+          {ext_label}
+        ),
+        sm::make_counter(
+          "cache_miss",
+          [this, ext] {
+            uint64_t total = 0;
+            for (auto& per_src : stats.access_by_src_ext) {
+              total += get_by_ext(per_src, ext).load_absent;
+            }
+            return total;
+          },
+          sm::description("read_extent misses requiring disk I/O by extent type"),
+          {ext_label}
+        ),
       }
     );
   }

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -534,6 +534,26 @@ void Cache::register_metrics(store_index_t store_index)
 
   pinboard->register_metrics(store_index);
 
+  for (auto& [ext, ext_label] : labels_by_ext) {
+    metrics.add_group(
+      "cache",
+      {
+        sm::make_counter(
+          "pinboard_hit",
+          get_by_ext(pinboard->hits_by_ext, ext),
+          sm::description("extents found already in pinboard when touched, by type"),
+          {ext_label}
+        ),
+        sm::make_counter(
+          "pinboard_miss",
+          get_by_ext(pinboard->misses_by_ext, ext),
+          sm::description("extents not in pinboard when touched (newly added), by type"),
+          {ext_label}
+        ),
+      }
+    );
+  }
+
   /**
    * tree stats
    */

--- a/src/crimson/os/seastore/extent_pinboard.cc
+++ b/src/crimson/os/seastore/extent_pinboard.cc
@@ -290,6 +290,7 @@ public:
 
   void register_metrics(store_index_t store_index) final {
     namespace sm = seastar::metrics;
+    auto shard_label = sm::label_instance("shard_store_index", std::to_string(store_index));
     metrics.add_group(
       "cache",
       {
@@ -299,7 +300,7 @@ public:
             return get_current_size_bytes();
           },
           sm::description("total bytes pinned by the lru"),
-          {sm::label_instance("shard_store_index", std::to_string(store_index))}
+          {shard_label}
         ),
         sm::make_counter(
           "lru_num_extents",
@@ -307,7 +308,7 @@ public:
             return get_current_num_extents();
           },
           sm::description("total extents pinned by the lru"),
-          {sm::label_instance("shard_store_index", std::to_string(store_index))}
+          {shard_label}
         ),
       }
     );
@@ -788,6 +789,7 @@ void ExtentPinboardTwoQ::get_stats(
 
 void ExtentPinboardTwoQ::register_metrics(store_index_t store_index) {
   namespace sm = seastar::metrics;
+  auto shard_label = sm::label_instance("shard_store_index", std::to_string(store_index));
   metrics.add_group(
     "cache",
     {
@@ -797,7 +799,7 @@ void ExtentPinboardTwoQ::register_metrics(store_index_t store_index) {
           return warm_in.get_current_size_bytes();
         },
         sm::description("total bytes pinned by the 2q warm_in queue"),
-        {sm::label_instance("shard_store_index", std::to_string(store_index))}
+        {shard_label}
       ),
       sm::make_counter(
         "2q_warm_in_num_extents",
@@ -805,7 +807,7 @@ void ExtentPinboardTwoQ::register_metrics(store_index_t store_index) {
           return warm_in.get_current_num_extents();
         },
         sm::description("total extents pinned by the 2q warm_in queue"),
-        {sm::label_instance("shard_store_index", std::to_string(store_index))}
+        {shard_label}
       ),
       sm::make_counter(
         "2q_hot_size_bytes",
@@ -813,7 +815,7 @@ void ExtentPinboardTwoQ::register_metrics(store_index_t store_index) {
           return hot.get_current_size_bytes();
         },
         sm::description("total bytes pinned by the 2q hot queue"),
-        {sm::label_instance("shard_store_index", std::to_string(store_index))}
+        {shard_label}
       ),
       sm::make_counter(
         "2q_hot_num_extents",
@@ -821,7 +823,7 @@ void ExtentPinboardTwoQ::register_metrics(store_index_t store_index) {
           return hot.get_current_num_extents();
         },
         sm::description("total extents pinned by the 2q hot queue"),
-        {sm::label_instance("shard_store_index", std::to_string(store_index))}
+        {shard_label}
       ),
     }
   );

--- a/src/crimson/os/seastore/extent_pinboard.cc
+++ b/src/crimson/os/seastore/extent_pinboard.cc
@@ -270,10 +270,6 @@ class ExtentPinboardLRU : public ExtentPinboard {
   ExtentQueue lru;
   seastar::metrics::metric_group metrics;
 
-  // hit and miss indicates if an extent is linked when touching it
-  uint64_t hit = 0;
-  uint64_t miss = 0;
-
 public:
   ExtentPinboardLRU(std::size_t capacity) : lru(capacity) {
     LOG_PREFIX(ExtentPinboardLRU::ExtentPinboardLRU);
@@ -313,16 +309,6 @@ public:
           sm::description("total extents pinned by the lru"),
           {sm::label_instance("shard_store_index", std::to_string(store_index))}
         ),
-        sm::make_counter(
-          "lru_hit", hit,
-          sm::description("total count of the extents that are linked to lru when touching them"),
-          {sm::label_instance("shard_store_index", std::to_string(store_index))}
-        ),
-        sm::make_counter(
-          "lru_miss", miss,
-          sm::description("total count of the extents that are not linked to lru when touching them"),
-          {sm::label_instance("shard_store_index", std::to_string(store_index))}
-        ),
       }
     );
   }
@@ -347,10 +333,10 @@ public:
     extent_len_t /*load_length*/) final {
     if (extent.is_linked_to_list()) {
       lru.move_to_top(extent, p_src);
-      hit++;
+      ++get_by_ext(hits_by_ext, extent.get_type());
     } else {
       lru.add_to_top(extent, p_src);
-      miss++;
+      ++get_by_ext(misses_by_ext, extent.get_type());
     }
   }
 
@@ -546,7 +532,7 @@ public:
 	// hot until it is evicted to the warm out queue and accessed once
 	// again.
       }
-      hit++;
+      ++get_by_ext(hits_by_ext, type);
     } else if (!is_logical_type(extent.get_type())) {
       // put physical extents to hot queue directly
       ceph_assert(state == extent_2q_state_t::Fresh);
@@ -554,7 +540,7 @@ public:
       auto trimmed_extents = hot.add_to_top(extent, p_src);
       on_update_hot(trimmed_extents);
       hit_queue(overall_hits.absent, p_src, type);
-      miss++;
+      ++get_by_ext(misses_by_ext, type);
     } else { // the logical extent which is not in warm_in and not in hot
       ceph_assert(state == extent_2q_state_t::Fresh);
       auto lext = extent.cast<LogicalCachedExtent>();
@@ -579,7 +565,7 @@ public:
 	  hit_queue(overall_hits.sequential_absent, p_src, type);
 	}
       }
-      miss++;
+      ++get_by_ext(misses_by_ext, type);
     }
     auto end = load_start + load_length;
     assert(end != 0);
@@ -720,9 +706,6 @@ private:
   mutable hit_stats_t overall_hits;
   mutable hit_stats_t last_hits;
 
-  // hit and miss indicates if an extent is linked when touching it
-  uint64_t hit = 0;
-  uint64_t miss = 0;
 };
 
 void ExtentPinboardTwoQ::get_stats(
@@ -838,16 +821,6 @@ void ExtentPinboardTwoQ::register_metrics(store_index_t store_index) {
           return hot.get_current_num_extents();
         },
         sm::description("total extents pinned by the 2q hot queue"),
-        {sm::label_instance("shard_store_index", std::to_string(store_index))}
-      ),
-      sm::make_counter(
-        "2q_hit", hit,
-        sm::description("total count of the extents that are linked to 2Q when touching them"),
-        {sm::label_instance("shard_store_index", std::to_string(store_index))}
-      ),
-      sm::make_counter(
-        "2q_miss", miss,
-        sm::description("total count of the extents that are not linked to 2Q when touching them"),
         {sm::label_instance("shard_store_index", std::to_string(store_index))}
       ),
     }

--- a/src/crimson/os/seastore/extent_pinboard.h
+++ b/src/crimson/os/seastore/extent_pinboard.h
@@ -28,6 +28,9 @@ struct ExtentPinboard {
     extent_len_t increased_length,
     const Transaction::src_t *p_src) = 0;
   virtual void clear() = 0;
+
+  counter_by_extent_t<uint64_t> hits_by_ext = {};
+  counter_by_extent_t<uint64_t> misses_by_ext = {};
 };
 using ExtentPinboardRef = std::unique_ptr<ExtentPinboard>;
 ExtentPinboardRef create_extent_pinboard(std::size_t capacity);


### PR DESCRIPTION
```
Move hit/miss tracking to per-extent type ones
for example:
  cache_pinboard_hit{ext="LADDR_LEAF",...}
  cache_pinboard_miss{ext="LADDR_LEAF",...}

This should help with an extent type e.g DATA_BLOCK fills
the cache and blocks other types from using it (mainly ONODE_BLOCK)
If this proves to be the case, a dedicated sub cache per type might
be useful.
```

Note, with https://github.com/ceph/ceph/pull/69281 it seems that ONODE lookup takes almost half of the txn build stage. If Onode blocks would be better reused we might be able to largely reduce the total build time.
We already lookup the Onode at get_obc stage, so the second lookup for the write itself should (**must**?) be cached.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
