### PR TITLE
pybind/ceph_argparse: enforce non-empty validation and clean CLI error output

### DIFF
--- a/qa/suites/fs/volumes/tasks/volumes/test/basic.yaml
+++ b/qa/suites/fs/volumes/tasks/volumes/test/basic.yaml
@@ -9,3 +9,4 @@ tasks:
         - tasks.cephfs.test_volumes.TestCorruptedSubvolumes
         - tasks.cephfs.test_subvolume.TestSubvolume
         - tasks.cephfs.test_subvolume.TestSubvolumeReplicated
+        - tasks.cephfs.test_volumes.TestEmptyStringForCreates

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -10880,3 +10880,82 @@ class TestCorruptedSubvolumes(TestVolumesHelper):
         self.run_ceph_cmd(f'fs subvolume snapshot rm {self.volname} {sv1} {ss1} '
                            '--force')
         self.run_ceph_cmd(f'fs subvolume rm {self.volname} {sv1} --force')
+
+class TestEmptyStringForCreates(CephFSTestCase):
+    CLIENTS_REQUIRED = 1
+    MDSS_REQUIRED = 1
+
+    def setUp(self):
+        super().setUp()
+        result = json.loads(self.get_ceph_cmd_stdout("fs", "volume", "ls"))
+        self.assertTrue(len(result) > 0)
+        self.volname = result[0]['name']
+
+    def tearDown(self):
+        # If tests failed and created bad entries,  attempt an aggressive purge
+        # so we don't brick the rest of the teuthology run.
+        # If the test passes, no empty subvolumegroup was created,
+        # so this 'rm' will fail. We cleanly catch and ignore that failure.
+        try:
+            self.run_ceph_cmd("fs", "subvolumegroup", "rm", self.volname, "")
+        except CommandFailedError:
+            pass
+        except Exception:
+            pass
+
+        # Defensive addition for test_empty_subvolume_group_corruption
+        try:
+            self.run_ceph_cmd("fs", "subvolumegroup", "rm", self.volname, "group1")
+        except Exception:
+            pass
+
+        super().tearDown()
+
+    def test_empty_name_string_for_subvolumegroup_name(self):
+        """Reject empty, literal empty, and whitespace-only strings for subvolume groups"""
+        invalid_inputs = ["", "''", '""', " ", "   "]
+        for inp in invalid_inputs:
+            with self.assertRaises(CommandFailedError):
+                self.run_ceph_cmd("fs", "subvolumegroup", "create", self.volname, inp)
+
+    def test_empty_name_string_for_subvolume_name(self):
+        """Reject empty, literal empty, and whitespace-only strings for subvolumes"""
+        invalid_inputs = ["", "''", '""', " ", "   "]
+        for inp in invalid_inputs:
+            with self.assertRaises(CommandFailedError):
+                self.run_ceph_cmd("fs", "subvolume", "create", self.volname, inp)
+
+    def test_empty_name_string_for_subvolumegroup_name_argument(self):
+        """Reject empty values assigned to optional group flag targets"""
+        invalid_inputs = ["", "''", '""', " "]
+        for inp in invalid_inputs:
+            with self.assertRaises(CommandFailedError):
+                # Explicitly attach the bad input directly linked to the key argument
+                self.run_ceph_cmd("fs", "subvolume", "create", self.volname, "sv1", "--group_name", inp)
+
+    def test_empty_subvolume_group_corruption(self):
+        """
+        Ensure empty string create attempts do not accidentally
+        set the 'ceph.dir.subvolume' attribute of a parent group.
+        """
+        # Create a normal parent subvolume group
+        self.run_ceph_cmd("fs", "subvolumegroup", "create", self.volname, "group1")
+
+        # Create a normal valid subvolume inside it
+        self.run_ceph_cmd("fs", "subvolume", "create", self.volname, "subvol1", "--group_name", "group1")
+
+        # Attempt the empty creation that caused the bug.
+        # The argparse validation safely intercepts this and blocks it.
+        with self.assertRaises(CommandFailedError):
+            self.run_ceph_cmd("fs", "subvolume", "create", self.volname, "", "--group_name", "group1")
+
+        # If the bug is fixed, 'group1' still has its ceph.dir.subvolume attribute at 0.
+        # This means we can create 'subvol2' cleanly. If the layout was corrupted, this fails with EINVAL.
+        try:
+            self.run_ceph_cmd("fs", "subvolume", "create", self.volname, "subvol2", "--group_name", "group1")
+        except CommandFailedError as e:
+            self.fail(f"Parent group was converted to a subvolume! Error: {e}")
+
+        # Clean up before ending the test
+        self.run_ceph_cmd("fs", "subvolume", "rm", self.volname, "subvol1", "--group_name", "group1")
+        self.run_ceph_cmd("fs", "subvolume", "rm", self.volname, "subvol2", "--group_name", "group1")

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -340,10 +340,15 @@ class CephString(CephArgtype):
         )
 
     def valid(self, s: str, partial: bool = False) -> None:
+        # If a strict format rule (like goodchars) is defined on a subvolume name,
+        # an empty string input is inherently an invalid format structure.
+        if self.goodchars and s == "":
+            raise ArgumentFormat("argument can't be an empty string")
+
         sset = set(s)
         if self.goodset and not sset <= self.goodset:
-            raise ArgumentFormat("invalid chars {0} in {1}".
-                                 format(''.join(sset - self.goodset), s))
+            raise ArgumentFormat("invalid chars '{0}' in input string '{1}'".
+                                 format(''.join(sorted(list(sset - self.goodset))), s))
         self.val = s
 
     def __str__(self) -> str:

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -143,7 +143,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                    'name=vol_name,type=CephString '
                    f'name=sub_name,type=CephString,goodchars={goodchars} '
                    'name=size,type=CephInt,req=false '
-                   'name=group_name,type=CephString,req=false '
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} '
                    'name=pool_layout,type=CephString,req=false '
                    'name=uid,type=CephInt,req=false '
                    'name=gid,type=CephInt,req=false '

--- a/src/test/pybind/test_ceph_argparse.py
+++ b/src/test/pybind/test_ceph_argparse.py
@@ -18,7 +18,7 @@
 
 from ceph_argparse import validate_command, parse_json_funcsigs, validate, \
     parse_funcsig, ArgumentError, ArgumentTooFew, ArgumentMissing, \
-    ArgumentNumber, ArgumentValid
+    ArgumentNumber, ArgumentValid, CephString, ArgumentFormat
 
 import os
 import random
@@ -1370,6 +1370,34 @@ class TestValidate(unittest.TestCase):
         result = validate(['nqn1', '--force'], sig)
         self.assertEqual(result.get('force'), '--force')
 
+    def test_ceph_string_empty_rejection(self):
+        """
+        Verify that CephString.valid() inherently rejects an empty string
+        whenever a strict formatting pattern constraint (goodchars) is active.
+        """
+        arg_parser = CephString(goodchars='[a-z]')
+        with self.assertRaises(ArgumentFormat) as context:
+            arg_parser.valid("")
+        self.assertEqual(str(context.exception), "argument can't be an empty string")
+
+    def test_ceph_string_error_formatting(self):
+        """
+        Verify that CephString.valid() outputs a deterministic, cleanly delimited
+        error message when encountering whitelisted character violations.
+        """
+        # Initialize with a strict whitelist class [a-z]
+        arg_parser = CephString(goodchars='[a-z]')
+
+        # Pass input string containing multiple scrambled, violating whitespace/symbol characters
+        bad_input = "abc$% #"
+
+        with self.assertRaises(ArgumentFormat) as context:
+            arg_parser.valid(bad_input)
+
+        # Assert the output string is cleanly wrapped in single quotes AND strictly sorted alphabetically
+        # " ", "$", "%" sort to ' $% ' in ASCII order
+        expected_error = "invalid chars ' #$%' in input string 'abc$% #'"
+        self.assertEqual(str(context.exception), expected_error)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/58645

* Updates CephString.valid() in ceph_argparse.py to reject literal empty string inputs ("") whenever strict validation rules (goodchars) are active, preventing malformed creation commands from silently passing it.
* Refactors CephString validation exceptions to be better readable.
* Modifies volumes/module.py to explicitly apply the goodchars regex string filtering pattern to the optional group_name parameter signature, ensuring subvolume group names match the identical syntax validation constraints enforced on subvolumes.
* Introduces unit tests inside test_ceph_argparse.py, provisions an integration suite task in test_volumes.py to protect against parent directory metadata xattr corruption.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
