### PR TITLE
tentacle: qa: ignore evicted client warnings for singletone bluestore

### DIFF
--- a/qa/suites/rados/singleton-bluestore/all/cephtool.yaml
+++ b/qa/suites/rados/singleton-bluestore/all/cephtool.yaml
@@ -41,6 +41,7 @@ tasks:
     - \(MON_DOWN\)
     - \(SLOW_OPS\)
     - slow request
+    - evicting unresponsive client
 - workunit:
     clients:
       all:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77281

---

backport of https://github.com/ceph/ceph/pull/68837
parent tracker: https://tracker.ceph.com/issues/76497

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh