### PR TITLE
standalone: pg-subcommand move under crimson directory

### DIFF
--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -683,7 +683,7 @@ EOF
 # Create (prepare) and run (activate) a crimson osd by the name osd.**id**
 # with data in **dir**/**id**.
 #
-# The remaining arguments are passed verbatim to crimson-osd.
+# The remaining arguments are passed verbatim to ceph-osd-crimson.
 #
 # Two mandatory arguments must be provided: --fsid and --mon-host
 # Instead of adding them to every call to run_crimson_osd, they can be
@@ -695,7 +695,7 @@ EOF
 #
 # @param dir path name of the environment
 # @param id osd identifier
-# @param ... can be any option valid for crimson-osd
+# @param ... can be any option valid for ceph-osd-crimson
 # @return 0 on success, 1 on error
 #
 function run_crimson_osd() {
@@ -726,14 +726,16 @@ function run_crimson_osd() {
     ceph_args+="$@"
     mkdir -p $osd_data
 
-    # Find crimson-osd binary
+    # Find ceph-osd-crimson binary
     local crimson_osd=""
     if [ -f "./bin/crimson-osd" ]; then
         crimson_osd="./bin/crimson-osd"
     elif [ -f "$CEPH_ROOT/build/bin/crimson-osd" ]; then
         crimson_osd="$CEPH_ROOT/build/bin/crimson-osd"
+    elif command -v ceph-osd-crimson &>/dev/null; then
+        crimson_osd="ceph-osd-crimson"
     else
-        echo "ERROR: crimson-osd binary not found"
+        echo "ERROR: ceph-osd-crimson binary not found"
         return 1
     fi
 
@@ -742,7 +744,7 @@ function run_crimson_osd() {
     ceph osd set-allow-crimson --yes-i-really-mean-it || return 1
 
     # Standalone tests do not set crimson_cpu_set/crimson_cpu_num (vstart.sh does).
-    # Without this, crimson-osd aborts in get_early_config.
+    # Without this, ceph-osd-crimson aborts in get_early_config.
     ceph config set osd.$id crimson_cpu_num 1 || return 1
 
     local uuid=`uuidgen`
@@ -752,10 +754,10 @@ function run_crimson_osd() {
     ceph osd new $uuid -i $osd_data/new.json
     rm $osd_data/new.json
 
-    # Use crimson-osd for mkfs (not ceph-osd!)
-    echo "Running crimson-osd mkfs..."
+    # Use ceph-osd-crimson for mkfs (not ceph-osd!)
+    echo "Running ceph-osd-crimson mkfs..."
     if ! $crimson_osd -i $id $ceph_args --mkfs --key $OSD_SECRET --osd-uuid $uuid 2>&1; then
-        echo "ERROR: crimson-osd --mkfs failed"
+        echo "ERROR: ceph-osd-crimson --mkfs failed"
         return 1
     fi
 

--- a/qa/standalone/crimson/pg-subcommands.sh
+++ b/qa/standalone/crimson/pg-subcommands.sh
@@ -205,5 +205,5 @@ function TEST_b_crimson_save_and_compare() {
     delete_pool $poolname
 }
 
-# Run cd build && ../qa/run-standalone.sh osd/pg-subcommands.sh
+# Run cd build && ../qa/run-standalone.sh crimson/pg-subcommands.sh
 main pg-subcommands "$@"


### PR DESCRIPTION

Since that test was originally created under osd directory,
classic osd teuthology tests run and tried to execute all tests under osd
standalone directory and failed to find crimson binaries under that
test.

moved the test under crimson directory.

Fixes: https://tracker.ceph.com/issues/77337


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
