### PR TITLE
cmake: build pmdk from the maintained daos-stack fork

### DIFF
--- a/cmake/modules/Buildpmdk.cmake
+++ b/cmake/modules/Buildpmdk.cmake
@@ -6,10 +6,20 @@ function(build_pmdk enable_ndctl)
     set(source_dir_args
       SOURCE_DIR "${PROJECT_SOURCE_DIR}/src/pmdk")
   else()
+    # ceph/pmdk 1.10 predates RISC-V support (its Makefile.inc aborts with
+    # "unsupported architecture: riscv64"). daos-stack/pmdk carries that
+    # support, so use it on riscv64.
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "^riscv64$")
+      set(pmdk_git_repository https://github.com/daos-stack/pmdk.git)
+      set(pmdk_git_tag "2.1.3")
+    else()
+      set(pmdk_git_repository https://github.com/ceph/pmdk.git)
+      set(pmdk_git_tag "1.10")
+    endif()
     set(source_dir_args
       SOURCE_DIR ${CMAKE_BINARY_DIR}/src/pmdk
-      GIT_REPOSITORY https://github.com/ceph/pmdk.git
-      GIT_TAG "1.10"
+      GIT_REPOSITORY ${pmdk_git_repository}
+      GIT_TAG ${pmdk_git_tag}
       GIT_SHALLOW TRUE
       GIT_CONFIG advice.detachedHead=false)
   endif()
@@ -30,11 +40,14 @@ function(build_pmdk enable_ndctl)
   endif()
 
   set(pmdk_cflags "-Wno-error -fno-lto")
+  # daos-stack pmdk turns the "no NDCTL -> can't detect dirty shutdowns / bad
+  # blocks" warnings into hard build errors; acknowledge them so libpmemobj
+  # builds without NDCTL (matches the long-standing ceph/pmdk 1.10 behavior).
   include(ExternalProject)
   ExternalProject_Add(pmdk_ext
       ${source_dir_args}
       CONFIGURE_COMMAND ""
-      BUILD_COMMAND ${make_cmd} CC=${CMAKE_C_COMPILER} "EXTRA_CFLAGS=${pmdk_cflags}" NDCTL_ENABLE=${ndctl} BUILD_EXAMPLES=n BUILD_BENCHMARKS=n DOC=n
+      BUILD_COMMAND ${make_cmd} CC=${CMAKE_C_COMPILER} "EXTRA_CFLAGS=${pmdk_cflags}" NDCTL_ENABLE=${ndctl} BUILD_EXAMPLES=n BUILD_BENCHMARKS=n DOC=n PMEMOBJ_IGNORE_DIRTY_SHUTDOWN=y PMEMOBJ_IGNORE_BAD_BLOCKS=y
       BUILD_IN_SOURCE 1
       BUILD_BYPRODUCTS "<SOURCE_DIR>/src/${PMDK_LIB_DIR}/libpmem.a" "<SOURCE_DIR>/src/${PMDK_LIB_DIR}/libpmemobj.a"
       INSTALL_COMMAND "")


### PR DESCRIPTION
Ceph pins PMDK to ceph/pmdk 1.10, a fork of the now-archived
https://github.com/pmem/pmdk. Development moved to
https://github.com/daos-stack/pmdk, so 1.10 is no longer maintained.

This switches to daos-stack/pmdk 2.1.3, which includes libpmemobj allocator fixes
on the heap path Ceph's PWL/RWL cache uses.

To avoid forcing a major bump on arches that build fine on 1.10, the switch is
gated to riscv64 only — every other arch keeps ceph/pmdk 1.10 unchanged. 1.10
predates RISC-V support and aborts with `unsupported architecture: riscv64`.

2.x also needs `PMEMOBJ_IGNORE_DIRTY_SHUTDOWN=y` / `PMEMOBJ_IGNORE_BAD_BLOCKS=y`
to build libpmemobj without NDCTL, preserving 1.10's existing behavior.

If other arches want to move to 2.1.3 too, I'll drop the riscv64 gate.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests