### PR TITLE
test/crimson/seastore: assert omap extent retirement on split/merge/balance

### DIFF
--- a/src/test/crimson/seastore/test_omap_manager.cc
+++ b/src/test/crimson/seastore/test_omap_manager.cc
@@ -195,6 +195,22 @@ struct omap_manager_test_t :
     return keys;
   }
 
+  unsigned count_live_omap_extents() {
+    auto t = create_read_transaction();
+    unsigned count = 0;
+    with_trans_intr(*t, [this, &count](auto &t) {
+      return tm->get_lba_manager()->scan_mapped_space(
+        t,
+        [&count](paddr_t paddr, extent_len_t len, extent_types_t type, laddr_t laddr) {
+          if (type == extent_types_t::OMAP_INNER ||
+              type == extent_types_t::OMAP_LEAF) {
+            count++;
+          }
+        });
+    }).unsafe_get();
+    return count;
+  }
+
   void list(
     const omap_root_t &omap_root,
     Transaction &t,
@@ -529,6 +545,17 @@ TEST_P(omap_manager_test_t, leafnode_split_merge_balancing)
       submit_transaction(std::move(t));
       check_mappings(omap_root);
     }
+    auto final_count = count_live_omap_extents();
+    logger().debug("leafnode_split_merge_balancing final live omap extents: {}",
+                   final_count);
+    // After contracting back to depth 1, the tree consists of exactly the root leaf node.
+    EXPECT_EQ(final_count, 1U);
+
+    logger().debug("== clearing entire tree and verifying no leaks");
+    auto t_clear = create_mutate_transaction();
+    clear(omap_root, *t_clear);
+    submit_transaction(std::move(t_clear));
+    EXPECT_EQ(count_live_omap_extents(), 0U);
   });
 }
 
@@ -581,6 +608,18 @@ TEST_P(omap_manager_test_t, innernode_split_merge_balancing)
       submit_transaction(std::move(t));
     }
     check_mappings(omap_root);
+    auto final_count = count_live_omap_extents();
+    logger().debug("innernode_split_merge_balancing final live omap extents: {}",
+                   final_count);
+    // Bound derivation: 64 KiB OMAP_LEAF_BLOCK_SIZE / ~580 B entry size (50 B key + 512 B value
+    // + overhead) => healthy post-merge leaves hold >=55 entries, so count is <= size / 55 + C.
+    EXPECT_LE(final_count, test_omap_mappings.size() / 40 + 20U);
+
+    logger().debug("== clearing entire tree and verifying no leaks");
+    auto t_clear = create_mutate_transaction();
+    clear(omap_root, *t_clear);
+    submit_transaction(std::move(t_clear));
+    EXPECT_EQ(count_live_omap_extents(), 0U);
   });
 }
 
@@ -603,6 +642,7 @@ TEST_P(omap_manager_test_t, clear)
     auto t = create_mutate_transaction();
     clear(omap_root, *t);
     submit_transaction(std::move(t));
+    EXPECT_EQ(count_live_omap_extents(), 0U);
   });
 }
 


### PR DESCRIPTION
Adds a `count_live_omap_extents()` helper (via `scan_mapped_space`) plus assertions to the omap-manager split/merge/balance tests, so the omap B-tree's caller-layer node-retirement contract is enforced by CI.

Background: while investigating a suspected omap extent leak, adding retirement assertions showed the omap B-tree already retires old nodes at the caller layer (`do_merge`'s retire of `{l,r}`, `do_balance`, `handle_split`, and `OMapLeafNode::insert` on split) — so a proposed in-helper retire would have been a second `tm.remove` of the same laddr → ENOENT. That retire change was withdrawn; these assertions remain to lock in the existing contract.

Assertions use exact counts where the tree shape is deterministic (exactly 1 root leaf after contraction to depth 1; exactly 0 after `clear`) and a derived upper bound elsewhere.

Validated with `ctest -R omap` (all green).

Split out of #69351 per review (thanks @Matan-B).

## Checklist
- Tracker (select at least one)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
