### PR TITLE
librados: export rados_* C API symbols in version script

### DIFF
--- a/src/librados/librados.map
+++ b/src/librados/librados.map
@@ -1,5 +1,6 @@
 LIBRADOS_PRIVATE {
 	global:
+		rados_*;
 		extern "C++" {
 			"guard variable for boost::asio::detail::call_stack<boost::asio::detail::strand_executor_service::strand_impl, unsigned char>::top_";
 			"guard variable for boost::asio::detail::call_stack<boost::asio::detail::strand_service::strand_impl, unsigned char>::top_";


### PR DESCRIPTION
Some API symbols (rados_*) were not explicitly listed in the linker version script, making them unavailable for external linking (e.g. from Mold).
