### PR TITLE
tentacle: mgr: guard close_section calls in get_perf_schema_python

### DIFF
--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -1263,8 +1263,10 @@ PyObject* ActivePyModules::get_perf_schema_python(
 		<< dendl;
 	  }
 	}
-	f.close_section();  // close 'counters'
-	f.close_section();  // close 'counter object' section
+	if (!prev_key_name.empty()) {
+	  f.close_section();  // close 'counters'
+	  f.close_section();  // close 'counter object' section
+	}
       });
     }
   } else {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77375

---

backport of https://github.com/ceph/ceph/pull/68213
parent tracker: https://tracker.ceph.com/issues/75745

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh