### PR TITLE
mgr/dashboard : Enable cephadm-signed TLS for NVMeOf

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
@@ -104,6 +104,7 @@ import { MultiClusterFormComponent } from './multi-cluster/multi-cluster-form/mu
 import { MultiClusterListComponent } from './multi-cluster/multi-cluster-list/multi-cluster-list.component';
 import { DashboardV3Module } from '../dashboard-v3/dashboard-v3.module';
 import { MultiClusterDetailsComponent } from './multi-cluster/multi-cluster-details/multi-cluster-details.component';
+import { CertificateAuthorityFormComponent } from '~/app/shared/components/certificate-authority-form/certificate-authority-form.component';
 import { TextLabelListComponent } from '~/app/shared/components/text-label-list/text-label-list.component';
 
 @NgModule({
@@ -143,6 +144,7 @@ import { TextLabelListComponent } from '~/app/shared/components/text-label-list/
     TagModule,
     TabsModule,
     TextLabelListComponent,
+    CertificateAuthorityFormComponent,
     SelectModule,
     LayoutModule,
     NumberModule,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
@@ -1666,7 +1666,14 @@
             serviceForm.controls.service_type.value
           )
         ) {
-          <ng-container *ngTemplateOutlet="certificateAuthorityManagement"></ng-container>
+          <cd-certificate-authority-form
+            [formGroup]="serviceForm"
+            [editing]="editing"
+            [currentCertificate]="currentCertificate"
+            [showCertSourceChangeWarning]="showCertSourceChangeWarning"
+            (certificateTypeChange)="onCertificateTypeChange($event)"
+          >
+          </cd-certificate-authority-form>
         }
 
         <!-- ssl_cert - Only show when SSL is enabled AND certificate type is external -->
@@ -1898,7 +1905,14 @@
           </fieldset>
         </div>
         @if (serviceForm.controls.enable_mtls.value) {
-          <ng-container *ngTemplateOutlet="certificateAuthorityManagement"></ng-container>
+          <cd-certificate-authority-form
+            [formGroup]="serviceForm"
+            [editing]="editing"
+            [currentCertificate]="currentCertificate"
+            [showCertSourceChangeWarning]="showCertSourceChangeWarning"
+            (certificateTypeChange)="onCertificateTypeChange($event)"
+          >
+          </cd-certificate-authority-form>
 
           @if (serviceForm.controls.certificateType.value === CertificateType.external) {
             <!-- root_ca_cert -->
@@ -2062,174 +2076,6 @@
       >https://ssl-config.mozilla.org/#server=nginx</a
     >
   </span>
-</ng-template>
-
-<ng-template #certificateAuthorityManagement>
-  <div [formGroup]="serviceForm">
-    <!-- Current Certificate Section - Only shown in Edit mode when certificate exists -->
-    @if (editing && currentCertificate?.has_certificate) {
-      <div class="form-item">
-        <legend
-          class="cds--label cds--type-heading-compact-01"
-          i18n
-        >
-          Current Certificate
-        </legend>
-        <div class="row">
-          <div class="col-6">
-            <legend
-              class="cds--label"
-              i18n
-            >
-              Certificate
-            </legend>
-            <div>{{ currentCertificate.cert_name }}</div>
-          </div>
-          <div class="col-6">
-            <legend
-              class="cds--label"
-              i18n
-            >
-              Valid Until
-            </legend>
-            <div>
-              {{ currentCertificate.expiry_date | cdDate }} •
-              {{ currentCertificate.days_to_expiration }} <span i18n>days left</span>
-            </div>
-          </div>
-        </div>
-        <div class="row mt-3">
-          <div class="col-6">
-            <legend
-              class="cds--label"
-              i18n
-            >
-              Status
-            </legend>
-            <div class="align-items-center">
-              <cd-icon
-                [type]="statusIconMap[currentCertificate.status] || statusIconMap['default']"
-              ></cd-icon>
-              @switch (currentCertificate.status) {
-                @case ('valid') {
-                  <span i18n>Valid</span>
-                }
-                @case ('expiring') {
-                  <span i18n>Expiring soon</span>
-                }
-                @case ('expired') {
-                  <span i18n>Expired</span>
-                }
-                @case ('not_configured') {
-                  <span i18n>Not configured</span>
-                }
-                @case ('invalid') {
-                  <span i18n>Invalid</span>
-                }
-                @default {
-                  {{ currentCertificate.status }}
-                }
-              }
-            </div>
-          </div>
-          <div class="col-6">
-            <legend
-              class="cds--label"
-              i18n
-            >
-              Issuer
-            </legend>
-            <div>
-              @if (currentCertificate.signed_by === 'cephadm') {
-                <span i18n>Internal (Cephadm CA)</span>
-              } @else {
-                {{ currentCertificate.issuer || 'External' }}
-              }
-            </div>
-          </div>
-        </div>
-      </div>
-    }
-
-    <!-- Certificate Authority Selection -->
-    <div class="form-item">
-      <label
-        class="cds--label cds--type-heading-compact-01"
-        for="certificateType"
-        i18n
-        >Choose Certificate Authority</label
-      >
-      <cds-radio-group
-        formControlName="certificateType"
-        orientation="horizontal"
-        helperText="Select how certificates will be signed for this service. Choose internal to use the cluster's CA, or external to upload certificates signed by your organization."
-        i18n-helperText
-      >
-        <cds-radio
-          [value]="CertificateType.internal"
-          (change)="onCertificateTypeChange(CertificateType.internal)"
-          i18n
-        >
-          Internal
-        </cds-radio>
-        <cds-radio
-          [value]="CertificateType.external"
-          (change)="onCertificateTypeChange(CertificateType.external)"
-          i18n
-        >
-          External
-        </cds-radio>
-      </cds-radio-group>
-    </div>
-
-    @if (showCertSourceChangeWarning) {
-      <cd-alert-panel
-        type="warning"
-        spacingClass="mb-3"
-        i18n
-      >
-        Changing the certificate source will redeploy the service daemons to apply the new
-        certificate configuration.
-      </cd-alert-panel>
-    }
-
-    @if (serviceForm.controls.certificateType.value === CertificateType.internal) {
-      <cd-alert-panel
-        type="info"
-        spacingClass="mb-3"
-        i18n
-      >
-        Certificate will be generated automatically by Cephadm CA for internal certificate type.
-      </cd-alert-panel>
-      <div class="form-item">
-        <cd-text-label-list
-          formControlName="custom_sans"
-          label="Custom SAN Entries"
-          i18n-label
-          helperText="Optional list of Subject Alternative Names (hostnames, IPs, or DNS names) to include in the auto-generated certificate."
-          i18n-helperText
-        >
-        </cd-text-label-list>
-      </div>
-      @if (
-        serviceForm.controls.service_type.value === 'rgw' &&
-        serviceForm.controls.virtual_host_enabled.value
-      ) {
-        <div class="form-item">
-          <cds-checkbox
-            i18n-label
-            formControlName="wildcard_enabled"
-          >
-            Include wildcard certificate for bucket subdomains
-            <cd-help-text i18n>
-              Add wildcard certificates (*.domain) to allow SSL for all bucket subdomains. Required
-              for virtual-host style with SSL.
-            </cd-help-text>
-          </cds-checkbox>
-        </div>
-      }
-    }
-  </div>
 </ng-template>
 
 <ng-template

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
@@ -40,8 +40,7 @@ import {
   CephServiceSpec,
   CertificateType,
   QatOptions,
-  QatSepcs,
-  CERTIFICATE_STATUS_ICON_MAP
+  QatSepcs
 } from '~/app/shared/models/service.interface';
 import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
@@ -129,7 +128,6 @@ export class ServiceFormComponent extends CdForm implements OnInit {
   hostsAndLabels$: Observable<{ hosts: { content: string }[]; labels: { content: string }[] }>;
   currentCertificate: CephServiceCertificate = null;
   currentSpecCertificateSource: string = null;
-  statusIconMap = CERTIFICATE_STATUS_ICON_MAP;
 
   constructor(
     public actionLabels: ActionLabelsI18n,

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/certificate-authority-form/certificate-authority-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/certificate-authority-form/certificate-authority-form.component.html
@@ -1,0 +1,214 @@
+<div [formGroup]="formGroup">
+  @if (editing && currentCertificate?.has_certificate) {
+    <div class="form-item">
+      <span
+        class="cds--label cds--type-heading-compact-01"
+        i18n
+        >Current Certificate</span
+      >
+      <div
+        cdsRow
+        [condensed]="true"
+      >
+        <div
+          cdsCol
+          [columnNumbers]="[
+            ['sm', 4],
+            ['md', 4]
+          ]"
+        >
+          <div
+            cdsStack="vertical"
+            [gap]="1"
+          >
+            <span
+              class="cds--type-label-01"
+              i18n
+              >Certificate</span
+            >
+            <span class="cds--type-body-compact-01">{{ currentCertificate.cert_name }}</span>
+          </div>
+        </div>
+        <div
+          cdsCol
+          [columnNumbers]="[
+            ['sm', 4],
+            ['md', 4]
+          ]"
+        >
+          <div
+            cdsStack="vertical"
+            [gap]="1"
+          >
+            <span
+              class="cds--type-label-01"
+              i18n
+              >Valid Until</span
+            >
+            <span class="cds--type-body-compact-01">
+              {{ currentCertificate.expiry_date | cdDate }} •
+              {{ currentCertificate.days_to_expiration }}
+              <span i18n>days left</span>
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        cdsRow
+        [condensed]="true"
+        class="cds-mt-3"
+      >
+        <div
+          cdsCol
+          [columnNumbers]="[
+            ['sm', 4],
+            ['md', 4]
+          ]"
+        >
+          <div
+            cdsStack="vertical"
+            [gap]="1"
+          >
+            <span
+              class="cds--type-label-01"
+              i18n
+              >Status</span
+            >
+            <div
+              cdsStack="horizontal"
+              [gap]="2"
+            >
+              <cd-icon
+                [type]="statusIconMap[currentCertificate.status] || statusIconMap['default']"
+              ></cd-icon>
+              @switch (currentCertificate.status) {
+                @case ('valid') {
+                  <span i18n>Valid</span>
+                }
+                @case ('expiring') {
+                  <span i18n>Expiring soon</span>
+                }
+                @case ('expired') {
+                  <span i18n>Expired</span>
+                }
+                @case ('not_configured') {
+                  <span i18n>Not configured</span>
+                }
+                @case ('invalid') {
+                  <span i18n>Invalid</span>
+                }
+                @default {
+                  {{ currentCertificate.status }}
+                }
+              }
+            </div>
+          </div>
+        </div>
+        <div
+          cdsCol
+          [columnNumbers]="[
+            ['sm', 4],
+            ['md', 4]
+          ]"
+        >
+          <div
+            cdsStack="vertical"
+            [gap]="1"
+          >
+            <span
+              class="cds--type-label-01"
+              i18n
+              >Issuer</span
+            >
+            <span class="cds--type-body-compact-01">
+              @if (currentCertificate.signed_by === 'cephadm') {
+                <span i18n>Internal (Cephadm CA)</span>
+              } @else {
+                {{ currentCertificate.issuer || 'External' }}
+              }
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  }
+
+  <div class="form-item">
+    <label
+      class="cds--label cds--type-heading-compact-01"
+      for="certificateType"
+      i18n
+      >Choose Certificate Authority</label
+    >
+    <cds-radio-group
+      id="certificateType"
+      formControlName="certificateType"
+      orientation="horizontal"
+      helperText="Select how certificates will be signed for this service. Choose internal to use the cluster's CA, or external to upload certificates signed by your organization."
+      i18n-helperText
+    >
+      <cds-radio
+        [value]="CertificateType.internal"
+        (change)="onCertificateTypeChange(CertificateType.internal)"
+        i18n
+      >
+        Internal
+      </cds-radio>
+      <cds-radio
+        [value]="CertificateType.external"
+        (change)="onCertificateTypeChange(CertificateType.external)"
+        i18n
+      >
+        External
+      </cds-radio>
+    </cds-radio-group>
+  </div>
+
+  @if (showCertSourceChangeWarning) {
+    <cd-alert-panel
+      type="warning"
+      spacingClass="mb-3"
+      i18n
+    >
+      Changing the certificate source will redeploy the service daemons to apply the new certificate
+      configuration.
+    </cd-alert-panel>
+  }
+
+  @if (formGroup.controls.certificateType.value === CertificateType.internal) {
+    <cd-alert-panel
+      type="info"
+      spacingClass="mb-3"
+      i18n
+    >
+      Certificate will be generated automatically by Cephadm CA for internal certificate type.
+    </cd-alert-panel>
+    <div class="form-item">
+      <cd-text-label-list
+        formControlName="custom_sans"
+        label="Custom SAN Entries"
+        i18n-label
+        helperText="Optional list of Subject Alternative Names (hostnames, IPs, or DNS names) to include in the auto-generated certificate."
+        i18n-helperText
+      >
+      </cd-text-label-list>
+    </div>
+    @if (
+      formGroup.controls.service_type?.value === 'rgw' &&
+      formGroup.controls.virtual_host_enabled?.value
+    ) {
+      <div class="form-item">
+        <cds-checkbox
+          i18n-label
+          formControlName="wildcard_enabled"
+        >
+          Include wildcard certificate for bucket subdomains
+          <cd-help-text i18n>
+            Add wildcard certificates (*.domain) to allow SSL for all bucket subdomains. Required
+            for virtual-host style with SSL.
+          </cd-help-text>
+        </cds-checkbox>
+      </div>
+    }
+  }
+</div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/certificate-authority-form/certificate-authority-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/certificate-authority-form/certificate-authority-form.component.spec.ts
@@ -1,0 +1,41 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { expect as jestExpect } from '@jest/globals';
+
+import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
+import { CertificateType } from '~/app/shared/models/service.interface';
+import { CertificateAuthorityFormComponent } from './certificate-authority-form.component';
+
+describe('CertificateAuthorityFormComponent', () => {
+  let component: CertificateAuthorityFormComponent;
+  let fixture: ComponentFixture<CertificateAuthorityFormComponent>;
+  let formBuilder: CdFormBuilder;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule, CertificateAuthorityFormComponent]
+    }).compileComponents();
+
+    formBuilder = new CdFormBuilder();
+    fixture = TestBed.createComponent(CertificateAuthorityFormComponent);
+    component = fixture.componentInstance;
+    component.formGroup = formBuilder.group({
+      certificateType: [CertificateType.internal],
+      custom_sans: [[]],
+      service_type: ['rgw'],
+      virtual_host_enabled: [false],
+      wildcard_enabled: [false]
+    });
+  });
+
+  it('should create', () => {
+    fixture.detectChanges();
+    jestExpect(component).toBeTruthy();
+  });
+
+  it('should emit certificateTypeChange', () => {
+    const emitSpy = jest.spyOn(component.certificateTypeChange, 'emit');
+    component.onCertificateTypeChange(CertificateType.external);
+    jestExpect(emitSpy).toHaveBeenCalledWith(CertificateType.external);
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/certificate-authority-form/certificate-authority-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/certificate-authority-form/certificate-authority-form.component.ts
@@ -1,0 +1,47 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { CheckboxModule, GridModule, LayoutModule, RadioModule } from 'carbon-components-angular';
+
+import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
+import {
+  CephServiceCertificate,
+  CertificateType,
+  CERTIFICATE_STATUS_ICON_MAP
+} from '~/app/shared/models/service.interface';
+import { PipesModule } from '~/app/shared/pipes/pipes.module';
+import { ComponentsModule } from '../components.module';
+import { TextLabelListComponent } from '../text-label-list/text-label-list.component';
+
+@Component({
+  selector: 'cd-certificate-authority-form',
+  templateUrl: './certificate-authority-form.component.html',
+  styleUrls: ['./certificate-authority-form.component.scss'],
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    RadioModule,
+    CheckboxModule,
+    GridModule,
+    LayoutModule,
+    PipesModule,
+    ComponentsModule,
+    TextLabelListComponent
+  ]
+})
+export class CertificateAuthorityFormComponent {
+  readonly CertificateType = CertificateType;
+  readonly statusIconMap = CERTIFICATE_STATUS_ICON_MAP;
+
+  @Input() formGroup: CdFormGroup;
+  @Input() editing = false;
+  @Input() currentCertificate: CephServiceCertificate = null;
+  @Input() showCertSourceChangeWarning = false;
+
+  @Output() certificateTypeChange = new EventEmitter<CertificateType>();
+
+  onCertificateTypeChange(type: CertificateType): void {
+    this.certificateTypeChange.emit(type);
+  }
+}


### PR DESCRIPTION
fixes: https://tracker.ceph.com/issues/77406
Signed-off-by: Abhishek Desai <abhishek.desai1@ibm.com>

### UTC : 

https://github.com/user-attachments/assets/a0753024-a029-4b80-af50-10894525888a




```
[ceph: root@ceph-node-00 /]# ceph orch ls --export nvmeof
service_type: nvmeof
service_id: rbd.default
service_name: nvmeof.rbd.default
placement:
  count: 1
spec:
  abort_discovery_on_errors: true
  abort_on_errors: true
  abort_on_update_error: true
  allowed_consecutive_spdk_ping_failures: 1
  break_update_interval_sec: 25
  certificate_source: cephadm-signed
  cluster_connections: 32
  conn_retries: 10
  discovery_bind_retries_limit: 10
  discovery_bind_sleep_interval: 0.5
  discovery_port: 8009
  enable_auth: true
  enable_monitor_client: true
  enable_prometheus_exporter: true
  group: default
  io_stats_enabled: true
  kmip_cert_dir: ./certs/kmip/{server_name}
  log_directory: /var/log/ceph/
  log_files_enabled: true
  log_files_rotation_enabled: true
  log_level: INFO
  max_gws_in_grp: 16
  max_hosts: 2048
  max_hosts_per_namespace: 16
  max_hosts_per_subsystem: 128
  max_log_directory_backups: 10
  max_log_file_size_in_mb: 10
  max_log_files_count: 20
  max_message_length_in_mb: 4
  max_namespaces: 4096
  max_namespaces_per_subsystem: 512
  max_namespaces_with_netmask: 1000
  max_ns_to_change_lb_grp: 8
  max_subsystems: 128
  monitor_timeout: 1.0
  notifications_interval: 60
  omap_file_lock_duration: 40
  omap_file_lock_on_read: true
  omap_file_lock_retries: 30
  omap_file_lock_retry_sleep_interval: 1.0
  omap_file_update_attempts: 500
  omap_file_update_reloads: 10
  pool: rbd
  port: 5500
  prometheus_connection_list_cache_expiration: 60
  prometheus_cycles_to_adjust_speed: 3
  prometheus_frequency_slow_down_factor: 3.0
  prometheus_port: 10008
  prometheus_startup_delay: 240
  prometheus_stats_interval: 10
  rbd_with_crc32c: true
  rebalance_period_sec: 7
  rpc_socket_dir: /var/tmp/
  rpc_socket_name: spdk.sock
  spdk_path: /usr/local/bin/nvmf_tgt
  spdk_ping_interval_in_seconds: 2.0
  spdk_protocol_log_level: WARNING
  spdk_timeout: 60.0
  ssl: true
  state_update_interval_sec: 5
  state_update_notify: true
  subsystem_cache_expiration: 30
  tgt_path: /usr/local/bin/nvmf_tgt
  transport_tcp_options:
    in_capsule_data_size: 8192
    max_io_qpairs_per_ctrlr: 7
  transports: tcp
  verbose_log_messages: true
  verify_keys: true
  verify_listener_ip: true
  verify_nqns: true
[ceph: root@ceph-node-00 /]# 


```



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
