### PR TITLE
ceph-volume: fix raw activate when device path is stale

### DIFF
--- a/src/ceph-volume/ceph_volume/objectstore/baseobjectstore.py
+++ b/src/ceph-volume/ceph_volume/objectstore/baseobjectstore.py
@@ -112,7 +112,7 @@ class BaseObjectStore:
     def unlink_bs_symlinks(self) -> None:
         for link_name in ['block', 'block.db', 'block.wal']:
             link_path = os.path.join(self.osd_path, link_name)
-            if os.path.exists(link_path):
+            if os.path.lexists(link_path):
                 os.unlink(os.path.join(self.osd_path, link_name))
 
     def prepare_osd_req(self, tmpfs: bool = True) -> None:

--- a/src/ceph-volume/ceph_volume/tests/objectstore/test_raw.py
+++ b/src/ceph-volume/ceph_volume/tests/objectstore/test_raw.py
@@ -177,7 +177,7 @@ class TestRaw:
     @patch('ceph_volume.objectstore.raw.prepare_utils.link_wal')
     @patch('ceph_volume.objectstore.raw.prepare_utils.link_db')
     @patch('ceph_volume.objectstore.raw.prepare_utils.link_block')
-    @patch('os.path.exists')
+    @patch('os.path.lexists')
     @patch('os.unlink')
     @patch('ceph_volume.objectstore.raw.prepare_utils.create_osd_path')
     @patch('ceph_volume.objectstore.raw.process.run')


### PR DESCRIPTION
This changes unlink_bs_symlinks to use os.path.lexists instead of os.path.exists. It can happen that devices get renumbered, in that case, the OSD symlink still exists but its target device is gone which means os.path.exists returns False, so the symlink is never cleaned up and ceph-volume activate can fail later.

Fixes: https://tracker.ceph.com/issues/77295


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
