### PR TITLE
tentacle: mds: fix crash and shutdown hang when ephemeral pins active and max_mds is 0

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -933,6 +933,8 @@ MDSCacheObject *MDCache::get_object(const MDSCacheObjectInfo &info)
 mds_rank_t MDCache::hash_into_rank_bucket(inodeno_t ino, frag_t fg)
 {
   const mds_rank_t max_mds = mds->mdsmap->get_max_mds();
+  if (max_mds == 0)
+    return MDS_RANK_NONE;
   uint64_t hash = rjhash64(ino);
   if (fg)
     hash = rjhash64(hash + rjhash64(fg.value()));

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -7977,7 +7977,8 @@ bool MDCache::shutdown_pass()
           dir->is_freezing() ||
           dir->is_ambiguous_dir_auth() ||
           dir->state_test(CDir::STATE_EXPORTING) ||
-          dir->get_inode()->is_ephemerally_pinned()) {
+          (mds->mdsmap->get_max_mds() > 0 &&
+           dir->get_inode()->is_ephemerally_pinned())) {
         continue;
       }
       ls.push_back(dir);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77260

---

backport of https://github.com/ceph/ceph/pull/68413
parent tracker: https://tracker.ceph.com/issues/76059

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh