### PR TITLE
tools/rbd/action/DiskUsage: allow checking the disk usage of non-user snapshots

### DIFF
--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -738,7 +738,7 @@
   usage: rbd disk-usage [--pool <pool>] [--namespace <namespace>] 
                         [--image <image>] [--snap <snap>] [--format <format>] 
                         [--pretty-format] [--from-snap <from-snap>] [--exact] 
-                        [--merge-snapshots] 
+                        [--merge-snapshots] [--all-snapshots] 
                         <image-or-snap-spec> 
   
   Show disk usage stats for pool, image or snapshot.
@@ -758,6 +758,8 @@
     --from-snap arg       snapshot starting point
     --exact               compute exact disk usage (slow)
     --merge-snapshots     merge snapshot sizes with its image
+    --all-snapshots       allow inspecting the disk usage of all snapshots, like
+                          group/trash/mirror snapshots
   
   rbd help encryption format
   usage: rbd encryption format [--pool <pool>] [--namespace <namespace>] 

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -737,7 +737,9 @@
   rbd help disk-usage
   usage: rbd disk-usage [--pool <pool>] [--namespace <namespace>] 
                         [--image <image>] [--snap <snap>] [--format <format>] 
-                        [--pretty-format] [--from-snap <from-snap>] [--exact] 
+                        [--pretty-format] [--snap-id <snap-id>] 
+                        [--from-snap <from-snap>] 
+                        [--from-snap-id <from-snap-id>] [--exact] 
                         [--merge-snapshots] [--all-snapshots] 
                         <image-or-snap-spec> 
   
@@ -755,11 +757,12 @@
     --snap arg            snapshot name
     --format arg          output format (plain, json, or xml) [default: plain]
     --pretty-format       pretty formatting (json and xml)
+    --snap-id arg         snapshot id
     --from-snap arg       snapshot starting point
+    --from-snap-id arg    starting snapshot id
     --exact               compute exact disk usage (slow)
     --merge-snapshots     merge snapshot sizes with its image
-    --all-snapshots       allow inspecting the disk usage of all snapshots, like
-                          group/trash/mirror snapshots
+    --all-snapshots       include snapshots from all namespaces
   
   rbd help encryption format
   usage: rbd encryption format [--pool <pool>] [--namespace <namespace>] 

--- a/src/tools/rbd/ArgumentTypes.h
+++ b/src/tools/rbd/ArgumentTypes.h
@@ -54,6 +54,7 @@ static const std::string SNAPSHOT_ID("snap-id");
 static const std::string DEST_SNAPSHOT_NAME("dest-snap");
 static const std::string PATH("path");
 static const std::string FROM_SNAPSHOT_NAME("from-snap");
+static const std::string FROM_SNAPSHOT_ID("from-snap-id");
 static const std::string WHOLE_OBJECT("whole-object");
 
 // encryption arguments

--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -1106,6 +1106,22 @@ uint64_t get_rbd_default_features(CephContext* cct) {
   return boost::lexical_cast<uint64_t>(features);
 }
 
+std::string get_snap_namespace_name(librbd::snap_namespace_type_t type)
+{
+  switch (type) {
+  case RBD_SNAP_NAMESPACE_TYPE_USER:
+    return "user";
+  case RBD_SNAP_NAMESPACE_TYPE_GROUP:
+    return "group";
+  case RBD_SNAP_NAMESPACE_TYPE_TRASH:
+    return "trash";
+  case RBD_SNAP_NAMESPACE_TYPE_MIRROR:
+    return "mirror";
+  default:
+    return "unknown (" + stringify(type) + ")";
+  }
+}
+
 bool is_not_user_snap_namespace(librbd::Image* image,
                                 const librbd::snap_info_t &snap_info)
 {

--- a/src/tools/rbd/Utils.h
+++ b/src/tools/rbd/Utils.h
@@ -238,7 +238,7 @@ void calc_sparse_extent(const bufferptr &bp,
                         uint64_t length,
                         size_t *write_length,
 			bool *zeroed);
-
+std::string get_snap_namespace_name(librbd::snap_namespace_type_t);
 bool is_not_user_snap_namespace(librbd::Image* image,
                                 const librbd::snap_info_t &snap_info);
 

--- a/src/tools/rbd/action/DiskUsage.cc
+++ b/src/tools/rbd/action/DiskUsage.cc
@@ -72,7 +72,16 @@ void format_image_disk_usage(const std::string& name,
                               uint64_t snap_id,
                               uint64_t size,
                               uint64_t used_size,
+                              librbd::Image &image,
                               TextTable& tbl, Formatter *f) {
+  std::string snap_ns_type_name;
+  if (!snap_name.empty()) {
+    librbd::snap_namespace_type_t namespace_type;
+    int r = image.snap_get_namespace_type(snap_id, &namespace_type);
+    if (r == 0) {
+      snap_ns_type_name = utils::get_snap_namespace_name(namespace_type);
+    }
+  }
   if (f) {
     f->open_object_section("image");
     f->dump_string("name", name);
@@ -80,6 +89,7 @@ void format_image_disk_usage(const std::string& name,
     if (!snap_name.empty()) {
       f->dump_string("snapshot", snap_name);
       f->dump_unsigned("snapshot_id", snap_id);
+      f->dump_string("snapshot_namespace_type", snap_ns_type_name);
     }
     f->dump_unsigned("provisioned_size", size);
     f->dump_unsigned("used_size" , used_size);
@@ -87,7 +97,7 @@ void format_image_disk_usage(const std::string& name,
   } else {
     std::string full_name = name;
     if (!snap_name.empty()) {
-      full_name += "@" + snap_name;
+      full_name += "@" + snap_name + " (" + snap_ns_type_name + ")";
     }
     tbl << full_name
         << stringify(byte_u_t(size))
@@ -234,7 +244,7 @@ static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
         }
         if (!merge_snap) {
           format_image_disk_usage(image_spec.name, image_spec.id, snap->name,
-                                   snap->id, snap->size, used_size, tbl, f);
+                                   snap->id, snap->size, used_size, image, tbl, f);
         }
 
         image_full_used_size += used_size;
@@ -272,10 +282,10 @@ static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
 
       if (!merge_snap) {
         format_image_disk_usage(image_spec.name, image_spec.id, "", CEPH_NOSNAP,
-                                 info.size, used_size, tbl, f);
+                                 info.size, used_size, image, tbl, f);
       } else {
         format_image_disk_usage(image_spec.name, image_spec.id, "", CEPH_NOSNAP,
-                                 info.size, image_full_used_size, tbl, f);
+                                 info.size, image_full_used_size, image, tbl, f);
       }
 
       total_prov += info.size;

--- a/src/tools/rbd/action/DiskUsage.cc
+++ b/src/tools/rbd/action/DiskUsage.cc
@@ -34,16 +34,11 @@ static int disk_usage_callback(uint64_t offset, size_t len, int exists,
 
 static int get_image_disk_usage(const std::string& name,
                                 const std::string& snap_name,
-                                const std::string& from_snap_name,
+                                uint64_t from_snap_id,
                                 librbd::Image &image,
                                 bool exact,
                                 uint64_t size,
                                 uint64_t *used_size){
-
-  const char* from = NULL;
-  if (!from_snap_name.empty()) {
-    from = from_snap_name.c_str();
-  }
 
   uint64_t flags;
   int r = image.get_flags(&flags);
@@ -59,7 +54,8 @@ static int get_image_disk_usage(const std::string& name,
   }
 
   *used_size = 0;
-  r = image.diff_iterate2(from, 0, size, false, !exact,
+  r = image.diff_iterate3(from_snap_id, 0, size,
+                          exact ? 0 : RBD_DIFF_ITERATE_FLAG_WHOLE_OBJECT,
                           &disk_usage_callback, used_size);
   if (r < 0) {
     std::cerr << "rbd: failed to iterate diffs: " << cpp_strerror(r)
@@ -182,7 +178,7 @@ static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
     bool found_from_snap = (from_snapname == nullptr);
     bool found_snap = (snapname == nullptr);
     bool found_from = (from_snapname == nullptr);
-    std::string last_snap_name;
+    uint64_t last_snap_id = 0;
     std::sort(snap_list.begin(), snap_list.end(),
               boost::bind(&librbd::snap_info_t::id, _1) <
                 boost::bind(&librbd::snap_info_t::id, _2));
@@ -232,7 +228,7 @@ static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
       if (imgname == nullptr || found_from_snap ||
          (found_from_snap && snapname != nullptr && snap->name == snapname)) {
 
-        r = get_image_disk_usage(image_spec.name, snap->name, last_snap_name, image, exact, snap->size, &used_size);
+        r = get_image_disk_usage(image_spec.name, snap->name, last_snap_id, image, exact, snap->size, &used_size);
         if (r < 0) {
           goto out;
         }
@@ -257,7 +253,7 @@ static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
       if (snapname != nullptr && snap->name == snapname) {
         break;
       }
-      last_snap_name = snap->name;
+      last_snap_id = snap->id;
     }
 
     if (snapname == NULL) {
@@ -267,7 +263,7 @@ static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
                  << " to head: " << cpp_strerror(r) << std::endl;
         goto out;
       }
-      r = get_image_disk_usage(image_spec.name, "", last_snap_name, image, exact, info.size, &used_size);
+      r = get_image_disk_usage(image_spec.name, "", last_snap_id, image, exact, info.size, &used_size);
       if (r < 0) {
         goto out;
       }

--- a/src/tools/rbd/action/DiskUsage.cc
+++ b/src/tools/rbd/action/DiskUsage.cc
@@ -103,7 +103,7 @@ void format_image_disk_usage(const std::string& name,
 static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
                          const char *imgname, const char *snapname,
                          const char *from_snapname, bool exact, Formatter *f,
-                         bool merge_snap) {
+                         bool merge_snap, bool all_snap) {
   std::vector<librbd::image_spec_t> images;
   int r = rbd.list2(io_ctx, &images);
   if (r == -ENOENT) {
@@ -172,10 +172,12 @@ static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
       continue;
     }
 
-    snap_list.erase(remove_if(snap_list.begin(),
-                              snap_list.end(),
-                              boost::bind(utils::is_not_user_snap_namespace, &image, _1)),
-                    snap_list.end());
+    if (!all_snap) {
+      snap_list.erase(remove_if(snap_list.begin(),
+                                snap_list.end(),
+                                boost::bind(utils::is_not_user_snap_namespace, &image, _1)),
+                      snap_list.end());
+    }
 
     bool found_from_snap = (from_snapname == nullptr);
     bool found_snap = (snapname == nullptr);
@@ -218,19 +220,19 @@ static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
 
     for (std::vector<librbd::snap_info_t>::const_iterator snap =
          snap_list.begin(); snap != snap_list.end(); ++snap) {
-      librbd::Image snap_image;
-      r = rbd.open_read_only(io_ctx, snap_image, image_spec.name.c_str(),
-                             snap->name.c_str());
+      r = image.snap_set_by_id(snap->id);
       if (r < 0) {
-        std::cerr << "rbd: error opening snapshot " << image_spec.name << "@"
-                  << snap->name << ": " << cpp_strerror(r) << std::endl;
+        std::cerr << "rbd: error setting image "
+                  << image_spec.name << "@" << snap->name
+                  << " to snap id " << snap->id
+                  << ": " << cpp_strerror(r) << std::endl;
         goto out;
       }
 
       if (imgname == nullptr || found_from_snap ||
          (found_from_snap && snapname != nullptr && snap->name == snapname)) {
 
-        r = get_image_disk_usage(image_spec.name, snap->name, last_snap_name, snap_image, exact, snap->size, &used_size);
+        r = get_image_disk_usage(image_spec.name, snap->name, last_snap_name, image, exact, snap->size, &used_size);
         if (r < 0) {
           goto out;
         }
@@ -259,6 +261,12 @@ static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
     }
 
     if (snapname == NULL) {
+      r = image.snap_set_by_id(CEPH_NOSNAP);
+      if (r < 0) {
+        std::cerr << "rbd: error setting image " << image_spec.name
+                 << " to head: " << cpp_strerror(r) << std::endl;
+        goto out;
+      }
       r = get_image_disk_usage(image_spec.name, "", last_snap_name, image, exact, info.size, &used_size);
       if (r < 0) {
         goto out;
@@ -316,7 +324,10 @@ void get_arguments(po::options_description *positional,
      "snapshot starting point")
     ("exact", po::bool_switch(), "compute exact disk usage (slow)")
     ("merge-snapshots", po::bool_switch(),
-     "merge snapshot sizes with its image");
+     "merge snapshot sizes with its image")
+    ("all-snapshots", po::bool_switch(),
+     "allow inspecting the disk usage of all snapshots, "
+     "like group/trash/mirror snapshots");
 }
 
 int execute(const po::variables_map &vm,
@@ -360,7 +371,8 @@ int execute(const po::variables_map &vm,
                     snap_name.empty() ? nullptr : snap_name.c_str(),
                     from_snap_name.empty() ? nullptr : from_snap_name.c_str(),
                     vm["exact"].as<bool>(), formatter.get(),
-                    vm["merge-snapshots"].as<bool>());
+                    vm["merge-snapshots"].as<bool>(),
+                    vm["all-snapshots"].as<bool>());
   if (r < 0) {
     std::cerr << "rbd: du failed: " << cpp_strerror(r) << std::endl;
     return r;
@@ -368,7 +380,7 @@ int execute(const po::variables_map &vm,
   return 0;
 }
 
-Shell::SwitchArguments switched_arguments({"exact", "merge-snapshots"});
+Shell::SwitchArguments switched_arguments({"exact", "merge-snapshots", "all-snapshots"});
 Shell::Action action(
   {"disk-usage"}, {"du"}, "Show disk usage stats for pool, image or snapshot.",
   "", &get_arguments, &execute);

--- a/src/tools/rbd/action/DiskUsage.cc
+++ b/src/tools/rbd/action/DiskUsage.cc
@@ -103,7 +103,7 @@ void format_image_disk_usage(const std::string& name,
 static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
                          const char *imgname, const char *snapname,
                          const char *from_snapname, bool exact, Formatter *f,
-                         bool merge_snap) {
+                         bool merge_snap, bool all_snap) {
   std::vector<librbd::image_spec_t> images;
   int r = rbd.list2(io_ctx, &images);
   if (r == -ENOENT) {
@@ -172,10 +172,12 @@ static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
       continue;
     }
 
-    snap_list.erase(remove_if(snap_list.begin(),
-                              snap_list.end(),
-                              boost::bind(utils::is_not_user_snap_namespace, &image, _1)),
-                    snap_list.end());
+    if (!all_snap) {
+      snap_list.erase(remove_if(snap_list.begin(),
+                                snap_list.end(),
+                                boost::bind(utils::is_not_user_snap_namespace, &image, _1)),
+                      snap_list.end());
+    }
 
     bool found_from_snap = (from_snapname == nullptr);
     bool found_snap = (snapname == nullptr);
@@ -218,19 +220,18 @@ static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
 
     for (std::vector<librbd::snap_info_t>::const_iterator snap =
          snap_list.begin(); snap != snap_list.end(); ++snap) {
-      librbd::Image snap_image;
-      r = rbd.open_read_only(io_ctx, snap_image, image_spec.name.c_str(),
-                             snap->name.c_str());
+      r = image.snap_set_by_id(snap->id);
       if (r < 0) {
-        std::cerr << "rbd: error opening snapshot " << image_spec.name << "@"
-                  << snap->name << ": " << cpp_strerror(r) << std::endl;
+        std::cerr << "rbd: error setting image " << image_spec.name
+          << " to snap id " << snap->id << ": " << cpp_strerror(r)
+          << std::endl;
         goto out;
       }
 
       if (imgname == nullptr || found_from_snap ||
          (found_from_snap && snapname != nullptr && snap->name == snapname)) {
 
-        r = get_image_disk_usage(image_spec.name, snap->name, last_snap_name, snap_image, exact, snap->size, &used_size);
+        r = get_image_disk_usage(image_spec.name, snap->name, last_snap_name, image, exact, snap->size, &used_size);
         if (r < 0) {
           goto out;
         }
@@ -259,6 +260,12 @@ static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
     }
 
     if (snapname == NULL) {
+      r = image.snap_set_by_id(CEPH_NOSNAP);
+      if (r < 0) {
+        std::cerr << "rbd: error setting image " << image_spec.name
+                 << " to head: " << cpp_strerror(r) << std::endl;
+        goto out;
+      }
       r = get_image_disk_usage(image_spec.name, "", last_snap_name, image, exact, info.size, &used_size);
       if (r < 0) {
         goto out;
@@ -316,7 +323,10 @@ void get_arguments(po::options_description *positional,
      "snapshot starting point")
     ("exact", po::bool_switch(), "compute exact disk usage (slow)")
     ("merge-snapshots", po::bool_switch(),
-     "merge snapshot sizes with its image");
+     "merge snapshot sizes with its image")
+    ("all-snapshots", po::bool_switch(),
+     "allow inspecting the disk usage of all snapshots, "
+     "like group/trash/mirror snapshots");
 }
 
 int execute(const po::variables_map &vm,
@@ -360,7 +370,8 @@ int execute(const po::variables_map &vm,
                     snap_name.empty() ? nullptr : snap_name.c_str(),
                     from_snap_name.empty() ? nullptr : from_snap_name.c_str(),
                     vm["exact"].as<bool>(), formatter.get(),
-                    vm["merge-snapshots"].as<bool>());
+                    vm["merge-snapshots"].as<bool>(),
+                    vm["all-snapshots"].as<bool>());
   if (r < 0) {
     std::cerr << "rbd: du failed: " << cpp_strerror(r) << std::endl;
     return r;
@@ -368,7 +379,7 @@ int execute(const po::variables_map &vm,
   return 0;
 }
 
-Shell::SwitchArguments switched_arguments({"exact", "merge-snapshots"});
+Shell::SwitchArguments switched_arguments({"exact", "merge-snapshots", "all-snapshots"});
 Shell::Action action(
   {"disk-usage"}, {"du"}, "Show disk usage stats for pool, image or snapshot.",
   "", &get_arguments, &execute);

--- a/src/tools/rbd/action/DiskUsage.cc
+++ b/src/tools/rbd/action/DiskUsage.cc
@@ -34,16 +34,11 @@ static int disk_usage_callback(uint64_t offset, size_t len, int exists,
 
 static int get_image_disk_usage(const std::string& name,
                                 const std::string& snap_name,
-                                const std::string& from_snap_name,
+                                uint64_t from_snap_id,
                                 librbd::Image &image,
                                 bool exact,
                                 uint64_t size,
                                 uint64_t *used_size){
-
-  const char* from = NULL;
-  if (!from_snap_name.empty()) {
-    from = from_snap_name.c_str();
-  }
 
   uint64_t flags;
   int r = image.get_flags(&flags);
@@ -59,7 +54,8 @@ static int get_image_disk_usage(const std::string& name,
   }
 
   *used_size = 0;
-  r = image.diff_iterate2(from, 0, size, false, !exact,
+  r = image.diff_iterate3(from_snap_id, 0, size,
+                          exact ? 0 : RBD_DIFF_ITERATE_FLAG_WHOLE_OBJECT,
                           &disk_usage_callback, used_size);
   if (r < 0) {
     std::cerr << "rbd: failed to iterate diffs: " << cpp_strerror(r)
@@ -182,7 +178,7 @@ static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
     bool found_from_snap = (from_snapname == nullptr);
     bool found_snap = (snapname == nullptr);
     bool found_from = (from_snapname == nullptr);
-    std::string last_snap_name;
+    uint64_t last_snap_id = 0;
     std::sort(snap_list.begin(), snap_list.end(),
               boost::bind(&librbd::snap_info_t::id, _1) <
                 boost::bind(&librbd::snap_info_t::id, _2));
@@ -231,7 +227,7 @@ static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
       if (imgname == nullptr || found_from_snap ||
          (found_from_snap && snapname != nullptr && snap->name == snapname)) {
 
-        r = get_image_disk_usage(image_spec.name, snap->name, last_snap_name, image, exact, snap->size, &used_size);
+        r = get_image_disk_usage(image_spec.name, snap->name, last_snap_id, image, exact, snap->size, &used_size);
         if (r < 0) {
           goto out;
         }
@@ -256,7 +252,7 @@ static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
       if (snapname != nullptr && snap->name == snapname) {
         break;
       }
-      last_snap_name = snap->name;
+      last_snap_id = snap->id;
     }
 
     if (snapname == NULL) {
@@ -266,7 +262,7 @@ static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
                  << " to head: " << cpp_strerror(r) << std::endl;
         goto out;
       }
-      r = get_image_disk_usage(image_spec.name, "", last_snap_name, image, exact, info.size, &used_size);
+      r = get_image_disk_usage(image_spec.name, "", last_snap_id, image, exact, info.size, &used_size);
       if (r < 0) {
         goto out;
       }

--- a/src/tools/rbd/action/DiskUsage.cc
+++ b/src/tools/rbd/action/DiskUsage.cc
@@ -108,7 +108,8 @@ void format_image_disk_usage(const std::string& name,
 
 static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
                          const char *imgname, const char *snapname,
-                         const char *from_snapname, bool exact, Formatter *f,
+                         const char *from_snapname, uint64_t from_id,
+                         uint64_t snap_id, bool exact, Formatter *f,
                          bool merge_snap, bool all_snap) {
   std::vector<librbd::image_spec_t> images;
   int r = rbd.list2(io_ctx, &images);
@@ -132,8 +133,6 @@ static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
   uint64_t used_size = 0;
   uint64_t total_prov = 0;
   uint64_t total_used = 0;
-  uint64_t snap_id = CEPH_NOSNAP;
-  uint64_t from_id = CEPH_NOSNAP;
   bool found = false;
   for (auto& image_spec : images) {
     if (imgname != NULL && image_spec.name != imgname) {
@@ -185,7 +184,7 @@ static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
                       snap_list.end());
     }
 
-    bool found_from_snap = (from_snapname == nullptr);
+    bool found_from_snap = ((from_snapname == nullptr) && (from_id == CEPH_NOSNAP));
     bool found_snap = (snapname == nullptr);
     bool found_from = (from_snapname == nullptr);
     uint64_t last_snap_id = 0;
@@ -222,6 +221,33 @@ static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
       }
     }
 
+    if (snap_id != CEPH_NOSNAP) {
+      bool found = false;
+      for (auto &snap_info : snap_list) {
+        if (snap_id == snap_info.id) {
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        std::cerr << "invalid snap id " << snap_id << std::endl;
+        return -EINVAL;
+      }
+    }
+    if (from_id != CEPH_NOSNAP) {
+      bool found = false;
+      for (auto &snap_info : snap_list) {
+        if (from_id == snap_info.id) {
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        std::cerr << "invalid from snap id " << from_id << std::endl;
+        return -EINVAL;
+      }
+    }
+
     uint64_t image_full_used_size = 0;
 
     for (std::vector<librbd::snap_info_t>::const_iterator snap =
@@ -248,24 +274,26 @@ static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
 
         image_full_used_size += used_size;
 
-        if (snapname != NULL) {
+        if (snapname != NULL && snap_id != CEPH_NOSNAP) {
           total_prov += snap->size;
         }
         total_used += used_size;
         ++count;
       }
 
-      if (!found_from_snap && from_snapname != nullptr &&
-          snap->name == from_snapname) {
+      if (!found_from_snap &&
+          ((from_snapname != nullptr && snap->name == from_snapname) ||
+           (from_id != CEPH_NOSNAP && snap->id == from_id))) {
         found_from_snap = true;
       }
-      if (snapname != nullptr && snap->name == snapname) {
+      if ((snapname != nullptr && snap->name == snapname) ||
+          (snap_id != CEPH_NOSNAP && snap->id == snap_id)) {
         break;
       }
       last_snap_id = snap->id;
     }
 
-    if (snapname == NULL) {
+    if (snapname == NULL && snap_id == CEPH_NOSNAP) {
       r = image.snap_set_by_id(CEPH_NOSNAP);
       if (r < 0) {
         std::cerr << "rbd: error setting image " << image_spec.name
@@ -324,15 +352,17 @@ void get_arguments(po::options_description *positional,
   at::add_image_or_snap_spec_options(positional, options,
                                      at::ARGUMENT_MODIFIER_NONE);
   at::add_format_options(options);
+  at::add_snap_id_option(options, at::ARGUMENT_MODIFIER_DEST);
   options->add_options()
     (at::FROM_SNAPSHOT_NAME.c_str(), po::value<std::string>(),
      "snapshot starting point")
+    (at::FROM_SNAPSHOT_ID.c_str(), po::value<uint64_t>(),
+     "starting snapshot id")
     ("exact", po::bool_switch(), "compute exact disk usage (slow)")
     ("merge-snapshots", po::bool_switch(),
      "merge snapshot sizes with its image")
     ("all-snapshots", po::bool_switch(),
-     "allow inspecting the disk usage of all snapshots, "
-     "like group/trash/mirror snapshots");
+     "include snapshots from all namespaces");
 }
 
 int execute(const po::variables_map &vm,
@@ -355,6 +385,32 @@ int execute(const po::variables_map &vm,
     from_snap_name = vm[at::FROM_SNAPSHOT_NAME].as<std::string>();
   }
 
+  uint64_t from_snap_id = CEPH_NOSNAP;
+  if (vm.count(at::FROM_SNAPSHOT_ID)) {
+    if (!from_snap_name.empty()) {
+      std::cerr << "--from-snap and --from-snap-id can't be set at the same time" << std::endl;
+      return -EINVAL;
+    }
+    from_snap_id = vm[at::FROM_SNAPSHOT_ID].as<uint64_t>();
+    if (from_snap_id >= CEPH_MAXSNAP) {
+      std::cerr << "invalid --from-snap-id" << std::endl;
+      return -EINVAL;
+    }
+  }
+
+  uint64_t snap_id = CEPH_NOSNAP;
+  if (vm.count(at::SNAPSHOT_ID)) {
+    if (!snap_name.empty()) {
+      std::cerr << "--snap and --snap-id can't be set at the same time" << std::endl;
+      return -EINVAL;
+    }
+    snap_id = vm[at::SNAPSHOT_ID].as<uint64_t>();
+    if (snap_id >= CEPH_MAXSNAP) {
+      std::cerr << "invalid --snap-id" << std::endl;
+      return -EINVAL;
+    }
+  }
+
   at::Format::Formatter formatter;
   r = utils::get_formatter(vm, &formatter);
   if (r < 0) {
@@ -375,6 +431,7 @@ int execute(const po::variables_map &vm,
                     image_name.empty() ? nullptr: image_name.c_str(),
                     snap_name.empty() ? nullptr : snap_name.c_str(),
                     from_snap_name.empty() ? nullptr : from_snap_name.c_str(),
+                    from_snap_id, snap_id,
                     vm["exact"].as<bool>(), formatter.get(),
                     vm["merge-snapshots"].as<bool>(),
                     vm["all-snapshots"].as<bool>());

--- a/src/tools/rbd/action/DiskUsage.cc
+++ b/src/tools/rbd/action/DiskUsage.cc
@@ -260,8 +260,7 @@ static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
         goto out;
       }
 
-      if (imgname == nullptr || found_from_snap ||
-         (found_from_snap && snapname != nullptr && snap->name == snapname)) {
+      if (imgname == nullptr || found_from_snap) {
 
         r = get_image_disk_usage(image_spec.name, snap->name, last_snap_id, image, exact, snap->size, &used_size);
         if (r < 0) {

--- a/src/tools/rbd/action/DiskUsage.cc
+++ b/src/tools/rbd/action/DiskUsage.cc
@@ -72,7 +72,16 @@ void format_image_disk_usage(const std::string& name,
                               uint64_t snap_id,
                               uint64_t size,
                               uint64_t used_size,
+                              librbd::Image &image,
                               TextTable& tbl, Formatter *f) {
+  std::string snap_ns_type_name;
+  if (!snap_name.empty()) {
+    librbd::snap_namespace_type_t namespace_type;
+    int r = image.snap_get_namespace_type(snap_id, &namespace_type);
+    if (r == 0) {
+      snap_ns_type_name = utils::get_snap_namespace_name(namespace_type);
+    }
+  }
   if (f) {
     f->open_object_section("image");
     f->dump_string("name", name);
@@ -80,6 +89,7 @@ void format_image_disk_usage(const std::string& name,
     if (!snap_name.empty()) {
       f->dump_string("snapshot", snap_name);
       f->dump_unsigned("snapshot_id", snap_id);
+      f->dump_string("snapshot_namespace_type", snap_ns_type_name);
     }
     f->dump_unsigned("provisioned_size", size);
     f->dump_unsigned("used_size" , used_size);
@@ -87,7 +97,7 @@ void format_image_disk_usage(const std::string& name,
   } else {
     std::string full_name = name;
     if (!snap_name.empty()) {
-      full_name += "@" + snap_name;
+      full_name += "@" + snap_name + " (" + snap_ns_type_name + ")";
     }
     tbl << full_name
         << stringify(byte_u_t(size))
@@ -233,7 +243,7 @@ static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
         }
         if (!merge_snap) {
           format_image_disk_usage(image_spec.name, image_spec.id, snap->name,
-                                   snap->id, snap->size, used_size, tbl, f);
+                                   snap->id, snap->size, used_size, image, tbl, f);
         }
 
         image_full_used_size += used_size;
@@ -271,10 +281,10 @@ static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
 
       if (!merge_snap) {
         format_image_disk_usage(image_spec.name, image_spec.id, "", CEPH_NOSNAP,
-                                 info.size, used_size, tbl, f);
+                                 info.size, used_size, image, tbl, f);
       } else {
         format_image_disk_usage(image_spec.name, image_spec.id, "", CEPH_NOSNAP,
-                                 info.size, image_full_used_size, tbl, f);
+                                 info.size, image_full_used_size, image, tbl, f);
       }
 
       total_prov += info.size;

--- a/src/tools/rbd/action/Snap.cc
+++ b/src/tools/rbd/action/Snap.cc
@@ -25,22 +25,6 @@ static const std::string ALL_NAME("all");
 namespace at = argument_types;
 namespace po = boost::program_options;
 
-std::string get_snap_namespace_name(librbd::snap_namespace_type_t type)
-{
-  switch (type) {
-  case RBD_SNAP_NAMESPACE_TYPE_USER:
-    return "user";
-  case RBD_SNAP_NAMESPACE_TYPE_GROUP:
-    return "group";
-  case RBD_SNAP_NAMESPACE_TYPE_TRASH:
-    return "trash";
-  case RBD_SNAP_NAMESPACE_TYPE_MIRROR:
-    return "mirror";
-  default:
-    return "unknown (" + stringify(type) + ")";
-  }
-}
-
 int do_list_snaps(librbd::Image& image, Formatter *f, bool all_snaps, librados::Rados& rados)
 {
   std::vector<librbd::snap_info_t> snaps;
@@ -153,7 +137,7 @@ int do_list_snaps(librbd::Image& image, Formatter *f, bool all_snaps, librados::
       f->dump_string("timestamp", tt_str);
       if (all_snaps) {
         f->open_object_section("namespace");
-        f->dump_string("type", get_snap_namespace_name(snap_namespace));
+        f->dump_string("type", utils::get_snap_namespace_name(snap_namespace));
         if (get_group_res == 0) {
           std::string pool_name = pool_map[group_snap.group_pool];
           f->dump_string("pool", pool_name);
@@ -161,7 +145,7 @@ int do_list_snaps(librbd::Image& image, Formatter *f, bool all_snaps, librados::
           f->dump_string("group snap", group_snap.group_snap_name);
         } else if (get_trash_res == 0) {
           f->dump_string("original_namespace_type",
-                         get_snap_namespace_name(
+                         utils::get_snap_namespace_name(
                            trash_snap.original_namespace_type));
           f->dump_string("original_name", trash_snap.original_name);
         } else if (get_mirror_res == 0) {
@@ -191,7 +175,7 @@ int do_list_snaps(librbd::Image& image, Formatter *f, bool all_snaps, librados::
 
       if (all_snaps) {
         std::ostringstream oss;
-        oss << get_snap_namespace_name(snap_namespace);
+        oss << utils::get_snap_namespace_name(snap_namespace);
 
         if (get_group_res == 0) {
           std::string pool_name = pool_map[group_snap.group_pool];
@@ -200,7 +184,7 @@ int do_list_snaps(librbd::Image& image, Formatter *f, bool all_snaps, librados::
                       << group_snap.group_snap_name << ")";
         } else if (get_trash_res == 0) {
           oss << " ("
-              << get_snap_namespace_name(trash_snap.original_namespace_type)
+              << utils::get_snap_namespace_name(trash_snap.original_namespace_type)
               << " " << trash_snap.original_name << ")";
         } else if (get_mirror_res == 0) {
           oss << " (" << mirror_snap_state << " "


### PR DESCRIPTION
Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
