### PR TITLE
crimson/test: shrink messenger-thrash max_message_len to 1MB

### DIFF
--- a/src/test/crimson/test_messenger_thrash.cc
+++ b/src/test/crimson/test_messenger_thrash.cc
@@ -244,7 +244,7 @@ class SyntheticWorkload {
    const unsigned min_connections = 10;
    const unsigned max_in_flight = 64;
    const unsigned max_connections = 128;
-   const unsigned max_message_len = 1024 * 1024 * 4;
+   const unsigned max_message_len = 1024 * 1024;
    const uint64_t  servers, clients;
 
    SyntheticWorkload(int servers, int clients, int random_num,


### PR DESCRIPTION
```
$ bin/unittest-seastar-messenger-thrash --memory 256M --smp 1
INFO  [shard 0:main] test - test_stress():
ERROR [shard 0:main] test - Test failed: got exception ceph::buffer::v15_2_0::bad_alloc (Bad allocation [buffer:1])
/ceph/src/seastar/include/seastar/core/sharded.hh:573: seastar::sharded<Service>::~sharded() [with Service = crimson::common::ConfigProxy]: Assertion `_instances.empty()` failed.
terminate called without an active exception
```

```
$ bin/unittest-seastar-messenger-thrash --memory 1024M --smp 1
INFO  [shard 0:main] test - test_stress() DONE
INFO  [shard 0:main] test - test_injection():
INFO  [shard 0:main] test - test_inejction() DONE
INFO  [shard 0:main] test - All tests succeeded
```

Stability across pool sizes (repeated runs of the same binary):

| `--memory` | runs | pass | fail |
|------------|------|------|------|
| 256M       | 5    | 0    | 5    |
| 512M       | 5    | 3    | 2    |
| 1024M      | 5    | 5    | 0    |

## Environment

- SOPHGO SG2044 (64-core riscv64)
- openRuyi container

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests