### PR TITLE
doc, bluestore: Documentation for Fast Onode Recovery feature

### DIFF
--- a/doc/man/8/ceph-bluestore-tool.rst
+++ b/doc/man/8/ceph-bluestore-tool.rst
@@ -20,6 +20,7 @@ Synopsis
 | **ceph-bluestore-tool** qfsck       --path *osd path*
 | **ceph-bluestore-tool** allocmap    --path *osd path*
 | **ceph-bluestore-tool** restore_cfb --path *osd path*
+| **ceph-bluestore-tool** recovery-compare --path *osd path*
 | **ceph-bluestore-tool** show-label --dev *device* ...
 | **ceph-bluestore-tool** show-label-at --dev *device* --offset *lba* ...
 | **ceph-bluestore-tool** prime-osd-dir --dev *device* --path *osd path*
@@ -72,6 +73,9 @@ Commands
 
    Reverses changes done by the new NCB code (either through ceph restart or when running allocmap command) and restores RocksDB B Column-Family (allocator-map).
 
+:command:`recovery-compare`
+
+   Runs legacy onode recovery and multithread onode recovery. Prints timings and compares results.
 
 :command:`bluefs-export`
 

--- a/doc/rados/bluestore/fast-onode-scan.rst
+++ b/doc/rados/bluestore/fast-onode-scan.rst
@@ -1,0 +1,168 @@
+============================
+ Multithread Onode Scanning
+============================
+
+.. index:: bluestore; rocksdb; allocator
+
+Since Pacific release BlueStore has the option to select 5-10% latency reduction
+at a cost of significantly longer ``OSD`` recovery after crash.
+
+.. confval:: bluestore_allocation_from_file
+
+During crash recovery BlueStore must reconstruct allocator state by scanning all stored objects.
+On systems with millions of objects this process can take several minutes.
+This page presents new multithreaded onode recovery that significantly reduces recovery time.
+
+Allocator
+=========
+
+In BlueStore ``Allocator`` is responsible for tracking unused allocation units on the disk.
+Up to 3 allocators can be in use concurrently, one for Main, one for DB, and one for WAL.
+Only Main device can contain RADOS object, and only Main's allocator is relevant here.
+When BlueStore is running, allocator state is fully loaded to memory. That way
+allocator can quickly respond when there is a need to allocate disk space for object,
+or when object no longer exists on disk.
+
+RocksDB persisted allocator
+---------------------------
+
+Original design envisioned that allocator state updates are stored in RocksDB's ``b`` column.
+When RADOS object change allocates or releases allocation unit the relevant state update information
+is kept together with object-modifying RocksDB atomic transaction. The information transfer is unidirectional,
+BlueStore is updating allocator state in RocksDB, but never retrieving it.
+The exception is OSD bootup when BlueStore retrieves allocator state from RocksDB ``b`` column.
+
+File persisted allocator
+------------------------
+
+It was tested that keeping RocksDB busy updating ``b`` column with allocation data
+has observable cost on write latency and cpu burden on compaction.
+To get that extra performance back the new default mode is to update in-memory allocator state only.
+Instead, on shutdown state is saved to BlueFS file named ``ALLOCATOR_NCB_DIR/ALLOCATOR_NCB_FILE``.
+
+Crash recovery
+--------------
+
+If BlueStore was not shutdown orderly there is no file to read allocator state from.
+Since it is the objects that define what is in use, the recovery procedure iterates over all objects and extracts used allocations.
+
+Multi-thread recovery
+=====================
+
+Iterating over all onodes in the RocksDB can take several minutes.
+To help with that a multi-threaded recovery procedure is created.
+It is significantly different procedure than the original one.
+There is just one configurable that selects and controls recovery.
+
+.. confval:: bluestore_allocation_recovery_threads
+
+
+Performance
+-----------
+
+Example recovery timings.
+OSD with NVME SSD, hosting 7.5M RBD objects, 4.6TiB used.
+
++------------------------+------------+------------+
+| recovery mechanism     | threads    | time(s)    |
++========================+============+============+
+| original               | 1          | 76.0       |
++------------------------+------------+------------+
+| multithread            | 1          | 55.8       |
++------------------------+------------+------------+
+| multithread            | 4          | 18.1       |
++------------------------+------------+------------+
+| multithread            | 8          | 10.8       |
++------------------------+------------+------------+
+| multithread            | 12         | 8.0        |
++------------------------+------------+------------+
+| multithread            | 16         | 6.8        |
++------------------------+------------+------------+
+| multithread            | 32         | 5.3        |
++------------------------+------------+------------+
+
+Testing
+-------
+
+If long recovery time has been a deciding factor for staying with allocations in RocksDB,
+there is a procedure for measuring directly recovery time.
+
+.. prompt:: bash #
+
+  ceph-bluestore-tool --path <osd-data-path> recovery-compare
+
+.. code-block::
+
+  recovery-compare bluestore compare new and legacy onode recovery
+  Legacy recovery start
+  Legacy recovery result=0 took 76.033992 seconds
+  Legacy recovery stats=
+  ==========================================================
+  onode_count             =    7500217
+  shard_count             =    9754950
+  shared_blob_count       =          0
+  compressed_blob_count   =          0
+  spanning_blob_count     =     264519
+  skipped_illegal_extent  =  100815206
+  extent_count            =  188685236
+  insert_count            =          0
+  store store_statfs(0x0/0x0/0x0, data 0x0/0x0, compress 0x0/0x0/0x0, omap 0x0, meta 0x0)
+  pool 1 store_statfs(0x0/0x0/0x0, data 0x90220/0x94000, compress 0x0/0x0/0x0, omap 0x0, meta 0x0)
+  pool 2 store_statfs(0x0/0x0/0x0, data 0x4348a70e000/0x4c7ee684000, compress 0x0/0x0/0x0, omap 0x0, meta 0x0)
+  pool 18446744073709551615 store_statfs(0x0/0x0/0x0, data 0x26a3f/0x150000, compress 0x0/0x0/0x0, omap 0x0, meta 0x0)
+  ==========================================================
+
+  bluestore_allocation_recovery_threads = 0
+  No multithread recovery to compare.
+  recovery-compare success
+
+.. prompt:: bash #
+
+  ceph-bluestore-tool --path <osd-data-path> --bluestore_allocation_recovery_threads=12 recovery-compare
+
+.. code-block::
+
+  recovery-compare bluestore compare new and legacy onode recovery
+  New recovery start
+  New recovery result=0 took 8.033309 seconds
+  New recovery stats=
+  ==========================================================
+  onode_count             =    7500217
+  shard_count             =    9754950
+  shared_blob_count       =          0
+  compressed_blob_count   =          0
+  spanning_blob_count     =     264519
+  skipped_illegal_extent  =          0
+  extent_count            =  188685236
+  insert_count            =          0
+  store store_statfs(0x0/0x0/0x0, data 0x0/0x0, compress 0x0/0x0/0x0, omap 0x0, meta 0x0)
+  pool 1 store_statfs(0x0/0x0/0x0, data 0x90220/0x94000, compress 0x0/0x0/0x0, omap 0x0, meta 0x0)
+  pool 2 store_statfs(0x0/0x0/0x0, data 0x4348a70e000/0x4c7ee684000, compress 0x0/0x0/0x0, omap 0x0, meta 0x0)
+  pool 18446744073709551615 store_statfs(0x0/0x0/0x0, data 0x26a3f/0x150000, compress 0x0/0x0/0x0, omap 0x0, meta 0x0)
+  ==========================================================
+
+  Legacy recovery start
+  Legacy recovery result=0 took 62.210723 seconds
+  Legacy recovery stats=
+  ==========================================================
+  onode_count             =    7500217
+  shard_count             =    9754950
+  shared_blob_count       =          0
+  compressed_blob_count   =          0
+  spanning_blob_count     =     264519
+  skipped_illegal_extent  =  100815206
+  extent_count            =  188685236
+  insert_count            =          0
+  store store_statfs(0x0/0x0/0x0, data 0x0/0x0, compress 0x0/0x0/0x0, omap 0x0, meta 0x0)
+  pool 1 store_statfs(0x0/0x0/0x0, data 0x90220/0x94000, compress 0x0/0x0/0x0, omap 0x0, meta 0x0)
+  pool 2 store_statfs(0x0/0x0/0x0, data 0x4348a70e000/0x4c7ee684000, compress 0x0/0x0/0x0, omap 0x0, meta 0x0)
+  pool 18446744073709551615 store_statfs(0x0/0x0/0x0, data 0x26a3f/0x150000, compress 0x0/0x0/0x0, omap 0x0, meta 0x0)
+  ==========================================================
+
+  FSstats the same.
+  Allocators the same.
+  recovery-compare success
+
+One can see above discrepancy between legacy recovery times: 76.0s vs 62.2s.
+This is an effect of RocksDB having the data already cached by new recovery when legacy recovery is the second one.
+

--- a/doc/rados/configuration/index.rst
+++ b/doc/rados/configuration/index.rst
@@ -22,6 +22,7 @@ For general object store configuration, refer to the following:
    Storage devices <storage-devices>
    BlueStore RocksDB cache <../bluestore/rocksdb-config>
    BlueFS Spillover Cleaner <../bluestore/bluefs-spillover-cleaner>
+   Fast Crash Recovery for file-stored allocations <../bluestore/fast-onode-scan>
    ceph-conf
 
 

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -5460,6 +5460,8 @@ options:
   desc: Remove allocation info from RocksDB and store the info in a new allocation file
   default: true
   with_legacy: true
+  flags:
+    - startup
 - name: bluestore_allocation_recovery_threads
   type: uint
   level: basic


### PR DESCRIPTION
Documentation for fast, multi-threaded onode recovery.
https://github.com/ceph/ceph/pull/64369


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
