### PR TITLE
mgr: OSDs in bucket must be displayed in upgrade status

### DIFF
--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -247,6 +247,99 @@ def test_upgrade_state_crush_roundtrip():
     assert restored.crush_bucket_name == 'rack1'
 
 
+def _test_osd_dd(osd_id: int, digests: List[str]) -> DaemonDescription:
+    return DaemonDescription(
+        daemon_type='osd',
+        daemon_id=str(osd_id),
+        hostname=f'host{osd_id}',
+        container_image_digests=digests,
+    )
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+def test_cache_empty_bucket_from_ok_to_upgrade_report(
+        cephadm_module: CephadmOrchestrator):
+    # Empty osds_in_crush_bucket is cached as set(), not None.
+    cephadm_module.upgrade._ok_to_upgrade_osds_in_crush_bucket = None
+    report = OkToUpgradeMonReport(
+        ok_to_upgrade=True,
+        all_osds_upgraded=False,
+        osds_ok_to_upgrade=[],
+        osds_in_crush_bucket=[],
+        osds_upgraded=[],
+        bad_no_version=[],
+    )
+    cephadm_module.upgrade._cache_osds_in_crush_bucket_from_ok_to_upgrade_report(
+        report)
+    assert cephadm_module.upgrade._ok_to_upgrade_osds_in_crush_bucket == set()
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+def test_get_upgrade_info_bucket_scope_progress(cephadm_module: CephadmOrchestrator):
+    # Upgrade progress denominator uses bucket OSD count, not cluster-wide total.
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'target', 'pid',
+        target_digests=['digest1'],
+        target_version='19.2.3',
+        daemon_types=['osd'],
+        crush_bucket_type='rack',
+        crush_bucket_name='rack1',
+    )
+    cephadm_module.upgrade._ok_to_upgrade_osds_in_crush_bucket = {
+        'osd.0', 'osd.1', 'osd.2',
+    }
+    all_osds = [
+        _test_osd_dd(0, ['digest1']),
+        _test_osd_dd(1, ['digest1']),
+        _test_osd_dd(2, ['old-digest']),
+        _test_osd_dd(3, ['digest1']),
+        _test_osd_dd(4, ['digest1']),
+    ]
+    with mock.patch.object(
+            cephadm_module.cache, 'get_daemons', return_value=all_osds):
+        progress, _ = cephadm_module.upgrade._get_upgrade_info()
+    assert progress == '2/3 daemons upgraded'
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+def test_get_upgrade_info_refreshes_bucket_osds_for_upgrade_status(
+        cephadm_module: CephadmOrchestrator):
+    # Status path refreshes cold bucket cache via max_osds=0 before computing progress.
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'target', 'pid',
+        target_digests=['digest1'],
+        target_version='19.2.3',
+        daemon_types=['osd'],
+        crush_bucket_type='rack',
+        crush_bucket_name='rack1',
+    )
+    bucket_rep = OkToUpgradeMonReport(
+        ok_to_upgrade=True,
+        all_osds_upgraded=False,
+        osds_ok_to_upgrade=[],
+        osds_in_crush_bucket=[0, 1, 2],
+        osds_upgraded=[0, 1],
+        bad_no_version=[],
+    )
+    all_osds = [
+        _test_osd_dd(0, ['digest1']),
+        _test_osd_dd(1, ['digest1']),
+        _test_osd_dd(2, ['old-digest']),
+        _test_osd_dd(3, ['digest1']),
+        _test_osd_dd(4, ['digest1']),
+    ]
+    with mock.patch(
+            'cephadm.upgrade.request_osd_ok_to_upgrade_report',
+            return_value=bucket_rep,
+    ) as mock_request:
+        with mock.patch.object(
+                cephadm_module.cache, 'get_daemons', return_value=all_osds):
+            progress, _ = cephadm_module.upgrade._get_upgrade_info()
+    mock_request.assert_called_once()
+    assert mock_request.call_args.kwargs['max_osds'] == 0
+    assert progress == '2/3 daemons upgraded'
+
+
 @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
 def test_upgrade_status_which_crush_osd_only(cephadm_module: CephadmOrchestrator):
     cephadm_module.upgrade.upgrade_state = UpgradeState(

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -374,10 +374,20 @@ class CephadmUpgrade:
         # filtering parameters (or all daemons in upgrade order if no filtering
         # parameter are set).
         assert self.upgrade_state is not None
-        if self.upgrade_state.daemon_types is not None:
+        if self._upgrade_uses_ok_to_upgrade_for_osds():
+            logger.debug(
+                f'Filtering OSD daemons to upgrade in CRUSH bucket '
+                f'{self.upgrade_state.crush_bucket_type}='
+                f'{self.upgrade_state.crush_bucket_name!r}')
+            daemons = self._get_bucket_scoped_osd_daemons()
+        elif self.upgrade_state.daemon_types is not None:
+            logger.debug(
+                f'Filtering daemons to upgrade by daemon types: {self.upgrade_state.daemon_types}')
             daemons = [d for d in self.mgr.cache.get_daemons(
             ) if d.daemon_type in self.upgrade_state.daemon_types]
         elif self.upgrade_state.services is not None:
+            logger.debug(
+                f'Filtering daemons to upgrade by services: {self.upgrade_state.services}')
             daemons = []
             for service in self.upgrade_state.services:
                 daemons += self.mgr.cache.get_daemons_by_service(service)
@@ -385,8 +395,75 @@ class CephadmUpgrade:
             daemons = [d for d in self.mgr.cache.get_daemons(
             ) if d.daemon_type in CEPH_UPGRADE_ORDER]
         if self.upgrade_state.hosts is not None:
+            logger.debug(
+                f'Filtering daemons to upgrade by hosts: {self.upgrade_state.hosts}')
             daemons = [d for d in daemons if d.hostname in self.upgrade_state.hosts]
         return daemons
+
+    def _get_bucket_scoped_osd_daemons(self) -> List[DaemonDescription]:
+        assert self.upgrade_state is not None
+        bset = self._get_osds_in_crush_bucket_names()
+
+        if bset is None:
+            logger.warning(
+                'Upgrade: could not determine OSDs in CRUSH bucket %r, '
+                'returning empty daemon list',
+                self.upgrade_state.crush_bucket_name)
+            return []
+
+        if not bset:
+            logger.info(
+                'Upgrade: CRUSH bucket %r contains no OSDs',
+                self.upgrade_state.crush_bucket_name)
+            return []
+
+        return [
+            d for d in self.mgr.cache.get_daemons()
+            if d.daemon_type == 'osd' and d.name() in bset]
+
+    def _get_osds_in_crush_bucket_names(self) -> Optional[Set[str]]:
+        """
+        Return ``osd.<id>`` names for OSDs under the upgrade CRUSH bucket.
+        """
+        # Return the cached value if it exists from an earlier ok-to-upgrade batch
+        if self._ok_to_upgrade_osds_in_crush_bucket is not None:
+            return self._ok_to_upgrade_osds_in_crush_bucket
+
+        # Otherwise, refresh the cache using ok-to-upgrade with max_osds=0
+        if self._refresh_osds_in_crush_bucket_for_upgrade_status():
+            return self._ok_to_upgrade_osds_in_crush_bucket
+        return None
+
+    def _refresh_osds_in_crush_bucket_for_upgrade_status(self) -> bool:
+        """
+        Populate bucket OSD cache for upgrade status using ``osd ok-to-upgrade``
+        with max_osds=0.
+        """
+        assert self.upgrade_state is not None
+
+        if not self._upgrade_uses_ok_to_upgrade_for_osds():
+            return False
+
+        crush_bucket_name = self.upgrade_state.crush_bucket_name
+        target_version_short = self.upgrade_state.target_version
+
+        if not crush_bucket_name or not target_version_short:
+            return False
+        try:
+            ok_to_upgrade_report = request_osd_ok_to_upgrade_report(
+                self.mgr,
+                crush_bucket_name,
+                target_version_short,
+                max_osds=0,
+            )
+        except (json.JSONDecodeError, MonCommandFailed) as err:
+            logger.debug(
+                'Upgrade: could not refresh osds_in_crush_bucket for upgrade status: %s',
+                err)
+            return False
+        self._cache_osds_in_crush_bucket_from_ok_to_upgrade_report(
+            ok_to_upgrade_report)
+        return self._ok_to_upgrade_osds_in_crush_bucket is not None
 
     def _get_current_version(self) -> Tuple[int, int, str]:
         current_version = self.mgr.version.split('ceph version ')[1]
@@ -860,6 +937,10 @@ class CephadmUpgrade:
     def _cache_osds_in_crush_bucket_from_ok_to_upgrade_report(
             self, report: OkToUpgradeMonReport) -> None:
         ids = report.osds_in_crush_bucket
+        if not ids:
+            # set empty set to indicate no OSDs in CRUSH bucket
+            self._ok_to_upgrade_osds_in_crush_bucket = set()
+            return
         self._ok_to_upgrade_osds_in_crush_bucket = {
             f'osd.{osd_id}' for osd_id in ids
         }
@@ -1792,23 +1873,7 @@ class CephadmUpgrade:
 
         image_settings = self.get_distinct_container_image_settings()
 
-        if self.upgrade_state.daemon_types is not None:
-            logger.debug(
-                f'Filtering daemons to upgrade by daemon types: {self.upgrade_state.daemon_types}')
-            daemons = [d for d in self.mgr.cache.get_daemons(
-            ) if d.daemon_type in self.upgrade_state.daemon_types]
-        elif self.upgrade_state.services is not None:
-            logger.debug(
-                f'Filtering daemons to upgrade by services: {self.upgrade_state.daemon_types}')
-            daemons = []
-            for service in self.upgrade_state.services:
-                daemons += self.mgr.cache.get_daemons_by_service(service)
-        else:
-            daemons = [d for d in self.mgr.cache.get_daemons(
-            ) if d.daemon_type in CEPH_UPGRADE_ORDER]
-        if self.upgrade_state.hosts is not None:
-            logger.debug(f'Filtering daemons to upgrade by hosts: {self.upgrade_state.hosts}')
-            daemons = [d for d in daemons if d.hostname in self.upgrade_state.hosts]
+        daemons = self._get_filtered_daemons()
         upgraded_daemon_count: int = 0
         for daemon_type in CEPH_UPGRADE_ORDER:
             if self.upgrade_state.remaining_count is not None and self.upgrade_state.remaining_count <= 0:
@@ -1833,7 +1898,9 @@ class CephadmUpgrade:
             need_upgrade_self, need_upgrade, need_upgrade_deployer, done = self._detect_need_upgrade(
                 daemons_of_type, target_digests, target_image)
             upgraded_daemon_count += done
-            self._update_upgrade_progress(upgraded_daemon_count / len(daemons))
+            if daemons:
+                self._update_upgrade_progress(
+                    upgraded_daemon_count / len(daemons))
 
             # make sure mgr and monitoring stack daemons are properly redeployed in staggered upgrade scenarios
             # The idea here is to upgrade the mointoring daemons after the mgr is done upgrading as

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -376,10 +376,20 @@ class CephadmUpgrade:
         # filtering parameters (or all daemons in upgrade order if no filtering
         # parameter are set).
         assert self.upgrade_state is not None
-        if self.upgrade_state.daemon_types is not None:
+        if self._upgrade_uses_ok_to_upgrade_for_osds():
+            logger.debug(
+                f'Filtering OSD daemons to upgrade in CRUSH bucket '
+                f'{self.upgrade_state.crush_bucket_type}='
+                f'{self.upgrade_state.crush_bucket_name!r}')
+            daemons = self._get_bucket_scoped_osd_daemons()
+        elif self.upgrade_state.daemon_types is not None:
+            logger.debug(
+                f'Filtering daemons to upgrade by daemon types: {self.upgrade_state.daemon_types}')
             daemons = [d for d in self.mgr.cache.get_daemons(
             ) if d.daemon_type in self.upgrade_state.daemon_types]
         elif self.upgrade_state.services is not None:
+            logger.debug(
+                f'Filtering daemons to upgrade by services: {self.upgrade_state.services}')
             daemons = []
             for service in self.upgrade_state.services:
                 daemons += self.mgr.cache.get_daemons_by_service(service)
@@ -387,8 +397,75 @@ class CephadmUpgrade:
             daemons = [d for d in self.mgr.cache.get_daemons(
             ) if d.daemon_type in CEPH_UPGRADE_ORDER]
         if self.upgrade_state.hosts is not None:
+            logger.debug(
+                f'Filtering daemons to upgrade by hosts: {self.upgrade_state.hosts}')
             daemons = [d for d in daemons if d.hostname in self.upgrade_state.hosts]
         return daemons
+
+    def _get_bucket_scoped_osd_daemons(self) -> List[DaemonDescription]:
+        assert self.upgrade_state is not None
+        bset = self._get_osds_in_crush_bucket_names()
+
+        if bset is None:
+            logger.warning(
+                'Upgrade: could not determine OSDs in CRUSH bucket %r, '
+                'returning empty daemon list',
+                self.upgrade_state.crush_bucket_name)
+            return []
+
+        if not bset:
+            logger.info(
+                'Upgrade: CRUSH bucket %r contains no OSDs',
+                self.upgrade_state.crush_bucket_name)
+            return []
+
+        return [
+            d for d in self.mgr.cache.get_daemons()
+            if d.daemon_type == 'osd' and d.name() in bset]
+
+    def _get_osds_in_crush_bucket_names(self) -> Optional[Set[str]]:
+        """
+        Return ``osd.<id>`` names for OSDs under the upgrade CRUSH bucket.
+        """
+        # Return the cached value if it exists from an earlier ok-to-upgrade batch
+        if self._ok_to_upgrade_osds_in_crush_bucket is not None:
+            return self._ok_to_upgrade_osds_in_crush_bucket
+
+        # Otherwise, refresh the cache using ok-to-upgrade with max_osds=0
+        if self._refresh_osds_in_crush_bucket_for_upgrade_status():
+            return self._ok_to_upgrade_osds_in_crush_bucket
+        return None
+
+    def _refresh_osds_in_crush_bucket_for_upgrade_status(self) -> bool:
+        """
+        Populate bucket OSD cache for upgrade status using ``osd ok-to-upgrade``
+        with max_osds=0.
+        """
+        assert self.upgrade_state is not None
+
+        if not self._upgrade_uses_ok_to_upgrade_for_osds():
+            return False
+
+        crush_bucket_name = self.upgrade_state.crush_bucket_name
+        target_version_short = self.upgrade_state.target_version
+
+        if not crush_bucket_name or not target_version_short:
+            return False
+        try:
+            ok_to_upgrade_report = request_osd_ok_to_upgrade_report(
+                self.mgr,
+                crush_bucket_name,
+                target_version_short,
+                max_osds=0,
+            )
+        except (json.JSONDecodeError, MonCommandFailed) as err:
+            logger.debug(
+                'Upgrade: could not refresh osds_in_crush_bucket for upgrade status: %s',
+                err)
+            return False
+        self._cache_osds_in_crush_bucket_from_ok_to_upgrade_report(
+            ok_to_upgrade_report)
+        return self._ok_to_upgrade_osds_in_crush_bucket is not None
 
     def _get_current_version(self) -> Tuple[int, int, str]:
         current_version = self.mgr.version.split('ceph version ')[1]
@@ -873,6 +950,10 @@ class CephadmUpgrade:
     def _cache_osds_in_crush_bucket_from_ok_to_upgrade_report(
             self, report: OkToUpgradeMonReport) -> None:
         ids = report.osds_in_crush_bucket
+        if not ids:
+            # set empty set to indicate no OSDs in CRUSH bucket
+            self._ok_to_upgrade_osds_in_crush_bucket = set()
+            return
         self._ok_to_upgrade_osds_in_crush_bucket = {
             f'osd.{osd_id}' for osd_id in ids
         }
@@ -1899,23 +1980,7 @@ class CephadmUpgrade:
 
         image_settings = self.get_distinct_container_image_settings()
 
-        if self.upgrade_state.daemon_types is not None:
-            logger.debug(
-                f'Filtering daemons to upgrade by daemon types: {self.upgrade_state.daemon_types}')
-            daemons = [d for d in self.mgr.cache.get_daemons(
-            ) if d.daemon_type in self.upgrade_state.daemon_types]
-        elif self.upgrade_state.services is not None:
-            logger.debug(
-                f'Filtering daemons to upgrade by services: {self.upgrade_state.daemon_types}')
-            daemons = []
-            for service in self.upgrade_state.services:
-                daemons += self.mgr.cache.get_daemons_by_service(service)
-        else:
-            daemons = [d for d in self.mgr.cache.get_daemons(
-            ) if d.daemon_type in CEPH_UPGRADE_ORDER]
-        if self.upgrade_state.hosts is not None:
-            logger.debug(f'Filtering daemons to upgrade by hosts: {self.upgrade_state.hosts}')
-            daemons = [d for d in daemons if d.hostname in self.upgrade_state.hosts]
+        daemons = self._get_filtered_daemons()
         upgraded_daemon_count: int = 0
         for daemon_type in CEPH_UPGRADE_ORDER:
             if self.upgrade_state.remaining_count is not None and self.upgrade_state.remaining_count <= 0:


### PR DESCRIPTION
This PR solves the following defect of improper status for number of OSDs during bucket scoped OSD upgrades. OSD upgrade progress showed denominator as total cluster OSDs instead of OSDs within CRUSH bucket scope
  Example: Displayed "2/5" when should show "2/3" (3 OSDs in bucket, 5 total in cluster)

 This PR has the following code changes:
- Unifies common code in _get_filtered_daemons() and _do_upgrade().
- _get_filtered_daemons() restricts the progress denominator to bucket OSDs for CRUSH bucket scope using an in-memory cache. 
- Status path: When the cache is empty, _get_filtered_daemons() triggers an osd ok-to-upgrade query with max_osds=0 so status is correct before the first upgrade batch.
- Upgrade path: _do_upgrade() now reuses _get_filtered_daemons() for the same bucket-scoped denominator which also populates the cache if empty.
- The bucket-scoped OSD denominator cache is therefore filled either while checking upgrade status, or on the first osd ok-to-upgrade request during the upgrade loop.


**Tests**

Bucket Rack R1 just has 4 OSDs, and mgr/cephadm/max_parallel_osd_upgrades set to just 1 for checking updates.

```
[ceph: root@ceph-node-0 /]# ceph osd tree                                                                                                                                                        
ID  CLASS  WEIGHT   TYPE NAME                 STATUS  REWEIGHT  PRI-AFF                         
-1         0.05878  root default                                                                
-9         0.03918      rack R1                                                                                                                                                                  
-3         0.01959          host ceph-node-0                                                    
 0    hdd  0.00980              osd.0             up   1.00000  1.00000                         
 2    hdd  0.00980              osd.2             up   1.00000  1.00000                                                                                                                          
-5         0.01959          host ceph-node-1                                                                                                                                                     
 1    hdd  0.00980              osd.1             up   1.00000  1.00000                                                                                                                          
 3    hdd  0.00980              osd.3             up   1.00000  1.00000                         
-7         0.01959      host ceph-node-2                                                        
 4    hdd  0.00980          osd.4                 up   1.00000  1.00000                         
 5    hdd  0.00980          osd.5                 up   1.00000  1.00000                         
[ceph: root@ceph-node-0 /]#  

[ceph: root@ceph-node-0 /]# ceph orch upgrade start --image=quay.io/ashjoshi/ceph:upgradetesting --daemon_types=osd --crush-bucket-type=rack --crush-bucket-name=R1  
Initiating upgrade to quay.io/ashjoshi/ceph:upgradetesting                                                                                                                                       
[ceph: root@ceph-node-0 /]# ceph orch upgrade status                                             
{                                                                                               
    "in_progress": true,               
    "target_image": "quay.io/ashjoshi/ceph:upgradetesting",
    "services_complete": [],
    "which": "Upgrading daemons of type(s) osd (OSDs in bucket scope)",
    "progress": "",                                                                             
    "message": "Doing first pull of quay.io/ashjoshi/ceph:upgradetesting image",
    "is_paused": false  
}                                                                                                                                                                                                
[ceph: root@ceph-node-0 /]# ceph orch upgrade status
{                                                                                               
    "in_progress": true,               
    "target_image": "quay.io/ashjoshi/ceph@sha256:d65c297cd74c155f5158490e3baa01afd7643288c96ca2d3426b5678a7a6d0d9",
    "services_complete": [],
    "which": "Upgrading daemons of type(s) osd (OSDs in bucket scope)",
    "progress": "0/4 daemons upgraded",         <<<<<<<<<<< correctly showing number of OSDs in the bucket as denominator 
    "message": "Currently upgrading osd daemons",
    "is_paused": false
}

[ceph: root@ceph-node-0 /]# ceph orch upgrade status
{
    "in_progress": true,
    "target_image": "quay.io/ashjoshi/ceph@sha256:d65c297cd74c155f5158490e3baa01afd7643288c96ca2d3426b5678a7a6d0d9",
    "services_complete": [],
    "which": "Upgrading daemons of type(s) osd (OSDs in bucket scope)",
    "progress": "1/4 daemons upgraded",
    "message": "Currently upgrading osd daemons",
    "is_paused": false
}
…

[ceph: root@ceph-node-0 /]# ceph orch upgrade status
There are no upgrades in progress currently.
[ceph: root@ceph-node-0 /]#

```


**Continue without bucket scope for full cluster upgrade**

```
[ceph: root@ceph-node-0 /]# ceph orch upgrade start --image=quay.io/ashjoshi/ceph:upgradetesting 
Initiating upgrade to quay.io/ashjoshi/ceph:upgradetesting
[ceph: root@ceph-node-0 /]# ceph orch upgrade status
{
    "in_progress": true,
    "target_image": "quay.io/ashjoshi/ceph@sha256:d65c297cd74c155f5158490e3baa01afd7643288c96ca2d3426b5678a7a6d0d9",
    "services_complete": [
        "crash",
        "osd",
        "mgr",
        "mon"
    ],
    "which": "Upgrading all daemon types on all hosts",
    "progress": "14/14 daemons upgraded",
    "message": "Currently upgrading osd daemons",
    "is_paused": false
}
[ceph: root@ceph-node-0 /]# ceph orch upgrade status
There are no upgrades in progress currently.
[ceph: root@ceph-node-0 /]#

[ceph: root@ceph-node-0 /]# ceph orch ps
NAME                    HOST         PORTS   STATUS          REFRESHED  AGE  MEM USE  MEM LIM  VERSION              IMAGE ID      CONTAINER ID  
crash.ceph-node-0       ceph-node-0          running (8m)       4m ago  60m    7204k        -  21.3.0-94-gca0bc48a  5e4b2cd46137  caf2fd2d6c88  
crash.ceph-node-1       ceph-node-1          running (7m)       3m ago  58m    7208k        -  21.3.0-94-gca0bc48a  5e4b2cd46137  fa397d33d443  
crash.ceph-node-2       ceph-node-2          running (7m)      61s ago  56m    7208k        -  21.3.0-94-gca0bc48a  5e4b2cd46137  703c06304c73  
mgr.ceph-node-0.qiugug  ceph-node-0  *:8765  running (13m)      4m ago  61m     179M        -  21.3.0-94-gca0bc48a  5e4b2cd46137  0312a4190d63  
mgr.ceph-node-1.ucsgpf  ceph-node-1  *:8765  running (12m)      3m ago  57m     141M        -  21.3.0-94-gca0bc48a  5e4b2cd46137  e5b1b907be31  
mon.ceph-node-0         ceph-node-0          running (12m)      4m ago  61m    52.5M    2048M  21.3.0-94-gca0bc48a  5e4b2cd46137  c153035923df  
mon.ceph-node-1         ceph-node-1          running (11m)      3m ago  57m    38.8M    2048M  21.3.0-94-gca0bc48a  5e4b2cd46137  2dd2c8863129  
mon.ceph-node-2         ceph-node-2          running (9m)      61s ago  55m    37.9M    2048M  21.3.0-94-gca0bc48a  5e4b2cd46137  f3da27d4c37d  
osd.0                   ceph-node-0          running (5m)       4m ago  58m    45.5M    4096M  21.3.0-94-gca0bc48a  5e4b2cd46137  ab87ac7f546a  
osd.1                   ceph-node-1          running (3m)       3m ago  58m    30.4M    4096M  21.3.0-94-gca0bc48a  5e4b2cd46137  04670eb3f571  
osd.2                   ceph-node-0          running (4m)       4m ago  58m    30.2M    4096M  21.3.0-94-gca0bc48a  5e4b2cd46137  bd476510b171  
osd.3                   ceph-node-1          running (3m)       3m ago  58m    46.1M    4096M  21.3.0-94-gca0bc48a  5e4b2cd46137  9cd61b00e37d  
osd.4                   ceph-node-2          running (109s)    61s ago  55m    45.3M    1492M  21.3.0-94-gca0bc48a  5e4b2cd46137  cf37891ebf07  
osd.5                   ceph-node-2          running (65s)     61s ago  55m    44.0M    1492M  21.3.0-94-gca0bc48a  5e4b2cd46137  d869b3df5c05  
[ceph: root@ceph-node-0 /]#
```

Fixes: https://tracker.ceph.com/issues/77294
Signed-off-by: Ashwin M. Joshi <ashjosh1@in.ibm.com>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
