### PR TITLE
doc: Replace Python 2 package names with Python 3 equivalents

### DIFF
--- a/doc/rados/api/librados-intro.rst
+++ b/doc/rados/api/librados-intro.rst
@@ -70,8 +70,7 @@ Getting librados for Python
 ---------------------------
 
 The ``rados`` module provides ``librados`` support to Python
-applications. You may install ``python3-rados`` for Debian, Ubuntu, SLE or
-openSUSE or the ``python-rados`` package for CentOS/RHEL.
+applications. You may install the ``python3-rados`` package.
 
 To install ``librados`` development support files for Python on Debian/Ubuntu
 distributions, execute the following:
@@ -85,7 +84,7 @@ distributions, execute the following:
 
 .. prompt:: bash $
 
-   sudo yum install python-rados
+   sudo yum install python3-rados
 
 To install ``librados`` development support files for Python on SLE/openSUSE
 distributions, execute the following:

--- a/doc/rbd/rbd-openstack.rst
+++ b/doc/rbd/rbd-openstack.rst
@@ -117,8 +117,8 @@ Install Ceph client packages
 
 On the ``glance-api`` node, you will need the Python bindings for ``librbd``::
 
-  sudo apt-get install python-rbd
-  sudo yum install python-rbd
+  sudo apt-get install python3-rbd
+  sudo yum install python3-rbd
 
 On the ``nova-compute``, ``cinder-backup`` and on the ``cinder-volume`` node,
 use both the Python bindings and the client command line tools::


### PR DESCRIPTION
## Problem

Two user-facing install-command pages referenced Python 2 package
names. Python 2 reached end-of-life in January 2020.

- `doc/rados/api/librados-intro.rst:74,88` — prose and `yum install`
  command used `python-rados`
- `doc/rbd/rbd-openstack.rst:120-121` — both `apt-get` and `yum`
  install commands used `python-rbd`

## Changes

- `librados-intro.rst`: simplify prose to "You may install the
  ``python3-rados`` package" (avoids repeating the package name);
  update `yum install` command from `python-rados` to `python3-rados`
- `rbd-openstack.rst`: update both `apt-get` and `yum` install
  commands from `python-rbd` to `python3-rbd`

Fixes: https://tracker.ceph.com/issues/77200

Signed-off-by: Emmanuel Ameh <eameh@contractor.linuxfoundation.org>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [x] No tests