### PR TITLE
mgr/nfs:NFS Transparent State Migration (TSM) support

### DIFF
--- a/doc/cephadm/services/nfs.rst
+++ b/doc/cephadm/services/nfs.rst
@@ -112,6 +112,35 @@ Example with RDMA enabled:
    address is RDMA-capable. On the host, run ``rdma link show`` and confirm the
    netdev for the interface with the bind IP is listed.
 
+Transparent State Migration (TSM)
+----------------------------------
+
+Transparent State Migration (TSM) is a high-availability feature that allows NFS
+clients to maintain their state (open files, locks, etc.) when failing over to
+another NFS server. TSM is disabled by default.
+
+To enable TSM, set ``enable_tsm: true`` in the NFS service spec. You can optionally
+set ``tsm_port`` to use a custom TSM port. If omitted, NFS Ganesha uses its default.
+
+Example with TSM enabled:
+
+.. code-block:: yaml
+
+    service_type: nfs
+    service_id: mynfs
+    placement:
+      count: 1
+      hosts: [host1]
+    spec:
+      port: 2049
+      enable_tsm: true
+      tsm_port: 5000   # optional
+
+.. note::
+   * TSM is configured in the NFS_CORE_PARAM block of the ganesha.conf file.
+   * When using daemon colocation, each colocated daemon requires a unique ``tsm_port``
+     in the ``colocation_ports`` list. See :ref:`colocation-with-tsm` for a complete example.
+
 NFS Daemon Colocation
 ----------------------
 
@@ -169,6 +198,7 @@ In this configuration, 4 daemons total are deployed (2 per host), distributed ac
      to cover the node down scenario (or ``count_per_host - 1`` when using ``count_per_host``).
    * Each entry must specify ``data_port``, ``monitoring_port``, and ``qos_cluster_port``.
      When ``enable_rdma`` is true, each entry must also include ``rdma_port``.
+     When ``enable_tsm`` is true, each entry must also include ``tsm_port``.
    * If ``colocation_ports`` is not specified, ports will be automatically
      incremented for colocated daemons (e.g., 2049 → 2050 → 2051 for data ports,
      and 9587 → 9588 → 9589 for monitoring ports).
@@ -200,6 +230,54 @@ run on each host:
 
 This will deploy exactly 3 NFS daemons on each of the 3 hosts (9 daemons total),
 with custom ports for the 2nd and 3rd daemons on each host.
+
+Colocation with TSM
+~~~~~~~~~~~~~~~~~~~
+
+When TSM (Transparent State Migration) is enabled with colocation, each colocated daemon
+requires a unique ``tsm_port`` in addition to the standard ports. This example demonstrates
+both TSM colocation and the failure scenario where daemons may be redeployed to maintain
+the desired count:
+
+.. code-block:: yaml
+
+    service_type: nfs
+    service_id: mynfs
+    placement:
+      count: 2
+      hosts:
+        - host1
+        - host2
+    spec:
+      port: 2049
+      monitoring_port: 9587
+      enable_tsm: true
+      tsm_port: 36369
+      colocation_ports:
+        - data_port: 3049
+          monitoring_port: 9588
+          cluster_qos_port: 31312
+          tsm_port: 36370
+
+**Normal operation** - 2 daemons total deployed (1 per host), distributed across
+``host1`` and ``host2``:
+
+* **host1, daemon 1**: ``port: 2049``, ``monitoring_port: 9587``, ``cluster_qos_port: 31311``, ``tsm_port: 36369``
+* **host2, daemon 1**: ``port: 2049``, ``monitoring_port: 9587``, ``cluster_qos_port: 31311``, ``tsm_port: 36369``
+
+**Failure scenario** - If ``host2`` becomes unavailable:
+
+* Cephadm automatically redeploys the daemon from ``host2`` onto ``host1``
+* Result: Both daemons now run on ``host1`` (temporarily colocated)
+* **host1, daemon 1**: ``port: 2049``, ``monitoring_port: 9587``, ``cluster_qos_port: 31311``, ``tsm_port: 36369``
+* **host1, daemon 2**: ``data_port: 3049``, ``monitoring_port: 9588``, ``cluster_qos_port: 31312``, ``tsm_port: 36370``
+* When ``host2`` recovers, cephadm may rebalance the daemons back to the original distribution
+
+.. note::
+   * Always provide ``colocation_ports`` entries equal to ``count - 1`` (or ``count_per_host - 1``)
+     to ensure sufficient port configurations for the worst-case scenario where all daemons
+     end up on a single host due to failures.
+   * If ``colocation_ports`` is not specified, cephadm will auto-increment ports as needed.
 
 TLS/SSL Example
 ---------------

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -136,6 +136,8 @@ class NFSService(CephService):
         deps.append(f'tls_debug: {nfs_spec.tls_debug}')
         deps.append(f'tls_min_version: {nfs_spec.tls_min_version}')
         deps.append(f'tls_ciphers: {nfs_spec.tls_ciphers}')
+        deps.append(f'enable_tsm: {nfs_spec.enable_tsm}')
+        deps.append(f'tsm_port: {nfs_spec.tsm_port}')
         parent_deps = super().get_dependencies(mgr, spec, daemon_type)
         return sorted(deps + parent_deps)
 
@@ -237,6 +239,18 @@ class NFSService(CephService):
         elif spec.enable_rdma:
             rdma_port = spec.rdma_port
 
+        tsm_port = None
+        if spec.enable_tsm and daemon_spec.ports:
+            # If RDMA enabled: ports = [nfs, mon, qos, rdma, tsm] -> index 4
+            # If RDMA disabled: ports = [nfs, mon, qos, tsm] -> index 3
+            tsm_port_index = 4 if spec.enable_rdma else 3
+            if len(daemon_spec.ports) > tsm_port_index:
+                tsm_port = daemon_spec.ports[tsm_port_index]
+            else:
+                tsm_port = spec.tsm_port
+        elif spec.enable_tsm:
+            tsm_port = spec.tsm_port
+
         def get_ganesha_conf() -> str:
             context: Dict[str, Any] = {
                 "user": rados_user,
@@ -262,7 +276,9 @@ class NFSService(CephService):
                 "tls_min_version": spec.tls_min_version,
                 "tls_ktls": spec.tls_ktls,
                 "tls_debug": spec.tls_debug,
-                "ceph_nodes": ceph_nodes
+                "ceph_nodes": ceph_nodes,
+                "enable_tsm": spec.enable_tsm,
+                "tsm_port": tsm_port
             }
             if spec.enable_haproxy_protocol:
                 context["haproxy_hosts"] = self._haproxy_hosts()

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -136,8 +136,10 @@ class NFSService(CephService):
         deps.append(f'tls_debug: {nfs_spec.tls_debug}')
         deps.append(f'tls_min_version: {nfs_spec.tls_min_version}')
         deps.append(f'tls_ciphers: {nfs_spec.tls_ciphers}')
-        deps.append(f'enable_tsm: {nfs_spec.enable_tsm}')
-        deps.append(f'tsm_port: {nfs_spec.tsm_port}')
+        if nfs_spec.enable_tsm:
+            deps.append(f'enable_tsm: {nfs_spec.enable_tsm}')
+            if nfs_spec.tsm_port:
+                deps.append(f'tsm_port: {nfs_spec.tsm_port}')
         parent_deps = super().get_dependencies(mgr, spec, daemon_type)
         return sorted(deps + parent_deps)
 

--- a/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
@@ -27,6 +27,12 @@ NFS_CORE_PARAM {
 {% if cqos_port %}
         Cqos_Port = {{ cqos_port }};
 {% endif %}
+{% if enable_tsm %}
+        enable_TSM = {{ enable_tsm|lower }};
+{% if tsm_port %}
+        Tsm_Port = {{ tsm_port }};
+{% endif %}
+{% endif %}
 }
 
 NFSv4 {

--- a/src/pybind/mgr/cephadm/tests/test_scheduling.py
+++ b/src/pybind/mgr/cephadm/tests/test_scheduling.py
@@ -847,6 +847,32 @@ class NodeAssignmentTest(NamedTuple):
              'nfs:host2(rank=2.0 *:2050,9588,31312)', 'nfs:host1(rank=3.0 *:2050,9588,31312)'],
             []
         ),
+        # NFS with TSM - no colocation, one daemon per host
+        NodeAssignmentTest(
+            'nfs',
+            PlacementSpec(count=2),
+            'host1 host2'.split(),
+            [],
+            {},
+            {0: {0: None}, 1: {0: None}},
+            ['nfs:host2(rank=0.0 *:2049,9587,31311,36369)', 'nfs:host1(rank=1.0 *:2049,9587,31311,36369)'],
+            ['nfs:host2(rank=0.0 *:2049,9587,31311,36369)', 'nfs:host1(rank=1.0 *:2049,9587,31311,36369)'],
+            []
+        ),
+        # NFS colocation with TSM - count > hosts, TSM ports should increment
+        NodeAssignmentTest(
+            'nfs',
+            PlacementSpec(count=4),
+            'host1 host2'.split(),
+            [],
+            {},
+            {0: {0: None}, 1: {0: None}, 2: {0: None}, 3: {0: None}},
+            ['nfs:host2(rank=0.0 *:2049,9587,31311,36369)', 'nfs:host1(rank=1.0 *:2049,9587,31311,36369)',
+             'nfs:host2(rank=2.0 *:2050,9588,31312,36370)', 'nfs:host1(rank=3.0 *:2050,9588,31312,36370)'],
+            ['nfs:host2(rank=0.0 *:2049,9587,31311,36369)', 'nfs:host1(rank=1.0 *:2049,9587,31311,36369)',
+             'nfs:host2(rank=2.0 *:2050,9588,31312,36370)', 'nfs:host1(rank=3.0 *:2050,9588,31312,36370)'],
+            []
+        ),
         # NFS colocation with existing daemons
         NodeAssignmentTest(
             'nfs',
@@ -892,8 +918,15 @@ def test_node_assignment(service_type, placement, hosts, daemons, rank_map, post
     elif service_type == 'nfs':
         service_id = 'mynfs'
         allow_colo = True
+        # Check if this is a TSM test by looking for TSM port (36369) in expected output
+        if expected and any('36369' in str(e) for e in expected):
+            # TSM enabled test case
+            spec = NFSServiceSpec(service_type=service_type,
+                                  service_id=service_id,
+                                  placement=placement,
+                                  enable_tsm=True)
         # Check if this is the custom ports test by looking at expected ports
-        if expected and any('3049' in str(e) for e in expected):
+        elif expected and any('3049' in str(e) for e in expected):
             # Custom colocation ports test case
             # First daemon uses base ports (port, monitoring_port, cluster_qos_port)
             # colocation_ports defines ADDITIONAL daemons only
@@ -2082,3 +2115,4 @@ def test_related_service_downsize(service_type, placement, hosts, daemons, relat
     assert sorted(got_add) == sorted(expected_add)
 
     assert sorted([d.name() for d in to_remove]) == sorted(expected_remove)
+

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -1819,6 +1819,50 @@ def test_ganesha_validate_squash():
         _validate_squash("toot")
 
 
+def test_nfs_service_spec_with_tsm():
+    """Test NFSServiceSpec with TSM parameters."""
+    cluster_id = "foo"
+    
+    # Test with TSM enabled
+    spec_with_tsm = NFSServiceSpec(
+        service_id=cluster_id,
+        enable_tsm=True,
+        tsm_port=5000
+    )
+    assert spec_with_tsm.enable_tsm is True
+    assert spec_with_tsm.tsm_port == 5000
+
+    # Test with TSM disabled (default)
+    spec_without_tsm = NFSServiceSpec(service_id=cluster_id)
+    assert spec_without_tsm.enable_tsm is False
+    assert spec_without_tsm.tsm_port is None
+
+    # Test with TSM enabled but no port specified
+    spec_tsm_no_port = NFSServiceSpec(
+        service_id=cluster_id,
+        enable_tsm=True
+    )
+    assert spec_tsm_no_port.enable_tsm is True
+    assert spec_tsm_no_port.tsm_port is None
+
+
+def test_nfs_service_spec_tsm_serialization():
+    """Test that TSM parameters are properly serialized."""
+    cluster_id = "foo"
+    spec = NFSServiceSpec(
+        service_id=cluster_id,
+        enable_tsm=True,
+        tsm_port=6000
+    )
+    # Convert to dict and back
+    spec_dict = spec.to_json()
+    assert 'enable_tsm' in spec_dict['spec']
+    assert spec_dict['spec']['enable_tsm'] is True
+    assert 'tsm_port' in spec_dict['spec']
+    assert spec_dict['spec']['tsm_port'] == 6000
+
+
+
 def test_ganesha_validate_access_type():
     """Check error handling of internal validation function for access type value."""
     from nfs.ganesha_conf import _validate_access_type
@@ -1855,3 +1899,5 @@ class TestCephfsClientForMgr:
             r2 = mgr_util.CephFSEarmarkResolver(mgr=mgr, client=cephfs_client_for_mgr(mgr))
             assert r1._cephfs_client is r2._cephfs_client
             mock_cephfs_cls.assert_called_once_with(mgr)
+
+

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1381,12 +1381,6 @@ yaml.add_representer(ServiceSpec, ServiceSpec.yaml_representer)
 
 class NFSServiceSpec(ServiceSpec):
     COLOCATION_PORT_FIELDS = ['data_port', 'monitoring_port', 'cluster_qos_port']
-    COLOCATION_PORT_FIELDS_WITH_RDMA = [
-        'data_port',
-        'monitoring_port',
-        'cluster_qos_port',
-        'rdma_port'
-    ]
 
     def __init__(self,
                  service_type: str = 'nfs',
@@ -1423,6 +1417,8 @@ class NFSServiceSpec(ServiceSpec):
                  tls_min_version: Optional[str] = None,
                  tls_ciphers: Optional[str] = None,
                  colocation_ports: Optional[List[Dict[str, int]]] = None,
+                 enable_tsm: bool = False,
+                 tsm_port: Optional[int] = None,
                  ):
         assert service_type == 'nfs'
         super(NFSServiceSpec, self).__init__(
@@ -1463,16 +1459,25 @@ class NFSServiceSpec(ServiceSpec):
         self.tls_debug = tls_debug
         self.tls_min_version = tls_min_version
 
+        # TSM (Transparent State Migration) fields
+        self.enable_tsm = enable_tsm
+        self.tsm_port = tsm_port
+
     def get_colocation_port_fields(self) -> List[str]:
-        """Return port fields for colocation; include rdma_port when RDMA is enabled."""
+        """Return port fields for colocation; dynamically include rdma_port and/or tsm_port when enabled."""
+        fields = list(self.COLOCATION_PORT_FIELDS)
         if self.enable_rdma:
-            return self.COLOCATION_PORT_FIELDS_WITH_RDMA
-        return self.COLOCATION_PORT_FIELDS
+            fields.append('rdma_port')
+        if self.enable_tsm:
+            fields.append('tsm_port')
+        return fields
 
     def get_port_start(self) -> List[int]:
         ports = [self.port or 2049, self.monitoring_port or 9587, self.cluster_qos_port or 31311]
         if self.enable_rdma:
             ports.append(self.rdma_port or 20049)
+        if self.enable_tsm:
+            ports.append(self.tsm_port or 36369)  # Default TSM port from NFS-Ganesha
         return ports
 
     def get_colocation_ports_list(self) -> List[List[int]]:

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -638,6 +638,78 @@ def test_nfs_spec_from_json_rdma():
     assert out.get('spec', {}).get('rdma_port') == 1234
 
 
+def test_nfs_spec_tsm_default():
+    """NFS spec without TSM: enable_tsm is False."""
+    spec = NFSServiceSpec(service_id='mynfs', placement=PlacementSpec(count=1))
+    assert spec.enable_tsm is False
+    assert spec.tsm_port is None
+    assert spec.get_port_start() == [2049, 9587, 31311]
+    assert spec.get_colocation_port_fields() == ['data_port', 'monitoring_port', 'cluster_qos_port']
+
+
+def test_nfs_spec_tsm_enabled():
+    """NFS spec with enable_tsm: get_port_start returns 4 ports, default tsm_port 36369."""
+    spec = NFSServiceSpec(
+        service_id='mynfs',
+        placement=PlacementSpec(count=1),
+        enable_tsm=True,
+    )
+    assert spec.enable_tsm is True
+    assert spec.tsm_port is None
+    assert spec.get_port_start() == [2049, 9587, 31311, 36369]
+    assert spec.get_colocation_port_fields() == ['data_port', 'monitoring_port', 'cluster_qos_port', 'tsm_port']
+
+
+def test_nfs_spec_tsm_custom_port():
+    """NFS spec with enable_tsm and custom tsm_port."""
+    spec = NFSServiceSpec(
+        service_id='mynfs',
+        placement=PlacementSpec(count=1),
+        enable_tsm=True,
+        tsm_port=40000,
+    )
+    assert spec.enable_tsm is True
+    assert spec.tsm_port == 40000
+    assert spec.get_port_start() == [2049, 9587, 31311, 40000]
+    assert spec.get_colocation_port_fields() == ['data_port', 'monitoring_port', 'cluster_qos_port', 'tsm_port']
+    
+
+def test_nfs_spec_colocation_with_tsm_and_rdma():
+    """NFS spec with both TSM and RDMA colocation."""
+    spec = NFSServiceSpec(
+        service_id='mynfs',
+        placement=PlacementSpec(count=3),
+        enable_tsm=True,
+        enable_rdma=True,
+        colocation_ports=[
+            {'data_port': 3049, 'monitoring_port': 9597, 'cluster_qos_port': 31312, 'tsm_port': 36370, 'rdma_port': 20050},
+            {'data_port': 4049, 'monitoring_port': 9607, 'cluster_qos_port': 31313, 'tsm_port': 36371, 'rdma_port': 20051},
+        ]
+    )
+    spec.validate()
+    assert spec.enable_tsm is True
+    assert spec.enable_rdma is True
+    assert spec.get_colocation_port_fields() == ['data_port', 'monitoring_port', 'cluster_qos_port', 'rdma_port', 'tsm_port']
+
+def test_nfs_spec_from_json_tsm():
+    """NFS spec enable_tsm and tsm_port roundtrip via from_json/to_json."""
+    data = {
+        'service_id': 'mynfs',
+        'service_type': 'nfs',
+        'placement': {'count': 1},
+        'spec': {
+            'enable_tsm': True,
+            'tsm_port': 40000,
+        },
+    }
+    spec = NFSServiceSpec.from_json(data)
+    assert spec.enable_tsm is True
+    assert spec.tsm_port == 40000
+    out = spec.to_json()
+    assert out.get('spec', {}).get('enable_tsm') is True
+    assert out.get('spec', {}).get('tsm_port') == 40000
+
+
 def test_repr():
     val = """ServiceSpec.from_json(yaml.safe_load('''service_type: crash
 service_name: crash


### PR DESCRIPTION
Add Transparent State Migration (TSM) support for NFS

Signed-off-by: Pooja Dwivedi pooja.dwivedi@ibm.com 
Fixes:- https://tracker.ceph.com/issues/77324 

### Description
This PR adds support for Transparent State Migration (TSM) in NFS-Ganesha deployments managed by cephadm. It allows NFS clients to maintain their state (open files, locks, etc.) when failing over to another NFS server.

To provide support, cephadm added enable_TSM  and Tsm_Port as part of the NFS core parameters. Which can be changed via the specification file.

### Testing log

Enable TSM with custom port

```yaml
service_type: nfs 
service_id: mynfs 
placement: 
  hosts: 
    - ceph-node-0 
    - ceph-node-1 
spec: 
  port: 2049 
  enable_tsm: true
  tsm_port: 5000
```
```
[ceph: root@ceph-node-0 /]# vi nfs.yaml 
[ceph: root@ceph-node-0 /]# ceph orch apply -i nfs.yaml
Scheduled nfs.mynfs update...
[ceph: root@ceph-node-0 /]# exit
exit
[root@ceph-node-0 ganesha]# pwd
/var/lib/ceph/64ba6c8c-64cc-11f1-a5b7-525400b73517/nfs.mynfs.1.0.ceph-node-0.geqkwe/etc/ganesha
[root@ceph-node-0 ganesha]# cat ganesha.conf | grep -A 2 TSM
        enable_TSM = true;
        Tsm_Port = 50001;
}
```
Without TSM

```yaml
service_type: nfs 
service_id: mynfs 
placement: 
  hosts: 
    - ceph-node-0 
    - ceph-node-1 
spec: 
  port: 2049 
```
```
[ceph: root@ceph-node-0 /]# vi nfs.yaml 
[ceph: root@ceph-node-0 /]# ceph orch apply -i nfs.yaml
Scheduled nfs.mynfs update...
[ceph: root@ceph-node-0 /]# exit
exit
[root@ceph-node-0 ganesha]# pwd
/var/lib/ceph/64ba6c8c-64cc-11f1-a5b7-525400b73517/nfs.mynfs.1.0.ceph-node-0.geqkwe/etc/ganesha
[root@ceph-node-0 ganesha]# cat ganesha.conf | grep TSM

```
NFS Spec with Colocation Port
``` yaml
service_type: nfs
service_id: tsm-coloc-no-rdma
placement:
  count: 4
  hosts:
    - ceph-node-0
    - ceph-node-1
spec:
  port: 2049
  monitoring_port: 9587
  cluster_qos_port: 31311
  enable_tsm: true
  tsm_port: 5000
  colocation_ports:
    - data_port: 3049
      monitoring_port: 9588
      cluster_qos_port: 31312
      tsm_port: 5001
    - data_port: 4049
      monitoring_port: 9589
      cluster_qos_port: 31313
      tsm_port: 5002
    - data_port: 5049
      monitoring_port: 9590
      cluster_qos_port: 31314
      tsm_port: 5003
```
```
[ceph: root@ceph-node-0 /]# ceph orch apply -i nfs.yaml
Scheduled nfs.tsm-coloc-no-rdma update...
[ceph: root@ceph-node-0 /]# ceph orch ps --service_name=nfs.tsm-coloc-no-rdma
NAME                                          HOST         PORTS                   STATUS         REFRESHED  AGE  MEM USE  MEM LIM  VERSION    IMAGE ID      CONTAINER ID  
nfs.tsm-coloc-no-rdma.0.0.ceph-node-0.bfucka  ceph-node-0  *:2049,9587,31311,5000  running (30s)    23s ago  71s    11.9M        -  7.0        0c86fc1274ea  a231889e5e8b  
nfs.tsm-coloc-no-rdma.1.0.ceph-node-1.pmmeoo  ceph-node-1  *:2049,9587,31311,5000  running (34s)    23s ago  62s    11.5M        -  7.0        0c86fc1274ea  24d2c1bdce23  
nfs.tsm-coloc-no-rdma.2.0.ceph-node-0.cjcaho  ceph-node-0  *:3049,9588,31312,5001  unknown          23s ago  51s        -        -  <unknown>  <unknown>     <unknown>     
nfs.tsm-coloc-no-rdma.3.0.ceph-node-1.bwhcfx  ceph-node-1  *:3049,9588,31312,5001  unknown          23s ago  41s        -        -  <unknown>  <unknown>     <unknown>     

[ceph: root@ceph-node-0 /]# exit
exit

[root@ceph-node-0 923aaca0-6894-11f1-96ee-5254006e8eb1]# podman exec -it ceph-923aaca0-6894-11f1-96ee-5254006e8eb1-nfs-tsm-coloc-no-rdma-2-0-ceph-node-0-cjcaho cat /etc/ganesha/ganesha.conf | grep -iA 4 "tsm"
        enable_TSM = true;
        Tsm_Port = 5001;
}
[root@ceph-node-0 923aaca0-6894-11f1-96ee-5254006e8eb1]# cat nfs.tsm-coloc-no-rdma.0.0.ceph-node-0.bfucka/etc/ganesha/ganesha.conf | grep -iA 4 "tsm"
        enable_TSM = true;
        Tsm_Port = 5000;
}
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [X] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [X] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
