### PR TITLE
mon: fix ConnectionTracker::notify_rank_removed

### DIFF
--- a/src/mon/ConnectionTracker.cc
+++ b/src/mon/ConnectionTracker.cc
@@ -261,17 +261,14 @@ void ConnectionTracker::notify_rank_removed(int rank_removed, int new_rank)
   ceph_assert((peer_reports.size() == starting_size) ||
 	  (peer_reports.size() + 1 == starting_size));
 
-  if (rank_removed < rank) { // if the rank removed is lower than us, we need to adjust.
-    --rank;
-    my_reports.rank = rank; // also adjust my_reports.rank.
-  }
+  // Trust the caller's new_rank from the monmap rather than trying to compute it.
+  // This handles cases where multiple ranks are removed simultaneously.
+  rank = new_rank;
+  my_reports.rank = new_rank;
 
   ldout(cct, 20) << "my rank after: " << rank << dendl;
   ldout(cct, 20) << "peer_reports after: " << peer_reports << dendl;
   ldout(cct, 20) << "my_reports after: " << my_reports << dendl;
-
-  //check if the new_rank from monmap is equal to our adjusted rank.
-  ceph_assert(rank == new_rank);
 
   increase_version();
 }


### PR DESCRIPTION
### Problem:
When multiple monitors are removed from the monmap in a single update, the iterative rank adjustment in notify_rank_removed() fails to maintain the invariant that our local rank matches the monmap's new_rank until all iterations complete.

The old code decremented rank for each removed rank:
```
  for (auto i = monmap->removed_ranks.rbegin(); ...) {
    int remove_rank = *i;
    int new_rank = monmap->get_rank(messenger->get_myaddrs());

    // Old logic (in ConnectionTracker):
    if (remove_rank < rank) {
      --rank;
    }

    // This assert would fail on first iteration when removed_ranks.size() > 1
    ceph_assert(rank == new_rank);
  }
```

When removed_ranks = {0, 1} and we are mon.d (originally rank 3):
- new_rank from monmap = 1 (final correct value after removing 0 and 1)

Iteration 1 (remove rank 1):
  Before: rank = 3 Execute: rank_removed=1 < 3, so --rank -> rank = 2 Check: rank == new_rank? -> 2 == 1? FAIL

Iteration 2 (remove rank 0):
  Before: rank = 2 Execute: rank_removed=0 < 2, so --rank -> rank = 1 Check: rank == new_rank? → 1 == 1? PASS

The invariant is violated during intermediate iterations because each --rank adjustment only accounts for ONE removed rank, but new_rank from monmap already accounts for ALL removed ranks.

### Solution:
Trust the caller's new_rank from monmap instead of trying to compute it iteratively. The monmap has already recalculated ranks correctly by removing all monitors atomically, so we should just use that value.

Changed:
```
  if (rank_removed < rank) {
    --rank;
  }
```
To:
  // Trust the caller's new_rank from the monmap rather than trying to compute it.
  // This handles cases where multiple ranks are removed simultaneously.
  rank = new_rank;

Now the invariant holds on every iteration regardless of how many ranks are removed.

Fixes: https://tracker.ceph.com/issues/77423

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
