### PR TITLE
mgr/test_orchestrator: accept force_delete_data in remove_daemons

### DIFF
--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -225,12 +225,12 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
         return [self._create_osds(dg) for dg in specs]
 
     @handle_orch_error
-    def remove_daemons(self, names):
+    def remove_daemons(self, names, force_delete_data=False):
         assert isinstance(names, list)
         return 'done'
 
     @handle_orch_error
-    def remove_service(self, service_name, force = False):
+    def remove_service(self, service_name, force=False, force_delete_data=False):
         assert isinstance(service_name, str)
         return 'done'
 


### PR DESCRIPTION
PR #68428 plumbed force_delete_data through orchestrator daemon/service removal; update the test_orchestrator stub so orchestrator_cli QA (test_mds_rm, etc.) does not fail with an unexpected keyword argument.

Fixes: https://tracker.ceph.com/issues/77374
Signed-off-by: Kobi Ginon <kginon@redhat.com>

Verification of the fix

cd /root/ceph-adm-projects/ceph/src/pybind/mgr

UNITTEST=true PYTHONPATH=.:.. python3 -m pytest orchestrator/tests/test_orchestrator.py -v

=================================================================== test session starts ====================================================================
platform linux -- Python 3.10.12, pytest-7.4.4, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /root/ceph-adm-projects/ceph/src/pybind/mgr
configfile: tox.ini
plugins: requests-mock-1.12.1, pyfakefs-6.1.3, cov-2.7.1
collected 20 items

orchestrator/tests/test_orchestrator.py::test_inventory PASSED                                                                                       [  5%]
orchestrator/tests/test_orchestrator.py::test_daemon_description PASSED                                                                              [ 10%]
orchestrator/tests/test_orchestrator.py::test_apply PASSED                                                                                           [ 15%]
orchestrator/tests/test_orchestrator.py::test_yaml PASSED                                                                                            [ 20%]
orchestrator/tests/test_orchestrator.py::test_event_multiline PASSED                                                                                 [ 25%]
orchestrator/tests/test_orchestrator.py::test_handle_command PASSED                                                                                  [ 30%]
orchestrator/tests/test_orchestrator.py::test_orch_ls PASSED                                                                                         [ 35%]
orchestrator/tests/test_orchestrator.py::test_orch_ps PASSED                                                                                         [ 40%]
orchestrator/tests/test_orchestrator.py::test_orch_host_ls PASSED                                                                                    [ 45%]
orchestrator/tests/test_orchestrator.py::test_orch_device_ls PASSED                                                                                  [ 50%]
orchestrator/tests/test_orchestrator.py::test_preview_table_osd_smoke PASSED                                                                         [ 55%]
orchestrator/tests/test_orchestrator.py::TestApplyNvmeof::test_missing_group_raises_validation_error PASSED                                          [ 60%]
orchestrator/tests/test_orchestrator.py::TestApplyNvmeof::test_inbuf_raises_validation_error PASSED                                                  [ 65%]
orchestrator/tests/test_orchestrator.py::TestApplyNvmeof::test_custom_pool_skips_metadata_pool_creation PASSED                                       [ 70%]
orchestrator/tests/test_orchestrator.py::TestApplyNvmeof::test_default_pool_fails_if_module_disabled PASSED                                          [ 75%]
orchestrator/tests/test_orchestrator.py::TestApplyNvmeof::test_default_pool_creates_metadata_pool_if_module_enabled PASSED                           [ 80%]
orchestrator/tests/test_orchestrator.py::TestApplyOAuth2Proxy::test_missing_required_fields_raises_error PASSED                                      [ 85%]
orchestrator/tests/test_orchestrator.py::TestApplyOAuth2Proxy::test_inbuf_with_missing_fields_is_rejected PASSED                                     [ 90%]
orchestrator/tests/test_orchestrator.py::TestApplyOAuth2Proxy::test_inbuf_with_valid_spec_is_rejected PASSED                                         [ 95%]
orchestrator/tests/test_orchestrator.py::TestApplyOAuth2ProxyYaml::test_apply_yaml_missing_required_fields PASSED                                    [100%]

==================================================================== 20 passed in 0.27s ====================================================================


or 

cd /root/ceph-adm-projects/ceph/src/pybind/mgr

UNITTEST=true PYTHONPATH=.:.. python3 -c "
import orchestrator.tests.test_orchestrator as t
to = t._TestOrchestrator('', 0, 0)

# This is what failed before the fix:
r = to.remove_daemons(['mds.fsname'], force_delete_data=False)
assert r.result == 'done'

r = to.remove_daemons(['mds.fsname'], force_delete_data=True)
assert r.result == 'done'

r = to.remove_service('mds', force=False, force_delete_data=True)
assert r.result == 'done'

print('stub smoke test: OK')
"


**before the fix reproduction**

root@C-PF4513NK:~/ceph-adm-projects/ceph/src/pybind/mgr# UNITTEST=true PYTHONPATH=.:.. python3 -c "
import orchestrator.tests.test_orchestrator as t
to = t._TestOrchestrator('', 0, 0)

# This is what failed before the fix:
r = to.remove_daemons(['mds.fsname'], force_delete_data=False)
assert r.result == 'done'

r = to.remove_daemons(['mds.fsname'], force_delete_data=True)
assert r.result == 'done'

r = to.remove_service('mds', force=False)
assert r.result == 'done'

print('stub smoke test: OK')
"
TestOrchestrator.remove_daemons() got an unexpected keyword argument 'force_delete_data'
Traceback (most recent call last):
  File "/root/ceph-adm-projects/ceph/src/pybind/mgr/orchestrator/_interface.py", line 115, in wrapper
    return OrchResult(f(*args, **kwargs))
TypeError: TestOrchestrator.remove_daemons() got an unexpected keyword argument 'force_delete_data'
Traceback (most recent call last):
  File "<string>", line 6, in <module>
  File "/root/ceph-adm-projects/ceph/src/pybind/mgr/orchestrator/_interface.py", line 115, in wrapper
    return OrchResult(f(*args, **kwargs))
TypeError: TestOrchestrator.remove_daemons() got an unexpected keyword argument 'force_delete_data'


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
