### PR TITLE
tentacle: ceph-volume: fix raw activate when device path is stale

### DIFF
--- a/src/ceph-volume/ceph_volume/objectstore/baseobjectstore.py
+++ b/src/ceph-volume/ceph_volume/objectstore/baseobjectstore.py
@@ -110,7 +110,7 @@ class BaseObjectStore:
     def unlink_bs_symlinks(self) -> None:
         for link_name in ['block', 'block.db', 'block.wal']:
             link_path = os.path.join(self.osd_path, link_name)
-            if os.path.exists(link_path):
+            if os.path.lexists(link_path):
                 os.unlink(os.path.join(self.osd_path, link_name))
 
     def prepare_osd_req(self, tmpfs: bool = True) -> None:

--- a/src/ceph-volume/ceph_volume/tests/objectstore/test_raw.py
+++ b/src/ceph-volume/ceph_volume/tests/objectstore/test_raw.py
@@ -145,7 +145,7 @@ class TestRaw:
     @patch('ceph_volume.objectstore.raw.prepare_utils.link_wal')
     @patch('ceph_volume.objectstore.raw.prepare_utils.link_db')
     @patch('ceph_volume.objectstore.raw.prepare_utils.link_block')
-    @patch('os.path.exists')
+    @patch('os.path.lexists')
     @patch('os.unlink')
     @patch('ceph_volume.objectstore.raw.prepare_utils.create_osd_path')
     @patch('ceph_volume.objectstore.raw.process.run')


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77327

---

backport of https://github.com/ceph/ceph/pull/69391
parent tracker: https://tracker.ceph.com/issues/77295

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh