### PR TITLE
umbrella: rgw/multisite: Balance sync traffic across DNS-resolved backends using CURLOPT_CONNECT_TO

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -158,6 +158,17 @@
   than instantly aborting I/O and returning an error. It's possible to switch
   from ``RBD_LOCK_MODE_EXCLUSIVE`` to ``RBD_LOCK_MODE_EXCLUSIVE_TRANSIENT``
   policy and vice versa even if the lock is already held.
+* RGW: In multisite deployments, zone endpoints configured in the zonegroup
+  (e.g. ``https://zone-a.example.com``) can now be resolved to all IP addresses
+  returned by DNS, with inter-zone traffic distributed across them using
+  round-robin and per-IP health tracking. This enables DNS-based service discovery
+  for inter-zone traffic without an external load balancer. This feature is disabled
+  by default: to opt in, set ``rgw_rest_conn_connect_to_resolved_ips = true``. The
+  per-IP retry-after-failure timeout is controlled by ``rgw_rest_conn_ip_fail_timeout_secs``
+  (default: 2 seconds). Deployments that work around libcurl's single-address behavior
+  by repeating the same endpoint multiple times in zone configuration should review that
+  setup before enabling, as round-robin distribution makes such duplication unnecessary.
+
 * OSD: A health warning is reported when BlueFS usage exceeds the
   configured ratio of the main OSD data device size. This warning is
   informational and can be muted with:

--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -58,6 +58,8 @@ instances or all radosgw-admin options can be put into the ``[global]`` or the
 .. confval:: rgw_account_default_quota_max_objects
 .. confval:: rgw_account_default_quota_max_size
 .. confval:: rgw_verify_ssl
+.. confval:: rgw_rest_conn_connect_to_resolved_ips
+.. confval:: rgw_rest_conn_ip_fail_timeout_secs
 .. confval:: rgw_max_chunk_size
 .. confval:: rgw_multi_obj_del_max_aio
 

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -2080,6 +2080,24 @@ options:
   default: false
   services:
   - rgw
+  see_also:
+  - rgw_rest_conn_ip_fail_timeout_secs
+  with_legacy: true
+- name: rgw_rest_conn_ip_fail_timeout_secs
+  desc: IP failure tracking timeout (requires rgw_rest_conn_connect_to_resolved_ips=true)
+  type: uint
+  level: advanced
+  long_desc: When rgw_rest_conn_connect_to_resolved_ips is enabled, RGW tracks
+    per-IP connection failures by remembering the timestamp of the most recent
+    failure. This option controls how long (in seconds) an IP address remains
+    marked as "failed" before RGW considers it eligible for retry.
+    After this timeout expires, the IP will be tried again in the normal
+    round-robin rotation.
+  default: 2
+  services:
+  - rgw
+  see_also:
+  - rgw_rest_conn_connect_to_resolved_ips
   with_legacy: true
 - name: rgw_obj_stripe_size
   type: size

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -2065,6 +2065,22 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_rest_conn_connect_to_resolved_ips
+  type: bool
+  level: advanced
+  long_desc: When an RGW endpoint hostname resolves to multiple A or AAAA
+    records, libcurl normally connects to only the first address returned by
+    DNS. Enabling this option causes RGW to resolve each configured endpoint
+    into all of its addresses and distribute outgoing requests across them
+    using round-robin, with per-IP health tracking. This applies to
+    multisite replication traffic between zones (via RGWRESTConn). For example, in a
+    multisite deployment where zone endpoints such as "https://zone-a.example.com"
+    map to several backend RGW nodes, this allows inter-zone traffic to be spread
+    across all peers without requiring an external load balancer.
+  default: false
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_obj_stripe_size
   type: size
   level: advanced

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -5400,7 +5400,7 @@ bool RadosZone::is_writeable()
 bool RadosZone::get_redirect_endpoint(std::string* endpoint)
 {
   if (local_zone)
-    return store->svc()->zone->get_redirect_zone_endpoint(endpoint);
+    return store->svc()->zone->get_redirect_zone_endpoint_url(endpoint);
 
   endpoint = &rgw_zone.redirect_zone;
   return true;

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -310,7 +310,6 @@ RGWHTTPClient::RGWHTTPClient(CephContext *cct,
       verify_ssl(cct->_conf->rgw_verify_ssl),
       cct(cct),
       method(_method),
-      endpoint_orig(_endpoint),
       endpoint(_endpoint) {
   init();
 }

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -586,8 +586,7 @@ int RGWHTTPClient::init_request(rgw_http_req_data *_req_data)
 
   CURL *easy_handle = req_data->get_easy_handle();
 
-  dout(20) << "sending request to url=" << endpoint.get_url()
-    << " connect_to=" << endpoint.get_connect_to() << dendl;
+  dout(20) << "sending request to " << endpoint << dendl;
 
   curl_slist *h = headers_to_slist(headers);
 
@@ -605,9 +604,9 @@ int RGWHTTPClient::init_request(rgw_http_req_data *_req_data)
 
     req_data->connect_to_slist = curl_slist_append(req_data->connect_to_slist, endpoint.get_connect_to().c_str());
     if (! req_data->connect_to_slist) {
-      dout(0) << "ERROR: RGWHTTPClient::init_request failed to allocate connect_to_slist" << dendl;
+      dout(0) << "ERROR: RGWHTTPClient::init_request failed to allocate connect_to_slist: " << endpoint << dendl;
     } else {
-      dout(20) << "applying CURLOPT_CONNECT_TO=" << endpoint.get_connect_to() << " for url=" << endpoint.get_url() << dendl;
+      dout(20) << "applying CURLOPT_CONNECT_TO " << endpoint << dendl;
       curl_easy_setopt(easy_handle, CURLOPT_CONNECT_TO, req_data->connect_to_slist);
     }
   }

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -333,7 +333,7 @@ void RGWHTTPClient::init()
     }
   }
 
-  const string& url = endpoint.get_url();
+  const string url = endpoint.get_url();
 
   auto pos = url.find("://");
   if (pos == string::npos) {

--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -20,9 +20,24 @@ void rgw_http_client_cleanup();
 struct rgw_http_req_data;
 class RGWHTTPManager;
 
+/**
+ * RGWEndpoint - Represents an HTTP endpoint with additional metdata such as connection routing.
+ *
+ * Unlike a plain URL string, RGWEndpoint carries additional information needed
+ * to leverage libcurl's CURLOPT_CONNECT_TO option. This enables RGW to route
+ * requests to specific IP addresses while preserving the original hostname for
+ * TLS/SNI and Host headers.
+ *
+ * Fields:
+ *  - url:          The effective URL for the request (may be modified with paths).
+ *  - original_url: The initially configured endpoint URL (preserved for reference).
+ *  - connect_to:   libcurl CONNECT_TO string (format: "host:port:addr:port") to
+ *                  override connection routing without changing the request URL.
+ */
 struct RGWEndpoint {
 private:
   std::string url;
+  std::string original_url;
   std::string connect_to;
 
 public:
@@ -31,7 +46,7 @@ public:
   RGWEndpoint(const char* u) : RGWEndpoint(std::string(u)) {}
 
   RGWEndpoint(std::string u, std::string c = {})
-    : url(std::move(u)), connect_to(std::move(c)) {}
+    : url(std::move(u)), original_url(url), connect_to(std::move(c)) {}
 
   RGWEndpoint with_url(std::string new_url) const {
     RGWEndpoint e = *this;
@@ -39,8 +54,15 @@ public:
     return e;
   }
 
-  void set_url(const std::string& _url) { url = _url; }
+  void set_url(const std::string& _url) {
+    url = _url;
+    // Capture the first URL assignment as the original
+    if (original_url.empty()) {
+      original_url = _url;
+    }
+  }
   const std::string& get_url() const { return url; }
+  const std::string& get_original_url() const { return original_url; }
 
   void set_connect_to(const std::string& _connect_to) { connect_to = _connect_to; }
   const std::string& get_connect_to() const { return connect_to; }
@@ -86,7 +108,6 @@ protected:
   CephContext *cct;
 
   std::string method;
-  RGWEndpoint endpoint_orig;
   RGWEndpoint endpoint;
 
   std::string protocol;
@@ -204,16 +225,16 @@ public:
 
   int get_req_retcode();
 
+  const RGWEndpoint& get_endpoint() const {
+    return endpoint;
+  }
+
   void set_endpoint(const RGWEndpoint& _endpoint) {
     endpoint = _endpoint;
   }
 
   void set_url(const std::string& _url) {
     endpoint.set_url(_url);
-  }
-
-  const RGWEndpoint& get_endpoint_orig() const {
-    return endpoint_orig;
   }
 
   void set_method(const std::string& _method) {

--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -10,6 +10,7 @@
 #include "rgw_http_client_types.h"
 
 #include <atomic>
+#include <boost/url.hpp>
 
 using param_pair_t = std::pair<std::string, std::string>;
 using param_vec_t = std::vector<param_pair_t>;
@@ -23,21 +24,22 @@ class RGWHTTPManager;
 /**
  * RGWEndpoint - Represents an HTTP endpoint with additional metdata such as connection routing.
  *
- * Unlike a plain URL string, RGWEndpoint carries additional information needed
- * to leverage libcurl's CURLOPT_CONNECT_TO option. This enables RGW to route
- * requests to specific IP addresses while preserving the original hostname for
- * TLS/SNI and Host headers.
+ * Wraps boost::urls::url for proper URL manipulation (set_path, set_query,
+ * set_host) instead of raw string concatenation.
+ *
+ * Carries a CURLOPT_CONNECT_TO override for IP-level routing.
  *
  * Fields:
- *  - url:          The effective URL for the request (may be modified with paths).
- *  - original_url: The initially configured endpoint URL (preserved for reference).
- *  - connect_to:   libcurl CONNECT_TO string (format: "host:port:addr:port") to
- *                  override connection routing without changing the request URL.
+ *  - endpoint_url_lookup_id: The initially configured endpoint URL (immutable).
+ *                 Used as a lookup key in RGWRESTConn to find the ResolvedEndpoint
+ *                 for health tracking (marking IPs as up/down).
+ *  - url:         boost::urls::url for the request URL (mutable via set_path, etc.).
+ *  - connect_to:  libcurl CONNECT_TO string (format: "host:port:addr:port").
  */
 struct RGWEndpoint {
 private:
-  std::string url;
-  std::string original_url;
+  std::string endpoint_url_lookup_id;
+  boost::urls::url url;
   std::string connect_to;
 
 public:
@@ -45,45 +47,57 @@ public:
 
   RGWEndpoint(const char* u) : RGWEndpoint(std::string(u)) {}
 
-  RGWEndpoint(std::string u, std::string c = {})
-    : url(std::move(u)), original_url(url), connect_to(std::move(c)) {}
-
-  RGWEndpoint with_url(std::string new_url) const {
-    RGWEndpoint e = *this;
-    e.set_url(std::move(new_url));
-    return e;
-  }
-
-  void set_url(const std::string& _url) {
-    url = _url;
-    // Capture the first URL assignment as the original
-    if (original_url.empty()) {
-      original_url = _url;
+  RGWEndpoint(const std::string& u) : endpoint_url_lookup_id(u) {
+    auto r = boost::urls::parse_uri(u);
+    if (r.has_value()) {
+      url = r.value();
     }
   }
-  const std::string& get_url() const { return url; }
-  const std::string& get_original_url() const { return original_url; }
 
-  void set_connect_to(const std::string& _connect_to) { connect_to = _connect_to; }
-  const std::string& get_connect_to() const { return connect_to; }
+  RGWEndpoint(const std::string& u, const std::string& c)
+    : endpoint_url_lookup_id(u), connect_to(c) {
+    auto r = boost::urls::parse_uri(u);
+    if (r.has_value()) {
+      url = r.value();
+    }
+  }
+
+  void set_url(const std::string& u) {
+    auto r = boost::urls::parse_uri(u);
+    if (r.has_value()) {
+      url = r.value();
+    }
+    if (endpoint_url_lookup_id.empty()) {
+      endpoint_url_lookup_id = u;
+    }
+  }
+
+  std::string get_url() const { return std::string(url.buffer()); }
+  const std::string& get_endpoint_url_lookup_id() const { return endpoint_url_lookup_id; }
+
+  void set_path(const std::string& path) { url.set_encoded_path(path); }
+  void set_query(const std::string& q) {
+    if (q.empty()) return;
+    // strip leading '?' - if present, boost::urls adds it automatically
+    url.set_encoded_query(q[0] == '?' ? q.substr(1) : q);
+  }
+  void set_host(const std::string& h) { url.set_host(h); }
 
   void add_trailing_slash() {
-    if (! url.empty() && url.back() != '/')
-      append_to_url("/");
+    auto path = std::string(url.encoded_path());
+    if (path.empty() || path.back() != '/') {
+      path += '/';
+      url.set_encoded_path(path);
+    }
   }
 
-  void append_to_url(const std::string& suffix) {
-    url.append(suffix);
-  }
+  void set_connect_to(const std::string& c) { connect_to = c; }
+  const std::string& get_connect_to() const { return connect_to; }
 
   friend std::ostream& operator<<(std::ostream& os, const RGWEndpoint& ep) {
-    os << "RGWEndpoint: url=" << ep.url;
-    if (!ep.original_url.empty() && ep.original_url != ep.url) {
-      os << " original_url=" << ep.original_url;
-    }
-    if (!ep.connect_to.empty()) {
-      os << " connect_to=" << ep.connect_to;
-    }
+    os << "RGWEndpoint: url=" << ep.url.buffer()
+       << " endpoint_url_lookup_id=" << (ep.endpoint_url_lookup_id.empty() ? "<empty>" : ep.endpoint_url_lookup_id)
+       << " connect_to=" << (ep.connect_to.empty() ? "<empty>" : ep.connect_to);
     return os;
   }
 };

--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -20,6 +20,41 @@ void rgw_http_client_cleanup();
 struct rgw_http_req_data;
 class RGWHTTPManager;
 
+struct RGWEndpoint {
+private:
+  std::string url;
+  std::string connect_to;
+
+public:
+  RGWEndpoint() = default;
+
+  RGWEndpoint(const char* u) : RGWEndpoint(std::string(u)) {}
+
+  RGWEndpoint(std::string u, std::string c = {})
+    : url(std::move(u)), connect_to(std::move(c)) {}
+
+  RGWEndpoint with_url(std::string new_url) const {
+    RGWEndpoint e = *this;
+    e.set_url(std::move(new_url));
+    return e;
+  }
+
+  void set_url(const std::string& _url) { url = _url; }
+  const std::string& get_url() const { return url; }
+
+  void set_connect_to(const std::string& _connect_to) { connect_to = _connect_to; }
+  const std::string& get_connect_to() const { return connect_to; }
+
+  void add_trailing_slash() {
+    if (! url.empty() && url.back() != '/')
+      append_to_url("/");
+  }
+
+  void append_to_url(const std::string& suffix) {
+    url.append(suffix);
+  }
+};
+
 class RGWHTTPClient : public RGWIOProvider,
                       public NoDoutPrefix
 {
@@ -47,13 +82,12 @@ class RGWHTTPClient : public RGWIOProvider,
 
   std::atomic<unsigned> stopped { 0 };
 
-
 protected:
   CephContext *cct;
 
   std::string method;
-  std::string url_orig;
-  std::string url;
+  RGWEndpoint endpoint_orig;
+  RGWEndpoint endpoint;
 
   std::string protocol;
   std::string host;
@@ -116,7 +150,7 @@ public:
   virtual ~RGWHTTPClient();
   explicit RGWHTTPClient(CephContext *cct,
                          const std::string& _method,
-                         const std::string& _url);
+                         const RGWEndpoint& _endpoint);
 
   std::ostream& gen_prefix(std::ostream& out) const override;
 
@@ -170,12 +204,16 @@ public:
 
   int get_req_retcode();
 
-  void set_url(const std::string& _url) {
-    url = _url;
+  void set_endpoint(const RGWEndpoint& _endpoint) {
+    endpoint = _endpoint;
   }
 
-  const std::string& get_url_orig() const {
-    return url_orig;
+  void set_url(const std::string& _url) {
+    endpoint.set_url(_url);
+  }
+
+  const RGWEndpoint& get_endpoint_orig() const {
+    return endpoint_orig;
   }
 
   void set_method(const std::string& _method) {
@@ -212,9 +250,9 @@ public:
 
   RGWHTTPHeadersCollector(CephContext * const cct,
                           const std::string& method,
-                          const std::string& url,
+                          const RGWEndpoint& endpoint,
                           const header_spec_t &relevant_headers)
-    : RGWHTTPClient(cct, method, url),
+    : RGWHTTPClient(cct, method, endpoint),
       relevant_headers(relevant_headers) {
   }
 
@@ -244,21 +282,21 @@ class RGWHTTPTransceiver : public RGWHTTPHeadersCollector {
 public:
   RGWHTTPTransceiver(CephContext * const cct,
                      const std::string& method,
-                     const std::string& url,
+                     const RGWEndpoint& endpoint,
                      bufferlist * const read_bl,
                      const header_spec_t intercept_headers = {})
-    : RGWHTTPHeadersCollector(cct, method, url, intercept_headers),
+    : RGWHTTPHeadersCollector(cct, method, endpoint, intercept_headers),
       read_bl(read_bl),
       post_data_index(0) {
   }
 
   RGWHTTPTransceiver(CephContext * const cct,
                      const std::string& method,
-                     const std::string& url,
+                     const RGWEndpoint& endpoint,
                      bufferlist * const read_bl,
                      const bool verify_ssl,
                      const header_spec_t intercept_headers = {})
-    : RGWHTTPHeadersCollector(cct, method, url, intercept_headers),
+    : RGWHTTPHeadersCollector(cct, method, endpoint, intercept_headers),
       read_bl(read_bl),
       post_data_index(0) {
     set_verify_ssl(verify_ssl);

--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -75,6 +75,17 @@ public:
   void append_to_url(const std::string& suffix) {
     url.append(suffix);
   }
+
+  friend std::ostream& operator<<(std::ostream& os, const RGWEndpoint& ep) {
+    os << "RGWEndpoint: url=" << ep.url;
+    if (!ep.original_url.empty() && ep.original_url != ep.url) {
+      os << " original_url=" << ep.original_url;
+    }
+    if (!ep.connect_to.empty()) {
+      os << " connect_to=" << ep.connect_to;
+    }
+    return os;
+  }
 };
 
 class RGWHTTPClient : public RGWIOProvider,

--- a/src/rgw/rgw_keystone.h
+++ b/src/rgw/rgw_keystone.h
@@ -89,9 +89,9 @@ public:
   public:
     RGWKeystoneHTTPTransceiver(CephContext * const cct,
                                const std::string& method,
-                               const std::string& url,
+                               const RGWEndpoint& endpoint,
                                bufferlist * const token_body_bl)
-      : RGWHTTPTransceiver(cct, method, url, token_body_bl,
+      : RGWHTTPTransceiver(cct, method, endpoint, token_body_bl,
                            cct->_conf->rgw_keystone_verify_ssl,
                            { "X-Subject-Token" }) {
     }

--- a/src/rgw/rgw_opa.cc
+++ b/src/rgw/rgw_opa.cc
@@ -28,7 +28,7 @@ int rgw_opa_authorize(RGWOp *& op,
 
   int ret;
   bufferlist bl;
-  RGWHTTPTransceiver req(s->cct, "POST", opa_url.c_str(), &bl);
+  RGWHTTPTransceiver req(s->cct, "POST", opa_url, &bl);
 
   /* set required headers for OPA request */
   req.append_header("X-Auth-Token", opa_token);

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -425,16 +425,8 @@ auto RGWRESTSimpleRequest::forward_request(const DoutPrefixProvider *dpp, const 
   string params_str;
   get_params_str(new_info.args.get_params(), params_str);
 
-  string new_url = endpoint.get_url();
-  string& resource = new_info.request_uri;
-  string new_resource = resource;
-  if (new_url[new_url.size() - 1] == '/' && resource[0] == '/') {
-    new_url = new_url.substr(0, new_url.size() - 1);
-  } else if (resource[0] != '/') {
-    new_resource = "/";
-    new_resource.append(resource);
-  }
-  new_url.append(new_resource + params_str);
+  endpoint.set_path(new_info.request_uri);
+  endpoint.set_query(params_str);
 
   bufferlist::iterator bliter;
 
@@ -446,7 +438,6 @@ auto RGWRESTSimpleRequest::forward_request(const DoutPrefixProvider *dpp, const 
   }
 
   method = new_info.method;
-  endpoint.set_url(new_url);
 
   std::ignore = process(dpp, y);
 
@@ -581,7 +572,9 @@ void RGWRESTGenerateHTTPHeaders::init(const string& _method, const string& host,
                           url_encode(iter->second, encode_slash));
   }
 
-  endpoint = _endpoint.with_url(_endpoint.get_url() + resource + params_str);
+  endpoint = _endpoint;
+  endpoint.set_path(resource);
+  endpoint.set_query(params_str);
 
   const std::string date_str = get_gmt_date_str();
   new_env->set("HTTP_DATE", date_str.c_str());
@@ -692,8 +685,8 @@ void RGWRESTStreamS3PutObj::send_init(const rgw_obj& obj)
 
   if (host_style == VirtualStyle) {
     resource_str = obj.get_oid();
-    new_endpoint.set_url(protocol + "://" + bucket_name + "." + host);
     new_host = bucket_name + "." + new_host;
+    new_endpoint.set_host(new_host);
   } else {
     resource_str = bucket_name + "/" + obj.get_oid();
   }
@@ -847,13 +840,13 @@ int RGWRESTStreamRWRequest::do_send_prepare(const DoutPrefixProvider *dpp, RGWAc
   }
 
   if (host_style == VirtualStyle) {
-    new_endpoint.set_url(protocol + "://" + bucket_name + "." + host);
+    new_host = bucket_name + "." + host;
+    new_endpoint.set_host(new_host);
     if(pos == string::npos) {
       new_resource = "";
     } else {
       new_resource = new_resource.substr(pos+1);
     }
-    new_host = bucket_name + "." + host;
   }
   new_endpoint.add_trailing_slash();
 

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -425,7 +425,7 @@ auto RGWRESTSimpleRequest::forward_request(const DoutPrefixProvider *dpp, const 
   string params_str;
   get_params_str(new_info.args.get_params(), params_str);
 
-  string new_url = url;
+  string new_url = endpoint.get_url();
   string& resource = new_info.request_uri;
   string new_resource = resource;
   if (new_url[new_url.size() - 1] == '/' && resource[0] == '/') {
@@ -446,7 +446,7 @@ auto RGWRESTSimpleRequest::forward_request(const DoutPrefixProvider *dpp, const 
   }
 
   method = new_info.method;
-  url = new_url;
+  endpoint.set_url(new_url);
 
   std::ignore = process(dpp, y);
 
@@ -564,7 +564,7 @@ RGWRESTGenerateHTTPHeaders::RGWRESTGenerateHTTPHeaders(CephContext *_cct, RGWEnv
 }
 
 void RGWRESTGenerateHTTPHeaders::init(const string& _method, const string& host,
-                                      const string& resource_prefix, const string& _url,
+                                      const string& resource_prefix, const RGWEndpoint& _endpoint,
                                       const string& resource, const param_vec_t& params,
                                       std::optional<string> api_name)
 {
@@ -581,7 +581,7 @@ void RGWRESTGenerateHTTPHeaders::init(const string& _method, const string& host,
                           url_encode(iter->second, encode_slash));
   }
 
-  url = _url + resource + params_str;
+  endpoint = _endpoint.with_url(_endpoint.get_url() + resource + params_str);
 
   const std::string date_str = get_gmt_date_str();
   new_env->set("HTTP_DATE", date_str.c_str());
@@ -685,32 +685,29 @@ void RGWRESTStreamS3PutObj::send_init(const rgw_obj& obj)
 {
   string resource_str;
   string resource;
-  string new_url = url;
+  RGWEndpoint new_endpoint = endpoint;
   string new_host = host;
 
    const auto& bucket_name = obj.bucket.name;
 
   if (host_style == VirtualStyle) {
     resource_str = obj.get_oid();
-
-    new_url = protocol + "://" + bucket_name + "." + host;
+    new_endpoint.set_url(protocol + "://" + bucket_name + "." + host);
     new_host = bucket_name + "." + new_host;
   } else {
     resource_str = bucket_name + "/" + obj.get_oid();
   }
+  new_endpoint.add_trailing_slash();
 
   //do not encode slash in object key name
   url_encode(resource_str, resource, false);
 
-  if (new_url[new_url.size() - 1] != '/')
-    new_url.append("/");
-
-  ldpp_dout(this, 20) << __func__ << "(): host = " << host << " , resource = " << resource << " , new_host = " << new_host << " , new_url = " << new_url  << dendl;
+  ldpp_dout(this, 20) << __func__ << "(): host = " << host << " , resource = " << resource << " , new_host = " << new_host << " , new_url = " << new_endpoint.get_url()  << dendl;
 
   method = "PUT";
-  headers_gen.init(method, new_host, resource_prefix, new_url, resource, params, api_name);
+  headers_gen.init(method, new_host, resource_prefix, new_endpoint, resource, params, api_name);
 
-  url = headers_gen.get_url();
+  endpoint = headers_gen.get_endpoint();
 }
 
 void RGWRESTStreamS3PutObj::send_ready(const DoutPrefixProvider *dpp, RGWAccessKey& key, map<string, bufferlist>& rgw_attrs)
@@ -825,10 +822,10 @@ int RGWRESTStreamRWRequest::send_prepare(const DoutPrefixProvider *dpp, RGWAcces
 int RGWRESTStreamRWRequest::do_send_prepare(const DoutPrefixProvider *dpp, RGWAccessKey *key, map<string, string>& extra_headers, const string& resource,
                                          bufferlist *send_data)
 {
-  string new_url = url;
-  if (!new_url.empty() && new_url.back() != '/')
-    new_url.append("/");
-  
+  RGWEndpoint new_endpoint = endpoint;
+
+  new_endpoint.add_trailing_slash();
+
   string new_resource;
   string bucket_name;
   string old_resource = resource;
@@ -849,7 +846,7 @@ int RGWRESTStreamRWRequest::do_send_prepare(const DoutPrefixProvider *dpp, RGWAc
   }
 
   if (host_style == VirtualStyle) {
-    new_url = protocol + "://" + bucket_name + "." + host;
+    new_endpoint.set_url(protocol + "://" + bucket_name + "." + host);
     if(pos == string::npos) {
       new_resource = "";
     } else {
@@ -857,15 +854,13 @@ int RGWRESTStreamRWRequest::do_send_prepare(const DoutPrefixProvider *dpp, RGWAc
     }
     new_host = bucket_name + "." + host;
   }
-
-  if (new_url[new_url.size() - 1] != '/')
-    new_url.append("/");
+  new_endpoint.add_trailing_slash();
 
   headers_gen.emplace(cct, &new_env, &new_info);
 
-  ldpp_dout(this, 20) << __func__ << "(): host = " << host << " , resource = " << resource << " , new_host = " << new_host << " , new_url = " << new_url  << " , new_resource = " << new_resource << dendl;
+  ldpp_dout(this, 20) << __func__ << "(): host = " << host << " , resource = " << resource << " , new_host = " << new_host << " , new_url = " << new_endpoint.get_url()  << " , new_resource = " << new_resource << dendl;
 
-  headers_gen->init(method, new_host, resource_prefix, new_url, new_resource, params, api_name);
+  headers_gen->init(method, new_host, resource_prefix, new_endpoint, new_resource, params, api_name);
 
   headers_gen->set_http_attrs(extra_headers);
 
@@ -880,7 +875,7 @@ int RGWRESTStreamRWRequest::do_send_prepare(const DoutPrefixProvider *dpp, RGWAc
   }
 
   method = new_info.method;
-  url = headers_gen->get_url();
+  endpoint = headers_gen->get_endpoint();
 
   return 0;
 }

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -702,7 +702,8 @@ void RGWRESTStreamS3PutObj::send_init(const rgw_obj& obj)
   //do not encode slash in object key name
   url_encode(resource_str, resource, false);
 
-  ldpp_dout(this, 20) << __func__ << "(): host = " << host << " , resource = " << resource << " , new_host = " << new_host << " , new_url = " << new_endpoint.get_url()  << dendl;
+  ldpp_dout(this, 20) << __func__ << "(): host = " << host << " , resource = " << resource
+    << " , new_host = " << new_host << " , new_endpoint = " << new_endpoint  << dendl;
 
   method = "PUT";
   headers_gen.init(method, new_host, resource_prefix, new_endpoint, resource, params, api_name);
@@ -858,7 +859,9 @@ int RGWRESTStreamRWRequest::do_send_prepare(const DoutPrefixProvider *dpp, RGWAc
 
   headers_gen.emplace(cct, &new_env, &new_info);
 
-  ldpp_dout(this, 20) << __func__ << "(): host = " << host << " , resource = " << resource << " , new_host = " << new_host << " , new_url = " << new_endpoint.get_url()  << " , new_resource = " << new_resource << dendl;
+  ldpp_dout(this, 20) << __func__ << "(): host = " << host << " , resource = " << resource
+    << " , new_host = " << new_host << " , new_endpoint = " << new_endpoint
+    << " , new_resource = " << new_resource << dendl;
 
   headers_gen->init(method, new_host, resource_prefix, new_endpoint, new_resource, params, api_name);
 

--- a/src/rgw/rgw_rest_client.h
+++ b/src/rgw/rgw_rest_client.h
@@ -29,8 +29,8 @@ protected:
   void get_params_str(std::map<std::string, std::string>& extra_args, std::string& dest);
 
 public:
-  RGWHTTPSimpleRequest(CephContext *_cct, const std::string& _method, const std::string& _url,
-                       param_vec_t *_headers, param_vec_t *_params) : RGWHTTPClient(_cct, _method, _url),
+  RGWHTTPSimpleRequest(CephContext *_cct, const std::string& _method, const RGWEndpoint& _endpoint,
+                       param_vec_t *_headers, param_vec_t *_params) : RGWHTTPClient(_cct, _method, _endpoint),
                 http_status(0), status(0),
                 send_iter(NULL),
                 max_response(0) {
@@ -63,9 +63,9 @@ public:
 class RGWRESTSimpleRequest : public RGWHTTPSimpleRequest {
   std::optional<std::string> api_name;
 public:
-  RGWRESTSimpleRequest(CephContext *_cct, const std::string& _method, const std::string& _url,
+  RGWRESTSimpleRequest(CephContext *_cct, const std::string& _method, const RGWEndpoint& _endpoint,
                        param_vec_t *_headers, param_vec_t *_params,
-                       std::optional<std::string> _api_name) : RGWHTTPSimpleRequest(_cct, _method, _url, _headers, _params), api_name(_api_name) {}
+                       std::optional<std::string> _api_name) : RGWHTTPSimpleRequest(_cct, _method, _endpoint, _headers, _params), api_name(_api_name) {}
 
   // return the http status of the response or an error code from the transport
   auto forward_request(const DoutPrefixProvider *dpp, const RGWAccessKey& key, const req_info& info, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y, std::string service="")
@@ -86,13 +86,13 @@ class RGWRESTGenerateHTTPHeaders : public DoutPrefix {
   std::string region;
   std::string service;
   std::string method;
-  std::string url;
+  RGWEndpoint endpoint;
   std::string resource;
 
 public:
   RGWRESTGenerateHTTPHeaders(CephContext *_cct, RGWEnv *_env, req_info *_info);
   void init(const std::string& method, const std::string& host,
-            const std::string& resource_prefix, const std::string& url,
+            const std::string& resource_prefix, const RGWEndpoint& endpoint,
             const std::string& resource, const param_vec_t& params,
             std::optional<std::string> api_name);
   void set_extra_headers(const std::map<std::string, std::string>& extra_headers);
@@ -101,7 +101,7 @@ public:
   void set_policy(const RGWAccessControlPolicy& policy);
   int sign(const DoutPrefixProvider *dpp, RGWAccessKey& key, const bufferlist *opt_content);
 
-  const std::string& get_url() { return url; }
+  const RGWEndpoint& get_endpoint() { return endpoint; }
 };
 
 class RGWHTTPStreamRWRequest : public RGWHTTPSimpleRequest {
@@ -145,11 +145,11 @@ public:
       }
   };
 
-  RGWHTTPStreamRWRequest(CephContext *_cct, const std::string& _method, const std::string& _url,
-                         param_vec_t *_headers, param_vec_t *_params) : RGWHTTPSimpleRequest(_cct, _method, _url, _headers, _params) {
+  RGWHTTPStreamRWRequest(CephContext *_cct, const std::string& _method, const RGWEndpoint& _endpoint,
+                         param_vec_t *_headers, param_vec_t *_params) : RGWHTTPSimpleRequest(_cct, _method, _endpoint, _headers, _params) {
   }
-  RGWHTTPStreamRWRequest(CephContext *_cct, const std::string& _method, const std::string& _url, ReceiveCB *_cb,
-                         param_vec_t *_headers, param_vec_t *_params) : RGWHTTPSimpleRequest(_cct, _method, _url, _headers, _params),
+  RGWHTTPStreamRWRequest(CephContext *_cct, const std::string& _method, const RGWEndpoint& _endpoint, ReceiveCB *_cb,
+                         param_vec_t *_headers, param_vec_t *_params) : RGWHTTPSimpleRequest(_cct, _method, _endpoint, _headers, _params),
 									cb(_cb) {
   }
   virtual ~RGWHTTPStreamRWRequest() override {}
@@ -192,10 +192,10 @@ protected:
   std::optional<std::string> api_name;
   HostStyle host_style;
 public:
-  RGWRESTStreamRWRequest(CephContext *_cct, const std::string& _method, const std::string& _url, RGWHTTPStreamRWRequest::ReceiveCB *_cb,
+  RGWRESTStreamRWRequest(CephContext *_cct, const std::string& _method, const RGWEndpoint& _endpoint, RGWHTTPStreamRWRequest::ReceiveCB *_cb,
                          param_vec_t *_headers, param_vec_t *_params,
                          std::optional<std::string> _api_name, HostStyle _host_style = PathStyle) :
-                         RGWHTTPStreamRWRequest(_cct, _method, _url, _cb, _headers, _params),
+                         RGWHTTPStreamRWRequest(_cct, _method, _endpoint, _cb, _headers, _params),
                          new_info(_cct, &new_env),
                          api_name(_api_name), host_style(_host_style) {
   }
@@ -216,24 +216,24 @@ private:
 
 class RGWRESTStreamReadRequest : public RGWRESTStreamRWRequest {
 public:
-  RGWRESTStreamReadRequest(CephContext *_cct, const std::string& _url, ReceiveCB *_cb, param_vec_t *_headers,
+  RGWRESTStreamReadRequest(CephContext *_cct, const RGWEndpoint& _endpoint, ReceiveCB *_cb, param_vec_t *_headers,
 		param_vec_t *_params, std::optional<std::string> _api_name,
-                HostStyle _host_style = PathStyle) : RGWRESTStreamRWRequest(_cct, "GET", _url, _cb, _headers, _params, _api_name, _host_style) {}
+                HostStyle _host_style = PathStyle) : RGWRESTStreamRWRequest(_cct, "GET", _endpoint, _cb, _headers, _params, _api_name, _host_style) {}
 };
 
 class RGWRESTStreamHeadRequest : public RGWRESTStreamRWRequest {
 public:
-  RGWRESTStreamHeadRequest(CephContext *_cct, const std::string& _url, ReceiveCB *_cb, param_vec_t *_headers,
-		param_vec_t *_params, std::optional<std::string> _api_name) : RGWRESTStreamRWRequest(_cct, "HEAD", _url, _cb, _headers, _params, _api_name) {}
+  RGWRESTStreamHeadRequest(CephContext *_cct, const RGWEndpoint& _endpoint, ReceiveCB *_cb, param_vec_t *_headers,
+		param_vec_t *_params, std::optional<std::string> _api_name) : RGWRESTStreamRWRequest(_cct, "HEAD", _endpoint, _cb, _headers, _params, _api_name) {}
 };
 
 class RGWRESTStreamSendRequest : public RGWRESTStreamRWRequest {
 public:
   RGWRESTStreamSendRequest(CephContext *_cct, const std::string& method,
-                           const std::string& _url,
+                           const RGWEndpoint& _endpoint,
                            ReceiveCB *_cb, param_vec_t *_headers, param_vec_t *_params,
                            std::optional<std::string> _api_name,
-                           HostStyle _host_style = PathStyle) : RGWRESTStreamRWRequest(_cct, method, _url, _cb, _headers, _params, _api_name, _host_style) {}
+                           HostStyle _host_style = PathStyle) : RGWRESTStreamRWRequest(_cct, method, _endpoint, _cb, _headers, _params, _api_name, _host_style) {}
 };
 
 class RGWRESTStreamS3PutObj : public RGWHTTPStreamRWRequest {
@@ -244,9 +244,9 @@ class RGWRESTStreamS3PutObj : public RGWHTTPStreamRWRequest {
   req_info new_info;
   RGWRESTGenerateHTTPHeaders headers_gen;
 public:
-  RGWRESTStreamS3PutObj(CephContext *_cct, const std::string& _method, const std::string& _url, param_vec_t *_headers,
+  RGWRESTStreamS3PutObj(CephContext *_cct, const std::string& _method, const RGWEndpoint& _endpoint, param_vec_t *_headers,
 		param_vec_t *_params, std::optional<std::string> _api_name,
-                HostStyle _host_style) : RGWHTTPStreamRWRequest(_cct, _method, _url, nullptr, _headers, _params),
+                HostStyle _host_style) : RGWHTTPStreamRWRequest(_cct, _method, _endpoint, nullptr, _headers, _params),
                 api_name(_api_name), host_style(_host_style),
                 out_cb(NULL), new_info(cct, &new_env), headers_gen(_cct, &new_env, &new_info) {}
   ~RGWRESTStreamS3PutObj() override;

--- a/src/rgw/rgw_rest_client.h
+++ b/src/rgw/rgw_rest_client.h
@@ -101,7 +101,7 @@ public:
   void set_policy(const RGWAccessControlPolicy& policy);
   int sign(const DoutPrefixProvider *dpp, RGWAccessKey& key, const bufferlist *opt_content);
 
-  const RGWEndpoint& get_endpoint() { return endpoint; }
+  const RGWEndpoint& get_endpoint() const { return endpoint; }
 };
 
 class RGWHTTPStreamRWRequest : public RGWHTTPSimpleRequest {

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -78,7 +78,7 @@ RGWRESTConn& RGWRESTConn::operator=(RGWRESTConn&& other)
   return *this;
 }
 
-int RGWRESTConn::get_url(string& endpoint)
+int RGWRESTConn::get_endpoint(RGWEndpoint& endpoint)
 {
   if (endpoints.empty()) {
     ldout(cct, 0) << "ERROR: endpoints not configured for upstream zone" << dendl;
@@ -88,15 +88,17 @@ int RGWRESTConn::get_url(string& endpoint)
   size_t num = 0;
   while (num < endpoints.size()) {
     int i = ++counter;
-    endpoint = endpoints[i % endpoints.size()];
 
-    if (endpoints_status.find(endpoint) == endpoints_status.end()) {
-      ldout(cct, 1) << "ERROR: missing status for endpoint " << endpoint << dendl;
+    const string& ep_url = endpoints[i % endpoints.size()];
+    endpoint.set_url(ep_url);
+
+    if (endpoints_status.find(ep_url) == endpoints_status.end()) {
+      ldout(cct, 1) << "ERROR: missing status for endpoint " << ep_url << dendl;
       num++;
       continue;
     }
 
-    const auto& upd_time = endpoints_status[endpoint].load();
+    const auto& upd_time = endpoints_status[ep_url].load();
 
     if (ceph::real_clock::is_zero(upd_time)) {
       break;
@@ -104,15 +106,15 @@ int RGWRESTConn::get_url(string& endpoint)
 
     auto diff = ceph::to_seconds<double>(ceph::real_clock::now() - upd_time);
 
-    ldout(cct, 20) << "endpoint url=" << endpoint
+    ldout(cct, 20) << "endpoint url=" << ep_url
                    << " last endpoint status update time="
                    << ceph::real_clock::to_double(upd_time)
                    << " diff=" << diff << dendl;
 
     static constexpr uint32_t CONN_STATUS_EXPIRE_SECS = 2;
     if (diff >= CONN_STATUS_EXPIRE_SECS) {
-      endpoints_status[endpoint].store(ceph::real_clock::zero());
-      ldout(cct, 10) << "endpoint " << endpoint << " unconnectable status expired. mark it connectable" << dendl;
+      endpoints_status[ep_url].store(ceph::real_clock::zero());
+      ldout(cct, 10) << "endpoint " << endpoint.get_url() << " unconnectable status expired. mark it connectable" << dendl;
       break;
     }
     num++;
@@ -122,29 +124,32 @@ int RGWRESTConn::get_url(string& endpoint)
     ldout(cct, 5) << "ERROR: no valid endpoint" << dendl;
     return -EINVAL;
   }
-  ldout(cct, 20) << "get_url picked endpoint=" << endpoint << dendl;
+  ldout(cct, 20) << "get_endpoint picked url=" << endpoint.get_url()
+    << " connect_to=" << endpoint.get_connect_to() << dendl;
 
   return 0;
 }
 
-string RGWRESTConn::get_url()
+RGWEndpoint RGWRESTConn::get_endpoint()
 {
-  string endpoint;
-  get_url(endpoint);
+  RGWEndpoint endpoint;
+  get_endpoint(endpoint);
   return endpoint;
 }
 
-void RGWRESTConn::set_url_unconnectable(const std::string& endpoint)
+void RGWRESTConn::set_endpoint_unconnectable(const RGWEndpoint& endpoint)
 {
-  if (endpoint.empty() || endpoints_status.find(endpoint) == endpoints_status.end()) {
+  const string& url = endpoint.get_url();
+
+  if (url.empty() || endpoints_status.find(url) == endpoints_status.end()) {
     ldout(cct, 0) << "ERROR: endpoint is not a valid or doesn't have status. endpoint="
-                  << endpoint << dendl;
+                  << url << dendl;
     return;
   }
 
-  endpoints_status[endpoint].store(ceph::real_clock::now());
+  endpoints_status[url].store(ceph::real_clock::now());
 
-  ldout(cct, 10) << "set endpoint unconnectable. url=" << endpoint << dendl;
+  ldout(cct, 10) << "set endpoint unconnectable. url=" << url << dendl;
 }
 
 void RGWRESTConn::populate_params(param_vec_t& params, const rgw_owner* uid, const string& zonegroup)
@@ -160,21 +165,22 @@ auto RGWRESTConn::forward(const DoutPrefixProvider *dpp, const rgw_owner& uid,
 {
   static constexpr int NUM_ENPOINT_IOERROR_RETRIES = 20;
   for (int tries = 0; tries < NUM_ENPOINT_IOERROR_RETRIES; tries++) {
-    string url;
-    int ret = get_url(url);
+    RGWEndpoint endpoint;
+    int ret = get_endpoint(endpoint);
     if (ret < 0) {
       return tl::unexpected(ret);
     }
+
     param_vec_t params;
     populate_params(params, &uid, self_zone_group);
-    RGWRESTSimpleRequest req(cct, info.method, url, NULL, &params, api_name);
+    RGWRESTSimpleRequest req(cct, info.method, endpoint, NULL, &params, api_name);
     auto result = req.forward_request(dpp, key, info, max_response, inbl, outbl, y);
     if (result) {
       return result;
     } else if (result.error() != -EIO) {
       return result;
     }
-    set_url_unconnectable(url);
+    set_endpoint_unconnectable(endpoint);
     if (tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
       ldpp_dout(dpp, 20) << __func__  << "(): failed to forward request. retries=" << tries << dendl;
     }
@@ -189,14 +195,15 @@ auto RGWRESTConn::forward_iam(const DoutPrefixProvider *dpp, const req_info& inf
 {
   static constexpr int NUM_ENPOINT_IOERROR_RETRIES = 20;
   for (int tries = 0; tries < NUM_ENPOINT_IOERROR_RETRIES; tries++) {
-    string url;
-    int ret = get_url(url);
+    RGWEndpoint endpoint;
+    int ret = get_endpoint(endpoint);
     if (ret < 0) {
       return tl::unexpected(ret);
     }
+
     param_vec_t params;
     std::string service = "iam";
-    RGWRESTSimpleRequest req(cct, info.method, url, NULL, &params, api_name);
+    RGWRESTSimpleRequest req(cct, info.method, endpoint, NULL, &params, api_name);
     // coverity[uninit_use_in_call:SUPPRESS]
     auto result = req.forward_request(dpp, key, info, max_response, inbl, outbl, y, service);
     if (result) {
@@ -204,7 +211,7 @@ auto RGWRESTConn::forward_iam(const DoutPrefixProvider *dpp, const req_info& inf
     } else if (result.error() != -EIO) {
       return result;
     }
-    set_url_unconnectable(url);
+    set_endpoint_unconnectable(endpoint);
     if (tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
       ldpp_dout(dpp, 20) << __func__  << "(): failed to forward request. retries=" << tries << dendl;
     }
@@ -214,8 +221,8 @@ auto RGWRESTConn::forward_iam(const DoutPrefixProvider *dpp, const req_info& inf
 
 int RGWRESTConn::put_obj_send_init(const rgw_obj& obj, const rgw_http_param_pair *extra_params, RGWRESTStreamS3PutObj **req)
 {
-  string url;
-  int ret = get_url(url);
+  RGWEndpoint endpoint;
+  int ret = get_endpoint(endpoint);
   if (ret < 0)
     return ret;
 
@@ -226,7 +233,7 @@ int RGWRESTConn::put_obj_send_init(const rgw_obj& obj, const rgw_http_param_pair
     append_param_list(params, extra_params);
   }
 
-  RGWRESTStreamS3PutObj *wr = new RGWRESTStreamS3PutObj(cct, "PUT", url, NULL, &params, api_name, host_style);
+  RGWRESTStreamS3PutObj *wr = new RGWRESTStreamS3PutObj(cct, "PUT", endpoint, NULL, &params, api_name, host_style);
   // coverity[uninit_use_in_call:SUPPRESS]
   wr->send_init(obj);
   *req = wr;
@@ -237,14 +244,14 @@ int RGWRESTConn::put_obj_async_init(const DoutPrefixProvider *dpp, const rgw_own
                                     map<string, bufferlist>& attrs,
                                     RGWRESTStreamS3PutObj **req)
 {
-  string url;
-  int ret = get_url(url);
+  RGWEndpoint endpoint;
+  int ret = get_endpoint(endpoint);
   if (ret < 0)
     return ret;
 
   param_vec_t params;
   populate_params(params, &uid, self_zone_group);
-  RGWRESTStreamS3PutObj *wr = new RGWRESTStreamS3PutObj(cct, "PUT", url, NULL, &params, api_name, host_style);
+  RGWRESTStreamS3PutObj *wr = new RGWRESTStreamS3PutObj(cct, "PUT", endpoint, NULL, &params, api_name, host_style);
   // coverity[uninit_use_in_call:SUPPRESS]
   wr->put_obj_init(dpp, key, obj, attrs);
   *req = wr;
@@ -258,7 +265,7 @@ int RGWRESTConn::complete_request(const DoutPrefixProvider* dpp,
   int ret = req->complete_request(dpp, y, &etag, mtime);
   if (ret == -EIO) {
     ldout(cct, 5) << __func__ << ": complete_request() returned ret=" << ret << dendl;
-    set_url_unconnectable(req->get_url_orig());
+    set_endpoint_unconnectable(req->get_endpoint_orig());
   }
 
   delete req;
@@ -319,8 +326,8 @@ int RGWRESTConn::get_obj(const DoutPrefixProvider *dpp, const rgw_owner *uid,
 
 int RGWRESTConn::get_obj(const DoutPrefixProvider *dpp, const rgw_obj& obj, const get_obj_params& in_params, bool send, RGWRESTStreamRWRequest **req)
 {
-  string url;
-  int ret = get_url(url);
+  RGWEndpoint endpoint;
+  int ret = get_endpoint(endpoint);
   if (ret < 0)
     return ret;
 
@@ -351,9 +358,9 @@ int RGWRESTConn::get_obj(const DoutPrefixProvider *dpp, const rgw_obj& obj, cons
     params.push_back(param_pair_t("versionId", obj.key.instance));
   }
   if (in_params.get_op) {
-    *req = new RGWRESTStreamReadRequest(cct, url, in_params.cb, NULL, &params, api_name, host_style);
+    *req = new RGWRESTStreamReadRequest(cct, endpoint, in_params.cb, NULL, &params, api_name, host_style);
   } else {
-    *req = new RGWRESTStreamHeadRequest(cct, url, in_params.cb, NULL, &params, api_name);
+    *req = new RGWRESTStreamHeadRequest(cct, endpoint, in_params.cb, NULL, &params, api_name);
   }
   map<string, string> extra_headers;
   if (in_params.info) {
@@ -421,7 +428,7 @@ int RGWRESTConn::complete_request(const DoutPrefixProvider* dpp,
   int ret = req->complete_request(dpp, y, etag, mtime, psize, pattrs, pheaders);
   if (ret == -EIO) {
     ldout(cct, 5) << __func__ << ": complete_request() returned ret=" << ret << dendl;
-    set_url_unconnectable(req->get_url_orig());
+    set_endpoint_unconnectable(req->get_endpoint_orig());
   }
   delete req;
 
@@ -441,8 +448,8 @@ int RGWRESTConn::get_resource(const DoutPrefixProvider *dpp,
 
   static constexpr int NUM_ENPOINT_IOERROR_RETRIES = 20;
   for (int tries = 0; tries < NUM_ENPOINT_IOERROR_RETRIES; tries++) {
-    string url;
-    ret = get_url(url);
+    RGWEndpoint endpoint;
+    ret = get_endpoint(endpoint);
     if (ret < 0)
       return ret;
 
@@ -456,7 +463,7 @@ int RGWRESTConn::get_resource(const DoutPrefixProvider *dpp,
 
     RGWStreamIntoBufferlist cb(bl);
 
-    RGWRESTStreamReadRequest req(cct, url, &cb, NULL, &params, api_name, host_style);
+    RGWRESTStreamReadRequest req(cct, endpoint, &cb, NULL, &params, api_name, host_style);
 
     map<string, string> headers;
     if (extra_headers) {
@@ -471,7 +478,7 @@ int RGWRESTConn::get_resource(const DoutPrefixProvider *dpp,
 
     ret = req.complete_request(dpp, y);
     if (ret == -EIO) {
-      set_url_unconnectable(url);
+      set_endpoint_unconnectable(endpoint);
       if (tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
         ldpp_dout(dpp, 20) << __func__  << "(): failed to get resource. retries=" << tries << dendl;
         continue;
@@ -495,8 +502,8 @@ int RGWRESTConn::send_resource(const DoutPrefixProvider *dpp, const std::string&
 
   static constexpr int NUM_ENPOINT_IOERROR_RETRIES = 20;
   for (int tries = 0; tries < NUM_ENPOINT_IOERROR_RETRIES; tries++) {
-    std::string url;
-    ret = get_url(url);
+    RGWEndpoint endpoint;
+    ret = get_endpoint(endpoint);
     if (ret < 0)
       return ret;
 
@@ -510,7 +517,7 @@ int RGWRESTConn::send_resource(const DoutPrefixProvider *dpp, const std::string&
 
     RGWStreamIntoBufferlist cb(bl);
 
-    RGWRESTStreamSendRequest req(cct, method, url, &cb, NULL, &params, api_name, host_style);
+    RGWRESTStreamSendRequest req(cct, method, endpoint, &cb, NULL, &params, api_name, host_style);
 
     std::map<std::string, std::string> headers;
     if (extra_headers) {
@@ -525,7 +532,7 @@ int RGWRESTConn::send_resource(const DoutPrefixProvider *dpp, const std::string&
 
     ret = req.complete_request(dpp, y);
     if (ret == -EIO) {
-      set_url_unconnectable(url);
+      set_endpoint_unconnectable(endpoint);
       if (tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
         ldpp_dout(dpp, 20) << __func__  << "(): failed to send resource. retries=" << tries << dendl;
         continue;
@@ -547,7 +554,7 @@ RGWRESTReadResource::RGWRESTReadResource(RGWRESTConn *_conn,
                                          RGWHTTPManager *_mgr)
   : cct(_conn->get_ctx()), conn(_conn), resource(_resource),
     params(make_param_list(pp)), cb(bl), mgr(_mgr),
-    req(cct, conn->get_url(), &cb, NULL, NULL, _conn->get_api_name())
+    req(cct, conn->get_endpoint(), &cb, NULL, NULL, _conn->get_api_name())
 {
   init_common(extra_headers);
 }
@@ -558,7 +565,7 @@ RGWRESTReadResource::RGWRESTReadResource(RGWRESTConn *_conn,
 					 param_vec_t *extra_headers,
                                          RGWHTTPManager *_mgr)
   : cct(_conn->get_ctx()), conn(_conn), resource(_resource), params(_params),
-    cb(bl), mgr(_mgr), req(cct, conn->get_url(), &cb, NULL, NULL, _conn->get_api_name())
+    cb(bl), mgr(_mgr), req(cct, conn->get_endpoint(), &cb, NULL, NULL, _conn->get_api_name())
 {
   init_common(extra_headers);
 }
@@ -584,7 +591,7 @@ int RGWRESTReadResource::read(const DoutPrefixProvider *dpp, optional_yield y)
 
   ret = req.complete_request(dpp, y);
   if (ret == -EIO) {
-    conn->set_url_unconnectable(req.get_url_orig());
+    conn->set_endpoint_unconnectable(req.get_endpoint_orig());
     ldpp_dout(dpp, 20) << __func__ << ": complete_request() returned ret=" << ret << dendl;
   }
 
@@ -610,7 +617,7 @@ RGWRESTSendResource::RGWRESTSendResource(RGWRESTConn *_conn,
                                          RGWHTTPManager *_mgr)
   : cct(_conn->get_ctx()), conn(_conn), method(_method), resource(_resource),
     params(make_param_list(pp)), cb(bl), mgr(_mgr),
-    req(cct, method.c_str(), conn->get_url(), &cb, NULL, NULL, _conn->get_api_name(), _conn->get_host_style())
+    req(cct, method.c_str(), conn->get_endpoint(), &cb, NULL, NULL, _conn->get_api_name(), _conn->get_host_style())
 {
   init_common(extra_headers);
 }
@@ -622,7 +629,7 @@ RGWRESTSendResource::RGWRESTSendResource(RGWRESTConn *_conn,
 					 param_vec_t *extra_headers,
                                          RGWHTTPManager *_mgr)
   : cct(_conn->get_ctx()), conn(_conn), method(_method), resource(_resource), params(params),
-    cb(bl), mgr(_mgr), req(cct, method.c_str(), conn->get_url(), &cb, NULL, NULL, _conn->get_api_name(), _conn->get_host_style())
+    cb(bl), mgr(_mgr), req(cct, method.c_str(), conn->get_endpoint(), &cb, NULL, NULL, _conn->get_api_name(), _conn->get_host_style())
 {
   init_common(extra_headers);
 }
@@ -651,7 +658,7 @@ int RGWRESTSendResource::send(const DoutPrefixProvider *dpp, bufferlist& outbl, 
 
   ret = req.complete_request(dpp, y);
   if (ret == -EIO) {
-    conn->set_url_unconnectable(req.get_url_orig());
+    conn->set_endpoint_unconnectable(req.get_endpoint_orig());
     ldpp_dout(dpp, 20) << __func__ << ": complete_request() returned ret=" << ret << dendl;
   }
 

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -15,12 +15,7 @@
 using namespace std;
 
 void RGWRESTConn::resolve_endpoints() {
-  resolved_endpoints.reserve(endpoints.size());
-
-  for (const auto& ep_url : endpoints) {
-    ResolvedEndpoint res_ep;
-    res_ep.url = ep_url;
-
+  for (auto& [ep_url, res_ep] : resolved_endpoints) {
     // parse URL
     boost::system::result<boost::urls::url_view> r = boost::urls::parse_uri(ep_url);
     if (r.has_error()) {
@@ -78,8 +73,6 @@ void RGWRESTConn::resolve_endpoints() {
       ldout(cct, 0) << "WARNING: RGWRESTConn no IP addresses found for endpoint=" << ep_url
                     << (ec ? " err=" + ec.message() : "") << dendl;
     }
-
-    resolved_endpoints.emplace(ep_url, std::move(res_ep));
   }
 }
 
@@ -89,19 +82,17 @@ RGWRESTConn::RGWRESTConn(CephContext *_cct, rgw::sal::Driver* driver,
                          std::optional<string> _api_name,
                          HostStyle _host_style)
   : cct(_cct),
-    endpoints(remote_endpoints.begin(), remote_endpoints.end()),
+    endpoint_urls(remote_endpoints.begin(), remote_endpoints.end()),
     remote_id(_remote_id),
     api_name(_api_name),
     host_style(_host_style)
 {
-  endpoints_status.reserve(remote_endpoints.size());
-  std::for_each(remote_endpoints.begin(), remote_endpoints.end(),
-                [this](const auto& url) {
-                  this->endpoints_status.emplace(url, ceph::real_clock::zero());
-                });
-  if (cct->_conf->rgw_rest_conn_connect_to_resolved_ips) {
-    resolve_endpoints();
+  resolved_endpoints.reserve(remote_endpoints.size());
+  for (const auto& ep_url : remote_endpoints) {
+    ResolvedEndpoint& res_ep = resolved_endpoints[ep_url];
+    res_ep.status.store(ceph::real_clock::zero());  // Initial status: connectable
   }
+  resolve_endpoints();
 
   if (driver) {
     key = driver->get_zone()->get_system_key();
@@ -117,45 +108,41 @@ RGWRESTConn::RGWRESTConn(CephContext *_cct,
                          std::optional<string> _api_name,
                          HostStyle _host_style)
   : cct(_cct),
-    endpoints(remote_endpoints.begin(), remote_endpoints.end()),
+    endpoint_urls(remote_endpoints.begin(), remote_endpoints.end()),
     key(_cred),
     self_zone_group(_zone_group),
     remote_id(_remote_id),
     api_name(_api_name),
     host_style(_host_style)
 {
-  endpoints_status.reserve(remote_endpoints.size());
-  std::for_each(remote_endpoints.begin(), remote_endpoints.end(),
-                [this](const auto& url) {
-                  this->endpoints_status.emplace(url, ceph::real_clock::zero());
-                });
-  if (cct->_conf->rgw_rest_conn_connect_to_resolved_ips) {
-    resolve_endpoints();
+  resolved_endpoints.reserve(remote_endpoints.size());
+  for (const auto& ep_url : remote_endpoints) {
+    ResolvedEndpoint& res_ep = resolved_endpoints[ep_url];
+    res_ep.status.store(ceph::real_clock::zero());  // Initial status: connectable
   }
+  resolve_endpoints();
 }
 
 RGWRESTConn::RGWRESTConn(RGWRESTConn&& other)
   : cct(other.cct),
-    endpoints(std::move(other.endpoints)),
+    endpoint_urls(std::move(other.endpoint_urls)),
+    endpoint_urls_counter(other.endpoint_urls_counter.load()),
     resolved_endpoints(std::move(other.resolved_endpoints)),
-    endpoints_status(std::move(other.endpoints_status)),
     key(std::move(other.key)),
     self_zone_group(std::move(other.self_zone_group)),
-    remote_id(std::move(other.remote_id)),
-    counter(other.counter.load())
+    remote_id(std::move(other.remote_id))
 {
 }
 
 RGWRESTConn& RGWRESTConn::operator=(RGWRESTConn&& other)
 {
   cct = other.cct;
-  endpoints = std::move(other.endpoints);
+  endpoint_urls = std::move(other.endpoint_urls);
+  endpoint_urls_counter = other.endpoint_urls_counter.load();
   resolved_endpoints = std::move(other.resolved_endpoints);
-  endpoints_status = std::move(other.endpoints_status);
   key = std::move(other.key);
   self_zone_group = std::move(other.self_zone_group);
   remote_id = std::move(other.remote_id);
-  counter = other.counter.load();
   return *this;
 }
 
@@ -179,25 +166,25 @@ void RGWRESTConn::get_connect_to_mapping_for_url(RGWEndpoint& endpoint)
 
 int RGWRESTConn::get_endpoint(RGWEndpoint& endpoint)
 {
-  if (endpoints.empty()) {
+  if (endpoint_urls.empty()) {
     ldout(cct, 0) << "ERROR: endpoints not configured for upstream zone" << dendl;
     return -EINVAL;
   }
 
   size_t num = 0;
-  while (num < endpoints.size()) {
-    int i = ++counter;
+  while (num < endpoint_urls.size()) {
+    int i = ++endpoint_urls_counter;
 
-    const string& ep_url = endpoints[i % endpoints.size()];
+    const string& ep_url = endpoint_urls[i % endpoint_urls.size()];
     endpoint.set_url(ep_url);
 
-    if (endpoints_status.find(ep_url) == endpoints_status.end()) {
+    if (resolved_endpoints.find(ep_url) == resolved_endpoints.end()) {
       ldout(cct, 1) << "ERROR: missing status for endpoint " << ep_url << dendl;
       num++;
       continue;
     }
 
-    const auto& upd_time = endpoints_status[ep_url].load();
+    const auto& upd_time = resolved_endpoints[ep_url].status.load();
 
     if (ceph::real_clock::is_zero(upd_time)) {
       break;
@@ -212,14 +199,14 @@ int RGWRESTConn::get_endpoint(RGWEndpoint& endpoint)
 
     static constexpr uint32_t CONN_STATUS_EXPIRE_SECS = 2;
     if (diff >= CONN_STATUS_EXPIRE_SECS) {
-      endpoints_status[ep_url].store(ceph::real_clock::zero());
+      resolved_endpoints[ep_url].status.store(ceph::real_clock::zero());
       ldout(cct, 10) << "endpoint " << endpoint.get_url() << " unconnectable status expired. mark it connectable" << dendl;
       break;
     }
     num++;
   };
 
-  if (num == endpoints.size()) {
+  if (num == endpoint_urls.size()) {
     ldout(cct, 5) << "ERROR: no valid endpoint" << dendl;
     return -EINVAL;
   }
@@ -242,13 +229,13 @@ void RGWRESTConn::set_endpoint_unconnectable(const RGWEndpoint& endpoint)
 {
   const string& url = endpoint.get_url();
 
-  if (url.empty() || endpoints_status.find(url) == endpoints_status.end()) {
+  if (url.empty() || resolved_endpoints.find(url) == resolved_endpoints.end()) {
     ldout(cct, 0) << "ERROR: endpoint is not a valid or doesn't have status. endpoint="
                   << url << dendl;
     return;
   }
 
-  endpoints_status[url].store(ceph::real_clock::now());
+  resolved_endpoints[url].status.store(ceph::real_clock::now());
 
   ldout(cct, 10) << "set endpoint unconnectable. url=" << url << dendl;
 }

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -5,10 +5,79 @@
 #include "rgw_rest_conn.h"
 #include "rgw_http_errors.h"
 #include "rgw_sal.h"
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/ip/tcp.hpp>
+
+#include <boost/url.hpp>
 
 #define dout_subsys ceph_subsys_rgw
 
 using namespace std;
+
+void RGWRESTConn::resolve_endpoints() {
+  resolved_endpoints.reserve(endpoints.size());
+
+  for (const auto& ep_url : endpoints) {
+    ResolvedEndpoint res_ep;
+    res_ep.url = ep_url;
+
+    // parse URL
+    boost::system::result<boost::urls::url_view> r = boost::urls::parse_uri(ep_url);
+    if (r.has_error()) {
+      ldout(cct, 0) << "RGWRESTConn: invalid endpoint url=" << ep_url
+                    << " err=" << r.error().message() << dendl;
+      continue;
+    }
+    boost::urls::url_view u = r.value();
+
+    // scheme
+    std::string scheme = std::string(u.scheme());
+    if (scheme.empty()) {
+      scheme = "http";
+    }
+    res_ep.scheme = scheme;
+
+    // host
+    res_ep.host = std::string(u.host());
+    if (res_ep.host.empty()) {
+      ldout(cct, 0) << "RGWRESTConn: endpoint url=" << ep_url
+                    << " has empty host" << dendl;
+      continue;
+    }
+
+    // port
+    if (u.has_port()) {
+      try {
+        res_ep.port = static_cast<uint16_t>(std::stoi(std::string(u.port())));
+      } catch (...) {
+        ldout(cct, 0) << "RGWRESTConn: invalid port in endpoint url=" << ep_url<< dendl;
+        continue;
+      }
+    } else {
+      res_ep.port = (scheme == "https" ? 443 : 80);
+    }
+
+    // resolve all IP addresses for the host
+    boost::asio::io_context io_ctx;
+    boost::asio::ip::tcp::resolver resolver(io_ctx);
+    boost::system::error_code ec;
+    auto results = resolver.resolve(res_ep.host, "", ec);
+    if (!ec && !results.empty()) {
+      for (const auto& entry : results) {
+        auto ip_str = entry.endpoint().address().to_string();
+        res_ep.ips.push_back(ip_str);
+        ldout(cct, 1) << "endpoint_url=" << ep_url << " resolved to ip=" << ip_str << dendl;
+      }
+      ldout(cct, 1) << "endpoint=" << ep_url << " resolved to "
+                << res_ep.ips.size() << " IP addresses" << dendl;
+    } else {
+      ldout(cct, 0) << "WARNING: RGWRESTConn no IP addresses found for endpoint=" << ep_url
+                    << (ec ? " err=" + ec.message() : "") << dendl;
+    }
+
+    resolved_endpoints.push_back(std::move(res_ep));
+  }
+}
 
 RGWRESTConn::RGWRESTConn(CephContext *_cct, rgw::sal::Driver* driver,
                          const string& _remote_id,
@@ -26,6 +95,9 @@ RGWRESTConn::RGWRESTConn(CephContext *_cct, rgw::sal::Driver* driver,
                 [this](const auto& url) {
                   this->endpoints_status.emplace(url, ceph::real_clock::zero());
                 });
+  if (cct->_conf->rgw_rest_conn_connect_to_resolved_ips) {
+    resolve_endpoints();
+  }
 
   if (driver) {
     key = driver->get_zone()->get_system_key();
@@ -53,11 +125,15 @@ RGWRESTConn::RGWRESTConn(CephContext *_cct,
                 [this](const auto& url) {
                   this->endpoints_status.emplace(url, ceph::real_clock::zero());
                 });
+  if (cct->_conf->rgw_rest_conn_connect_to_resolved_ips) {
+    resolve_endpoints();
+  }
 }
 
 RGWRESTConn::RGWRESTConn(RGWRESTConn&& other)
   : cct(other.cct),
     endpoints(std::move(other.endpoints)),
+    resolved_endpoints(std::move(other.resolved_endpoints)),
     endpoints_status(std::move(other.endpoints_status)),
     key(std::move(other.key)),
     self_zone_group(std::move(other.self_zone_group)),
@@ -70,6 +146,7 @@ RGWRESTConn& RGWRESTConn::operator=(RGWRESTConn&& other)
 {
   cct = other.cct;
   endpoints = std::move(other.endpoints);
+  resolved_endpoints = std::move(other.resolved_endpoints);
   endpoints_status = std::move(other.endpoints_status);
   key = std::move(other.key);
   self_zone_group = std::move(other.self_zone_group);

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -13,6 +13,11 @@
 using namespace std;
 
 void RGWRESTConn::resolve_endpoints() {
+  // TODO: resolve endpoints concurrently using async_resolve on a shared io_context.
+  //       In practice zones have a single endpoint or at most a handful of individual
+  //       RGW instances, and resolution runs once at process startup, so sequential
+  //       cost is negligible. A natural time to address this would be when adding
+  //       periodic DNS re-resolution.
   for (auto& res_ep : resolved_endpoints) {
     const std::string& ep_url = res_ep.url;
     // parse URL

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -329,7 +329,7 @@ auto RGWRESTConn::forward(const DoutPrefixProvider *dpp, const rgw_owner& uid,
     auto result = req.forward_request(dpp, key, info, max_response, inbl, outbl, y);
     if (result) {
       return result;
-    } else if (result.error() != -EIO) {
+    } else if (result.error() != -ERR_SERVICE_UNAVAILABLE) {
       return result;
     }
     set_endpoint_unconnectable(endpoint);
@@ -360,7 +360,7 @@ auto RGWRESTConn::forward_iam(const DoutPrefixProvider *dpp, const req_info& inf
     auto result = req.forward_request(dpp, key, info, max_response, inbl, outbl, y, service);
     if (result) {
       return result;
-    } else if (result.error() != -EIO) {
+    } else if (result.error() != -ERR_SERVICE_UNAVAILABLE) {
       return result;
     }
     set_endpoint_unconnectable(endpoint);
@@ -415,7 +415,7 @@ int RGWRESTConn::complete_request(const DoutPrefixProvider* dpp,
                                   real_time *mtime, optional_yield y)
 {
   int ret = req->complete_request(dpp, y, &etag, mtime);
-  if (ret == -EIO) {
+  if (ret == -ERR_INTERNAL_ERROR) {
     ldout(cct, 5) << __func__ << ": complete_request() returned ret=" << ret << dendl;
     set_endpoint_unconnectable(req->get_endpoint());
   }
@@ -578,7 +578,7 @@ int RGWRESTConn::complete_request(const DoutPrefixProvider* dpp,
                                   optional_yield y)
 {
   int ret = req->complete_request(dpp, y, etag, mtime, psize, pattrs, pheaders);
-  if (ret == -EIO) {
+  if (ret == -ERR_INTERNAL_ERROR) {
     ldout(cct, 5) << __func__ << ": complete_request() returned ret=" << ret << dendl;
     set_endpoint_unconnectable(req->get_endpoint());
   }
@@ -629,7 +629,7 @@ int RGWRESTConn::get_resource(const DoutPrefixProvider *dpp,
     }
 
     ret = req.complete_request(dpp, y);
-    if (ret == -EIO) {
+    if (ret == -ERR_INTERNAL_ERROR) {
       set_endpoint_unconnectable(endpoint);
       if (tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
         ldpp_dout(dpp, 20) << __func__  << "(): failed to get resource. retries=" << tries << dendl;
@@ -683,7 +683,7 @@ int RGWRESTConn::send_resource(const DoutPrefixProvider *dpp, const std::string&
     }
 
     ret = req.complete_request(dpp, y);
-    if (ret == -EIO) {
+    if (ret == -ERR_INTERNAL_ERROR) {
       set_endpoint_unconnectable(endpoint);
       if (tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
         ldpp_dout(dpp, 20) << __func__  << "(): failed to send resource. retries=" << tries << dendl;
@@ -742,7 +742,7 @@ int RGWRESTReadResource::read(const DoutPrefixProvider *dpp, optional_yield y)
   }
 
   ret = req.complete_request(dpp, y);
-  if (ret == -EIO) {
+  if (ret == -ERR_INTERNAL_ERROR) {
     conn->set_endpoint_unconnectable(req.get_endpoint());
     ldpp_dout(dpp, 20) << __func__ << ": complete_request() returned ret=" << ret << dendl;
   }
@@ -809,7 +809,7 @@ int RGWRESTSendResource::send(const DoutPrefixProvider *dpp, bufferlist& outbl, 
   }
 
   ret = req.complete_request(dpp, y);
-  if (ret == -EIO) {
+  if (ret == -ERR_INTERNAL_ERROR) {
     conn->set_endpoint_unconnectable(req.get_endpoint());
     ldpp_dout(dpp, 20) << __func__ << ": complete_request() returned ret=" << ret << dendl;
   }

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -273,11 +273,11 @@ RGWEndpoint RGWRESTConn::get_endpoint()
 
 void RGWRESTConn::set_endpoint_unconnectable(const RGWEndpoint& endpoint)
 {
-  const string& orig_url = endpoint.get_original_url();
+  const string& endpoint_id = endpoint.get_endpoint_url_lookup_id();
   const string& connect_to = endpoint.get_connect_to();
 
-  ResolvedEndpoint* res_ep = find_resolved_endpoint(orig_url);
-  if (orig_url.empty() || !res_ep) {
+  ResolvedEndpoint* res_ep = find_resolved_endpoint(endpoint_id);
+  if (endpoint_id.empty() || !res_ep) {
     ldout(cct, 0) << "ERROR: endpoint is not valid or not found: "
       << endpoint << dendl;
     return;
@@ -301,7 +301,7 @@ void RGWRESTConn::set_endpoint_unconnectable(const RGWEndpoint& endpoint)
   for (auto& res_ip : res_ep->resolved_ips) {
     res_ip.mark_down();
   }
-  ldout(cct, 10) << "set all IPs unconnectable for endpoint url=" << orig_url << dendl;
+  ldout(cct, 10) << "set all IPs unconnectable for endpoint=" << endpoint << dendl;
 }
 
 void RGWRESTConn::populate_params(param_vec_t& params, const rgw_owner* uid, const string& zonegroup)

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -15,7 +15,8 @@
 using namespace std;
 
 void RGWRESTConn::resolve_endpoints() {
-  for (auto& [ep_url, res_ep] : resolved_endpoints) {
+  for (auto& res_ep : resolved_endpoints) {
+    const std::string& ep_url = res_ep.url;
     // parse URL
     boost::system::result<boost::urls::url_view> r = boost::urls::parse_uri(ep_url);
     if (r.has_error()) {
@@ -82,15 +83,16 @@ RGWRESTConn::RGWRESTConn(CephContext *_cct, rgw::sal::Driver* driver,
                          std::optional<string> _api_name,
                          HostStyle _host_style)
   : cct(_cct),
-    endpoint_urls(remote_endpoints.begin(), remote_endpoints.end()),
     remote_id(_remote_id),
     api_name(_api_name),
     host_style(_host_style)
 {
   resolved_endpoints.reserve(remote_endpoints.size());
   for (const auto& ep_url : remote_endpoints) {
-    ResolvedEndpoint& res_ep = resolved_endpoints[ep_url];
+    ResolvedEndpoint res_ep;
+    res_ep.url = ep_url;
     res_ep.status.store(ceph::real_clock::zero());  // Initial status: connectable
+    resolved_endpoints.push_back(std::move(res_ep));
   }
   resolve_endpoints();
 
@@ -108,7 +110,6 @@ RGWRESTConn::RGWRESTConn(CephContext *_cct,
                          std::optional<string> _api_name,
                          HostStyle _host_style)
   : cct(_cct),
-    endpoint_urls(remote_endpoints.begin(), remote_endpoints.end()),
     key(_cred),
     self_zone_group(_zone_group),
     remote_id(_remote_id),
@@ -117,16 +118,17 @@ RGWRESTConn::RGWRESTConn(CephContext *_cct,
 {
   resolved_endpoints.reserve(remote_endpoints.size());
   for (const auto& ep_url : remote_endpoints) {
-    ResolvedEndpoint& res_ep = resolved_endpoints[ep_url];
+    ResolvedEndpoint res_ep;
+    res_ep.url = ep_url;
     res_ep.status.store(ceph::real_clock::zero());  // Initial status: connectable
+    resolved_endpoints.push_back(std::move(res_ep));
   }
   resolve_endpoints();
 }
 
 RGWRESTConn::RGWRESTConn(RGWRESTConn&& other)
   : cct(other.cct),
-    endpoint_urls(std::move(other.endpoint_urls)),
-    endpoint_urls_counter(other.endpoint_urls_counter.load()),
+    endpoint_round_robin_counter(other.endpoint_round_robin_counter.load()),
     resolved_endpoints(std::move(other.resolved_endpoints)),
     key(std::move(other.key)),
     self_zone_group(std::move(other.self_zone_group)),
@@ -139,8 +141,7 @@ RGWRESTConn::RGWRESTConn(RGWRESTConn&& other)
 RGWRESTConn& RGWRESTConn::operator=(RGWRESTConn&& other)
 {
   cct = other.cct;
-  endpoint_urls = std::move(other.endpoint_urls);
-  endpoint_urls_counter = other.endpoint_urls_counter.load();
+  endpoint_round_robin_counter = other.endpoint_round_robin_counter.load();
   resolved_endpoints = std::move(other.resolved_endpoints);
   key = std::move(other.key);
   self_zone_group = std::move(other.self_zone_group);
@@ -150,45 +151,46 @@ RGWRESTConn& RGWRESTConn::operator=(RGWRESTConn&& other)
   return *this;
 }
 
-void RGWRESTConn::get_connect_to_mapping_for_url(RGWEndpoint& endpoint)
+ResolvedEndpoint* RGWRESTConn::find_resolved_endpoint(const std::string& url)
+{
+  for (auto& res_ep : resolved_endpoints) {
+    if (res_ep.url == url) {
+      return &res_ep;
+    }
+  }
+  return nullptr;
+}
+
+void RGWRESTConn::populate_connect_to(RGWEndpoint& endpoint, ResolvedEndpoint& resolved_endpoint)
 {
   if (!cct->_conf->rgw_rest_conn_connect_to_resolved_ips) {
     return;
   }
 
-  std::string connect_to;
-
-  auto it = resolved_endpoints.find(endpoint.get_url());
-  if (it != resolved_endpoints.end() && !it->second.connect_to_strings.empty()) {
-    auto& res_ep = it->second;
-    size_t idx = res_ep.rr_index++;
-    connect_to = res_ep.connect_to_strings[idx % res_ep.connect_to_strings.size()];
+  if (!resolved_endpoint.connect_to_strings.empty()) {
+    size_t idx = resolved_endpoint.rr_index++;
+    endpoint.set_connect_to(resolved_endpoint.connect_to_strings[idx % resolved_endpoint.connect_to_strings.size()]);
   }
-
-  endpoint.set_connect_to(connect_to);
 }
 
 int RGWRESTConn::get_endpoint(RGWEndpoint& endpoint)
 {
-  if (endpoint_urls.empty()) {
+  if (resolved_endpoints.empty()) {
     ldout(cct, 0) << "ERROR: endpoints not configured for upstream zone" << dendl;
     return -EINVAL;
   }
 
   size_t num = 0;
-  while (num < endpoint_urls.size()) {
-    int i = ++endpoint_urls_counter;
+  size_t selected_idx = 0;
+  while (num < resolved_endpoints.size()) {
+    int i = ++endpoint_round_robin_counter;
+    selected_idx = i % resolved_endpoints.size();
 
-    const string& ep_url = endpoint_urls[i % endpoint_urls.size()];
+    ResolvedEndpoint& res_ep = resolved_endpoints[selected_idx];
+    const std::string& ep_url = res_ep.url;
     endpoint.set_url(ep_url);
 
-    if (resolved_endpoints.find(ep_url) == resolved_endpoints.end()) {
-      ldout(cct, 1) << "ERROR: missing status for endpoint " << ep_url << dendl;
-      num++;
-      continue;
-    }
-
-    const auto& upd_time = resolved_endpoints[ep_url].status.load();
+    const auto& upd_time = res_ep.status.load();
 
     if (ceph::real_clock::is_zero(upd_time)) {
       break;
@@ -203,19 +205,19 @@ int RGWRESTConn::get_endpoint(RGWEndpoint& endpoint)
 
     static constexpr uint32_t CONN_STATUS_EXPIRE_SECS = 2;
     if (diff >= CONN_STATUS_EXPIRE_SECS) {
-      resolved_endpoints[ep_url].status.store(ceph::real_clock::zero());
+      res_ep.status.store(ceph::real_clock::zero());
       ldout(cct, 10) << endpoint << " unconnectable status expired. mark it connectable" << dendl;
       break;
     }
     num++;
   };
 
-  if (num == endpoint_urls.size()) {
+  if (num == resolved_endpoints.size()) {
     ldout(cct, 5) << "ERROR: no valid endpoint" << dendl;
     return -EINVAL;
   }
 
-  get_connect_to_mapping_for_url(endpoint);
+  populate_connect_to(endpoint, resolved_endpoints[selected_idx]);
   ldout(cct, 20) << "get_endpoint picked " << endpoint << dendl;
 
   return 0;
@@ -232,13 +234,14 @@ void RGWRESTConn::set_endpoint_unconnectable(const RGWEndpoint& endpoint)
 {
   const string& orig_url = endpoint.get_original_url();
 
-  if (orig_url.empty() || resolved_endpoints.find(orig_url) == resolved_endpoints.end()) {
+  ResolvedEndpoint* res_ep = find_resolved_endpoint(orig_url);
+  if (orig_url.empty() || !res_ep) {
     ldout(cct, 0) << "ERROR: endpoint is not a valid or doesn't have status: "
                   << endpoint << dendl;
     return;
   }
 
-  resolved_endpoints[orig_url].status.store(ceph::real_clock::now());
+  res_ep->status.store(ceph::real_clock::now());
 
   ldout(cct, 10) << "set endpoint unconnectable. url=" << orig_url << dendl;
 }

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -231,17 +231,17 @@ RGWEndpoint RGWRESTConn::get_endpoint()
 
 void RGWRESTConn::set_endpoint_unconnectable(const RGWEndpoint& endpoint)
 {
-  const string& url = endpoint.get_url();
+  const string& orig_url = endpoint.get_original_url();
 
-  if (url.empty() || resolved_endpoints.find(url) == resolved_endpoints.end()) {
-    ldout(cct, 0) << "ERROR: endpoint is not a valid or doesn't have status. endpoint="
-                  << url << dendl;
+  if (orig_url.empty() || resolved_endpoints.find(orig_url) == resolved_endpoints.end()) {
+    ldout(cct, 0) << "ERROR: endpoint is not a valid or doesn't have status. "
+                  << " original_url=" << orig_url << " current_url=" << endpoint.get_url() << dendl;
     return;
   }
 
-  resolved_endpoints[url].status.store(ceph::real_clock::now());
+  resolved_endpoints[orig_url].status.store(ceph::real_clock::now());
 
-  ldout(cct, 10) << "set endpoint unconnectable. url=" << url << dendl;
+  ldout(cct, 10) << "set endpoint unconnectable. url=" << orig_url << dendl;
 }
 
 void RGWRESTConn::populate_params(param_vec_t& params, const rgw_owner* uid, const string& zonegroup)
@@ -357,7 +357,7 @@ int RGWRESTConn::complete_request(const DoutPrefixProvider* dpp,
   int ret = req->complete_request(dpp, y, &etag, mtime);
   if (ret == -EIO) {
     ldout(cct, 5) << __func__ << ": complete_request() returned ret=" << ret << dendl;
-    set_endpoint_unconnectable(req->get_endpoint_orig());
+    set_endpoint_unconnectable(req->get_endpoint());
   }
 
   delete req;
@@ -520,7 +520,7 @@ int RGWRESTConn::complete_request(const DoutPrefixProvider* dpp,
   int ret = req->complete_request(dpp, y, etag, mtime, psize, pattrs, pheaders);
   if (ret == -EIO) {
     ldout(cct, 5) << __func__ << ": complete_request() returned ret=" << ret << dendl;
-    set_endpoint_unconnectable(req->get_endpoint_orig());
+    set_endpoint_unconnectable(req->get_endpoint());
   }
   delete req;
 
@@ -683,7 +683,7 @@ int RGWRESTReadResource::read(const DoutPrefixProvider *dpp, optional_yield y)
 
   ret = req.complete_request(dpp, y);
   if (ret == -EIO) {
-    conn->set_endpoint_unconnectable(req.get_endpoint_orig());
+    conn->set_endpoint_unconnectable(req.get_endpoint());
     ldpp_dout(dpp, 20) << __func__ << ": complete_request() returned ret=" << ret << dendl;
   }
 
@@ -750,7 +750,7 @@ int RGWRESTSendResource::send(const DoutPrefixProvider *dpp, bufferlist& outbl, 
 
   ret = req.complete_request(dpp, y);
   if (ret == -EIO) {
-    conn->set_endpoint_unconnectable(req.get_endpoint_orig());
+    conn->set_endpoint_unconnectable(req.get_endpoint());
     ldpp_dout(dpp, 20) << __func__ << ": complete_request() returned ret=" << ret << dendl;
   }
 

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -130,7 +130,9 @@ RGWRESTConn::RGWRESTConn(RGWRESTConn&& other)
     resolved_endpoints(std::move(other.resolved_endpoints)),
     key(std::move(other.key)),
     self_zone_group(std::move(other.self_zone_group)),
-    remote_id(std::move(other.remote_id))
+    remote_id(std::move(other.remote_id)),
+    api_name(std::move(other.api_name)),
+    host_style(other.host_style)
 {
 }
 
@@ -143,6 +145,8 @@ RGWRESTConn& RGWRESTConn::operator=(RGWRESTConn&& other)
   key = std::move(other.key);
   self_zone_group = std::move(other.self_zone_group);
   remote_id = std::move(other.remote_id);
+  api_name = std::move(other.api_name);
+  host_style = other.host_style;
   return *this;
 }
 

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -63,19 +63,23 @@ void RGWRESTConn::resolve_endpoints() {
     boost::system::error_code ec;
     auto results = resolver.resolve(res_ep.host, "", ec);
     if (!ec && !results.empty()) {
+      std::string port_str = std::to_string(res_ep.port);
+      std::string host_port_prefix = res_ep.host + ":" + port_str + ":";
+
       for (const auto& entry : results) {
         auto ip_str = entry.endpoint().address().to_string();
         res_ep.ips.push_back(ip_str);
-        ldout(cct, 1) << "endpoint_url=" << ep_url << " resolved to ip=" << ip_str << dendl;
+        res_ep.connect_to_strings.emplace_back(host_port_prefix + ip_str + ":" + port_str);
+        ldout(cct, 2) << "endpoint_url=" << ep_url << " resolved to ip=" << ip_str << dendl;
       }
-      ldout(cct, 1) << "endpoint=" << ep_url << " resolved to "
+      ldout(cct, 2) << "endpoint=" << ep_url << " resolved to "
                 << res_ep.ips.size() << " IP addresses" << dendl;
     } else {
       ldout(cct, 0) << "WARNING: RGWRESTConn no IP addresses found for endpoint=" << ep_url
                     << (ec ? " err=" + ec.message() : "") << dendl;
     }
 
-    resolved_endpoints.push_back(std::move(res_ep));
+    resolved_endpoints.emplace(ep_url, std::move(res_ep));
   }
 }
 
@@ -155,6 +159,24 @@ RGWRESTConn& RGWRESTConn::operator=(RGWRESTConn&& other)
   return *this;
 }
 
+void RGWRESTConn::get_connect_to_mapping_for_url(RGWEndpoint& endpoint)
+{
+  if (!cct->_conf->rgw_rest_conn_connect_to_resolved_ips) {
+    return;
+  }
+
+  std::string connect_to;
+
+  auto it = resolved_endpoints.find(endpoint.get_url());
+  if (it != resolved_endpoints.end() && !it->second.connect_to_strings.empty()) {
+    auto& res_ep = it->second;
+    size_t idx = res_ep.rr_index++;
+    connect_to = res_ep.connect_to_strings[idx % res_ep.connect_to_strings.size()];
+  }
+
+  endpoint.set_connect_to(connect_to);
+}
+
 int RGWRESTConn::get_endpoint(RGWEndpoint& endpoint)
 {
   if (endpoints.empty()) {
@@ -201,7 +223,9 @@ int RGWRESTConn::get_endpoint(RGWEndpoint& endpoint)
     ldout(cct, 5) << "ERROR: no valid endpoint" << dendl;
     return -EINVAL;
   }
-  ldout(cct, 20) << "get_endpoint picked url=" << endpoint.get_url()
+
+  get_connect_to_mapping_for_url(endpoint);
+  ldout(cct, 20) << "get_endpoint picked endpoint url=" << endpoint.get_url()
     << " connect_to=" << endpoint.get_connect_to() << dendl;
 
   return 0;

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -124,7 +124,7 @@ RGWRESTConn::RGWRESTConn(CephContext *_cct,
 
 RGWRESTConn::RGWRESTConn(RGWRESTConn&& other)
   : cct(other.cct),
-    endpoint_round_robin_counter(other.endpoint_round_robin_counter.load()),
+    endpoint_rr_index(other.endpoint_rr_index.load()),
     resolved_endpoints(std::move(other.resolved_endpoints)),
     key(std::move(other.key)),
     self_zone_group(std::move(other.self_zone_group)),
@@ -137,7 +137,7 @@ RGWRESTConn::RGWRESTConn(RGWRESTConn&& other)
 RGWRESTConn& RGWRESTConn::operator=(RGWRESTConn&& other)
 {
   cct = other.cct;
-  endpoint_round_robin_counter = other.endpoint_round_robin_counter.load();
+  endpoint_rr_index = other.endpoint_rr_index.load();
   resolved_endpoints = std::move(other.resolved_endpoints);
   key = std::move(other.key);
   self_zone_group = std::move(other.self_zone_group);
@@ -169,10 +169,11 @@ void RGWRESTConn::populate_connect_to(RGWEndpoint& endpoint, ResolvedEndpoint& r
 
   const auto ip_fail_timeout = cct->_conf->rgw_rest_conn_ip_fail_timeout_secs;
   const size_t num_ips = resolved_endpoint.resolved_ips.size();
+  auto now = ceph::real_clock::now();
 
   // Round-robin through IPs, skipping any that are marked down
   for (size_t i = 0; i < num_ips; ++i) {
-    size_t idx = resolved_endpoint.endpoint_ips_round_robin_counter++ % num_ips;
+    size_t idx = resolved_endpoint.ip_rr_index++ % num_ips;
     ResolvedIP& ip_status = resolved_endpoint.resolved_ips[idx];
 
     const auto& last_fail = ip_status.last_failure.load();
@@ -181,7 +182,7 @@ void RGWRESTConn::populate_connect_to(RGWEndpoint& endpoint, ResolvedEndpoint& r
       return;
     }
 
-    auto diff = ceph::to_seconds<double>(ceph::real_clock::now() - last_fail);
+    auto diff = ceph::to_seconds<double>(now - last_fail);
     if (diff >= ip_fail_timeout) {
       // Failure expired, mark IP as up and use it
       ip_status.mark_up();
@@ -238,7 +239,7 @@ int RGWRESTConn::get_endpoint(RGWEndpoint& endpoint)
   size_t num = 0;
   size_t selected_idx = 0;
   while (num < resolved_endpoints.size()) {
-    int i = ++endpoint_round_robin_counter;
+    int i = ++endpoint_rr_index;
     selected_idx = i % resolved_endpoints.size();
 
     ResolvedEndpoint& res_ep = resolved_endpoints[selected_idx];

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -60,14 +60,14 @@ void RGWRESTConn::resolve_endpoints() {
       std::string port_str = std::to_string(res_ep.port);
       std::string host_port_prefix = res_ep.host + ":" + port_str + ":";
 
+      res_ep.resolved_ips.reserve(results.size());
       for (const auto& entry : results) {
         auto ip_str = entry.endpoint().address().to_string();
-        res_ep.ips.push_back(ip_str);
-        res_ep.connect_to_strings.emplace_back(host_port_prefix + ip_str + ":" + port_str);
+        res_ep.resolved_ips.emplace_back(host_port_prefix + ip_str + ":" + port_str);
         ldout(cct, 2) << "endpoint_url=" << ep_url << " resolved to ip=" << ip_str << dendl;
       }
       ldout(cct, 2) << "endpoint=" << ep_url << " resolved to "
-                << res_ep.ips.size() << " IP addresses" << dendl;
+                << res_ep.resolved_ips.size() << " IP addresses" << dendl;
     } else {
       ldout(cct, 0) << "WARNING: RGWRESTConn no IP addresses found for endpoint=" << ep_url
                     << (ec ? " err=" + ec.message() : "") << dendl;
@@ -89,7 +89,6 @@ RGWRESTConn::RGWRESTConn(CephContext *_cct, rgw::sal::Driver* driver,
   for (const auto& ep_url : remote_endpoints) {
     ResolvedEndpoint res_ep;
     res_ep.url = ep_url;
-    res_ep.status.store(ceph::real_clock::zero());  // Initial status: connectable
     resolved_endpoints.push_back(std::move(res_ep));
   }
   resolve_endpoints();
@@ -118,7 +117,6 @@ RGWRESTConn::RGWRESTConn(CephContext *_cct,
   for (const auto& ep_url : remote_endpoints) {
     ResolvedEndpoint res_ep;
     res_ep.url = ep_url;
-    res_ep.status.store(ceph::real_clock::zero());  // Initial status: connectable
     resolved_endpoints.push_back(std::move(res_ep));
   }
   resolve_endpoints();
@@ -165,10 +163,38 @@ void RGWRESTConn::populate_connect_to(RGWEndpoint& endpoint, ResolvedEndpoint& r
     return;
   }
 
-  if (!resolved_endpoint.connect_to_strings.empty()) {
-    size_t idx = resolved_endpoint.rr_index++;
-    endpoint.set_connect_to(resolved_endpoint.connect_to_strings[idx % resolved_endpoint.connect_to_strings.size()]);
+  if (resolved_endpoint.resolved_ips.empty()) {
+    return;
   }
+
+  static constexpr uint32_t CONN_STATUS_EXPIRE_SECS = 2;
+  const size_t num_ips = resolved_endpoint.resolved_ips.size();
+
+  // Round-robin through IPs, skipping any that are marked down
+  for (size_t i = 0; i < num_ips; ++i) {
+    size_t idx = resolved_endpoint.endpoint_ips_round_robin_counter++ % num_ips;
+    ResolvedIP& ip_status = resolved_endpoint.resolved_ips[idx];
+
+    const auto& last_fail = ip_status.last_failure.load();
+    if (ceph::real_clock::is_zero(last_fail)) {
+      endpoint.set_connect_to(ip_status.connect_to);  // IP is up
+      return;
+    }
+
+    auto diff = ceph::to_seconds<double>(ceph::real_clock::now() - last_fail);
+    if (diff >= CONN_STATUS_EXPIRE_SECS) {
+      // Failure expired, mark IP as up and use it
+      ip_status.mark_up();
+      ldout(cct, 5) << "IP " << ip_status.connect_to << " failure expired, marking up" << dendl;
+      endpoint.set_connect_to(ip_status.connect_to);
+      return;
+    }
+  }
+
+  // All IPs are down - do not populate connect_to; i.e.,
+  // let libcurl handle it without connect_to hint.
+  ldout(cct, 5) << "All IPs down for endpoint=" << resolved_endpoint.url
+    << " - skip connect_to hint" << dendl;
 }
 
 int RGWRESTConn::get_endpoint(RGWEndpoint& endpoint)
@@ -178,6 +204,37 @@ int RGWRESTConn::get_endpoint(RGWEndpoint& endpoint)
     return -EINVAL;
   }
 
+  static constexpr uint32_t CONN_STATUS_EXPIRE_SECS = 2;
+  auto now = ceph::real_clock::now();
+
+  // Helper to check if an endpoint has at least one available IP
+  auto endpoint_has_available_ip = [&](ResolvedEndpoint& res_ep) -> bool {
+    // If no IP resolution, endpoint is available (will use DNS directly)
+    if (res_ep.resolved_ips.empty()) {
+      return true;
+    }
+
+    // Fast path: if no recent failures at endpoint level, all IPs are available
+    const auto& ep_last_fail = res_ep.last_failure_time.load();
+    if (ceph::real_clock::is_zero(ep_last_fail) ||
+        ceph::to_seconds<double>(now - ep_last_fail) >= CONN_STATUS_EXPIRE_SECS) {
+      return true;
+    }
+
+    // Slow path: check individual IPs (only when there's a recent failure)
+    for (auto& ip_status : res_ep.resolved_ips) {
+      const auto& last_fail = ip_status.last_failure.load();
+      if (ceph::real_clock::is_zero(last_fail)) {
+        return true;  // This IP is up
+      }
+      auto diff = ceph::to_seconds<double>(now - last_fail);
+      if (diff >= CONN_STATUS_EXPIRE_SECS) {
+        return true;  // This IP's failure has expired
+      }
+    }
+    return false;  // All IPs are down
+  };
+
   size_t num = 0;
   size_t selected_idx = 0;
   while (num < resolved_endpoints.size()) {
@@ -185,33 +242,18 @@ int RGWRESTConn::get_endpoint(RGWEndpoint& endpoint)
     selected_idx = i % resolved_endpoints.size();
 
     ResolvedEndpoint& res_ep = resolved_endpoints[selected_idx];
-    const std::string& ep_url = res_ep.url;
-    endpoint.set_url(ep_url);
 
-    const auto& upd_time = res_ep.status.load();
-
-    if (ceph::real_clock::is_zero(upd_time)) {
+    if (endpoint_has_available_ip(res_ep)) {
+      endpoint.set_url(res_ep.url);
       break;
     }
 
-    auto diff = ceph::to_seconds<double>(ceph::real_clock::now() - upd_time);
-
-    ldout(cct, 20) << "endpoint url=" << ep_url
-                   << " last endpoint status update time="
-                   << ceph::real_clock::to_double(upd_time)
-                   << " diff=" << diff << dendl;
-
-    static constexpr uint32_t CONN_STATUS_EXPIRE_SECS = 2;
-    if (diff >= CONN_STATUS_EXPIRE_SECS) {
-      res_ep.status.store(ceph::real_clock::zero());
-      ldout(cct, 10) << endpoint << " unconnectable status expired. mark it connectable" << dendl;
-      break;
-    }
+    ldout(cct, 5) << "endpoint url=" << res_ep.url << " all IPs down, trying next" << dendl;
     num++;
-  };
+  }
 
   if (num == resolved_endpoints.size()) {
-    ldout(cct, 5) << "ERROR: no valid endpoint" << dendl;
+    ldout(cct, 1) << "ERROR: no valid endpoint (all IPs down for all endpoints)" << dendl;
     return -EINVAL;
   }
 
@@ -231,17 +273,34 @@ RGWEndpoint RGWRESTConn::get_endpoint()
 void RGWRESTConn::set_endpoint_unconnectable(const RGWEndpoint& endpoint)
 {
   const string& orig_url = endpoint.get_original_url();
+  const string& connect_to = endpoint.get_connect_to();
 
   ResolvedEndpoint* res_ep = find_resolved_endpoint(orig_url);
   if (orig_url.empty() || !res_ep) {
-    ldout(cct, 0) << "ERROR: endpoint is not a valid or doesn't have status: "
-                  << endpoint << dendl;
+    ldout(cct, 0) << "ERROR: endpoint is not valid or not found: "
+      << endpoint << dendl;
     return;
   }
 
-  res_ep->status.store(ceph::real_clock::now());
+  // Update endpoint-level last_failure_time for fast-path optimization
+  auto now = ceph::real_clock::now();
+  res_ep->last_failure_time.store(now);
 
-  ldout(cct, 10) << "set endpoint unconnectable. url=" << orig_url << dendl;
+  // If we have a connect_to string, mark that specific IP as down as well
+  if (!connect_to.empty()) {
+    ResolvedIP* res_ip = res_ep->find_ip_status(connect_to);
+    if (res_ip) {
+      res_ip->mark_down();
+      ldout(cct, 10) << "set IP unconnectable: " << connect_to << dendl;
+      return;
+    }
+  }
+
+  // Fallback: mark all IPs for this endpoint as down
+  for (auto& res_ip : res_ep->resolved_ips) {
+    res_ip.mark_down();
+  }
+  ldout(cct, 10) << "set all IPs unconnectable for endpoint url=" << orig_url << dendl;
 }
 
 void RGWRESTConn::populate_params(param_vec_t& params, const rgw_owner* uid, const string& zonegroup)

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -1,9 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
 // vim: ts=8 sw=2 sts=2 expandtab ft=cpp
 
-#include "rgw_zone.h"
 #include "rgw_rest_conn.h"
-#include "rgw_http_errors.h"
 #include "rgw_sal.h"
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -167,7 +167,7 @@ void RGWRESTConn::populate_connect_to(RGWEndpoint& endpoint, ResolvedEndpoint& r
     return;
   }
 
-  static constexpr uint32_t CONN_STATUS_EXPIRE_SECS = 2;
+  const auto ip_fail_timeout = cct->_conf->rgw_rest_conn_ip_fail_timeout_secs;
   const size_t num_ips = resolved_endpoint.resolved_ips.size();
 
   // Round-robin through IPs, skipping any that are marked down
@@ -182,7 +182,7 @@ void RGWRESTConn::populate_connect_to(RGWEndpoint& endpoint, ResolvedEndpoint& r
     }
 
     auto diff = ceph::to_seconds<double>(ceph::real_clock::now() - last_fail);
-    if (diff >= CONN_STATUS_EXPIRE_SECS) {
+    if (diff >= ip_fail_timeout) {
       // Failure expired, mark IP as up and use it
       ip_status.mark_up();
       ldout(cct, 5) << "IP " << ip_status.connect_to << " failure expired, marking up" << dendl;
@@ -204,7 +204,7 @@ int RGWRESTConn::get_endpoint(RGWEndpoint& endpoint)
     return -EINVAL;
   }
 
-  static constexpr uint32_t CONN_STATUS_EXPIRE_SECS = 2;
+  const auto ip_fail_timeout = cct->_conf->rgw_rest_conn_ip_fail_timeout_secs;
   auto now = ceph::real_clock::now();
 
   // Helper to check if an endpoint has at least one available IP
@@ -217,7 +217,7 @@ int RGWRESTConn::get_endpoint(RGWEndpoint& endpoint)
     // Fast path: if no recent failures at endpoint level, all IPs are available
     const auto& ep_last_fail = res_ep.last_failure_time.load();
     if (ceph::real_clock::is_zero(ep_last_fail) ||
-        ceph::to_seconds<double>(now - ep_last_fail) >= CONN_STATUS_EXPIRE_SECS) {
+        ceph::to_seconds<double>(now - ep_last_fail) >= ip_fail_timeout) {
       return true;
     }
 
@@ -228,7 +228,7 @@ int RGWRESTConn::get_endpoint(RGWEndpoint& endpoint)
         return true;  // This IP is up
       }
       auto diff = ceph::to_seconds<double>(now - last_fail);
-      if (diff >= CONN_STATUS_EXPIRE_SECS) {
+      if (diff >= ip_fail_timeout) {
         return true;  // This IP's failure has expired
       }
     }

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -204,7 +204,7 @@ int RGWRESTConn::get_endpoint(RGWEndpoint& endpoint)
     static constexpr uint32_t CONN_STATUS_EXPIRE_SECS = 2;
     if (diff >= CONN_STATUS_EXPIRE_SECS) {
       resolved_endpoints[ep_url].status.store(ceph::real_clock::zero());
-      ldout(cct, 10) << "endpoint " << endpoint.get_url() << " unconnectable status expired. mark it connectable" << dendl;
+      ldout(cct, 10) << endpoint << " unconnectable status expired. mark it connectable" << dendl;
       break;
     }
     num++;
@@ -216,8 +216,7 @@ int RGWRESTConn::get_endpoint(RGWEndpoint& endpoint)
   }
 
   get_connect_to_mapping_for_url(endpoint);
-  ldout(cct, 20) << "get_endpoint picked endpoint url=" << endpoint.get_url()
-    << " connect_to=" << endpoint.get_connect_to() << dendl;
+  ldout(cct, 20) << "get_endpoint picked " << endpoint << dendl;
 
   return 0;
 }
@@ -234,8 +233,8 @@ void RGWRESTConn::set_endpoint_unconnectable(const RGWEndpoint& endpoint)
   const string& orig_url = endpoint.get_original_url();
 
   if (orig_url.empty() || resolved_endpoints.find(orig_url) == resolved_endpoints.end()) {
-    ldout(cct, 0) << "ERROR: endpoint is not a valid or doesn't have status. "
-                  << " original_url=" << orig_url << " current_url=" << endpoint.get_url() << dendl;
+    ldout(cct, 0) << "ERROR: endpoint is not a valid or doesn't have status: "
+                  << endpoint << dendl;
     return;
   }
 

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -101,9 +101,9 @@ public:
   RGWRESTConn& operator=(RGWRESTConn&& other);
   virtual ~RGWRESTConn() = default;
 
-  int get_url(std::string& endpoint);
-  std::string get_url();
-  void set_url_unconnectable(const std::string& endpoint);
+  int get_endpoint(RGWEndpoint& endpoint);
+  RGWEndpoint get_endpoint();
+  void set_endpoint_unconnectable(const RGWEndpoint& endpoint);
   const std::string& get_self_zonegroup() {
     return self_zone_group;
   }
@@ -358,7 +358,7 @@ public:
     int ret = req.wait(dpp, y);
     if (ret < 0) {
       if (ret == -ERR_INTERNAL_ERROR) {
-        conn->set_url_unconnectable(req.get_url_orig());
+        conn->set_endpoint_unconnectable(req.get_endpoint_orig());
       }
       return ret;
     }
@@ -414,7 +414,7 @@ int RGWRESTReadResource::wait(const DoutPrefixProvider* dpp, T *dest,
   int ret = req.wait(dpp, y);
   if (ret < 0) {
     if (ret == -ERR_INTERNAL_ERROR) {
-      conn->set_url_unconnectable(req.get_url_orig());
+      conn->set_endpoint_unconnectable(req.get_endpoint_orig());
     }
     return ret;
   }
@@ -489,7 +489,7 @@ public:
     *pbl = bl;
 
     if (ret == -ERR_INTERNAL_ERROR) {
-      conn->set_url_unconnectable(req.get_url_orig());
+      conn->set_endpoint_unconnectable(req.get_endpoint_orig());
     }
 
     if (ret < 0 && err_result ) {
@@ -510,7 +510,7 @@ int RGWRESTSendResource::wait(const DoutPrefixProvider* dpp, T *dest,
 {
   int ret = req.wait(dpp, y);
   if (ret == -ERR_INTERNAL_ERROR) {
-    conn->set_url_unconnectable(req.get_url_orig());
+    conn->set_endpoint_unconnectable(req.get_endpoint_orig());
   }
 
   if (ret >= 0) {

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -111,7 +111,7 @@ struct ResolvedEndpoint {
   std::string host;               // e.g., "s3.abc.com"
   int port = -1;                  // e.g., 8443
   std::vector<ResolvedIP> resolved_ips;  // Per-IP connect_to strings with health status
-  mutable size_t endpoint_ips_round_robin_counter = 0;    // round-robin index for IPs
+  mutable std::atomic<size_t> ip_rr_index{0};    // round-robin index for IPs
   mutable std::atomic<ceph::real_time> last_failure_time; // most recent IP failure seen on this endpoint
 
   ResolvedEndpoint() : last_failure_time(ceph::real_clock::zero()) {}
@@ -123,7 +123,7 @@ struct ResolvedEndpoint {
       host(std::move(other.host)),
       port(other.port),
       resolved_ips(std::move(other.resolved_ips)),
-      endpoint_ips_round_robin_counter(other.endpoint_ips_round_robin_counter),
+      ip_rr_index(other.ip_rr_index.load()),
       last_failure_time(other.last_failure_time.load())
   {}
 
@@ -134,7 +134,7 @@ struct ResolvedEndpoint {
     host = std::move(other.host);
     port = other.port;
     resolved_ips = std::move(other.resolved_ips);
-    endpoint_ips_round_robin_counter = other.endpoint_ips_round_robin_counter;
+    ip_rr_index.store(other.ip_rr_index.load());
     last_failure_time.store(other.last_failure_time.load());
     return *this;
   }
@@ -155,7 +155,7 @@ struct ResolvedEndpoint {
 class RGWRESTConn
 {
   CephContext *cct;
-  std::atomic<int64_t> endpoint_round_robin_counter = { 0 }; // Round-robin counter for resolved_endpoints
+  std::atomic<int64_t> endpoint_rr_index = { 0 }; // Round-robin counter for resolved_endpoints
   std::vector<ResolvedEndpoint> resolved_endpoints;
   RGWAccessKey key;
   std::string self_zone_group;

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -69,7 +69,7 @@ inline param_vec_t make_param_list(const std::map<std::string, std::string> *pp)
  * ResolvedIP - Per-IP connection status tracking.
  *
  * Each resolved IP address has its own failure status. An IP is considered
- * "down" if last_failure is non-zero and less than CONN_STATUS_EXPIRE_SECS old.
+ * "down" if last_failure is non-zero and less than rgw_rest_conn_ip_fail_timeout_secs old.
  * After the timeout, the IP becomes eligible for retry.
  */
 struct ResolvedIP {

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -112,9 +112,8 @@ struct ResolvedEndpoint {
 class RGWRESTConn
 {
   CephContext *cct;
-  std::vector<std::string> endpoint_urls;             // For ordered round-robin
-  std::atomic<int64_t> endpoint_urls_counter = { 0 }; // Round-robin counter for endpoint_urls
-  std::unordered_map<std::string, ResolvedEndpoint> resolved_endpoints;
+  std::atomic<int64_t> endpoint_round_robin_counter = { 0 }; // Round-robin counter for resolved_endpoints
+  std::vector<ResolvedEndpoint> resolved_endpoints;
   RGWAccessKey key;
   std::string self_zone_group;
   std::string remote_id;
@@ -146,7 +145,8 @@ public:
 
   int get_endpoint(RGWEndpoint& endpoint);
   RGWEndpoint get_endpoint();
-  const std::unordered_map<std::string, ResolvedEndpoint>& get_resolved_endpoints() const { return resolved_endpoints; }
+  const std::vector<ResolvedEndpoint>& get_resolved_endpoints() const { return resolved_endpoints; }
+  ResolvedEndpoint* find_resolved_endpoint(const std::string& url);
   void set_endpoint_unconnectable(const RGWEndpoint& endpoint);
   const std::string& get_self_zonegroup() {
     return self_zone_group;
@@ -169,7 +169,7 @@ public:
   CephContext *get_ctx() {
     return cct;
   }
-  size_t get_endpoint_count() const { return endpoint_urls.size(); }
+  size_t get_endpoint_count() const { return resolved_endpoints.size(); }
 
   virtual void populate_params(param_vec_t& params, const rgw_owner* uid, const std::string& zonegroup);
 
@@ -194,7 +194,7 @@ public:
                        ceph::real_time *mtime, optional_yield y);
 
   /* pick an IP to 'connect-to' given the endpoint url */
-  void get_connect_to_mapping_for_url(RGWEndpoint& endpoint);
+  void populate_connect_to(RGWEndpoint& endpoint, ResolvedEndpoint& res_ep);
 
   struct get_obj_params {
     const rgw_owner *uid{nullptr};

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -405,7 +405,7 @@ public:
     int ret = req.wait(dpp, y);
     if (ret < 0) {
       if (ret == -ERR_INTERNAL_ERROR) {
-        conn->set_endpoint_unconnectable(req.get_endpoint_orig());
+        conn->set_endpoint_unconnectable(req.get_endpoint());
       }
       return ret;
     }
@@ -461,7 +461,7 @@ int RGWRESTReadResource::wait(const DoutPrefixProvider* dpp, T *dest,
   int ret = req.wait(dpp, y);
   if (ret < 0) {
     if (ret == -ERR_INTERNAL_ERROR) {
-      conn->set_endpoint_unconnectable(req.get_endpoint_orig());
+      conn->set_endpoint_unconnectable(req.get_endpoint());
     }
     return ret;
   }
@@ -536,7 +536,7 @@ public:
     *pbl = bl;
 
     if (ret == -ERR_INTERNAL_ERROR) {
-      conn->set_endpoint_unconnectable(req.get_endpoint_orig());
+      conn->set_endpoint_unconnectable(req.get_endpoint());
     }
 
     if (ret < 0 && err_result ) {
@@ -557,7 +557,7 @@ int RGWRESTSendResource::wait(const DoutPrefixProvider* dpp, T *dest,
 {
   int ret = req.wait(dpp, y);
   if (ret == -ERR_INTERNAL_ERROR) {
-    conn->set_endpoint_unconnectable(req.get_endpoint_orig());
+    conn->set_endpoint_unconnectable(req.get_endpoint());
   }
 
   if (ret >= 0) {

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -65,6 +65,15 @@ inline param_vec_t make_param_list(const std::map<std::string, std::string> *pp)
   return params;
 }
 
+struct ResolvedEndpoint {
+  std::string url;                // e.g., "https://s3.abc.com:8443"
+  std::string scheme;             // e.g., "https"
+  std::string host;               // e.g., "s3.abc.com"
+  int port = -1;                  // e.g., 443
+  std::vector<std::string> ips; // the IPs the endpoint resolves to
+  size_t rr_index = 0;            // round-robin index for IPs
+};
+
 class RGWRESTConn
 {
   /* the endpoint is not able to connect if the timestamp is not real_clock::zero */
@@ -72,6 +81,7 @@ class RGWRESTConn
 
   CephContext *cct;
   std::vector<std::string> endpoints;
+  std::vector<ResolvedEndpoint> resolved_endpoints;
   endpoint_status_map endpoints_status;
   RGWAccessKey key;
   std::string self_zone_group;
@@ -79,6 +89,8 @@ class RGWRESTConn
   std::optional<std::string> api_name;
   HostStyle host_style;
   std::atomic<int64_t> counter = { 0 };
+
+  void resolve_endpoints(void);
 
 public:
 
@@ -103,6 +115,7 @@ public:
 
   int get_endpoint(RGWEndpoint& endpoint);
   RGWEndpoint get_endpoint();
+  const std::vector<ResolvedEndpoint>& get_resolved_endpoints() const { return resolved_endpoints; }
   void set_endpoint_unconnectable(const RGWEndpoint& endpoint);
   const std::string& get_self_zonegroup() {
     return self_zone_group;

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -69,27 +69,57 @@ struct ResolvedEndpoint {
   std::string url;                // e.g., "https://s3.abc.com:8443"
   std::string scheme;             // e.g., "https"
   std::string host;               // e.g., "s3.abc.com"
-  int port = -1;                  // e.g., 443
+  int port = -1;                  // e.g., 8443
   std::vector<std::string> ips; // the IPs the endpoint resolves to
   std::vector<std::string> connect_to_strings;  // Pre-computed full connect_to strings for each IP
   size_t rr_index = 0;            // round-robin index for IPs
+
+  /* endpoint health state: the endpoint is not able to connect if the timestamp is not real_clock::zero */
+  std::atomic<ceph::real_time> status;
+
+  ResolvedEndpoint() = default;
+
+  // Custom move constructor (required because std::atomic is not movable)
+  ResolvedEndpoint(ResolvedEndpoint&& other) noexcept
+    : url(std::move(other.url)),
+      scheme(std::move(other.scheme)),
+      host(std::move(other.host)),
+      port(other.port),
+      ips(std::move(other.ips)),
+      connect_to_strings(std::move(other.connect_to_strings)),
+      rr_index(other.rr_index),
+      status(other.status.load())
+  {}
+
+  // Custom move assignment (required because std::atomic is not movable)
+  ResolvedEndpoint& operator=(ResolvedEndpoint&& other) noexcept {
+    url = std::move(other.url);
+    scheme = std::move(other.scheme);
+    host = std::move(other.host);
+    port = other.port;
+    ips = std::move(other.ips);
+    connect_to_strings = std::move(other.connect_to_strings);
+    rr_index = other.rr_index;
+    status.store(other.status.load());
+    return *this;
+  }
+
+  // Delete copy operations (std::atomic is not copyable)
+  ResolvedEndpoint(const ResolvedEndpoint&) = delete;
+  ResolvedEndpoint& operator=(const ResolvedEndpoint&) = delete;
 };
 
 class RGWRESTConn
 {
-  /* the endpoint is not able to connect if the timestamp is not real_clock::zero */
-  using endpoint_status_map = std::unordered_map<std::string, std::atomic<ceph::real_time>>;
-
   CephContext *cct;
-  std::vector<std::string> endpoints;
+  std::vector<std::string> endpoint_urls;             // For ordered round-robin
+  std::atomic<int64_t> endpoint_urls_counter = { 0 }; // Round-robin counter for endpoint_urls
   std::unordered_map<std::string, ResolvedEndpoint> resolved_endpoints;
-  endpoint_status_map endpoints_status;
   RGWAccessKey key;
   std::string self_zone_group;
   std::string remote_id;
   std::optional<std::string> api_name;
   HostStyle host_style;
-  std::atomic<int64_t> counter = { 0 };
 
   void resolve_endpoints(void);
 
@@ -139,7 +169,7 @@ public:
   CephContext *get_ctx() {
     return cct;
   }
-  size_t get_endpoint_count() const { return endpoints.size(); }
+  size_t get_endpoint_count() const { return endpoint_urls.size(); }
 
   virtual void populate_params(param_vec_t& params, const rgw_owner* uid, const std::string& zonegroup);
 

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -65,48 +65,91 @@ inline param_vec_t make_param_list(const std::map<std::string, std::string> *pp)
   return params;
 }
 
+/**
+ * ResolvedIP - Per-IP connection status tracking.
+ *
+ * Each resolved IP address has its own failure status. An IP is considered
+ * "down" if last_failure is non-zero and less than CONN_STATUS_EXPIRE_SECS old.
+ * After the timeout, the IP becomes eligible for retry.
+ */
+struct ResolvedIP {
+  std::string connect_to;  // Pre-computed "host:port:ip:port" for CURLOPT_CONNECT_TO
+  mutable std::atomic<ceph::real_time> last_failure;
+
+  ResolvedIP() : last_failure(ceph::real_clock::zero()) {}
+
+  explicit ResolvedIP(std::string _connect_to)
+    : connect_to(std::move(_connect_to)), last_failure(ceph::real_clock::zero()) {}
+
+  // Move & assignment operations (required because std::atomic is not movable)
+  ResolvedIP(ResolvedIP&& o) noexcept
+    : connect_to(std::move(o.connect_to)), last_failure(o.last_failure.load()) {}
+
+  ResolvedIP& operator=(ResolvedIP&& o) noexcept {
+    connect_to = std::move(o.connect_to);
+    last_failure.store(o.last_failure.load());
+    return *this;
+  }
+
+  // Delete copy (std::atomic is not copyable)
+  ResolvedIP(const ResolvedIP&) = delete;
+  ResolvedIP& operator=(const ResolvedIP&) = delete;
+
+  void mark_down() const { last_failure.store(ceph::real_clock::now()); }
+  void mark_up() const { last_failure.store(ceph::real_clock::zero()); }
+};
+
+/**
+ * ResolvedEndpoint - A zone endpoint URL with its resolved IP addresses.
+ *
+ * Tracks per-IP connection status. An endpoint is considered "down" only when
+ * ALL of its IPs are marked as failed (within the retry timeout window).
+ */
 struct ResolvedEndpoint {
   std::string url;                // e.g., "https://s3.abc.com:8443"
   std::string scheme;             // e.g., "https"
   std::string host;               // e.g., "s3.abc.com"
   int port = -1;                  // e.g., 8443
-  std::vector<std::string> ips; // the IPs the endpoint resolves to
-  std::vector<std::string> connect_to_strings;  // Pre-computed full connect_to strings for each IP
-  size_t rr_index = 0;            // round-robin index for IPs
+  std::vector<ResolvedIP> resolved_ips;  // Per-IP connect_to strings with health status
+  mutable size_t endpoint_ips_round_robin_counter = 0;    // round-robin index for IPs
+  mutable std::atomic<ceph::real_time> last_failure_time; // most recent IP failure seen on this endpoint
 
-  /* endpoint health state: the endpoint is not able to connect if the timestamp is not real_clock::zero */
-  std::atomic<ceph::real_time> status;
+  ResolvedEndpoint() : last_failure_time(ceph::real_clock::zero()) {}
 
-  ResolvedEndpoint() = default;
-
-  // Custom move constructor (required because std::atomic is not movable)
+  // Custom move constructor (required because of atomics in ResolvedIP)
   ResolvedEndpoint(ResolvedEndpoint&& other) noexcept
     : url(std::move(other.url)),
       scheme(std::move(other.scheme)),
       host(std::move(other.host)),
       port(other.port),
-      ips(std::move(other.ips)),
-      connect_to_strings(std::move(other.connect_to_strings)),
-      rr_index(other.rr_index),
-      status(other.status.load())
+      resolved_ips(std::move(other.resolved_ips)),
+      endpoint_ips_round_robin_counter(other.endpoint_ips_round_robin_counter),
+      last_failure_time(other.last_failure_time.load())
   {}
 
-  // Custom move assignment (required because std::atomic is not movable)
+  // Custom move assignment
   ResolvedEndpoint& operator=(ResolvedEndpoint&& other) noexcept {
     url = std::move(other.url);
     scheme = std::move(other.scheme);
     host = std::move(other.host);
     port = other.port;
-    ips = std::move(other.ips);
-    connect_to_strings = std::move(other.connect_to_strings);
-    rr_index = other.rr_index;
-    status.store(other.status.load());
+    resolved_ips = std::move(other.resolved_ips);
+    endpoint_ips_round_robin_counter = other.endpoint_ips_round_robin_counter;
+    last_failure_time.store(other.last_failure_time.load());
     return *this;
   }
 
-  // Delete copy operations (std::atomic is not copyable)
+  // Delete copy operations
   ResolvedEndpoint(const ResolvedEndpoint&) = delete;
   ResolvedEndpoint& operator=(const ResolvedEndpoint&) = delete;
+
+  // Find IP status by connect_to string
+  ResolvedIP* find_ip_status(const std::string& connect_to_str) {
+    for (auto& ip : resolved_ips) {
+      if (ip.connect_to == connect_to_str) return &ip;
+    }
+    return nullptr;
+  }
 };
 
 class RGWRESTConn

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -71,6 +71,7 @@ struct ResolvedEndpoint {
   std::string host;               // e.g., "s3.abc.com"
   int port = -1;                  // e.g., 443
   std::vector<std::string> ips; // the IPs the endpoint resolves to
+  std::vector<std::string> connect_to_strings;  // Pre-computed full connect_to strings for each IP
   size_t rr_index = 0;            // round-robin index for IPs
 };
 
@@ -81,7 +82,7 @@ class RGWRESTConn
 
   CephContext *cct;
   std::vector<std::string> endpoints;
-  std::vector<ResolvedEndpoint> resolved_endpoints;
+  std::unordered_map<std::string, ResolvedEndpoint> resolved_endpoints;
   endpoint_status_map endpoints_status;
   RGWAccessKey key;
   std::string self_zone_group;
@@ -115,7 +116,7 @@ public:
 
   int get_endpoint(RGWEndpoint& endpoint);
   RGWEndpoint get_endpoint();
-  const std::vector<ResolvedEndpoint>& get_resolved_endpoints() const { return resolved_endpoints; }
+  const std::unordered_map<std::string, ResolvedEndpoint>& get_resolved_endpoints() const { return resolved_endpoints; }
   void set_endpoint_unconnectable(const RGWEndpoint& endpoint);
   const std::string& get_self_zonegroup() {
     return self_zone_group;
@@ -161,6 +162,9 @@ public:
   int complete_request(const DoutPrefixProvider* dpp,
                        RGWRESTStreamS3PutObj *req, std::string& etag,
                        ceph::real_time *mtime, optional_yield y);
+
+  /* pick an IP to 'connect-to' given the endpoint url */
+  void get_connect_to_mapping_for_url(RGWEndpoint& endpoint);
 
   struct get_obj_params {
     const rgw_owner *uid{nullptr};

--- a/src/rgw/services/svc_zone.cc
+++ b/src/rgw/services/svc_zone.cc
@@ -671,7 +671,7 @@ int RGWSI_Zone::select_bucket_placement(const DoutPrefixProvider *dpp, const RGW
                                     pselected_rule, rule_info, y);
 }
 
-bool RGWSI_Zone::get_redirect_zone_endpoint(string *endpoint)
+bool RGWSI_Zone::get_redirect_zone_endpoint_url(string *url)
 {
   if (zone_public_config->redirect_zone.empty()) {
     return false;
@@ -685,11 +685,13 @@ bool RGWSI_Zone::get_redirect_zone_endpoint(string *endpoint)
 
   RGWRESTConn *conn = iter->second;
 
-  int ret = conn->get_url(*endpoint);
+  RGWEndpoint ep{*url};
+  int ret = conn->get_endpoint(ep);
   if (ret < 0) {
     ldout(cct, 0) << "ERROR: redirect zone, conn->get_endpoint() returned ret=" << ret << dendl;
     return false;
   }
+  *url = ep.get_url();
 
   return true;
 }

--- a/src/rgw/services/svc_zone.cc
+++ b/src/rgw/services/svc_zone.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 sts=2 expandtab ft=cpp
 
 #include "svc_zone.h"
+#include "common/admin_socket.h"
 #include "svc_sys_obj.h"
 #include "svc_sync_modules.h"
 
@@ -19,6 +20,188 @@
 
 using namespace std;
 using namespace rgw_zone_defaults;
+
+
+// Admin socket hook for zone connection information
+class RGWSI_Zone_ASocketHook : public AdminSocketHook {
+  RGWSI_Zone *svc;
+
+  static constexpr std::string_view admin_commands[][2] = {
+    {
+      "zone connections",
+      "zone connections: list zone connections with endpoints and IP health status"
+    }
+  };
+
+public:
+  RGWSI_Zone_ASocketHook(RGWSI_Zone *_svc) : svc(_svc) {}
+
+  int start();
+  void shutdown();
+
+  int call(std::string_view command, const cmdmap_t& cmdmap,
+           const bufferlist&,
+           Formatter *f,
+           std::ostream& ss,
+           bufferlist& out) override;
+};
+
+int RGWSI_Zone_ASocketHook::start()
+{
+  auto admin_socket = svc->ctx()->get_admin_socket();
+  for (auto cmd : admin_commands) {
+    int r = admin_socket->register_command(cmd[0], this, cmd[1]);
+    if (r < 0) {
+      ldout(svc->ctx(), 0) << "ERROR: fail to register admin socket command (r="
+        << r << ")" << dendl;
+      return r;
+    }
+  }
+  return 0;
+}
+
+void RGWSI_Zone_ASocketHook::shutdown()
+{
+  auto admin_socket = svc->ctx()->get_admin_socket();
+  admin_socket->unregister_commands(this);
+}
+
+static void dump_resolved_ip(Formatter *f, const ResolvedIP& ip,
+                             double timeout_secs) {
+  f->open_object_section("ip");
+  f->dump_string("connect_to", ip.connect_to);
+  auto last_fail = ip.last_failure.load();
+  if (ceph::real_clock::is_zero(last_fail)) {
+    f->dump_string("status", "up");
+    f->dump_string("last_failure", "");
+  } else {
+    // Check if failure has expired based on timeout
+    auto now = ceph::real_clock::now();
+    auto diff = ceph::to_seconds<double>(now - last_fail);
+    if (diff >= timeout_secs) {
+      f->dump_string("status", "retry-ready");  // Timeout expired, eligible for retry but unknown if actually up
+    } else {
+      f->dump_string("status", "down");
+    }
+    f->dump_string("last_failure", ceph::to_iso_8601(last_fail));
+  }
+  f->close_section();
+}
+
+static void dump_resolved_endpoint(Formatter *f, const ResolvedEndpoint& ep,
+                                   double timeout_secs) {
+  f->open_object_section("endpoint");
+  f->dump_string("url", ep.url);
+  f->dump_string("scheme", ep.scheme);
+  f->dump_string("host", ep.host);
+  f->dump_int("port", ep.port);
+  f->dump_string("last_failure_time",
+                 ceph::real_clock::is_zero(ep.last_failure_time.load())
+                   ? "" : ceph::to_iso_8601(ep.last_failure_time.load()));
+
+  f->open_array_section("resolved_ips");
+  for (const auto& ip : ep.resolved_ips) {
+    dump_resolved_ip(f, ip, timeout_secs);
+  }
+  f->close_section();
+
+  f->close_section();
+}
+
+static void dump_rest_conn(Formatter *f, const std::string& name,
+                           RGWRESTConn* conn) {
+  if (!conn) return;
+
+  f->open_object_section(name);
+  f->dump_string("remote_id", conn->get_remote_id());
+  f->dump_unsigned("endpoint_count", conn->get_endpoint_count());
+
+  double timeout_secs = conn->get_ctx()->_conf->rgw_rest_conn_ip_fail_timeout_secs;
+
+  const auto& endpoints = conn->get_resolved_endpoints();
+  f->open_array_section("endpoints");
+  for (const auto& ep : endpoints) {
+    dump_resolved_endpoint(f, ep, timeout_secs);
+  }
+  f->close_section();
+
+  f->close_section();
+}
+
+int RGWSI_Zone_ASocketHook::call(
+  std::string_view command, const cmdmap_t& cmdmap,
+  const bufferlist&,
+  Formatter *f,
+  std::ostream& ss,
+  bufferlist& out)
+{
+  if (command == "zone connections"sv) {
+    f->open_object_section("zone_connections");
+
+    f->dump_string("current_time", ceph::to_iso_8601(ceph::real_clock::now()));
+    f->dump_string("current_zone_id", svc->zone_id().id);
+    f->dump_string("current_zone_name", svc->zone_name());
+
+    auto* master_conn = svc->get_master_conn();
+    if (master_conn) {
+      dump_rest_conn(f, "master_conn", master_conn);
+    }
+
+    // Zone connections map
+    auto& zone_conn_map = svc->get_zone_conn_map();
+    f->open_object_section("zone_conn_map");
+    for (auto& [zone_id, conn] : zone_conn_map) {
+      dump_rest_conn(f, zone_id.id, conn);
+    }
+    f->close_section();
+
+    // Only show zonegroup_conn_map if it has connections beyond the master
+    auto& zonegroup_conn_map = svc->get_zonegroup_conn_map();
+    bool zg_differs_from_master = false;
+    if (!master_conn) {
+      zg_differs_from_master = !zonegroup_conn_map.empty();
+    } else if (zonegroup_conn_map.size() > 1) {
+      zg_differs_from_master = true;
+    } else if (zonegroup_conn_map.size() == 1) {
+      auto& [zg_name, conn] = *zonegroup_conn_map.begin();
+      zg_differs_from_master = (conn->get_remote_id() != master_conn->get_remote_id());
+    }
+    if (zg_differs_from_master) {
+      f->open_object_section("zonegroup_conn_map");
+      for (auto& [zg_name, conn] : zonegroup_conn_map) {
+        dump_rest_conn(f, zg_name, conn);
+      }
+      f->close_section();
+    }
+
+    // Only show zone_data_notify_to_map if it differs from zone_conn_map
+    auto& notify_map = svc->get_zone_data_notify_to_map();
+    bool notify_differs = false;
+    if (notify_map.size() != zone_conn_map.size()) {
+      notify_differs = true;
+    } else {
+      for (auto& [zone_id, conn] : notify_map) {
+        auto it = zone_conn_map.find(zone_id);
+        if (it == zone_conn_map.end() || it->second != conn) {
+          notify_differs = true;
+          break;
+        }
+      }
+    }
+    if (notify_differs) {
+      f->open_object_section("zone_data_notify_to_map");
+      for (auto& [zone_id, conn] : notify_map) {
+        dump_rest_conn(f, zone_id.id, conn);
+      }
+      f->close_section();
+    }
+
+    f->close_section();
+    return 0;
+  }
+
+  return -ENOSYS;
+}
 
 RGWSI_Zone::RGWSI_Zone(CephContext *cct, rgw::sal::ConfigStore* _cfgstore, const rgw::SiteConfig* _site)
         : RGWServiceInstance(cct), cfgstore(_cfgstore), site(_site)
@@ -212,11 +395,20 @@ int RGWSI_Zone::do_start(optional_yield y, const DoutPrefixProvider *dpp)
   ldpp_dout(dpp, 20) << "started zone id=" << zone_params->get_id() << " (name=" << zone_params->get_name() << 
         ") with tier type = " << zone_public_config->tier_type << dendl;
 
+
+  // Initialize admin socket hook
+  asocket_hook = std::make_unique<RGWSI_Zone_ASocketHook>(this);
+  asocket_hook->start();
   return 0;
 }
 
 void RGWSI_Zone::shutdown()
 {
+  // Shutdown admin socket hook
+  if (asocket_hook) {
+    asocket_hook->shutdown();
+  }
+
   delete rest_master_conn;
 
   for (auto& item : zone_conn_map) {

--- a/src/rgw/services/svc_zone.h
+++ b/src/rgw/services/svc_zone.h
@@ -92,7 +92,7 @@ public:
   bool zone_is_writeable();
   bool zone_syncs_from(const RGWZone& target_zone, const RGWZone& source_zone) const;
   bool zone_syncs_from(const RGWZone& source_zone) const;
-  bool get_redirect_zone_endpoint(std::string *endpoint);
+  bool get_redirect_zone_endpoint_url(std::string *url);
   bool sync_module_supports_writes() const { return writeable_zone; }
   bool sync_module_exports_data() const { return exports_data; }
 

--- a/src/rgw/services/svc_zone.h
+++ b/src/rgw/services/svc_zone.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "driver/rados/rgw_service.h"
+#include <memory>
 
 
 class RGWSI_SysObj;
@@ -22,6 +23,7 @@ class RGWBucketSyncPolicyHandler;
 class RGWRESTConn;
 
 struct rgw_sync_policy_info;
+class RGWSI_Zone_ASocketHook;
 
 class RGWSI_Zone : public RGWServiceInstance
 {
@@ -57,6 +59,7 @@ class RGWSI_Zone : public RGWServiceInstance
   std::unique_ptr<rgw_sync_policy_info> sync_policy;
   rgw::sal::ConfigStore *cfgstore{nullptr};
   const rgw::SiteConfig* site{nullptr};
+  std::unique_ptr<RGWSI_Zone_ASocketHook> asocket_hook;
 
   void init(RGWSI_SysObj *_sysobj_svc,
 	    librados::Rados* rados_,

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -476,3 +476,9 @@ target_link_libraries(unittest_rgw_async_utils ${rgw_libs} ${UNITTEST_LIBS})
 add_executable(unittest_rgw_tag test_rgw_tag.cc)
 add_ceph_unittest(unittest_rgw_tag)
 target_link_libraries(unittest_rgw_tag ${rgw_libs} ${UNITTEST_LIBS})
+
+# unittest_rgw_http_client
+add_executable(unittest_rgw_http_client test_rgw_http_client.cc)
+add_ceph_unittest(unittest_rgw_http_client)
+target_link_libraries(unittest_rgw_http_client
+  rgw_common ${rgw_libs} ${UNITTEST_LIBS})

--- a/src/test/rgw/test_rgw_http_client.cc
+++ b/src/test/rgw/test_rgw_http_client.cc
@@ -1,0 +1,132 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+#include <gtest/gtest.h>
+#include <sstream>
+
+#include "rgw_http_client.h"
+
+using namespace std;
+
+// Tests for RGWEndpoint
+
+TEST(RGWEndpointTest, default_constructor) {
+  RGWEndpoint ep;
+  EXPECT_TRUE(ep.get_url().empty());
+  EXPECT_TRUE(ep.get_original_url().empty());
+  EXPECT_TRUE(ep.get_connect_to().empty());
+}
+
+TEST(RGWEndpointTest, constructor_sets_url_and_original_url) {
+  RGWEndpoint ep("http://example.com:8080");
+  EXPECT_EQ(ep.get_url(), "http://example.com:8080");
+  EXPECT_EQ(ep.get_original_url(), "http://example.com:8080");
+}
+
+TEST(RGWEndpointTest, constructor_with_connect_to) {
+  RGWEndpoint ep("http://example.com:8080", "example.com:8080:192.168.1.1:8080");
+  EXPECT_EQ(ep.get_url(), "http://example.com:8080");
+  EXPECT_EQ(ep.get_original_url(), "http://example.com:8080");
+  EXPECT_EQ(ep.get_connect_to(), "example.com:8080:192.168.1.1:8080");
+}
+
+TEST(RGWEndpointTest, set_url_on_default_constructed_sets_original) {
+  RGWEndpoint ep;
+  EXPECT_TRUE(ep.get_original_url().empty());
+
+  ep.set_url("http://first.example.com");
+  EXPECT_EQ(ep.get_url(), "http://first.example.com");
+  EXPECT_EQ(ep.get_original_url(), "http://first.example.com");
+
+  // Second set_url should NOT change original_url
+  ep.set_url("http://second.example.com");
+  EXPECT_EQ(ep.get_url(), "http://second.example.com");
+  EXPECT_EQ(ep.get_original_url(), "http://first.example.com");
+}
+
+TEST(RGWEndpointTest, set_url_does_not_change_original_after_constructor) {
+  RGWEndpoint ep("http://original.example.com");
+
+  ep.set_url("http://modified.example.com");
+  EXPECT_EQ(ep.get_url(), "http://modified.example.com");
+  EXPECT_EQ(ep.get_original_url(), "http://original.example.com");
+}
+
+TEST(RGWEndpointTest, with_url_returns_copy_with_new_url) {
+  RGWEndpoint ep("http://original.example.com");
+  ep.set_connect_to("original.example.com:80:192.168.1.1:80");
+
+  RGWEndpoint ep2 = ep.with_url("http://modified.example.com");
+
+  // Original unchanged
+  EXPECT_EQ(ep.get_url(), "http://original.example.com");
+  EXPECT_EQ(ep.get_original_url(), "http://original.example.com");
+
+  // Copy has new url but preserves original_url and connect_to
+  EXPECT_EQ(ep2.get_url(), "http://modified.example.com");
+  EXPECT_EQ(ep2.get_original_url(), "http://original.example.com");
+  EXPECT_EQ(ep2.get_connect_to(), "original.example.com:80:192.168.1.1:80");
+}
+
+TEST(RGWEndpointTest, set_connect_to) {
+  RGWEndpoint ep("http://example.com:8080");
+  EXPECT_TRUE(ep.get_connect_to().empty());
+
+  ep.set_connect_to("example.com:8080:192.168.1.1:8080");
+  EXPECT_EQ(ep.get_connect_to(), "example.com:8080:192.168.1.1:8080");
+}
+
+TEST(RGWEndpointTest, add_trailing_slash) {
+  RGWEndpoint ep("http://example.com:8080");
+  ep.add_trailing_slash();
+  EXPECT_EQ(ep.get_url(), "http://example.com:8080/");
+
+  // Should not add another slash
+  ep.add_trailing_slash();
+  EXPECT_EQ(ep.get_url(), "http://example.com:8080/");
+}
+
+TEST(RGWEndpointTest, append_to_url) {
+  RGWEndpoint ep("http://example.com:8080");
+  ep.append_to_url("/path/to/resource");
+  EXPECT_EQ(ep.get_url(), "http://example.com:8080/path/to/resource");
+}
+
+// Tests for operator<<
+
+TEST(RGWEndpointTest, ostream_operator_url_only) {
+  RGWEndpoint ep("http://example.com:8080");
+  std::ostringstream oss;
+  oss << ep;
+  EXPECT_EQ(oss.str(), "RGWEndpoint: url=http://example.com:8080");
+}
+
+TEST(RGWEndpointTest, ostream_operator_with_different_original_url) {
+  RGWEndpoint ep;
+  ep.set_url("http://original.example.com:8080");
+  ep.set_url("http://modified.example.com:8080");  // original_url stays the same
+
+  std::ostringstream oss;
+  oss << ep;
+  EXPECT_EQ(oss.str(), "RGWEndpoint: url=http://modified.example.com:8080 original_url=http://original.example.com:8080");
+}
+
+TEST(RGWEndpointTest, ostream_operator_with_connect_to) {
+  RGWEndpoint ep("http://example.com:8080");
+  ep.set_connect_to("example.com:8080:192.168.1.1:8080");
+
+  std::ostringstream oss;
+  oss << ep;
+  EXPECT_EQ(oss.str(), "RGWEndpoint: url=http://example.com:8080 connect_to=example.com:8080:192.168.1.1:8080");
+}
+
+TEST(RGWEndpointTest, ostream_operator_full) {
+  RGWEndpoint ep;
+  ep.set_url("http://original.example.com:8080");
+  ep.set_url("http://192.168.1.1:8080");
+  ep.set_connect_to("original.example.com:8080:192.168.1.1:8080");
+
+  std::ostringstream oss;
+  oss << ep;
+  EXPECT_EQ(oss.str(), "RGWEndpoint: url=http://192.168.1.1:8080 original_url=http://original.example.com:8080 connect_to=original.example.com:8080:192.168.1.1:8080");
+}

--- a/src/test/rgw/test_rgw_http_client.cc
+++ b/src/test/rgw/test_rgw_http_client.cc
@@ -13,59 +13,98 @@ using namespace std;
 TEST(RGWEndpointTest, default_constructor) {
   RGWEndpoint ep;
   EXPECT_TRUE(ep.get_url().empty());
-  EXPECT_TRUE(ep.get_original_url().empty());
+  EXPECT_TRUE(ep.get_endpoint_url_lookup_id().empty());
   EXPECT_TRUE(ep.get_connect_to().empty());
 }
 
-TEST(RGWEndpointTest, constructor_sets_url_and_original_url) {
+TEST(RGWEndpointTest, constructor_sets_url_and_lookup_id) {
   RGWEndpoint ep("http://example.com:8080");
   EXPECT_EQ(ep.get_url(), "http://example.com:8080");
-  EXPECT_EQ(ep.get_original_url(), "http://example.com:8080");
+  EXPECT_EQ(ep.get_endpoint_url_lookup_id(), "http://example.com:8080");
 }
 
 TEST(RGWEndpointTest, constructor_with_connect_to) {
   RGWEndpoint ep("http://example.com:8080", "example.com:8080:192.168.1.1:8080");
   EXPECT_EQ(ep.get_url(), "http://example.com:8080");
-  EXPECT_EQ(ep.get_original_url(), "http://example.com:8080");
+  EXPECT_EQ(ep.get_endpoint_url_lookup_id(), "http://example.com:8080");
   EXPECT_EQ(ep.get_connect_to(), "example.com:8080:192.168.1.1:8080");
 }
 
-TEST(RGWEndpointTest, set_url_on_default_constructed_sets_original) {
+TEST(RGWEndpointTest, set_url_on_default_constructed_sets_base) {
   RGWEndpoint ep;
-  EXPECT_TRUE(ep.get_original_url().empty());
+  EXPECT_TRUE(ep.get_endpoint_url_lookup_id().empty());
 
   ep.set_url("http://first.example.com");
   EXPECT_EQ(ep.get_url(), "http://first.example.com");
-  EXPECT_EQ(ep.get_original_url(), "http://first.example.com");
+  EXPECT_EQ(ep.get_endpoint_url_lookup_id(), "http://first.example.com");
 
-  // Second set_url should NOT change original_url
+  // Second set_url should NOT change endpoint_url_lookup_id
   ep.set_url("http://second.example.com");
   EXPECT_EQ(ep.get_url(), "http://second.example.com");
-  EXPECT_EQ(ep.get_original_url(), "http://first.example.com");
+  EXPECT_EQ(ep.get_endpoint_url_lookup_id(), "http://first.example.com");
 }
 
-TEST(RGWEndpointTest, set_url_does_not_change_original_after_constructor) {
-  RGWEndpoint ep("http://original.example.com");
-
-  ep.set_url("http://modified.example.com");
-  EXPECT_EQ(ep.get_url(), "http://modified.example.com");
-  EXPECT_EQ(ep.get_original_url(), "http://original.example.com");
+TEST(RGWEndpointTest, set_path) {
+  RGWEndpoint ep("http://example.com:8080");
+  ep.set_path("/path/to/resource");
+  EXPECT_EQ(ep.get_url(), "http://example.com:8080/path/to/resource");
+  EXPECT_EQ(ep.get_endpoint_url_lookup_id(), "http://example.com:8080");
 }
 
-TEST(RGWEndpointTest, with_url_returns_copy_with_new_url) {
-  RGWEndpoint ep("http://original.example.com");
-  ep.set_connect_to("original.example.com:80:192.168.1.1:80");
+TEST(RGWEndpointTest, set_query) {
+  RGWEndpoint ep("http://example.com:8080/path");
+  ep.set_query("key=val&k2=v2");
+  EXPECT_EQ(ep.get_url(), "http://example.com:8080/path?key=val&k2=v2");
+  EXPECT_EQ(ep.get_endpoint_url_lookup_id(), "http://example.com:8080/path");
+}
 
-  RGWEndpoint ep2 = ep.with_url("http://modified.example.com");
+TEST(RGWEndpointTest, set_query_with_leading_question_mark) {
+  RGWEndpoint ep("http://example.com:8080/path");
+  ep.set_query("?key=val");
+  EXPECT_EQ(ep.get_url(), "http://example.com:8080/path?key=val");
+  EXPECT_EQ(ep.get_endpoint_url_lookup_id(), "http://example.com:8080/path");
+}
 
-  // Original unchanged
-  EXPECT_EQ(ep.get_url(), "http://original.example.com");
-  EXPECT_EQ(ep.get_original_url(), "http://original.example.com");
+TEST(RGWEndpointTest, set_host) {
+  RGWEndpoint ep("http://example.com:8080");
+  ep.set_host("bucket.example.com");
+  EXPECT_EQ(ep.get_url(), "http://bucket.example.com:8080");
+  EXPECT_EQ(ep.get_endpoint_url_lookup_id(), "http://example.com:8080");
+}
 
-  // Copy has new url but preserves original_url and connect_to
-  EXPECT_EQ(ep2.get_url(), "http://modified.example.com");
-  EXPECT_EQ(ep2.get_original_url(), "http://original.example.com");
-  EXPECT_EQ(ep2.get_connect_to(), "original.example.com:80:192.168.1.1:80");
+TEST(RGWEndpointTest, add_trailing_slash) {
+  RGWEndpoint ep("http://example.com:8080");
+  ep.add_trailing_slash();
+  EXPECT_EQ(ep.get_url(), "http://example.com:8080/");
+  EXPECT_EQ(ep.get_endpoint_url_lookup_id(), "http://example.com:8080");
+
+  // Should not add another slash
+  ep.add_trailing_slash();
+  EXPECT_EQ(ep.get_url(), "http://example.com:8080/");
+}
+
+TEST(RGWEndpointTest, set_query_empty_is_noop) {
+  RGWEndpoint ep("http://example.com:8080/path");
+  ep.set_query("");
+  // Empty query should not add a '?' to the URL
+  EXPECT_EQ(ep.get_url(), "http://example.com:8080/path");
+}
+
+TEST(RGWEndpointTest, set_path_without_leading_slash) {
+  RGWEndpoint ep("http://example.com:8080");
+  ep.set_path("admin/bucket");
+  // boost::urls should auto-add leading '/' for URLs with authority
+  EXPECT_EQ(ep.get_url(), "http://example.com:8080/admin/bucket");
+  EXPECT_EQ(ep.get_endpoint_url_lookup_id(), "http://example.com:8080");
+}
+
+TEST(RGWEndpointTest, set_path_then_set_query) {
+  // This mirrors the forward_request() usage pattern
+  RGWEndpoint ep("http://example.com:8080");
+  ep.set_path("/admin/bucket");
+  ep.set_query("?max-entries=100&stats=true");
+  EXPECT_EQ(ep.get_url(), "http://example.com:8080/admin/bucket?max-entries=100&stats=true");
+  EXPECT_EQ(ep.get_endpoint_url_lookup_id(), "http://example.com:8080");
 }
 
 TEST(RGWEndpointTest, set_connect_to) {
@@ -76,39 +115,22 @@ TEST(RGWEndpointTest, set_connect_to) {
   EXPECT_EQ(ep.get_connect_to(), "example.com:8080:192.168.1.1:8080");
 }
 
-TEST(RGWEndpointTest, add_trailing_slash) {
-  RGWEndpoint ep("http://example.com:8080");
-  ep.add_trailing_slash();
-  EXPECT_EQ(ep.get_url(), "http://example.com:8080/");
-
-  // Should not add another slash
-  ep.add_trailing_slash();
-  EXPECT_EQ(ep.get_url(), "http://example.com:8080/");
-}
-
-TEST(RGWEndpointTest, append_to_url) {
-  RGWEndpoint ep("http://example.com:8080");
-  ep.append_to_url("/path/to/resource");
-  EXPECT_EQ(ep.get_url(), "http://example.com:8080/path/to/resource");
-}
-
 // Tests for operator<<
 
 TEST(RGWEndpointTest, ostream_operator_url_only) {
   RGWEndpoint ep("http://example.com:8080");
   std::ostringstream oss;
   oss << ep;
-  EXPECT_EQ(oss.str(), "RGWEndpoint: url=http://example.com:8080");
+  EXPECT_EQ(oss.str(), "RGWEndpoint: url=http://example.com:8080 endpoint_url_lookup_id=http://example.com:8080 connect_to=<empty>");
 }
 
-TEST(RGWEndpointTest, ostream_operator_with_different_original_url) {
-  RGWEndpoint ep;
-  ep.set_url("http://original.example.com:8080");
-  ep.set_url("http://modified.example.com:8080");  // original_url stays the same
+TEST(RGWEndpointTest, ostream_operator_with_modified_url) {
+  RGWEndpoint ep("http://example.com:8080");
+  ep.set_path("/modified");
 
   std::ostringstream oss;
   oss << ep;
-  EXPECT_EQ(oss.str(), "RGWEndpoint: url=http://modified.example.com:8080 original_url=http://original.example.com:8080");
+  EXPECT_EQ(oss.str(), "RGWEndpoint: url=http://example.com:8080/modified endpoint_url_lookup_id=http://example.com:8080 connect_to=<empty>");
 }
 
 TEST(RGWEndpointTest, ostream_operator_with_connect_to) {
@@ -117,7 +139,7 @@ TEST(RGWEndpointTest, ostream_operator_with_connect_to) {
 
   std::ostringstream oss;
   oss << ep;
-  EXPECT_EQ(oss.str(), "RGWEndpoint: url=http://example.com:8080 connect_to=example.com:8080:192.168.1.1:8080");
+  EXPECT_EQ(oss.str(), "RGWEndpoint: url=http://example.com:8080 endpoint_url_lookup_id=http://example.com:8080 connect_to=example.com:8080:192.168.1.1:8080");
 }
 
 TEST(RGWEndpointTest, ostream_operator_full) {
@@ -128,5 +150,5 @@ TEST(RGWEndpointTest, ostream_operator_full) {
 
   std::ostringstream oss;
   oss << ep;
-  EXPECT_EQ(oss.str(), "RGWEndpoint: url=http://192.168.1.1:8080 original_url=http://original.example.com:8080 connect_to=original.example.com:8080:192.168.1.1:8080");
+  EXPECT_EQ(oss.str(), "RGWEndpoint: url=http://192.168.1.1:8080 endpoint_url_lookup_id=http://original.example.com:8080 connect_to=original.example.com:8080:192.168.1.1:8080");
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77473

---

backport of https://github.com/ceph/ceph/pull/67141
parent tracker: https://tracker.ceph.com/issues/74677

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh