### PR TITLE
mgr/smb: Added a Mac client support for samba cluster

### DIFF
--- a/doc/mgr/smb.rst
+++ b/doc/mgr/smb.rst
@@ -55,7 +55,7 @@ Create Cluster
 
 .. prompt:: bash #
 
-   ceph smb cluster create <cluster_id> {user|active-directory} [--domain-realm=<domain_realm>] [--domain-join-user-pass=<domain_join_user_pass>] [--define-user-pass=<define_user_pass>] [--custom-dns=<custom_dns>] [--placement=<placement>] [--clustering=<clustering>] [--password-filter=<password_filter>] [--password-filter-out=<password_filter_out>]
+   ceph smb cluster create <cluster_id> {user|active-directory} [--domain-realm=<domain_realm>] [--domain-join-user-pass=<domain_join_user_pass>] [--define-user-pass=<define_user_pass>] [--custom-dns=<custom_dns>] [--placement=<placement>] [--clustering=<clustering>] [--client-compat={default|macos}] [--password-filter=<password_filter>] [--password-filter-out=<password_filter_out>]
 
 Create a new logical cluster, identified by the cluster ID value. The cluster
 create command must specify the authentication mode the cluster will use. This
@@ -100,6 +100,11 @@ clustering
     enables clustering regardless of the placement count. A value of ``never``
     disables clustering regardless of the placement count. If unspecified,
     ``default`` is assumed.
+client_compat
+    Optional. One of ``default`` or ``macos``. Controls client-specific SMB
+    features and optimizations. The ``default`` mode provides standard SMB
+    behavior with broad compatibility. The ``macos`` mode enables macOS-specific
+    optimized settings for macOS clients. If unspecified, ``default`` is assumed.
 public_addrs
     Optional. A string in the form of <ipaddress/prefixlength>[%<destination address>].
     Supported only when using Samba's clustering. Assign "virtual" IP addresses
@@ -165,6 +170,15 @@ previous example. Set three CTDB public address values and a custom placement:
         --public-address=192.168.76.112/24 \
         --placement="3 label:smb"
 
+Create a cluster for macOS clients with user authentication:
+
+.. prompt:: bash #
+
+    ceph smb cluster create mac_cluster user \
+        --define-user-pass=macuser%Passw0rd1 \
+        --client-compat=macos \
+        --placement="label:smb"
+
 
 Update Cluster QoS
 ++++++++++++++++++
@@ -214,6 +228,53 @@ Disable QoS for all shares in a cluster:
      --write-iops-limit=0 \
      --read-bw-limit=0 \
      --write-bw-limit=0
+
+
+
+Update Cluster Client Compatibility
+++++++++++++++++++++++++++++++++++++
+
+.. prompt:: bash #
+
+   ceph smb cluster update client-compat {default|macos} <cluster_id>
+
+Update the client compatibility mode for an SMB cluster. This setting controls whether client-specific SMB features and optimizations are enabled.
+
+The client compatibility mode determines how the Samba server is configured to optimize for specific client types:
+
+- ``default``: Standard SMB behavior without client-specific optimizations. This is the default mode and provides broad compatibility with all SMB clients.
+- ``macos``: Enable macOS-specific features including the Samba's fruit VFS module for proper handling of macOS metadata and optimized settings for macOS clients.
+
+When ``macos`` mode is enabled, the following features are automatically configured:
+
+- Fruit VFS module for proper handling of macOS-specific file attributes
+- Streams_xattr VFS module for extended attribute support
+
+Options:
+
+client_compat
+    One of ``default`` or ``macos``
+cluster_id
+    A short string uniquely identifying the cluster
+
+Examples
+~~~~~~~~
+
+Enable macOS compatibility mode for a cluster:
+
+.. prompt:: bash #
+
+   ceph smb cluster update client-compat macos mycluster
+
+Revert to default (standard) compatibility mode:
+
+.. prompt:: bash #
+
+   ceph smb cluster update client-compat default mycluster
+
+.. note::
+   The ``macos`` compatibility mode is recommended when the primary clients accessing the SMB shares are macOS systems. Otherwise default mode is recommended.
+
 
 
 Remove Cluster
@@ -879,6 +940,12 @@ custom_smb_global_options
     indicator that the user is aware that using this option can easily break
     things in ways that the Ceph team can not help with. This special key will
     automatically be removed from the list of options passed to Samba.
+client_compat
+    Optional. One of ``default`` or ``macos``. Controls client-specific SMB
+    features and optimizations. The ``default`` mode provides standard SMB
+    behavior with broad compatibility. The ``macos`` mode enables macOS-specific
+    features including Samba's fruit VFS module for proper handling of macOS and
+    optimized settings for macOS clients. If unspecified, ``default`` is assumed.
 
 .. warning::
    Setting the ``clustering`` option allows an administrator to choose exactly
@@ -976,6 +1043,20 @@ The following is an example of a cluster configured for standalone operation:
     placement:
       hosts:
         - node6.mycluster.sink.test
+
+The following is an example of a cluster optimized for macOS clients:
+
+.. code-block:: yaml
+
+    resource_type: ceph.smb.cluster
+    cluster_id: macshare
+    auth_mode: user
+    client_compat: macos
+    user_group_settings:
+      - source_type: resource
+        ref: ug1
+    placement:
+      count: 1
 
 An example cluster resource with intent to remove:
 

--- a/src/pybind/mgr/smb/enums.py
+++ b/src/pybind/mgr/smb/enums.py
@@ -124,6 +124,19 @@ class ShowResults(_StrEnum):
     COLLAPSED = 'collapsed'
 
 
+class ClientSupportMode(_StrEnum):
+    """Determines if client-specific SMB features should be enabled.
+
+    - DEFAULT: Standard SMB behavior without client-specific optimizations
+    - MACOS: Enable macOS-specific features (AAPL extensions, fruit VFS, etc.)
+
+    Future values could include: WINDOWS_OPTIMIZED, LINUX_OPTIMIZED, etc.
+    """
+
+    DEFAULT = 'default'
+    MACOS = 'macos'
+
+
 class PasswordFilter(_StrEnum):
     """Filter type for password values."""
 

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -759,6 +759,7 @@ def order_resources(
 @dataclasses.dataclass(frozen=True)
 class _ShareConf:
     resource: resources.Share
+    cluster: resources.Cluster
     resolver: PathResolver
     cephx_entity: str
     ceph_cluster: str
@@ -807,7 +808,13 @@ class _ClusterConf:
         return cls(
             change_group.cluster,
             [
-                _ShareConf(s, resolver, cephx_entity, ceph_cluster)
+                _ShareConf(
+                    s,
+                    change_group.cluster,
+                    resolver,
+                    cephx_entity,
+                    ceph_cluster,
+                )
                 for s in change_group.shares
             ],
             change_group,
@@ -847,7 +854,14 @@ def _generate_share(conf: _ShareConf) -> Dict[str, Dict[str, str]]:
         if conf.ceph_cluster
         else '/etc/ceph/ceph.conf'
     )
-    modules = ["acl_xattr", "ceph_snapshots"]
+    # Build VFS modules list based on cluster configuration
+    modules = []
+    # Add macOS support modules if enabled
+    if conf.cluster.is_macos_compatibility_enabled:
+        modules.extend(["fruit", "streams_xattr"])
+
+    # Add standard modules
+    modules.extend(["acl_xattr", "ceph_snapshots"])
 
     if qos := cephfs.qos:
         vfs_rl = "aio_ratelimit"

--- a/src/pybind/mgr/smb/module.py
+++ b/src/pybind/mgr/smb/module.py
@@ -31,6 +31,7 @@ from . import (
 from .cli import SMBCLICommand
 from .enums import (
     AuthMode,
+    ClientSupportMode,
     InputPasswordFilter,
     JoinSourceType,
     PasswordFilter,
@@ -223,6 +224,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         placement: Optional[str] = None,
         clustering: Optional[SMBClustering] = None,
         public_addrs: Optional[List[str]] = None,
+        client_compat: Optional[ClientSupportMode] = None,
         password_filter: InputPasswordFilter = InputPasswordFilter.NONE,
         password_filter_out: Optional[PasswordFilter] = None,
     ) -> results.Result:
@@ -333,6 +335,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             placement=pspec,
             clustering=clustering,
             public_addrs=c_public_addrs,
+            client_compat=client_compat,
         )
         to_apply.append(cluster)
         return self._apply_res(
@@ -441,6 +444,75 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             rm_res,
             password_filter_out=password_filter,
         )
+
+    @SMBCLICommand('cluster update client-compat', perm='rw')
+    def cluster_update_client_compat(
+        self,
+        client_compat: ClientSupportMode,
+        cluster_id: str,
+    ) -> Simplified:
+        """Update client compatibility mode for an SMB cluster and all its shares"""
+        # Get the existing cluster
+        clusters = self._handler.matching_resources(
+            [f'ceph.smb.cluster.{cluster_id}']
+        )
+
+        active_clusters = [
+            c for c in clusters if isinstance(c, resources.Cluster)
+        ]
+
+        if not active_clusters:
+            raise ValueError(f"Cluster {cluster_id} not found")
+
+        if len(active_clusters) > 1:
+            raise ValueError(f"Multiple clusters found matching {cluster_id}")
+
+        cluster = active_clusters[0]
+
+        # Create updated cluster with new client_compat setting
+        updated_cluster = replace(cluster, client_compat=client_compat)
+
+        # Get all shares for this cluster
+        shares = self._handler.matching_resources(
+            [f'ceph.smb.share.{cluster_id}']
+        )
+
+        active_shares = [s for s in shares if isinstance(s, resources.Share)]
+
+        # Prepare resources to update: cluster + all shares
+        resources_to_update: List[resources.SMBResource] = [updated_cluster]
+        resources_to_update.extend(active_shares)
+
+        # Apply the updates
+        result_group = self._apply_res(resources_to_update)
+
+        # Process results
+        cluster_updated = False
+        successful_share_updates = []
+        failed_share_updates = []
+
+        for result in result_group:
+            if result.success:
+                if isinstance(result.src, resources.Cluster):
+                    cluster_updated = True
+                elif hasattr(result.src, 'share_id'):
+                    successful_share_updates.append(result.src.share_id)
+            else:
+                if isinstance(result.src, resources.Share) and hasattr(
+                    result.src, 'share_id'
+                ):
+                    failed_share_updates.append(
+                        {"share_id": result.src.share_id, "error": result.msg}
+                    )
+
+        return {
+            "cluster_id": cluster_id,
+            "client_compat": client_compat.value,
+            "cluster_updated": cluster_updated,
+            "successful_share_updates": successful_share_updates,
+            "failed_share_updates": failed_share_updates,
+            "total_shares": len(active_shares),
+        }
 
     @SMBCLICommand('cluster update cephfs qos', perm='rw')
     def cluster_update_qos(

--- a/src/pybind/mgr/smb/resources.py
+++ b/src/pybind/mgr/smb/resources.py
@@ -29,6 +29,7 @@ from . import resourcelib, validation
 from .enums import (
     AuthMode,
     CephFSStorageProvider,
+    ClientSupportMode,
     HostAccess,
     Intent,
     JoinSourceType,
@@ -902,6 +903,8 @@ class Cluster(_RBase):
     debug_level: Optional[dict[str, str]] = None
     # configure the keybridge (KMS integration) for this cluster
     keybridge: Optional[KeyBridge] = None
+    # client support mode for client-specific optimizations (macOS, etc.)
+    client_compat: Optional[ClientSupportMode] = None
 
     def validate(self) -> None:
         if not self.cluster_id:
@@ -949,6 +952,24 @@ class Cluster(_RBase):
     @property
     def clustering_mode(self) -> SMBClustering:
         return self.clustering if self.clustering else SMBClustering.DEFAULT
+
+    @property
+    def effective_client_compat(self) -> ClientSupportMode:
+        """Return the effective client compat mode.
+
+        Returns ClientSupportMode.DEFAULT if not explicitly set, ensuring
+        client-specific features are disabled by default.
+        """
+        return (
+            self.client_compat
+            if self.client_compat
+            else ClientSupportMode.DEFAULT
+        )
+
+    @property
+    def is_macos_compatibility_enabled(self) -> bool:
+        """Return true if macOS-specific SMB features should be enabled."""
+        return self.effective_client_compat == ClientSupportMode.MACOS
 
     @property
     def remote_control_is_enabled(self) -> bool:

--- a/src/pybind/mgr/smb/tests/test_enums.py
+++ b/src/pybind/mgr/smb/tests/test_enums.py
@@ -43,3 +43,23 @@ def test_login_access_expand():
         == smb.enums.LoginAccess.READ_WRITE
     )
     assert smb.enums.LoginAccess.NONE.expand() == smb.enums.LoginAccess.NONE
+
+
+def test_client_compat_enum():
+    """Test ClientSupportMode enum values and string representation."""
+    assert smb.enums.ClientSupportMode.DEFAULT == 'default'
+    assert smb.enums.ClientSupportMode.MACOS == 'macos'
+    assert str(smb.enums.ClientSupportMode.DEFAULT) == 'default'
+    assert str(smb.enums.ClientSupportMode.MACOS) == 'macos'
+
+
+def test_client_compat_values():
+    """Test that ClientSupportMode can be constructed from string values."""
+    assert (
+        smb.enums.ClientSupportMode('default')
+        == smb.enums.ClientSupportMode.DEFAULT
+    )
+    assert (
+        smb.enums.ClientSupportMode('macos')
+        == smb.enums.ClientSupportMode.MACOS
+    )

--- a/src/pybind/mgr/smb/tests/test_resources.py
+++ b/src/pybind/mgr/smb/tests/test_resources.py
@@ -750,6 +750,89 @@ login_control:
     assert share.login_control[3].access == enums.LoginAccess.NONE
 
 
+def test_cluster_client_compat_default():
+    """Test cluster with default client support mode (not set)."""
+    import yaml
+
+    yaml_str = """
+resource_type: ceph.smb.cluster
+cluster_id: testcluster
+auth_mode: user
+user_group_settings:
+  - source_type: resource
+    ref: testusers
+"""
+    data = yaml.safe_load_all(yaml_str)
+    loaded = smb.resources.load(data)
+    assert loaded
+    cluster = loaded[0]
+
+    # When not set, should default to None
+    assert cluster.client_compat is None
+    # effective_client_compat should return DEFAULT
+    assert cluster.effective_client_compat == enums.ClientSupportMode.DEFAULT
+    # is_macos_compatibility_enabled should be False
+    assert cluster.is_macos_compatibility_enabled is False
+
+
+def test_cluster_client_compat_macos():
+    """Test cluster with macos client support mode enabled."""
+    import yaml
+
+    yaml_str = """
+resource_type: ceph.smb.cluster
+cluster_id: maccluster
+auth_mode: user
+user_group_settings:
+  - source_type: resource
+    ref: macusers
+client_compat: macos
+"""
+    data = yaml.safe_load_all(yaml_str)
+    loaded = smb.resources.load(data)
+    assert loaded
+    cluster = loaded[0]
+
+    # Should be set to MACOS
+    assert cluster.client_compat == enums.ClientSupportMode.MACOS
+    # effective_client_compat should return MACOS
+    assert cluster.effective_client_compat == enums.ClientSupportMode.MACOS
+    # is_macos_compatibility_enabled should be True
+    assert cluster.is_macos_compatibility_enabled is True
+
+    # Verify it's in the simplified output
+    sd = cluster.to_simplified()
+    assert sd
+    assert 'client_compat' in sd
+    assert sd['client_compat'] == 'macos'
+
+
+def test_cluster_client_compat_explicit_default():
+    """Test cluster with explicitly set default client support mode."""
+    import yaml
+
+    yaml_str = """
+resource_type: ceph.smb.cluster
+cluster_id: defaultcluster
+auth_mode: user
+user_group_settings:
+  - source_type: resource
+    ref: defaultusers
+client_compat: default
+"""
+    data = yaml.safe_load_all(yaml_str)
+    loaded = smb.resources.load(data)
+    assert loaded
+    cluster = loaded[0]
+
+    # Should be explicitly set to DEFAULT
+    assert cluster.client_compat == enums.ClientSupportMode.DEFAULT
+    # effective_client_compat should return DEFAULT
+    assert cluster.effective_client_compat == enums.ClientSupportMode.DEFAULT
+    # is_macos_compatibility_enabled should be False
+    assert cluster.is_macos_compatibility_enabled is False
+
+
 def test_tls_credential():
     import yaml
 

--- a/src/pybind/mgr/smb/tests/test_smb.py
+++ b/src/pybind/mgr/smb/tests/test_smb.py
@@ -1324,3 +1324,103 @@ def test_cluster_rm_wildcard_no_match(tmodule):
 
     with pytest.raises(smb.cli.NoMatchingValue):
         tmodule.cluster_rm('gonk', wildcard=True)
+
+
+def test_cluster_update_client_compat(tmodule):
+    """Test updating cluster client compatibility mode with shares."""
+    # Create a cluster with default client_compat
+    cluster = _cluster(
+        cluster_id='foo',
+        auth_mode=smb.enums.AuthMode.USER,
+        user_group_settings=[
+            smb.resources.UserGroupSource(
+                source_type=smb.resources.UserGroupSourceType.EMPTY,
+            ),
+        ],
+    )
+    rg = tmodule._handler.apply([cluster])
+    assert rg.success, rg.to_simplified()
+
+    # Create some shares
+    share1 = smb.resources.Share(
+        cluster_id='foo',
+        share_id='share1',
+        cephfs=smb.resources.CephFSStorage(
+            volume='cephfs',
+            path='/share1',
+        ),
+    )
+    share2 = smb.resources.Share(
+        cluster_id='foo',
+        share_id='share2',
+        cephfs=smb.resources.CephFSStorage(
+            volume='cephfs',
+            path='/share2',
+        ),
+    )
+    rg = tmodule._handler.apply([share1, share2])
+    assert rg.success, rg.to_simplified()
+
+    # Verify initial state (should be None/DEFAULT)
+    clusters = tmodule._handler.matching_resources(['ceph.smb.cluster.foo'])
+    assert len(clusters) == 1
+    initial_cluster = clusters[0]
+    assert initial_cluster.client_compat is None
+    assert (
+        initial_cluster.effective_client_compat
+        == smb.enums.ClientSupportMode.DEFAULT
+    )
+
+    # Update to MACOS compatibility mode
+    result = tmodule.cluster_update_client_compat(
+        smb.enums.ClientSupportMode.MACOS, 'foo'
+    )
+    assert isinstance(result, dict)
+    assert result['cluster_id'] == 'foo'
+    assert result['client_compat'] == 'macos'
+    assert result['cluster_updated'] is True
+    assert result['total_shares'] == 2
+    assert len(result['successful_share_updates']) == 2
+    assert 'share1' in result['successful_share_updates']
+    assert 'share2' in result['successful_share_updates']
+    assert len(result['failed_share_updates']) == 0
+
+    # Verify the update
+    clusters = tmodule._handler.matching_resources(['ceph.smb.cluster.foo'])
+    assert len(clusters) == 1
+    updated_cluster = clusters[0]
+    assert updated_cluster.client_compat == smb.enums.ClientSupportMode.MACOS
+    assert (
+        updated_cluster.effective_client_compat
+        == smb.enums.ClientSupportMode.MACOS
+    )
+    assert updated_cluster.is_macos_compatibility_enabled is True
+
+    # Update back to DEFAULT
+    result = tmodule.cluster_update_client_compat(
+        smb.enums.ClientSupportMode.DEFAULT, 'foo'
+    )
+    assert isinstance(result, dict)
+    assert result['cluster_id'] == 'foo'
+    assert result['client_compat'] == 'default'
+    assert result['cluster_updated'] is True
+    assert result['total_shares'] == 2
+
+    # Verify the update back to DEFAULT
+    clusters = tmodule._handler.matching_resources(['ceph.smb.cluster.foo'])
+    assert len(clusters) == 1
+    final_cluster = clusters[0]
+    assert final_cluster.client_compat == smb.enums.ClientSupportMode.DEFAULT
+    assert (
+        final_cluster.effective_client_compat
+        == smb.enums.ClientSupportMode.DEFAULT
+    )
+    assert final_cluster.is_macos_compatibility_enabled is False
+
+
+def test_cluster_update_client_compat_nonexistent(tmodule):
+    """Test updating client_compat for a non-existent cluster."""
+    with pytest.raises(ValueError, match="Cluster nonexistent not found"):
+        tmodule.cluster_update_client_compat(
+            smb.enums.ClientSupportMode.MACOS, 'nonexistent'
+        )


### PR DESCRIPTION

mgr/smb: Add client support mode for macOS-specific SMB features 

This commit introduces a new cluster-level configuration option to enable
client-specific SMB optimizations, starting with macOS support.

Usage:
 create the smb cluster with macos support enable
      ceph smb cluster create <cluster-id> --client-compat macos

Update the existing cluster with macos support enable
      ceph smb cluster update client-compat macos <cluster-id>

Test Logs : 
 1)  Create the cluster
```
[root@mycephfs14 ~]# ceph smb cluster create testsmb user --define-user-pass test1%x --client-compat macos                    
{                                                                                                                             
  "resource": {                                                                                                               
    "resource_type": "ceph.smb.cluster",                                                                                      
    "cluster_id": "testsmb",                                                                                                  
    "auth_mode": "user",                                                                                                      
    "intent": "present",                                                                                                      
    "user_group_settings": [                                                                                                  
      {                                                                                                                       
        "source_type": "resource",                                                                                            
        "ref": "testsmbpdioctkb"                                                                                              
      }                                                                                                                       
    ],
    "placement": {},
    "public_addrs": [],
    "client_compat": "macos"
  },
  "state": "created",
  "additional_results": [
    {
      "resource": {
        "resource_type": "ceph.smb.usersgroups",
        "users_groups_id": "testsmbpdioctkb",
        "intent": "present",
        "values": {
          "users": [
            {
              "name": "test1",
              "password": "x"
            }
          ],
          "groups": []
        },
        "linked_to_cluster": "testsmb"
      },
      "state": "created",
      "success": true
    }
  ],
  "success": true
}
```

2) Update the existing cluster "mysmb"
```
[root@mycephfs14 ~]# ceph smb cluster update client-compat macos mysmb
{
  "resource": {
    "resource_type": "ceph.smb.cluster",
    "cluster_id": "mysmb",
    "auth_mode": "user",
    "intent": "present",
    "user_group_settings": [
      {
        "source_type": "resource",
        "ref": "mysmbynrredgt"
      }
    ],
    "placement": {},
    "public_addrs": [],
    "client_compat": "macos"
  },
  "state": "updated",
  "success": true
}

```

Signed-off-by: Shweta Sodani <ssodani@redhat.com>


## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [X] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [X] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [X] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

