### PR TITLE
tentacle: cephadm/smb: Bind mount /run with 0755

### DIFF
--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_domain.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_domain.yaml
@@ -53,6 +53,16 @@ tasks:
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{'host.a'|role_to_remote|attr('ip_address')}}/share1 -c ls"
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{'host.a'|role_to_remote|attr('ip_address')}}/share2 -c ls"
 
+# Verify SID to name resolution in smbd container (tracker#77421)
+- template.exec:
+    host.a:
+      - "{{ctx.cephadm}} enter -i smb.modtest1 wbinfo -n DOMAIN1\\\\bwayne | awk '{print $1}' > /tmp/user_sid"
+      - cat /tmp/user_sid
+      - "{{ctx.cephadm}} enter -i smb.modtest1 rpcclient localhost -U DOMAIN1\\\\bwayne%1115Rose. -c \"lookupsids $(cat /tmp/user_sid)\" > /tmp/lookupsids_result"
+      - cat /tmp/lookupsids_result
+      - grep bwayne /tmp/lookupsids_result
+      - rm -f /tmp/user_sid /tmp/lookupsids_result
+
 - cephadm.shell:
     host.a:
       - cmd: ceph smb share rm modtest1 share2

--- a/src/cephadm/cephadmlib/daemons/smb.py
+++ b/src/cephadm/cephadmlib/daemons/smb.py
@@ -942,7 +942,7 @@ class SMB(ContainerDaemonForm):
         etc_samba_ctr = ddir / 'etc-samba-container'
         file_utils.makedirs(etc_samba_ctr, uid, gid, 0o770)
         file_utils.makedirs(ddir / 'lib-samba', uid, gid, 0o755)
-        file_utils.makedirs(ddir / 'run', uid, gid, 0o770)
+        file_utils.makedirs(ddir / 'run', uid, gid, 0o755)
         if self._files:
             file_utils.populate_files(data_dir, self._files, uid, gid)
         if self._tls_files:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77421

---

backport of https://github.com/ceph/ceph/pull/69289
parent tracker: https://tracker.ceph.com/issues/77120

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

> **NOTE**: Due to missing new smb test infrastructure from the `main` branch, there is a deviation in how the associated regression test is backported and cherry-picked here. The required test steps are added directly into the job YAML files instead of using dedicated workunit test files under _qa/workunits/smb/tests_, because those files are not yet present in `tentacle`. Otherwise the bug fix lines are intact.
