### PR TITLE
tentacle: qa/workunits: test perf collection in telemetry tests

### DIFF
--- a/qa/workunits/test_telemetry_reef.sh
+++ b/qa/workunits/test_telemetry_reef.sh
@@ -5,7 +5,7 @@ ceph config set mgr mgr/telemetry/channel_ident true
 ceph config set mgr mgr/telemetry/organization 'ceph-qa'
 ceph config set mgr mgr/telemetry/description 'upgrade test cluster'
 
-#Run preview commands
+# Run preview commands
 ceph telemetry preview
 ceph telemetry preview-device
 ceph telemetry preview-all
@@ -47,7 +47,23 @@ for col in ${KNOWN_COLLECTIONS[@]}; do
     fi
 done
 
-#Run preview commands
+# Verify that perf collection works when an OSD is destroyed
+# --- See https://tracker.ceph.com/issues/77384
+
+RANDOM_OSD=$(ceph osd ls -f json | jq -r '.[]' | shuf -n1)
+echo "Chose to stop osd.$RANDOM_OSD..."
+
+ceph mgr module enable selftest
+ceph mgr self-test eval 'mgr.get_perf_schema("osd", "")'
+ceph orch daemon stop osd."$RANDOM_OSD"
+ceph orch restart mgr
+sleep 10 # give mgr time to restart
+ceph mgr self-test eval 'mgr.get_perf_schema("osd", "")'
+ceph telemetry show perf
+ceph telemetry preview perf
+ceph orch daemon restart osd."$RANDOM_OSD"
+
+# Run preview commands
 ceph telemetry preview
 ceph telemetry preview-device
 ceph telemetry preview-all

--- a/qa/workunits/test_telemetry_reef_x.sh
+++ b/qa/workunits/test_telemetry_reef_x.sh
@@ -36,7 +36,23 @@ for col in ${KNOWN_COLLECTIONS[@]}; do
     fi
 done
 
-#Run preview commands
+# Verify that perf collection works when an OSD is destroyed
+# --- See https://tracker.ceph.com/issues/77384
+
+RANDOM_OSD=$(ceph osd ls -f json | jq -r '.[]' | shuf -n1)
+echo "Chose to stop osd.$RANDOM_OSD..."
+
+ceph mgr module enable selftest
+ceph mgr self-test eval 'mgr.get_perf_schema("osd", "")'
+ceph orch daemon stop osd."$RANDOM_OSD"
+ceph orch restart mgr
+sleep 10 # give mgr time to restart
+ceph mgr self-test eval 'mgr.get_perf_schema("osd", "")'
+ceph telemetry show perf
+ceph telemetry preview perf
+ceph orch daemon restart osd."$RANDOM_OSD"
+
+# Run preview commands
 ceph telemetry preview
 ceph telemetry preview-device
 ceph telemetry preview-all

--- a/qa/workunits/test_telemetry_squid.sh
+++ b/qa/workunits/test_telemetry_squid.sh
@@ -5,7 +5,7 @@ ceph config set mgr mgr/telemetry/channel_ident true
 ceph config set mgr mgr/telemetry/organization 'ceph-qa'
 ceph config set mgr mgr/telemetry/description 'upgrade test cluster'
 
-#Run preview commands
+# Run preview commands
 ceph telemetry preview
 ceph telemetry preview-device
 ceph telemetry preview-all
@@ -47,7 +47,23 @@ for col in ${KNOWN_COLLECTIONS[@]}; do
     fi
 done
 
-#Run preview commands
+# Verify that perf collection works when an OSD is destroyed
+# --- See https://tracker.ceph.com/issues/77384
+
+RANDOM_OSD=$(ceph osd ls -f json | jq -r '.[]' | shuf -n1)
+echo "Chose to stop osd.$RANDOM_OSD..."
+
+ceph mgr module enable selftest
+ceph mgr self-test eval 'mgr.get_perf_schema("osd", "")'
+ceph orch daemon stop osd."$RANDOM_OSD"
+ceph orch restart mgr
+sleep 10 # give mgr time to restart
+ceph mgr self-test eval 'mgr.get_perf_schema("osd", "")'
+ceph telemetry show perf
+ceph telemetry preview perf
+ceph orch daemon restart osd."$RANDOM_OSD"
+
+# Run preview commands
 ceph telemetry preview
 ceph telemetry preview-device
 ceph telemetry preview-all

--- a/qa/workunits/test_telemetry_squid_x.sh
+++ b/qa/workunits/test_telemetry_squid_x.sh
@@ -36,7 +36,23 @@ for col in ${KNOWN_COLLECTIONS[@]}; do
     fi
 done
 
-#Run preview commands
+# Verify that perf collection works when an OSD is destroyed
+# --- See https://tracker.ceph.com/issues/77384
+
+RANDOM_OSD=$(ceph osd ls -f json | jq -r '.[]' | shuf -n1)
+echo "Chose to stop osd.$RANDOM_OSD..."
+
+ceph mgr module enable selftest
+ceph mgr self-test eval 'mgr.get_perf_schema("osd", "")'
+ceph orch daemon stop osd."$RANDOM_OSD"
+ceph orch restart mgr
+sleep 10 # give mgr time to restart
+ceph mgr self-test eval 'mgr.get_perf_schema("osd", "")'
+ceph telemetry show perf
+ceph telemetry preview perf
+ceph orch daemon restart osd."$RANDOM_OSD"
+
+# Run preview commands
 ceph telemetry preview
 ceph telemetry preview-device
 ceph telemetry preview-all


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77387

---

backport of https://github.com/ceph/ceph/pull/69442
parent tracker: https://tracker.ceph.com/issues/77384

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh