### PR TITLE
cmake: find Protobuf via cmake config before module mode

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1023,10 +1023,12 @@ option(WITH_NVMEOF_GATEWAY_MONITOR_CLIENT "build nvmeof gateway monitor client" 
 
 if(WITH_NVMEOF_GATEWAY_MONITOR_CLIENT)
 
-  # Find Protobuf installation
-  # Looks for protobuf-config.cmake file installed by Protobuf's cmake installation.
-  option(protobuf_MODULE_COMPATIBLE TRUE)
-  find_package(Protobuf REQUIRED)
+  # Prefer config mode so gRPC sees protobuf's full target set
+  # (incl. upb); fall back to module mode.
+  find_package(Protobuf CONFIG)
+  if(NOT Protobuf_FOUND)
+    find_package(Protobuf REQUIRED)
+  endif()
 
   set(_REFLECTION grpc++_reflection)
   if(CMAKE_CROSSCOMPILING)


### PR DESCRIPTION
Module-mode FindProtobuf defines only the classic protobuf targets, so
gRPCConfig.cmake's config-mode `find_dependency(Protobuf)` fails on the
partial export set ("Some (but not all) targets ... already defined").
Prefer config mode so the full target set comes from one place; fall
back to module mode for distros without protobuf cmake config files.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests