### PR TITLE
squid: ceph-volume: fix raw activate when device path is stale

### DIFF
--- a/src/ceph-volume/ceph_volume/objectstore/bluestore.py
+++ b/src/ceph-volume/ceph_volume/objectstore/bluestore.py
@@ -61,7 +61,7 @@ class BlueStore(BaseObjectStore):
     def unlink_bs_symlinks(self) -> None:
         for link_name in ['block', 'block.db', 'block.wal']:
             link_path = os.path.join(self.osd_path, link_name)
-            if os.path.exists(link_path):
+            if os.path.lexists(link_path):
                 os.unlink(os.path.join(self.osd_path, link_name))
 
 

--- a/src/ceph-volume/ceph_volume/tests/objectstore/test_rawbluestore.py
+++ b/src/ceph-volume/ceph_volume/tests/objectstore/test_rawbluestore.py
@@ -97,7 +97,7 @@ class TestRawBlueStore:
     @patch('ceph_volume.objectstore.rawbluestore.prepare_utils.link_wal')
     @patch('ceph_volume.objectstore.rawbluestore.prepare_utils.link_db')
     @patch('ceph_volume.objectstore.rawbluestore.prepare_utils.link_block')
-    @patch('os.path.exists')
+    @patch('os.path.lexists')
     @patch('os.unlink')
     @patch('ceph_volume.objectstore.rawbluestore.prepare_utils.create_osd_path')
     @patch('ceph_volume.objectstore.rawbluestore.process.run')


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77326

---

backport of https://github.com/ceph/ceph/pull/69391
parent tracker: https://tracker.ceph.com/issues/77295

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh