### PR TITLE
doc: Remove SysVinit/upstart references from user-facing docs

### DIFF
--- a/doc/ceph-volume/index.rst
+++ b/doc/ceph-volume/index.rst
@@ -12,8 +12,7 @@ follow a predictable and robust way of preparing, activating, and starting OSDs.
 
 **Command Line Subcommands**
 
-There is currently support for ``lvm``, and plain disks (with GPT partitions)
-that may have been deployed with ``ceph-disk``.
+There is currently support for ``lvm``, and plain disks (with GPT partitions).
 
 ``zfs`` support is available for running a FreeBSD cluster.
 

--- a/doc/ceph-volume/index.rst
+++ b/doc/ceph-volume/index.rst
@@ -2,7 +2,7 @@
 
 ceph-volume
 ===========
-Deploy OSDs with different device technologies like LVM or physical disks using
+Deploy OSDs with different device technologies like LVM or physical devices using
 pluggable tools (:doc:`lvm/index` itself is treated like a plugin) and trying to
 follow a predictable and robust way of preparing, activating, and starting OSDs.
 
@@ -12,7 +12,7 @@ follow a predictable and robust way of preparing, activating, and starting OSDs.
 
 **Command Line Subcommands**
 
-There is currently support for ``lvm``, and plain disks (with GPT partitions)
+There is currently support for ``lvm``, and plain devices (with GPT partitions)
 that may have been deployed with ``ceph-disk``.
 
 ``zfs`` support is available for running a FreeBSD cluster.
@@ -24,7 +24,7 @@ that may have been deployed with ``ceph-disk``.
 **Node inventory**
 
 The :ref:`ceph-volume-inventory` subcommand provides information and metadata
-about a node's physical disk inventory.
+about a node's physical device inventory.
 
 
 Migrating
@@ -53,8 +53,8 @@ ceph-disk <ceph-disk-replaced>` section.
 New deployments
 ^^^^^^^^^^^^^^^
 For new deployments, :ref:`ceph-volume-lvm` is recommended. It can use any
-logical volume as input for data OSDs, or it can setup a minimal/naive logical
-volume from a device.
+logical volume for OSDs, or it can set up a minimal logical
+volume on a device.
 
 Existing OSDs
 ^^^^^^^^^^^^^

--- a/doc/ceph-volume/index.rst
+++ b/doc/ceph-volume/index.rst
@@ -12,7 +12,8 @@ follow a predictable and robust way of preparing, activating, and starting OSDs.
 
 **Command Line Subcommands**
 
-There is currently support for ``lvm``, and plain disks (with GPT partitions).
+There is currently support for ``lvm``, and plain disks (with GPT partitions)
+that may have been deployed with ``ceph-disk``.
 
 ``zfs`` support is available for running a FreeBSD cluster.
 

--- a/doc/rados/operations/operating.rst
+++ b/doc/rados/operations/operating.rst
@@ -10,7 +10,9 @@ Running Ceph with systemd
 
 In deployments managed by systemd, Ceph daemons behave like any other
 daemons that can be controlled by the ``systemctl`` command, as in
-the following examples:
+the following examples. Note that this applies to Podman-based container
+deployments. Docker-based deployments do not integrate with systemd in the
+same way and may require different management commands.
 
 .. prompt:: bash $
 

--- a/doc/rados/operations/operating.rst
+++ b/doc/rados/operations/operating.rst
@@ -8,10 +8,9 @@
 Running Ceph with systemd
 =========================
 
-In all distributions that support systemd (CentOS 7, Fedora, Debian
-Jessie 8 and later, and SUSE), systemd files (and NOT legacy SysVinit scripts) 
-are used to manage Ceph daemons. Ceph daemons therefore behave like any other daemons 
-that can be controlled by the ``systemctl`` command, as in the following examples:
+In deployments managed by systemd, Ceph daemons behave like any other
+daemons that can be controlled by the ``systemctl`` command, as in
+the following examples:
 
 .. prompt:: bash $
 
@@ -115,60 +114,4 @@ For example:
    sudo systemctl stop ceph-mds@ceph-server
 
 
-.. index:: sysvinit; operating a cluster
-
-Running Ceph with SysVinit
-==========================
-
-Each time you start, restart, or stop Ceph daemons, you must specify at least one option and one command.
-Likewise, each time you start, restart, or stop your entire cluster, you must specify at least one option and one command.
-In both cases, you can also specify a daemon type or a daemon instance. ::
-
-    {commandline} [options] [commands] [daemons]
-
-The ``ceph`` options include:
-
-+-----------------+----------+-------------------------------------------------+
-| Option          | Shortcut | Description                                     |
-+=================+==========+=================================================+
-| ``--verbose``   |  ``-v``  | Use verbose logging.                            |
-+-----------------+----------+-------------------------------------------------+
-| ``--valgrind``  | ``N/A``  | (Dev and QA only) Use `Valgrind`_ debugging.    |
-+-----------------+----------+-------------------------------------------------+
-| ``--allhosts``  |  ``-a``  | Execute on all nodes listed in ``ceph.conf``.   |
-|                 |          | Otherwise, it only executes on ``localhost``.   |
-+-----------------+----------+-------------------------------------------------+
-| ``--restart``   | ``N/A``  | Automatically restart daemon if it core dumps.  |
-+-----------------+----------+-------------------------------------------------+
-| ``--norestart`` | ``N/A``  | Do not restart a daemon if it core dumps.       |
-+-----------------+----------+-------------------------------------------------+
-| ``--conf``      |  ``-c``  | Use an alternate configuration file.            |
-+-----------------+----------+-------------------------------------------------+
-
-The ``ceph`` commands include:
-
-+------------------+------------------------------------------------------------+
-| Command          | Description                                                |
-+==================+============================================================+
-|    ``start``     | Start the daemon(s).                                       |
-+------------------+------------------------------------------------------------+
-|    ``stop``      | Stop the daemon(s).                                        |
-+------------------+------------------------------------------------------------+
-|  ``forcestop``   | Force the daemon(s) to stop. Same as ``kill -9``.          |
-+------------------+------------------------------------------------------------+
-|   ``killall``    | Kill all daemons of a particular type.                     |
-+------------------+------------------------------------------------------------+
-|  ``cleanlogs``   | Cleans out the log directory.                              |
-+------------------+------------------------------------------------------------+
-| ``cleanalllogs`` | Cleans out **everything** in the log directory.            |
-+------------------+------------------------------------------------------------+
-
-The ``[daemons]`` option allows the ``ceph`` service to target specific daemon types
-in order to perform subsystem operations. Daemon types include:
-
-- ``mon``
-- ``osd``
-- ``mds``
-
 .. _Valgrind: http://www.valgrind.org/
-.. _initctl: http://manpages.ubuntu.com/manpages/raring/en/man8/initctl.8.html

--- a/doc/rados/operations/operating.rst
+++ b/doc/rados/operations/operating.rst
@@ -9,10 +9,10 @@ Running Ceph with systemd
 =========================
 
 In deployments managed by systemd, Ceph daemons behave like any other
-daemons that can be controlled by the ``systemctl`` command, as in
+services controlled by the ``systemctl`` command, as in
 the following examples. Note that this applies to Podman-based container
 deployments. Docker-based deployments do not integrate with systemd in the
-same way and may require different management commands.
+same way and might require different management commands.
 
 .. prompt:: bash $
 

--- a/doc/start/os-recommendations.rst
+++ b/doc/start/os-recommendations.rst
@@ -63,9 +63,9 @@ The chart below shows the platforms for which Ceph provides packages, and
 the platforms on which Ceph has been tested.
 
 Ceph does not require a specific Linux distribution. Ceph can run on any
-distribution that includes a supported kernel and supported system startup
-framework, for example ``sysvinit`` or ``systemd``. Ceph is sometimes ported to
-non-Linux systems but these are not supported by the core Ceph effort.
+distribution that includes a supported kernel and ``systemd``. Ceph is
+sometimes ported to non-Linux systems but these are not supported by the
+core Ceph effort.
 
 +----------------+-------------------------+----------------+-------------------+-----------------+----------------+----------------+----------------+
 | Distribution   | Distribution EOL        | Squid (19.2.z) | Tentacle (20.2.z) | Umbrella (21.x) | Vampire (22.x) | W (23.x)       | X (24.x)       |


### PR DESCRIPTION
## Problem

Ceph has required systemd for several release cycles, but three
user-facing pages still referenced SysVinit and upstart as valid
init systems:

- `rados/operations/operating.rst` contained a full indexed
  \"Running Ceph with SysVinit\" section (54 lines of tables and
  commands) and mentioned a stale set of distros (CentOS 7, Debian
  Jessie 8, SUSE) in the systemd intro paragraph.
- `ceph-volume/intro.rst:54` listed \"upstart, sysvinit, etc.\" as
  init systems ceph-disk had to support.
- `start/os-recommendations.rst:65` listed ``sysvinit`` alongside
  ``systemd`` as an example supported init framework.

## Changes

- **operating.rst**: Remove the SysVinit section and its index entry.
  Clean up the systemd intro paragraph to remove the outdated distro
  list and the \"(and NOT legacy SysVinit scripts)\" parenthetical.
  Remove the now-unused ``initctl`` link reference.
- **ceph-volume/intro.rst**: Replace \"(upstart, sysvinit, etc.)\" with
  \"multiple init systems\" in the historical ceph-disk context paragraph.
- **os-recommendations.rst**: Remove ``sysvinit`` from the supported
  init framework list; retain only ``systemd``.

Fixes: https://tracker.ceph.com/issues/77187

Signed-off-by: Emmanuel Ameh <eameh@contractor.linuxfoundation.org>