### PR TITLE
doc/ceph-volume: document udev metadata dependency

### DIFF
--- a/doc/ceph-volume/intro.rst
+++ b/doc/ceph-volume/intro.rst
@@ -6,18 +6,28 @@ The ``ceph-volume`` tool aims to be a single purpose command line tool to deploy
 logical volumes as OSDs, trying to maintain a similar API to ``ceph-disk`` when
 preparing, activating, and creating OSDs.
 
-It deviates from ``ceph-disk`` by not interacting or relying on the udev rules
-that come installed for Ceph. These rules allow automatic detection of
-previously set up devices that are in turn fed into ``ceph-disk`` to activate
-them.
+Unlike ``ceph-disk``, ``ceph-volume`` does not install or react to the
+Ceph specific udev rules that automatically triggered ``ceph-disk`` to activate
+OSDs at boot. That activation path relied on udev as an event bus, ``ceph-volume``
+uses systemd units instead.
+
+Separately, ``ceph-volume`` needs device metadata provider by udev to discover and
+classify block devices (for example in ``inventory`` or ``raw list``). It reads
+this metadata from ``/run/udev/data/``, a cache populated by ``systemd-udevd``,
+rather than spawning ``udevadm`` subprocesses for each device. This is an
+operational requirement distinct from the ceph-disk udev rules above:
+``systemd-udevd`` must be running on the host, block devices must have been
+processed by udev, and ``/run/udev`` must be visible wherever ``ceph-volume``
+runs.
 
 Cephadm shell
 -------------
 Do not run ``ceph-volume`` from a container session that was started with
 ``cephadm shell`` while relying on that shell's default bind mounts. By design,
 ``cephadm shell`` omits several host bind mounts that ``ceph-volume`` expects
-(for example /run/udev, /run/lvm, etc.). Invoking ``ceph-volume`` in that
-environment is likely to fail or behave incorrectly.
+(for example ``/run/udev``, ``/run/lvm``, etc.). Without ``/run/udev``, the
+udev metadata cache is unavailable and commands such as ``inventory`` or
+``raw list`` are likely to fail.
 
 Running ``ceph-volume`` yourself, outside of what ``ceph orch`` / cephadm
 drives, is not the normal operational path: it is mainly for debugging,

--- a/doc/man/8/ceph-volume.rst
+++ b/doc/man/8/ceph-volume.rst
@@ -27,10 +27,16 @@ Description
 volumes as OSDs, trying to maintain a similar API to ``ceph-disk`` when
 preparing, activating, and creating OSDs.
 
-It deviates from ``ceph-disk`` by not interacting or relying on the udev rules
-that come installed for Ceph. These rules allow automatic detection of
-previously setup devices that are in turn fed into ``ceph-disk`` to activate
-them.
+Unlike ``ceph-disk``, it does not rely on Ceph specific udev rules that
+trigger automatic OSD activation at boot; activation is handled through
+systemd units instead.
+
+To identify block devices (for example in ``inventory`` or ``raw list``),
+``ceph-volume`` reads device metadata from ``/run/udev/data/``, a cache
+maintained by ``systemd-udevd`` on the host. This avoids spawning
+``udevadm`` subprocesses for each device. ``/run/udev`` must be visible to
+``ceph-volume`` (for example when run inside a container), and block devices
+must already have been processed by udev before these commands are invoked.
 
 
 Commands


### PR DESCRIPTION
This clarifies that ceph-volume requires systemd-udevd to populate /run/udev/data/ for device discovery commands such as inventory and raw list.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
