### PR TITLE
umbrella: crimson/osd: fix PGBackend::remove() to return ENOENT on no-op deletes

### DIFF
--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -1022,16 +1022,12 @@ PGBackend::remove(ObjectState& os, ceph::os::Transaction& txn,
   int num_bytes)
 {
   if (!os.exists) {
-    return crimson::ct_error::enoent::make();
-  }
-
-  if (!os.exists) {
     logger().debug("{} {} does not exist",__func__, os.oi.soid);
-    return seastar::now();
+    return crimson::ct_error::enoent::make();
   }
   if (whiteout && os.oi.is_whiteout()) {
     logger().debug("{} whiteout set on {} ",__func__, os.oi.soid);
-    return seastar::now();
+    return crimson::ct_error::enoent::make();
   }
   txn.remove(coll->get_cid(),
 	     ghobject_t{os.oi.soid, ghobject_t::NO_GEN, get_shard()});


### PR DESCRIPTION
PGBackend::remove() was returning success when asked to delete a non-existent object or an already-whiteout object that must remain a whiteout. The classic OSD returns -ENOENT in both cases. Fix both paths to return enoent, and remove the duplicate !os.exists check.

Fixes: https://tracker.ceph.com/issues/77409
Original tracker: https://tracker.ceph.com/issues/76529
Backport of: https://github.com/ceph/ceph/pull/69415
(cherry picked from commit cae12eccddf0499f9c4dffa75ee23fd4b088ffb3)

