### PR TITLE
mgr/cephadm: optionally pre-pull target image on all hosts before upgrade

### DIFF
--- a/doc/cephadm/upgrade.rst
+++ b/doc/cephadm/upgrade.rst
@@ -88,6 +88,37 @@ Starting the Upgrade
    #. Bring CephFS filesystems back up, bringing the state of active
       MDS daemon(s) from ``up:standby`` to ``up:active``.
 
+Pre-pulling the target image
+----------------------------
+
+By default, cephadm pulls the target container image on each host on demand,
+just before the first daemon on that host is upgraded. On clusters with many
+hosts and/or a large image, these sequential pulls add up and lengthen the
+upgrade.
+
+To pull the target image on every host in the upgrade scope up front, in
+parallel, before any daemon is upgraded, enable:
+
+.. prompt:: bash #
+
+   ceph config set mgr mgr/cephadm/upgrade_pre_pull_images true
+
+Hosts that already have the target image are skipped. The number of hosts
+pulled in parallel is capped by ``mgr/cephadm/upgrade_max_parallel_image_pulls``
+(default ``8``) to avoid overwhelming the registry:
+
+.. prompt:: bash #
+
+   ceph config set mgr mgr/cephadm/upgrade_max_parallel_image_pulls 8
+
+When the upgrade is scoped (``--hosts``, ``--services`` or ``--daemon-types``),
+only the hosts that have a daemon in scope are pre-pulled. If the image cannot
+be pulled on one or more hosts (for example because a host is out of disk
+space), the upgrade is paused before any daemon is touched, and the failing
+host(s) and reason are reported in ``ceph status`` and ``ceph health detail``.
+Because nothing has been upgraded yet, no daemon is left down while the problem
+is resolved.
+
 Before you use cephadm to upgrade Ceph, verify that all hosts are currently
 online and that your cluster is healthy by running the following command:
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -419,6 +419,23 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             desc='Maximum number of OSD daemons upgraded in parallel.'
         ),
         Option(
+            'upgrade_pre_pull_images',
+            type='bool',
+            default=False,
+            desc='Before upgrading any daemon, pull the target container image '
+                 'in parallel on every host that has a daemon in the upgrade '
+                 'scope. This moves image download time off the critical path. '
+                 'If the image cannot be pulled on any host, the upgrade is '
+                 'paused before any daemon is touched.'
+        ),
+        Option(
+            'upgrade_max_parallel_image_pulls',
+            type='int',
+            default=8,
+            desc='Maximum number of hosts on which the target image is pulled '
+                 'in parallel when upgrade_pre_pull_images is enabled.'
+        ),
+        Option(
             'pg_autoscale_during_upgrade',
             type='bool',
             default=False,
@@ -633,6 +650,8 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             self.apply_spec_fails: List[Tuple[str, str]] = []
             self.max_osd_draining_count = 10
             self.max_parallel_osd_upgrades = 16
+            self.upgrade_pre_pull_images = False
+            self.upgrade_max_parallel_image_pulls = 8
             self.device_enhanced_scan = False
             self.inventory_list_all = False
             self.cgroups_split = True

--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -1170,3 +1170,117 @@ def test_do_upgrade_limit_exhausted_marks_complete_without_scope_check(
 
     mark_complete.assert_called_once()
     filtered_scope.assert_not_called()
+
+
+def _prepull_upgrade_state(cephadm_module: CephadmOrchestrator):
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'quay.io/ceph/ceph:vtest', 0,
+        target_digests=['sha256:targetdigest'])
+
+
+def _inspect_or_pull(present_hosts, fail_pull_hosts):
+    # Return an async _run_cephadm replacement handling both inspect-image and
+    # pull commands used by _pre_pull_image_on_hosts.
+    async def fake_run(self, host, entity, command, args, image=None,
+                       no_fsid=None, error_ok=None, **kwargs):
+        if command == 'inspect-image':
+            if host in present_hosts:
+                return (['{"repo_digests": ["sha256:targetdigest"]}'], [], 0)
+            return (['{"repo_digests": ["sha256:other"]}'], [], 0)
+        # command == 'pull'
+        if host in fail_pull_hosts:
+            return ([], ['no space left on device'], 1)
+        return (['{"repo_digests": ["sha256:targetdigest"]}'], [], 0)
+    return fake_run
+
+
+def test_pre_pull_success_on_all_hosts(cephadm_module: CephadmOrchestrator):
+    _prepull_upgrade_state(cephadm_module)
+    cephadm_module.upgrade_max_parallel_image_pulls = 8
+    with mock.patch("cephadm.serve.CephadmServe._run_cephadm",
+                    new=_inspect_or_pull(set(), set())):
+        ok = cephadm_module.upgrade._pre_pull_image_on_hosts(
+            'quay.io/ceph/ceph:vtest', ['h1', 'h2', 'h3'])
+    assert ok is True
+    assert not cephadm_module.upgrade.upgrade_state.paused
+    assert 'UPGRADE_FAILED_PULL' not in cephadm_module.health_checks
+
+
+def test_pre_pull_skips_hosts_that_already_have_image(cephadm_module: CephadmOrchestrator):
+    _prepull_upgrade_state(cephadm_module)
+    cephadm_module.upgrade_max_parallel_image_pulls = 8
+    pulled = []
+
+    async def fake_run(self, host, entity, command, args, image=None,
+                       no_fsid=None, error_ok=None, **kwargs):
+        if command == 'inspect-image':
+            # h2 already has the target image, others do not
+            digest = 'sha256:targetdigest' if host == 'h2' else 'sha256:other'
+            return ([f'{{"repo_digests": ["{digest}"]}}'], [], 0)
+        pulled.append(host)
+        return (['{"repo_digests": ["sha256:targetdigest"]}'], [], 0)
+
+    with mock.patch("cephadm.serve.CephadmServe._run_cephadm", new=fake_run):
+        ok = cephadm_module.upgrade._pre_pull_image_on_hosts(
+            'quay.io/ceph/ceph:vtest', ['h1', 'h2', 'h3'])
+    assert ok is True
+    # h2 was skipped (already present); h1 and h3 were pulled
+    assert 'h2' not in pulled
+    assert sorted(pulled) == ['h1', 'h3']
+
+
+def test_pre_pull_failure_pauses_and_reports_host(cephadm_module: CephadmOrchestrator):
+    _prepull_upgrade_state(cephadm_module)
+    cephadm_module.upgrade_max_parallel_image_pulls = 8
+    with mock.patch("cephadm.serve.CephadmServe._run_cephadm",
+                    new=_inspect_or_pull(set(), {'h2'})):
+        ok = cephadm_module.upgrade._pre_pull_image_on_hosts(
+            'quay.io/ceph/ceph:vtest', ['h1', 'h2', 'h3'])
+    assert ok is False
+    assert cephadm_module.upgrade.upgrade_state.paused
+    assert 'UPGRADE_FAILED_PULL' in cephadm_module.health_checks
+    detail = ' '.join(cephadm_module.health_checks['UPGRADE_FAILED_PULL']['detail'])
+    assert 'h2' in detail
+    assert 'no space left on device' in detail
+
+
+def test_pre_pull_respects_parallelism_limit(cephadm_module: CephadmOrchestrator):
+    _prepull_upgrade_state(cephadm_module)
+    cephadm_module.upgrade_max_parallel_image_pulls = 3
+    import asyncio as _asyncio
+    state = {'current': 0, 'max': 0}
+    lock = _asyncio.Lock()
+
+    async def fake_run(self, host, entity, command, args, image=None,
+                       no_fsid=None, error_ok=None, **kwargs):
+        if command == 'inspect-image':
+            return (['{"repo_digests": ["sha256:other"]}'], [], 0)
+        async with lock:
+            state['current'] += 1
+            state['max'] = max(state['max'], state['current'])
+        await _asyncio.sleep(0.01)
+        async with lock:
+            state['current'] -= 1
+        return (['{"repo_digests": ["sha256:targetdigest"]}'], [], 0)
+
+    with mock.patch("cephadm.serve.CephadmServe._run_cephadm", new=fake_run):
+        ok = cephadm_module.upgrade._pre_pull_image_on_hosts(
+            'quay.io/ceph/ceph:vtest', [f'h{i}' for i in range(10)])
+    assert ok is True
+    assert state['max'] <= 3, state['max']
+
+
+def test_pre_pull_empty_host_list_is_noop(cephadm_module: CephadmOrchestrator):
+    _prepull_upgrade_state(cephadm_module)
+    called = []
+
+    async def fake_run(self, host, entity, command, args, image=None,
+                       no_fsid=None, error_ok=None, **kwargs):
+        called.append(host)
+        return ([], [], 0)
+
+    with mock.patch("cephadm.serve.CephadmServe._run_cephadm", new=fake_run):
+        ok = cephadm_module.upgrade._pre_pull_image_on_hosts(
+            'quay.io/ceph/ceph:vtest', [])
+    assert ok is True
+    assert called == []

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -1,3 +1,4 @@
+import asyncio
 import errno
 import json
 import logging
@@ -204,6 +205,7 @@ class UpgradeState:
                  crush_bucket_name: Optional[str] = None,
                  noautoscale_set: Optional[bool] = False,
                  prior_autoscale: Optional[bool] = True,
+                 pre_pull_done: Optional[bool] = False,
                  ):
 
         self._target_name: str = target_name  # Use CephadmUpgrade.target_image instead.
@@ -226,6 +228,7 @@ class UpgradeState:
         self.crush_bucket_name = crush_bucket_name
         self.noautoscale_set = noautoscale_set
         self.prior_autoscale = prior_autoscale
+        self.pre_pull_done = pre_pull_done or False
 
     def to_json(self) -> dict:
         return {
@@ -248,6 +251,7 @@ class UpgradeState:
             'crush_bucket_name': self.crush_bucket_name,
             'noautoscale_set': self.noautoscale_set,
             'prior_autoscale': self.prior_autoscale,
+            'pre_pull_done': self.pre_pull_done,
         }
 
     @classmethod
@@ -1747,6 +1751,94 @@ class CephadmUpgrade:
         self._ok_to_upgrade_osds_in_crush_bucket = None
         self._save_upgrade_state()
 
+    def _pre_pull_image_on_hosts(self, target_image: str, hosts: List[str]) -> bool:
+        # Pull the target image on the given hosts in parallel, up to
+        # upgrade_max_parallel_image_pulls at a time, before any daemon is
+        # upgraded. Returns True on success. On any failure the upgrade is
+        # paused via _fail_upgrade (visible in 'ceph status' / 'ceph health
+        # detail') with the failing host(s) and reason, and no daemon has been
+        # touched yet.
+        if not hosts:
+            return True
+        limit = max(1, int(self.mgr.upgrade_max_parallel_image_pulls))
+        logger.info('Upgrade: pre-pulling image %s on %d host(s), up to %d in '
+                    'parallel' % (target_image, len(hosts), limit))
+        self.upgrade_info_str = 'Pre-pulling image %s on %d hosts' % (
+            target_image, len(hosts))
+        done = 0
+        total = len(hosts)
+        target_digests = self.upgrade_state.target_digests or [] if self.upgrade_state else []
+
+        async def _pull_one(sem: asyncio.Semaphore, host: str) -> Tuple[str, int, str]:
+            nonlocal done
+            async with sem:
+                # If the upgrade was paused/stopped while pulls were queued,
+                # don't start new pulls. Pulls already running are left to
+                # finish (interrupting podman/docker mid-pull is unsafe).
+                if not self.upgrade_state or self.upgrade_state.paused:
+                    return host, 0, ''
+                # Skip the pull if the target image is already present on the
+                # host (matching one of the target digests), like the
+                # per-daemon path does, to avoid needless registry round-trips.
+                try:
+                    out, _, code = await CephadmServe(self.mgr)._run_cephadm(
+                        host, '', 'inspect-image', [],
+                        image=target_image, no_fsid=True, error_ok=True)
+                    present = (code == 0 and any(
+                        d in target_digests
+                        for d in json.loads(''.join(out)).get('repo_digests', [])))
+                except Exception:
+                    present = False
+                if present:
+                    done += 1
+                    logger.info('Upgrade: image already present on host %s '
+                                '(%d/%d done)' % (host, done, total))
+                    return host, 0, ''
+                logger.info('Upgrade: pulling image %s on host %s'
+                            % (target_image, host))
+                out, errs, code = await CephadmServe(self.mgr)._run_cephadm(
+                    host, '', 'pull', [],
+                    image=target_image, no_fsid=True, error_ok=True)
+                done += 1
+                if code:
+                    logger.error('Upgrade: failed to pull image on host %s '
+                                 '(%d/%d done)' % (host, done, total))
+                else:
+                    logger.info('Upgrade: pulled image on host %s (%d/%d done)'
+                                % (host, done, total))
+                return host, code, ''.join(errs) if code else ''
+
+        async def _pull_all() -> List[Tuple[str, int, str]]:
+            sem = asyncio.Semaphore(limit)
+            return await asyncio.gather(*[_pull_one(sem, h) for h in hosts])
+
+        try:
+            with self.mgr.async_timeout_handler('cephadm pre-pull'):
+                results = self.mgr.wait_async(_pull_all())
+        except Exception as e:
+            self._fail_upgrade('UPGRADE_FAILED_PULL', {
+                'severity': 'warning',
+                'summary': 'Upgrade: failed to pre-pull target image',
+                'count': 1,
+                'detail': ['failed to pre-pull %s: %s' % (target_image, str(e))],
+            })
+            return False
+
+        failures = ['failed to pull %s on host %s: %s'
+                    % (target_image, host, err or 'unknown error')
+                    for host, code, err in results if code]
+        if failures:
+            self._fail_upgrade('UPGRADE_FAILED_PULL', {
+                'severity': 'warning',
+                'summary': 'Upgrade: failed to pre-pull target image on %d host(s)'
+                           % len(failures),
+                'count': len(failures),
+                'detail': failures,
+            })
+            return False
+        logger.info('Upgrade: pre-pull complete on all %d host(s)' % len(hosts))
+        return True
+
     def _do_upgrade(self):
         # type: () -> None
         if not self.upgrade_state:
@@ -1849,6 +1941,18 @@ class CephadmUpgrade:
         if self.upgrade_state.hosts is not None:
             logger.debug(f'Filtering daemons to upgrade by hosts: {self.upgrade_state.hosts}')
             daemons = [d for d in daemons if d.hostname in self.upgrade_state.hosts]
+
+        # Optionally pre-pull the target image, in parallel, on every host that
+        # has a daemon in this upgrade's scope, before upgrading any daemon. On
+        # failure the upgrade is paused before anything is touched (no daemon
+        # down), surfacing the failing host(s) in the status.
+        if self.mgr.upgrade_pre_pull_images and not self.upgrade_state.pre_pull_done:
+            pre_pull_hosts = sorted({d.hostname for d in daemons if d.hostname})
+            if not self._pre_pull_image_on_hosts(target_image, pre_pull_hosts):
+                return
+            self.upgrade_state.pre_pull_done = True
+            self._save_upgrade_state()
+
         upgraded_daemon_count: int = 0
         for daemon_type in CEPH_UPGRADE_ORDER:
             if self.upgrade_state.remaining_count is not None and self.upgrade_state.remaining_count <= 0:


### PR DESCRIPTION
On clusters with many hosts and a large container image (ceph upstream container image is 1.2GB in size), cephadm's on-demand image pulls (one per host, just before the first daemon on that host is upgraded) are performed serially as the upgrade progresses and add up to a significant share of the total upgrade time.

This is especially harmful when upgrading MDS daemons. The MDS upgrade fails (or scales down) the filesystem first, and only then redeploys its MDS, which pulls the target image on the host as part of the redeployment. The image download therefore happens while the filesystem is already offline, so the pull time is counted directly against filesystem unavailability and is felt by CephFS clients. Pulling a large image on a host that does not yet have it can take a while, needlessly extending the outage.

Add an **optional** phase that, before any daemon is upgraded (and before any filesystem is failed), **pulls the target image in parallel on every host in the upgrade scope**, capped by upgrade_max_parallel_image_pulls (default 8) to avoid overwhelming the registry. The subsequent per-daemon pull then becomes a no-op, so MDS redeployment no longer waits on an image download while the filesystem is down.

Hosts that already have the target image are skipped, and each pull is logged per host with progress. When the upgrade is scoped (--hosts/--services/--daemon-types), only hosts with a daemon in scope are pre-pulled. If the image cannot be pulled on any host, the upgrade is paused before any daemon is touched and the failing host(s) and reason are surfaced in the cluster status, so no daemon is left down while the issue (often a full disk) is resolved.

Successfully tested on a Reef v18.2.8 cluster, with the expected behavior.

Opt-in via the following setting:
`ceph config set mgr mgr/cephadm/upgrade_pre_pull_images true`

Optionally, tune the parallelism (default 8):
`ceph config set mgr mgr/cephadm/upgrade_max_parallel_image_pulls 8`

Fixes: https://tracker.ceph.com/issues/77270

Assisted-by: Claude Opus 4.8 High

Expected behavior successfully validated in the lab on a live Ceph cluster.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [X] New feature (ticket optional)
  - [X] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [X] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [X] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [X] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
