### PR TITLE
doc/rados/configuration: Fix FileStore contradiction in journal-ref.rst

### DIFF
--- a/doc/rados/configuration/journal-ref.rst
+++ b/doc/rados/configuration/journal-ref.rst
@@ -1,34 +1,13 @@
 ==========================
  Journal Config Reference
 ==========================
-.. warning:: Filestore has been deprecated in the Reef release and is no longer supported.
+.. warning:: Filestore is not supported. Migrate existing Filestore OSDs to
+   BlueStore. See :ref:`rados_operations_bluestore_migration`.
+
 .. index:: journal; journal configuration
 
-Filestore OSDs use a journal for two reasons: speed and consistency.  Note
-that since Luminous, the BlueStore OSD back end has been preferred and default.
-This information is provided for pre-existing OSDs and for rare situations where
-Filestore is preferred for new deployments.
-
-- **Speed:** The journal enables the Ceph OSD Daemon to commit small writes 
-  quickly. Ceph writes small, random I/O to the journal sequentially, which 
-  tends to speed up bursty workloads by allowing the backing file system more 
-  time to coalesce writes. The Ceph OSD Daemon's journal, however, can lead 
-  to spiky performance with short spurts of high-speed writes followed by 
-  periods without any write progress as the file system catches up to the 
-  journal.
-
-- **Consistency:** Ceph OSD Daemons require a file system interface that 
-  guarantees atomic compound operations. Ceph OSD Daemons write a description 
-  of the operation to the journal and apply the operation to the file system. 
-  This enables atomic updates to an object (for example, placement group 
-  metadata). Every few seconds--between ``filestore max sync interval`` and
-  ``filestore min sync interval``--the Ceph OSD Daemon stops writes and 
-  synchronizes the journal with the file system, allowing Ceph OSD Daemons to 
-  trim operations from the journal and reuse the space. On failure, Ceph 
-  OSD Daemons replay the journal starting after the last synchronization 
-  operation.
-
-Ceph OSD Daemons recognize the following journal settings: 
+The following journal settings are provided for reference to assist with
+migration of existing Filestore OSDs to BlueStore.
 
 .. confval:: journal_dio
 .. confval:: journal_aio


### PR DESCRIPTION
## Problem

`journal-ref.rst` contained a direct contradiction:

- Line 4: `.. warning:: Filestore has been deprecated in the Reef
  release and is no longer supported.`
- Line 10: `This information is provided for pre-existing OSDs and
  for rare situations where **Filestore is preferred for new
  deployments**.`

An operator reading line 10 would conclude that deploying new
Filestore OSDs is acceptable, directly contradicting the deprecation
warning on line 4.

## Changes

- Expand the warning to explicitly state: "Do not use Filestore for
  new deployments. Use BlueStore instead." This removes any ambiguity.
- Add a blank line after the warning directive for correct RST
  rendering.
- Update the intro paragraph: remove "preferred for new deployments",
  establish BlueStore as the default/recommended back end, and scope
  the page to pre-existing Filestore OSDs pending migration.

Fixes: https://tracker.ceph.com/issues/77183

Signed-off-by: Emmanuel Ameh <eameh@contractor.linuxfoundation.org>