### PR TITLE
umbrella: cephadm/smb: Bind mount /run with 0755

### DIFF
--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_domain.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_domain.yaml
@@ -62,7 +62,7 @@ tasks:
     timeout: 1h
     clients:
       client.0:
-        - [default, hosts_access]
+        - [default, hosts_access, domain]
 
 - cephadm.shell:
     host.a:

--- a/qa/workunits/smb/tests/cephutil.py
+++ b/qa/workunits/smb/tests/cephutil.py
@@ -1,5 +1,6 @@
 import enum
 import json
+import shlex
 import subprocess
 
 
@@ -66,3 +67,27 @@ def cephadm_shell_cmd(
     elif load is LoadJSON.ERROR:
         return JSONResult(proc.returncode, None, proc.stderr.decode())
     return proc
+
+
+def cephadm_enter_cmd(smb_cfg, cluster_id, args, **kwargs):
+    """Run a command inside the primary smbd container for the given
+    cluster_id on the cluster's admin node (derived via smb_cfg).
+    All kwargs are treated as arguments to subprocess.run.
+    """
+    remote_cmd = [
+        'sudo',
+        f'/home/{smb_cfg.ssh_user}/cephtest/cephadm',
+        'enter',
+        '-i',
+        f'smb.{cluster_id}',
+    ] + list(args)
+    cmd = [
+        'ssh',
+        '-oBatchMode=yes',
+        '-oUserKnownHostsFile=/dev/null',
+        '-oStrictHostKeyChecking=no',
+        '-q',
+        f'{smb_cfg.ssh_user}@{smb_cfg.ssh_admin_host}',
+        shlex.join(remote_cmd),
+    ]
+    return subprocess.run(cmd, **kwargs)

--- a/qa/workunits/smb/tests/pytest.ini
+++ b/qa/workunits/smb/tests/pytest.ini
@@ -6,3 +6,4 @@ markers =
     hosts_access: Host access tests
     rate_limiting: Rate limit tests
     ceph_smb_ctl_local: Local/container test of ceph-smb-ctl tool
+    domain: Domain integration tests

--- a/qa/workunits/smb/tests/test_sid_resolution.py
+++ b/qa/workunits/smb/tests/test_sid_resolution.py
@@ -1,0 +1,46 @@
+import pytest
+
+import cephutil
+import smbutil
+
+
+@pytest.mark.domain
+def test_sid_resolution(smb_cfg):
+    """Verify that rpcclient lookupsids resolves domain user SIDs correctly
+    inside the smbd container, preventing regressions on /run bind mount
+    permissions that break smbd to winbindd communication (tracker#77120).
+    """
+    cluster_id = smbutil.get_shares(smb_cfg)[0]['cluster_id']
+    username = smb_cfg.username
+    password = smb_cfg.password
+
+    result = cephutil.cephadm_enter_cmd(
+        smb_cfg,
+        cluster_id,
+        ['wbinfo', '-n', username],
+        capture_output=True,
+        check=True,
+    )
+    user_sid = result.stdout.decode().split()[0]
+    assert user_sid.startswith('S-'), f'unexpected SID format: {user_sid}'
+
+    auth = f'{username}%{password}'
+    result = cephutil.cephadm_enter_cmd(
+        smb_cfg,
+        cluster_id,
+        [
+            'rpcclient',
+            'localhost',
+            '-U',
+            auth,
+            '-c',
+            f'lookupsids {user_sid}',
+        ],
+        capture_output=True,
+        check=True,
+    )
+    output = result.stdout.decode()
+    short_name = username.split('\\')[-1]
+    assert short_name in output, (
+        f'SID resolution failed: {short_name!r} not found in: {output}'
+    )

--- a/src/cephadm/cephadmlib/daemons/smb.py
+++ b/src/cephadm/cephadmlib/daemons/smb.py
@@ -1055,7 +1055,7 @@ class SMB(ContainerDaemonForm):
         etc_samba_ctr = ddir / 'etc-samba-container'
         file_utils.makedirs(etc_samba_ctr, uid, gid, 0o770)
         file_utils.makedirs(ddir / 'lib-samba', uid, gid, 0o755)
-        file_utils.makedirs(ddir / 'run', uid, gid, 0o770)
+        file_utils.makedirs(ddir / 'run', uid, gid, 0o755)
         if self._files:
             file_utils.populate_files(data_dir, self._files, uid, gid)
         if self._tls_files:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77420

---

backport of https://github.com/ceph/ceph/pull/69289
parent tracker: https://tracker.ceph.com/issues/77120

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests