### PR TITLE
pybind/cephfs: drop redundant int32_t typedef

### DIFF
--- a/src/pybind/cephfs/c_cephfs.pxd
+++ b/src/pybind/cephfs/c_cephfs.pxd
@@ -26,7 +26,6 @@ cdef extern from *:
     unsigned long DIRENT_D_OFF(dirent *d)
 
 cdef extern from "../include/platform_errno.h":
-    ctypedef signed int int32_t;
     int32_t ceph_to_hostos_errno(int32_t e)
 
 cdef extern from "cephfs/ceph_ll_client.h":


### PR DESCRIPTION
`int32_t` is already provided by `from libc.stdint cimport *`, so 

```
warning: c_cephfs.pxd:29:4: 'int32_t' redeclared
```

Fixes: https://tracker.ceph.com/issues/77440

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests