### PR TITLE
test/crimson/seastore: tolerate enoent in concurrent remap/overwrite helpers

### DIFF
--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -602,6 +602,9 @@ struct transaction_manager_test_t :
       [](const crimson::ct_error::eagain &e) {
 	return seastar::make_ready_future<TestBlockRef>();
       },
+      [](const crimson::ct_error::enoent &e) {
+	return seastar::make_ready_future<TestBlockRef>();
+      },
       crimson::ct_error::assert_all(
 	"get_extent got invalid error"
       )
@@ -630,6 +633,9 @@ struct transaction_manager_test_t :
       return ertr::make_ready_future<TestBlockRef>(ret.extent);
     }).handle_error(
       [](const crimson::ct_error::eagain &e) {
+	return seastar::make_ready_future<TestBlockRef>();
+      },
+      [](const crimson::ct_error::enoent &e) {
 	return seastar::make_ready_future<TestBlockRef>();
       },
       crimson::ct_error::assert_all(
@@ -758,6 +764,9 @@ struct transaction_manager_test_t :
       return ertr::make_ready_future<std::optional<LBAMapping>>(std::move(pin));
     }).handle_error(
       [](const crimson::ct_error::eagain &e) {
+	return seastar::make_ready_future<std::optional<LBAMapping>>();
+      },
+      [](const crimson::ct_error::enoent &e) {
 	return seastar::make_ready_future<std::optional<LBAMapping>>();
       },
       crimson::ct_error::assert_all(


### PR DESCRIPTION
`test_remap_pin_concurrent` intermittently aborts with
`get_extent got invalid error`. The concurrent remap/overwrite harness helpers
`try_get_pin()` and `try_get_extent()` tolerate only `ct_error::eagain`; when a
racing transaction retires or remaps a mapping, a follow-up lookup of that laddr
legitimately returns `ct_error::enoent` (ENOENT from
`BtreeLBAManager::get_cursor`), which falls through to `ct_error::assert_all()`
and aborts the test.

We treat `enoent` the same as `eagain`: return an empty result so the existing
`is_conflicted()`/null-check path counts the transaction as conflicted and the
test backs out cleanly.

This is a pre-existing race in the test harness, not a regression in the store.
It reproduces on current `main` with no other changes and is resolved by this
single test-file change:

```
ninja -C build unittest-transaction-manager
./bin/unittest-transaction-manager \
    --gtest_filter='*test_remap_pin_concurrent*' --smp 1 --gtest_repeat=30
```

Without the change the run aborts within a few iterations; with it, 30
iterations across all four device variants pass.

## Checklist
- Tracker (select at least one)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] No tests