### PR TITLE
cmake: disable Catch2 tests when Catch2 is unavailable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -545,7 +545,14 @@ if(WITH_CATCH2)
   # Restore the original CPM settings in case someone else wants to use the module:
   set(CPM_USE_LOCAL_PACKAGES_ONLY, ${ORIG_CPM_USE_LOCAL_PACKAGES_ONLY})
 
-  message("-- Enabled Catch2 support")
+  # CPM skips the fetch silently if downloads are disabled,
+  # e.g. with FETCHCONTENT_FULLY_DISCONNECTED=ON on deb builds
+  if(NOT TARGET Catch2::Catch2WithMain)
+    message(WARNING "Catch2 unavailable, disabling Catch2 tests")
+    set(WITH_CATCH2 OFF)
+  else()
+    message("-- Enabled Catch2 support")
+  endif()
 endif()
 
 # enable breakpad unless win32 or power


### PR DESCRIPTION
CPM fetches Catch2 at configure time. When downloads are disabled — e.g.
debhelper on noble passes `-DFETCHCONTENT_FULLY_DISCONNECTED=ON` — it skips
`add_subdirectory()` silently, so no Catch2 targets exist and the generate
step fails:

```
CMake Error at cmake/modules/AddCephTest.cmake:191 (target_link_libraries):
  Target "unittest_rgw_hex" links to:

    Catch2::Catch2WithMain

  but the target was not found.
```

see
- https://github.com/ceph/ceph/pull/69372
- https://github.com/ceph/ceph/pull/69165#issuecomment-4665201947

Check that the target exists after `CPMAddPackage()` and fall back to
`WITH_CATCH2=OFF` with a warning.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests