### PR TITLE
mon: enforce strict power-of-two validation for bluestore settings

### DIFF
--- a/qa/tasks/mgr/dashboard/test_pool.py
+++ b/qa/tasks/mgr/dashboard/test_pool.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=too-many-public-methods
 from __future__ import absolute_import
 
 import logging
@@ -277,6 +278,24 @@ class PoolTest(DashboardTestCase):
             new_pool = self._get_pool(pool['pool'])
             for conf in expected_configuration:
                 self.assertIn(conf, new_pool['configuration'])
+
+    def test_pool_create_with_compression_failure(self):
+        pool = {
+            'pool': 'dashboard_pool3_failure',
+            'pg_num': '32',
+            'pool_type': 'replicated',
+            'compression_algorithm': 'zstd',
+            'compression_mode': 'aggressive',
+            'compression_max_blob_size': '10000000',
+            'compression_required_ratio': '0.8',
+            'application_metadata': ['rbd'],
+            'configuration': {
+                'rbd_qos_bps_limit': 2048,
+                'rbd_qos_iops_limit': None,
+            },
+        }
+        self._task_post('/api/pool/', pool)
+        self.assertNotEqual(self._resp.status_code, 201)
 
     def test_pool_create_with_quotas(self):
         pools = [

--- a/qa/tasks/mgr/dashboard/test_pool.py
+++ b/qa/tasks/mgr/dashboard/test_pool.py
@@ -256,7 +256,7 @@ class PoolTest(DashboardTestCase):
             'pool_type': 'replicated',
             'compression_algorithm': 'zstd',
             'compression_mode': 'aggressive',
-            'compression_max_blob_size': '10000000',
+            'compression_max_blob_size': '8388608',
             'compression_required_ratio': '0.8',
             'application_metadata': ['rbd'],
             'configuration': {
@@ -375,7 +375,7 @@ class PoolTest(DashboardTestCase):
             properties = {
                 'compression_algorithm': 'zstd',
                 'compression_mode': 'aggressive',
-                'compression_max_blob_size': '10000000',
+                'compression_max_blob_size': '8388608',
                 'compression_required_ratio': '0.8',
             }
             self._task_put('/api/pool/' + pool_name, properties)

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -933,6 +933,17 @@ int md_config_t::set_val(ConfigValues& values,
 
   string k(ConfFile::normalize_key_name(key));
 
+  if (k == "bluestore_compression_min_blob_size" ||
+      k == "bluestore_compression_max_blob_size" ||
+      k == "bluestore_csum_min_block" ||
+      k == "bluestore_csum_max_block") {
+    std::string err;
+    int64_t n = strict_si_cast<int64_t>(v, &err);
+    if (!err.empty() || n < 0 || (n > 0 && (n & (n - 1)) != 0)) {
+      return -EINVAL;
+    }
+  }
+
   const auto &opt_iter = schema.find(k);
   if (opt_iter != schema.end()) {
     const Option &opt = opt_iter->second;

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -544,6 +544,22 @@ bool ConfigMonitor::prepare_command(MonOpRequestRef op)
     cmd_getval(cmdmap, "value", value);
     cmd_getval(cmdmap, "force", force);
     name = ConfFile::normalize_key_name(name);
+
+
+    if (prefix == "config set") {
+      if (name == "bluestore_compression_min_blob_size" ||
+          name == "bluestore_compression_max_blob_size") {
+        std::string cast_err;
+        int64_t n = strict_si_cast<int64_t>(value, &cast_err);
+        if (!cast_err.empty() || n < 0 || (n > 0 && (n & (n - 1)) != 0)) {
+          ss << "invalid value '" << value << "' for " << name 
+             << ": must be 0 or a positive power of 2.";
+          err = -EINVAL;
+          goto reply;
+        }
+      }
+    }
+    
     
     if (prefix == "config set" && !force) {
       const Option *opt = g_conf().find_option(name);

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -9311,6 +9311,10 @@ int OSDMonitor::prepare_command_pool_set(const cmdmap_t& cmdmap,
         ss << "error parsing int value '" << val << "': " << interr;
         return -EINVAL;
       }
+      if (n <= 0 || (n & (n - 1)) != 0) {
+        ss << "invalid value '" << n << "', input must be positive and a power of 2.";
+        return -EINVAL;
+      }
     } else if (var == "fingerprint_algorithm") {
       if (!unset) {
         auto alg = pg_pool_t::get_fingerprint_from_str(val);

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -9311,7 +9311,7 @@ int OSDMonitor::prepare_command_pool_set(const cmdmap_t& cmdmap,
         ss << "error parsing int value '" << val << "': " << interr;
         return -EINVAL;
       }
-      if (n <= 0 || (n & (n - 1)) != 0) {
+      if (n < 0 || (n > 0 && (n & (n - 1)) != 0)) {
         ss << "invalid value '" << n << "', input must be positive and a power of 2.";
         return -EINVAL;
       }


### PR DESCRIPTION
This enforces validation for BlueStore configuration variables that are required to be a power of two. The system now explicitly rejects non-power-of-two values for compression_min_blob_size / bluestore_compression_min_blob_size, compression_max_blob_size / bluestore_compression_max_blob_size, csum_min_block, and csum_max_block.
This prevents potential OSD crashes caused by invalid inputs for these variables. 


Fixes: http://tracker.ceph.com/issues/74257 
Signed-off-by: Aaryan Kumar <kumaraaryan511@gmail.com>


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
