### PR TITLE
mgr/dashboard : Implement dependent resource handling for gateway Deletion

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
@@ -105,6 +105,7 @@ import { NvmeSubsystemViewBreadcrumbResolver } from './nvme-subsystem-view/nvme-
 import { NvmeSubsystemViewComponent } from './nvme-subsystem-view/nvme-subsystem-view.component';
 import { NvmeofSubsystemPerformanceComponent } from './nvmeof-subsystem-performance/nvmeof-subsystem-performance.component';
 import { NvmeofTabsComponent } from './nvmeof-tabs/nvmeof-tabs.component';
+import { NvmeofGatewayGroupDeleteGuardModalComponent } from './nvmeof-gateway-group/nvmeof-gateway-group-delete-guard-modal.component';
 
 @NgModule({
   imports: [
@@ -194,7 +195,8 @@ import { NvmeofTabsComponent } from './nvmeof-tabs/nvmeof-tabs.component';
     NvmeofSubsystemsStepFourComponent,
     NvmeofSubsystemOverviewComponent,
     NvmeofSubsystemPerformanceComponent,
-    NvmeofTabsComponent
+    NvmeofTabsComponent,
+    NvmeofGatewayGroupDeleteGuardModalComponent
   ],
 
   exports: [RbdConfigurationListComponent, RbdConfigurationFormComponent]

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group-delete-guard-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group-delete-guard-modal.component.html
@@ -1,0 +1,31 @@
+<cds-modal size="sm"
+           [open]="open"
+           (overlaySelected)="closeModal()">
+  <cds-modal-header (closeSelect)="closeModal()">
+    <h2 cdsModalHeaderLabel
+        modal-primary-focus
+        i18n>Manage {{ gatewayName }}</h2>
+    <span class="cds--type-heading-03"
+        cdsModalHeaderHeading
+        i18n>Can't delete {{ gatewayName }}</span>
+  </cds-modal-header>
+  <section cdsModalContent>
+    <p class="cds--type-body-01 cds--mb-05"
+       i18n>
+      This resource has connected items that must be deleted first. Delete the connected items, and try again.
+    </p>
+    <p class="cds--type-label-01 cds--mb-04"
+       i18n>View connected items:</p>
+    <div>
+      @for (sub of connectedSubsystems; track sub.nqn) {
+      <div class="cds--mb-04">
+        <a class="cds--link cds--type-body-01"
+           (click)="navigateToSubsystem(sub.nqn)">
+          <span class="cds--mr-03">{{ sub.nqn }}</span>
+          <cd-icon type="launch"></cd-icon>
+        </a>
+      </div>
+      }
+    </div>
+  </section>
+</cds-modal>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group-delete-guard-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group-delete-guard-modal.component.spec.ts
@@ -1,0 +1,55 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { NvmeofGatewayGroupDeleteGuardModalComponent } from './nvmeof-gateway-group-delete-guard-modal.component';
+
+describe('NvmeofGatewayGroupDeleteGuardModalComponent', () => {
+  let component: NvmeofGatewayGroupDeleteGuardModalComponent;
+  let fixture: ComponentFixture<NvmeofGatewayGroupDeleteGuardModalComponent>;
+  let router: Router;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      declarations: [NvmeofGatewayGroupDeleteGuardModalComponent],
+      providers: [
+        { provide: 'gatewayName', useValue: 'gateway-dev' },
+        {
+          provide: 'connectedSubsystems',
+          useValue: [{ nqn: 'subsystem-1' }, { nqn: 'subsystem-2' }]
+        }
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NvmeofGatewayGroupDeleteGuardModalComponent);
+    component = fixture.componentInstance;
+    router = TestBed.inject(Router);
+    jest.spyOn(router, 'navigate').mockImplementation();
+    fixture.detectChanges();
+  });
+
+  it('should create the modal component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should load dynamic inputs', () => {
+    expect(component.gatewayName).toBe('gateway-dev');
+    expect(component.connectedSubsystems).toEqual([{ nqn: 'subsystem-1' }, { nqn: 'subsystem-2' }]);
+  });
+
+  it('should navigate to subsystem detail page and close modal', () => {
+    const closeSpy = jest.spyOn(component, 'closeModal').mockImplementation();
+
+    component.navigateToSubsystem('subsystem-1');
+
+    expect(router.navigate).toHaveBeenCalledWith(
+      ['/block/nvmeof/subsystems', 'subsystem-1', 'overview'],
+      { queryParams: { group: 'gateway-dev' } }
+    );
+    expect(closeSpy).toHaveBeenCalled();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group-delete-guard-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group-delete-guard-modal.component.ts
@@ -1,0 +1,29 @@
+import { Component, Inject, Optional } from '@angular/core';
+import { Router } from '@angular/router';
+import { BaseModal } from 'carbon-components-angular';
+
+interface ConnectedSubsystem {
+  nqn: string;
+}
+
+@Component({
+  selector: 'cd-nvmeof-gateway-group-delete-guard-modal',
+  templateUrl: './nvmeof-gateway-group-delete-guard-modal.component.html',
+  standalone: false
+})
+export class NvmeofGatewayGroupDeleteGuardModalComponent extends BaseModal {
+  constructor(
+    private router: Router,
+    @Optional() @Inject('gatewayName') public gatewayName: string,
+    @Optional() @Inject('connectedSubsystems') public connectedSubsystems: ConnectedSubsystem[] = []
+  ) {
+    super();
+  }
+
+  navigateToSubsystem(nqn: string): void {
+    this.router.navigate(['/block/nvmeof/subsystems', nqn, 'overview'], {
+      queryParams: { group: this.gatewayName }
+    });
+    this.closeModal();
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group.component.html
@@ -56,6 +56,7 @@
     }
   </div>
 </ng-template>
+
 <ng-template #deleteTpl
              let-groupName="groupName"
              let-subsystemCount="subsystemCount">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group.component.spec.ts
@@ -1,10 +1,15 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { NvmeofGatewayGroupComponent } from './nvmeof-gateway-group.component';
-import { GridModule, TabsModule } from 'carbon-components-angular';
+import { GridModule, TabsModule, ModalModule } from 'carbon-components-angular';
 import { NvmeofService } from '~/app/shared/api/nvmeof.service';
 import { of } from 'rxjs';
 import { HttpClientModule } from '@angular/common/http';
 import { SharedModule } from '~/app/shared/shared.module';
+import { Router } from '@angular/router';
+import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
+import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component';
+import { NvmeofGatewayGroupDeleteGuardModalComponent } from './nvmeof-gateway-group-delete-guard-modal.component';
 
 describe('NvmeofGatewayGroupComponent', () => {
   let component: NvmeofGatewayGroupComponent;
@@ -18,9 +23,20 @@ describe('NvmeofGatewayGroupComponent', () => {
     };
 
     await TestBed.configureTestingModule({
-      imports: [HttpClientModule, SharedModule, TabsModule, GridModule],
+      imports: [HttpClientModule, SharedModule, TabsModule, GridModule, ModalModule],
       declarations: [NvmeofGatewayGroupComponent],
-      providers: [{ provide: NvmeofService, useValue: nvmeofServiceSpy }]
+      providers: [
+        { provide: NvmeofService, useValue: nvmeofServiceSpy },
+        {
+          provide: Router,
+          useValue: { navigate: jest.fn() }
+        },
+        {
+          provide: ModalCdsService,
+          useValue: { show: jest.fn() }
+        }
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
 
     fixture = TestBed.createComponent(NvmeofGatewayGroupComponent);
@@ -240,6 +256,46 @@ describe('NvmeofGatewayGroupComponent', () => {
     component.gatewayGroup$.subscribe((data) => {
       expect(data).toEqual(mockData);
       done();
+    });
+  });
+
+  describe('Delete Flow with/without Subsystems', () => {
+    let mockGroup: any;
+
+    beforeEach(() => {
+      mockGroup = {
+        service_name: 'nvmeof.rbd.default',
+        spec: { group: 'default' },
+        subSystemCount: 0
+      };
+      component.selection.first = jest.fn().mockReturnValue(mockGroup);
+    });
+
+    it('should show can-not-delete modal if subsystems exist', () => {
+      const mockSubsystems = [{ nqn: 'subsystem-1' }, { nqn: 'subsystem-2' }];
+      nvmeofService.listSubsystems.mockReturnValue(of(mockSubsystems));
+      const modalService = TestBed.inject(ModalCdsService);
+
+      component.deleteGatewayGroupModal();
+
+      expect(nvmeofService.listSubsystems).toHaveBeenCalledWith('default');
+      expect(modalService.show).toHaveBeenCalledWith(NvmeofGatewayGroupDeleteGuardModalComponent, {
+        gatewayName: 'default',
+        connectedSubsystems: [{ nqn: 'subsystem-1' }, { nqn: 'subsystem-2' }]
+      });
+    });
+
+    it('should show delete confirmation modal if no subsystems exist', () => {
+      nvmeofService.listSubsystems.mockReturnValue(of([]));
+      const modalService = TestBed.inject(ModalCdsService);
+
+      component.deleteGatewayGroupModal();
+
+      expect(nvmeofService.listSubsystems).toHaveBeenCalledWith('default');
+      expect(modalService.show).toHaveBeenCalledWith(
+        DeleteConfirmationModalComponent,
+        expect.any(Object)
+      );
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group.component.ts
@@ -13,7 +13,7 @@ import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
 import { Permission } from '~/app/shared/models/permissions';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { Icons, IconSize } from '~/app/shared/enum/icons.enum';
-import { NvmeofGatewayGroup } from '~/app/shared/models/nvmeof';
+import { NvmeofGatewayGroup, NvmeofSubsystem } from '~/app/shared/models/nvmeof';
 import { CephServiceSpec } from '~/app/shared/models/service.interface';
 import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 import { CephServiceService } from '~/app/shared/api/ceph-service.service';
@@ -24,6 +24,7 @@ import { DeletionImpact } from '~/app/shared/enum/delete-confirmation-modal-impa
 import { NotificationService } from '~/app/shared/services/notification.service';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
 import { URLBuilderService } from '~/app/shared/services/url-builder.service';
+import { NvmeofGatewayGroupDeleteGuardModalComponent } from './nvmeof-gateway-group-delete-guard-modal.component';
 
 const BASE_URL = 'block/nvmeof/gateways';
 
@@ -194,16 +195,42 @@ export class NvmeofGatewayGroupComponent implements OnInit {
       spec: { group }
     } = selectedGroup;
 
-    const disableForm = selectedGroup.subSystemCount > 0 || !group;
+    if (!group) {
+      return;
+    }
 
+    // Fetch actual subsystem list to decide which modal to show
+    this.nvmeofService
+      .listSubsystems(group)
+      .pipe(catchError(() => of([])))
+      .subscribe((subsystems: NvmeofSubsystem[]) => {
+        let subsList: NvmeofSubsystem[] = [];
+        if (subsystems) {
+          const rawList = Array.isArray(subsystems) ? subsystems : [subsystems];
+          subsList = rawList.filter((subsystem: NvmeofSubsystem) => subsystem && subsystem.nqn);
+        }
+
+        if (subsList.length > 0) {
+          this.modalService.show(NvmeofGatewayGroupDeleteGuardModalComponent, {
+            gatewayName: group,
+            connectedSubsystems: subsList.map((subsystem: NvmeofSubsystem) => ({
+              nqn: subsystem.nqn
+            }))
+          });
+        } else {
+          // No subsystems — show the regular delete confirmation modal
+          this.showDeleteConfirmationModal(selectedGroup, serviceName);
+        }
+      });
+  }
+
+  private showDeleteConfirmationModal(selectedGroup: CephServiceSpec, serviceName: string) {
     this.modalService.show(DeleteConfirmationModalComponent, {
       impact: DeletionImpact.high,
       itemDescription: $localize`gateway group`,
       bodyTemplate: this.deleteTpl,
       itemNames: [selectedGroup.spec.group],
       bodyContext: {
-        disableForm,
-        subsystemCount: selectedGroup.subSystemCount,
         deletionMessage: $localize`Deleting <strong>${selectedGroup.spec.group}</strong> will remove all associated subsystems and may disrupt traffic routing for services relying on it. This action cannot be undone.`
       },
       submitActionObservable: () => {


### PR DESCRIPTION

<img width="3834" height="2076" alt="image" src="https://github.com/user-attachments/assets/8e2edc04-3ce6-41ce-8364-9150f3024e79" />

Fixes: https://tracker.ceph.com/issues/77403
Signed-off-by: pujaoshahu <pshahu@redhat.com>

Summary:

Added a pre-deletion check to prevent deleting a gateway group that still has associated resources.
Display a modal dialog when deletion is blocked, clearly explaining why the action cannot proceed.
List all connected subsystems linked to the selected gateway group.
Provide direct navigation links to the dependent subsystems for easier cleanup.
Guide users to remove dependent resources before retrying the deletion.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
