### PR TITLE
umbrella: .github/milestone: add umbrella

### DIFF
--- a/.github/milestone.yml
+++ b/.github/milestone.yml
@@ -7,3 +7,4 @@ base-branch:
   - "(reef)"
   - "(squid)"
   - "(tentacle)"
+  - "(umbrella)"

--- a/doc/dev/release-checklists.rst
+++ b/doc/dev/release-checklists.rst
@@ -140,7 +140,7 @@ After dev freeze
 - [x] cherry-pick 8cf9ad62949516666ad0f2c0bb7726ef68e4d666 ("doc: add releases links to toc"). There will be trivial conflicts.
 - [x] add redirect for new major release at `RTD <https://readthedocs.org/dashboard/ceph/redirects/>`_.
 - [x] add release name to redmine (using https://tracker.ceph.com/custom_fields/16/edit)
-- [ ] add release name to .github/milestone.yml for github actions to automatically add milestone to backports (this commit must be backported to the release branch)
+- [x] add release name to .github/milestone.yml for github actions to automatically add milestone to backports (this commit must be backported to the release branch)
 - [x] add release branch to nightlies: qa/crontab/teuthology-cronjobs
 
 First release candidate


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77320

---

backport of https://github.com/ceph/ceph/pull/69404
parent tracker: https://tracker.ceph.com/issues/77308

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh