### PR TITLE
osd: Tests for truncate and sparse write in the same transaction

### DIFF
--- a/src/test/osd/PGBackendTestFixture.cc
+++ b/src/test/osd/PGBackendTestFixture.cc
@@ -600,6 +600,98 @@ int PGBackendTestFixture::write(
   return result;
 }
 
+int PGBackendTestFixture::write(
+  const std::string& obj_name,
+  uint64_t object_size,
+  std::optional<uint64_t> truncate_size,
+  const std::vector<std::pair<uint64_t, std::string>>& writes)
+{
+  hobject_t hoid = make_test_object(obj_name);
+  PGTransactionUPtr pg_t = std::make_unique<PGTransaction>();
+
+  ObjectContextRef obc = get_or_create_obc(hoid, true, object_size);
+  pg_t->obc_map[hoid] = obc;
+
+  // Track outstanding write
+  outstanding_writes[hoid]++;
+
+  // Apply truncate if specified
+  if (truncate_size.has_value()) {
+    pg_t->truncate(hoid, truncate_size.value());
+  }
+
+  // Apply all writes
+  uint64_t new_size = truncate_size.value_or(object_size);
+  for (const auto& [offset, data] : writes) {
+    bufferlist bl;
+    bl.append(data);
+    pg_t->write(hoid, offset, bl.length(), bl);
+    new_size = std::max(new_size, offset + bl.length());
+  }
+
+  object_stat_sum_t delta_stats;
+  if (new_size > object_size) {
+    delta_stats.num_bytes = new_size - object_size;
+  } else if (new_size < object_size) {
+    delta_stats.num_bytes = -(int64_t)(object_size - new_size);
+  } else {
+    delta_stats.num_bytes = 0;
+  }
+
+  // Prior version comes from the object's current version
+  eversion_t prior_version = obc->obs.oi.version;
+  eversion_t at_version = get_next_version();
+
+  // Build the NEW OI
+  object_info_t new_oi = obc->obs.oi;
+  new_oi.version = at_version;
+  new_oi.prior_version = prior_version;
+  new_oi.size = new_size;
+
+  // Encode new OI into PGTransaction
+  {
+    bufferlist oi_bl;
+    new_oi.encode(oi_bl,
+      osdmap->get_features(CEPH_ENTITY_TYPE_OSD, nullptr));
+    pg_t->setattr(hoid, OI_ATTR, oi_bl);
+  }
+
+  // Update OBC obs to new state BEFORE submitting
+  obc->obs.oi = new_oi;
+
+  std::vector<pg_log_entry_t> log_entries;
+  pg_log_entry_t entry;
+  entry.op = pg_log_entry_t::MODIFY;
+  entry.soid = hoid;
+  entry.version = at_version;
+  entry.prior_version = prior_version;
+  log_entries.push_back(entry);
+
+  // Create completion lambda for write-specific cleanup
+  auto write_complete = [this, hoid, obc, prior_version, object_size](int r) {
+    // Decrement outstanding writes counter
+    if (outstanding_writes[hoid] > 0) {
+      outstanding_writes[hoid]--;
+      if (outstanding_writes[hoid] == 0) {
+        outstanding_writes.erase(hoid);
+      }
+    }
+
+    if (r != 0 && r != -EINPROGRESS) {
+      // Roll back OBC on failure
+      obc->obs.oi.version = prior_version;
+      obc->obs.oi.size = object_size;
+      obc->attr_cache.clear();
+      outstanding_writes.erase(hoid);
+    }
+  };
+
+  int result = do_transaction_and_complete(
+    hoid, std::move(pg_t), delta_stats, at_version, std::move(log_entries), write_complete);
+
+  return result;
+}
+
 int PGBackendTestFixture::read_object(
   const std::string& obj_name,
   uint64_t offset,

--- a/src/test/osd/PGBackendTestFixture.h
+++ b/src/test/osd/PGBackendTestFixture.h
@@ -379,6 +379,21 @@ public:
     const std::string& data,
     uint64_t object_size);
 
+  /**
+   * Write operation with optional truncate and multiple writes in a single transaction.
+   *
+   * @param obj_name Name of the object
+   * @param object_size Current size of the object
+   * @param truncate_size Optional truncate size (nullopt means no truncate)
+   * @param writes Vector of {offset, data} pairs to write
+   * @return Result code (0 on success, negative on error)
+   */
+  int write(
+    const std::string& obj_name,
+    uint64_t object_size,
+    std::optional<uint64_t> truncate_size,
+    const std::vector<std::pair<uint64_t, std::string>>& writes);
+
   int read_object(
     const std::string& obj_name,
     uint64_t offset,

--- a/src/test/osd/TestBackendBasics.cc
+++ b/src/test/osd/TestBackendBasics.cc
@@ -384,6 +384,247 @@ TEST_P(TestBackendBasics, DirectRead) {
 }
 
 // ---------------------------------------------------------------------------
+// TestBackendBasics: TruncateAndWrite
+// ---------------------------------------------------------------------------
+
+/**
+ * TruncateAndWrite - test truncate to 0 followed by writes in a single transaction.
+ *
+ * This test verifies the behavior described in the failing test_ec_transaction test
+ * "truncate_then_write_one_shard" at a higher level using the full backend.
+ *
+ * The test:
+ * 1. Creates a 20k object
+ * 2. In one transaction, truncates to 0, then writes at:
+ *    - chunk_size~chunk_size (e.g., 4k~4k for k=4,m=2,su=4k)
+ *    - (chunk_size * (k+1))~chunk_size (e.g., 20k~4k)
+ * 3. Reads back and verifies the resulting 16k object
+ *
+ * This exercises the EC transaction planning logic for truncate+write operations
+ * and ensures data integrity across the operation.
+ */
+TEST_P(TestBackendBasics, TruncateAndWrite) {
+  const auto& param = GetParam().write_read;
+  const auto& backend_config = GetParam().backend;
+
+  // Skip test for non-EC backends - truncate behavior is different
+  if (backend_config.pool_type != EC) {
+    GTEST_SKIP() << "TruncateAndWrite test only applies to EC backends";
+  }
+
+  std::string obj_name = "test_truncate_write_" + backend_config.label + "_" + param.label;
+
+  // Step 1: Create a 20k object
+  const size_t initial_size = (2 * k + 1) * stripe_unit;
+  std::string initial_data(initial_size, 'X');
+  
+  int result = create_and_write(obj_name, initial_data);
+  EXPECT_EQ(result, 0) << param.label << " initial write should complete successfully";
+  verify_object(obj_name, initial_data, 0, initial_size);
+
+  // Step 2: In one transaction, truncate to 0 and write at two offsets
+  uint64_t first_write_offset = stripe_unit;
+  uint64_t second_write_offset = stripe_unit * (k + 1);
+  uint64_t final_size = second_write_offset + stripe_unit;
+  
+  result = write(
+    obj_name,
+    initial_size,
+    0,  // truncate to 0
+    {
+      {first_write_offset, std::string(stripe_unit, 'A')},
+      {second_write_offset, std::string(stripe_unit, 'B')}
+    }
+  );
+  
+  EXPECT_EQ(result, 0) << param.label << " truncate+write transaction should complete successfully";
+  
+  // Step 3: Build expected data and verify
+  std::string expected_data(final_size, '\0');
+  for (size_t i = first_write_offset; i < first_write_offset + stripe_unit; i++) {
+    expected_data[i] = 'A';
+  }
+  for (size_t i = second_write_offset; i < second_write_offset + stripe_unit; i++) {
+    expected_data[i] = 'B';
+  }
+  
+  verify_object(obj_name, expected_data, 0, final_size);
+  
+  // Clean up
+  auto* primary_listener = get_primary_listener();
+  if (primary_listener) {
+    primary_listener->sent_messages.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// TestBackendBasics: TruncateToChunkSizeAndWrite
+// ---------------------------------------------------------------------------
+
+/**
+ * TruncateToChunkSizeAndWrite - test truncate to chunk_size followed by writes in a single transaction.
+ *
+ * This is a variant of TruncateAndWrite that truncates to chunk_size (4k) instead of 0.
+ * This tests a different code path in the EC transaction planning logic.
+ *
+ * The test:
+ * 1. Creates a (2*k+1)*chunk_size object (e.g., 36k for k=4)
+ * 2. In one transaction, truncates to chunk_size (4k), then writes at:
+ *    - chunk_size~chunk_size (e.g., 4k~4k for k=4,m=2,su=4k)
+ *    - (chunk_size * (k+1))~chunk_size (e.g., 20k~4k)
+ * 3. Reads back and verifies the resulting object
+ *
+ * Expected result is an object with:
+ * - [0, chunk_size): original data (preserved by truncate to 4k)
+ * - [chunk_size, 2*chunk_size): 'A' characters (first write)
+ * - [2*chunk_size, (k+1)*chunk_size): zeros (sparse region)
+ * - [(k+1)*chunk_size, (k+2)*chunk_size): 'B' characters (second write)
+ */
+TEST_P(TestBackendBasics, TruncateToChunkSizeAndWrite) {
+  const auto& param = GetParam().write_read;
+  const auto& backend_config = GetParam().backend;
+
+  // Skip test for non-EC backends - truncate behavior is different
+  if (backend_config.pool_type != EC) {
+    GTEST_SKIP() << "TruncateToChunkSizeAndWrite test only applies to EC backends";
+  }
+
+  std::string obj_name = "test_truncate4k_write_" + backend_config.label + "_" + param.label;
+
+  // Step 1: Create object which will be shrunk
+  const size_t initial_size = (2 * k + 1) * stripe_unit;
+  std::string initial_data(initial_size, 'X');
+  
+  int result = create_and_write(obj_name, initial_data);
+  EXPECT_EQ(result, 0) << param.label << " initial write should complete successfully";
+  verify_object(obj_name, initial_data, 0, initial_size);
+
+  // Step 2: In one transaction, truncate to chunk_size and write at two offsets
+  uint64_t first_write_offset = stripe_unit;
+  uint64_t second_write_offset = stripe_unit * (k + 1);
+  uint64_t final_size = second_write_offset + stripe_unit;
+  
+  result = write(
+    obj_name,
+    initial_size,
+    stripe_unit,  // truncate to chunk_size (4k)
+    {
+      {first_write_offset, std::string(stripe_unit, 'A')},
+      {second_write_offset, std::string(stripe_unit, 'B')}
+    }
+  );
+  
+  EXPECT_EQ(result, 0) << param.label << " truncate+write transaction should complete successfully";
+  
+  // Step 3: Build expected data and verify
+  std::string expected_data(final_size, '\0');
+  // Preserved region [0, chunk_size) with original 'X' data
+  for (size_t i = 0; i < stripe_unit; i++) {
+    expected_data[i] = 'X';
+  }
+  // 'A' region at [chunk_size, 2*chunk_size)
+  for (size_t i = first_write_offset; i < first_write_offset + stripe_unit; i++) {
+    expected_data[i] = 'A';
+  }
+  // 'B' region at [(k+1)*chunk_size, (k+2)*chunk_size)
+  for (size_t i = second_write_offset; i < second_write_offset + stripe_unit; i++) {
+    expected_data[i] = 'B';
+  }
+  
+  verify_object(obj_name, expected_data, 0, final_size);
+  
+  // Clean up
+  auto* primary_listener = get_primary_listener();
+  if (primary_listener) {
+    primary_listener->sent_messages.clear();
+  }
+}
+
+
+// ---------------------------------------------------------------------------
+// TestBackendBasics: TruncateToChunkSizeAndWrite
+// ---------------------------------------------------------------------------
+
+/**
+ * TruncateToChunkSizeAndWrite - test truncate to chunk_size followed by writes in a single transaction.
+ *
+ * This is a variant of TruncateAndWrite that truncates to chunk_size (4k) instead of 0.
+ * This tests a different code path in the EC transaction planning logic.
+ *
+ * The test:
+ * 1. Creates a 20k object
+ * 2. In one transaction, truncates to chunk_size (4k), then writes at:
+ *    - chunk_size~chunk_size (e.g., 4k~4k for k=4,m=2,su=4k)
+ *    - (chunk_size * (k+1))~chunk_size (e.g., 20k~4k)
+ * 3. Reads back and verifies the resulting object
+ *
+ * Expected result is an object with:
+ * - [0, chunk_size): original data (preserved by truncate to 4k)
+ * - [chunk_size, 2*chunk_size): 'A' characters (first write)
+ * - [2*chunk_size, (k+1)*chunk_size): zeros (sparse region)
+ * - [(k+1)*chunk_size, (k+2)*chunk_size): 'B' characters (second write)
+ */
+TEST_P(TestBackendBasics, TruncateToChunkSizeAndWriteToSameSize) {
+  const auto& param = GetParam().write_read;
+  const auto& backend_config = GetParam().backend;
+
+  // Skip test for non-EC backends - truncate behavior is different
+  if (backend_config.pool_type != EC) {
+    GTEST_SKIP() << "TruncateToChunkSizeAndWrite test only applies to EC backends";
+  }
+
+  std::string obj_name = "test_truncate4k_write_" + backend_config.label + "_" + param.label;
+
+  // Step 1: Create object which will be shrunk
+  const size_t initial_size = (k + 2) * stripe_unit;
+  std::string initial_data(initial_size, 'X');
+  
+  int result = create_and_write(obj_name, initial_data);
+  EXPECT_EQ(result, 0) << param.label << " initial write should complete successfully";
+  verify_object(obj_name, initial_data, 0, initial_size);
+
+  // Step 2: In one transaction, truncate to chunk_size and write at two offsets
+  uint64_t first_write_offset = stripe_unit;
+  uint64_t second_write_offset = stripe_unit * (k + 1);
+  uint64_t final_size = second_write_offset + stripe_unit;
+  
+  result = write(
+    obj_name,
+    initial_size,
+    stripe_unit,  // truncate to chunk_size (4k)
+    {
+      {first_write_offset, std::string(stripe_unit, 'A')},
+      {second_write_offset, std::string(stripe_unit, 'B')}
+    }
+  );
+  
+  EXPECT_EQ(result, 0) << param.label << " truncate+write transaction should complete successfully";
+  
+  // Step 3: Build expected data and verify
+  std::string expected_data(final_size, '\0');
+  // Preserved region [0, chunk_size) with original 'X' data
+  for (size_t i = 0; i < stripe_unit; i++) {
+    expected_data[i] = 'X';
+  }
+  // 'A' region at [chunk_size, 2*chunk_size)
+  for (size_t i = first_write_offset; i < first_write_offset + stripe_unit; i++) {
+    expected_data[i] = 'A';
+  }
+  // 'B' region at [(k+1)*chunk_size, (k+2)*chunk_size)
+  for (size_t i = second_write_offset; i < second_write_offset + stripe_unit; i++) {
+    expected_data[i] = 'B';
+  }
+  
+  verify_object(obj_name, expected_data, 0, final_size);
+  
+  // Clean up
+  auto* primary_listener = get_primary_listener();
+  if (primary_listener) {
+    primary_listener->sent_messages.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Backend configurations and size parameters
 // ---------------------------------------------------------------------------
 

--- a/src/test/osd/test_ec_transaction.cc
+++ b/src/test/osd/test_ec_transaction.cc
@@ -505,3 +505,62 @@ TEST(ectransaction, truncate_to_stripe) {
   ECUtil::shard_extent_set_t ref_write(sinfo.get_k_plus_m());
   ASSERT_EQ(ref_write, plan.will_write);
 }
+
+TEST(ectransaction, truncate_then_write_one_shard) {
+  hobject_t h;
+  PGTransaction::ObjectOperation op;
+  bufferlist a, b;
+
+  // Simulate a sparsify operation that overwrites an existing object with data at
+  // specific offsets, creating a sparse pattern.
+  //
+  // Initial object is 20k, with zeros at 0~4k, 8k~4k, 16k~4k
+  //
+  // The sparsify operation writes at offsets 4k~4k and 12k~4k.
+  op.truncate = std::pair(0, 0);
+  
+  // First write at offset 4096, length 4KB (0~4096)
+  a.append_zero(4096);
+  op.buffer_updates.insert(4096, a.length(), PGTransaction::ObjectOperation::BufferUpdate::Write{a, 0});
+  
+  // Second write at offset 12288 (12KB), length 4KB
+  b.append_zero(4096);
+  op.buffer_updates.insert(12288, b.length(), PGTransaction::ObjectOperation::BufferUpdate::Write{b, 0});
+
+  pg_pool_t pool;
+  pool.set_flag(pg_pool_t::FLAG_EC_OPTIMIZATIONS);
+  
+  // EC configuration: k=2, m=1, chunk_size=4096 (matching FastEC profile)
+  ECUtil::stripe_info_t sinfo(2, 1, 8192, &pool, std::vector<shard_id_t>(0));
+  
+  // Set current object size to 16384 (16KB) - the object exists with this size
+  object_info_t oi;
+  oi.size = 16384;
+  
+  shard_id_set shards;
+  shards.insert_range(shard_id_t(0), 3);  // k=2 + m=1 = 3 shards
+
+  ECTransaction::WritePlanObj plan(
+    h,
+    op,
+    sinfo,
+    shards,
+    shards,
+    false,
+    20480,  // current_size
+    oi,
+    std::nullopt,
+    0);
+
+  generic_derr << "plan " << plan << dendl;
+
+  // With truncate 0, we're starting fresh - no reads should be required
+  ASSERT_FALSE(plan.to_read);
+  
+  // Truncates are handled by the transaction generation. 
+  ECUtil::shard_extent_set_t ref_write(sinfo.get_k_plus_m());
+  ref_write[shard_id_t(1)].insert(0, 8192);
+  ref_write[shard_id_t(2)].insert(0, 8192);
+  
+  ASSERT_EQ(ref_write, plan.will_write);
+}


### PR DESCRIPTION
See https://github.com/ceph/ceph/pull/69368 for the bug fix that these tests are testing. 
Don't merge this PR until that PR has been merged! 

Testing
Commit 1: Adds unit test truncate_then_write_one_shard to verify read mask calculation
Commit 2: Adds three integration tests using full PGBackend to verify end-to-end behavior:
TruncateAndWrite: truncate to 0 + writes
TruncateToChunkSizeAndWrite: truncate to chunk_size + writes (object grows)
TruncateToChunkSizeAndWriteToSameSize: truncate to chunk_size + writes (same final size, creates sparse pattern)
Also includes a new write() helper in PGBackendTestFixture to support truncate+write in a single transaction for testing.

Fixes: https://tracker.ceph.com/issues/77276

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
