### PR TITLE
ceph-volume: restore block.db/wal tags when using a raw partition

### DIFF
--- a/src/ceph-volume/ceph_volume/objectstore/lvm.py
+++ b/src/ceph-volume/ceph_volume/objectstore/lvm.py
@@ -285,6 +285,17 @@ class Lvm(BaseObjectStore):
             lv.set_tags(tags)
             return lv.lv_path
 
+        # A partition is used directly rather than being wrapped in an LV.
+        # Its PARTUUID and path must still be recorded as tags on the OSD's
+        # block LV, otherwise activation cannot locate the device and the
+        # block.db/block.wal symlink is never created.
+        tags.update(
+            {
+                f"ceph.{device_type}_uuid": self.get_ptuuid(device_name),
+                f"ceph.{device_type}_device": device_name,
+            }
+        )
+        self.tags.update(tags)
         return device_name
 
     def get_osd_device_path(self,

--- a/src/ceph-volume/ceph_volume/tests/objectstore/test_lvm.py
+++ b/src/ceph-volume/ceph_volume/tests/objectstore/test_lvm.py
@@ -379,6 +379,9 @@ class TestLvm:
         self.lvm.setup_metadata_devices()
         m_create_lv.assert_not_called()
         m_set_tags.assert_not_called()
+        assert self.lvm.tags['ceph.db_device'] == '/dev/foo1'
+        assert self.lvm.tags['ceph.db_uuid'] == 'c6798f59-01'
+        assert self.lvm.db_device_path == '/dev/foo1'
 
     def test_get_osd_device_path_lv_block(self):
         lvs = [Volume(lv_name='lv_foo',


### PR DESCRIPTION
## What

`ceph-volume lvm create --data <dev> --block.db <partition>` (a raw
partition for the DB) provisions the OSD at mkfs time but the OSD fails to
start afterwards. BlueFS aborts decoding its superblock because the DB device
is never wired up:

bluestore(...) No valid bdev label found
...
BlueFS::_open_super -> bluefs_super_t::decode -> ceph::buffer::malformed_input

## Reproduction

ceph-volume lvm create --data /dev/sdb --block.db /dev/nvme0n1p1
ls -l /var/lib/ceph/osd/ceph-0/      # <-- no block.db symlink is created
systemctl status ceph-osd@0          # <-- daemon crashed

Using an LV instead of a partition (`--block.db vg/lv`) works, which isolates
the problem to the raw-partition path.

## Root cause

`Lvm.setup_metadata_devices()` -> `_handle_physical_device()` deliberately does
not wrap a partition in an LV (only whole devices get an LV created). In that
path it returns the partition path but never records the
`ceph.{db,wal}_device` / `ceph.{db,wal}_uuid` tags on the OSD's block LV.

Activation relies on those tags (`get_osd_device_path()` reads `ceph.db_uuid`
and resolves the device via `get_device_from_partuuid()`), so without them the
`block.db`/`block.wal` symlink is never recreated and the OSD starts without
its DB device.

This is a regression from commit 7626c12e5fd4 ("ceph-volume: refactor
LvmBlueStore.setup_device()"), which dropped the pre-existing `get_ptuuid()`
tagging branch for bare partitions.

## Fix

In the partition branch, record the partition's PARTUUID (via `get_ptuuid()`)
and its path as tags, restoring the pre-refactor behavior. Whole-device and
existing-LV paths are unchanged.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket https://tracker.ceph.com/issues/77127
  - [x] Very recent bug; references commit where it was introduced (7626c12e5fd4)
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
