### PR TITLE
tentacle:  mds: improve debugging for snaprealms marked subvolume

### DIFF
--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -207,7 +207,7 @@ ostream& operator<<(ostream& out, const CInode& in)
   }
 
   if (in.snaprealm)
-    out << " snaprealm=" << in.snaprealm;
+    out << " sr=" << in.snaprealm;
 
   if (in.state_test(CInode::STATE_AMBIGUOUSAUTH)) out << " AMBIGAUTH";
   if (in.state_test(CInode::STATE_NEEDSRECOVER)) out << " NEEDSRECOVER";

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -7711,6 +7711,8 @@ void Server::handle_client_link(const MDRequestRef& mdr)
 
   CInode* target_pin = targeti->get_projected_parent_dir()->inode;
   SnapRealm *target_realm = target_pin->find_snaprealm();
+  ceph_assert(target_realm);
+  dout(20) << "target_realm " << *target_realm << dendl;
   if (target_pin != dir->inode &&
       target_realm->get_subvolume_ino() !=
       dir->inode->find_snaprealm()->get_subvolume_ino() &&
@@ -9292,6 +9294,10 @@ void Server::handle_client_rename(const MDRequestRef& mdr)
       src_realm = dest_realm;
     else
       src_realm = srcdir->inode->find_snaprealm();
+    ceph_assert(dest_realm);
+    ceph_assert(src_realm);
+    dout(20) << "src_realm " << *src_realm << dendl;
+    dout(20) << "dest_realm " << *dest_realm << dendl;
     if (src_realm != dest_realm &&
 	src_realm->get_subvolume_ino() != dest_realm->get_subvolume_ino()) {
       respond_to_request(mdr, -EXDEV);

--- a/src/mds/SnapRealm.cc
+++ b/src/mds/SnapRealm.cc
@@ -54,11 +54,15 @@ ostream& operator<<(ostream& out, const SnapRealm& realm)
     out << " past_parent_snaps=" << realm.srnode.past_parent_snaps;
   }
 
-  if (realm.srnode.is_parent_global())
-    out << " global ";
+  if (realm.srnode.is_parent_global()) {
+    out << " global";
+  }
+  if (realm.srnode.is_subvolume()) {
+    out << " subvol";
+  }
   out << " last_modified " << realm.srnode.last_modified
-      << " change_attr " << realm.srnode.change_attr;
-  out << " " << &realm << ")";
+      << " change_attr " << realm.srnode.change_attr
+      << " " << &realm << ")";
   return out;
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75552

---

backport of https://github.com/ceph/ceph/pull/67124
parent tracker: https://tracker.ceph.com/issues/74652

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh