### PR TITLE
doc/man: Remove stale EOL release names from deprecation notices

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -756,10 +756,7 @@ Usage::
 
 Subcommand ``create`` creates new OSD (with optional UUID and ID).
 
-This command is DEPRECATED as of the Luminous release, and will be removed in
-a future release.
-
-Subcommand ``new`` should instead be used.
+This command is deprecated. Use ``ceph osd new`` instead.
 
 Usage::
 

--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -783,11 +783,10 @@ Per client instance `rbd device map` options:
   For msgr2.1 protocol this option is ignored.
 
 * cephx_require_signatures - Require msgr1 message signing feature (since 3.19,
-  default).  This option is deprecated and will be removed in the future as the
-  feature has been supported since the Bobtail release.
+  default).  This option is deprecated and will be removed in a future release.
 
 * nocephx_require_signatures - Don't require msgr1 message signing feature
-  (since 3.19).  This option is deprecated and will be removed in the future.
+  (since 3.19).  This option is deprecated and will be removed in a future release.
 
 * tcp_nodelay - Disable Nagle's algorithm on client sockets (since 4.0,
   default).


### PR DESCRIPTION
## Problem

Two man pages contained deprecation notices anchored to EOL releases:

- `man/8/ceph.rst`: `ceph osd create` was marked **"DEPRECATED as of
  the Luminous release"** (Luminous: 2017, EOL 2020). The notice cited
  an 8-year-old release as its anchor.
- `man/8/rbd.rst:786`: `cephx_require_signatures` option was
  deprecated with the explanation "the feature has been supported since
  the **Bobtail** release" (Bobtail: 2013, EOL 2015). The 12-year-old
  release name was the only justification given.

## Changes

- **ceph.rst**: Replace the verbose DEPRECATED-as-of-Luminous sentence
  with a concise "This command is deprecated. Use ``ceph osd new``
  instead."
- **rbd.rst**: Remove "as the feature has been supported since the
  Bobtail release" from the `cephx_require_signatures` notice. Fix
  the companion `nocephx_require_signatures` notice for consistency
  ("in a future release" vs "in the future").

Note: `man/8/monmaptool.rst` and `man/8/ceph-conf.rst` were reviewed
and found to contain current guidance with no stale release names —
no changes made to those files.

Fixes: https://tracker.ceph.com/issues/77191

Signed-off-by: Emmanuel Ameh <eameh@contractor.linuxfoundation.org>