### PR TITLE
squid: mds: session reclaim could miss blocklisting an old session

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -616,7 +616,11 @@ void Server::handle_client_session(const cref_t<MClientSession> &m)
     if (!session->client_opened) {
       session->client_opened = true;
     }
-    if (session->is_opening() ||
+    if (session->is_closing()) {
+      mdlog->wait_for_safe(
+        new MDSInternalContextWrapper(mds, new C_MDS_RetryMessage(mds, m)));
+      return;
+    } else if (session->is_opening() ||
 	session->is_open() ||
 	session->is_stale() ||
 	session->is_killing() ||


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/73768

---

backport of https://github.com/ceph/ceph/pull/66180
parent tracker: https://tracker.ceph.com/issues/66003

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh