### PR TITLE
build/script: print sccache stats alongside ccache

### DIFF
--- a/src/script/run-make.sh
+++ b/src/script/run-make.sh
@@ -190,6 +190,10 @@ function build() {
     ci_debug "Running cmake"
     $DRY_RUN cmake --build . $targets -- $BUILD_MAKEOPTS || return 1
     $DRY_RUN ccache -s # print the ccache statistics to evaluate the efficiency
+    # print sccache stats too when built with WITH_SCCACHE
+    if type sccache > /dev/null 2>&1; then
+        $DRY_RUN sccache --show-stats
+    fi
 }
 
 DEFAULT_MAKEOPTS=${DEFAULT_MAKEOPTS:--j$(get_processors)}


### PR DESCRIPTION
sccache is enabled via WITH_SCCACHE, but run-make.sh only printed
ccache statistics after the build. Print `sccache --show-stats` too
when sccache is available.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests