### PR TITLE
doc/dev/release-checklists: reset to skeleton

### DIFF
--- a/doc/dev/release-checklists.rst
+++ b/doc/dev/release-checklists.rst
@@ -15,10 +15,10 @@ that was just released (X-1).2.0.
 Versions and tags
 -----------------
 
-- [x] Update CMakeLists.txt VERSION (right at the top to X.0.0)
-- [x] Update src/librbd/CMakeLists.txt VERSION (librbd target at the bottom to 1.X.0)
-- [x] Update src/ceph_release with the new release name, number, and type ('dev')
-- [x] Initial tag vX.0.0 so that we can distinguish from (and sort after) the backported (X-1).2.Z versions.
+- [ ] Update CMakeLists.txt VERSION (right at the top to X.0.0)
+- [ ] Update src/librbd/CMakeLists.txt VERSION (librbd target at the bottom to 1.X.0)
+- [ ] Update src/ceph_release with the new release name, number, and type ('dev')
+- [ ] Initial tag vX.0.0 so that we can distinguish from (and sort after) the backported (X-1).2.Z versions.
 
 .. note::
 
@@ -31,35 +31,35 @@ Define release names and constants
 
 Make sure X (and, ideally, X+1) is defined:
 
-- [x] src/common/ceph_releases.h (`ceph_release_t`)
-- [x] src/common/ceph_strings.cc (`ceph_release_name()`)
-- [x] src/include/rados.h (`CEPH_RELEASE_*` and `MAX`)
-- [x] src/include/rbd/librbd.h (`LIBRBD_VER_MINOR` to X)
-- [x] src/mds/cephfs_features.h (`CEPHFS_CURRENT_RELEASE`)
-- [x] src/mon/mon_types.h (`ceph::features::mon::FEATURE_*` and related structs and helpers)
+- [ ] src/common/ceph_releases.h (`ceph_release_t`)
+- [ ] src/common/ceph_strings.cc (`ceph_release_name()`)
+- [ ] src/include/rados.h (`CEPH_RELEASE_*` and `MAX`)
+- [ ] src/include/rbd/librbd.h (`LIBRBD_VER_MINOR` to X)
+- [ ] src/mds/cephfs_features.h (`CEPHFS_CURRENT_RELEASE`)
+- [ ] src/mon/mon_types.h (`ceph::features::mon::FEATURE_*` and related structs and helpers)
 
 Github Actions
 ~~~~~~~~~~~~~~
 
-- [x] .github/workflows/redmine-upkeep.yml add release branch to pull_request_target trigger
-- [x] .github/workflows/releng-audit.yml add release branch to pull_request_target trigger
+- [ ] .github/workflows/redmine-upkeep.yml add release branch to pull_request_target trigger
+- [ ] .github/workflows/releng-audit.yml add release branch to pull_request_target trigger
 
 Scripts
 ~~~~~~~
 
-- [x] src/script/backport-create-issue (`releases()`)
-- [x] src/script/ceph-release-notes (up to X)
+- [ ] src/script/backport-create-issue (`releases()`)
+- [ ] src/script/ceph-release-notes (up to X)
 
 Misc
 ~~~~
-- [x] update src/ceph-volume/ceph_volume/__init__.py (`__release__`)
-- [x] update src/cephadm/cephadmlib/constants.py (`DEFAULT_IMAGE_RELEASE` and `LATEST_STABLE_RELEASE` to X)
+- [ ] update src/ceph-volume/ceph_volume/__init__.py (`__release__`)
+- [ ] update src/cephadm/cephadmlib/constants.py (`DEFAULT_IMAGE_RELEASE` and `LATEST_STABLE_RELEASE` to X)
 
 Feature bits
 ------------
 
-- [x] ensure that `SERVER_X` is defined
-- [x] change any features `DEPRECATED` in release X-3 are now marked `RETIRED`.
+- [ ] ensure that `SERVER_X` is defined
+- [ ] change any features `DEPRECATED` in release X-3 are now marked `RETIRED`.
 - [ ] look for features that (1) were present in X-2 and (2) have no
   client dependency and mark them `DEPRECATED` as of X.
 
@@ -67,57 +67,57 @@ Feature bits
 Compatsets
 ----------
 
-- [x] mon/Monitor.h (`CEPH_MON_FEATURE_INCOMPAT_X`)
-- [x] mon/Monitor.cc (include in `get_supported_features()`)
-- [x] mon/Monitor.cc (`apply_monmap_to_compatset_features()`)
-- [x] mon/Monitor.cc (`calc_quorum_requirements()`)
-- [x] test/cli/monmaptool/feature-set-unset-list.t (`supported`, `persistent`)
-- [x] test/cli/monmaptool/feature-set-unset-list.t Update "unknown(X)" to next unused and update monmaptool --feature-unset examples
+- [ ] mon/Monitor.h (`CEPH_MON_FEATURE_INCOMPAT_X`)
+- [ ] mon/Monitor.cc (include in `get_supported_features()`)
+- [ ] mon/Monitor.cc (`apply_monmap_to_compatset_features()`)
+- [ ] mon/Monitor.cc (`calc_quorum_requirements()`)
+- [ ] test/cli/monmaptool/feature-set-unset-list.t (`supported`, `persistent`)
+- [ ] test/cli/monmaptool/feature-set-unset-list.t Update "unknown(X)" to next unused and update monmaptool --feature-unset examples
 
 Mon
 ---
 
-- [x] src/tools/monmaptool.cc: bump min_mon_release to X for created (new) clusters
-- [x] src/test/cli/monmaptool/8.t: update output for monmaptool to X
-- [x] qa/standalone/mon/misc adjust `TEST_mon_features` (add X cases and adjust `--mon-debug-no-require-X`)
-- [x] qa/standalone/mon/misc bump up `jqfilter='.monmap.features.persistent | length == N'` to `N+1`
-- [x] mon/MgrMonitor.cc adjust `always_on_modules`
-- [x] common/options/global.yaml.in define `mon_debug_no_require_X`
-- [x] common/options/global.yaml.in remove `mon_debug_no_require_X-2`
-- [x] mon/OSDMonitor.cc `create_initial`: adjust new `require_osd_release`, and add associated `mon_debug_no_require_X`
-- [x] mon/OSDMonitor.cc `preprocess_boot`: adjust "disallow boot of " condition to disallow X if `require_osd_release` < X-2.
-- [x] mon/OSDMonitor.cc: adjust "osd require-osd-release" to (1) allow setting X, and (2) check that all mons *and* OSDs have X
-- [x] mon/MonCommands.h: adjust "osd require-osd-release" allows options to include X
-- [x] qa/workunits/cephtool/test.sh: adjust `require-osd-release` test
+- [ ] src/tools/monmaptool.cc: bump min_mon_release to X for created (new) clusters
+- [ ] src/test/cli/monmaptool/8.t: update output for monmaptool to X
+- [ ] qa/standalone/mon/misc adjust `TEST_mon_features` (add X cases and adjust `--mon-debug-no-require-X`)
+- [ ] qa/standalone/mon/misc bump up `jqfilter='.monmap.features.persistent | length == N'` to `N+1`
+- [ ] mon/MgrMonitor.cc adjust `always_on_modules`
+- [ ] common/options/global.yaml.in define `mon_debug_no_require_X`
+- [ ] common/options/global.yaml.in remove `mon_debug_no_require_X-2`
+- [ ] mon/OSDMonitor.cc `create_initial`: adjust new `require_osd_release`, and add associated `mon_debug_no_require_X`
+- [ ] mon/OSDMonitor.cc `preprocess_boot`: adjust "disallow boot of " condition to disallow X if `require_osd_release` < X-2.
+- [ ] mon/OSDMonitor.cc: adjust "osd require-osd-release" to (1) allow setting X, and (2) check that all mons *and* OSDs have X
+- [ ] mon/MonCommands.h: adjust "osd require-osd-release" allows options to include X
+- [ ] qa/workunits/cephtool/test.sh: adjust `require-osd-release` test
 
 OSDMap
 ------
 
-- [x] src/osd/OSDMap.cc add release name mapping for `SERVER_X` in `pending_require_osd_release()`
+- [ ] src/osd/OSDMap.cc add release name mapping for `SERVER_X` in `pending_require_osd_release()`
 - [ ] OSDMap::get_min_compat_client: core team evaluate
 
 Code cleanup
 ------------
 
-- [x] search code for "after X-1" or "X" for conditional checks
-- [x] search code for X-2 and X-3 (`CEPH_FEATURE_SERVER_*` and
+- [ ] search code for "after X-1" or "X" for conditional checks
+- [ ] search code for X-2 and X-3 (`CEPH_FEATURE_SERVER_*` and
   `ceph_release_t::*`)
 - [ ] search code for `require_osd_release`
 - [ ] search code for `min_mon_release`
-- [x] check include/denc.h if DENC_START macro still needs reference to squid
+- [ ] check include/denc.h if DENC_START macro still needs reference to squid
 
 QA suite
 --------
 
-- [x] create qa/workunits/test_telemetry_(X-1).sh
-- [x] create qa/workunits/test_telemetry_(X-1)_x.sh
-- [x] create qa/suites/upgrade/(X-1)-x
-- [x] remove qa/suites/upgrade/(X-3)-x-*
-- [x] update qa/fs/upgrade/ to remove (X-3) and add (X-1); check with fs team to confirm / help
-- [x] update qa/ upgrade suites require-osd-release calls to tentacle
-- [x] create qa/releases/X.yaml
-- [x] create qa/suites/rados/thrash-old-clients/1-install/(X-1).yaml
-- [x] update qa/suites/rados/encoder/1-task.yaml to remove (X-3) and add X
+- [ ] create qa/workunits/test_telemetry_(X-1).sh
+- [ ] create qa/workunits/test_telemetry_(X-1)_x.sh
+- [ ] create qa/suites/upgrade/(X-1)-x
+- [ ] remove qa/suites/upgrade/(X-3)-x-*
+- [ ] update qa/fs/upgrade/ to remove (X-3) and add (X-1); check with fs team to confirm / help
+- [ ] update qa/ upgrade suites require-osd-release calls to tentacle
+- [ ] create qa/releases/X.yaml
+- [ ] create qa/suites/rados/thrash-old-clients/1-install/(X-1).yaml
+- [ ] update qa/suites/rados/encoder/1-task.yaml to remove (X-3) and add X
 
 
 ceph-build


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
