### PR TITLE
squid: mgr: change cleanup and scanning cephfs connection logs to be less noisy

### DIFF
--- a/src/pybind/mgr/mgr_util.py
+++ b/src/pybind/mgr/mgr_util.py
@@ -214,15 +214,15 @@ class CephfsConnectionPool(object):
 
     def cleanup_connections(self) -> None:
         with self.lock:
-            logger.info("scanning for idle connections..")
+            logger.debug("scanning for idle connections...")
             idle_conns = []
             for fs_name, connections in self.connections.items():
                 logger.debug(f'fs_name ({fs_name}) connections ({connections})')
                 for connection in connections:
                     if connection.is_connection_idle(CephfsConnectionPool.CONNECTION_IDLE_INTERVAL):
                         idle_conns.append((fs_name, connection))
-            logger.info(f'cleaning up connections: {idle_conns}')
             for idle_conn in idle_conns:
+                logger.info(f'cleaning up connection: {idle_conn}')
                 self._del_connection(idle_conn[0], idle_conn[1])
 
     def get_fs_handle(self, fs_name: str) -> "cephfs.LibCephFS":


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77252

---

backport of https://github.com/ceph/ceph/pull/68634
parent tracker: https://tracker.ceph.com/issues/77249

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh