### PR TITLE
doc/install: Update mirrors.rst to use https and current release

### DIFF
--- a/doc/install/mirrors.rst
+++ b/doc/install/mirrors.rst
@@ -24,17 +24,18 @@ These mirrors are available on the following locations:
 - **US-West: US West Coast**: http://us-west.ceph.com/
 - **CN: China**: http://mirrors.ustc.edu.cn/ceph/
 
-You can replace all download.ceph.com URLs with any of the mirrors, for example:
+You can replace all ``download.ceph.com`` URLs with any of the mirrors,
+for example:
 
-- http://download.ceph.com/tarballs/
-- http://download.ceph.com/debian-hammer/
-- http://download.ceph.com/rpm-hammer/
+- https://download.ceph.com/tarballs/
+- https://download.ceph.com/debian-tentacle/
+- https://download.ceph.com/rpm-tentacle/
 
 Change this to:
 
-- http://eu.ceph.com/tarballs/
-- http://eu.ceph.com/debian-hammer/
-- http://eu.ceph.com/rpm-hammer/
+- https://eu.ceph.com/tarballs/
+- https://eu.ceph.com/debian-tentacle/
+- https://eu.ceph.com/rpm-tentacle/
 
 
 Mirroring
@@ -62,4 +63,4 @@ set for all mirrors. These can be found on `GitHub`_.
 If you want to apply for an official mirror, please contact the ceph-users mailinglist.
 
 
-.. _GitHub: https://github.com/ceph/ceph/tree/master/mirroring
+.. _GitHub: https://github.com/ceph/ceph/tree/main/mirroring


### PR DESCRIPTION
## Problem

`doc/install/mirrors.rst` had two categories of stale content:

1. The example ``download.ceph.com`` URLs used insecure `http://`.
2. The example repository paths used `debian-hammer` and `rpm-hammer`
   (Hammer EOL April 2016 — nine years ago).

## Changes

- Update example ``download.ceph.com`` URLs from `http://` to `https://`
  and add backticks in prose (reviewer request).
- Update example repository paths from `debian-hammer`/`rpm-hammer`
  to `debian-tentacle`/`rpm-tentacle` (current stable release).
- Update the GitHub mirroring reference link from `master` to `main`.
- Community mirror entries (eu.ceph.com, au.ceph.com, etc.) are
  retained as `http://` — reviewer confirmed that at least DE and FR
  mirrors do not respond on HTTPS. Changing the official
  ``download.ceph.com`` canonical URL to HTTPS is safe and verified;
  community mirror protocol is left for the mirror operators to resolve.

Fixes: https://tracker.ceph.com/issues/77197

Signed-off-by: Emmanuel Ameh <eameh@contractor.linuxfoundation.org>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [x] No tests