### PR TITLE
mgr/dashboard: Add "gw refresh_network" cmd

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -330,6 +330,43 @@ else:
                 NVMeoFClient.pb2.get_thread_stats_req()
             )
 
+        @UpdatePermission
+        @Endpoint('PUT', '/refresh_network')
+        @NvmeofCLICommand(
+            "nvmeof gateway refresh_network", model.GwRefreshNetworkStatus,
+            alias="nvmeof gw refresh_network",
+            success_message_template=("Refreshed configured network masks for subsystem "
+                                      "{nqn} on this gateway: Successful{added}{removed}"),
+            success_message_map={
+                "added": lambda v, _f: f"\nAdded: {', '.join(v)}" if v else "",
+                "removed": lambda v, _f: f"\nRemoved: {', '.join(v)}" if v else "",
+            }
+        )
+        @EndpointDoc(
+            "Re-evaluate subsystem network masks and update auto-listeners for this gateway",
+            parameters={
+                "nqn": Param(str, "NVMeoF subsystem NQN"),
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
+            },
+        )
+        @convert_to_model(model.GwRefreshNetworkStatus)
+        @handle_nvmeof_error
+        def refresh_network(self, nqn: str, gw_group: Optional[str] = None,
+                            server_address: Optional[str] = None,
+                            traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.gw_refresh_network(
+                NVMeoFClient.pb2.gw_refresh_network_req(subsystem_nqn=nqn)
+            )
+
     @APIRouter("/nvmeof/spdk", Scope.NVME_OF)
     @APIDoc("NVMe-oF SPDK Management API", "NVMe-oF SPDK")
     class NVMeoFSpdk(RESTController):

--- a/src/pybind/mgr/dashboard/model/nvmeof.py
+++ b/src/pybind/mgr/dashboard/model/nvmeof.py
@@ -369,6 +369,13 @@ class RequestStatus(NamedTuple):
     error_message: str
 
 
+class GwRefreshNetworkStatus(NamedTuple):
+    status: int
+    error_message: str
+    added: List[str]
+    removed: List[str]
+
+
 class ListenAdress(NamedTuple):
     trtype: str
     adrfam: str

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -12916,6 +12916,63 @@ paths:
       summary: Set NVMeoF gateway log levels
       tags:
       - NVMe-oF Gateway
+  /api/nvmeof/gateway/refresh_network:
+    put:
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                gw_group:
+                  description: NVMeoF gateway group
+                  type: string
+                nqn:
+                  description: NVMeoF subsystem NQN
+                  type: string
+                server_address:
+                  description: NVMeoF gateway address
+                  type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
+                  type: string
+              required:
+              - nqn
+              type: object
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+            application/vnd.ceph.api.v1.0+json:
+              schema:
+                type: object
+          description: Resource updated.
+        '202':
+          content:
+            application/json:
+              schema:
+                type: object
+            application/vnd.ceph.api.v1.0+json:
+              schema:
+                type: object
+          description: Operation is still executing. Please check the task queue.
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: Re-evaluate subsystem network masks and update auto-listeners for this
+        gateway
+      tags:
+      - NVMe-oF Gateway
   /api/nvmeof/gateway/stats:
     get:
       parameters:


### PR DESCRIPTION
This command lets users reconfigure auto-listeners in the subsystem's network masks to current
network config (i.e. add/delete auto-listeners within the subnets accordingly).

1. Add dummy network: 
```
[root@refresh-vallari-cluster-node1 ~]# ip link add eth0-alias type dummy
[root@refresh-vallari-cluster-node1 ~]# ip addr add 10.240.63.4/24 dev eth0-alias
[root@refresh-vallari-cluster-node1 ~]# ip link set eth0-alias up
[root@refresh-vallari-cluster-node1 ~]# ip addr show eth0-alias
202: eth0-alias: <BROADCAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN group default qlen 1000
    link/ether b2:2a:a8:ae:2b:00 brd ff:ff:ff:ff:ff:ff
    inet 10.240.63.4/24 scope global eth0-alias
       valid_lft forever preferred_lft forever
    inet6 fe80::b02a:a8ff:feae:2b00/64 scope link proto kernel_ll 
       valid_lft forever preferred_lft forever
```
2. Add subsystem with auto-listeners (a subnet which includes above IP)
```
[root@refresh-vallari-cluster-node1 ~]# ceph nvmeof subsystem add nqn.2016-06.io.spdk:cnode25 --network-mask '0.0.0.0/0'
Adding subsystem nqn.2016-06.io.spdk:cnode25.mygroup1: Successful
[root@refresh-vallari-cluster-node1 ~]# ceph nvmeof listener list 'nqn.2016-06.io.spdk:cnode25.mygroup1'
+-----------------------------+---------+--------------+------------+----+------+------+------+
|Host                         |Transport|Address Family|Address     |Port|Secure|Active|Manual|
+-----------------------------+---------+--------------+------------+----+------+------+------+
|refresh-vallari-cluster-node1|TCP      |ipv4          |10.240.63.4 |4420|False |True  |False |
|refresh-vallari-cluster-node1|TCP      |ipv4          |10.243.64.31|4420|False |True  |False |
|refresh-vallari-cluster-node1|TCP      |ipv4          |127.0.0.1   |4420|False |True  |False |
|refresh-vallari-cluster-node2|TCP      |ipv4          |10.243.64.32|4420|False |False |False |
|refresh-vallari-cluster-node1|TCP      |ipv4          |127.0.0.1   |4420|False |True  |False |
|refresh-vallari-cluster-node3|TCP      |ipv4          |10.243.64.35|4420|False |False |False |
|refresh-vallari-cluster-node1|TCP      |ipv4          |127.0.0.1   |4420|False |True  |False |
+-----------------------------+---------+--------------+------------+----+------+------+------+
```
3. bring down the network interface:
```
[root@refresh-vallari-cluster-node1 ~]# ip link set eth0-alias down
[root@refresh-vallari-cluster-node1 ~]# ip addr show eth0-alias
202: eth0-alias: <BROADCAST,NOARP> mtu 1500 qdisc noqueue state DOWN group default qlen 1000
    link/ether b2:2a:a8:ae:2b:00 brd ff:ff:ff:ff:ff:ff
    inet 10.240.63.4/24 scope global eth0-alias
       valid_lft forever preferred_lft forever
```
4. refresh network and see scale down:
```
[root@refresh-vallari-cluster-node1 ~]# ceph nvmeof gw refresh_network 'nqn.2016-06.io.spdk:cnode25.mygroup1' --server-address 10.243.64.31
Refreshed configured network masks for subsystem nqn.2016-06.io.spdk:cnode25.mygroup1 on this gateway: Successful
Removed: 10.240.63.4:4420
```
5. bring up the network and refresh and see scale up: 
```
[root@refresh-vallari-cluster-node1 ~]# ip link set eth0-alias up
[root@refresh-vallari-cluster-node1 ~]# ceph nvmeof gw refresh_network 'nqn.2016-06.io.spdk:cnode25.mygroup1' --server-address 10.243.64.31
Refreshed configured network masks for subsystem nqn.2016-06.io.spdk:cnode25.mygroup1 on this gateway: Successful
Added: 10.240.63.4:4420
```


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
