### PR TITLE
crimson/osd: gate write ops at OSDOp boundary when local store is full

### DIFF
--- a/src/crimson/os/futurized_store.h
+++ b/src/crimson/os/futurized_store.h
@@ -52,6 +52,11 @@ public:
       return true;
     }
 
+    // Returns true when the local store is full (failsafe limit); checked at
+    // OSDOp boundary, where data-allocating ops are dropped with -EAGAIN so
+    // the client resends. Default false.
+    virtual bool is_storage_full() const { return false; }
+
     using CollectionRef = boost::intrusive_ptr<FuturizedCollection>;
     using base_errorator = crimson::errorator<crimson::ct_error::input_output_error>;
     using read_errorator = crimson::errorator<crimson::ct_error::enoent,

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -10,6 +10,7 @@
 
 #include "osd/osd_types.h"
 
+#include "crimson/common/config_proxy.h"
 #include "crimson/os/seastore/cached_extent.h"
 #include "crimson/os/seastore/seastore_types.h"
 #include "crimson/os/seastore/segment_manager.h"
@@ -1885,8 +1886,12 @@ public:
     if (st.total == 0) {
       return false;
     }
-    // 3% free, matching the default osd_failsafe_full_ratio (0.97)
-    return st.available < (st.total * 3 / 100);
+    // Failsafe limit: full once the used fraction reaches the same ratio
+    // classic uses for its failsafe check (osd_failsafe_full_ratio, default
+    // 0.97), i.e. free fraction drops below (1 - ratio).
+    const double failsafe_full_ratio =
+      crimson::common::get_conf<double>("osd_failsafe_full_ratio");
+    return st.available < st.total * (1.0 - failsafe_full_ratio);
   }
 
   bool can_clean_space() const final {

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -1292,6 +1292,10 @@ public:
 
   virtual void release_projected_usage(std::size_t) = 0;
 
+  // Returns true when the allocator is full (failsafe limit) and writes should
+  // be refused. Only RBMCleaner overrides this; SegmentCleaner returns false.
+  virtual bool is_storage_full() const { return false; }
+
   virtual bool should_block_io_on_clean() const = 0;
 
   virtual bool can_clean_space() const = 0;
@@ -1874,6 +1878,15 @@ public:
 
   bool should_block_io_on_clean() const final {
     return false;
+  }
+
+  bool is_storage_full() const final {
+    auto st = get_stat();
+    if (st.total == 0) {
+      return false;
+    }
+    // 3% free, matching the default osd_failsafe_full_ratio (0.97)
+    return st.available < (st.total * 3 / 100);
   }
 
   bool can_clean_space() const final {

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -694,6 +694,11 @@ public:
     background_process.release_projected_usage(usage);
   }
 
+  bool is_storage_full() const {
+    auto *cleaner = background_process.get_main_cleaner();
+    return cleaner ? cleaner->is_storage_full() : false;
+  }
+
   backend_type_t get_main_backend_type() const {
     if (!background_process.is_no_background()) {
       return background_process.get_main_backend_type();
@@ -1110,6 +1115,10 @@ private:
         return cold_cleaner->get_alive_ratio() >= 0.99;
       }
       return main_cleaner->get_alive_ratio() >= 0.99;
+    }
+
+    const AsyncCleaner* get_main_cleaner() const {
+      return main_cleaner.get();
     }
 
     void maybe_wake_background() final {

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -210,6 +210,7 @@ public:
     bool is_storage_full() const override final {
       return transaction_manager ? transaction_manager->is_storage_full() : false;
     }
+
     omap_root_t select_log_omap_root(Onode& onode) const;
 
   // only exposed to SeaStore

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -207,6 +207,9 @@ public:
       return 256;
     }
 
+    bool is_storage_full() const override final {
+      return transaction_manager ? transaction_manager->is_storage_full() : false;
+    }
     omap_root_t select_log_omap_root(Onode& onode) const;
 
   // only exposed to SeaStore

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -1203,6 +1203,10 @@ public:
     return epm->get_stat();
   }
 
+  bool is_storage_full() const {
+    return epm->is_storage_full();
+  }
+
   ExtentTransViewRetriever& get_etvr() {
     return *cache;
   }

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -609,6 +609,28 @@ OpsExecuter::do_execute_op(OSDOp& osd_op)
     "handling op {} on object {}",
     ceph_osd_op_name(osd_op.op.op),
     get_target());
+  // Best-effort capacity gate (failsafe): drop data-allocating ops before a
+  // transaction is created if the local store is full. This is Crimson's
+  // analog to classic's osd_failsafe_full_ratio check (PrimaryLogPG.cc:2162),
+  // preventing allocator exhaustion assert aborts when the local store fills
+  // before the monitor's pool FLAG_FULL has propagated. We reply -EAGAIN so
+  // the client resends, matching both classic's silent drop and Crimson's own
+  // mon-driven full path (PG::run_executer_fut, pg.cc), rather than returning
+  // a result that depends on whether full flags have reached the client yet.
+  switch (osd_op.op.op) {
+  case CEPH_OSD_OP_CREATE:
+  case CEPH_OSD_OP_WRITE:
+  case CEPH_OSD_OP_WRITEFULL:
+  case CEPH_OSD_OP_WRITESAME:
+  case CEPH_OSD_OP_APPEND:
+  case CEPH_OSD_OP_COPY_FROM2:
+    if (pg->is_local_store_full() && !get_message().has_flag(CEPH_OSD_FLAG_FULL_TRY)) {
+      return crimson::ct_error::eagain::make();
+    }
+    break;
+  default:
+    break;
+  }
   switch (const ceph_osd_op& op = osd_op.op; op.op) {
   case CEPH_OSD_OP_SYNC_READ:
     [[fallthrough]];

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -240,6 +240,10 @@ public:
     return false;
   }
 
+  bool is_local_store_full() const {
+    return shard_services.is_local_storage_full(get_store_index());
+  }
+
   epoch_t get_last_peering_reset_epoch() const final {
     return get_last_peering_reset();
   }
@@ -269,7 +273,7 @@ public:
     return pgid;
   }
 
-  const unsigned int get_store_index() {
+  unsigned get_store_index() const {
     return store_index;
   }
   PGBackend& get_backend() {

--- a/src/crimson/osd/shard_services.h
+++ b/src/crimson/osd/shard_services.h
@@ -533,6 +533,12 @@ public:
     return store;
   }
 
+  bool is_local_storage_full(store_index_t store_index) const {
+    const auto &shard_store =
+        local_state.b_store.f_store.get_sharded_store(store_index);
+    return shard_store.is_storage_full();
+  }
+
   struct shard_stats_t {
     double reactor_utilization;
   };

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -1913,6 +1913,46 @@ TEST_P(tm_random_block_device_test_t, scatter_allocation)
   });
 }
 
+TEST_P(tm_random_block_device_test_t, storage_full_failsafe_threshold)
+{
+  run_async([this] {
+    // A fresh store is far below the default failsafe ratio (0.97).
+    EXPECT_FALSE(tm->is_storage_full());
+
+    auto st = tm->store_stat();
+    ASSERT_GT(st.total, 0);
+    ASSERT_GE(st.total, st.available);
+
+    // Lower the ratio to just above the current used fraction, leaving half
+    // of the upcoming allocation as margin on each side of the threshold, so
+    // the allocation below is what crosses it.
+    constexpr extent_len_t EXTENT_SIZE = 16384;
+    constexpr unsigned NUM_EXTENTS = 64;
+    constexpr uint64_t alloc_bytes = uint64_t(EXTENT_SIZE) * NUM_EXTENTS;
+    const double used_fraction =
+      double(st.total - st.available) / double(st.total);
+    const double ratio =
+      used_fraction + double(alloc_bytes) / (2.0 * double(st.total));
+    crimson::common::local_conf().set_val(
+      "osd_failsafe_full_ratio", std::to_string(ratio)).get();
+    EXPECT_FALSE(tm->is_storage_full());
+
+    laddr_t ADDR = get_laddr_hint(0xFF * 4096);
+    auto t = create_transaction();
+    for (unsigned i = 0; i < NUM_EXTENTS; i++) {
+      alloc_extents(
+	t, (ADDR + i * EXTENT_SIZE).checked_to_laddr(), EXTENT_SIZE, 'a');
+    }
+    submit_transaction(std::move(t));
+    EXPECT_TRUE(tm->is_storage_full());
+
+    // The threshold tracks the config knob: restoring the default clears it.
+    crimson::common::local_conf().set_val(
+      "osd_failsafe_full_ratio", "0.97").get();
+    EXPECT_FALSE(tm->is_storage_full());
+  });
+}
+
 TEST_P(tm_single_device_test_t, basic)
 {
   constexpr size_t SIZE = 4096;


### PR DESCRIPTION
Crimson's analog of classic's failsafe full check (`PrimaryLogPG.cc:2162`): data-allocating client ops (CREATE/WRITE/WRITEFULL/WRITESAME/APPEND/COPY_FROM2) are dropped with `-EAGAIN` (the client resends) when the local store reports full (`RBMCleaner`, threshold derived from `osd_failsafe_full_ratio`, default 0.97), exempting `CEPH_OSD_FLAG_FULL_TRY` exactly as classic does.

The mon-driven pool `FLAG_FULL` handling in `run_executer` is untouched and remains the authoritative policy path with its FULL_TRY/FULL_FORCE/MDS semantics. This gate exists for the same reason classic's failsafe does: OSDMap flag propagation can't outrun local allocator exhaustion. Space-reclaiming ops (ZERO/TRUNCATE/ROLLBACK) are deliberately **not** gated.

Dropping via `-EAGAIN` matches both classic's silent drop (`PrimaryLogPG.cc:2164`) and Crimson's own mon-driven full path (the "drop request" case in `pg.cc`), so the outcome is consistent regardless of whether the pool full flags have reached the client yet: the write retries until space is freed or the flags propagate.

The threshold currently derives from the store's statfs accounting; #69352 moves RBM capacity checks to the allocator's authoritative view, and mon-side NEARFULL/FULL integration via statfs reporting is the natural follow-up that lets clients get a clean stop rather than resend-until-resolved.

---

Restructured per review (thanks @Matan-B): this PR is now scoped to the failsafe gate alone, on top of `main`. The omap extent-retirement test coverage that was previously bundled here is split out into #69482.

## Checklist
- Tracker (select at least one)
  - [x] New feature (ticket optional)
- Component impact
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] No tests

<!-- scoped to the failsafe gate; no cross-PR dependency -->
