### PR TITLE
run-make-check.sh: build ctest cpu resource pool from sched_getaffinity

### DIFF
--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -24,9 +24,12 @@ set -e
 
 function gen_ctest_resource_file() {
     local file_name=$(mktemp /tmp/ctest-resource-XXXXXX)
-    local max_cpuid=$(($(nproc) - 1))
+    # Usable CPU ids for this process: excludes offline cores and honors cgroup/
+    # taskset limits. Not necessarily contiguous 0..nproc-1, so a crimson seastar
+    # unittest could otherwise get an offline id in --cpuset and abort.
+    local ids=$(python3 -c 'import os; print(*sorted(os.sched_getaffinity(0)))')
     jq -n '$ARGS.positional | map({id:., slots:1}) | {cpus:.} | {version: {major:1, minor:0}, local:[.]}' \
-        --args $(seq 0 $max_cpuid) > $file_name
+        --args $ids > $file_name
     echo "$file_name"
 }
 


### PR DESCRIPTION
`gen_ctest_resource_file` assumed online CPUs are a contiguous `0..nproc-1`
range. When a middle core is hot-offlined (e.g. for a hardware fault), that
both hands out the offline cpu id and drops an online one. crimson seastar
unittests feed the ctest resource id straight to seastar `--cpuset`, so hitting
the offline id aborts with: `Bad value for --cpuset: N not allowed`

Use the CPUs actually schedulable by the process via `sched_getaffinity()`.

Hit on a 64-core CI host where one bad core slowed the run ~50%; after
`echo 0 > /sys/devices/system/cpu/cpuXX/online` the online ids were no longer
contiguous.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests