### PR TITLE
rgw: declare rgw_a's dependency on rgw_schedulers and kmip

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -508,6 +508,10 @@ if(COMPILER_SUPPORTS_VLA_ERROR)
     $<$<COMPILE_LANGUAGE:CXX>:-Werror=vla>)
 endif()
 
+# rgw_a references rgw::dmclock::* (rgw_schedulers) and kmip_* (kmip); declare
+# it here so the dependency propagates to every consumer. PRIVATE: not in headers.
+target_link_libraries(rgw_a PRIVATE rgw_schedulers kmip)
+
 set(radosgw_srcs
   rgw_main.cc)
 
@@ -532,8 +536,6 @@ target_include_directories(radosgw SYSTEM PUBLIC "../rapidjson/include")
 target_link_libraries(radosgw PRIVATE
   legacy-option-headers
   ${rgw_libs}
-  rgw_schedulers
-  kmip
   ${ALLOC_LIBS})
 
 install(TARGETS radosgw DESTINATION bin)
@@ -642,8 +644,6 @@ target_include_directories(rgw SYSTEM PUBLIC "../rapidjson/include")
 target_link_libraries(rgw
   PRIVATE
   ${rgw_libs}
-  rgw_schedulers
-  kmip
   librados
   cls_rgw_client
   cls_otp_client


### PR DESCRIPTION
rgw: declare rgw_a's dependency on rgw_schedulers and kmip

rgw_a uses rgw::dmclock::* (rgw_schedulers) and kmip_* (kmip) but never
declared either, so each consumer relinked them by hand. ld.bfd hid this
via lazy archive extraction; mold pulls the members and fails with
undefined symbols. Declare it on rgw_a (PRIVATE) and drop the now
redundant explicit links from radosgw and the rgw shared library.

As an aside, actually linking with mold also requires

- https://github.com/rui314/mold/pull/1609
- https://github.com/ceph/ceph/pull/69473

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests