### PR TITLE
mgr/dashboard: Fix daemon_name for NVMeoFClient

### DIFF
--- a/src/pybind/mgr/dashboard/services/nvmeof_client.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_client.py
@@ -74,6 +74,7 @@ else:
                     None
                 )
                 if matched_gateway:
+                    self.daemon_name = matched_gateway.get('daemon_name')
                     self.gateway_addr = matched_gateway.get('service_url')
                     logger.debug("Gateway address set to: %s", self.gateway_addr)
                 else:

--- a/src/pybind/mgr/dashboard/tests/test_nvmeof_client.py
+++ b/src/pybind/mgr/dashboard/tests/test_nvmeof_client.py
@@ -6,8 +6,8 @@ import pytest
 
 from ..exceptions import DashboardException
 from ..services import nvmeof_client
-from ..services.nvmeof_client import MaxRecursionDepthError, convert_to_model, \
-    handle_nvmeof_error, obj_to_namedtuple, pick
+from ..services.nvmeof_client import MaxRecursionDepthError, NVMeoFClient, \
+    convert_to_model, handle_nvmeof_error, obj_to_namedtuple, pick
 
 
 class TestObjToNamedTuple:
@@ -646,3 +646,53 @@ class TestHandleNvmeofError:
         # Should not raise an exception when status is None (default)
         result = mock_function()
         assert result is not None
+
+
+class TestNVMeoFClientInit:
+
+    _GW1_ADDR = '10.0.0.1:5500'
+    _GW2_ADDR = '10.0.0.2:5500'
+    _GW1_DAEMON = 'nvmeof.nvmeof.mygroup1.node1.aaaaaa'
+    _GW2_DAEMON = 'nvmeof.nvmeof.mygroup1.node2.bbbbbb'
+    _SERVICE_INFO = ('nvmeof.nvmeof.mygroup1', _GW1_ADDR, _GW1_DAEMON)
+    _GATEWAYS_CONFIG = {
+        'gateways': {
+            'nvmeof.nvmeof.mygroup1': [
+                {'service_url': _GW1_ADDR, 'group': 'mygroup1', 'daemon_name': _GW1_DAEMON},
+                {'service_url': _GW2_ADDR, 'group': 'mygroup1', 'daemon_name': _GW2_DAEMON},
+            ]
+        }
+    }
+
+    @pytest.fixture
+    def mock_env(self):
+        with patch('dashboard.services.nvmeof_client.NvmeofGatewaysConfig.get_service_info',
+                   return_value=self._SERVICE_INFO), \
+             patch('dashboard.services.nvmeof_client.NvmeofGatewaysConfig.get_gateways_config',
+                   return_value=self._GATEWAYS_CONFIG), \
+             patch('dashboard.services.nvmeof_client.is_mtls_enabled', return_value=False), \
+             patch('dashboard.services.nvmeof_client.grpc') as mock_grpc, \
+             patch('dashboard.services.nvmeof_client.pb2_grpc'):
+            mock_grpc.insecure_channel.return_value = MagicMock()
+            yield
+
+    def test_client_without_server_address(self, mock_env):
+        # pylint: disable=unused-argument
+        client = NVMeoFClient()
+        assert client.daemon_name == self._GW1_DAEMON
+        assert client.gateway_addr == self._GW1_ADDR
+
+    def test_client_server_address_matched_gateway(self, mock_env):
+        # pylint: disable=unused-argument
+        client = NVMeoFClient(server_address='10.0.0.2')
+        assert client.daemon_name == self._GW2_DAEMON
+        assert client.gateway_addr == self._GW2_ADDR
+        client2 = NVMeoFClient(server_address='10.0.0.1')
+        assert client2.daemon_name == self._GW1_DAEMON
+        assert client2.gateway_addr == self._GW1_ADDR
+
+    def test_client_server_address_not_found_raises(self, mock_env):
+        # pylint: disable=unused-argument
+        with pytest.raises(DashboardException) as exc_info:
+            NVMeoFClient(server_address='10.0.0.99')
+        assert exc_info.value.code == 'server_address_not_found'


### PR DESCRIPTION
Reset self.daemon_name for matched gateway, to ensure correct daemon_name is set when server_address param is passed to the NVMeoFClient object.

Right now, NVMeoFClient().daemon_name shows same daemon_name for all gateways within the group.

Fixes: https://tracker.ceph.com/issues/77469





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
