### PR TITLE
crimson/os: tolerate duplicate symbols when linking with mold

### DIFF
--- a/src/crimson/os/CMakeLists.txt
+++ b/src/crimson/os/CMakeLists.txt
@@ -14,3 +14,7 @@ target_link_libraries(crimson-os
   ${alienstore_lib}
   crimson-seastore
   crimson)
+
+# crimson-alienstore and crimson-common define the same symbols (src/common/*.cc
+# built with and without WITH_CRIMSON); let the first definition win, like ld.bfd.
+target_link_options(crimson-os INTERFACE -Wl,--allow-multiple-definition)

--- a/src/crimson/os/alienstore/CMakeLists.txt
+++ b/src/crimson/os/alienstore/CMakeLists.txt
@@ -82,3 +82,7 @@ target_link_libraries(crimson-alienstore
     ${BLKID_LIBRARIES}
     ${UDEV_LIBRARIES}
     blk)
+
+# Same duplicate-symbol workaround as src/crimson/os/CMakeLists.txt, for
+# executables that link crimson-alienstore directly rather than via crimson-os.
+target_link_options(crimson-alienstore INTERFACE -Wl,--allow-multiple-definition)


### PR DESCRIPTION
crimson-alienstore and crimson-common both compile some src/common/*.cc
(e.g. PluginRegistry.cc) without and with WITH_CRIMSON, exporting the same
symbols. ld.bfd keeps the first definition and links fine, but mold extracts
both archive members and aborts on the duplicates.

Pass `-Wl,--allow-multiple-definition` as an INTERFACE link option on
crimson-os and crimson-alienstore so the first definition wins, like ld.bfd.

Maybe this should be fixed comprehensively instead of adding a flag,
but I'm not sure whether this is intentional by design, so I'm only making a minimal change for now.

As an aside, actually linking with mold also requires
https://github.com/rui314/mold/pull/1609.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
