### PR TITLE
rgw/multisite: add notification metadata sync and delivery test

### DIFF
--- a/src/rgw/driver/rados/topic.cc
+++ b/src/rgw/driver/rados/topic.cc
@@ -357,7 +357,15 @@ class MetadataHandler : public RGWMetadataHandler {
       librados::IoCtx ioctx;
       r = rgw_init_ioctx(dpp, &rados, zone.notif_pool, ioctx, true, false);
       if (r >= 0) {
-        r = rgw::notify::add_persistent_topic(dpp, ioctx, info.dest.persistent_queue, y);
+        // create all shards of the persistent queue, matching CreateTopic, so
+        // that notification delivery works on zones that receive the topic
+        // through metadata sync rather than a local CreateTopic request.
+        for (const auto& q : info.dest.get_shard_names()) {
+          r = rgw::notify::add_persistent_topic(dpp, ioctx, q, y);
+          if (r < 0) {
+            break;
+          }
+        }
       }
       if (r < 0) {
         ldpp_dout(dpp, 1) << "ERROR: failed to create queue for persistent topic "
@@ -395,7 +403,13 @@ class MetadataHandler : public RGWMetadataHandler {
       librados::IoCtx ioctx;
       r = rgw_init_ioctx(dpp, &rados, zone.notif_pool, ioctx, true, false);
       if (r >= 0) {
-        r = rgw::notify::remove_persistent_topic(dpp, ioctx, dest.persistent_queue, y);
+        // remove all shards of the persistent queue (matches CreateTopic)
+        for (const auto& q : dest.get_shard_names()) {
+          r = rgw::notify::remove_persistent_topic(dpp, ioctx, q, y);
+          if (r < 0 && r != -ENOENT) {
+            break;
+          }
+        }
       }
       if (r < 0 && r != -ENOENT) {
         ldpp_dout(dpp, 1) << "Failed to delete queue for persistent topic: "

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -9,6 +9,8 @@ import contextlib
 import dateutil.parser
 from datetime import datetime
 import threading
+import socket
+from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
 from typing import Dict, List, Any
 
 from itertools import combinations
@@ -4200,8 +4202,6 @@ def test_notification_metadata_sync_and_delivery():
     notifications are delivered when an object is put on a secondary zone.
     uses an http endpoint to verify actual event delivery, not just metadata sync.
     covers: persistent notifications, s3:ObjectCreated:* events."""
-    from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
-    import socket
 
     zonegroup = realm.master_zonegroup()
     zonegroup_conns = ZonegroupConns(zonegroup)
@@ -4214,12 +4214,16 @@ def test_notification_metadata_sync_and_delivery():
     zone_b = zonegroup_conns.rw_zones[1]
 
     # get a reachable ip for the http receiver
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     try:
-        s.connect(('10.255.255.255', 1))
-        host = s.getsockname()[0]
-    finally:
-        s.close()
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            s.connect(('10.255.255.255', 1))
+            host = s.getsockname()[0]
+        finally:
+            s.close()
+    except OSError:
+        host = socket.gethostbyname(socket.gethostname())
+    log.info('using host ip %s for http receiver', host)
 
     # http receiver that stores received events
     received_events = []
@@ -4256,7 +4260,6 @@ def test_notification_metadata_sync_and_delivery():
     try:
         # wait for zones to sync
         zonegroup_meta_checkpoint(zonegroup)
-        time.sleep(config.checkpoint_delay)
 
         # create topic with real http endpoint on zone_a
         topic_name = gen_topic_name()
@@ -4326,13 +4329,15 @@ def test_notification_metadata_sync_and_delivery():
         record = event['Records'][0]
         assert_equal(record['s3']['bucket']['name'], bucket_name)
         assert_equal(record['s3']['object']['key'], key)
-        assert_true('ObjectCreated' in record['eventName'])
+        assert_equal(record['eventName'], 's3:ObjectCreated:Put')
 
         log.info('notification delivery verified: %s', record['eventName'])
 
     finally:
         http_server.shutdown()
         http_thread.join(5)
+        if http_thread.is_alive():
+            log.warning('http server thread did not exit within 5s')
         http_server.server_close()
         if bucket_name is not None:
             try:

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -4197,6 +4197,76 @@ def test_topic_notification_sync():
         topic_list = conn.list_topics()
         assert_equal(len(topic_list), 0)
 
+class NotificationHTTPHandler(BaseHTTPRequestHandler):
+    """http request handler that stores received notification events."""
+    def do_POST(self):
+        content_length = int(self.headers.get('Content-Length', 0))
+        if content_length > 0:
+            body = self.rfile.read(content_length)
+            try:
+                event = json.loads(body)
+                with self.server.events_lock:
+                    self.server.events.append(event)
+                log.info('http receiver got event: %s', str(event))
+            except Exception:
+                log.warning('http receiver got non-json body: %s', body)
+        self.send_response(200)
+        self.end_headers()
+
+    def log_message(self, format, *args):
+        pass
+
+
+def start_notification_http_receiver():
+    """start an http server that collects notification events.
+    returns (server, thread, endpoint_url)."""
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            s.connect(('10.255.255.255', 1))
+            host = s.getsockname()[0]
+        finally:
+            s.close()
+    except OSError:
+        host = socket.gethostbyname(socket.gethostname())
+    log.info('using host ip %s for http receiver', host)
+
+    server = ThreadingHTTPServer((host, 0), NotificationHTTPHandler)
+    server.events = []
+    server.events_lock = threading.Lock()
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+    endpoint_url = 'http://' + host + ':' + str(port)
+    log.info('http receiver started on %s', endpoint_url)
+    return server, thread, endpoint_url
+
+
+def stop_notification_http_receiver(server, thread):
+    """shutdown an http server started by start_notification_http_receiver."""
+    server.shutdown()
+    thread.join(5)
+    if thread.is_alive():
+        log.warning('http server thread did not exit within 5s')
+    server.server_close()
+
+
+def poll_notification_events(server, timeout=None):
+    """poll until at least one event is received or timeout expires.
+    returns the list of received events."""
+    if timeout is None:
+        timeout = config.checkpoint_retries * config.checkpoint_delay
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        with server.events_lock:
+            if len(server.events) > 0:
+                break
+        time.sleep(config.checkpoint_delay)
+    with server.events_lock:
+        return list(server.events)
+
+
 def test_notification_metadata_sync_and_delivery():
     """test that bucket notification metadata syncs across zones and
     notifications are delivered when an object is put on a secondary zone.
@@ -4213,47 +4283,7 @@ def test_notification_metadata_sync_and_delivery():
     zone_a = zonegroup_conns.rw_zones[0]
     zone_b = zonegroup_conns.rw_zones[1]
 
-    # get a reachable ip for the http receiver
-    try:
-        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        try:
-            s.connect(('10.255.255.255', 1))
-            host = s.getsockname()[0]
-        finally:
-            s.close()
-    except OSError:
-        host = socket.gethostbyname(socket.gethostname())
-    log.info('using host ip %s for http receiver', host)
-
-    # http receiver that stores received events
-    received_events = []
-    received_lock = threading.Lock()
-
-    class NotificationHandler(BaseHTTPRequestHandler):
-        def do_POST(self):
-            content_length = int(self.headers.get('Content-Length', 0))
-            if content_length > 0:
-                body = self.rfile.read(content_length)
-                try:
-                    event = json.loads(body)
-                    with received_lock:
-                        received_events.append(event)
-                    log.info('http receiver got event: %s', str(event))
-                except Exception:
-                    log.warning('http receiver got non-json body: %s', body)
-            self.send_response(200)
-            self.end_headers()
-
-        def log_message(self, format, *args):
-            pass
-
-    # let the os assign a free port
-    http_server = ThreadingHTTPServer((host, 0), NotificationHandler)
-    port = http_server.server_address[1]
-    http_thread = threading.Thread(target=http_server.serve_forever)
-    http_thread.daemon = True
-    http_thread.start()
-    log.info('http receiver started on %s:%d', host, port)
+    http_server, http_thread, endpoint_url = start_notification_http_receiver()
 
     topic_arn = None
     bucket_name = None
@@ -4263,28 +4293,17 @@ def test_notification_metadata_sync_and_delivery():
 
         # create topic with real http endpoint on zone_a
         topic_name = gen_topic_name()
-        endpoint_address = 'http://' + host + ':' + str(port)
         attributes = {
-            'push-endpoint': endpoint_address,
+            'push-endpoint': endpoint_url,
             'persistent': 'true',
         }
         topic_arn = zone_a.create_topic(topic_name, attributes)
-        log.info('created topic=%s arn=%s endpoint=%s', topic_name, topic_arn, endpoint_address)
-
-        zonegroup_meta_checkpoint(zonegroup)
-
-        # verify topic synced to zone_b
-        zone_b_topics = zone_b.list_topics()
-        zone_b_arns = [t['TopicArn'] for t in zone_b_topics]
-        assert_true(topic_arn in zone_b_arns,
-                    'topic did not sync to secondary zone')
+        log.info('created topic=%s arn=%s endpoint=%s', topic_name, topic_arn, endpoint_url)
 
         # create bucket on zone_a
         bucket_name = gen_bucket_name()
         bucket = zone_a.create_bucket(bucket_name)
         log.info('created bucket=%s on zone=%s', bucket_name, zone_a.name)
-
-        zonegroup_meta_checkpoint(zonegroup)
 
         # create notification on the bucket
         notification_id = 'notif-' + run_prefix
@@ -4294,37 +4313,23 @@ def test_notification_metadata_sync_and_delivery():
         zone_a.create_notification(bucket.name, topic_conf)
         log.info('created notification=%s on bucket=%s', notification_id, bucket_name)
 
+        # wait for metadata sync to zone_b
         zonegroup_meta_checkpoint(zonegroup)
-
-        # verify notification synced to zone_b
-        zone_b_notifs = zone_b.list_notifications(bucket.name)
-        assert_true(len(zone_b_notifs) > 0,
-                    'notification did not sync to secondary zone')
 
         # put object on zone_b (the secondary) to trigger notification
         key = 'test-object'
         zone_b.s3_client.put_object(Bucket=bucket_name, Key=key, Body=b'test content')
         log.info('put object=%s on zone=%s', key, zone_b.name)
 
-        # poll for notification delivery with timeout
-        deadline = time.time() + config.checkpoint_retries * config.checkpoint_delay
-        while time.time() < deadline:
-            with received_lock:
-                if len(received_events) > 0:
-                    break
-            time.sleep(config.checkpoint_delay)
+        # poll for notification delivery
+        events = poll_notification_events(http_server)
 
-        # verify notification was delivered to the http receiver
-        with received_lock:
-            event_count = len(received_events)
-
-        log.info('http receiver got %d events', event_count)
-        assert_true(event_count > 0,
+        log.info('http receiver got %d events', len(events))
+        assert_true(len(events) > 0,
                     'no notifications delivered to http endpoint')
 
         # verify event contains expected fields
-        with received_lock:
-            event = received_events[0]
+        event = events[0]
         assert_true('Records' in event, 'event missing Records field')
         record = event['Records'][0]
         assert_equal(record['s3']['bucket']['name'], bucket_name)
@@ -4334,11 +4339,7 @@ def test_notification_metadata_sync_and_delivery():
         log.info('notification delivery verified: %s', record['eventName'])
 
     finally:
-        http_server.shutdown()
-        http_thread.join(5)
-        if http_thread.is_alive():
-            log.warning('http server thread did not exit within 5s')
-        http_server.server_close()
+        stop_notification_http_receiver(http_server, http_thread)
         if bucket_name is not None:
             try:
                 zone_a.delete_notifications(bucket_name)

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -4195,6 +4195,160 @@ def test_topic_notification_sync():
         topic_list = conn.list_topics()
         assert_equal(len(topic_list), 0)
 
+def test_notification_metadata_sync_and_delivery():
+    """test that bucket notification metadata syncs across zones and
+    notifications are delivered when an object is put on a secondary zone.
+    uses an http endpoint to verify actual event delivery, not just metadata sync.
+    covers: persistent notifications, s3:ObjectCreated:* events."""
+    from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
+    import socket
+
+    zonegroup = realm.master_zonegroup()
+    zonegroup_conns = ZonegroupConns(zonegroup)
+
+    # need at least 2 rw zones for a meaningful multisite test
+    if len(zonegroup_conns.rw_zones) < 2:
+        raise SkipTest('multisite notification delivery test requires >= 2 rw zones')
+
+    zone_a = zonegroup_conns.rw_zones[0]
+    zone_b = zonegroup_conns.rw_zones[1]
+
+    # get a reachable ip for the http receiver
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.connect(('10.255.255.255', 1))
+        host = s.getsockname()[0]
+    finally:
+        s.close()
+
+    # http receiver that stores received events
+    received_events = []
+    received_lock = threading.Lock()
+
+    class NotificationHandler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            content_length = int(self.headers.get('Content-Length', 0))
+            if content_length > 0:
+                body = self.rfile.read(content_length)
+                try:
+                    event = json.loads(body)
+                    with received_lock:
+                        received_events.append(event)
+                    log.info('http receiver got event: %s', str(event))
+                except Exception:
+                    log.warning('http receiver got non-json body: %s', body)
+            self.send_response(200)
+            self.end_headers()
+
+        def log_message(self, format, *args):
+            pass
+
+    # let the os assign a free port
+    http_server = ThreadingHTTPServer((host, 0), NotificationHandler)
+    port = http_server.server_address[1]
+    http_thread = threading.Thread(target=http_server.serve_forever)
+    http_thread.daemon = True
+    http_thread.start()
+    log.info('http receiver started on %s:%d', host, port)
+
+    topic_arn = None
+    bucket_name = None
+    try:
+        # wait for zones to sync
+        zonegroup_meta_checkpoint(zonegroup)
+        time.sleep(config.checkpoint_delay)
+
+        # create topic with real http endpoint on zone_a
+        topic_name = gen_topic_name()
+        endpoint_address = 'http://' + host + ':' + str(port)
+        attributes = {
+            'push-endpoint': endpoint_address,
+            'persistent': 'true',
+        }
+        topic_arn = zone_a.create_topic(topic_name, attributes)
+        log.info('created topic=%s arn=%s endpoint=%s', topic_name, topic_arn, endpoint_address)
+
+        zonegroup_meta_checkpoint(zonegroup)
+
+        # verify topic synced to zone_b
+        zone_b_topics = zone_b.list_topics()
+        zone_b_arns = [t['TopicArn'] for t in zone_b_topics]
+        assert_true(topic_arn in zone_b_arns,
+                    'topic did not sync to secondary zone')
+
+        # create bucket on zone_a
+        bucket_name = gen_bucket_name()
+        bucket = zone_a.create_bucket(bucket_name)
+        log.info('created bucket=%s on zone=%s', bucket_name, zone_a.name)
+
+        zonegroup_meta_checkpoint(zonegroup)
+
+        # create notification on the bucket
+        notification_id = 'notif-' + run_prefix
+        topic_conf = [{'Id': notification_id,
+                       'TopicArn': topic_arn,
+                       'Events': ['s3:ObjectCreated:*']}]
+        zone_a.create_notification(bucket.name, topic_conf)
+        log.info('created notification=%s on bucket=%s', notification_id, bucket_name)
+
+        zonegroup_meta_checkpoint(zonegroup)
+
+        # verify notification synced to zone_b
+        zone_b_notifs = zone_b.list_notifications(bucket.name)
+        assert_true(len(zone_b_notifs) > 0,
+                    'notification did not sync to secondary zone')
+
+        # put object on zone_b (the secondary) to trigger notification
+        key = 'test-object'
+        zone_b.s3_client.put_object(Bucket=bucket_name, Key=key, Body=b'test content')
+        log.info('put object=%s on zone=%s', key, zone_b.name)
+
+        # poll for notification delivery with timeout
+        deadline = time.time() + config.checkpoint_retries * config.checkpoint_delay
+        while time.time() < deadline:
+            with received_lock:
+                if len(received_events) > 0:
+                    break
+            time.sleep(config.checkpoint_delay)
+
+        # verify notification was delivered to the http receiver
+        with received_lock:
+            event_count = len(received_events)
+
+        log.info('http receiver got %d events', event_count)
+        assert_true(event_count > 0,
+                    'no notifications delivered to http endpoint')
+
+        # verify event contains expected fields
+        with received_lock:
+            event = received_events[0]
+        assert_true('Records' in event, 'event missing Records field')
+        record = event['Records'][0]
+        assert_equal(record['s3']['bucket']['name'], bucket_name)
+        assert_equal(record['s3']['object']['key'], key)
+        assert_true('ObjectCreated' in record['eventName'])
+
+        log.info('notification delivery verified: %s', record['eventName'])
+
+    finally:
+        http_server.shutdown()
+        http_thread.join(5)
+        http_server.server_close()
+        if bucket_name is not None:
+            try:
+                zone_a.delete_notifications(bucket_name)
+            except Exception as e:
+                log.warning('failed to delete notifications: %s', e)
+            try:
+                zone_a.delete_bucket(bucket_name)
+            except Exception as e:
+                log.warning('failed to delete bucket: %s', e)
+        if topic_arn is not None:
+            try:
+                zone_a.delete_topic(topic_arn)
+            except Exception as e:
+                log.warning('failed to delete topic: %s', e)
+
 def test_account_metadata_sync():
     zonegroup = realm.master_zonegroup()
     zonegroup_conns = ZonegroupConns(zonegroup)

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -4334,7 +4334,7 @@ def test_notification_metadata_sync_and_delivery():
         record = event['Records'][0]
         assert_equal(record['s3']['bucket']['name'], bucket_name)
         assert_equal(record['s3']['object']['key'], key)
-        assert_equal(record['eventName'], 's3:ObjectCreated:Put')
+        assert_equal(record['eventName'], 'ObjectCreated:Put')
 
         log.info('notification delivery verified: %s', record['eventName'])
 


### PR DESCRIPTION
## Summary

Add test_notification_metadata_sync_and_delivery to verify that bucket notification metadata syncs across zones and notifications are delivered when an object is put on a secondary zone.

The existing test_topic_notification_sync only verifies metadata sync (topics/notifications exist on all zones) but uses a fake unreachable endpoint (http://kaboom:9999). This test uses a real HTTP receiver to validate end-to-end notification delivery.

## What this tests

- Topic creation on zone_a with a real HTTP push-endpoint
- Topic metadata sync from zone_a to zone_b
- Notification creation on zone_a subscribing to s3:ObjectCreated:*
- Notification metadata sync from zone_a to zone_b
- Object PUT on zone_b (secondary zone) triggering a local notification
- Notification delivery to the HTTP endpoint from zone_b

## Note

This test covers metadata sync + local notification delivery. The tracker issue https://tracker.ceph.com/issues/67178 is about a different scenario: s3:ObjectSynced events that fire when objects replicate across zones. A separate PR will address that.

## Contribution Guidelines

- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

## Checklist

- Tracker (select at least one)
    - References tracker ticket
- Component impact
    - No impact that needs to be tracked
- Documentation (select at least one)
    - No doc update is appropriate
- Tests (select at least one)
    - Includes integration test(s)