### PR TITLE
crimson,mgr,test: fix unused variable/function warnings

### DIFF
--- a/src/crimson/os/seastore/lba/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.cc
@@ -1075,7 +1075,7 @@ BtreeLBAManager::remap_mappings(
   assert(cursor->is_viewable());
   auto orig_indirect = cursor->is_indirect();
   auto orig_laddr = cursor->get_laddr();
-  auto orig_len = cursor->get_length();
+  [[maybe_unused]] auto orig_len = cursor->get_length();
   auto c = get_context(t);
   auto btree = co_await get_btree<LBABtree>(cache, c);
   auto iter = btree.make_partial_iter(c, *cursor);

--- a/src/crimson/os/seastore/omap_manager/log/log_manager.cc
+++ b/src/crimson/os/seastore/omap_manager/log/log_manager.cc
@@ -70,7 +70,7 @@ LogManager::omap_set_keys(
   auto resync_node = [&](LogNodeRef e)
     -> log_load_extent_iertr::future<CachedExtentRef> {
     CachedExtentRef node;
-    Transaction::get_extent_ret ret;
+    [[maybe_unused]] Transaction::get_extent_ret ret;
     // To find mutable extent in the same transaction
     ret = t.get_extent(e->get_paddr(), &node);
     assert(ret == Transaction::get_extent_ret::PRESENT);

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -79,18 +79,6 @@ namespace crimson::os::seastore {
 using crimson::os::seastore::omap_manager::BtreeOMapManager;
 using crimson::os::seastore::log_manager::LogManager;
 
-static OMapManager::initialize_omap_ret
-omaptree_initialize(
-  Transaction& t,
-  BtreeOMapManager& mgr,
-  omap_type_t type,
-  Onode& onode,
-  Device& device)
-{
-  return mgr.initialize_omap(
-    t, onode.get_metadata_hint(device.get_block_size()), type);
-}
-
 class FileMDStore final : public SeaStore::MDStore {
   std::string root;
 public:

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -379,7 +379,7 @@ TransactionManager::resolve_cursor_to_mapping(
 
   ceph_assert(direct_cursors.size() == 1);
   auto& direct_cursor = direct_cursors.front();
-  auto intermediate_key = cursor->get_intermediate_key();
+  [[maybe_unused]] auto intermediate_key = cursor->get_intermediate_key();
   assert(!direct_cursor->is_indirect());
   assert(direct_cursor->get_laddr() <= intermediate_key);
   assert(direct_cursor->get_laddr() + direct_cursor->get_length()

--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -730,11 +730,6 @@ ReplicatedRecoveryBackend::read_object_for_push_op(
   }));
 }
 
-static std::optional<std::string> nullopt_if_empty(const std::string& s)
-{
-  return s.empty() ? std::nullopt : std::make_optional(s);
-}
-
 static bool is_too_many_entries_per_chunk(const PushOp* push_op)
 {
   const uint64_t entries_per_chunk =

--- a/src/mgr/PyModule.cc
+++ b/src/mgr/PyModule.cc
@@ -163,7 +163,7 @@ std::span<std::byte const> py_bytes_as_span(PyObject *bytes)
   assert(PyBytes_CheckExact(bytes));
   Py_ssize_t length;
   char *buf;
-  int r = PyBytes_AsStringAndSize(
+  [[maybe_unused]] int r = PyBytes_AsStringAndSize(
     bytes, &buf, &length);
   assert(r == 0);
   return std::span<std::byte const>((const std::byte*)buf, size_t(length));
@@ -183,7 +183,7 @@ std::vector<std::byte> py_bytes_as_vec(PyObject *bytes)
   assert(PyBytes_CheckExact(bytes));
   Py_ssize_t length;
   char *buf;
-  int r = PyBytes_AsStringAndSize(
+  [[maybe_unused]] int r = PyBytes_AsStringAndSize(
     bytes, &buf, &length);
   assert(r == 0);
   return std::vector<std::byte>{

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -342,8 +342,9 @@ struct lba_btree_test : btree_test_base {
 	    get_op_context(t), addr,
             get_map_val(len, extent->get_type()), extent.get()
 	  ).si_then([addr, extent](auto p){
-	    auto& [iter, inserted] = p;
-	    assert(inserted);
+	    // there should be no element at the given addr before insert(),
+	    // so the insertion (p.second) should take place here.
+	    EXPECT_TRUE(p.second);
 	    extent->set_laddr(addr);
 	  });
 	});

--- a/src/test/crimson/seastore/test_cbjournal.cc
+++ b/src/test/crimson/seastore/test_cbjournal.cc
@@ -594,6 +594,6 @@ TEST_F(cbjournal_test_t, multiple_submit_at_end)
       return Journal::replay_ertr::make_ready_future<
 	std::pair<bool, CachedExtentRef>>(true, nullptr);
     }).unsafe_get();
-    assert(get_written_to() == old_written_to);
+    ASSERT_EQ(get_written_to(), old_written_to);
   });
 }

--- a/src/test/librados/test_cxx.cc
+++ b/src/test/librados/test_cxx.cc
@@ -212,10 +212,6 @@ std::string set_pool_flags_pp(const std::string &pool_name, librados::Rados &clu
       flags
   );
 
-  char *cmd[2];
-  cmd[0] = (char *)cmdstr.c_str();
-  cmd[1] = NULL;
-
   int ret = cluster.mon_command(std::move(cmdstr), {}, NULL, NULL);
   if (ret) {
     oss << "rados_mon_command osd pool set set_pool_flags_pp failed with error " << ret;

--- a/src/test/rgw/test_rgw_kms_cache.cc
+++ b/src/test/rgw/test_rgw_kms_cache.cc
@@ -60,12 +60,6 @@ class TestKMSCacheReaperLifecycle : public ::testing::Test,
       : rgw::kms::KMSCache(g_ceph_context, std::make_unique<FakeKeyring>()) {};
 };
 
-static void rethrow(const std::exception_ptr& eptr) {
-  if (eptr) {
-    std::rethrow_exception(eptr);
-  }
-}
-
 TEST_F(TestKMSCacheReaperLifecycle, Threaded) {
   initialize_ttl_reaper(std::nullopt);
   EXPECT_TRUE(reaper_initialized());


### PR DESCRIPTION
1. **Remove unused functions and a dead variable**

```
src/crimson/os/seastore/seastore.cc:83: 'omaptree_initialize' defined but not used [-Wunused-function]
src/crimson/osd/replicated_recovery_backend.cc:733: 'nullopt_if_empty' defined but not used [-Wunused-function]
src/test/rgw/test_rgw_kms_cache.cc:63: 'rethrow' defined but not used [-Wunused-function]
src/test/librados/test_cxx.cc:215: variable 'cmd' set but not used [-Wunused-but-set-variable]
```

2. **Use gtest assertion macros instead of `assert()`** 

in tests the checked value is only read by a plain `assert()`, which is compiled out
under NDEBUG and leaves the variable unused. Switch to the
always-evaluated gtest macros so the check always runs:

```
src/test/crimson/seastore/test_cbjournal.cc:586: variable 'old_written_to' set but not used [-Wunused-but-set-variable]
src/test/crimson/seastore/test_btree_lba_manager.cc:345: unused structured binding declaration [-Wunused-variable]
```

3. **Mark assert-only variables `[[maybe_unused]]`** 

non-test code where the variable is deliberately only read inside `assert()`; keep the
debug-only assert style used by the surrounding code and just silence the
warning:

```
src/crimson/os/seastore/lba/btree_lba_manager.cc:1078: unused variable 'orig_len' [-Wunused-variable]
src/crimson/os/seastore/omap_manager/log/log_manager.cc:73: variable 'ret' set but not used [-Wunused-but-set-variable]
src/crimson/os/seastore/transaction_manager.cc:382: variable 'intermediate_key' set but not used [-Wunused-but-set-variable]
src/mgr/PyModule.cc:166,186: unused variable 'r' [-Wunused-variable]
```

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
