### PR TITLE
crimson/os/seastore: ObjectContext to cache OnodeRef

### DIFF
--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -189,6 +189,11 @@ options:
   desc: default logical address space reservation for seastore objects' data
   default: 16777216
 # TODO: implement sub-extent checksum and deprecate this configuration.
+- name: seastore_onode_cache_bypass
+  type: bool
+  level: dev
+  desc: Enable OBC onode cache bypass in _do_transaction_step to skip fltree lookup on reuse
+  default: true
 - name: seastore_full_integrity_check
   type: bool
   level: dev

--- a/src/crimson/os/futurized_store.h
+++ b/src/crimson/os/futurized_store.h
@@ -91,6 +91,19 @@ public:
       const ghobject_t& oid,
       uint32_t op_flags = 0) = 0;
 
+    // Similar to get_attrs but also returns the OnodeRef during onode tree lookup.
+    // This allows caching the Onode and skip the lookup on the next wirte.
+    // Non-SeaStore stores return nullptr for the onode.
+    virtual get_attrs_ertr::future<std::pair<attrs_t, std::shared_ptr<void>>>
+    get_attrs_with_onode(
+      CollectionRef c,
+      const ghobject_t& oid,
+      uint32_t op_flags = 0) {
+      return get_attrs(c, oid, op_flags).safe_then([](attrs_t a) {
+        return std::make_pair(std::move(a), std::shared_ptr<void>{});
+      });
+    }
+
     virtual seastar::future<struct stat> stat(
       CollectionRef c,
       const ghobject_t& oid,

--- a/src/crimson/os/seastore/linked_tree_node.h
+++ b/src/crimson/os/seastore/linked_tree_node.h
@@ -370,6 +370,9 @@ public:
     auto child = children[pos];
     ceph_assert(!is_reserved_ptr(child));
     if (is_valid_child_ptr(child)) {
+      if (!static_cast<ChildT*>(child)->is_valid()) {
+        return child_pos_t<T>(&me, pos);
+      }
       return etvr.get_extent_viewable_by_trans<ChildT>(
         t, static_cast<ChildT*>(child));
     } else if (me.is_pending()) {
@@ -377,6 +380,9 @@ public:
       auto spos = sparent.lower_bound(key).get_offset();
       auto child = sparent.children[spos];
       if (is_valid_child_ptr(child)) {
+        if (!static_cast<ChildT*>(child)->is_valid()) {
+          return child_pos_t<T>(&sparent, spos);
+        }
         return etvr.get_extent_viewable_by_trans<ChildT>(
           t, static_cast<ChildT*>(child));
       } else {

--- a/src/crimson/os/seastore/onode.h
+++ b/src/crimson/os/seastore/onode.h
@@ -119,6 +119,7 @@ public:
 
   virtual bool is_alive() const = 0;
   virtual const onode_layout_t &get_layout() const = 0;
+  virtual bool is_reusable() const { return false; }
   virtual ~Onode() = default;
 
   const hobject_t &get_hobj() const {

--- a/src/crimson/os/seastore/onode.h
+++ b/src/crimson/os/seastore/onode.h
@@ -120,6 +120,7 @@ public:
   virtual bool is_alive() const = 0;
   virtual const onode_layout_t &get_layout() const = 0;
   virtual bool is_reusable() const { return false; }
+  virtual void register_with_transaction(Transaction&) const {}
   virtual ~Onode() = default;
 
   const hobject_t &get_hobj() const {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
@@ -133,6 +133,9 @@ struct FLTreeOnode final : Onode, Value {
   bool is_reusable() const final {
     return is_alive() && is_cursor_leaf_extent_valid();
   }
+  void register_with_transaction(Transaction& t) const final {
+    add_cursor_leaf_to_read_set(t);
+  }
   const onode_layout_t &get_layout() const final {
     assert(status != status_t::DELETED);
     return *read_payload<onode_layout_t>();

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
@@ -130,6 +130,9 @@ struct FLTreeOnode final : Onode, Value {
   bool is_alive() const {
     return status != status_t::DELETED;
   }
+  bool is_reusable() const final {
+    return is_alive() && is_cursor_leaf_extent_valid();
+  }
   const onode_layout_t &get_layout() const final {
     assert(status != status_t::DELETED);
     return *read_payload<onode_layout_t>();

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
@@ -1618,12 +1618,18 @@ eagain_ifuture<Ref<Node>> InternalNode::get_or_track_child(
       child->as_child(position, this);
       return child;
     });
-  }().si_then([this_ref, this, position, child_addr] (auto child) {
+  }().si_then([this_ref, this, position, child_addr, c, FNAME] (auto child) {
     assert(child_addr == child->impl->laddr());
     assert(position == child->parent_info().position);
     std::ignore = position;
     std::ignore = child_addr;
     validate_child_tracked(*child);
+    if (unlikely(!child->is_node_extent_valid())) {
+      DEBUGT("loaded child at pos({}) addr={} became invalid, conflicting",
+             c.t, position, child_addr);
+      child->deref_parent();
+      c.t.test_set_conflict();
+    }
     return child;
   });
 }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
@@ -187,6 +187,11 @@ void tree_cursor_t::invalidate()
   // I must be removed from LeafNode
 }
 
+bool tree_cursor_t::is_leaf_extent_valid() const
+{
+  return is_tracked() && ref_leaf_node->is_node_extent_valid();
+}
+
 /*
  * tree_cursor_t::Cache
  */
@@ -293,6 +298,11 @@ tree_cursor_t::Cache::prepare_mutate_value_payload(
  */
 
 Node::Node(NodeImplURef&& impl) : impl{std::move(impl)} {}
+
+bool Node::is_node_extent_valid() const
+{
+  return impl->is_node_extent_valid();
+}
 
 Node::~Node()
 {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
@@ -223,7 +223,6 @@ void tree_cursor_t::Cache::update_all(const node_version_t& current_version,
          (int)ref_leaf_node->get_node_size());
 
   value_payload_mut.reset();
-  p_value_recorder = nullptr;
 }
 
 void tree_cursor_t::Cache::maybe_duplicate(const node_version_t& current_version)
@@ -244,7 +243,6 @@ void tree_cursor_t::Cache::maybe_duplicate(const node_version_t& current_version
         reset_ptr(p_value_header, p_node_base, current_p_node_base, node_size);
         key_view->reset_to(p_node_base, current_p_node_base, node_size);
         value_payload_mut.reset();
-        p_value_recorder = nullptr;
         p_node_base = current_p_node_base;
       }
     }
@@ -263,7 +261,6 @@ void tree_cursor_t::Cache::maybe_duplicate(const node_version_t& current_version
               current_p_node_base, node_size);
     key_view->reset_to(p_node_base, current_p_node_base, node_size);
     value_payload_mut.reset();
-    p_value_recorder = nullptr;
 
     p_node_base = current_p_node_base;
   } else {
@@ -304,16 +301,12 @@ tree_cursor_t::Cache::prepare_mutate_value_payload(
     context_t c, const search_position_t& pos)
 {
   make_latest(c.vb.get_header_magic(), pos);
-  if (!value_payload_mut.has_value()) {
-    assert(!p_value_recorder);
-    auto value_mutable = ref_leaf_node->prepare_mutate_value_payload(c);
-    auto current_version = ref_leaf_node->get_version();
-    maybe_duplicate(current_version);
-    value_payload_mut = p_value_header->get_payload_mutable(value_mutable.first);
-    p_value_recorder = value_mutable.second;
-    validate_is_latest(pos);
-  }
-  return {*value_payload_mut, p_value_recorder};
+  auto value_mutable = ref_leaf_node->prepare_mutate_value_payload(c);
+  auto current_version = ref_leaf_node->get_version();
+  maybe_duplicate(current_version);
+  value_payload_mut = p_value_header->get_payload_mutable(value_mutable.first);
+  validate_is_latest(pos);
+  return {*value_payload_mut, value_mutable.second};
 }
 
 /*

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
@@ -231,7 +231,23 @@ void tree_cursor_t::Cache::maybe_duplicate(const node_version_t& current_version
   assert(!needs_update_all);
   assert(version.layout == current_version.layout);
   if (version.state == current_version.state) {
-    // cache is already latest.
+    // Normally the cache is already latest
+    // On FLTreeOnode cursor reuse reset the state changes from MUTATION_PENDING to
+    // READ_ONLY back to MUTATION_PENDING, making the before/after states identical
+    // even though the buffer was changed. Instead detect this by comparing buffer pointers.
+    if (p_node_base != nullptr) {
+      auto current_p_node_base = ref_leaf_node->read();
+      if (current_p_node_base != p_node_base) {
+        assert(key_view.has_value());
+        assert(p_value_header != nullptr);
+        auto node_size = ref_leaf_node->get_node_size();
+        reset_ptr(p_value_header, p_node_base, current_p_node_base, node_size);
+        key_view->reset_to(p_node_base, current_p_node_base, node_size);
+        value_payload_mut.reset();
+        p_value_recorder = nullptr;
+        p_node_base = current_p_node_base;
+      }
+    }
   } else if (version.state < current_version.state) {
     // the extent has been copied but the layout has not been changed.
     assert(p_node_base != nullptr);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
@@ -192,6 +192,13 @@ bool tree_cursor_t::is_leaf_extent_valid() const
   return is_tracked() && ref_leaf_node->is_node_extent_valid();
 }
 
+void tree_cursor_t::add_leaf_to_read_set(Transaction& t) const
+{
+  if (is_tracked()) {
+    ref_leaf_node->add_node_extent_to_read_set(t);
+  }
+}
+
 /*
  * tree_cursor_t::Cache
  */
@@ -302,6 +309,11 @@ Node::Node(NodeImplURef&& impl) : impl{std::move(impl)} {}
 bool Node::is_node_extent_valid() const
 {
   return impl->is_node_extent_valid();
+}
+
+void Node::add_node_extent_to_read_set(Transaction& t) const
+{
+  impl->add_to_transaction(t);
 }
 
 Node::~Node()

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
@@ -103,6 +103,10 @@ class tree_cursor_t final
   // Returns false if the leaf extent has been invalidated by GC or conflict.
   bool is_leaf_extent_valid() const;
 
+  // Registers the leaf node extent with t's read_set so that prepare_mutate
+  // can find it via read_set.count().
+  void add_leaf_to_read_set(Transaction& t) const;
+
   /**
    * is_invalid
    *
@@ -398,6 +402,7 @@ class Node
 
 public:
   bool is_node_extent_valid() const;
+  void add_node_extent_to_read_set(Transaction& t) const;
 
  protected:
   Node(NodeImplURef&&);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
@@ -218,7 +218,10 @@ class tree_cursor_t final
    public:
     Cache(Ref<LeafNode>&);
     void validate_is_latest(const search_position_t&) const;
-    void invalidate() { needs_update_all = true; }
+    void invalidate() {
+      needs_update_all = true;
+      value_payload_mut.reset();
+    }
     void update_all(const node_version_t&, const key_view_t&, const value_header_t*);
     const key_view_t& get_key_view(
         value_magic_t magic, const search_position_t& pos) {
@@ -249,7 +252,6 @@ class tree_cursor_t final
 
     // cached data-structures to update value payload
     std::optional<NodeExtentMutable> value_payload_mut;
-    ValueDeltaRecorder* p_value_recorder = nullptr;
   };
   mutable Cache cache;
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
@@ -100,6 +100,9 @@ class tree_cursor_t final
    */
   bool is_tracked() const { return !!ref_leaf_node && !position.is_end(); }
 
+  // Returns false if the leaf extent has been invalidated by GC or conflict.
+  bool is_leaf_extent_valid() const;
+
   /**
    * is_invalid
    *
@@ -392,6 +395,9 @@ class Node
   virtual bool is_tracking() const = 0;
 
   virtual void track_merge(Ref<Node>, match_stage_t, search_position_t&) = 0;
+
+public:
+  bool is_node_extent_valid() const;
 
  protected:
   Node(NodeImplURef&&);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
@@ -351,6 +351,11 @@ class NodeExtentAccessorT {
     }
   }
 
+  // Returns false if the underlying extent has been invalidated by GC or conflict.
+  bool is_extent_valid() const {
+    return !is_retired() && extent->is_valid();
+  }
+
   // must be called before any mutate attempes.
   // for the safety of mixed read and mutate, call before read.
   void prepare_mutate(context_t c) {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
@@ -361,10 +361,42 @@ class NodeExtentAccessorT {
     return extent;
   }
 
+  // A node that is tracked across transaction keeps the same NodeExtentAccessorT
+  // instance after the transaction that wrote it commits.
+  void reset_after_commit(context_t c) {
+    assert(!is_retired());
+    if (state == nextent_state_t::READ_ONLY) {
+      // nothing carried over, or already reset
+      return;
+    }
+    if (!extent->is_stable()) {
+      // in-flight mutation, do not reset
+      return;
+    }
+    assert(state == nextent_state_t::MUTATION_PENDING ||
+           state == nextent_state_t::FRESH);
+    // a *stable* extent has been fully committed, the prior recorder is gone
+    assert(extent->is_stable_ready());
+    assert(extent->get_recorder() == nullptr ||
+           extent->get_recorder()->is_empty());
+    LOG_PREFIX(OTree::Extent::reset_after_commit);
+    SUBDEBUGT(seastore_onode,
+        "reused extent {} carried stale state={} from a committed txn, "
+        "resetting to READ_ONLY",
+        c.t, extent->get_laddr(), static_cast<int>(state));
+    state = nextent_state_t::READ_ONLY;
+    mut.reset();
+    recorder = nullptr;
+  }
+
   // must be called before any mutate attempes.
   // for the safety of mixed read and mutate, call before read.
   void prepare_mutate(context_t c) {
     assert(!is_retired());
+    // TODO: lazily re-sync the accessor state to the already-committed extent
+    // for the next (onoderef) re-use. Logically, this should happen at the extent's commit.
+    // A reused accessor carrying stale MUTATION_PENDING/FRESH might be worth removing.
+    reset_after_commit(c);
     if (state == nextent_state_t::READ_ONLY) {
       assert(extent->is_stable());
       assert(extent->is_stable_ready());

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
@@ -356,6 +356,11 @@ class NodeExtentAccessorT {
     return !is_retired() && extent->is_valid();
   }
 
+  NodeExtentRef get_extent_ref() const {
+    assert(!is_retired());
+    return extent;
+  }
+
   // must be called before any mutate attempes.
   // for the safety of mixed read and mutate, call before read.
   void prepare_mutate(context_t c) {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
@@ -62,6 +62,10 @@ class SeastoreNodeExtent final: public NodeExtent {
     prior.recorder = std::move(recorder);
   }
 
+  void clear_delta() override {
+    recorder.reset();
+  }
+
   DeltaRecorder* get_recorder() const override {
     return recorder.get();
   }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
@@ -85,6 +85,7 @@ class NodeImpl {
   virtual extent_len_t total_size() const = 0;
   virtual bool is_extent_retired() const = 0;
   virtual bool is_node_extent_valid() const = 0;
+  virtual void add_to_transaction(Transaction& t) const = 0;
   virtual std::optional<key_view_t> get_pivot_index() const = 0;
   virtual bool is_size_underflow() const = 0;
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
@@ -84,6 +84,7 @@ class NodeImpl {
   virtual node_offset_t free_size() const = 0;
   virtual extent_len_t total_size() const = 0;
   virtual bool is_extent_retired() const = 0;
+  virtual bool is_node_extent_valid() const = 0;
   virtual std::optional<key_view_t> get_pivot_index() const = 0;
   virtual bool is_size_underflow() const = 0;
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
@@ -130,6 +130,7 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
   node_offset_t free_size() const override { return extent.read().free_size(); }
   extent_len_t total_size() const override { return extent.read().total_size(); }
   bool is_extent_retired() const override { return extent.is_retired(); }
+  bool is_node_extent_valid() const override { return extent.is_extent_valid(); }
 
   std::optional<key_view_t> get_pivot_index() const override {
     if (is_level_tail()) {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
@@ -131,6 +131,12 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
   extent_len_t total_size() const override { return extent.read().total_size(); }
   bool is_extent_retired() const override { return extent.is_retired(); }
   bool is_node_extent_valid() const override { return extent.is_extent_valid(); }
+  void add_to_transaction(Transaction& t) const override {
+    auto ref = extent.get_extent_ref();
+    if (!t.is_in_read_set(ref)) {
+      t.add_to_read_set(ref);
+    }
+  }
 
   std::optional<key_view_t> get_pivot_index() const override {
     if (is_level_tail()) {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
@@ -47,6 +47,13 @@ bool Value::is_cursor_leaf_extent_valid() const
   return p_cursor && p_cursor->is_leaf_extent_valid();
 }
 
+void Value::add_cursor_leaf_to_read_set(Transaction& t) const
+{
+  if (p_cursor) {
+    p_cursor->add_leaf_to_read_set(t);
+  }
+}
+
 void Value::invalidate()
 {
   p_cursor.reset();

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
@@ -37,6 +37,16 @@ bool Value::is_tracked() const
   return p_cursor->is_tracked();
 }
 
+bool Value::is_cursor_tracked() const
+{
+  return p_cursor && p_cursor->is_tracked();
+}
+
+bool Value::is_cursor_leaf_extent_valid() const
+{
+  return p_cursor && p_cursor->is_leaf_extent_valid();
+}
+
 void Value::invalidate()
 {
   p_cursor.reset();

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
@@ -222,6 +222,7 @@ class Value {
 
   bool is_cursor_tracked() const;
   bool is_cursor_leaf_extent_valid() const;
+  void add_cursor_leaf_to_read_set(Transaction& t) const;
 
   /// Extends the payload size.
   eagain_ifuture<> extend(Transaction&, value_size_t extend_size);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
@@ -220,6 +220,9 @@ class Value {
  protected:
   Value(NodeExtentManager&, const ValueBuilder&, Ref<tree_cursor_t>&);
 
+  bool is_cursor_tracked() const;
+  bool is_cursor_leaf_extent_valid() const;
+
   /// Extends the payload size.
   eagain_ifuture<> extend(Transaction&, value_size_t extend_size);
 

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -1914,17 +1914,44 @@ SeaStore::Shard::_do_transaction_step(
       op->op == Transaction::OP_ZERO) {
     create = true;
   }
+
+  if (onodes[op->oid] && !onodes[op->oid]->is_reusable()) {
+    DEBUGT("[onode_cache] stale onodes[] entry (extent invalidated), re-fetch oid={}",
+           *ctx.transaction, i.get_oid(op->oid));
+    onodes[op->oid].reset();
+  }
   if (!onodes[op->oid]) {
     const ghobject_t& oid = i.get_oid(op->oid);
     auto t0 = std::chrono::steady_clock::now();
-    if (!create) {
-      DEBUGT("op {}, get oid={} ...",
-             *ctx.transaction, (uint32_t)op->op, oid);
-      fut = onode_manager->get_onode(*ctx.transaction, oid);
+    auto& cache = ctx.ext_transaction.onode_cache;
+
+    // Fast path: cache hit — assign directly and skip the fltree lookup below.
+    auto it = cache.find(oid);
+    if (it != cache.end()) {
+      auto sp = std::static_pointer_cast<OnodeRef>(it->second);
+      if ((*sp)->is_reusable()) {
+        DEBUGT("[onode_cache] hit oid={}", *ctx.transaction, oid);
+        onodes[op->oid] = *sp;
+      } else {
+        DEBUGT("[onode_cache] stale (cursor invalidated) oid={}", *ctx.transaction, oid);
+      }
     } else {
-      DEBUGT("op {}, get_or_create oid={} ...",
-             *ctx.transaction, (uint32_t)op->op, oid);
-      fut = onode_manager->get_or_create_onode(*ctx.transaction, oid);
+      DEBUGT("[onode_cache] miss oid={}", *ctx.transaction, oid);
+    }
+
+    if (!onodes[op->oid]) {
+      if (!create) {
+        DEBUGT("op {}, get oid={} ...",
+               *ctx.transaction, (uint32_t)op->op, oid);
+        fut = onode_manager->get_onode(*ctx.transaction, oid);
+      } else {
+        DEBUGT("op {}, get_or_create oid={} ...",
+               *ctx.transaction, (uint32_t)op->op, oid);
+        fut = onode_manager->get_or_create_onode(*ctx.transaction, oid);
+      }
+      fut = std::move(fut).si_then([&ctx](auto onode) {
+        return onode_iertr::make_ready_future<OnodeRef>(std::move(onode));
+      });
     }
     fut = std::move(fut).si_then([&ctx, t0](auto onode) {
       ctx.get_onode_time += std::chrono::steady_clock::now() - t0;

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -123,6 +123,8 @@ SeaStore::Shard::Shard(
   :root(root),
    max_object_size(
      get_conf<uint64_t>("seastore_default_max_object_size")),
+   onode_cache_bypass(
+     get_conf<bool>("seastore_onode_cache_bypass")),
    is_test(is_test),
    throttler(
       get_conf<uint64_t>("seastore_max_concurrent_transactions")),
@@ -1927,7 +1929,7 @@ SeaStore::Shard::_do_transaction_step(
 
     // Fast path: cache hit — assign directly and skip the fltree lookup below.
     auto it = cache.find(oid);
-    if (it != cache.end()) {
+    if (it != cache.end() && onode_cache_bypass) {
       auto sp = std::static_pointer_cast<OnodeRef>(it->second);
       if ((*sp)->is_reusable()) {
         DEBUGT("[onode_cache] hit oid={}", *ctx.transaction, oid);

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -1431,7 +1431,10 @@ SeaStore::Shard::get_attrs(
   assert(store_active);
   ++(shard_stats.read_num);
   ++(shard_stats.pending_read_num);
-
+  auto _ = seastar::defer([this] noexcept {
+    assert(shard_stats.pending_read_num);
+    --(shard_stats.pending_read_num);
+  });
   return repeat_with_onode<attrs_t>(
     ch,
     oid,
@@ -1445,10 +1448,37 @@ SeaStore::Shard::get_attrs(
     crimson::ct_error::input_output_error::assert_failure{
       "EIO when getting attrs"},
     crimson::ct_error::pass_further_all{}
+  );
+}
+
+SeaStore::Shard::get_attrs_ertr::future<
+    std::pair<SeaStore::Shard::attrs_t, std::shared_ptr<void>>>
+SeaStore::Shard::get_attrs_with_onode(
+  CollectionRef ch,
+  const ghobject_t& oid,
+  uint32_t op_flags)
+{
+  assert(store_active);
+  ++(shard_stats.read_num);
+  ++(shard_stats.pending_read_num);
+  std::shared_ptr<void> onode_handle;
+  auto attrs = co_await repeat_with_onode<attrs_t>(
+    ch, oid, Transaction::src_t::READ, "get_attrs",
+    op_type_t::GET_ATTRS, op_flags,
+    [this, &onode_handle](auto& t, auto& onode) {
+      onode_handle = std::static_pointer_cast<void>(
+        std::make_shared<OnodeRef>(&onode));
+      return _get_attrs(t, onode);
+    }
+  ).handle_error(
+    crimson::ct_error::input_output_error::assert_failure{
+      "EIO when getting attrs"},
+    crimson::ct_error::pass_further_all{}
   ).finally([this] {
     assert(shard_stats.pending_read_num);
     --(shard_stats.pending_read_num);
   });
+  co_return std::make_pair(std::move(attrs), std::move(onode_handle));
 }
 
 seastar::future<struct stat> SeaStore::Shard::_stat(

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -1934,6 +1934,7 @@ SeaStore::Shard::_do_transaction_step(
       if ((*sp)->is_reusable()) {
         DEBUGT("[onode_cache] hit oid={}", *ctx.transaction, oid);
         onodes[op->oid] = *sp;
+        onodes[op->oid]->register_with_transaction(*ctx.transaction);
       } else {
         DEBUGT("[onode_cache] stale (cursor invalidated) oid={}", *ctx.transaction, oid);
       }

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -625,6 +625,7 @@ public:
     std::string root;
     Device* device;
     const uint32_t max_object_size;
+    const bool onode_cache_bypass;
     bool is_test;
 
     std::vector<Device*> secondaries;

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -149,6 +149,12 @@ public:
       const ghobject_t& oid,
       uint32_t op_flags = 0) override final;
 
+    get_attrs_ertr::future<std::pair<attrs_t, std::shared_ptr<void>>>
+    get_attrs_with_onode(
+      CollectionRef c,
+      const ghobject_t& oid,
+      uint32_t op_flags = 0) override final;
+
     read_errorator::future<omap_values_t> omap_get_values(
       CollectionRef c,
       const ghobject_t& oid,

--- a/src/crimson/osd/object_context.h
+++ b/src/crimson/osd/object_context.h
@@ -81,6 +81,10 @@ public:
 
   CommonOBCPipeline obc_pipeline;
 
+  // live SeaStore onode cached during obc load. SeaStore validates it with
+  // is_reusable() before each write to skip tree lookups.
+  std::shared_ptr<void> cached_onode;
+
   ObjectContext(hobject_t hoid) : lock(hoid.to_str()),
                                   obs(std::move(hoid)) {}
 

--- a/src/crimson/osd/object_context_loader.cc
+++ b/src/crimson/osd/object_context_loader.cc
@@ -27,6 +27,9 @@ ObjectContextLoader::load_and_lock_head(Manager &manager, RWState::State lock_ty
   }
 
   if (manager.target_state.obc->loading_started) {
+    DEBUGDPP("[onode_cache] OBC hot for {}, cached_onode={}",
+             dpp, manager.target,
+             manager.target_state.obc->cached_onode ? "present" : "absent");
     co_await manager.target_state.lock_to(lock_type);
   } else {
     manager.target_state.lock_excl_sync();
@@ -187,6 +190,10 @@ ObjectContextLoader::load_obc(
     obc->set_clone_state(std::move(md->os));
   }
   obc->attr_cache = std::move(md->attr_cache);
+  obc->cached_onode = std::move(md->cached_onode);
+  if (obc->cached_onode) {
+    DEBUGDPP("[onode_cache] cached from OBC load for {}", dpp, oid);
+  }
   DEBUGDPP("loaded obc {} for {}", dpp, obc->obs.oi, obc->obs.oi.soid);
 }
 

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -157,13 +157,17 @@ PGBackend::load_metadata_iertr::future
 PGBackend::load_metadata(const hobject_t& oid)
 {
   return interruptor::make_interruptible(
-    crimson::os::with_store<&crimson::os::FuturizedStore::Shard::get_attrs>(
+    crimson::os::with_store<
+      &crimson::os::FuturizedStore::Shard::get_attrs_with_onode>(
     store,
     coll,
     ghobject_t{oid, ghobject_t::NO_GEN, get_shard()}, 0)).safe_then_interruptible(
-      [oid, this](auto &&attrs) -> load_metadata_iertr::future<PGBackend::loaded_object_md_t::ref> {
+      [oid, this](auto &&attrs_and_onode)
+          -> load_metadata_iertr::future<PGBackend::loaded_object_md_t::ref> {
+        auto& [attrs, onode] = attrs_and_onode;
         if (auto maybe_decoded = decode_metadata2(oid, std::move(attrs));
             maybe_decoded.has_value()) {
+          (*maybe_decoded)->cached_onode = std::move(onode);
           return load_metadata_ertr::make_ready_future<loaded_object_md_t::ref>(
             std::move(*maybe_decoded));
         } else {

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -460,6 +460,7 @@ public:
     ObjectState os;
     crimson::osd::SnapSetContextRef ssc;
     crimson::os::FuturizedStore::Shard::attrs_t attr_cache;
+    std::shared_ptr<void> cached_onode;
     using ref = std::unique_ptr<loaded_object_md_t>;
   };
 

--- a/src/crimson/osd/replicated_backend.cc
+++ b/src/crimson/osd/replicated_backend.cc
@@ -180,6 +180,15 @@ ReplicatedBackend::submit_transaction(
     txn,
     false);
 
+  // Populate the per-oid onode cache so SeaStore can skip fltree lookups.
+  // See: get_attrs_with_onode
+  if (obc->cached_onode) {
+    txn.onode_cache[ghobject_t{hoid}] = obc->cached_onode;
+  }
+  if (_new_clone && _new_clone->cached_onode) {
+    txn.onode_cache[ghobject_t{_new_clone->obs.oi.soid}] = _new_clone->cached_onode;
+  }
+
   auto all_completed = interruptor::make_interruptible(
     crimson::os::with_store_do_transaction(
       shard_services.get_store(pg.get_store_index()),

--- a/src/os/Transaction.h
+++ b/src/os/Transaction.h
@@ -254,6 +254,9 @@ private:
   std::list<Context *> on_applied_sync;
 
 public:
+#ifdef WITH_CRIMSON
+  std::map<ghobject_t, std::shared_ptr<void>> onode_cache;
+#endif
   Transaction() = default;
   explicit Transaction(uint64_t data_features)
     : data_features(data_features) {
@@ -272,7 +275,11 @@ public:
     op_bl(std::move(other.op_bl)),
     on_applied(std::move(other.on_applied)),
     on_commit(std::move(other.on_commit)),
-    on_applied_sync(std::move(other.on_applied_sync)) {
+    on_applied_sync(std::move(other.on_applied_sync))
+#ifdef WITH_CRIMSON
+    , onode_cache(std::move(other.onode_cache))
+#endif
+    {
     other.coll_id = 0;
     other.object_id = 0;
   }
@@ -290,6 +297,9 @@ public:
     on_applied = std::move(other.on_applied);
     on_commit = std::move(other.on_commit);
     on_applied_sync = std::move(other.on_applied_sync);
+#ifdef WITH_CRIMSON
+    onode_cache = std::move(other.onode_cache);
+#endif
     other.coll_id = 0;
     other.object_id = 0;
     return *this;


### PR DESCRIPTION
This brings **Onode awareness** within Crimson-OSD's object context. While it's not optimal to _break_ isolation between the layers. Trying to reuse cached Onode extents (even if all are cache hit) - still require:
- `read_extent(leaf_laddr)` - cache (extent) map lookup
- `new LeafNode` - wrapping the extent
- `lower_bound()` scan thorugh the leaf keys with full `hobject_t` comparison **(<-- main cost)**
- another `new FLTreeOnode` alloc.

For every write we first scan the onode tree in `get_obc` stage then another time when actually performing the write.
Keeping the Onode ref should save us the second lookup entirely.  According to analysis made in https://github.com/ceph/ceph/pull/69281:
```
Seems Onode lookup takes almost 40% of build time which is ~20% of all txn stages.
```

Another approach here could be, keeping OnodeRef cache layer directly within Seastore - However, this would essentially duplicate the object context cache management - obc loader, lru/2q (eviction, invalidation on interval change) so reusing obc for this purpose is simpler.

Lastly, reducing the above overhead might largely impact randwrite workloads - keeping as draft for early reviews until proven impact is seen (I'm hitting another bug which is exposed with the changes here that blocks this from being tested properly, I'll address it in another PR ). 



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
