### PR TITLE
osd/EC: fix truncate and sparse write in single transaction

### DIFF
--- a/src/osd/ECTransaction.cc
+++ b/src/osd/ECTransaction.cc
@@ -266,15 +266,6 @@ ECTransaction::WritePlanObj::WritePlanObj(
    * read the existing data on the partial stripe.
    */
   if (op.truncate && op.truncate->first < orig_size) {
-    if (to_read) {
-      ECUtil::shard_extent_set_t truncate_mask(sinfo.get_k_plus_m());
-      sinfo.ro_range_to_shard_extent_set(0, op.truncate->first, truncate_mask);
-      
-      to_read->intersection_of(truncate_mask);
-      if (to_read->empty()) {
-          to_read = std::nullopt;
-      }
-    }
     ECUtil::shard_extent_set_t truncate_read(sinfo.get_k_plus_m());
     uint64_t prev_stripe = sinfo.ro_offset_to_prev_stripe_ro_offset(op.truncate->first);
     uint64_t next_align = ECUtil::align_next(op.truncate->first);

--- a/src/osd/ECTransaction.cc
+++ b/src/osd/ECTransaction.cc
@@ -148,7 +148,7 @@ ECTransaction::WritePlanObj::WritePlanObj(
    * 2. ALL delete operations (do NOT use is_delete() here!!!)
    * 3. Truncates that reduce size.
    */
-  invalidates_cache = op.has_source(&source) || op.delete_first || projected_size < orig_size;
+  invalidates_cache = op.has_source(&source) || op.delete_first || (op.truncate && op.truncate->first < orig_size);
 
   op.buffer_updates.to_interval_set(unaligned_ro_writes);
 
@@ -214,7 +214,7 @@ ECTransaction::WritePlanObj::WritePlanObj(
 
       /* Here we decide if we want to do a conventional write or a parity delta write. */
       if (sinfo.supports_parity_delta_writes() && !object_in_cache &&
-          orig_size == projected_size && !reads.empty()) {
+          orig_size == projected_size && !reads.empty() && !op.truncate) {
 
         shard_id_set read_shards = reads.get_shard_id_set();
         shard_id_set pdw_read_shards = pdw_reads.get_shard_id_set();
@@ -266,6 +266,15 @@ ECTransaction::WritePlanObj::WritePlanObj(
    * read the existing data on the partial stripe.
    */
   if (op.truncate && op.truncate->first < orig_size) {
+    if (to_read) {
+      ECUtil::shard_extent_set_t truncate_mask(sinfo.get_k_plus_m());
+      sinfo.ro_range_to_shard_extent_set(0, op.truncate->first, truncate_mask);
+      
+      to_read->intersection_of(truncate_mask);
+      if (to_read->empty()) {
+          to_read = std::nullopt;
+      }
+    }
     ECUtil::shard_extent_set_t truncate_read(sinfo.get_k_plus_m());
     uint64_t prev_stripe = sinfo.ro_offset_to_prev_stripe_ro_offset(op.truncate->first);
     uint64_t next_align = ECUtil::align_next(op.truncate->first);
@@ -293,7 +302,7 @@ ECTransaction::WritePlanObj::WritePlanObj(
 
       // We only need to update the parity buffer for the write
       for (auto && shard : sinfo.get_parity_shards()) {
-        will_write[shard] = truncate_write;
+        will_write[shard].insert(truncate_write);
       }
     }
   }

--- a/src/osd/ECTransaction.cc
+++ b/src/osd/ECTransaction.cc
@@ -266,6 +266,15 @@ ECTransaction::WritePlanObj::WritePlanObj(
    * read the existing data on the partial stripe.
    */
   if (op.truncate && op.truncate->first < orig_size) {
+    if (to_read) {
+      ECUtil::shard_extent_set_t truncate_mask(sinfo.get_k_plus_m());
+      sinfo.ro_range_to_shard_extent_set(0, op.truncate->first, truncate_mask);
+      
+      to_read->intersection_of(truncate_mask);
+      if (to_read->empty()) {
+          to_read = std::nullopt;
+      }
+    }
     ECUtil::shard_extent_set_t truncate_read(sinfo.get_k_plus_m());
     uint64_t prev_stripe = sinfo.ro_offset_to_prev_stripe_ro_offset(op.truncate->first);
     uint64_t next_align = ECUtil::align_next(op.truncate->first);

--- a/src/osd/ECTransaction.cc
+++ b/src/osd/ECTransaction.cc
@@ -757,17 +757,21 @@ void ECTransaction::Generate::appends_and_clone_ranges() {
 
   extent_set clone_ranges = plan.will_write.get_extent_superset();
   uint64_t clone_max = ECUtil::align_next(plan.orig_size);
+  uint64_t truncated_size = plan.orig_size;
   ldpp_dout(dpp, 20) << __func__ << dendl;
 
   if (op.delete_first) {
-    clone_max = 0;
-  } else if (op.truncate && op.truncate->first < clone_max) {
-    clone_max = ECUtil::align_next(op.truncate->first);
+    truncated_size = clone_max = 0;
+  } else if (op.truncate) {
+    truncated_size = op.truncate->first;
+    if (op.truncate->first < clone_max) {
+      clone_max = ECUtil::align_next(op.truncate->first);
+    }
   }
   ECUtil::shard_extent_set_t cloneable_range(sinfo.get_k_plus_m());
   sinfo.ro_size_to_read_mask(clone_max, cloneable_range);
 
-  if (plan.orig_size < plan.projected_size) {
+  if (truncated_size < plan.projected_size) {
     ECUtil::shard_extent_set_t projected_cloneable_range(sinfo.get_k_plus_m());
     sinfo.ro_size_to_read_mask(plan.projected_size,projected_cloneable_range);
 

--- a/src/test/osd/PGBackendTestFixture.cc
+++ b/src/test/osd/PGBackendTestFixture.cc
@@ -755,6 +755,124 @@ int PGBackendTestFixture::read_object(
   }
 }
 
+void PGBackendTestFixture::visualize_miscompare(
+  const std::string& obj_name,
+  const char* expected_buf,
+  const char* read_buf,
+  size_t size,
+  const std::string& phase)
+{
+  bool mismatch_found = false;
+  size_t first_mismatch = 0;
+  size_t last_mismatch = 0;
+  
+  // Find mismatches
+  for (size_t i = 0; i < size; i++) {
+    if (read_buf[i] != expected_buf[i]) {
+      if (!mismatch_found) {
+        first_mismatch = i;
+        mismatch_found = true;
+      }
+      last_mismatch = i;
+    }
+  }
+  
+  if (!mismatch_found) {
+    return;  // No mismatches to visualize
+  }
+  
+  std::cout << "\n=== MISCOMPARE DETECTED in " << phase << " ===" << std::endl;
+  std::cout << "Object: " << obj_name << std::endl;
+  if (pool_type == EC) {
+    std::cout << "Config: k=" << k << " m=" << m << " stripe_unit=" << stripe_unit << std::endl;
+  } else {
+    std::cout << "Config: Replicated pool, size=" << num_replicas << std::endl;
+  }
+  std::cout << "Miscompare range: [" << first_mismatch << ", " << last_mismatch << "]" << std::endl;
+  std::cout << "Total mismatches: " << (last_mismatch - first_mismatch + 1) << " bytes" << std::endl;
+  
+  // Show detailed hex+ASCII dump around first mismatch
+  size_t dump_start = (first_mismatch > 64) ? (first_mismatch - 64) : 0;
+  size_t dump_end = std::min(last_mismatch + 64, size);
+  
+  std::cout << "\nHex+ASCII dump around first mismatch [" << dump_start << ", " << dump_end << "):" << std::endl;
+  std::cout << "Offset   Hex                                              ASCII" << std::endl;
+  
+  std::string last_line_hex;
+  std::string last_line_ascii;
+  int repeat_count = 0;
+  
+  for (size_t i = dump_start; i < dump_end; i += 16) {
+    // Build hex representation
+    std::ostringstream hex_stream;
+    for (size_t j = 0; j < 16 && (i + j) < dump_end; j++) {
+      unsigned char c = read_buf[i + j];
+      bool mismatch = (c != expected_buf[i + j]);
+      if (mismatch) hex_stream << "\033[1;31m";
+      hex_stream << std::setw(2) << std::setfill('0') << std::hex << (int)c;
+      if (mismatch) hex_stream << "\033[0m";
+      hex_stream << " ";
+    }
+    std::string hex_line = hex_stream.str();
+    
+    // Build ASCII representation
+    std::ostringstream ascii_stream;
+    for (size_t j = 0; j < 16 && (i + j) < dump_end; j++) {
+      char c = read_buf[i + j];
+      bool mismatch = (c != expected_buf[i + j]);
+      if (mismatch) ascii_stream << "\033[1;31m";
+      ascii_stream << (isprint(c) ? c : '.');
+      if (mismatch) ascii_stream << "\033[0m";
+    }
+    std::string ascii_line = ascii_stream.str();
+    
+    // Check if this line is identical to the last line
+    if (hex_line == last_line_hex && ascii_line == last_line_ascii && i > dump_start) {
+      repeat_count++;
+      continue;
+    }
+    
+    // Print any accumulated repeats
+    if (repeat_count > 0) {
+      std::cout << "         * " << repeat_count << " identical line(s) omitted *" << std::endl;
+      repeat_count = 0;
+    }
+    
+    // Print current line
+    std::cout << std::setw(8) << std::setfill('0') << std::hex << i << " "
+              << std::setw(48) << std::left << hex_line << " " << ascii_line
+              << std::dec << std::endl;
+    
+    last_line_hex = hex_line;
+    last_line_ascii = ascii_line;
+  }
+  
+  // Print any remaining repeats
+  if (repeat_count > 0) {
+    std::cout << "         * " << repeat_count << " identical line(s) omitted *" << std::endl;
+  }
+  
+  // Show expected vs read comparison
+  std::cout << "\nExpected vs Read (first 128 bytes of miscompare):" << std::endl;
+  size_t compare_len = std::min(size_t(128), last_mismatch - first_mismatch + 1);
+  
+  std::cout << "Expected: ";
+  for (size_t i = 0; i < compare_len; i++) {
+    char c = expected_buf[first_mismatch + i];
+    std::cout << (isprint(c) ? c : '.');
+  }
+  std::cout << std::endl;
+  
+  std::cout << "Read:     ";
+  for (size_t i = 0; i < compare_len; i++) {
+    char c = read_buf[first_mismatch + i];
+    if (c != expected_buf[first_mismatch + i]) std::cout << "\033[1;31m";
+    std::cout << (isprint(c) ? c : '.');
+    if (c != expected_buf[first_mismatch + i]) std::cout << "\033[0m";
+  }
+  std::cout << std::endl;
+}
+
 void PGBackendTestFixture::verify_object(
   const std::string& obj_name,
   const std::string& expected_data,
@@ -768,8 +886,22 @@ void PGBackendTestFixture::verify_object(
   EXPECT_EQ(read_data.length(), expected_data.length()) << "Read data length should match";
   
   if (read_data.length() == expected_data.length()) {
-    std::string read_string(read_data.c_str(), read_data.length());
-    EXPECT_EQ(read_string, expected_data) << "Data should match";
+    const char* read_buf = read_data.c_str();
+    const char* expected_buf = expected_data.c_str();
+    
+    // Check for mismatches
+    bool has_mismatch = false;
+    for (size_t i = 0; i < expected_data.length(); i++) {
+      if (read_buf[i] != expected_buf[i]) {
+        has_mismatch = true;
+        break;
+      }
+    }
+    
+    if (has_mismatch) {
+      visualize_miscompare(obj_name, expected_buf, read_buf, expected_data.length(), "verify_object");
+      FAIL() << "Data mismatch detected";
+    }
   }
 }
 

--- a/src/test/osd/PGBackendTestFixture.cc
+++ b/src/test/osd/PGBackendTestFixture.cc
@@ -600,6 +600,98 @@ int PGBackendTestFixture::write(
   return result;
 }
 
+int PGBackendTestFixture::write(
+  const std::string& obj_name,
+  uint64_t object_size,
+  std::optional<uint64_t> truncate_size,
+  const std::vector<std::pair<uint64_t, std::string>>& writes)
+{
+  hobject_t hoid = make_test_object(obj_name);
+  PGTransactionUPtr pg_t = std::make_unique<PGTransaction>();
+
+  ObjectContextRef obc = get_or_create_obc(hoid, true, object_size);
+  pg_t->obc_map[hoid] = obc;
+
+  // Track outstanding write
+  outstanding_writes[hoid]++;
+
+  // Apply truncate if specified
+  if (truncate_size.has_value()) {
+    pg_t->truncate(hoid, truncate_size.value());
+  }
+
+  // Apply all writes
+  uint64_t new_size = truncate_size.value_or(object_size);
+  for (const auto& [offset, data] : writes) {
+    bufferlist bl;
+    bl.append(data);
+    pg_t->write(hoid, offset, bl.length(), bl);
+    new_size = std::max(new_size, offset + bl.length());
+  }
+
+  object_stat_sum_t delta_stats;
+  if (new_size > object_size) {
+    delta_stats.num_bytes = new_size - object_size;
+  } else if (new_size < object_size) {
+    delta_stats.num_bytes = -(int64_t)(object_size - new_size);
+  } else {
+    delta_stats.num_bytes = 0;
+  }
+
+  // Prior version comes from the object's current version
+  eversion_t prior_version = obc->obs.oi.version;
+  eversion_t at_version = get_next_version();
+
+  // Build the NEW OI
+  object_info_t new_oi = obc->obs.oi;
+  new_oi.version = at_version;
+  new_oi.prior_version = prior_version;
+  new_oi.size = new_size;
+
+  // Encode new OI into PGTransaction
+  {
+    bufferlist oi_bl;
+    new_oi.encode(oi_bl,
+      osdmap->get_features(CEPH_ENTITY_TYPE_OSD, nullptr));
+    pg_t->setattr(hoid, OI_ATTR, oi_bl);
+  }
+
+  // Update OBC obs to new state BEFORE submitting
+  obc->obs.oi = new_oi;
+
+  std::vector<pg_log_entry_t> log_entries;
+  pg_log_entry_t entry;
+  entry.op = pg_log_entry_t::MODIFY;
+  entry.soid = hoid;
+  entry.version = at_version;
+  entry.prior_version = prior_version;
+  log_entries.push_back(entry);
+
+  // Create completion lambda for write-specific cleanup
+  auto write_complete = [this, hoid, obc, prior_version, object_size](int r) {
+    // Decrement outstanding writes counter
+    if (outstanding_writes[hoid] > 0) {
+      outstanding_writes[hoid]--;
+      if (outstanding_writes[hoid] == 0) {
+        outstanding_writes.erase(hoid);
+      }
+    }
+
+    if (r != 0 && r != -EINPROGRESS) {
+      // Roll back OBC on failure
+      obc->obs.oi.version = prior_version;
+      obc->obs.oi.size = object_size;
+      obc->attr_cache.clear();
+      outstanding_writes.erase(hoid);
+    }
+  };
+
+  int result = do_transaction_and_complete(
+    hoid, std::move(pg_t), delta_stats, at_version, std::move(log_entries), write_complete);
+
+  return result;
+}
+
 int PGBackendTestFixture::read_object(
   const std::string& obj_name,
   uint64_t offset,

--- a/src/test/osd/PGBackendTestFixture.h
+++ b/src/test/osd/PGBackendTestFixture.h
@@ -379,6 +379,21 @@ public:
     const std::string& data,
     uint64_t object_size);
 
+  /**
+   * Write operation with optional truncate and multiple writes in a single transaction.
+   *
+   * @param obj_name Name of the object
+   * @param object_size Current size of the object
+   * @param truncate_size Optional truncate size (nullopt means no truncate)
+   * @param writes Vector of {offset, data} pairs to write
+   * @return Result code (0 on success, negative on error)
+   */
+  int write(
+    const std::string& obj_name,
+    uint64_t object_size,
+    std::optional<uint64_t> truncate_size,
+    const std::vector<std::pair<uint64_t, std::string>>& writes);
+
   int read_object(
     const std::string& obj_name,
     uint64_t offset,

--- a/src/test/osd/PGBackendTestFixture.h
+++ b/src/test/osd/PGBackendTestFixture.h
@@ -414,6 +414,22 @@ public:
    * @param offset Offset to read from (default: 0)
    * @param context_msg Optional context message to append to assertion messages
    */
+  /**
+   * Visualize data miscompare with hex+ASCII dump and line compression.
+   *
+   * @param obj_name Name of the object being compared
+   * @param expected_buf Expected data buffer
+   * @param read_buf Actual read data buffer
+   * @param size Size of both buffers
+   * @param phase Description of when the comparison occurred (e.g., "After shard 1 failure")
+   */
+  void visualize_miscompare(
+    const std::string& obj_name,
+    const char* expected_buf,
+    const char* read_buf,
+    size_t size,
+    const std::string& phase);
+
   void verify_object(
     const std::string& obj_name,
     const std::string& expected_data,

--- a/src/test/osd/TestBackendBasics.cc
+++ b/src/test/osd/TestBackendBasics.cc
@@ -384,6 +384,247 @@ TEST_P(TestBackendBasics, DirectRead) {
 }
 
 // ---------------------------------------------------------------------------
+// TestBackendBasics: TruncateAndWrite
+// ---------------------------------------------------------------------------
+
+/**
+ * TruncateAndWrite - test truncate to 0 followed by writes in a single transaction.
+ *
+ * This test verifies the behavior described in the failing test_ec_transaction test
+ * "truncate_then_write_one_shard" at a higher level using the full backend.
+ *
+ * The test:
+ * 1. Creates a 20k object
+ * 2. In one transaction, truncates to 0, then writes at:
+ *    - chunk_size~chunk_size (e.g., 4k~4k for k=4,m=2,su=4k)
+ *    - (chunk_size * (k+1))~chunk_size (e.g., 20k~4k)
+ * 3. Reads back and verifies the resulting 16k object
+ *
+ * This exercises the EC transaction planning logic for truncate+write operations
+ * and ensures data integrity across the operation.
+ */
+TEST_P(TestBackendBasics, TruncateAndWrite) {
+  const auto& param = GetParam().write_read;
+  const auto& backend_config = GetParam().backend;
+
+  // Skip test for non-EC backends - truncate behavior is different
+  if (backend_config.pool_type != EC) {
+    GTEST_SKIP() << "TruncateAndWrite test only applies to EC backends";
+  }
+
+  std::string obj_name = "test_truncate_write_" + backend_config.label + "_" + param.label;
+
+  // Step 1: Create a 20k object
+  const size_t initial_size = (2 * k + 1) * stripe_unit;
+  std::string initial_data(initial_size, 'X');
+  
+  int result = create_and_write(obj_name, initial_data);
+  EXPECT_EQ(result, 0) << param.label << " initial write should complete successfully";
+  verify_object(obj_name, initial_data, 0, initial_size);
+
+  // Step 2: In one transaction, truncate to 0 and write at two offsets
+  uint64_t first_write_offset = stripe_unit;
+  uint64_t second_write_offset = stripe_unit * (k + 1);
+  uint64_t final_size = second_write_offset + stripe_unit;
+  
+  result = write(
+    obj_name,
+    initial_size,
+    0,  // truncate to 0
+    {
+      {first_write_offset, std::string(stripe_unit, 'A')},
+      {second_write_offset, std::string(stripe_unit, 'B')}
+    }
+  );
+  
+  EXPECT_EQ(result, 0) << param.label << " truncate+write transaction should complete successfully";
+  
+  // Step 3: Build expected data and verify
+  std::string expected_data(final_size, '\0');
+  for (size_t i = first_write_offset; i < first_write_offset + stripe_unit; i++) {
+    expected_data[i] = 'A';
+  }
+  for (size_t i = second_write_offset; i < second_write_offset + stripe_unit; i++) {
+    expected_data[i] = 'B';
+  }
+  
+  verify_object(obj_name, expected_data, 0, final_size);
+  
+  // Clean up
+  auto* primary_listener = get_primary_listener();
+  if (primary_listener) {
+    primary_listener->sent_messages.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// TestBackendBasics: TruncateToChunkSizeAndWrite
+// ---------------------------------------------------------------------------
+
+/**
+ * TruncateToChunkSizeAndWrite - test truncate to chunk_size followed by writes in a single transaction.
+ *
+ * This is a variant of TruncateAndWrite that truncates to chunk_size (4k) instead of 0.
+ * This tests a different code path in the EC transaction planning logic.
+ *
+ * The test:
+ * 1. Creates a (2*k+1)*chunk_size object (e.g., 36k for k=4)
+ * 2. In one transaction, truncates to chunk_size (4k), then writes at:
+ *    - chunk_size~chunk_size (e.g., 4k~4k for k=4,m=2,su=4k)
+ *    - (chunk_size * (k+1))~chunk_size (e.g., 20k~4k)
+ * 3. Reads back and verifies the resulting object
+ *
+ * Expected result is an object with:
+ * - [0, chunk_size): original data (preserved by truncate to 4k)
+ * - [chunk_size, 2*chunk_size): 'A' characters (first write)
+ * - [2*chunk_size, (k+1)*chunk_size): zeros (sparse region)
+ * - [(k+1)*chunk_size, (k+2)*chunk_size): 'B' characters (second write)
+ */
+TEST_P(TestBackendBasics, TruncateToChunkSizeAndWrite) {
+  const auto& param = GetParam().write_read;
+  const auto& backend_config = GetParam().backend;
+
+  // Skip test for non-EC backends - truncate behavior is different
+  if (backend_config.pool_type != EC) {
+    GTEST_SKIP() << "TruncateToChunkSizeAndWrite test only applies to EC backends";
+  }
+
+  std::string obj_name = "test_truncate4k_write_" + backend_config.label + "_" + param.label;
+
+  // Step 1: Create object which will be shrunk
+  const size_t initial_size = (2 * k + 1) * stripe_unit;
+  std::string initial_data(initial_size, 'X');
+  
+  int result = create_and_write(obj_name, initial_data);
+  EXPECT_EQ(result, 0) << param.label << " initial write should complete successfully";
+  verify_object(obj_name, initial_data, 0, initial_size);
+
+  // Step 2: In one transaction, truncate to chunk_size and write at two offsets
+  uint64_t first_write_offset = stripe_unit;
+  uint64_t second_write_offset = stripe_unit * (k + 1);
+  uint64_t final_size = second_write_offset + stripe_unit;
+  
+  result = write(
+    obj_name,
+    initial_size,
+    stripe_unit,  // truncate to chunk_size (4k)
+    {
+      {first_write_offset, std::string(stripe_unit, 'A')},
+      {second_write_offset, std::string(stripe_unit, 'B')}
+    }
+  );
+  
+  EXPECT_EQ(result, 0) << param.label << " truncate+write transaction should complete successfully";
+  
+  // Step 3: Build expected data and verify
+  std::string expected_data(final_size, '\0');
+  // Preserved region [0, chunk_size) with original 'X' data
+  for (size_t i = 0; i < stripe_unit; i++) {
+    expected_data[i] = 'X';
+  }
+  // 'A' region at [chunk_size, 2*chunk_size)
+  for (size_t i = first_write_offset; i < first_write_offset + stripe_unit; i++) {
+    expected_data[i] = 'A';
+  }
+  // 'B' region at [(k+1)*chunk_size, (k+2)*chunk_size)
+  for (size_t i = second_write_offset; i < second_write_offset + stripe_unit; i++) {
+    expected_data[i] = 'B';
+  }
+  
+  verify_object(obj_name, expected_data, 0, final_size);
+  
+  // Clean up
+  auto* primary_listener = get_primary_listener();
+  if (primary_listener) {
+    primary_listener->sent_messages.clear();
+  }
+}
+
+
+// ---------------------------------------------------------------------------
+// TestBackendBasics: TruncateToChunkSizeAndWrite
+// ---------------------------------------------------------------------------
+
+/**
+ * TruncateToChunkSizeAndWrite - test truncate to chunk_size followed by writes in a single transaction.
+ *
+ * This is a variant of TruncateAndWrite that truncates to chunk_size (4k) instead of 0.
+ * This tests a different code path in the EC transaction planning logic.
+ *
+ * The test:
+ * 1. Creates a 20k object
+ * 2. In one transaction, truncates to chunk_size (4k), then writes at:
+ *    - chunk_size~chunk_size (e.g., 4k~4k for k=4,m=2,su=4k)
+ *    - (chunk_size * (k+1))~chunk_size (e.g., 20k~4k)
+ * 3. Reads back and verifies the resulting object
+ *
+ * Expected result is an object with:
+ * - [0, chunk_size): original data (preserved by truncate to 4k)
+ * - [chunk_size, 2*chunk_size): 'A' characters (first write)
+ * - [2*chunk_size, (k+1)*chunk_size): zeros (sparse region)
+ * - [(k+1)*chunk_size, (k+2)*chunk_size): 'B' characters (second write)
+ */
+TEST_P(TestBackendBasics, TruncateToChunkSizeAndWriteToSameSize) {
+  const auto& param = GetParam().write_read;
+  const auto& backend_config = GetParam().backend;
+
+  // Skip test for non-EC backends - truncate behavior is different
+  if (backend_config.pool_type != EC) {
+    GTEST_SKIP() << "TruncateToChunkSizeAndWrite test only applies to EC backends";
+  }
+
+  std::string obj_name = "test_truncate4k_write_" + backend_config.label + "_" + param.label;
+
+  // Step 1: Create object which will be shrunk
+  const size_t initial_size = (k + 2) * stripe_unit;
+  std::string initial_data(initial_size, 'X');
+  
+  int result = create_and_write(obj_name, initial_data);
+  EXPECT_EQ(result, 0) << param.label << " initial write should complete successfully";
+  verify_object(obj_name, initial_data, 0, initial_size);
+
+  // Step 2: In one transaction, truncate to chunk_size and write at two offsets
+  uint64_t first_write_offset = stripe_unit;
+  uint64_t second_write_offset = stripe_unit * (k + 1);
+  uint64_t final_size = second_write_offset + stripe_unit;
+  
+  result = write(
+    obj_name,
+    initial_size,
+    stripe_unit,  // truncate to chunk_size (4k)
+    {
+      {first_write_offset, std::string(stripe_unit, 'A')},
+      {second_write_offset, std::string(stripe_unit, 'B')}
+    }
+  );
+  
+  EXPECT_EQ(result, 0) << param.label << " truncate+write transaction should complete successfully";
+  
+  // Step 3: Build expected data and verify
+  std::string expected_data(final_size, '\0');
+  // Preserved region [0, chunk_size) with original 'X' data
+  for (size_t i = 0; i < stripe_unit; i++) {
+    expected_data[i] = 'X';
+  }
+  // 'A' region at [chunk_size, 2*chunk_size)
+  for (size_t i = first_write_offset; i < first_write_offset + stripe_unit; i++) {
+    expected_data[i] = 'A';
+  }
+  // 'B' region at [(k+1)*chunk_size, (k+2)*chunk_size)
+  for (size_t i = second_write_offset; i < second_write_offset + stripe_unit; i++) {
+    expected_data[i] = 'B';
+  }
+  
+  verify_object(obj_name, expected_data, 0, final_size);
+  
+  // Clean up
+  auto* primary_listener = get_primary_listener();
+  if (primary_listener) {
+    primary_listener->sent_messages.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Backend configurations and size parameters
 // ---------------------------------------------------------------------------
 

--- a/src/test/osd/TestBackendBasics.cc
+++ b/src/test/osd/TestBackendBasics.cc
@@ -617,6 +617,13 @@ TEST_P(TestBackendBasics, TruncateToChunkSizeAndWriteToSameSize) {
   
   verify_object(obj_name, expected_data, 0, final_size);
   
+  // Step 4: Fail shard 1 (which received the write) and verify object can still be read
+  // For optimized EC, shard 1 is a data shard that received part of the write
+  simulate_multiple_osd_failures({1});
+  
+  // Verify the object can still be read correctly via EC reconstruction
+  verify_object(obj_name, expected_data, 0, final_size);
+  
   // Clean up
   auto* primary_listener = get_primary_listener();
   if (primary_listener) {

--- a/src/test/osd/test_ec_transaction.cc
+++ b/src/test/osd/test_ec_transaction.cc
@@ -505,3 +505,62 @@ TEST(ectransaction, truncate_to_stripe) {
   ECUtil::shard_extent_set_t ref_write(sinfo.get_k_plus_m());
   ASSERT_EQ(ref_write, plan.will_write);
 }
+
+TEST(ectransaction, truncate_then_write_one_shard) {
+  hobject_t h;
+  PGTransaction::ObjectOperation op;
+  bufferlist a, b;
+
+  // Simulate a sparsify operation that overwrites an existing object with data at
+  // specific offsets, creating a sparse pattern.
+  //
+  // Initial object is 20k, with zeros at 0~4k, 8k~4k, 16k~4k
+  //
+  // The sparsify operation writes at offsets 4k~4k and 12k~4k.
+  op.truncate = std::pair(0, 0);
+  
+  // First write at offset 4096, length 4KB (0~4096)
+  a.append_zero(4096);
+  op.buffer_updates.insert(4096, a.length(), PGTransaction::ObjectOperation::BufferUpdate::Write{a, 0});
+  
+  // Second write at offset 12288 (12KB), length 4KB
+  b.append_zero(4096);
+  op.buffer_updates.insert(12288, b.length(), PGTransaction::ObjectOperation::BufferUpdate::Write{b, 0});
+
+  pg_pool_t pool;
+  pool.set_flag(pg_pool_t::FLAG_EC_OPTIMIZATIONS);
+  
+  // EC configuration: k=2, m=1, chunk_size=4096 (matching FastEC profile)
+  ECUtil::stripe_info_t sinfo(2, 1, 8192, &pool, std::vector<shard_id_t>(0));
+  
+  // Set current object size to 16384 (16KB) - the object exists with this size
+  object_info_t oi;
+  oi.size = 16384;
+  
+  shard_id_set shards;
+  shards.insert_range(shard_id_t(0), 3);  // k=2 + m=1 = 3 shards
+
+  ECTransaction::WritePlanObj plan(
+    h,
+    op,
+    sinfo,
+    shards,
+    shards,
+    false,
+    20480,  // current_size
+    oi,
+    std::nullopt,
+    0);
+
+  generic_derr << "plan " << plan << dendl;
+
+  // With truncate 0, we're starting fresh - no reads should be required
+  ASSERT_FALSE(plan.to_read);
+  
+  // Truncates are handled by the transaction generation. 
+  ECUtil::shard_extent_set_t ref_write(sinfo.get_k_plus_m());
+  ref_write[shard_id_t(1)].insert(0, 8192);
+  ref_write[shard_id_t(2)].insert(0, 8192);
+  
+  ASSERT_EQ(ref_write, plan.will_write);
+}


### PR DESCRIPTION
Issue : Incorrect clone range calculation
When determining if an object is growing (and thus needs clone operations), the code was comparing against orig_size rather than the effective size after truncate/delete operations. This caused incorrect clone behavior for truncate+write transactions.

Fix: Introduce a read_max variable that tracks the effective size after truncate/delete operations, separate from clone_max (the aligned size for cloning). Use read_max instead of orig_size when determining if the object is growing.

Fixes: https://tracker.ceph.com/issues/77276


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
