### PR TITLE
mgr/dashoard : Fix feedback module enablement

### DIFF
--- a/qa/tasks/mgr/dashboard/test_feedback.py
+++ b/qa/tasks/mgr/dashboard/test_feedback.py
@@ -6,7 +6,7 @@ class FeedbackTest(MgrModuleTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls._ceph_cmd(['mgr', 'module', 'enable', 'feedback'], wait=3)
+        cls._ceph_cmd(['mgr', 'module', 'enable', 'feedback', '--force'], wait=3)
         # Point the feedback module at an unreachable host so the test
         # does not depend on tracker.ceph.com being available. Any
         # create_issue call will fail fast with a ConnectionError

--- a/src/pybind/mgr/dashboard/controllers/mgr_modules.py
+++ b/src/pybind/mgr/dashboard/controllers/mgr_modules.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 
+from typing import Optional
+
 from .. import mgr
 from ..security import Scope
 from ..services.ceph_service import CephService
 from ..services.exception import handle_send_command_error
 from ..tools import find_object_in_list, str_to_bool
-from . import APIDoc, APIRouter, EndpointDoc, RESTController, allow_empty_body
+from . import APIDoc, APIRouter, EndpointDoc, Param, RESTController, allow_empty_body
 
 MGR_MODULE_SCHEMA = ([{
     "name": (str, "Module Name"),
@@ -94,15 +96,27 @@ class MgrModules(RESTController):
     @RESTController.Resource('POST')
     @handle_send_command_error('mgr_modules')
     @allow_empty_body
-    def enable(self, module_name):
+    @EndpointDoc("Enable Mgr module",
+                 parameters={
+                     'force': Param(
+                         bool,
+                         'Force enablement when not all mgr daemons support the module',
+                         True,
+                         False)
+                 })
+    def enable(self, module_name, force: Optional[bool] = False):
         """
         Enable the specified Ceph Mgr module.
         :param module_name: The name of the Ceph Mgr module.
         :type module_name: str
+        :param force: Force enablement when not all mgr daemons support the module.
+        :type force: bool
         """
         assert self._is_module_managed(module_name)
-        CephService.send_command(
-            'mon', 'mgr module enable', module=module_name)
+        cmd_kwargs = {'module': module_name}
+        if force:
+            cmd_kwargs['force'] = True
+        CephService.send_command('mon', 'mgr module enable', **cmd_kwargs)
 
     @RESTController.Resource('POST')
     @handle_send_command_error('mgr_modules')

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-list/mgr-module-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-list/mgr-module-list.component.spec.ts
@@ -146,7 +146,7 @@ describe('MgrModuleListComponent', () => {
       tick(mgrModuleService.REFRESH_INTERVAL);
       tick(mgrModuleService.REFRESH_INTERVAL);
       tick(mgrModuleService.REFRESH_INTERVAL);
-      expect(mgrModuleService.enable).toHaveBeenCalledWith('foo');
+      expect(mgrModuleService.enable).toHaveBeenCalledWith('foo', false);
       expect(mgrModuleService.list).toHaveBeenCalledTimes(2);
       expect(component.table.refreshBtn).toHaveBeenCalled();
     }));

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/feedback/feedback.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/feedback/feedback.component.html
@@ -17,13 +17,13 @@
       class="modal-wrapper"
     >
       @if (!isFeedbackEnabled) {
-      <cd-alert-panel type="error"
+      <cd-alert-panel type="info"
                       spacingClass="mb-3"
-                      actionName="Enable"
+                      actionName="Enable feedback"
                       class="align-items-center"
                       (action)="enableFeedbackModule()"
                       i18n-actionName>
-        In order to report an issue, Feedback module must be enabled.
+        Enable the feedback service to report issues.
       </cd-alert-panel>
       }
       <!-- api_key -->
@@ -31,14 +31,13 @@
       <div class="form-item">
         <cds-password-label
           labelInputID="api_key"
-          label="Ceph Tracker API Key"
-          cdRequiredField="Ceph Tracker API Key"
           [invalid]="!feedbackForm.controls.api_key.valid && feedbackForm.controls.api_key.dirty"
           [invalidText]="apiKeyError"
           [helperText]="apiKeyHelperTpl"
           [disabled]="!isFeedbackEnabled"
           i18n
         >
+          API key
           <input
             cdsPassword
             id="api_key"
@@ -50,18 +49,19 @@
         <ng-template #apiKeyError>
           @if (feedbackForm.showError('api_key', formDir, 'required')) {
           <span class="invalid-feedback"
-                i18n> Ceph Tracker API key is required. </span>
+                i18n>API key is required.</span>
           } @if (feedbackForm.showError('api_key', formDir, 'invalidApiKey')) {
           <span class="invalid-feedback"
-                i18n> Ceph Tracker API key is invalid. </span>
+                i18n>API key is invalid.</span>
           }
         </ng-template>
 
         <ng-template #apiKeyHelperTpl>
-          You can obtain your API key from
-          <a href="https://tracker.ceph.com/my/account"
-             target="_blank">https://tracker.ceph.com/my/account
-          </a>
+          <ng-container i18n>
+            Enter your Ceph Tracker API key. You can find your API key in your
+            <a href="https://tracker.ceph.com/my/account"
+               target="_blank">Ceph Tracker account</a>.
+          </ng-container>
         </ng-template>
       </div>
       }
@@ -72,12 +72,10 @@
           label="Project name"
           id="project"
           formControlName="project"
-          cdRequiredField="Project name"
           [invalid]="!feedbackForm.controls.project.valid && feedbackForm.controls.project.dirty"
           [invalidText]="projectError"
           i18n
         >
-          <option value="">--- Select a project ---</option>
           @for (project of projects; track project) {
           <option [value]="project">{{ project }}</option>
           }
@@ -90,25 +88,24 @@
         </ng-template>
       </div>
 
-      <!-- tracker -->
+      <!-- issue type -->
       <div class="form-item cds-select-label">
         <cds-select
-          label="Tracker"
+          label="Issue type"
           id="tracker"
           formControlName="tracker"
-          cdRequiredField="Tracker"
           [invalid]="!feedbackForm.controls.tracker.valid && feedbackForm.controls.tracker.dirty"
           [invalidText]="trackerError"
           i18n
-        > Tracker
-          @for (trackerName of tracker; track trackerName) {
-          <option [value]="trackerName">{{ trackerName }}</option>
+        >
+          @for (issueType of issueTypes; track issueType.value) {
+          <option [value]="issueType.value">{{ issueType.label }}</option>
           }
         </cds-select>
 
         <ng-template #trackerError>
           @if (feedbackForm.showError('tracker', formDir, 'required')) {
-          <span i18n>Tracker name is required.</span>
+          <span i18n>Issue type is required.</span>
           }
         </ng-template>
       </div>
@@ -116,25 +113,25 @@
       <!-- subject -->
       <div class="form-item">
         <cds-text-label
-          cdRequiredField="Subject"
           [invalid]="!feedbackForm.controls.subject.valid && feedbackForm.controls.subject.dirty"
           [invalidText]="subjectError"
           [disabled]="!isFeedbackEnabled"
           i18n
         >
-          Subject
+          Issue title
           <input
             cdsText
             id="subject"
             type="text"
             formControlName="subject"
-            placeholder="Add issue title"
+            placeholder="Enter a short summary of the issue"
+            i18n-placeholder
           />
         </cds-text-label>
 
         <ng-template #subjectError>
           @if (feedbackForm.showError('subject', formDir, 'required')) {
-          <span i18n>Subject is required.</span>
+          <span i18n>Issue title is required.</span>
           }
         </ng-template>
       </div>
@@ -142,7 +139,6 @@
       <!-- description -->
       <div class="form-item">
         <cds-text-label
-          cdRequiredField="Description"
           [invalid]="!feedbackForm.controls.description.valid && feedbackForm.controls.description.dirty"
           [invalidText]="descriptionError"
           [disabled]="!isFeedbackEnabled"
@@ -154,7 +150,8 @@
             id="description"
             type="text"
             formControlName="description"
-            placeholder="Explain your issue"
+            placeholder="Describe the issue and include steps to reproduce it, if applicable"
+            i18n-placeholder
           />
         </cds-text-label>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/feedback/feedback.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/feedback/feedback.component.spec.ts
@@ -5,9 +5,10 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 
-import { throwError } from 'rxjs';
+import { throwError, of as observableOf } from 'rxjs';
 
 import { FeedbackService } from '~/app/shared/api/feedback.service';
+import { MgrModuleService } from '~/app/shared/api/mgr-module.service';
 import { ComponentsModule } from '~/app/shared/components/components.module';
 import { configureTestBed, FormHelper } from '~/testing/unit-test-helper';
 import { FeedbackComponent } from './feedback.component';
@@ -18,6 +19,7 @@ describe('FeedbackComponent', () => {
   let component: FeedbackComponent;
   let fixture: ComponentFixture<FeedbackComponent>;
   let feedbackService: FeedbackService;
+  let mgrModuleService: MgrModuleService;
   let formHelper: FormHelper;
 
   configureTestBed({
@@ -37,6 +39,7 @@ describe('FeedbackComponent', () => {
     fixture = TestBed.createComponent(FeedbackComponent);
     component = fixture.componentInstance;
     feedbackService = TestBed.inject(FeedbackService);
+    mgrModuleService = TestBed.inject(MgrModuleService);
     fixture.detectChanges();
   });
 
@@ -72,5 +75,41 @@ describe('FeedbackComponent', () => {
     component.onSubmit();
 
     formHelper.expectError('api_key', 'invalidApiKey');
+  });
+
+  it('should enable feedback module with force', () => {
+    spyOn(mgrModuleService, 'updateModuleState');
+    spyOn(mgrModuleService.updateCompleted$, 'subscribe').and.callThrough();
+
+    component.enableFeedbackModule();
+
+    expect(mgrModuleService.updateModuleState).toHaveBeenCalledWith(
+      'feedback',
+      false,
+      null,
+      null,
+      'Enabled Feedback Module',
+      false,
+      undefined,
+      true
+    );
+    expect(mgrModuleService.updateCompleted$.subscribe).toHaveBeenCalled();
+  });
+
+  it('should refresh feedback state after module enablement', () => {
+    spyOn(feedbackService, 'isKeyExist').and.returnValues(
+      throwError({ status: 404 }),
+      observableOf(true)
+    );
+    spyOn(mgrModuleService, 'updateModuleState');
+
+    component.ngOnInit();
+    expect(component.isFeedbackEnabled).toEqual(false);
+
+    component.enableFeedbackModule();
+    mgrModuleService.updateCompleted$.next();
+
+    expect(component.isFeedbackEnabled).toEqual(true);
+    expect(component.feedbackForm.enabled).toEqual(true);
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/feedback/feedback.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/feedback/feedback.component.ts
@@ -28,7 +28,10 @@ export class FeedbackComponent extends CdForm implements OnInit, OnDestroy {
     'ceph_volume',
     'core_ceph'
   ];
-  tracker: string[] = ['bug', 'feature'];
+  issueTypes = [
+    { value: 'bug', label: $localize`Bug` },
+    { value: 'feature', label: $localize`Feature request` }
+  ];
   api_key: string;
   keySub: Subscription;
   submit: string;
@@ -48,8 +51,15 @@ export class FeedbackComponent extends CdForm implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.createForm();
+    this.loadFeedbackState();
+  }
+
+  private loadFeedbackState() {
+    this.keySub?.unsubscribe();
     this.keySub = this.feedbackService.isKeyExist().subscribe({
       next: (data: boolean) => {
+        this.isFeedbackEnabled = true;
+        this.feedbackForm.enable();
         this.isAPIKeySet = data;
         if (this.isAPIKeySet) {
           this.feedbackForm.get('api_key').clearValidators();
@@ -64,8 +74,8 @@ export class FeedbackComponent extends CdForm implements OnInit, OnDestroy {
 
   private createForm() {
     this.feedbackForm = new CdFormGroup({
-      project: new UntypedFormControl('', Validators.required),
-      tracker: new UntypedFormControl(this.tracker[0], Validators.required),
+      project: new UntypedFormControl(this.projects[0], Validators.required),
+      tracker: new UntypedFormControl(this.issueTypes[0].value, Validators.required),
       subject: new UntypedFormControl('', Validators.required),
       description: new UntypedFormControl('', Validators.required),
       api_key: new UntypedFormControl('', Validators.required)
@@ -110,7 +120,13 @@ export class FeedbackComponent extends CdForm implements OnInit, OnDestroy {
       null,
       null,
       'Enabled Feedback Module',
+      false,
+      undefined,
       true
     );
+    const subscription = this.mgrModuleService.updateCompleted$.subscribe(() => {
+      subscription.unsubscribe();
+      this.loadFeedbackState();
+    });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/feedback.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/feedback.service.ts
@@ -2,6 +2,8 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
 import * as _ from 'lodash';
+import { throwError as observableThrowError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root'
@@ -11,7 +13,14 @@ export class FeedbackService {
   baseUIURL = 'api/feedback';
 
   isKeyExist() {
-    return this.http.get('ui-api/feedback/api_key/exist');
+    return this.http.get('ui-api/feedback/api_key/exist').pipe(
+      catchError((error) => {
+        if (_.isFunction(error.preventDefault)) {
+          error.preventDefault();
+        }
+        return observableThrowError(() => error);
+      })
+    );
   }
 
   createIssue(

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/mgr-module.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/mgr-module.service.spec.ts
@@ -61,6 +61,21 @@ describe('MgrModuleService', () => {
     service.enable('foo').subscribe();
     const req = httpTesting.expectOne('api/mgr/module/foo/enable');
     expect(req.request.method).toBe('POST');
+    expect(req.request.body).toBeNull();
+  });
+
+  it('should call enable with force for whitelisted modules', () => {
+    service.enable('feedback').subscribe();
+    const req = httpTesting.expectOne('api/mgr/module/feedback/enable');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ force: true });
+  });
+
+  it('should call enable with explicit force', () => {
+    service.enable('foo', true).subscribe();
+    const req = httpTesting.expectOne('api/mgr/module/foo/enable');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ force: true });
   });
 
   it('should call disable', () => {
@@ -106,7 +121,7 @@ describe('MgrModuleService', () => {
       tick(service.REFRESH_INTERVAL);
       tick(service.REFRESH_INTERVAL);
       tick(service.REFRESH_INTERVAL);
-      expect(service.enable).toHaveBeenCalledWith('foo');
+      expect(service.enable).toHaveBeenCalledWith('foo', false);
       expect(service.list).toHaveBeenCalledTimes(2);
       expect(notificationService.suspendToasties).toHaveBeenCalledTimes(2);
       expect(blockUIService.start).toHaveBeenCalled();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/mgr-module.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/mgr-module.service.ts
@@ -13,6 +13,9 @@ import { SummaryService } from '../services/summary.service';
 
 const GLOBAL = 'global';
 
+/** Modules that require --force when not all mgr daemons support them. */
+const FORCE_ENABLE_MODULES = new Set(['feedback']);
+
 @Injectable({
   providedIn: 'root'
 })
@@ -60,9 +63,11 @@ export class MgrModuleService {
   /**
    * Enable the Ceph Mgr module.
    * @param {string} module The name of the mgr module.
+   * @param {boolean} force Force enablement when not all mgr daemons support the module.
    */
-  enable(module: string) {
-    return this.http.post(`${this.url}/${module}/enable`, null);
+  enable(module: string, force: boolean = false) {
+    const useForce = force || FORCE_ENABLE_MODULES.has(module);
+    return this.http.post(`${this.url}/${module}/enable`, useForce ? { force: true } : null);
   }
 
   /**
@@ -92,9 +97,10 @@ export class MgrModuleService {
     navigateTo: string = '',
     notificationText?: string,
     navigateByUrl?: boolean,
-    reconnectingMessage: string = $localize`Reconnecting, please wait ...`
+    reconnectingMessage: string = $localize`Reconnecting, please wait ...`,
+    force: boolean = false
   ): void {
-    const moduleToggle$ = enabled ? this.disable(module) : this.enable(module);
+    const moduleToggle$ = enabled ? this.disable(module) : this.enable(module, force);
 
     moduleToggle$.subscribe({
       next: () => {

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -10435,13 +10435,25 @@ paths:
     post:
       description: "\n        Enable the specified Ceph Mgr module.\n        :param\
         \ module_name: The name of the Ceph Mgr module.\n        :type module_name:\
-        \ str\n        "
+        \ str\n        :param force: Force enablement when not all mgr daemons support\
+        \ the module.\n        :type force: bool\n        "
       parameters:
       - in: path
         name: module_name
         required: true
         schema:
           type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                force:
+                  default: false
+                  description: Force enablement when not all mgr daemons support the
+                    module
+                  type: boolean
+              type: object
       responses:
         '201':
           content:
@@ -10472,6 +10484,7 @@ paths:
             trace.
       security:
       - jwt: []
+      summary: Enable Mgr module
       tags:
       - MgrModule
   /api/mgr/module/{module_name}/options:


### PR DESCRIPTION


<img width="968" height="746" alt="image" src="https://github.com/user-attachments/assets/41382a1c-35f3-4b4d-b666-fdbef5526afc" />

<img width="1536" height="777" alt="image" src="https://github.com/user-attachments/assets/3e9b0ec0-41dd-4958-9838-b3aa3dda921e" />

<img width="1226" height="775" alt="image" src="https://github.com/user-attachments/assets/ed75f8ab-842e-45e4-b7ef-7ee325da976f" />

Not able to see API key field as it was already enrolled. It if api key exists we do not show the field. 
This existing behaviour.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
