### PR TITLE
nvmeofgw: stretched cluster fix relocate

### DIFF
--- a/src/mon/NVMeofGwMap.cc
+++ b/src/mon/NVMeofGwMap.cc
@@ -818,7 +818,9 @@ void NVMeofGwMap::handle_abandoned_ana_groups(bool& propose)
 
 void NVMeofGwMap::check_relocate_ana_groups(const NvmeGroupKey& group_key,
          bool &propose) {
-  /* if location in disaster_locations found in recovering state state - find all gws in location.
+  /* loop for all locations:
+   * if location in normal state or "disaster_locations"
+   * found in recovering state state - find all gws in location.
    * add ana-grp of not Available gws to the list.
    * if ana-grp is already active on some gw in location skip it
    * for ana-grp in list make relocation.
@@ -830,48 +832,57 @@ void NVMeofGwMap::check_relocate_ana_groups(const NvmeGroupKey& group_key,
        return ;
   }
   std::list<NvmeAnaGrpId>  reloc_list;
+  std::unordered_set<NvmeLocation> locations_set;
   auto& gws_states = created_gws[group_key];
-  FailbackLocation location;
-  if (get_location_in_disaster_cleanup(group_key, location)) {
-    uint32_t num_gw_in_location = 0;
-    uint32_t num_active_ana_in_location = 0;
-    for (auto& gw_state : gws_states) { // loop for GWs inside group-key
-      NvmeGwMonState& state = gw_state.second;
-      if (state.location == location) {
-        num_gw_in_location ++;
-        if (state.availability != gw_availability_t::GW_AVAILABLE) {
-          reloc_list.push_back(state.ana_grp_id);
-        } else { // in parallel check condition to complete failback-in-process
-          for (auto& state_it: state.sm_state) {
-            if (state_it.second == gw_states_per_group_t::GW_ACTIVE_STATE) {
-              num_active_ana_in_location ++;
+  for (auto& gw_state : gws_states) {// build locations set
+    locations_set.insert(gw_state.second.location);
+  }
+  for (NvmeLocation location : locations_set) {
+    bool cleanup_in_process;
+    reloc_list.clear();
+    bool disaster =  is_location_in_disaster(group_key, location, cleanup_in_process);
+    if ((disaster && cleanup_in_process) || (!disaster)) {
+      uint32_t num_gw_in_location = 0;
+      uint32_t num_active_ana_in_location = 0;
+      for (auto& gw_state : gws_states) { // loop for GWs inside group-key
+        NvmeGwMonState& state = gw_state.second;
+        if (state.location == location) {
+          num_gw_in_location++;
+          if (state.availability != gw_availability_t::GW_AVAILABLE) {
+            reloc_list.push_back(state.ana_grp_id);
+          } else { // in parallel check condition to complete failback-in-process
+            for (auto& state_it: state.sm_state) {
+              if (state_it.second == gw_states_per_group_t::GW_ACTIVE_STATE) {
+                num_active_ana_in_location ++;
+              }
             }
           }
         }
       }
-    }
-    if (num_gw_in_location == num_active_ana_in_location) {// All ana groups of disaster location are in Active
-      disaster_map_remove_location(group_key, location);
-      dout(4) <<  "the location entry is erased "<< location
-          << " from disaster-locations num_ana_groups in location "
-          << num_gw_in_location
-          << " from the failbacks-in-progress of group " << group_key <<dendl;
-      propose = true;
-      return;
-    }
+      if (num_gw_in_location == num_active_ana_in_location) {// All ana groups of disaster location are in Active
+        disaster_map_remove_location(group_key, location);
+        dout(4) <<  "the location entry is erased "<< location
+            << " from disaster-locations num_ana_groups in location "
+            << num_gw_in_location
+            << " from the failbacks-in-progress of group " << group_key <<dendl;
+        propose = true;
+        return;
+      }
     // for all ana groups in the list do relocate
-    for (auto& anagrp : reloc_list) {
-      for (auto& gw_state : gws_states) { // loop for GWs inside group-key
-        NvmeGwMonState& state = gw_state.second;
-        if (state.sm_state[anagrp] == gw_states_per_group_t::GW_ACTIVE_STATE) {
-          if (state.location == location) { // already relocated to the location
-            dout(10) << "ana " << anagrp << " already in " << location << dendl;
-            break;
-          } else { // try to relocate
-              dout(10) << "ana " << anagrp
-                  << " to relocate to " << location << dendl;
-              relocate_ana_grp(gw_state.first, group_key, anagrp,
-                    location, propose);
+      for (auto& anagrp : reloc_list) {
+        for (auto& gw_state : gws_states) { // loop for GWs inside group-key
+          NvmeGwMonState& state = gw_state.second;
+          if (state.sm_state[anagrp] == gw_states_per_group_t::GW_ACTIVE_STATE) {
+            if (state.location == location) { // already relocated to the location
+              dout(10) << "ana " << anagrp << " already in " << location << dendl;
+              break;
+            } else { // try to relocate
+                dout(10) << "ana " << anagrp
+                    << " relocate to " << location << dendl;
+                relocate_ana_grp(gw_state.first, group_key, anagrp,
+                      location, propose);
+                return; // allow just 1 relocation during a tick()
+            }
           }
         }
       }
@@ -926,14 +937,8 @@ int NVMeofGwMap::relocate_ana_grp(const NvmeGwId &src_gw_id,
       << location << "min load " << min_num_ana_groups_in_gw << dendl;
 
   if (min_num_ana_groups_in_gw <  MAX_NUM_ANA_GROUPS_FOR_RELOCATE) {
-    dout(4) << "relocate starts " << grpid << " location " << location << dendl;
-    gws_states[src_gw_id].sm_state[grpid] =
-       gw_states_per_group_t::GW_WAIT_FAILBACK_PREPARED;
-    // Add timestamp of start Failback preparation
-    start_timer(src_gw_id, group_key, grpid, 3);
-    gws_states[min_gw_id].sm_state[grpid] =
-       gw_states_per_group_t::GW_OWNER_WAIT_FAILBACK_PREPARED;
-    propose = true;
+    dout(4) << "relocate starts ANA group " << grpid << " location " << location << dendl;
+    fsm_handle_failback_and_relocation(min_gw_id, src_gw_id, group_key, grpid, propose);
   }
   return 0;
 }
@@ -1031,14 +1036,8 @@ void NVMeofGwMap::find_failback_gw(
         << gw_id << dendl;
         return;
       }
-      st.sm_state[gw_state.ana_grp_id] =
-	gw_states_per_group_t::GW_WAIT_FAILBACK_PREPARED;
-
-      // Add timestamp of start Failback preparation
-      start_timer(failback_gw_id, group_key, gw_state.ana_grp_id, 3);
-      gw_state.sm_state[gw_state.ana_grp_id] =
-	gw_states_per_group_t::GW_OWNER_WAIT_FAILBACK_PREPARED;
-      propose = true;
+      fsm_handle_failback_and_relocation(gw_id, failback_gw_id, group_key,
+                    gw_state.ana_grp_id, propose);
       break;
     }
   }
@@ -1360,6 +1359,21 @@ void NVMeofGwMap::fsm_handle_gw_delete(
     validate_gw_map(group_key);
     increment_gw_epoch(group_key);
   }
+}
+
+void NVMeofGwMap::fsm_handle_failback_and_relocation(
+  const NvmeGwId &owner_gw_id, const NvmeGwId &failover_gw_id,
+  const NvmeGroupKey& group_key,
+  NvmeAnaGrpId grpid,  bool &map_modified)
+{
+  auto& gws_states = created_gws[group_key];
+  gws_states[failover_gw_id].sm_state[grpid] =
+    gw_states_per_group_t::GW_WAIT_FAILBACK_PREPARED;
+  start_timer(failover_gw_id, group_key, grpid, 3);
+
+  gws_states[owner_gw_id].sm_state[grpid] =
+    gw_states_per_group_t::GW_OWNER_WAIT_FAILBACK_PREPARED;
+  map_modified = true;
 }
 
 void NVMeofGwMap::fsm_handle_to_expired(

--- a/src/mon/NVMeofGwMap.h
+++ b/src/mon/NVMeofGwMap.h
@@ -165,6 +165,9 @@ private:
   void fsm_handle_to_expired(
     const NvmeGwId &gw_id, const NvmeGroupKey& group_key,
     NvmeAnaGrpId grpid,  bool &map_modified);
+  void fsm_handle_failback_and_relocation(const NvmeGwId &owner_gw_id,
+     const NvmeGwId &failover_gw_id, const NvmeGroupKey& group_key,
+     NvmeAnaGrpId grpid, bool &map_modified);
   void find_failover_candidate(
     const NvmeGwId &gw_id, const NvmeGroupKey& group_key,
     NvmeAnaGrpId grpid, bool &propose_pending);


### PR DESCRIPTION
Fix ANA relocation procedure - need to perform relocation not only when disaster location  is in cleanup state 
but also when location is  healthy. 

https://tracker.ceph.com/issues/77803

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
