### PR TITLE
tentacle: mgr/DaemonServer: clarify ok-to-upgrade error message for CRUSH buckets

### DIFF
--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -2367,9 +2367,11 @@ bool DaemonServer::_handle_command(
         cmdctx->reply(-EAGAIN, ss);
       }
       if (!pg_offline_report.ok_to_stop()) {
-        ss << "unsafe to upgrade osd(s) at this time ("
+        ss << "unsafe to upgrade OSD(s) at this time (at least "
            << pg_offline_report.not_ok.size()
-           << " PGs are or would become offline)";
+           << " PG(s) will become offline if any OSD out of the "
+           << osds_in_crush_bucket.size() << " in CRUSH bucket '"
+           << crush_bucket_name << "' is stopped)";
         cmdctx->reply(-EBUSY, ss);
       }
       // ok_to_upgrade() would be false in case all osds are upgraded


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77126

---

backport of https://github.com/ceph/ceph/pull/69270
parent tracker: https://tracker.ceph.com/issues/74612

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh