### PR TITLE
crimson: fix malformed logging message and enable compile-time fmt check

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -446,6 +446,8 @@ else()
   set(BUILD_SHARED_LIBS ${old_BUILD_SHARED_LIBS})
   unset(old_BUILD_SHARED_LIBS)
   include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/src/fmt/include")
+  get_target_property(FMT_VERSION fmt VERSION)
+  set(fmt_VERSION "${FMT_VERSION}")
 endif()
 
 # in osd/PeeringState.h, the number of elements in PeeringState::Active::reactions

--- a/src/crimson/net/io_handler.cc
+++ b/src/crimson/net/io_handler.cc
@@ -1293,6 +1293,14 @@ IOHandler::shard_states_t::notify_out_dispatching_stopped(
   }
 }
 
+void
+IOHandler::shard_states_t::abort_wrong_io_state(SocketConnection &conn)
+{
+  logger().error("{} try_enter_out_dispatching() got wrong io_state {}",
+                 conn, io_state);
+  ceph_abort_msg("impossible");
+}
+
 seastar::future<>
 IOHandler::shard_states_t::wait_io_exit_dispatching()
 {

--- a/src/crimson/net/io_handler.h
+++ b/src/crimson/net/io_handler.h
@@ -326,12 +326,15 @@ public:
         // do not dispatch out
         return false;
       default:
-        crimson::get_logger(ceph_subsys_ms).error(
-          "{} try_enter_out_dispatching() got wrong io_state {}",
-          conn, io_state);
-        ceph_abort_msg("impossible");
+        abort_wrong_io_state(conn);
       }
     }
+
+    // defined out of line: logging io_state_t here, inside IOHandler, would
+    // instantiate fmt::formatter<io_state_t> before it is declared (it can
+    // only be declared after IOHandler). only this impossible-state path
+    // formats it, so keep the hot switch inline and move the abort out.
+    [[noreturn]] void abort_wrong_io_state(SocketConnection &conn);
 
     void notify_out_dispatching_stopped(
         const char *what, SocketConnection &conn);

--- a/src/crimson/os/seastore/lba/lba_btree_node.h
+++ b/src/crimson/os/seastore/lba/lba_btree_node.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string.h>
 
+#include <fmt/ostream.h>
 
 #include "include/buffer.h"
 
@@ -23,6 +24,16 @@
 namespace crimson::os::seastore {
 class LogicalChildNode;
 }
+
+namespace crimson::os::seastore::lba {
+struct LBALeafNode;
+}
+
+// declared ahead of the struct so the consteval {fmt} check sees it from
+// LBALeafNode's own inline logging methods.
+#if FMT_VERSION >= 90000
+template <> struct fmt::formatter<crimson::os::seastore::lba::LBALeafNode> : fmt::ostream_formatter {};
+#endif
 
 namespace crimson::os::seastore::lba {
 
@@ -470,6 +481,5 @@ using LBACursorRef = boost::intrusive_ptr<LBACursor>;
 template <> struct fmt::formatter<crimson::os::seastore::lba::lba_node_meta_t> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<crimson::os::seastore::lba::lba_map_val_t> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<crimson::os::seastore::lba::LBAInternalNode> : fmt::ostream_formatter {};
-template <> struct fmt::formatter<crimson::os::seastore::lba::LBALeafNode> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<crimson::os::seastore::lba::LBACursor> : fmt::ostream_formatter {};
 #endif

--- a/src/crimson/os/seastore/object_data_handler.cc
+++ b/src/crimson/os/seastore/object_data_handler.cc
@@ -4,9 +4,22 @@
 #include <utility>
 #include <functional>
 
+#include <fmt/ostream.h>
+
 #include "crimson/common/log.h"
 
 #include "crimson/os/seastore/object_data_handler.h"
+
+// declared ahead of the logging functions below so the consteval {fmt}
+// check can see them at the call sites.
+#if FMT_VERSION >= 90000
+template <> struct fmt::formatter<crimson::os::seastore::overwrite_range_t>
+  : fmt::ostream_formatter {};
+template <> struct fmt::formatter<crimson::os::seastore::data_t>
+  : fmt::ostream_formatter {};
+template <> struct fmt::formatter<crimson::os::seastore::edge_t>
+  : fmt::ostream_formatter {};
+#endif
 
 namespace {
   seastar::logger& logger() {
@@ -1881,11 +1894,3 @@ ObjectDataHandler::rename(context_t ctx)
 
 } // namespace crimson::os::seastore
 
-#if FMT_VERSION >= 90000
-template <> struct fmt::formatter<crimson::os::seastore::overwrite_range_t>
-  : fmt::ostream_formatter {};
-template <> struct fmt::formatter<crimson::os::seastore::data_t>
-  : fmt::ostream_formatter {};
-template <> struct fmt::formatter<crimson::os::seastore::edge_t>
-  : fmt::ostream_formatter {};
-#endif

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
@@ -7,6 +7,8 @@
 #include <exception>
 #include <sstream>
 
+#include <fmt/std.h>  // for fmt::formatter<std::error_code>
+
 #include "common/likely.h"
 #include "crimson/common/utility.h"
 #include "crimson/os/seastore/logging.h"
@@ -693,7 +695,7 @@ eagain_ifuture<Ref<Node>> Node::load(
     crimson::ct_error::all_same_way(
       [FNAME, c, addr, expect_is_level_tail](const auto &e) {
       ERRORT("{} -- addr={}, is_level_tail={}",
-        c.t, addr, expect_is_level_tail);
+        c.t, e, addr, expect_is_level_tail);
       ceph_abort();
       return eagain_iertr::make_ready_future<NodeExtentRef>();
     })

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/dummy.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/dummy.h
@@ -11,11 +11,21 @@
 
 #include "crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager.h"
 
+#include <fmt/ostream.h>
+
 /**
  * dummy.h
  *
  * Dummy backend implementations for test purposes.
  */
+
+namespace crimson::os::seastore::onode {
+class DummyNodeExtent;
+}
+
+#if FMT_VERSION >= 90000
+template <> struct fmt::formatter<crimson::os::seastore::onode::DummyNodeExtent> : fmt::ostream_formatter {};
+#endif
 
 namespace crimson::os::seastore::onode {
 
@@ -191,7 +201,3 @@ class DummyNodeExtentManager final: public NodeExtentManager {
 };
 
 }
-
-#if FMT_VERSION >= 90000
-template <> struct fmt::formatter<crimson::os::seastore::onode::DummyNodeExtent> : fmt::ostream_formatter {};
-#endif

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -624,7 +624,7 @@ bool ClientRequest::is_misdirected_replica_read(const PG& pg) const
       flags & CEPH_OSD_FLAG_BALANCE_READS ||
       flags & CEPH_OSD_FLAG_LOCALIZE_READS) {
     if (op_info.rwordered()) {
-      DEBUGDPP("{}: dropping - rwoedered with balanced/localize read {}", pg, *this);
+      DEBUGDPP("dropping - reordered with balanced/localize read {}", pg, *this);
       return true;
     }
     if (!op_info.may_read()) {

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -760,7 +760,7 @@ PG::interruptible_future<bool> PG::do_recover_missing(
   }
   DEBUGDPP(
     "reqid {} need to wait for recovery, {} version {}",
-    *this, reqid, soid);
+    *this, reqid, soid, ver);
   if (recovery_backend->is_recovering(soid)) {
     DEBUGDPP(
       "reqid {} object {} version {}, already recovering",

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -11,6 +11,8 @@
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/sharded.hh>
 
+#include <fmt/ostream.h>
+
 #include "common/dout.h"
 #include "common/ostream_temp.h"
 #include "include/interval_set.h"
@@ -66,6 +68,16 @@ namespace crimson::net {
 namespace crimson::os {
   class FuturizedStore;
 }
+
+namespace crimson::osd {
+class PG;
+}
+
+// declared ahead of the class so the consteval {fmt} check can see it from
+// PG's own inline logging methods (which format *this) above the class.
+#if FMT_VERSION >= 90000
+template <> struct fmt::formatter<crimson::osd::PG> : fmt::ostream_formatter {};
+#endif
 
 namespace crimson::osd {
 class OpsExecuter;
@@ -1356,7 +1368,3 @@ struct PG::do_osd_ops_params_t {
 std::ostream& operator<<(std::ostream&, const PG& pg);
 
 }
-
-#if FMT_VERSION >= 90000
-template <> struct fmt::formatter<crimson::osd::PG> : fmt::ostream_formatter {};
-#endif

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -1451,7 +1451,7 @@ PGBackend::omap_get_keys(
   object_stat_sum_t& delta_stats) const
 {
   if (!os.exists || os.oi.is_whiteout()) {
-    logger().debug("{}: object does not exist: {}", os.oi.soid);
+    logger().debug("object does not exist: {}", os.oi.soid);
     co_await ll_read_ierrorator::future<>(crimson::ct_error::enoent::make());
   }
   std::string start_after;
@@ -1545,7 +1545,7 @@ PGBackend::omap_cmp(
   object_stat_sum_t& delta_stats) const
 {
   if (!os.exists || os.oi.is_whiteout()) {
-    logger().debug("{}: object does not exist: {}", os.oi.soid);
+    logger().debug("object does not exist: {}", os.oi.soid);
     return crimson::ct_error::enoent::make();
   }
 
@@ -1581,7 +1581,7 @@ PGBackend::omap_get_vals(
   object_stat_sum_t& delta_stats) const
 {
   if (!os.exists || os.oi.is_whiteout()) {
-    logger().debug("{}: object does not exist: {}", os.oi.soid);
+    logger().debug("object does not exist: {}", os.oi.soid);
     co_await ll_read_ierrorator::future<>(crimson::ct_error::enoent::make());
   }
   std::string start_after;
@@ -1778,7 +1778,7 @@ PGBackend::omap_clear(
   object_stat_sum_t& delta_stats)
 {
   if (!os.exists || os.oi.is_whiteout()) {
-    logger().debug("{}: object does not exist: {}", os.oi.soid);
+    logger().debug("object does not exist: {}", os.oi.soid);
     return crimson::ct_error::enoent::make();
   }
   if (!os.oi.is_omap()) {

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -933,7 +933,7 @@ seastar::future<Ref<PG>> ShardServices::handle_pg_create_info(
 	  const spg_t &pgid = info->pgid;
 	  if (!get_map()->is_up_acting_osd_shard(pgid, local_state.whoami)
 	      || !startmap->is_up_acting_osd_shard(pgid, local_state.whoami)) {
-	    DEBUG("ignore pgid {}, doesn't exist anymore, discarding");
+	    DEBUG("ignore pgid {}, doesn't exist anymore, discarding", pgid);
 	    local_state.pg_map.pg_creation_canceled(pgid);
 	    return seastar::make_ready_future<
 	      std::tuple<Ref<PG>, OSDMapService::cached_map_t>

--- a/src/crimson/osd/watch.cc
+++ b/src/crimson/osd/watch.cc
@@ -11,12 +11,22 @@
 
 #include "messages/MWatchNotify.h"
 
+#include <fmt/ostream.h>
+
 
 namespace {
   seastar::logger& logger() {
     return crimson::get_logger(ceph_subsys_osd);
   }
 }
+
+namespace crimson::osd {
+class WatchTimeoutRequest;
+}
+
+#if FMT_VERSION >= 90000
+template <> struct fmt::formatter<crimson::osd::WatchTimeoutRequest> : fmt::ostream_formatter {};
+#endif
 
 namespace crimson::osd {
 
@@ -348,7 +358,3 @@ void Notify::do_notify_timeout()
 }
 
 } // namespace crimson::osd
-
-#if FMT_VERSION >= 90000
-template <> struct fmt::formatter<crimson::osd::WatchTimeoutRequest> : fmt::ostream_formatter {};
-#endif

--- a/src/osd/osd_types_fmt.h
+++ b/src/osd/osd_types_fmt.h
@@ -8,6 +8,11 @@
 
 #include "common/hobject.h"
 #include "include/types_fmt.h"
+// formatter<osd_reqid_t> below formats req_id.name (entity_name_t), so its
+// formatter must be visible here, otherwise it gets instantiated before
+// msg_fmt.h is pulled in by a later include (explicit-specialization-after-
+// instantiation under compile-time {fmt} checking).
+#include "msg/msg_fmt.h"
 #include "osd/osd_types.h"
 #include <fmt/chrono.h>
 #include <fmt/ranges.h>


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
