### PR TITLE
pybind/rbd,rgw: place nogil after the exception specification

### DIFF
--- a/src/pybind/rbd/c_rbd.pxd
+++ b/src/pybind/rbd/c_rbd.pxd
@@ -631,12 +631,12 @@ cdef extern from "rbd/librbd.h" nogil:
                          uint64_t ofs, uint64_t len,
                          uint8_t include_parent, uint8_t whole_object,
                          int (*cb)(uint64_t, size_t, int, void *)
-                             nogil except? -9000,
+                             except? -9000 nogil,
                          void *arg) except? -9000
     int rbd_diff_iterate3(rbd_image_t image, uint64_t from_snap_id,
                           uint64_t ofs, uint64_t len, uint32_t flags,
                           int (*cb)(uint64_t, size_t, int, void *)
-                              nogil except? -9000,
+                              except? -9000 nogil,
                           void *arg) except? -9000
 
     int rbd_flush(rbd_image_t image)

--- a/src/pybind/rgw/c_rgw.pxd
+++ b/src/pybind/rgw/c_rgw.pxd
@@ -102,7 +102,7 @@ cdef extern from "rados/rgw_file.h" nogil:
 
     int rgw_readdir(rgw_fs *fs,
                     rgw_file_handle *parent_fh, uint64_t *offset,
-                    int (*cb)(const char *name, void *arg, uint64_t offset, stat *st, uint32_t st_mask, uint32_t flags) nogil except? -9000,
+                    int (*cb)(const char *name, void *arg, uint64_t offset, stat *st, uint32_t st_mask, uint32_t flags) except? -9000 nogil,
                     void *cb_arg, bool *eof, uint32_t flags) except? -9000
 
     int rgw_getattr(rgw_fs *fs,


### PR DESCRIPTION
Cython 3 warns that putting `nogil` before `except`/`noexcept` is deprecated
and will be disallowed in a future version. Move `nogil` to the end of the
function signature line, after the exception specification:

```
warning: c_rbd.pxd:639:49: The keyword 'nogil' should appear at the end of the function signature line. Placing it before 'except' or 'noexcept' will be disallowed in a future version of Cython.
warning: c_rgw.pxd:105:139: The keyword 'nogil' should appear at the end of the function signature line. Placing it before 'except' or 'noexcept' will be disallowed in a future version of Cython.
```

No behavioral change.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests