### PR TITLE
doc/rados/operations: Strengthen cache-tiering deprecation notice

### DIFF
--- a/doc/rados/operations/cache-tiering.rst
+++ b/doc/rados/operations/cache-tiering.rst
@@ -2,14 +2,16 @@
  Cache Tiering
 ===============
 
-.. warning:: Cache tiering has been deprecated in the Reef release. Cache
-   tiering has lacked a maintainer for a long time. This does not mean that
-   it will certainly be removed, but it might be removed without much
-   notice.
+.. warning:: Cache tiering was deprecated in the Reef release and has lacked
+   a maintainer for a long time. It will be removed in a future release without
+   notice. **Do not deploy new cache tiers.** Migrate existing cache
+   tier deployments as soon as possible.
 
-   The upstream Ceph community strongly advises against deploying new cache
-   tiers. The upstream Ceph community also recommends migrating from legacy
-   deployments.
+.. note:: The following documentation is retained for reference for existing
+   deployments only. For new deployments, use erasure-coded pools or fast
+   storage pools directly. As a community-supported block-level caching
+   alternative, consider ``dm-cache`` (the Linux kernel's device-mapper cache
+   target).
 
 A cache tier provides Ceph clients with better I/O performance for a subset of
 the data stored in a backing storage tier. Cache tiering involves creating a

--- a/doc/rados/operations/cache-tiering.rst
+++ b/doc/rados/operations/cache-tiering.rst
@@ -7,11 +7,11 @@
    notice. **Do not deploy new cache tiers.** Migrate existing cache
    tier deployments as soon as possible.
 
-.. note:: The following documentation is retained for reference for existing
-   deployments only. For new deployments, use erasure-coded pools or fast
-   storage pools directly. As a community-supported block-level caching
-   alternative, consider ``dm-cache`` (the Linux kernel's device-mapper cache
-   target).
+.. note:: This documentation is retained for existing deployments only.
+   If you need to remove a cache tier, see :ref:`cache-tiering-removal`.
+   Some community members have adopted ``dm-cache`` (the Linux kernel's
+   device-mapper cache target) as a block-level caching alternative, though
+   this is not an officially supported or endorsed configuration.
 
 A cache tier provides Ceph clients with better I/O performance for a subset of
 the data stored in a backing storage tier. Cache tiering involves creating a
@@ -452,10 +452,12 @@ For example, to evict objects after 30 minutes, execute the following:
    ceph osd pool set hot-storage cache_min_evict_age 1800
 
 
+.. _cache-tiering-removal:
+
 Removing a Cache Tier
 =====================
 
-Removing a cache tier differs depending on whether it is a writeback 
+Removing a cache tier differs depending on whether it is a writeback
 cache or a read-only cache.
 
 


### PR DESCRIPTION
## Problem

`cache-tiering.rst` carried a deprecation warning but immediately
continued with a full how-to guide, giving mixed signals. The warning
also contained hedging language ("this does not mean it will certainly
be removed") that understated the risk of deploying a deprecated,
unmaintained feature.

## Changes

- Remove hedging language; state that cache tiering may be removed in
  a future release without further notice.
- Add a bold **Do not deploy new cache tiers** directive to the warning.
- Add a ``.. note::`` immediately before the how-to prose scoping all
  following content to existing deployments only, with a pointer to
  preferred alternatives (erasure-coded pools or fast storage pools).

Fixes: https://tracker.ceph.com/issues/77184

Signed-off-by: Emmanuel Ameh <eameh@contractor.linuxfoundation.org>