### PR TITLE
mgr/dashboard: Add auto-fetch listeners option in subsystem page

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-1/nvmeof-subsystem-step-1.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-1/nvmeof-subsystem-step-1.component.html
@@ -55,8 +55,57 @@
       }
       <div cdsRow
            class="form-item">
+        <fieldset class="cds--fieldset">
+          <legend class="cds--label" 
+                  i18n>Listeners</legend>
+          <p class="cds--form__helper-text" i18n>Determine where and how hosts can connect to the subsystem over the network.</p>
+          <cds-radio-group
+            formControlName="listenerMode"
+            orientation="horizontal">
+            <cds-radio
+              [value]="LISTENER_MODE.AUTO_FETCH">
+              <span i18n>Auto-fetch</span>
+            </cds-radio>
+            <cds-radio
+              [value]="LISTENER_MODE.MANUAL">
+              <span i18n>Add manually</span>
+            </cds-radio>
+          </cds-radio-group>
+        </fieldset>
+      </div>
+      @if (listenerMode === LISTENER_MODE.AUTO_FETCH) {
+      <div cdsRow
+           class="form-item">
+        <cds-text-label
+          i18n
+          [invalid]="subnetMaskRef.isInvalid"
+          [invalidText]="subnetMaskInvalidText"
+          helperText="Listeners from this subnet-masks will be use."
+          i18n-helperText>
+          Subnet-mask
+          <input cdsText
+                 cdValidate
+                 #subnetMaskRef="cdValidate"
+                 type="text"
+                 placeholder="e.g. 255.0.0.0"
+                 i18n-placeholder
+                 id="subnetMask"
+                 name="subnetMask"
+                 formControlName="subnetMask"
+                 [invalid]="subnetMaskRef.isInvalid">
+        </cds-text-label>
+        <ng-template #subnetMaskInvalidText>
+          <span i18n>This field is required.</span>
+        </ng-template>
+      </div>
+      }
+      @if (listenerMode === LISTENER_MODE.MANUAL) {
+      <div cdsRow
+           class="form-item">
         <cds-combo-box i18n
-                       [invalid]="formGroup.get('listeners').invalid && (formGroup.get('listeners').dirty || formGroup.get('listeners').touched)"
+                       cdValidate
+                       #listenersRef="cdValidate"
+                       [invalid]="listenersRef.isInvalid"
                        [invalidText]="listenersInvalidText"
                        [label]="listenersLabel"
                        [helperText]="listenersHelperText"
@@ -79,7 +128,7 @@
           </div>
         }
         <ng-template #listenersLabel>
-          <span i18n>Listeners</span>
+          <span i18n>Select listeners</span>
         </ng-template>
         <ng-template #listenersHelperText>
           <span i18n>Select listeners for this subsystem.</span>
@@ -88,6 +137,7 @@
           <span i18n>This field is required.</span>
         </ng-template>
       </div>
+      }
     </div>
   </div>
 </form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-1/nvmeof-subsystem-step-1.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-1/nvmeof-subsystem-step-1.component.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 import { NgbActiveModal, NgbTypeaheadModule } from '@ng-bootstrap/ng-bootstrap';
 
@@ -10,7 +11,7 @@ import { SharedModule } from '~/app/shared/shared.module';
 import { NvmeofSubsystemsStepOneComponent } from './nvmeof-subsystem-step-1.component';
 import { FormHelper } from '~/testing/unit-test-helper';
 import { NvmeofService } from '~/app/shared/api/nvmeof.service';
-import { ComboBoxModule, GridModule, InputModule } from 'carbon-components-angular';
+import { ComboBoxModule, GridModule, InputModule, RadioModule } from 'carbon-components-angular';
 
 import { of } from 'rxjs';
 
@@ -35,9 +36,11 @@ describe('NvmeofSubsystemsStepOneComponent', () => {
         NgbTypeaheadModule,
         InputModule,
         GridModule,
-        ComboBoxModule
+        ComboBoxModule,
+        RadioModule
       ],
-      providers: [NgbActiveModal]
+      providers: [NgbActiveModal],
+      schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-1/nvmeof-subsystem-step-1.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-1/nvmeof-subsystem-step-1.component.ts
@@ -33,6 +33,11 @@ export class NvmeofSubsystemsStepOneComponent implements OnInit, TearsheetStep {
   };
 
   hosts: ListenerItem[] = [];
+  LISTENER_MODE = {
+    AUTO_FETCH: 'auto-fetch',
+    MANUAL: 'manual'
+  };
+  listenerMode: string = this.LISTENER_MODE.AUTO_FETCH;
 
   constructor(
     public actionLabels: ActionLabelsI18n,
@@ -76,9 +81,18 @@ export class NvmeofSubsystemsStepOneComponent implements OnInit, TearsheetStep {
   }
 
   createForm() {
+    const subnetMaskValidators = [
+      CdValidators.composeIf({ listenerMode: this.LISTENER_MODE.AUTO_FETCH }, [Validators.required])
+    ];
+    const listenersValidators = [
+      CdValidators.composeIf({ listenerMode: this.LISTENER_MODE.MANUAL }, [Validators.required])
+    ];
+
     if (this.listenersOnly) {
       this.formGroup = new CdFormGroup({
-        listeners: new UntypedFormControl([])
+        listenerMode: new UntypedFormControl(this.LISTENER_MODE.AUTO_FETCH),
+        subnetMask: new UntypedFormControl('', subnetMaskValidators),
+        listeners: new UntypedFormControl([], listenersValidators)
       });
     } else {
       this.formGroup = new CdFormGroup({
@@ -101,9 +115,15 @@ export class NvmeofSubsystemsStepOneComponent implements OnInit, TearsheetStep {
             )
           ]
         }),
-        listeners: new UntypedFormControl([])
+        listenerMode: new UntypedFormControl(this.LISTENER_MODE.AUTO_FETCH),
+        subnetMask: new UntypedFormControl('', subnetMaskValidators),
+        listeners: new UntypedFormControl([], listenersValidators)
       });
     }
+
+    this.formGroup.get('listenerMode').valueChanges.subscribe((mode: string) => {
+      this.listenerMode = mode;
+    });
   }
 
   removeListener(index: number) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.spec.ts
@@ -92,6 +92,7 @@ describe('NvmeofSubsystemsFormComponent', () => {
       nvmeofService = TestBed.inject(NvmeofService);
       spyOn(nvmeofService, 'createSubsystem').and.returnValue(of({}));
       spyOn(nvmeofService, 'addSubsystemInitiators').and.returnValue(of({}));
+      spyOn(nvmeofService, 'createListeners').and.returnValue(of({}));
     });
 
     it('should be creating request correctly', () => {
@@ -103,6 +104,99 @@ describe('NvmeofSubsystemsFormComponent', () => {
         gw_group: mockGroupName,
         dhchap_key: 'Q2VwaE52bWVvRkNoYXBTeW50aGV0aWNLZXkxMjM0NTY='
       });
+    });
+
+    it('should include network_mask in createSubsystem request when listenerMode is auto-fetch and subnetMask is set', () => {
+      const payload: SubsystemPayload = {
+        nqn: 'test-nqn',
+        gw_group: mockGroupName,
+        addedHosts: [],
+        hostType: HOST_TYPE.ALL,
+        subsystemDchapKey: '',
+        listeners: [],
+        authType: AUTHENTICATION.Unidirectional,
+        hostDchapKeyList: [],
+        listenerMode: 'auto-fetch',
+        subnetMask: '192.168.1.0/24'
+      };
+
+      component.group = mockGroupName;
+      component.onSubmit(payload);
+
+      expect(nvmeofService.createSubsystem).toHaveBeenCalledWith({
+        nqn: 'test-nqn',
+        gw_group: mockGroupName,
+        dhchap_key: '',
+        network_mask: ['192.168.1.0/24']
+      });
+    });
+
+    it('should not include network_mask in createSubsystem request when listenerMode is manual', () => {
+      const payload: SubsystemPayload = {
+        nqn: 'test-nqn',
+        gw_group: mockGroupName,
+        addedHosts: [],
+        hostType: HOST_TYPE.ALL,
+        subsystemDchapKey: '',
+        listeners: [],
+        authType: AUTHENTICATION.Unidirectional,
+        hostDchapKeyList: [],
+        listenerMode: 'manual',
+        subnetMask: '192.168.1.0/24'
+      };
+
+      component.group = mockGroupName;
+      component.onSubmit(payload);
+
+      expect(nvmeofService.createSubsystem).toHaveBeenCalledWith({
+        nqn: 'test-nqn',
+        gw_group: mockGroupName,
+        dhchap_key: ''
+      });
+    });
+
+    it('should call createListeners when listenerMode is manual and listeners are provided', () => {
+      const listeners = [{ content: 'host1', addr: '10.0.0.1' }];
+      const payload: SubsystemPayload = {
+        nqn: 'test-nqn',
+        gw_group: mockGroupName,
+        addedHosts: [],
+        hostType: HOST_TYPE.ALL,
+        subsystemDchapKey: '',
+        listeners,
+        authType: AUTHENTICATION.Unidirectional,
+        hostDchapKeyList: [],
+        listenerMode: 'manual'
+      };
+
+      component.group = mockGroupName;
+      component.onSubmit(payload);
+
+      expect(nvmeofService.createListeners).toHaveBeenCalledWith(
+        'test-nqn.default',
+        mockGroupName,
+        listeners
+      );
+    });
+
+    it('should not call createListeners when listenerMode is auto-fetch', () => {
+      const payload: SubsystemPayload = {
+        nqn: 'test-nqn',
+        gw_group: mockGroupName,
+        addedHosts: [],
+        hostType: HOST_TYPE.ALL,
+        subsystemDchapKey: '',
+        listeners: [{ content: 'host1', addr: '10.0.0.1' }],
+        authType: AUTHENTICATION.Unidirectional,
+        hostDchapKeyList: [],
+        listenerMode: 'auto-fetch',
+        subnetMask: '10.0.0.0/24'
+      };
+
+      component.group = mockGroupName;
+      component.onSubmit(payload);
+
+      expect(nvmeofService.createListeners).not.toHaveBeenCalled();
     });
 
     it('should add initiators with wildcard when hostType is ALL', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.ts
@@ -30,9 +30,25 @@ export type SubsystemPayload = {
   listeners: ListenerItem[];
   authType: AUTHENTICATION.Bidirectional | AUTHENTICATION.Unidirectional;
   hostDchapKeyList: Array<{ dhchap_key: string; host_nqn: string }>;
+  listenerMode?: string;
+  subnetMask?: string;
 };
 
 type StepResult = { step: string; success: boolean; error?: string };
+
+type CreateSubsystemRequest = {
+  nqn: string;
+  gw_group: string;
+  dhchap_key: string;
+  network_mask?: string[];
+};
+
+type SequentialStep = { step: string; call: () => Observable<unknown> };
+
+const LISTENER_MODE = {
+  AUTO_FETCH: 'auto-fetch',
+  MANUAL: 'manual'
+};
 
 const STEP_LABELS = {
   DETAILS: 'Subsystem details',
@@ -159,62 +175,69 @@ export class NvmeofSubsystemsFormComponent implements OnInit {
       hosts: payload.hostType === HOST_TYPE.SPECIFIC ? payload.hostDchapKeyList : [],
       gw_group: this.group
     };
-    this.nvmeofService
-      .createSubsystem({
-        nqn: payload.nqn,
-        gw_group: this.group,
-        dhchap_key: payload.subsystemDchapKey
-      })
-      .subscribe({
-        next: () => {
-          stepResults.push({ step: this.steps[0].label, success: true });
-          const sequentialSteps: { step: string; call: () => Observable<any> }[] = [];
 
-          if (payload.listeners && payload.listeners.length > 0) {
-            sequentialSteps.push({
-              step: $localize`Listeners`,
-              call: () =>
-                this.nvmeofService.createListeners(
-                  `${payload.nqn}.${this.group}`,
-                  this.group,
-                  payload.listeners
-                )
-            });
-          }
+    // Prepare subsystem creation request
+    const createSubsystemRequest: CreateSubsystemRequest = {
+      nqn: payload.nqn,
+      gw_group: this.group,
+      dhchap_key: payload.subsystemDchapKey
+    };
 
+    if (payload.listenerMode === LISTENER_MODE.AUTO_FETCH && payload.subnetMask) {
+      createSubsystemRequest.network_mask = [payload.subnetMask];
+    }
+
+    this.nvmeofService.createSubsystem(createSubsystemRequest).subscribe({
+      next: () => {
+        stepResults.push({ step: this.steps[0].label, success: true });
+        const sequentialSteps: SequentialStep[] = [];
+
+        if (
+          payload.listenerMode !== LISTENER_MODE.AUTO_FETCH &&
+          payload.listeners &&
+          payload.listeners.length > 0
+        ) {
           sequentialSteps.push({
-            step: this.steps[1].label,
+            step: $localize`Listeners`,
             call: () =>
-              this.nvmeofService.addSubsystemInitiators(
+              this.nvmeofService.createListeners(
                 `${payload.nqn}.${this.group}`,
-                initiatorRequest
+                this.group,
+                payload.listeners
               )
           });
-
-          this.runSequentialSteps(sequentialSteps, stepResults).subscribe({
-            complete: () => this.showFinalNotification(stepResults)
-          });
-        },
-        error: (err) => {
-          err.preventDefault();
-          const errorMsg = err?.error?.detail || $localize`Subsystem creation failed`;
-          this.notificationService.show(
-            NotificationType.error,
-            $localize`Subsystem creation failed`,
-            errorMsg
-          );
-          this.isSubmitLoading = false;
-          this.router.navigate(['block/nvmeof/subsystems'], {
-            queryParams: { group: this.group }
-          });
         }
-      });
+
+        sequentialSteps.push({
+          step: this.steps[1].label,
+          call: () =>
+            this.nvmeofService.addSubsystemInitiators(
+              `${payload.nqn}.${this.group}`,
+              initiatorRequest
+            )
+        });
+
+        this.runSequentialSteps(sequentialSteps, stepResults).subscribe({
+          complete: () => this.showFinalNotification(stepResults)
+        });
+      },
+      error: (err) => {
+        err.preventDefault();
+        const errorMsg = err?.error?.detail || $localize`Subsystem creation failed`;
+        this.notificationService.show(
+          NotificationType.error,
+          $localize`Subsystem creation failed`,
+          errorMsg
+        );
+        this.isSubmitLoading = false;
+        this.router.navigate(['block/nvmeof/subsystems'], {
+          queryParams: { group: this.group }
+        });
+      }
+    });
   }
 
-  private runSequentialSteps(
-    steps: { step: string; call: () => Observable<any> }[],
-    stepResults: StepResult[]
-  ): Observable<void> {
+  private runSequentialSteps(steps: SequentialStep[], stepResults: StepResult[]): Observable<void> {
     return from(steps).pipe(
       concatMap((step) =>
         step.call().pipe(

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
@@ -192,7 +192,12 @@ export class NvmeofService {
     return this.http.get(`${API_PATH}/subsystem/${subsystemNQN}?gw_group=${group}`);
   }
 
-  createSubsystem(request: { nqn: string; gw_group: string; dhchap_key: string }) {
+  createSubsystem(request: {
+    nqn: string;
+    gw_group: string;
+    dhchap_key: string;
+    network_mask?: string[];
+  }) {
     return this.http.post(`${API_PATH}/subsystem`, request, { observe: 'response' });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/nvmeof.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/nvmeof.ts
@@ -169,4 +169,6 @@ export type AuthStepType = {
 export type DetailsStepType = {
   nqn: string;
   listeners: Array<string>;
+  listenerMode?: string;
+  subnetMask?: string;
 };


### PR DESCRIPTION


https://github.com/user-attachments/assets/f45ea51e-48aa-4013-b4b2-a371d4ca9562



<img width="3716" height="1904" alt="image" src="https://github.com/user-attachments/assets/592a5403-422f-4168-8ae3-c9d1f1b14438" />

---

Fixes: https://tracker.ceph.com/issues/77083
Signed-off-by: pujaoshahu <pshahu@redhat.com>

Summary :

- Added dual-mode listener configuration: Auto-fetch and Manual

- Auto-fetch mode: Automatically discovers and configures listeners from gateway nodes matching a specified subnet mask

- Manual mode: Allows explicit selection of individual listeners from available gateway hosts

- Dynamic form validation that switches between subnet mask (auto-fetch) and listener selection (manual) requirements



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
