### PR TITLE
mgr/dashboard: obervability component revamp

### DIFF
--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -917,6 +917,51 @@ class LokiService(CephadmService):
             }
         }, sorted(deps)
 
+    def get_active_daemon(self, daemon_descrs: List[DaemonDescription]) -> DaemonDescription:
+        if daemon_descrs:
+            return daemon_descrs[0]
+        return DaemonDescription()
+
+    def config_dashboard(self, daemon_descrs: List[DaemonDescription]) -> None:
+        dd = self.get_active_daemon(daemon_descrs)
+        assert dd.hostname is not None
+        addr = dd.ip if dd.ip else self.mgr.get_fqdn(dd.hostname)
+        port = dd.ports[0] if dd.ports else self.DEFAULT_SERVICE_PORT
+        service_url = build_url(scheme='http', host=addr, port=port)
+        self._set_value_on_dashboard(
+            'Loki',
+            'dashboard get-loki-api-host',
+            'dashboard set-loki-api-host',
+            service_url
+        )
+
+    def pre_remove(self, daemon: DaemonDescription) -> None:
+        if daemon.hostname is None:
+            return
+        try:
+            current_api_host = self.mgr.check_mon_command(
+                {"prefix": "dashboard get-loki-api-host"}).stdout.strip()
+            daemon_addr = daemon.ip if daemon.ip else self.mgr.get_fqdn(daemon.hostname)
+            daemon_port = daemon.ports[0] if daemon.ports else self.DEFAULT_SERVICE_PORT
+            service_url = build_url(scheme='http', host=daemon_addr, port=daemon_port)
+
+            if current_api_host == service_url:
+                remaining_daemons = [
+                    d for d in self.mgr.cache.get_daemons_by_service(self.TYPE)
+                    if d.name() != daemon.name()
+                ]
+                if remaining_daemons:
+                    self.config_dashboard(remaining_daemons)
+                    logger.info("Updated dashboard Loki API settings to point to a remaining daemon")
+                else:
+                    self.mgr.check_mon_command({"prefix": "dashboard reset-loki-api-host"})
+                    self.mgr.check_mon_command({"prefix": "dashboard reset-loki-api-ssl-verify"})
+                    logger.info("Reset dashboard Loki API settings as no Loki daemons are remaining")
+            else:
+                logger.info(f"Loki {daemon.name()} removed; no changes to dashboard API settings")
+        except Exception as e:
+            logger.error(f"Error in Loki pre_remove: {str(e)}")
+
 
 @register_cephadm_service
 class AlloyService(CephadmService):

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -934,6 +934,12 @@ class LokiService(CephadmService):
             'dashboard set-loki-api-host',
             service_url
         )
+        self._set_value_on_dashboard(
+            'Loki',
+            'dashboard get-loki-api-ssl-verify',
+            'dashboard set-loki-api-ssl-verify',
+            'false'
+        )
 
     def pre_remove(self, daemon: DaemonDescription) -> None:
         if daemon.hostname is None:
@@ -952,11 +958,11 @@ class LokiService(CephadmService):
                 ]
                 if remaining_daemons:
                     self.config_dashboard(remaining_daemons)
-                    logger.info("Updated dashboard Loki API settings to point to a remaining daemon")
+                    logger.info("Updated dashboard API settings to point to a remaining Loki daemon")
                 else:
                     self.mgr.check_mon_command({"prefix": "dashboard reset-loki-api-host"})
                     self.mgr.check_mon_command({"prefix": "dashboard reset-loki-api-ssl-verify"})
-                    logger.info("Reset dashboard Loki API settings as no Loki daemons are remaining")
+                    logger.info("Reset dashboard API settings as no Loki daemons are remaining")
             else:
                 logger.info(f"Loki {daemon.name()} removed; no changes to dashboard API settings")
         except Exception as e:

--- a/src/pybind/mgr/dashboard/controllers/loki.py
+++ b/src/pybind/mgr/dashboard/controllers/loki.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+import json
+from typing import Optional
+
+import requests
+
+from ..exceptions import DashboardException
+from ..security import Scope
+from ..settings import Settings
+from . import APIDoc, APIRouter, RESTController
+
+
+class LokiRESTController(RESTController):
+
+    def _get_api_url(self, host: str) -> str:
+        return f'{host.rstrip("/")}/loki/api/v1'
+
+    def loki_proxy(self, method: str, path: str, params: Optional[dict] = None,
+                   payload: Optional[dict] = None):
+        response = self._proxy(self._get_api_url(Settings.LOKI_API_HOST),
+                               method, path, 'Loki', params, payload,
+                               verify=Settings.LOKI_API_SSL_VERIFY)
+        return response
+
+    def _proxy(self, base_url: str, method: str, path: str, api_name: str,
+               params: Optional[dict] = None, payload: Optional[dict] = None,
+               verify: bool = True):
+        content = None
+        try:
+            response = requests.request(method, base_url + path, params=params,
+                                        json=payload, verify=verify)
+        except Exception as e:
+            raise DashboardException(
+                "Could not reach {}'s API on {} error {}".format(api_name, base_url, e),
+                http_status_code=404,
+                component='loki')
+        try:
+            if response.content:
+                content = json.loads(response.content, strict=False)
+        except json.JSONDecodeError as e:
+            raise DashboardException(
+                "Error parsing Loki response: {}".format(e.msg),
+                component='loki')
+        if content['status'] == 'success':
+            if 'data' in content:
+                return content['data']
+            return content
+        raise DashboardException(content, http_status_code=400, component='loki')
+
+    def get_client_version():
+        try:
+            client_version = APIVersion.from_mime_type(
+                cherrypy.request.headers['Accept'])
+        except Exception:
+            raise cherrypy.HTTPError(
+                415, "Unable to find version in request header")
+
+@APIRouter('/loki', Scope.LOG)
+@APIDoc("Loki Management API", "Loki")
+class Loki(LokiRESTController):
+    """
+    Proxy controller for the Loki HTTP query API.
+
+    Supports instant metric queries (GET /loki/api/v1/query) and range queries
+    for logs and metrics (GET /loki/api/v1/query_range).
+    """
+
+    @RESTController.Collection(method='GET', path='/query')
+    def query(self, **params):
+        """
+        Instant query against Loki.
+
+        Evaluates a LogQL query at a single point in time. Intended for metric
+        queries such as rate() or count_over_time(). Accepts Loki query params:
+        query, limit, time, direction.
+        """
+        params['query'] = params.pop('params')
+        return self.loki_proxy('GET', '/query', params)
+
+    @RESTController.Collection(method='GET', path='/query_range')
+    def query_range(self, **params):
+        """
+        Range query against Loki.
+
+        Queries logs or metrics over a time range. Accepts Loki query params:
+        query, limit, start, end, since, step, interval, direction.
+        """
+        params['query'] = params.pop('params')
+        return self.loki_proxy('GET', '/query_range', params)

--- a/src/pybind/mgr/dashboard/controllers/loki.py
+++ b/src/pybind/mgr/dashboard/controllers/loki.py
@@ -1,133 +1,16 @@
 # -*- coding: utf-8 -*-
 import json
-import os
-import tempfile
-import time
-from typing import List, NamedTuple, Optional
+from typing import Optional
 
 import requests
-from mgr_util import build_url
 
-from .. import mgr
 from ..exceptions import DashboardException
 from ..security import Scope
-from ..services.orchestrator import OrchClient
-from ..services.settings import SettingsService
-from ..settings import Options, Settings
-from . import APIDoc, APIRouter, RESTController, UIRouter
-
-
-class Credentials(NamedTuple):
-    user: str
-    password: str
-    ca_cert_file: Optional[str]
-    cert_file: Optional[str]
-    pkey_file: Optional[str]
+from ..settings import Settings
+from . import APIDoc, APIRouter, RESTController
 
 
 class LokiRESTController(RESTController):
-
-    LOKI_DEFAULT_PORT = 3100
-
-    _credentials_cache = {}
-    _cache_timestamp = {}
-
-    def close_unlink_files(self, files):
-        # type (List[str])
-        valid_entries = [f for f in files if f is not None]
-        for f in valid_entries:
-            f.close()
-            os.unlink(f.name)
-
-    def _is_cache_valid(self, module_name):
-        if module_name not in self._cache_timestamp:
-            return False
-        current_time = time.time()
-        return ((current_time - self._cache_timestamp[module_name])
-                < Settings.PROM_ALERT_CREDENTIAL_CACHE_TTL)
-
-    def _get_cached_credentials(self, module_name):
-        if self._is_cache_valid(module_name):
-            return self._credentials_cache.get(module_name)
-        old_creds = self._credentials_cache.get(module_name)
-        if old_creds:
-            self.close_unlink_files([
-                old_creds.ca_cert_file,
-                old_creds.cert_file,
-                old_creds.pkey_file
-            ])
-            self._credentials_cache.pop(module_name, None)
-            self._cache_timestamp.pop(module_name, None)
-        return None
-
-    def _cache_credentials(self, module_name, credentials):
-        self._credentials_cache[module_name] = credentials
-        self._cache_timestamp[module_name] = time.time()
-
-    def get_access_info(self, module_name):
-        """
-        Fetches credentials and certificate files for Loki API access.
-
-        When the secure monitoring stack is enabled, Loki uses the same
-        credentials and client certificates as Prometheus.
-        """
-
-        def write_to_tmp_file(content):
-            if content is None:
-                return None
-            tmp_file = tempfile.NamedTemporaryFile(delete=False)
-            tmp_file.write(content.encode('utf-8'))
-            tmp_file.flush()
-            tmp_file.close()
-            return tmp_file
-
-        orch_backend = mgr.get_module_option_ex('orchestrator', 'orchestrator')
-        is_cephadm = orch_backend == 'cephadm'
-
-        if module_name not in ['loki', 'grafana', 'dashboard']:
-            raise DashboardException(f'Invalid module name {module_name}',
-                                     component='loki')
-
-        user = None
-        password = None
-        cert_file = None
-        pkey_file = None
-        ca_cert_file = None
-
-        if module_name == 'grafana':
-            return Credentials(Settings.GRAFANA_API_USERNAME,
-                               Settings.GRAFANA_API_PASSWORD,
-                               ca_cert_file, cert_file, pkey_file)
-
-        if module_name == 'dashboard':
-            return Credentials(user, password, ca_cert_file, cert_file, pkey_file)
-
-        if not is_cephadm:
-            return Credentials(user, password, ca_cert_file, cert_file, pkey_file)
-
-        cached_creds = self._get_cached_credentials(module_name)
-        if cached_creds:
-            return cached_creds
-
-        orch_client = OrchClient.instance()
-        security_config = orch_client.monitoring.get_security_config()
-        if not security_config.get('security_enabled', False):
-            return Credentials(user, password, ca_cert_file, cert_file, pkey_file)
-
-        if orch_client.available():
-            access_info = orch_client.monitoring.get_prometheus_access_info()
-            if access_info:
-                user = access_info.get('user')
-                password = access_info.get('password')
-                ca_cert_file = write_to_tmp_file(access_info.get('certificate'))
-                cert_file = write_to_tmp_file(mgr.get_localized_store("crt"))
-                pkey_file = write_to_tmp_file(mgr.get_localized_store("key"))
-                self._cache_credentials(
-                    module_name,
-                    Credentials(user, password, ca_cert_file, cert_file, pkey_file)
-                )
-
-        return Credentials(user, password, ca_cert_file, cert_file, pkey_file)
 
     def _get_api_url(self, host: str) -> str:
         return f'{host.rstrip("/")}/loki/api/v1'
@@ -137,31 +20,11 @@ class LokiRESTController(RESTController):
         if host and '://' in host:
             return host.rstrip('/')
 
-        discovered = self._discover_loki_host()
-        if discovered:
-            return discovered
-
         raise DashboardException(
             "Loki API host is not configured. Deploy the loki service or set "
             "'ceph dashboard set-loki-api-host <scheme>://<host>:3100'.",
             http_status_code=503,
             component='loki')
-
-    def _discover_loki_host(self) -> Optional[str]:
-        try:
-            orch = OrchClient.instance()
-            if not orch.available():
-                return None
-            daemons = orch.services.list_daemons(daemon_type='loki')
-            for daemon in daemons:
-                if daemon.status != 1 or not daemon.hostname:
-                    continue
-                addr = daemon.ip if daemon.ip else daemon.hostname
-                port = daemon.ports[0] if daemon.ports else self.LOKI_DEFAULT_PORT
-                return build_url(scheme='http', host=addr, port=port)
-        except Exception:
-            return None
-        return None
 
     @staticmethod
     def _prepare_loki_params(params: Optional[dict]) -> Optional[dict]:
@@ -172,62 +35,17 @@ class LokiRESTController(RESTController):
 
     def loki_proxy(self, method: str, path: str, params: Optional[dict] = None,
                    payload: Optional[dict] = None):
-        host = self._resolve_loki_host()
-        if self._uses_grafana_proxy(host):
-            user, password, ca_cert_file, cert_file, key_file = self.get_access_info('grafana')
-            verify = Settings.GRAFANA_API_SSL_VERIFY
-            cert = None
-            proxy_mode = 'grafana'
-            base_url = host
-        else:
-            user, password, ca_cert_file, cert_file, key_file = self.get_access_info('loki')
-            verify = ca_cert_file.name if ca_cert_file else Settings.LOKI_API_SSL_VERIFY
-            cert = (cert_file.name, key_file.name) if cert_file and key_file else None
-            proxy_mode = 'loki'
-            base_url = self._get_api_url(host)
-        return self._proxy(base_url,
+        return self._proxy(self._get_api_url(self._resolve_loki_host()),
                            method, path, 'Loki', params, payload,
-                           user=user, password=password, verify=verify,
-                           cert=cert, proxy_mode=proxy_mode)
+                           verify=Settings.LOKI_API_SSL_VERIFY)
 
-    @staticmethod
-    def _uses_grafana_proxy(host: str) -> bool:
-        grafana_url = (Settings.GRAFANA_API_URL or '').rstrip('/')
-        return bool(grafana_url and host.startswith(grafana_url))
-
-    def grafana_proxy(self, method: str, path: str, params: Optional[dict] = None,
-                      payload: Optional[dict] = None):
-        user, password, _, _, _ = self.get_access_info('grafana')
-        return self._proxy((Settings.GRAFANA_API_URL or '').rstrip('/'),
-                           method, path, 'Grafana', params, payload,
-                           user=user, password=password,
-                           verify=Settings.GRAFANA_API_SSL_VERIFY,
-                           proxy_mode='grafana')
-
-    def dashboard_proxy(self, method: str, base_url: str, path: str,
-                        params: Optional[dict] = None, payload: Optional[dict] = None,
-                        token: Optional[str] = None, verify=False):
-        headers = {
-            'Accept': 'application/vnd.ceph.api.v1.0+json',
-        }
-        if token:
-            headers['Authorization'] = 'Bearer ' + token
-        else:
-            headers['Content-Type'] = 'application/json'
-        return self._proxy(base_url.rstrip('/'), method, path, 'Dashboard', params, payload,
-                           verify=verify, proxy_mode='dashboard', headers=headers)
-
-    def _proxy(self, base_url, method, path, api_name, params=None, payload=None, verify=True,
-               user=None, password=None, cert=None, proxy_mode='loki', headers=None):
+    def _proxy(self, base_url: str, method: str, path: str, api_name: str,
+               params: Optional[dict] = None, payload: Optional[dict] = None,
+               verify: bool = True):
         content = None
         try:
-            from requests.auth import HTTPBasicAuth
-            auth = HTTPBasicAuth(user, password) if user and password else None
             response = requests.request(method, base_url + path, params=params,
-                                        json=payload, verify=verify,
-                                        cert=cert,
-                                        auth=auth,
-                                        headers=headers)
+                                        json=payload, verify=verify)
         except Exception as e:
             raise DashboardException(
                 "Could not reach {}'s API on {} error {}".format(api_name, base_url, e),
@@ -238,10 +56,8 @@ class LokiRESTController(RESTController):
                 content = json.loads(response.content, strict=False)
         except json.JSONDecodeError as e:
             raise DashboardException(
-                "Error parsing {} response: {}".format(api_name, e.msg),
+                "Error parsing Loki response: {}".format(e.msg),
                 component='loki')
-        if proxy_mode in ('grafana', 'dashboard'):
-            return content
         if content['status'] == 'success':
             if 'data' in content:
                 return content['data']
@@ -297,16 +113,3 @@ class Loki(LokiRESTController):
         """
         return self.loki_proxy('GET', f'/label/{name}/values',
                                self._prepare_loki_params(params))
-
-
-@UIRouter('/loki', Scope.LOG)
-class LokiSettings(RESTController):
-    def get(self, name):
-        with SettingsService.attribute_handler(name) as settings_name:
-            setting = getattr(Options, settings_name)
-        return {
-            'name': settings_name,
-            'default': setting.default_value,
-            'type': setting.types_as_str(),
-            'value': getattr(Settings, settings_name)
-        }

--- a/src/pybind/mgr/dashboard/controllers/loki.py
+++ b/src/pybind/mgr/dashboard/controllers/loki.py
@@ -1,34 +1,233 @@
 # -*- coding: utf-8 -*-
 import json
-from typing import Optional
+import os
+import tempfile
+import time
+from typing import List, NamedTuple, Optional
 
 import requests
+from mgr_util import build_url
 
+from .. import mgr
 from ..exceptions import DashboardException
 from ..security import Scope
-from ..settings import Settings
-from . import APIDoc, APIRouter, RESTController
+from ..services.orchestrator import OrchClient
+from ..services.settings import SettingsService
+from ..settings import Options, Settings
+from . import APIDoc, APIRouter, RESTController, UIRouter
+
+
+class Credentials(NamedTuple):
+    user: str
+    password: str
+    ca_cert_file: Optional[str]
+    cert_file: Optional[str]
+    pkey_file: Optional[str]
 
 
 class LokiRESTController(RESTController):
 
+    LOKI_DEFAULT_PORT = 3100
+
+    _credentials_cache = {}
+    _cache_timestamp = {}
+
+    def close_unlink_files(self, files):
+        # type (List[str])
+        valid_entries = [f for f in files if f is not None]
+        for f in valid_entries:
+            f.close()
+            os.unlink(f.name)
+
+    def _is_cache_valid(self, module_name):
+        if module_name not in self._cache_timestamp:
+            return False
+        current_time = time.time()
+        return ((current_time - self._cache_timestamp[module_name])
+                < Settings.PROM_ALERT_CREDENTIAL_CACHE_TTL)
+
+    def _get_cached_credentials(self, module_name):
+        if self._is_cache_valid(module_name):
+            return self._credentials_cache.get(module_name)
+        old_creds = self._credentials_cache.get(module_name)
+        if old_creds:
+            self.close_unlink_files([
+                old_creds.ca_cert_file,
+                old_creds.cert_file,
+                old_creds.pkey_file
+            ])
+            self._credentials_cache.pop(module_name, None)
+            self._cache_timestamp.pop(module_name, None)
+        return None
+
+    def _cache_credentials(self, module_name, credentials):
+        self._credentials_cache[module_name] = credentials
+        self._cache_timestamp[module_name] = time.time()
+
+    def get_access_info(self, module_name):
+        """
+        Fetches credentials and certificate files for Loki API access.
+
+        When the secure monitoring stack is enabled, Loki uses the same
+        credentials and client certificates as Prometheus.
+        """
+
+        def write_to_tmp_file(content):
+            if content is None:
+                return None
+            tmp_file = tempfile.NamedTemporaryFile(delete=False)
+            tmp_file.write(content.encode('utf-8'))
+            tmp_file.flush()
+            tmp_file.close()
+            return tmp_file
+
+        orch_backend = mgr.get_module_option_ex('orchestrator', 'orchestrator')
+        is_cephadm = orch_backend == 'cephadm'
+
+        if module_name not in ['loki', 'grafana', 'dashboard']:
+            raise DashboardException(f'Invalid module name {module_name}',
+                                     component='loki')
+
+        user = None
+        password = None
+        cert_file = None
+        pkey_file = None
+        ca_cert_file = None
+
+        if module_name == 'grafana':
+            return Credentials(Settings.GRAFANA_API_USERNAME,
+                               Settings.GRAFANA_API_PASSWORD,
+                               ca_cert_file, cert_file, pkey_file)
+
+        if module_name == 'dashboard':
+            return Credentials(user, password, ca_cert_file, cert_file, pkey_file)
+
+        if not is_cephadm:
+            return Credentials(user, password, ca_cert_file, cert_file, pkey_file)
+
+        cached_creds = self._get_cached_credentials(module_name)
+        if cached_creds:
+            return cached_creds
+
+        orch_client = OrchClient.instance()
+        security_config = orch_client.monitoring.get_security_config()
+        if not security_config.get('security_enabled', False):
+            return Credentials(user, password, ca_cert_file, cert_file, pkey_file)
+
+        if orch_client.available():
+            access_info = orch_client.monitoring.get_prometheus_access_info()
+            if access_info:
+                user = access_info.get('user')
+                password = access_info.get('password')
+                ca_cert_file = write_to_tmp_file(access_info.get('certificate'))
+                cert_file = write_to_tmp_file(mgr.get_localized_store("crt"))
+                pkey_file = write_to_tmp_file(mgr.get_localized_store("key"))
+                self._cache_credentials(
+                    module_name,
+                    Credentials(user, password, ca_cert_file, cert_file, pkey_file)
+                )
+
+        return Credentials(user, password, ca_cert_file, cert_file, pkey_file)
+
     def _get_api_url(self, host: str) -> str:
         return f'{host.rstrip("/")}/loki/api/v1'
 
+    def _resolve_loki_host(self) -> str:
+        host = (Settings.LOKI_API_HOST or '').strip()
+        if host and '://' in host:
+            return host.rstrip('/')
+
+        discovered = self._discover_loki_host()
+        if discovered:
+            return discovered
+
+        raise DashboardException(
+            "Loki API host is not configured. Deploy the loki service or set "
+            "'ceph dashboard set-loki-api-host <scheme>://<host>:3100'.",
+            http_status_code=503,
+            component='loki')
+
+    def _discover_loki_host(self) -> Optional[str]:
+        try:
+            orch = OrchClient.instance()
+            if not orch.available():
+                return None
+            daemons = orch.services.list_daemons(daemon_type='loki')
+            for daemon in daemons:
+                if daemon.status != 1 or not daemon.hostname:
+                    continue
+                addr = daemon.ip if daemon.ip else daemon.hostname
+                port = daemon.ports[0] if daemon.ports else self.LOKI_DEFAULT_PORT
+                return build_url(scheme='http', host=addr, port=port)
+        except Exception:
+            return None
+        return None
+
+    @staticmethod
+    def _prepare_loki_params(params: Optional[dict]) -> Optional[dict]:
+        if params and 'params' in params:
+            params = dict(params)
+            params['query'] = params.pop('params')
+        return params
+
     def loki_proxy(self, method: str, path: str, params: Optional[dict] = None,
                    payload: Optional[dict] = None):
-        response = self._proxy(self._get_api_url(Settings.LOKI_API_HOST),
-                               method, path, 'Loki', params, payload,
-                               verify=Settings.LOKI_API_SSL_VERIFY)
-        return response
+        host = self._resolve_loki_host()
+        if self._uses_grafana_proxy(host):
+            user, password, ca_cert_file, cert_file, key_file = self.get_access_info('grafana')
+            verify = Settings.GRAFANA_API_SSL_VERIFY
+            cert = None
+            proxy_mode = 'grafana'
+            base_url = host
+        else:
+            user, password, ca_cert_file, cert_file, key_file = self.get_access_info('loki')
+            verify = ca_cert_file.name if ca_cert_file else Settings.LOKI_API_SSL_VERIFY
+            cert = (cert_file.name, key_file.name) if cert_file and key_file else None
+            proxy_mode = 'loki'
+            base_url = self._get_api_url(host)
+        return self._proxy(base_url,
+                           method, path, 'Loki', params, payload,
+                           user=user, password=password, verify=verify,
+                           cert=cert, proxy_mode=proxy_mode)
 
-    def _proxy(self, base_url: str, method: str, path: str, api_name: str,
-               params: Optional[dict] = None, payload: Optional[dict] = None,
-               verify: bool = True):
+    @staticmethod
+    def _uses_grafana_proxy(host: str) -> bool:
+        grafana_url = (Settings.GRAFANA_API_URL or '').rstrip('/')
+        return bool(grafana_url and host.startswith(grafana_url))
+
+    def grafana_proxy(self, method: str, path: str, params: Optional[dict] = None,
+                      payload: Optional[dict] = None):
+        user, password, _, _, _ = self.get_access_info('grafana')
+        return self._proxy((Settings.GRAFANA_API_URL or '').rstrip('/'),
+                           method, path, 'Grafana', params, payload,
+                           user=user, password=password,
+                           verify=Settings.GRAFANA_API_SSL_VERIFY,
+                           proxy_mode='grafana')
+
+    def dashboard_proxy(self, method: str, base_url: str, path: str,
+                        params: Optional[dict] = None, payload: Optional[dict] = None,
+                        token: Optional[str] = None, verify=False):
+        headers = {
+            'Accept': 'application/vnd.ceph.api.v1.0+json',
+        }
+        if token:
+            headers['Authorization'] = 'Bearer ' + token
+        else:
+            headers['Content-Type'] = 'application/json'
+        return self._proxy(base_url.rstrip('/'), method, path, 'Dashboard', params, payload,
+                           verify=verify, proxy_mode='dashboard', headers=headers)
+
+    def _proxy(self, base_url, method, path, api_name, params=None, payload=None, verify=True,
+               user=None, password=None, cert=None, proxy_mode='loki', headers=None):
         content = None
         try:
+            from requests.auth import HTTPBasicAuth
+            auth = HTTPBasicAuth(user, password) if user and password else None
             response = requests.request(method, base_url + path, params=params,
-                                        json=payload, verify=verify)
+                                        json=payload, verify=verify,
+                                        cert=cert,
+                                        auth=auth,
+                                        headers=headers)
         except Exception as e:
             raise DashboardException(
                 "Could not reach {}'s API on {} error {}".format(api_name, base_url, e),
@@ -39,21 +238,16 @@ class LokiRESTController(RESTController):
                 content = json.loads(response.content, strict=False)
         except json.JSONDecodeError as e:
             raise DashboardException(
-                "Error parsing Loki response: {}".format(e.msg),
+                "Error parsing {} response: {}".format(api_name, e.msg),
                 component='loki')
+        if proxy_mode in ('grafana', 'dashboard'):
+            return content
         if content['status'] == 'success':
             if 'data' in content:
                 return content['data']
             return content
         raise DashboardException(content, http_status_code=400, component='loki')
 
-    def get_client_version():
-        try:
-            client_version = APIVersion.from_mime_type(
-                cherrypy.request.headers['Accept'])
-        except Exception:
-            raise cherrypy.HTTPError(
-                415, "Unable to find version in request header")
 
 @APIRouter('/loki', Scope.LOG)
 @APIDoc("Loki Management API", "Loki")
@@ -61,8 +255,7 @@ class Loki(LokiRESTController):
     """
     Proxy controller for the Loki HTTP query API.
 
-    Supports instant metric queries (GET /loki/api/v1/query) and range queries
-    for logs and metrics (GET /loki/api/v1/query_range).
+    Supports instant and range LogQL queries, plus label discovery endpoints.
     """
 
     @RESTController.Collection(method='GET', path='/query')
@@ -74,8 +267,7 @@ class Loki(LokiRESTController):
         queries such as rate() or count_over_time(). Accepts Loki query params:
         query, limit, time, direction.
         """
-        params['query'] = params.pop('params')
-        return self.loki_proxy('GET', '/query', params)
+        return self.loki_proxy('GET', '/query', self._prepare_loki_params(params))
 
     @RESTController.Collection(method='GET', path='/query_range')
     def query_range(self, **params):
@@ -85,5 +277,36 @@ class Loki(LokiRESTController):
         Queries logs or metrics over a time range. Accepts Loki query params:
         query, limit, start, end, since, step, interval, direction.
         """
-        params['query'] = params.pop('params')
-        return self.loki_proxy('GET', '/query_range', params)
+        return self.loki_proxy('GET', '/query_range', self._prepare_loki_params(params))
+
+    @RESTController.Collection(method='GET', path='/labels')
+    def labels(self, **params):
+        """
+        List known label names within a time span.
+
+        Accepts Loki query params: start, end, since, query.
+        """
+        return self.loki_proxy('GET', '/labels', self._prepare_loki_params(params))
+
+    @RESTController.Collection(method='GET', path='/label/{name}/values')
+    def label_values(self, name, **params):
+        """
+        List known values for a label within a time span.
+
+        Accepts Loki query params: start, end, since, query.
+        """
+        return self.loki_proxy('GET', f'/label/{name}/values',
+                               self._prepare_loki_params(params))
+
+
+@UIRouter('/loki', Scope.LOG)
+class LokiSettings(RESTController):
+    def get(self, name):
+        with SettingsService.attribute_handler(name) as settings_name:
+            setting = getattr(Options, settings_name)
+        return {
+            'name': settings_name,
+            'default': setting.default_value,
+            'type': setting.types_as_str(),
+            'value': getattr(Settings, settings_name)
+        }

--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -15,6 +15,7 @@ import { HostDetailsSectionComponent } from './ceph/cluster/hosts/host-details/h
 import { HostsComponent } from './ceph/cluster/hosts/hosts.component';
 import { InventoryComponent } from './ceph/cluster/inventory/inventory.component';
 import { LogsComponent } from './ceph/cluster/logs/logs.component';
+import { LokiLogsComponent } from './ceph/cluster/loki-logs/loki-logs.component';
 import { MgrModuleFormComponent } from './ceph/cluster/mgr-modules/mgr-module-form/mgr-module-form.component';
 import { MgrModuleListComponent } from './ceph/cluster/mgr-modules/mgr-module-list/mgr-module-list.component';
 import { MonitorComponent } from './ceph/cluster/monitor/monitor.component';
@@ -338,6 +339,11 @@ const routes: Routes = [
         path: 'logs',
         component: LogsComponent,
         data: { breadcrumbs: 'Observability/Logs' }
+      },
+      {
+        path: 'loki-logs',
+        component: LokiLogsComponent,
+        data: { breadcrumbs: 'Observability/Centralized Logs' }
       },
       {
         path: 'telemetry',

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
@@ -67,6 +67,7 @@ import { HostsComponent } from './hosts/hosts.component';
 import { InventoryDevicesComponent } from './inventory/inventory-devices/inventory-devices.component';
 import { InventoryComponent } from './inventory/inventory.component';
 import { LogsComponent } from './logs/logs.component';
+import { LokiLogsComponent } from './loki-logs/loki-logs.component';
 import { MgrModulesModule } from './mgr-modules/mgr-modules.module';
 import { MonitorComponent } from './monitor/monitor.component';
 import { OsdCreationPreviewModalComponent } from './osd/osd-creation-preview-modal/osd-creation-preview-modal.component';
@@ -164,6 +165,7 @@ import { TextLabelListComponent } from '~/app/shared/components/text-label-list/
     OsdReweightModalComponent,
     CrushmapComponent,
     LogsComponent,
+    LokiLogsComponent,
     OsdRecvSpeedModalComponent,
     OsdPgScrubModalComponent,
     OsdRecvSpeedModalComponent,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/loki-logs/loki-logs.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/loki-logs/loki-logs.component.html
@@ -1,0 +1,98 @@
+<cd-help-text page="centralized-logs">
+  Query log files collected by Alloy and stored in Loki. Select a file, then run the query to
+  display recent log lines.
+</cd-help-text>
+
+<ng-container *ngIf="!loadingServices; else loadingTpl">
+  <cd-alert-panel type="info"
+                  title="Loki/Alloy service not running"
+                  i18n-title
+                  *ngIf="!lokiAvailable || !alloyAvailable">
+    <ng-container i18n>
+      Please start the loki and alloy services to see centralized logs.
+    </ng-container>
+  </cd-alert-panel>
+
+  <ng-container *ngIf="lokiAvailable && alloyAvailable">
+    <ng-container *ngTemplateOutlet="logFiltersTpl"></ng-container>
+
+    @if (hasRun) {
+    <div class="log-viewer"
+         [class.log-viewer--scrollable]="scrollable">
+      @if (logLines.length && showDownloadCopyButton) {
+      <div class="log-actions">
+        <cd-download-button [objectItem]="logLines"
+                            [textItem]="logText"
+                            [fileName]="downloadFileName">
+        </cd-download-button>
+        <cd-copy-2-clipboard-button [source]="logText"
+                                    [byId]="false">
+        </cd-copy-2-clipboard-button>
+      </div>
+      }
+
+      <div class="log-entries">
+        @for (line of logLines; track trackByLogEntry($index, line)) {
+        <div class="log-entry cds--type-code-01">
+          <span class="log-entry__timestamp">{{ line.stamp | cdDate }}</span>
+          <span class="log-entry__message">{{ line.message }}</span>
+        </div>
+        }
+
+        @if (logLines.length === 0 && !loadingLogs) {
+        <div class="log-viewer__empty">
+          <ng-container *ngTemplateOutlet="noEntriesTpl"></ng-container>
+        </div>
+        }
+      </div>
+    </div>
+    } @else {
+    <cd-alert-panel type="info"
+                    title="No logs loaded"
+                    i18n-title>
+      <ng-container i18n>Select a log file and click Run to load log lines from Loki.</ng-container>
+    </cd-alert-panel>
+    }
+
+    <cd-loading-panel *ngIf="loadingLogs"></cd-loading-panel>
+  </ng-container>
+</ng-container>
+
+<ng-template #logFiltersTpl>
+  <div class="loki-toolbar row mb-3">
+    <div class="col-lg-10 d-flex flex-wrap align-items-end">
+      <div class="col-md-5 me-3 mb-2">
+        <cds-combo-box type="single"
+                       label="Log file"
+                       i18n-label
+                       placeholder="Select log file"
+                       i18n-placeholder
+                       id="loki-log-file"
+                       [appendInline]="true"
+                       [disabled]="loadingFilenames || loadingLogs"
+                       [items]="filenameItems"
+                       (selected)="onFilenameSelected($event)">
+          <cds-dropdown-list></cds-dropdown-list>
+        </cds-combo-box>
+      </div>
+
+      <div class="col-md-2 me-3 mb-2">
+        <button cdsButton="primary"
+                size="md"
+                [disabled]="!selectedFilename || loadingLogs || loadingFilenames"
+                (click)="runQuery()"
+                i18n>
+          Run
+        </button>
+      </div>
+    </div>
+  </div>
+</ng-template>
+
+<ng-template #loadingTpl>
+  <cd-loading-panel></cd-loading-panel>
+</ng-template>
+
+<ng-template #noEntriesTpl>
+  <span i18n>No log entries found.</span>
+</ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/loki-logs/loki-logs.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/loki-logs/loki-logs.component.scss
@@ -1,0 +1,11 @@
+.loki-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.loki-filename-select {
+  min-width: 22rem;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/loki-logs/loki-logs.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/loki-logs/loki-logs.component.spec.ts
@@ -1,0 +1,165 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { of, throwError } from 'rxjs';
+
+import { CephServiceService } from '~/app/shared/api/ceph-service.service';
+import { LokiService } from '~/app/shared/api/loki.service';
+import { NotificationService } from '~/app/shared/services/notification.service';
+import { SharedModule } from '~/app/shared/shared.module';
+import { configureTestBed } from '~/testing/unit-test-helper';
+import { LokiLogsComponent } from './loki-logs.component';
+
+describe('LokiLogsComponent', () => {
+  let component: LokiLogsComponent;
+  let fixture: ComponentFixture<LokiLogsComponent>;
+  let lokiService: {
+    getLogFilenames: jest.Mock;
+    getLogs: jest.Mock;
+    getViewState: jest.Mock;
+    saveViewState: jest.Mock;
+    logLinesToText: jest.Mock;
+    downloadFileNameFromPath: jest.Mock;
+  };
+  let cephService: { getDaemons: jest.Mock };
+  let notificationService: { show: jest.Mock };
+
+  configureTestBed({
+    imports: [HttpClientTestingModule, SharedModule, FormsModule],
+    declarations: [LokiLogsComponent],
+    providers: [
+      {
+        provide: LokiService,
+        useValue: {
+          getLogFilenames: jest.fn(),
+          getLogs: jest.fn(),
+          getViewState: jest.fn(),
+          saveViewState: jest.fn(),
+          logLinesToText: jest.fn(),
+          downloadFileNameFromPath: jest.fn()
+        }
+      },
+      {
+        provide: CephServiceService,
+        useValue: { getDaemons: jest.fn() }
+      },
+      {
+        provide: NotificationService,
+        useValue: { show: jest.fn() }
+      }
+    ]
+  });
+
+  beforeEach(() => {
+    lokiService = TestBed.inject(LokiService) as typeof lokiService;
+    cephService = TestBed.inject(CephServiceService) as typeof cephService;
+    notificationService = TestBed.inject(NotificationService) as typeof notificationService;
+
+    lokiService.getViewState.mockReturnValue(null);
+    lokiService.logLinesToText.mockImplementation((lines) =>
+      lines.map((line) => `${line.stamp}\t${line.message}`).join('\n')
+    );
+    lokiService.downloadFileNameFromPath.mockImplementation((filename: string) => {
+      if (!filename) {
+        return 'loki_log';
+      }
+      const base = filename.split('/').pop() ?? 'loki_log';
+      return base.replace(/\.log$/, '') || 'loki_log';
+    });
+    lokiService.getLogFilenames.mockReturnValue(
+      of(['/var/log/ceph/cephadm.log', '/var/log/ceph/ceph.log'])
+    );
+    lokiService.getLogs.mockReturnValue(
+      of([
+        {
+          stamp: '2026-06-15T10:00:00.000Z',
+          message: 'test log line',
+          filename: '/var/log/ceph/cephadm.log'
+        }
+      ])
+    );
+    cephService.getDaemons.mockImplementation((service: string) => {
+      if (service === 'loki') {
+        return of([{ status: 1 }]);
+      }
+      return of([{ status: 1 }]);
+    });
+
+    fixture = TestBed.createComponent(LokiLogsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    component.ngOnDestroy();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should load filenames when services are available', () => {
+    expect(lokiService.getLogFilenames).toHaveBeenCalledWith('7d');
+    expect(component.filenameItems.length).toBe(2);
+  });
+
+  it('should restore persisted view state and fetch fresh logs on init', () => {
+    lokiService.getViewState.mockReturnValue({
+      selectedFilename: '/var/log/ceph/cephadm.log',
+      hasRun: true
+    });
+
+    const restoredFixture = TestBed.createComponent(LokiLogsComponent);
+    const restored = restoredFixture.componentInstance;
+    restoredFixture.detectChanges();
+
+    expect(restored.hasRun).toBe(true);
+    expect(restored.selectedFilename).toBe('/var/log/ceph/cephadm.log');
+    expect(restored.logLines.length).toBe(1);
+    expect(lokiService.getLogs).toHaveBeenCalledWith('/var/log/ceph/cephadm.log');
+    expect(lokiService.saveViewState).not.toHaveBeenCalledWith(
+      expect.objectContaining({ logLines: expect.anything() })
+    );
+
+    restored.ngOnDestroy();
+  });
+
+  it('should run query, persist state without log lines, and start refresh', () => {
+    jest.spyOn(window, 'setInterval').mockReturnValue(42 as unknown as number);
+
+    component.selectedFilename = '/var/log/ceph/cephadm.log';
+    component.runQuery();
+
+    expect(lokiService.getLogs).toHaveBeenCalledWith('/var/log/ceph/cephadm.log');
+    expect(component.hasRun).toBe(true);
+    expect(component.logLines.length).toBe(1);
+    expect(lokiService.saveViewState).toHaveBeenCalledWith({
+      selectedFilename: '/var/log/ceph/cephadm.log',
+      hasRun: true
+    });
+    expect(window.setInterval).toHaveBeenCalled();
+  });
+
+  it('should not fetch logs when only the filename changes', () => {
+    component.hasRun = true;
+    component.selectedFilename = '/var/log/ceph/cephadm.log';
+    lokiService.getLogs.mockClear();
+
+    component.onFilenameSelected({ content: '/var/log/ceph/ceph.log', selected: true });
+
+    expect(component.selectedFilename).toBe('/var/log/ceph/ceph.log');
+    expect(lokiService.getLogs).not.toHaveBeenCalled();
+    expect(lokiService.saveViewState).toHaveBeenCalledWith({
+      selectedFilename: '/var/log/ceph/ceph.log',
+      hasRun: true
+    });
+  });
+
+  it('should show notification when filename load fails', () => {
+    lokiService.getLogFilenames.mockReturnValue(throwError(() => 'error'));
+
+    component.loadFilenames();
+
+    expect(notificationService.show).toHaveBeenCalled();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/loki-logs/loki-logs.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/loki-logs/loki-logs.component.ts
@@ -1,0 +1,214 @@
+import { Component, NgZone, OnDestroy, OnInit } from '@angular/core';
+import { forkJoin } from 'rxjs';
+import { finalize } from 'rxjs/operators';
+
+import { ListItem } from 'carbon-components-angular';
+
+import { CephServiceService } from '~/app/shared/api/ceph-service.service';
+import { LokiService } from '~/app/shared/api/loki.service';
+import { NotificationType } from '~/app/shared/enum/notification-type.enum';
+import { LokiLogLine } from '~/app/shared/models/loki.interface';
+import { NotificationService } from '~/app/shared/services/notification.service';
+
+@Component({
+  selector: 'cd-loki-logs',
+  templateUrl: './loki-logs.component.html',
+  styleUrls: ['./loki-logs.component.scss', '../logs/logs.component.scss'],
+  standalone: false
+})
+export class LokiLogsComponent implements OnInit, OnDestroy {
+  scrollable = true;
+  showDownloadCopyButton = true;
+
+  loadingServices = true;
+  lokiAvailable = false;
+  alloyAvailable = false;
+
+  loadingFilenames = false;
+  loadingLogs = false;
+
+  filenameItems: ListItem[] = [];
+  selectedFilename = '';
+  downloadFileName = 'loki_log';
+
+  logLines: LokiLogLine[] = [];
+  logText = '';
+  hasRun = false;
+
+  private readonly refreshIntervalMs = 5000;
+  private refreshInterval?: number;
+
+  constructor(
+    private cephService: CephServiceService,
+    private lokiService: LokiService,
+    private notificationService: NotificationService,
+    private ngZone: NgZone
+  ) {}
+
+  ngOnInit(): void {
+    this.restoreViewState();
+    this.checkServices();
+  }
+
+  ngOnDestroy(): void {
+    this.stopLogRefresh();
+  }
+
+  checkServices(): void {
+    this.loadingServices = true;
+    forkJoin({
+      loki: this.cephService.getDaemons('loki'),
+      alloy: this.cephService.getDaemons('alloy')
+    })
+      .pipe(finalize(() => (this.loadingServices = false)))
+      .subscribe({
+        next: ({ loki, alloy }) => {
+          this.lokiAvailable = loki.some((d) => d.status === 1);
+          this.alloyAvailable = alloy.some((d) => d.status === 1);
+          if (this.lokiAvailable && this.alloyAvailable) {
+            this.loadFilenames();
+          }
+        },
+        error: () => {
+          this.lokiAvailable = false;
+          this.alloyAvailable = false;
+        }
+      });
+  }
+
+  loadFilenames(): void {
+    this.loadingFilenames = true;
+    this.lokiService
+      .getLogFilenames('7d')
+      .pipe(finalize(() => (this.loadingFilenames = false)))
+      .subscribe({
+        next: (filenames) => {
+          const selected = this.selectedFilename;
+          this.filenameItems = filenames.sort().map((filename) => ({
+            content: filename,
+            selected: filename === selected
+          }));
+          if (!selected && this.filenameItems.length > 0) {
+            this.selectedFilename = this.filenameItems[0].content;
+            this.filenameItems[0].selected = true;
+            this.updateDownloadFileName();
+            this.persistViewState();
+          }
+          if (this.hasRun && this.selectedFilename) {
+            this.getInfo(true);
+            this.startLogRefresh();
+          }
+        },
+        error: (resp) => {
+          this.notificationService.show(
+            NotificationType.error,
+            resp,
+            $localize`Failed to load log files`
+          );
+        }
+      });
+  }
+
+  onFilenameSelected(event: ListItem | { item: ListItem }): void {
+    const item = 'item' in event ? event.item : event;
+    const previousFilename = this.selectedFilename;
+    this.selectedFilename = item.content;
+    this.updateDownloadFileName();
+    this.persistViewState();
+
+    if (previousFilename !== this.selectedFilename) {
+      this.stopLogRefresh();
+    }
+  }
+
+  runQuery(): void {
+    if (!this.selectedFilename) {
+      return;
+    }
+
+    this.hasRun = true;
+    this.persistViewState();
+    this.getInfo(true);
+    this.startLogRefresh();
+  }
+
+  getInfo(showLoading = false): void {
+    if (!this.selectedFilename) {
+      return;
+    }
+
+    if (showLoading) {
+      this.loadingLogs = true;
+    }
+
+    this.lokiService
+      .getLogLinesForFilename(this.selectedFilename, { since: '24h', limit: 5000 })
+      .pipe(
+        finalize(() => {
+          if (showLoading) {
+            this.loadingLogs = false;
+          }
+        })
+      )
+      .subscribe({
+        next: (lines) => {
+          this.logLines = lines;
+          this.logText = this.lokiService.logLinesToText(lines);
+        },
+        error: (resp) => {
+          if (showLoading) {
+            this.notificationService.show(
+              NotificationType.error,
+              resp,
+              $localize`Failed to query logs`
+            );
+          }
+        }
+      });
+  }
+
+  trackByLogEntry(index: number, entry: LokiLogLine): string {
+    return `${entry.stamp}-${index}`;
+  }
+
+  private restoreViewState(): void {
+    const saved = this.lokiService.getViewState();
+    if (!saved) {
+      return;
+    }
+    this.selectedFilename = saved.selectedFilename;
+    this.hasRun = saved.hasRun;
+    this.updateDownloadFileName();
+  }
+
+  private persistViewState(): void {
+    this.lokiService.saveViewState({
+      selectedFilename: this.selectedFilename,
+      hasRun: this.hasRun
+    });
+  }
+
+  private startLogRefresh(): void {
+    this.stopLogRefresh();
+    this.ngZone.runOutsideAngular(() => {
+      this.refreshInterval = window.setInterval(() => {
+        this.ngZone.run(() => {
+          if (this.hasRun && this.selectedFilename) {
+            this.getInfo();
+          }
+        });
+      }, this.refreshIntervalMs);
+    });
+  }
+
+  private stopLogRefresh(): void {
+    if (this.refreshInterval !== undefined) {
+      clearInterval(this.refreshInterval);
+      this.refreshInterval = undefined;
+    }
+  }
+
+  private updateDownloadFileName(): void {
+    this.downloadFileName = this.lokiService.downloadFileNameFromPath(this.selectedFilename);
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
@@ -84,7 +84,7 @@ export class ServicesComponent extends ListWithDetails implements OnChanges, OnI
   isLoadingServices = false;
   selection: CdTableSelection = new CdTableSelection();
   icons = Icons;
-  serviceUrls = { grafana: '', prometheus: '', alertmanager: '' };
+  serviceUrls = { grafana: '', prometheus: '', alertmanager: '', loki: '' };
   isMgmtGateway: boolean = false;
   statusIconMap = CERTIFICATE_STATUS_ICON_MAP;
 
@@ -224,7 +224,7 @@ export class ServicesComponent extends ListWithDetails implements OnChanges, OnI
       this.configureServiceUrl('api/grafana/url', 'grafana');
       this.configureServiceUrl('ui-api/prometheus/prometheus-api-host', 'prometheus');
       this.configureServiceUrl('ui-api/prometheus/alertmanager-api-host', 'alertmanager');
-      this.configureServiceUrl('ui-api/loki/loki-api-host', 'loki');
+      this.configureServiceUrl('api/settings/loki-api-host', 'loki');
     }
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
@@ -224,6 +224,7 @@ export class ServicesComponent extends ListWithDetails implements OnChanges, OnI
       this.configureServiceUrl('api/grafana/url', 'grafana');
       this.configureServiceUrl('ui-api/prometheus/prometheus-api-host', 'prometheus');
       this.configureServiceUrl('ui-api/prometheus/alertmanager-api-host', 'alertmanager');
+      this.configureServiceUrl('ui-api/loki/loki-api-host', 'loki');
     }
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
@@ -307,6 +307,12 @@
                             i18n-title
                             *ngIf="permissions.log.read"
                             class="tc_submenuitem tc_submenuitem_observe_log"><span i18n>Logs</span></cds-sidenav-item>
+          <cds-sidenav-item route="/loki-logs"
+                            [useRouter]="true"
+                            title="Centralized Logs"
+                            i18n-title
+                            *ngIf="permissions.log.read"
+                            class="tc_submenuitem tc_submenuitem_observe_loki_logs"><span i18n>Centralized Logs</span></cds-sidenav-item>
           <cds-sidenav-item route="/monitoring"
                             [useRouter]="true"
                             title="Alerts"

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/loki.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/loki.service.spec.ts
@@ -1,0 +1,141 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { LokiService } from './loki.service';
+
+describe('LokiService', () => {
+  let service: LokiService;
+  let httpTesting: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [LokiService]
+    });
+    service = TestBed.inject(LokiService);
+    httpTesting = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+    localStorage.clear();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should fetch label values', () => {
+    service.getLabelValues('filename', '{job="Cluster Logs"}', { since: '7d' }).subscribe((values) => {
+      expect(values).toEqual(['/var/log/ceph/cephadm.log']);
+    });
+
+    const req = httpTesting.expectOne(
+      (request) =>
+        request.url === 'api/loki/label/filename/values' &&
+        request.params.get('params') === '{job="Cluster Logs"}' &&
+        request.params.get('since') === '7d'
+    );
+    expect(req.request.method).toBe('GET');
+    req.flush(['/var/log/ceph/cephadm.log']);
+  });
+
+  it('should fetch labels', () => {
+    service.getLabels(undefined, { since: '24h' }).subscribe((labels) => {
+      expect(labels).toEqual(['filename', 'job']);
+    });
+
+    const req = httpTesting.expectOne(
+      (request) =>
+        request.url === 'api/loki/labels' && request.params.get('since') === '24h'
+    );
+    req.flush(['filename', 'job']);
+  });
+
+  it('should run instant query', () => {
+    service.query('count_over_time({job="Cluster Logs"}[1h])').subscribe((response) => {
+      expect(response.resultType).toBe('vector');
+    });
+
+    const req = httpTesting.expectOne(
+      (request) =>
+        request.url === 'api/loki/query' &&
+        request.params.get('params') === 'count_over_time({job="Cluster Logs"}[1h])'
+    );
+    req.flush({ resultType: 'vector', result: [] });
+  });
+
+  it('should format log lines for download', () => {
+    const lines = [
+      { stamp: '2026-06-15T10:00:00.000Z', message: 'hello', filename: '/var/log/ceph/cephadm.log' }
+    ];
+    expect(service.logLinesToText(lines)).toBe('2026-06-15T10:00:00.000Z\thello');
+    expect(service.downloadFileNameFromPath('/var/log/ceph/cephadm.log')).toBe('cephadm');
+  });
+
+  it('should persist and restore view state without log lines', () => {
+    const state = {
+      selectedFilename: '/var/log/ceph/cephadm.log',
+      hasRun: true
+    };
+
+    service.saveViewState(state);
+    expect(service.getViewState()).toEqual(state);
+
+    service.clearViewState();
+    expect(service.getViewState()).toBeNull();
+  });
+
+  it('should fetch logs via getLogs', () => {
+    service.getLogs('/var/log/ceph/cephadm.log').subscribe((lines) => {
+      expect(lines.length).toBe(1);
+      expect(lines[0].message).toBe('hello');
+    });
+
+    const req = httpTesting.expectOne(
+      (request) =>
+        request.url === 'api/loki/query_range' &&
+        request.params.get('params') ===
+          '{job="Cluster Logs", filename="/var/log/ceph/cephadm.log"}' &&
+        request.params.get('since') === '24h' &&
+        request.params.get('limit') === '5000'
+    );
+    req.flush({
+      resultType: 'streams',
+      result: [
+        {
+          stream: { filename: '/var/log/ceph/cephadm.log', job: 'Cluster Logs' },
+          values: [['1740000000000000000', 'hello']]
+        }
+      ]
+    });
+  });
+
+  it('should run query_range and parse log lines', () => {
+    service
+      .getLogLinesForFilename('/var/log/ceph/cephadm.log', { since: '1h', limit: 10 })
+      .subscribe((lines) => {
+        expect(lines.length).toBe(1);
+        expect(lines[0].message).toBe('hello');
+        expect(lines[0].filename).toBe('/var/log/ceph/cephadm.log');
+      });
+
+    const req = httpTesting.expectOne(
+      (request) =>
+        request.url === 'api/loki/query_range' &&
+        request.params.get('params') ===
+          '{job="Cluster Logs", filename="/var/log/ceph/cephadm.log"}' &&
+        request.params.get('since') === '1h' &&
+        request.params.get('limit') === '10'
+    );
+    req.flush({
+      resultType: 'streams',
+      result: [
+        {
+          stream: { filename: '/var/log/ceph/cephadm.log', job: 'Cluster Logs' },
+          values: [['1740000000000000000', 'hello']]
+        }
+      ]
+    });
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/loki.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/loki.service.ts
@@ -1,0 +1,183 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import {
+  LOKI_CLUSTER_LOGS_JOB,
+  LokiLogLine,
+  LokiLogsViewState,
+  LokiQueryRangeResponse,
+  LokiQueryResponse
+} from '../models/loki.interface';
+
+export interface LokiQueryOptions {
+  since?: string;
+  start?: string;
+  end?: string;
+  limit?: number;
+  direction?: 'forward' | 'backward';
+  step?: number | string;
+  interval?: number | string;
+  time?: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LokiService {
+  private readonly baseUrl = 'api/loki';
+  private readonly viewStateStorageKey = 'dashboard_loki_logs_view';
+
+  constructor(private http: HttpClient) {}
+
+  getLabels(streamSelector?: string, options: LokiQueryOptions = {}): Observable<string[]> {
+    return this.http.get<string[]>(`${this.baseUrl}/labels`, {
+      params: this.buildHttpParams(streamSelector, options)
+    });
+  }
+
+  getLabelValues(
+    label: string,
+    streamSelector?: string,
+    options: LokiQueryOptions = {}
+  ): Observable<string[]> {
+    return this.http.get<string[]>(`${this.baseUrl}/label/${label}/values`, {
+      params: this.buildHttpParams(streamSelector, options)
+    });
+  }
+
+  getLogFilenames(since = '7d'): Observable<string[]> {
+    return this.getLabelValues('filename', `{job="${LOKI_CLUSTER_LOGS_JOB}"}`, { since });
+  }
+
+  query(logql: string, options: LokiQueryOptions = {}): Observable<LokiQueryResponse> {
+    return this.http.get<LokiQueryResponse>(`${this.baseUrl}/query`, {
+      params: this.buildHttpParams(logql, options)
+    });
+  }
+
+  queryRange(logql: string, options: LokiQueryOptions = {}): Observable<LokiQueryRangeResponse> {
+    return this.http.get<LokiQueryRangeResponse>(`${this.baseUrl}/query_range`, {
+      params: this.buildHttpParams(logql, options)
+    });
+  }
+
+  // getLogs(filename: string): Observable<LokiLogLine[]> {
+  //   return this.getLogLinesForFilename(filename, { since: '24h', limit: 5000 });
+  // }
+
+  getLogLinesForFilename(
+    filename: string,
+    options: LokiQueryOptions = {}
+  ): Observable<LokiLogLine[]> {
+    const logql = this.buildFilenameQuery(filename);
+    const queryOptions: LokiQueryOptions = {
+      since: '24h',
+      limit: 1000,
+      direction: 'backward',
+      ...options
+    };
+    return this.queryRange(logql, queryOptions).pipe(
+      map((response) => this.parseLogLines(response, filename))
+    );
+  }
+
+  getViewState(): LokiLogsViewState | null {
+    try {
+      const raw = localStorage.getItem(this.viewStateStorageKey);
+      if (!raw) {
+        return null;
+      }
+      return JSON.parse(raw) as LokiLogsViewState;
+    } catch {
+      return null;
+    }
+  }
+
+  saveViewState(state: LokiLogsViewState): void {
+    localStorage.setItem(this.viewStateStorageKey, JSON.stringify(state));
+  }
+
+  clearViewState(): void {
+    localStorage.removeItem(this.viewStateStorageKey);
+  }
+
+  logLinesToText(lines: LokiLogLine[]): string {
+    return lines.map((line) => `${line.stamp}\t${line.message}`).join('\n');
+  }
+
+  downloadFileNameFromPath(filename: string): string {
+    if (!filename) {
+      return 'loki_log';
+    }
+    const base = filename.split('/').pop() ?? 'loki_log';
+    return base.replace(/\.log$/, '') || 'loki_log';
+  }
+
+  buildFilenameQuery(filename: string): string {
+    const escaped = filename.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    return `{job="${LOKI_CLUSTER_LOGS_JOB}", filename="${escaped}"}`;
+  }
+
+  parseLogLines(response: LokiQueryRangeResponse, defaultFilename = ''): LokiLogLine[] {
+    if (!response?.result?.length) {
+      return [];
+    }
+
+    const lines: LokiLogLine[] = [];
+    response.result.forEach((stream) => {
+      const filename = stream.stream?.filename ?? defaultFilename;
+      stream.values?.forEach(([timestampNs, message]) => {
+        lines.push({
+          stamp: this.timestampNsToIso(timestampNs),
+          message,
+          filename
+        });
+      });
+    });
+
+    return lines.sort((a, b) => b.stamp.localeCompare(a.stamp));
+  }
+
+  private buildHttpParams(logql: string | undefined, options: LokiQueryOptions): HttpParams {
+    let params = new HttpParams();
+    if (logql) {
+      params = params.set('params', logql);
+    }
+    if (options.since) {
+      params = params.set('since', options.since);
+    }
+    if (options.start) {
+      params = params.set('start', options.start);
+    }
+    if (options.end) {
+      params = params.set('end', options.end);
+    }
+    if (options.limit !== undefined) {
+      params = params.set('limit', String(options.limit));
+    }
+    if (options.direction) {
+      params = params.set('direction', options.direction);
+    }
+    if (options.step !== undefined) {
+      params = params.set('step', String(options.step));
+    }
+    if (options.interval !== undefined) {
+      params = params.set('interval', String(options.interval));
+    }
+    if (options.time) {
+      params = params.set('time', options.time);
+    }
+    return params;
+  }
+
+  private timestampNsToIso(timestampNs: string): string {
+    const ms = Math.floor(Number(timestampNs) / 1_000_000);
+    if (Number.isNaN(ms)) {
+      return timestampNs;
+    }
+    return new Date(ms).toISOString();
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/loki.interface.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/loki.interface.ts
@@ -1,0 +1,34 @@
+export interface LokiStreamValue {
+  stream: Record<string, string>;
+  values: [string, string][];
+}
+
+export interface LokiQueryRangeResponse {
+  resultType: 'streams' | 'matrix' | 'vector';
+  result: LokiStreamValue[];
+  stats?: Record<string, unknown>;
+}
+
+export interface LokiQueryResponse {
+  resultType: 'streams' | 'matrix' | 'vector';
+  result: LokiStreamValue[] | LokiInstantVector[];
+  stats?: Record<string, unknown>;
+}
+
+export interface LokiInstantVector {
+  metric: Record<string, string>;
+  value: [number, string];
+}
+
+export interface LokiLogLine {
+  stamp: string;
+  message: string;
+  filename: string;
+}
+
+export interface LokiLogsViewState {
+  selectedFilename: string;
+  hasRun: boolean;
+}
+
+export const LOKI_CLUSTER_LOGS_JOB = 'Cluster Logs';

--- a/src/pybind/mgr/dashboard/settings.py
+++ b/src/pybind/mgr/dashboard/settings.py
@@ -90,6 +90,10 @@ class Options(object):
     ALERTMANAGER_API_SSL_VERIFY = Setting(True, [bool])
     PROM_ALERT_CREDENTIAL_CACHE_TTL = Setting(60, [int])
 
+    # Loki settings
+    LOKI_API_HOST = Setting('', [str])
+    LOKI_API_SSL_VERIFY = Setting(True, [bool])
+
     # iSCSI management settings
     ISCSI_API_SSL_VERIFICATION = Setting(True, [bool])
 

--- a/src/pybind/mgr/dashboard/tests/test_loki.py
+++ b/src/pybind/mgr/dashboard/tests/test_loki.py
@@ -7,7 +7,7 @@ except ImportError:
 from requests import Response
 
 from .. import mgr
-from ..controllers.loki import Loki, LokiSettings
+from ..controllers.loki import Loki
 from ..tests import ControllerTestCase
 
 
@@ -21,7 +21,7 @@ class LokiControllerTest(ControllerTestCase):
             'LOKI_API_HOST': cls.loki_host,
         }
         mgr.get_module_option.side_effect = settings.get
-        cls.setup_controllers([Loki, LokiSettings])
+        cls.setup_controllers([Loki])
 
     @patch('requests.request')
     def test_query(self, mock_request):
@@ -36,10 +36,7 @@ class LokiControllerTest(ControllerTestCase):
             self.loki_host_api + '/query',
             json=None,
             params={'query': 'sum(rate({job="varlogs"}[10m]))'},
-            verify=True,
-            cert=None,
-            auth=None,
-            headers=None)
+            verify=True)
         self.assertStatus(200)
 
     @patch('requests.request')
@@ -59,10 +56,7 @@ class LokiControllerTest(ControllerTestCase):
             params={'query': '{job="varlogs"}',
                     'start': '1609459200000000000',
                     'end': '1609462800000000000'},
-            verify=True,
-            cert=None,
-            auth=None,
-            headers=None)
+            verify=True)
         self.assertStatus(200)
 
     @patch('requests.request')
@@ -78,10 +72,7 @@ class LokiControllerTest(ControllerTestCase):
             self.loki_host_api + '/labels',
             json=None,
             params={'since': '6h'},
-            verify=True,
-            cert=None,
-            auth=None,
-            headers=None)
+            verify=True)
         self.assertStatus(200)
         self.assertJsonBody(['filename', 'job'])
 
@@ -99,10 +90,7 @@ class LokiControllerTest(ControllerTestCase):
             self.loki_host_api + '/label/job/values',
             json=None,
             params={'query': '{job="Cluster Logs"}', 'since': '24h'},
-            verify=True,
-            cert=None,
-            auth=None,
-            headers=None)
+            verify=True)
         self.assertStatus(200)
         self.assertJsonBody(['Cluster Logs'])
 
@@ -116,72 +104,9 @@ class LokiControllerTest(ControllerTestCase):
         self._get('/api/loki/query', params={'params': 'invalid'})
         self.assertStatus(400)
 
-    @patch('dashboard.controllers.loki.LokiRESTController._discover_loki_host')
-    @patch('requests.request')
-    def test_query_discovers_loki_host_when_unconfigured(self, mock_request, mock_discover):
-        mgr.get_module_option.side_effect = lambda name, default=None: ''
-        mock_discover.return_value = self.loki_host
-
-        r = Response()
-        r.status_code = 200
-        r._content = b'{"status":"success","data":{"resultType":"vector","result":[]}}'
-        mock_request.return_value = r
-
-        self._get('/api/loki/query', params={'params': '{job="Cluster Logs"}'})
-        mock_discover.assert_called_once()
-        mock_request.assert_called_with(
-            'GET',
-            self.loki_host_api + '/query',
-            json=None,
-            params={'query': '{job="Cluster Logs"}'},
-            verify=True,
-            cert=None,
-            auth=None,
-            headers=None)
-        self.assertStatus(200)
-
-    @patch('dashboard.controllers.loki.LokiRESTController._discover_loki_host', return_value=None)
-    def test_query_unconfigured_host(self, mock_discover):
+    def test_query_unconfigured_host(self):
         mgr.get_module_option.side_effect = lambda name, default=None: ''
 
         self._get('/api/loki/query', params={'params': '{job="Cluster Logs"}'})
         self.assertStatus(503)
         self.assertIn(b'Loki API host is not configured', self.body)
-
-    @patch("dashboard.controllers.loki.mgr.get_module_option_ex", return_value='cephadm')
-    @patch('dashboard.controllers.loki.mgr.get_localized_store', return_value=None)
-    @patch('dashboard.services.orchestrator.OrchClient.instance')
-    @patch('dashboard.services.orchestrator.OrchClient.status', return_value={'available': True})
-    @patch('dashboard.services.orchestrator.OrchClient.available', return_value=True)
-    @patch('requests.request')
-    def test_label_values_with_secure_stack(self, mock_request, _mock_available,
-                                            _mock_status, mock_instance,
-                                            _mock_get_localized_store,
-                                            _mock_get_module_option_ex):
-        fake_orch = mock_instance.return_value
-        fake_orch.monitoring.get_security_config.return_value = {'security_enabled': True}
-        fake_orch.monitoring.get_prometheus_access_info.return_value = {
-            'user': 'loki-user',
-            'password': 'loki-password',
-            'certificate': 'ca-cert',
-        }
-
-        r = Response()
-        r.status_code = 200
-        r._content = b'{"status":"success","data":["/var/log/ceph/cephadm.log"]}'
-        mock_request.return_value = r
-
-        self._get('/api/loki/label/filename/values',
-                  params={'params': '{job="Cluster Logs"}', 'since': '24h'})
-        self.assertIsNotNone(mock_request.call_args.kwargs['auth'])
-        self.assertStatus(200)
-
-    def test_loki_settings(self):
-        self._get('/ui-api/loki/loki-api-host')
-        self.assertStatus(200)
-        self.assertJsonBody({
-            'name': 'LOKI_API_HOST',
-            'default': '',
-            'type': 'str',
-            'value': self.loki_host
-        })

--- a/src/pybind/mgr/dashboard/tests/test_loki.py
+++ b/src/pybind/mgr/dashboard/tests/test_loki.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+try:
+    from mock import patch
+except ImportError:
+    from unittest.mock import patch
+
+from requests import Response
+
+from .. import mgr
+from ..controllers.loki import Loki
+from ..tests import ControllerTestCase
+
+
+class LokiControllerTest(ControllerTestCase):
+    loki_host = 'http://loki:3100'
+    loki_host_api = loki_host + '/loki/api/v1'
+
+    @classmethod
+    def setup_server(cls):
+        settings = {
+            'LOKI_API_HOST': cls.loki_host,
+        }
+        mgr.get_module_option.side_effect = settings.get
+        cls.setup_controllers([Loki])
+
+    @patch('requests.request')
+    def test_query(self, mock_request):
+        r = Response()
+        r.status_code = 200
+        r._content = b'{"status":"success","data":{"resultType":"vector","result":[]}}'
+        mock_request.return_value = r
+
+        self._get('/api/loki/query', params={'params': 'sum(rate({job="varlogs"}[10m]))'})
+        mock_request.assert_called_with(
+            'GET',
+            self.loki_host_api + '/query',
+            json=None,
+            params={'query': 'sum(rate({job="varlogs"}[10m]))'},
+            verify=True)
+        self.assertStatus(200)
+
+    @patch('requests.request')
+    def test_query_range(self, mock_request):
+        r = Response()
+        r.status_code = 200
+        r._content = b'{"status":"success","data":{"resultType":"streams","result":[]}}'
+        mock_request.return_value = r
+
+        self._get('/api/loki/query_range',
+                  params={'params': '{job="varlogs"}', 'start': '1609459200000000000',
+                          'end': '1609462800000000000'})
+        mock_request.assert_called_with(
+            'GET',
+            self.loki_host_api + '/query_range',
+            json=None,
+            params={'query': '{job="varlogs"}',
+                    'start': '1609459200000000000',
+                    'end': '1609462800000000000'},
+            verify=True)
+        self.assertStatus(200)
+
+    @patch('requests.request')
+    def test_query_error(self, mock_request):
+        r = Response()
+        r.status_code = 200
+        r._content = b'{"status":"error","error":"parse error"}'
+        mock_request.return_value = r
+
+        self._get('/api/loki/query', params={'params': 'invalid'})
+        self.assertStatus(400)

--- a/src/pybind/mgr/dashboard/tests/test_loki.py
+++ b/src/pybind/mgr/dashboard/tests/test_loki.py
@@ -7,7 +7,7 @@ except ImportError:
 from requests import Response
 
 from .. import mgr
-from ..controllers.loki import Loki
+from ..controllers.loki import Loki, LokiSettings
 from ..tests import ControllerTestCase
 
 
@@ -21,7 +21,7 @@ class LokiControllerTest(ControllerTestCase):
             'LOKI_API_HOST': cls.loki_host,
         }
         mgr.get_module_option.side_effect = settings.get
-        cls.setup_controllers([Loki])
+        cls.setup_controllers([Loki, LokiSettings])
 
     @patch('requests.request')
     def test_query(self, mock_request):
@@ -36,7 +36,10 @@ class LokiControllerTest(ControllerTestCase):
             self.loki_host_api + '/query',
             json=None,
             params={'query': 'sum(rate({job="varlogs"}[10m]))'},
-            verify=True)
+            verify=True,
+            cert=None,
+            auth=None,
+            headers=None)
         self.assertStatus(200)
 
     @patch('requests.request')
@@ -56,8 +59,52 @@ class LokiControllerTest(ControllerTestCase):
             params={'query': '{job="varlogs"}',
                     'start': '1609459200000000000',
                     'end': '1609462800000000000'},
-            verify=True)
+            verify=True,
+            cert=None,
+            auth=None,
+            headers=None)
         self.assertStatus(200)
+
+    @patch('requests.request')
+    def test_labels(self, mock_request):
+        r = Response()
+        r.status_code = 200
+        r._content = b'{"status":"success","data":["filename","job"]}'
+        mock_request.return_value = r
+
+        self._get('/api/loki/labels', params={'since': '6h'})
+        mock_request.assert_called_with(
+            'GET',
+            self.loki_host_api + '/labels',
+            json=None,
+            params={'since': '6h'},
+            verify=True,
+            cert=None,
+            auth=None,
+            headers=None)
+        self.assertStatus(200)
+        self.assertJsonBody(['filename', 'job'])
+
+    @patch('requests.request')
+    def test_label_values(self, mock_request):
+        r = Response()
+        r.status_code = 200
+        r._content = b'{"status":"success","data":["Cluster Logs"]}'
+        mock_request.return_value = r
+
+        self._get('/api/loki/label/job/values',
+                  params={'params': '{job="Cluster Logs"}', 'since': '24h'})
+        mock_request.assert_called_with(
+            'GET',
+            self.loki_host_api + '/label/job/values',
+            json=None,
+            params={'query': '{job="Cluster Logs"}', 'since': '24h'},
+            verify=True,
+            cert=None,
+            auth=None,
+            headers=None)
+        self.assertStatus(200)
+        self.assertJsonBody(['Cluster Logs'])
 
     @patch('requests.request')
     def test_query_error(self, mock_request):
@@ -68,3 +115,73 @@ class LokiControllerTest(ControllerTestCase):
 
         self._get('/api/loki/query', params={'params': 'invalid'})
         self.assertStatus(400)
+
+    @patch('dashboard.controllers.loki.LokiRESTController._discover_loki_host')
+    @patch('requests.request')
+    def test_query_discovers_loki_host_when_unconfigured(self, mock_request, mock_discover):
+        mgr.get_module_option.side_effect = lambda name, default=None: ''
+        mock_discover.return_value = self.loki_host
+
+        r = Response()
+        r.status_code = 200
+        r._content = b'{"status":"success","data":{"resultType":"vector","result":[]}}'
+        mock_request.return_value = r
+
+        self._get('/api/loki/query', params={'params': '{job="Cluster Logs"}'})
+        mock_discover.assert_called_once()
+        mock_request.assert_called_with(
+            'GET',
+            self.loki_host_api + '/query',
+            json=None,
+            params={'query': '{job="Cluster Logs"}'},
+            verify=True,
+            cert=None,
+            auth=None,
+            headers=None)
+        self.assertStatus(200)
+
+    @patch('dashboard.controllers.loki.LokiRESTController._discover_loki_host', return_value=None)
+    def test_query_unconfigured_host(self, mock_discover):
+        mgr.get_module_option.side_effect = lambda name, default=None: ''
+
+        self._get('/api/loki/query', params={'params': '{job="Cluster Logs"}'})
+        self.assertStatus(503)
+        self.assertIn(b'Loki API host is not configured', self.body)
+
+    @patch("dashboard.controllers.loki.mgr.get_module_option_ex", return_value='cephadm')
+    @patch('dashboard.controllers.loki.mgr.get_localized_store', return_value=None)
+    @patch('dashboard.services.orchestrator.OrchClient.instance')
+    @patch('dashboard.services.orchestrator.OrchClient.status', return_value={'available': True})
+    @patch('dashboard.services.orchestrator.OrchClient.available', return_value=True)
+    @patch('requests.request')
+    def test_label_values_with_secure_stack(self, mock_request, _mock_available,
+                                            _mock_status, mock_instance,
+                                            _mock_get_localized_store,
+                                            _mock_get_module_option_ex):
+        fake_orch = mock_instance.return_value
+        fake_orch.monitoring.get_security_config.return_value = {'security_enabled': True}
+        fake_orch.monitoring.get_prometheus_access_info.return_value = {
+            'user': 'loki-user',
+            'password': 'loki-password',
+            'certificate': 'ca-cert',
+        }
+
+        r = Response()
+        r.status_code = 200
+        r._content = b'{"status":"success","data":["/var/log/ceph/cephadm.log"]}'
+        mock_request.return_value = r
+
+        self._get('/api/loki/label/filename/values',
+                  params={'params': '{job="Cluster Logs"}', 'since': '24h'})
+        self.assertIsNotNone(mock_request.call_args.kwargs['auth'])
+        self.assertStatus(200)
+
+    def test_loki_settings(self):
+        self._get('/ui-api/loki/loki-api-host')
+        self.assertStatus(200)
+        self.assertJsonBody({
+            'name': 'LOKI_API_HOST',
+            'default': '',
+            'type': 'str',
+            'value': self.loki_host
+        })


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/77452
Signed-off-by: Devika Babrekar <devika.babrekar@ibm.com>

https://github.com/user-attachments/assets/0e22c1ef-5586-47a9-a299-40712bc65d0a



Configurations:
1. Go to Administration -> Services. Configure Loki and Alloy services.
2. Configure grafana service (with password). 
3. Go to Administration -> Manager Module -> Dashboard -> Edit. Set LOKI_API_HOST = http://192.168.100.100:3100 click on Update
4. Go to Administration -> Configuration. Update variables log_to_file and mon_cluster_log_to_file, set global = true

https://github.com/user-attachments/assets/9b2b3484-7f9f-437f-8181-1efc349fbe4a



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
