### PR TITLE
doc/install: Update EOL version floor references in index.rst

### DIFF
--- a/doc/install/index.rst
+++ b/doc/install/index.rst
@@ -12,6 +12,7 @@ Recommended methods
 :ref:`Cephadm <cephadm_deploying_new_cluster>` is a tool that can be used to
 install and manage a Ceph cluster.
 
+* cephadm supports only Octopus and newer releases.
 * cephadm is fully integrated with the orchestration API and fully supports the
   CLI and dashboard features that are used to manage cluster deployment.
 * cephadm requires container support (in the form of Podman or Docker) and

--- a/doc/install/index.rst
+++ b/doc/install/index.rst
@@ -12,7 +12,6 @@ Recommended methods
 :ref:`Cephadm <cephadm_deploying_new_cluster>` is a tool that can be used to
 install and manage a Ceph cluster.
 
-* cephadm supports only Octopus and newer releases.
 * cephadm is fully integrated with the orchestration API and fully supports the
   CLI and dashboard features that are used to manage cluster deployment.
 * cephadm requires container support (in the form of Podman or Docker) and
@@ -24,7 +23,6 @@ in Kubernetes, while also enabling management of storage resources and
 provisioning via Kubernetes APIs. We recommend Rook as the way to run Ceph in
 Kubernetes or to connect an existing Ceph storage cluster to Kubernetes.
 
-* Rook supports only Nautilus and newer releases of Ceph.
 * Rook is the preferred method for running Ceph on Kubernetes, or for
   connecting a Kubernetes cluster to an existing (external) Ceph
   cluster.
@@ -33,15 +31,6 @@ Kubernetes or to connect an existing Ceph storage cluster to Kubernetes.
 
 Other methods
 ~~~~~~~~~~~~~
-
-`ceph-ansible <https://docs.ceph.com/ceph-ansible/>`_ deploys and manages
-Ceph clusters using Ansible.
-
-* ceph-ansible is widely deployed.
-* ceph-ansible is not integrated with the orchestrator APIs that were
-  introduced in Nautilus and Octopus, which means that the management features
-  and dashboard integration introduced in Nautilus and Octopus are not
-  available in Ceph clusters deployed by means of ceph-ansible.
 
 `ceph-salt <https://github.com/ceph/ceph-salt>`_ installs Ceph using Salt and cephadm.
 


### PR DESCRIPTION
## Problem

`doc/install/index.rst` contained version floor statements anchored to
EOL releases and an outdated reference to ceph-ansible.

## Changes

Per reviewer feedback:

- Remove the "cephadm supports only X and newer releases" bullet —
  version floor claims are hard to maintain accurately across backports
  and future releases; users should consult the cephadm documentation
  for current version support.
- Remove the "Rook supports only Y and newer releases of Ceph" bullet —
  Rook's supported Ceph versions change with each Rook release; users
  should consult https://rook.io/docs for current compatibility.
- Remove the ceph-ansible section — ceph-ansible is not recommended for
  new deployments and should not appear alongside cephadm and Rook as
  a peer option in the install overview.

Fixes: https://tracker.ceph.com/issues/77192

Signed-off-by: Emmanuel Ameh <eameh@contractor.linuxfoundation.org>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [x] No tests