### PR TITLE
doc/security: Add Security Lead and Working Group pages to toctree

### DIFF
--- a/doc/security/index.rst
+++ b/doc/security/index.rst
@@ -7,6 +7,8 @@
 
    Past Vulnerabilities / CVEs <cves>
    Vulnerability Management Process <process>
+   Security Lead <securitylead>
+   Security Working Group <workinggroup>
 
 Reporting a vulnerability
 =========================

--- a/doc/security/securitylead.rst
+++ b/doc/security/securitylead.rst
@@ -1,3 +1,7 @@
+================
+ Security Lead
+================
+
 The CSC designates a member as Security Lead, with responsibility for
 co-ordinating security posture. The Security Lead also keeps the CSC updated
 about vulnerabilities within Ceph and progress toward addressing them. The lead

--- a/doc/security/workinggroup.rst
+++ b/doc/security/workinggroup.rst
@@ -1,3 +1,7 @@
+==========================
+ Security Working Group
+==========================
+
 In order to fully support Ceph, the security working group
 co-ordinates security improvements. This is essential as industry
 focuses more on security, and Ceph has become a mature software


### PR DESCRIPTION
## Problem

`securitylead.rst` and `workinggroup.rst` existed in the `doc/security/`
tree but were not included in `security/index.rst`'s toctree. Both files
were invisible in the built documentation and caused Sphinx orphan
warnings.

## Changes

- Added RST document titles to `securitylead.rst` and `workinggroup.rst`
  (required by the Ceph doc style guide: all documents must have a title)
- Added both pages to the `security/index.rst` toctree

Fixes: https://tracker.ceph.com/issues/77206

Signed-off-by: Emmanuel Ameh <eameh@contractor.linuxfoundation.org>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [x] No tests