### PR TITLE
os/bluestore: add new allocator perf counters for  allocator lock wait and processing latency

### DIFF
--- a/src/os/bluestore/AllocatorBase.cc
+++ b/src/os/bluestore/AllocatorBase.cc
@@ -215,13 +215,18 @@ void AllocatorPerf::_init_logger(std::string_view name) {
 
   b.add_time_avg(l_bluestore_allocator_alloc_process_lat,
     "alloc_process_lat",
-    "Allocator processing latency",
+    "Allocator processing latency while holding lock",
     "apl",
     PerfCountersBuilder::PRIO_USEFUL);
   b.add_time_avg(l_bluestore_allocator_lock_wait_lat,
     "lock_wait_lat",
     "Allocator lock wait latency",
     "lwl",
+    PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_allocator_nolock_process_lat,
+    "nolock_process_lat",
+    "Allocator lockless fast-path allocation latency",
+    "fpl",
     PerfCountersBuilder::PRIO_USEFUL);
 
   logger = b.create_perf_counters();

--- a/src/os/bluestore/AllocatorBase.cc
+++ b/src/os/bluestore/AllocatorBase.cc
@@ -207,3 +207,31 @@ void AllocatorBase::FreeStateHistogram::foreach(
     ++i;
   }
 }
+void AllocatorPerf::_init_logger(std::string_view name) {
+  PerfCountersBuilder b(cct,
+                        "bluestore-alloc-" + std::string(name),
+                        l_bluestore_allocator_first,
+                        l_bluestore_allocator_last);
+
+  b.add_time_avg(l_bluestore_allocator_alloc_process_lat,
+    "alloc_process_lat",
+    "Allocator processing latency",
+    "apl",
+    PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_allocator_lock_wait_lat,
+    "lock_wait_lat",
+    "Allocator lock wait latency",
+    "lwl",
+    PerfCountersBuilder::PRIO_USEFUL);
+
+  logger = b.create_perf_counters();
+
+  cct->get_perfcounters_collection()->add(logger);
+}
+void AllocatorPerf::_shutdown_logger() {
+  if (logger) {
+    cct->get_perfcounters_collection()->remove(logger);
+    delete logger;
+    logger = nullptr;
+  }
+}

--- a/src/os/bluestore/AllocatorBase.h
+++ b/src/os/bluestore/AllocatorBase.h
@@ -19,6 +19,15 @@
 #include "bluestore_types.h"
 #include "common/ceph_mutex.h"
 #include "Allocator.h"
+#include "common/perf_counters.h"
+#include "common/perf_counters_collection.h"
+
+enum {
+  l_bluestore_allocator_first = 732300,
+  l_bluestore_allocator_alloc_process_lat,
+  l_bluestore_allocator_lock_wait_lat,
+  l_bluestore_allocator_last
+};
 
 class AllocatorBase : public Allocator {
 protected:
@@ -293,6 +302,26 @@ public:
 private:
   class SocketHook;
   SocketHook* asok_hook = nullptr;
+};
+
+class AllocatorPerf {
+private:
+  CephContext* cct = nullptr;
+protected:
+  PerfCounters *logger = nullptr;
+public:
+  AllocatorPerf() = delete;
+  AllocatorPerf(CephContext* cct, std::string_view name)
+    : cct(cct)
+  {
+    _init_logger(name);
+  }
+  ~AllocatorPerf() {
+    _shutdown_logger();
+  }
+private:
+  void _init_logger(std::string_view name);
+  void _shutdown_logger();
 };
 
 #endif

--- a/src/os/bluestore/AllocatorBase.h
+++ b/src/os/bluestore/AllocatorBase.h
@@ -26,6 +26,7 @@ enum {
   l_bluestore_allocator_first = 732300,
   l_bluestore_allocator_alloc_process_lat,
   l_bluestore_allocator_lock_wait_lat,
+  l_bluestore_allocator_nolock_process_lat,
   l_bluestore_allocator_last
 };
 

--- a/src/os/bluestore/AvlAllocator.cc
+++ b/src/os/bluestore/AvlAllocator.cc
@@ -368,6 +368,7 @@ AvlAllocator::AvlAllocator(CephContext* cct,
                            uint64_t max_mem,
                            std::string_view name) :
   AllocatorBase(name, device_size, block_size),
+  AllocatorPerf(cct, name),
   cct(cct),
   range_size_alloc_threshold(
     cct->_conf.get_val<uint64_t>("bluestore_avl_alloc_bf_threshold")),
@@ -421,8 +422,22 @@ int64_t AvlAllocator::allocate(
       max_alloc_size >= cap) {
     max_alloc_size = p2align(uint64_t(cap), (uint64_t)block_size);
   }
+  auto lock_wait_start = mono_clock::now();
+
   std::lock_guard l(lock);
-  return _allocate(want, unit, max_alloc_size, hint, extents);
+
+  auto lock_acquired = mono_clock::now();
+
+  auto ret = _allocate(want, unit, max_alloc_size, hint, extents);
+
+  logger->tinc_with_max(
+      l_bluestore_allocator_alloc_process_lat,
+      mono_clock::now() - lock_acquired);
+  logger->tinc_with_max(
+      l_bluestore_allocator_lock_wait_lat,
+      lock_acquired - lock_wait_start);
+
+  return ret;
 }
 
 void AvlAllocator::release(const release_set_t& release_set) {

--- a/src/os/bluestore/AvlAllocator.h
+++ b/src/os/bluestore/AvlAllocator.h
@@ -50,7 +50,7 @@ struct range_seg_t {
   boost::intrusive::avl_set_member_hook<> size_hook;
 };
 
-class AvlAllocator : public AllocatorBase {
+class AvlAllocator : public AllocatorBase, public AllocatorPerf {
   struct dispose_rs {
     void operator()(range_seg_t* p)
     {

--- a/src/os/bluestore/BitmapAllocator.cc
+++ b/src/os/bluestore/BitmapAllocator.cc
@@ -14,6 +14,7 @@ BitmapAllocator::BitmapAllocator(CephContext* _cct,
 					 int64_t alloc_unit,
 					 std::string_view name) :
     AllocatorBase(name, capacity, alloc_unit),
+    AllocatorLevel02<AllocatorLevel01Loose>(_cct, name),
     cct(_cct)
 {
   ldout(cct, 10) << __func__ << " 0x" << std::hex << capacity << "/"

--- a/src/os/bluestore/Btree2Allocator.cc
+++ b/src/os/bluestore/Btree2Allocator.cc
@@ -24,6 +24,7 @@ Btree2Allocator::Btree2Allocator(CephContext* _cct,
   bool with_cache,
   std::string_view name) :
     AllocatorBase(name, device_size, block_size),
+    AllocatorPerf(_cct, name),
     myTraits(RANGE_SIZE_BUCKET_COUNT),
     cct(_cct),
     range_count_cap(max_mem / sizeof(range_seg_t))
@@ -90,8 +91,22 @@ int64_t Btree2Allocator::allocate(
     extents->emplace_back(cached_chunk_offs, want);
     return want;
   }
+  auto lock_wait_start = mono_clock::now();
+
   std::lock_guard l(lock);
-  return _allocate(want, unit, max_alloc_size, hint, extents);
+
+  auto lock_acquired = mono_clock::now();
+
+  auto ret = _allocate(want, unit, max_alloc_size, hint, extents);
+
+  logger->tinc_with_max(
+      l_bluestore_allocator_alloc_process_lat,
+      mono_clock::now() - lock_acquired);
+  logger->tinc_with_max(
+      l_bluestore_allocator_lock_wait_lat,
+      lock_acquired - lock_wait_start);
+
+  return ret;
 }
 
 void Btree2Allocator::release(const release_set_t& release_set)

--- a/src/os/bluestore/Btree2Allocator.cc
+++ b/src/os/bluestore/Btree2Allocator.cc
@@ -86,9 +86,13 @@ int64_t Btree2Allocator::allocate(
     max_alloc_size = p2align(uint64_t(cap), (uint64_t)block_size);
   }
   uint64_t cached_chunk_offs = 0;
+  auto fast_alloc_start = mono_clock::now();
   if (cache && cache->try_get(&cached_chunk_offs, want)) {
     num_free -= want;
     extents->emplace_back(cached_chunk_offs, want);
+    logger->tinc_with_max(
+        l_bluestore_allocator_nolock_process_lat,
+        mono_clock::now() - fast_alloc_start);
     return want;
   }
   auto lock_wait_start = mono_clock::now();

--- a/src/os/bluestore/Btree2Allocator.h
+++ b/src/os/bluestore/Btree2Allocator.h
@@ -20,7 +20,7 @@
  *
  *
  */
-class Btree2Allocator : public AllocatorBase {
+class Btree2Allocator : public AllocatorBase, public AllocatorPerf {
   enum {
     RANGE_SIZE_BUCKET_COUNT = 14,
   };

--- a/src/os/bluestore/BtreeAllocator.cc
+++ b/src/os/bluestore/BtreeAllocator.cc
@@ -354,6 +354,7 @@ BtreeAllocator::BtreeAllocator(CephContext* cct,
 			       uint64_t max_mem,
 			       std::string_view name) :
   AllocatorBase(name, device_size, block_size),
+  AllocatorPerf(cct, name),
   range_size_alloc_threshold(
     cct->_conf.get_val<uint64_t>("bluestore_avl_alloc_bf_threshold")),
   range_size_alloc_free_pct(
@@ -397,8 +398,22 @@ int64_t BtreeAllocator::allocate(
       max_alloc_size >= cap) {
     max_alloc_size = p2align(uint64_t(cap), (uint64_t)block_size);
   }
+  auto lock_wait_start = mono_clock::now();
+
   std::lock_guard l(lock);
-  return _allocate(want, unit, max_alloc_size, hint, extents);
+
+  auto lock_acquired = mono_clock::now();
+
+  auto ret = _allocate(want, unit, max_alloc_size, hint, extents);
+
+  logger->tinc_with_max(
+      l_bluestore_allocator_alloc_process_lat,
+      mono_clock::now() - lock_acquired);
+  logger->tinc_with_max(
+      l_bluestore_allocator_lock_wait_lat,
+      lock_acquired - lock_wait_start);
+
+  return ret;
 }
 
 void BtreeAllocator::release(const interval_set<uint64_t>& release_set) {

--- a/src/os/bluestore/BtreeAllocator.h
+++ b/src/os/bluestore/BtreeAllocator.h
@@ -11,7 +11,7 @@
 #include "os/bluestore/bluestore_types.h"
 #include "include/mempool.h"
 
-class BtreeAllocator : public AllocatorBase {
+class BtreeAllocator : public AllocatorBase, public AllocatorPerf {
   struct range_seg_t {
     uint64_t start;   ///< starting offset of this segment
     uint64_t end;     ///< ending offset (non-inclusive)

--- a/src/os/bluestore/HybridAllocator_impl.h
+++ b/src/os/bluestore/HybridAllocator_impl.h
@@ -35,7 +35,11 @@ int64_t HybridAllocatorBase<T>::allocate(
     max_alloc_size = p2align(uint64_t(cap), (uint64_t)T::get_block_size());
   }
 
+  auto lock_wait_start = mono_clock::now();
+
   std::lock_guard l(T::get_lock());
+
+  auto lock_acquired = mono_clock::now();
 
   // try bitmap first to avoid unneeded contiguous extents split if
   // desired amount is less than shortes range in AVL or Btree2
@@ -63,6 +67,12 @@ int64_t HybridAllocatorBase<T>::allocate(
       ceph_assert(orig_size == extents->size());
     }
   }
+  this->logger->tinc_with_max(
+      l_bluestore_allocator_alloc_process_lat,
+      mono_clock::now() - lock_acquired);
+  this->logger->tinc_with_max(
+      l_bluestore_allocator_lock_wait_lat,
+      lock_acquired - lock_wait_start);
   return res ? res : -ENOSPC;
 }
 

--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -15,6 +15,7 @@ StupidAllocator::StupidAllocator(CephContext* cct,
                                  int64_t _block_size,
                                  std::string_view name)
   : AllocatorBase(name, capacity, _block_size),
+    AllocatorPerf(cct, name),
     cct(cct), num_free(0),
     free(10)
 {
@@ -56,7 +57,12 @@ int64_t StupidAllocator::allocate_int(
   uint64_t want_size, uint64_t alloc_unit, int64_t hint,
   uint64_t *offset, uint32_t *length)
 {
+  auto lock_wait_start = mono_clock::now();
+
   std::lock_guard l(lock);
+
+  auto lock_acquired = mono_clock::now();
+
   ldout(cct, 10) << __func__ << " want_size 0x" << std::hex << want_size
 	   	 << " alloc_unit 0x" << alloc_unit
 	   	 << " hint 0x" << hint << std::dec
@@ -164,6 +170,13 @@ int64_t StupidAllocator::allocate_int(
   num_free -= *length;
   ceph_assert(num_free >= 0);
   last_alloc = *offset + *length;
+
+  logger->tinc_with_max(
+      l_bluestore_allocator_alloc_process_lat,
+      mono_clock::now() - lock_acquired);
+  logger->tinc_with_max(
+      l_bluestore_allocator_lock_wait_lat,
+      lock_acquired - lock_wait_start);
   return 0;
 }
 

--- a/src/os/bluestore/StupidAllocator.h
+++ b/src/os/bluestore/StupidAllocator.h
@@ -14,7 +14,7 @@
 #include "include/mempool.h"
 #include "common/ceph_mutex.h"
 
-class StupidAllocator : public AllocatorBase {
+class StupidAllocator : public AllocatorBase, public AllocatorPerf {
   CephContext* cct;
   ceph::mutex lock = ceph::make_mutex("StupidAllocator::lock");
 

--- a/src/os/bluestore/fastbmap_allocator_impl.h
+++ b/src/os/bluestore/fastbmap_allocator_impl.h
@@ -15,6 +15,7 @@
 #include <vector>
 #include <algorithm>
 #include <mutex>
+#include <string_view>
 
 typedef uint64_t slot_t;
 
@@ -36,6 +37,7 @@ typedef std::vector<slot_t> slot_vector_t;
 #include "include/ceph_assert.h"
 #include "common/likely.h"
 #include "os/bluestore/bluestore_types.h"
+#include "AllocatorBase.h"
 #include "include/mempool.h"
 #include "common/ceph_mutex.h"
 
@@ -524,9 +526,13 @@ public:
 };
 
 template <class L1>
-class AllocatorLevel02 : public AllocatorLevel
+class AllocatorLevel02 : public AllocatorLevel, public AllocatorPerf
 {
 public:
+  AllocatorLevel02(CephContext* cct, std::string_view name)
+    : AllocatorPerf(cct, name)
+  {}
+
   uint64_t debug_get_free(uint64_t pos0 = 0, uint64_t pos1 = 0)
   {
     std::lock_guard l(lock);
@@ -720,9 +726,19 @@ protected:
 
     uint64_t l1_w = slots_per_slotset * l1._children_per_slot();
 
+    auto lock_wait_start = mono_clock::now();
+
     std::lock_guard l(lock);
 
+    auto lock_acquired = mono_clock::now();
+
     if (available < min_length) {
+      logger->tinc_with_max(
+        l_bluestore_allocator_alloc_process_lat,
+        mono_clock::now() - lock_acquired);
+      logger->tinc_with_max(
+        l_bluestore_allocator_lock_wait_lat,
+        lock_acquired - lock_wait_start);
       return;
     }
     if (hint != -1) {
@@ -783,6 +799,13 @@ protected:
     auto allocated_here = *allocated - prev_allocated;
     ceph_assert(available >= allocated_here);
     available -= allocated_here;
+
+    logger->tinc_with_max(
+      l_bluestore_allocator_alloc_process_lat,
+      mono_clock::now() - lock_acquired);
+    logger->tinc_with_max(
+      l_bluestore_allocator_lock_wait_lat,
+      lock_acquired - lock_wait_start);
   }
 
 #ifndef NON_CEPH_BUILD

--- a/src/test/objectstore/fastbmap_allocator_test.cc
+++ b/src/test/objectstore/fastbmap_allocator_test.cc
@@ -27,6 +27,8 @@ public:
 class TestAllocatorLevel02 : public AllocatorLevel02<AllocatorLevel01Loose>
 {
 public:
+  TestAllocatorLevel02()
+    : AllocatorLevel02(g_ceph_context, "bitmap-test") {}
   void init(uint64_t capacity, uint64_t alloc_unit)
   {
     _init(capacity, alloc_unit);


### PR DESCRIPTION
This PR add's new per-instance allocator perf counters for  measuring allocator lock wait and processing latency

```bash
{
  "bluestore-alloc-block": {
    "alloc_process_lat": {
      "avgcount": 11296,
      "sum": 0.018469493,
      "max_inc": 0.000024183,
      "avgtime": 0.000001635
    },
    "lock_wait_lat": {
      "avgcount": 11296,
      "sum": 0.001790098,
      "max_inc": 0.000011482,
      "avgtime": 1.58E-7
    }
  },
  "bluestore-alloc-bluefs-db": {
    "alloc_process_lat": {
      "avgcount": 8,
      "sum": 0.000014400,
      "max_inc": 0.000005742,
      "avgtime": 0.000001800
    },
    "lock_wait_lat": {
      "avgcount": 8,
      "sum": 6.15E-7,
      "max_inc": 3.35E-7,
      "avgtime": 7.6E-8
    }
  }
}
```

Fixes: https://tracker.ceph.com/issues/76936


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
