### PR TITLE
crimson/os/seastore/lba: don't update the lba mapping if its child is an initial pending one.

### DIFF
--- a/src/crimson/os/seastore/backref/backref_tree_node.h
+++ b/src/crimson/os/seastore/backref/backref_tree_node.h
@@ -105,7 +105,8 @@ public:
 
   void update(
     const_iterator iter,
-    backref_map_val_t val) final {
+    backref_map_val_t val,
+    modification_t) final {
     return journal_update(
       iter,
       val,

--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -20,6 +20,16 @@
 
 namespace crimson::os::seastore {
 
+enum modification_t {
+  USER_MODIFY,  // logical update (affects node state)
+  TRANS_SYNC    // synchronization-only update (should NOT count
+                // as modification and should avoid on_modify(),
+                // for example, BtreeLBAManager::update_paddr_sync
+                // does not change the logical mapping, only the
+                // physical location (paddr) of the same data, so
+                // TRANS_SYNC is used.
+};
+
 template <typename T>
 phy_tree_root_t& get_phy_tree_root(root_t& r);
 
@@ -1108,7 +1118,8 @@ public:
     op_context_t c,
     iterator iter,
     node_val_t val,
-    BaseChildNode<leaf_node_t, node_key_t> *child)
+    BaseChildNode<leaf_node_t, node_key_t> *child,
+    modification_t mod = modification_t::USER_MODIFY)
   {
     LOG_PREFIX(FixedKVBtree::update);
     SUBTRACET(
@@ -1116,6 +1127,9 @@ public:
       "update element at {}",
       c.trans,
       iter.is_end() ? min_max_t<node_key_t>::max : iter.get_key());
+    if (mod == modification_t::TRANS_SYNC) {
+      assert(child == nullptr);
+    }
     if (!iter.leaf.node->is_mutable()) {
       CachedExtentRef mut = c.cache.duplicate_for_write(
         c.trans, iter.leaf.node
@@ -1125,7 +1139,8 @@ public:
     ++(get_tree_stats<self_type>(c.trans).num_updates);
     iter.leaf.node->update(
       iter.leaf.node->iter_idx(iter.leaf.pos),
-      val);
+      val,
+      mod);
     if constexpr (std::is_base_of_v<
         ParentNode<leaf_node_t, node_key_t>, leaf_node_t>) {
       if (child) {

--- a/src/crimson/os/seastore/btree/fixed_kv_node.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_node.h
@@ -729,7 +729,8 @@ struct FixedKVLeafNode
 
   virtual void update(
     internal_const_iterator_t iter,
-    VAL val) = 0;
+    VAL val,
+    modification_t mod) = 0;
   virtual internal_const_iterator_t insert(
     internal_const_iterator_t iter,
     NODE_KEY addr,

--- a/src/crimson/os/seastore/lba/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.cc
@@ -1204,8 +1204,8 @@ BtreeLBAManager::_copy_mapping(
   c.trans.new_lba_key_copied(
     ret.src->get_key(),
     dest_laddr,
-    [this](Transaction &t, laddr_t laddr, paddr_t paddr) {
-      update_paddr_sync(t, laddr, paddr);
+    [this, c](laddr_t laddr, paddr_t paddr) {
+      update_paddr_sync(c.trans, laddr, paddr);
     });
   auto [niter, inserted] = co_await btree.copy(
       c,

--- a/src/crimson/os/seastore/lba/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.cc
@@ -1154,6 +1154,14 @@ void BtreeLBAManager::update_paddr_sync(
   auto btree = get_btree_sync<LBABtree>(c);
   auto iter = btree.lower_bound_sync(c, laddr);
   assert(iter.get_leaf_node()->is_pending());
+  auto child = iter.get_leaf_node()->get_child_sync<LogicalChildNode>(
+    c.trans, c.cache, iter.get_leaf_pos(), iter.get_key());
+  ceph_assert(child);
+  if (child->is_initial_pending()) {
+    TRACET("{} is initial_pending, skipping", t, *child);
+    return;
+  }
+  ceph_assert(child->is_exist_clean());
   auto cursor = iter.get_cursor(c);
   assert(cursor->get_laddr() == laddr);
   btree.update(

--- a/src/crimson/os/seastore/lba/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.cc
@@ -1173,7 +1173,8 @@ void BtreeLBAManager::update_paddr_sync(
       cursor->get_refcount(),
       cursor->get_checksum(),
       cursor->get_extent_type()},
-    nullptr);
+    nullptr,
+    modification_t::TRANS_SYNC);
 }
 
 BtreeLBAManager::move_mapping_ret

--- a/src/crimson/os/seastore/lba/lba_btree_node.cc
+++ b/src/crimson/os/seastore/lba/lba_btree_node.cc
@@ -46,13 +46,16 @@ void LBALeafNode::resolve_relative_addrs(paddr_t base)
 
 void LBALeafNode::update(
   internal_const_iterator_t iter,
-  lba_map_val_t val)
+  lba_map_val_t val,
+  modification_t mod)
 {
   LOG_PREFIX(LBALeafNode::update);
   SUBTRACE(seastore_fixedkv_tree, "trans.{}, pos {}",
     this->pending_for_transaction,
     iter.get_offset());
-  this->on_modify();
+  if (likely(mod == modification_t::USER_MODIFY)) {
+    this->on_modify();
+  }
   if (val.pladdr.is_paddr()) {
     val.pladdr = maybe_generate_relative(val.pladdr.get_paddr());
   }

--- a/src/crimson/os/seastore/lba/lba_btree_node.h
+++ b/src/crimson/os/seastore/lba/lba_btree_node.h
@@ -141,7 +141,8 @@ struct LBALeafNode
 
   void update(
     internal_const_iterator_t iter,
-    lba_map_val_t val) final;
+    lba_map_val_t val,
+    modification_t mod) final;
 
   internal_const_iterator_t insert(
     internal_const_iterator_t iter,

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -671,7 +671,7 @@ public:
   bool force_rewrite_conflict = false;
 
   using update_copied_lba_key_func_t =
-    std::function<void (Transaction&, laddr_t, paddr_t)>;
+    std::function<void (laddr_t, paddr_t)>;
   void new_lba_key_copied(
     laddr_t src,
     laddr_t dest,
@@ -691,7 +691,7 @@ public:
       return;
     }
     laddr_t key = it->second;
-    update_copied_lba_key(*this, key, paddr);
+    update_copied_lba_key(key, paddr);
   }
   RootBlockRef peek_root() {
     return root;
@@ -923,7 +923,7 @@ private:
   cache_hint_t cache_hint = CACHE_HINT_TOUCH;
 
   std::map<laddr_t, laddr_t> copied_lba_keys;
-  std::function<void (Transaction&, laddr_t, paddr_t)> update_copied_lba_key;
+  update_copied_lba_key_func_t update_copied_lba_key;
 };
 using TransactionRef = Transaction::Ref;
 


### PR DESCRIPTION
Because initial pending extents' paddrs are considered newer，so we shouldn't update its paddrs.

Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
