### PR TITLE
doc/radosgw: Remove stale versionadded directives for EOL releases

### DIFF
--- a/doc/radosgw/adminops.rst
+++ b/doc/radosgw/adminops.rst
@@ -1068,8 +1068,6 @@ generated key is added to the keyring without replacing an existing key pair.
 If ``access-key`` is specified and refers to an existing key owned by the user
 then it will be modified.
 
-.. versionadded:: Luminous
-
 A ``tenant`` may either be specified as a part of uid or as an additional
 request param.
 
@@ -1162,8 +1160,6 @@ A tenant name may also specified as a part of ``uid``, by following the syntax
 :Type: Boolean
 :Example: False [False]
 :Required: No
-
-.. versionadded:: Jewel
 
 ``tenant``
 

--- a/doc/radosgw/archive-sync-module.rst
+++ b/doc/radosgw/archive-sync-module.rst
@@ -2,8 +2,6 @@
 Archive Sync Module
 ===================
 
-.. versionadded:: Nautilus
-
 The Archive Sync module uses the RGW versioning feature of S3 objects to
 maintain an archive zone that captures successive versions of objects
 as they are updated in other zones.  Archive zone objects can

--- a/doc/radosgw/bucketpolicy.rst
+++ b/doc/radosgw/bucketpolicy.rst
@@ -2,8 +2,6 @@
 Bucket Policies
 ===============
 
-.. versionadded:: Luminous
-
 The Ceph Object Gateway supports a subset of the Amazon S3 policy
 language applied to buckets.
 

--- a/doc/radosgw/cloud-sync-module.rst
+++ b/doc/radosgw/cloud-sync-module.rst
@@ -2,8 +2,6 @@
 Cloud Sync Module
 =================
 
-.. versionadded:: Mimic
-
 This module syncs zone data to a remote cloud service. The sync is unidirectional; data is not synced back from the
 remote zone. The goal of this module is to enable syncing data to multiple cloud providers. The currently supported
 cloud providers are those that are compatible with AWS (S3).

--- a/doc/radosgw/compression.rst
+++ b/doc/radosgw/compression.rst
@@ -4,8 +4,6 @@
 Compression
 ===========
 
-.. versionadded:: Kraken
-
 The Ceph Object Gateway supports server-side compression of uploaded objects.
 
 .. note:: The Reef release added a :ref:`feature_compress_encrypted` zonegroup

--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -153,8 +153,6 @@ thread running:
 Multisite Settings
 ==================
 
-.. versionadded:: Jewel
-
 You may include the following settings in your Ceph configuration
 file under each ``[client.radosgw.{instance-name}]`` instance.
 
@@ -274,8 +272,6 @@ SSE-S3 Settings
 
 QoS Settings
 ============
-
-.. versionadded:: Nautilus
 
 The older and now non-default ``civetweb`` frontend has a threading model that uses a thread per
 connection and hence is automatically throttled by :confval:`rgw_thread_pool_size`

--- a/doc/radosgw/dynamicresharding.rst
+++ b/doc/radosgw/dynamicresharding.rst
@@ -4,8 +4,6 @@
 RGW Dynamic Bucket Index Resharding
 ===================================
 
-.. versionadded:: Luminous
-
 A bucket index object with too many entries can lead to performance
 problems. This can be addressed by resharding bucket indexes.  Until
 Luminous, changing the number of bucket shards (resharding) could only

--- a/doc/radosgw/elastic-sync-module.rst
+++ b/doc/radosgw/elastic-sync-module.rst
@@ -4,8 +4,6 @@
 Elasticsearch Sync Module
 =========================
 
-.. versionadded:: Kraken
-
 .. note::
      As of 31 May 2020, only Elasticsearch 6 and lower are supported. Elasticsearch 7 is not supported.
 
@@ -87,8 +85,6 @@ sync initialization.
 
 End user metadata queries
 -------------------------
-
-.. versionadded:: Luminous
 
 Since the Elasticsearch cluster now stores object metadata, it is important that
 the Elasticsearch endpoint is not exposed to the public and only accessible to

--- a/doc/radosgw/encryption.rst
+++ b/doc/radosgw/encryption.rst
@@ -4,8 +4,6 @@
 Encryption
 ==========
 
-.. versionadded:: Luminous
-
 The Ceph Object Gateway supports server-side encryption of uploaded objects,
 with 3 options for the management of encryption keys. Server-side encryption
 means that the data is sent over HTTP in its unencrypted form, and the Ceph

--- a/doc/radosgw/frontends.rst
+++ b/doc/radosgw/frontends.rst
@@ -13,8 +13,6 @@ for details about the syntax.
 Beast
 =====
 
-.. versionadded:: Mimic
-
 The ``beast`` frontend uses the Boost.Beast library for HTTP parsing
 and the Boost.Asio library for asynchronous network I/O.
 

--- a/doc/radosgw/ldap-auth.rst
+++ b/doc/radosgw/ldap-auth.rst
@@ -2,8 +2,6 @@
 LDAP Authentication
 ===================
 
-.. versionadded:: Jewel
-
 You can delegate the Ceph Object Gateway authentication to an LDAP server.
 
 How it works

--- a/doc/radosgw/mfa.rst
+++ b/doc/radosgw/mfa.rst
@@ -4,8 +4,6 @@
 RGW Support for Multifactor Authentication
 ==========================================
 
-.. versionadded:: Mimic
-
 The S3 multifactor authentication (MFA) feature allows
 users to require the use of one-time password when removing
 objects on certain buckets. The buckets need to be configured

--- a/doc/radosgw/multisite.rst
+++ b/doc/radosgw/multisite.rst
@@ -22,8 +22,6 @@ instances that make use of a single Ceph storage cluster.
 Varieties of Multi-site Configuration
 -------------------------------------
 
-.. versionadded:: Jewel
-
 Since the Kraken release, Ceph has supported several multi-site configurations
 for the Ceph Object Gateway:
 

--- a/doc/radosgw/multitenancy.rst
+++ b/doc/radosgw/multitenancy.rst
@@ -4,8 +4,6 @@
 RGW Multi-tenancy
 =================
 
-.. versionadded:: Jewel
-
 The multi-tenancy feature allows to use buckets and users of the same
 name simultaneously by segregating them under so-called ``tenants``.
 This may be useful, for instance, to permit users of Swift API to

--- a/doc/radosgw/nfs.rst
+++ b/doc/radosgw/nfs.rst
@@ -2,8 +2,6 @@
 NFS
 ===
 
-.. versionadded:: Jewel
-
 .. note:: Only the NFSv4 protocol is supported when using a cephadm or Rook based deployment.
 
 Ceph Object Gateway namespaces can be exported via NFSv4,

--- a/doc/radosgw/notifications.rst
+++ b/doc/radosgw/notifications.rst
@@ -4,8 +4,6 @@
 Bucket Notifications
 ====================
 
-.. versionadded:: Nautilus
-
 .. versionchanged:: Squid
    A new "v2" format for Topic and Notification metadata can be enabled with
    the :ref:`feature_notification_v2` zone feature.

--- a/doc/radosgw/orphans.rst
+++ b/doc/radosgw/orphans.rst
@@ -2,8 +2,6 @@
 Orphan List and Associated Tooling
 ==================================
 
-.. versionadded:: Luminous
-
 .. contents::
 
 Orphans are RADOS objects that are left behind after their associated

--- a/doc/radosgw/placement.rst
+++ b/doc/radosgw/placement.rst
@@ -7,8 +7,6 @@ Pool Placement and Storage Classes
 Placement Targets
 =================
 
-.. versionadded:: Jewel
-
 Placement targets control which :ref:`radosgw-pools` are associated with a particular
 bucket. A bucket's placement target is selected on creation, and cannot be
 modified. The ``radosgw-admin bucket stats`` command will display its
@@ -25,8 +23,6 @@ and a ``data_pool`` name for each storage class.
 
 Storage Classes
 ===============
-
-.. versionadded:: Nautilus
 
 Storage classes specify the placement of object data. S3 Bucket
 Lifecycle (LC) rules can automate the transition of objects between storage classes.

--- a/doc/radosgw/pools.rst
+++ b/doc/radosgw/pools.rst
@@ -25,8 +25,6 @@ pool creation.
 Pool Namespaces
 ===============
 
-.. versionadded:: Luminous
-
 Pool names particular to a zone follow the naming convention
 ``{zone-name}.pool-name``. For example, a zone named ``us-east`` will
 have the following pools:

--- a/doc/radosgw/sync-modules.rst
+++ b/doc/radosgw/sync-modules.rst
@@ -2,8 +2,6 @@
 Sync Modules
 ============
 
-.. versionadded:: Kraken
-
 The :ref:`multisite` functionality of RGW introduced in Jewel allowed the ability to
 create multiple zones and mirror data and metadata between them. *Sync Modules*
 are built on top of the multisite framework that allows for forwarding data and


### PR DESCRIPTION
## Problem

20 files in `doc/radosgw/` contained `.. versionadded::` directives
pinned to EOL releases (Jewel, Kraken, Luminous, Mimic, Nautilus).
Every feature covered by these directives has been present in all
currently-supported Ceph releases. The directives add visual noise
without providing useful information to users of supported releases.

## Changes

Remove all `.. versionadded::` directives referencing Jewel, Kraken,
Luminous, Mimic, or Nautilus from 20 radosgw files (48 lines removed).
Directives for Octopus and later are retained.

**Files changed:** adminops, archive-sync-module, bucketpolicy,
cloud-sync-module, compression, config-ref, dynamicresharding,
elastic-sync-module, encryption, frontends, ldap-auth, mfa, multisite,
multitenancy, nfs, notifications, orphans, placement, pools,
sync-modules.

Fixes: https://tracker.ceph.com/issues/77194

Signed-off-by: Emmanuel Ameh <eameh@contractor.linuxfoundation.org>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [x] No tests