### PR TITLE
rgw/posix: add in-memory user info cache to eliminate SQLite mutex bottleneck

### DIFF
--- a/src/common/cohort_lru.h
+++ b/src/common/cohort_lru.h
@@ -240,11 +240,14 @@ namespace cohort {
             } else {
               lane.q.erase(it);
             }
+            lane.q.push_front(*o);
 	    /* hiwat check */
-	    if (lane.q.size() > lane_hiwat) {
-	      tdo = o;
-	    } else {
-	      lane.q.push_front(*o);
+            if (lane.q.size() > lane_hiwat) {
+              /* discard the actual lane LRU immediately */
+              Object* o2 = &(lane.q.back());
+	      Object::Queue::iterator it = Object::Queue::s_iterator_to(*o2);
+	      lane.q.erase(it);
+	      tdo = o2;
 	    }
 	  }
 	  lane.lock.unlock();

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -4309,6 +4309,13 @@ options:
   default: 3
   services:
   - rgw
+- name: rgw_posix_cache_max_users
+  type: uint
+  level: advanced
+  desc: experimental Maximum number of users to maintain in the in-memory user info cache
+  default: 1000
+  services:
+  - rgw
 - name: rgw_luarocks_location
   type: str
   level: advanced

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -540,6 +540,12 @@ set(radosgw_admin_srcs
   radosgw-admin/sync_checkpoint.cc
   radosgw-admin/orphan.cc)
 
+set(radosgw_admin_srcs_without_rados
+  radosgw-admin/radosgw-admin.cc
+  driver/rados/rgw_user.cc
+  driver/rados/rgw_bucket.cc
+  driver/rados/rgw_obj_manifest.cc)
+
 # this is unsatisfying and hopefully temporary; ARROW should not be
 # part of radosgw_admin
 if(WITH_RADOSGW_ARROW_FLIGHT)
@@ -558,6 +564,12 @@ target_link_libraries(radosgw-admin
   OATH::OATH
   ${CURL_LIBRARIES} ${EXPAT_LIBRARIES} ${BLKID_LIBRARIES})
 endif()
+
+if(WITH_RADOSGW_POSIX AND NOT WITH_RADOSGW_RADOS)
+add_executable(radosgw-admin ${radosgw_admin_srcs_without_rados})
+target_link_libraries(radosgw-admin
+  ${rgw_libs} librados)
+endif(WITH_RADOSGW_POSIX AND NOT WITH_RADOSGW_RADOS)
 
 # this is unsatisfying and hopefully temporary; ARROW should not be
 # part of radosgw_admin

--- a/src/rgw/driver/dbstore/common/dbstore.cc
+++ b/src/rgw/driver/dbstore/common/dbstore.cc
@@ -104,6 +104,8 @@ std::shared_ptr<class DBOp> DB::getDBOp(const DoutPrefixProvider *dpp, std::stri
     return dbops.RemoveUser;
   if (!Op.compare("GetUser"))
     return dbops.GetUser;
+  if (!Op.compare("ListUsers"))
+    return dbops.ListUsers;
   if (!Op.compare("InsertBucket"))
     return dbops.InsertBucket;
   if (!Op.compare("UpdateBucket"))
@@ -425,6 +427,33 @@ int DB::remove_user(const DoutPrefixProvider *dpp,
   if (ret) {
     ldpp_dout(dpp, 0)<<"remove_user failed with err:(" <<ret<<") " << dendl;
     goto out;
+  }
+
+out:
+  return ret;
+}
+
+int DB::list_users(const DoutPrefixProvider *dpp,
+        const std::string& marker,
+        uint64_t max,
+        std::list<std::string>& keys,
+        bool *is_truncated)
+{
+  int ret = 0;
+  DBOpParams params = {};
+  InitializeParams(dpp, &params);
+
+  params.op.user.uinfo.user_id = marker;
+  params.op.list_max_count = max;
+
+  ret = ProcessOp(dpp, "ListUsers", &params);
+
+  if (ret) {
+    ldpp_dout(dpp, 0) << "list_users failed with err:(" << ret <<") " << dendl;
+    goto out;
+  }
+  for (auto& entry : params.op.user.list_entries) {
+    keys.push_back(entry.user_id.to_str());
   }
 
 out:

--- a/src/rgw/driver/dbstore/common/dbstore.cc
+++ b/src/rgw/driver/dbstore/common/dbstore.cc
@@ -234,6 +234,7 @@ int DB::InitializeParams(const DoutPrefixProvider *dpp, DBOpParams *params)
   params->cct = cct;
 
   //reset params here
+  params->account_table = account_table;
   params->user_table = user_table;
   params->bucket_table = bucket_table;
   params->quota_table = quota_table;
@@ -427,6 +428,157 @@ int DB::remove_user(const DoutPrefixProvider *dpp,
   }
 
 out:
+  return ret;
+}
+
+int DB::get_account(const DoutPrefixProvider *dpp,
+    const std::string& query_str, const std::string& query_str_val,
+    RGWAccountInfo& ainfo, map<string, bufferlist> *pattrs,
+    RGWObjVersionTracker *pobjv_tracker) {
+  int ret = 0;
+
+  if (query_str.empty() || query_str_val.empty()) {
+    ldpp_dout(dpp, 0)<<"In GetAccount - Invalid query(" << query_str <<"), query_str_val(" << query_str_val <<")" << dendl;
+    return -1;
+  }
+
+  DBOpParams params = {};
+  InitializeParams(dpp, &params);
+
+  params.op.query_str = query_str;
+
+  // validate query_str with AccountTable entries names
+  if (query_str == "name") {
+    params.op.account.info.name = query_str_val;
+  } else if (query_str == "email") {
+    params.op.account.info.email = query_str_val;
+  } else if (query_str == "account_id") {
+    params.op.account.info.id = query_str_val;
+  } else {
+    ldpp_dout(dpp, 0)<<"In GetAccount Invalid query string :" <<query_str.c_str()<<") " << dendl;
+    return -1;
+  }
+
+  ret = ProcessOp(dpp, "GetAccount", &params);
+
+  if (ret) {
+    return ret;
+  }
+
+  /* Verify if its a valid account */
+  if (params.op.account.info.id.empty()) {
+    ldpp_dout(dpp, 0)<<"In GetAccount - No account with query(" <<query_str.c_str()<<"), account_id(" << ainfo.id <<") found" << dendl;
+    return -ENOENT;
+  }
+
+  ainfo = params.op.account.info;
+
+  if (pattrs) {
+    *pattrs = params.op.account.account_attrs;
+  }
+
+  if (pobjv_tracker) {
+    pobjv_tracker->read_version = params.op.account.account_version;
+  }
+
+  return ret;
+}
+
+int DB::store_account(const DoutPrefixProvider *dpp,
+    const RGWAccountInfo& ainfo, bool exclusive, const map<string, bufferlist> *pattrs,
+    RGWObjVersionTracker *pobjv)
+{
+  DBOpParams params = {};
+  InitializeParams(dpp, &params);
+  int ret = 0;
+
+  /* Check if the account already exists and return the old info, caller will have a use for it */
+  RGWAccountInfo orig_info;
+  RGWObjVersionTracker objv_tracker = {};
+  obj_version& obj_ver = objv_tracker.read_version;
+
+  orig_info.id = ainfo.id;
+  ret = get_account(dpp, string("account_id"), ainfo.id, orig_info, nullptr, &objv_tracker);
+
+  if (!ret && obj_ver.ver) {
+    /* already exists. */
+    if (pobjv && (pobjv->read_version.ver != obj_ver.ver)) {
+      /* Object version mismatch.. return ECANCELED */
+      ret = -ECANCELED;
+      ldpp_dout(dpp, 0)<<"Account Read version mismatch err:(" <<ret<<") " << dendl;
+      return ret;
+    }
+
+    if (exclusive) {
+      // return
+      return ret;
+    }
+    obj_ver.ver++;
+  } else {
+    obj_ver.ver = 1;
+    obj_ver.tag = "AccountTAG";
+  }
+
+  params.op.account.account_version = obj_ver;
+  params.op.account.info = ainfo;
+
+  if (pattrs) {
+    params.op.account.account_attrs = *pattrs;
+  }
+
+  ret = ProcessOp(dpp, "InsertAccount", &params);
+
+  if (ret) {
+    ldpp_dout(dpp, 0)<<"store_account failed with err:(" <<ret<<") " << dendl;
+    return ret;
+  }
+  ldpp_dout(dpp, 20)<<"Account creation successful - account_id:(" <<ainfo.id<<") " << dendl;
+
+  if (pobjv) {
+    pobjv->read_version = obj_ver;
+    pobjv->write_version = obj_ver;
+  }
+
+  return ret;
+}
+
+int DB::remove_account(const DoutPrefixProvider *dpp,
+    const RGWAccountInfo &ainfo, RGWObjVersionTracker *pobjv)
+{
+  DBOpParams params = {};
+  InitializeParams(dpp, &params);
+  int ret = 0;
+
+  RGWAccountInfo orig_info;
+  RGWObjVersionTracker objv_tracker = {};
+
+  orig_info.id = ainfo.id;
+  ret = get_account(dpp, string("account_id"), ainfo.id, orig_info, nullptr, &objv_tracker);
+
+  if (ret) {
+    return ret;
+  }
+
+  if (!ret && objv_tracker.read_version.ver) {
+    /* already exists. */
+
+    if (pobjv && (pobjv->read_version.ver != objv_tracker.read_version.ver)) {
+      /* Object version mismatch.. return ECANCELED */
+      ret = -ECANCELED;
+      ldpp_dout(dpp, 0)<<"Account Read version mismatch err:(" <<ret<<") " << dendl;
+      return ret;
+    }
+  }
+
+  params.op.account.info.id = ainfo.id;
+
+  ret = ProcessOp(dpp, "RemoveAccount", &params);
+
+  if (ret) {
+    ldpp_dout(dpp, 0)<<"remove_account failed with err:(" <<ret<<") " << dendl;
+    return ret;
+  }
+
   return ret;
 }
 

--- a/src/rgw/driver/dbstore/common/dbstore.h
+++ b/src/rgw/driver/dbstore/common/dbstore.h
@@ -36,6 +36,7 @@ struct DBOpUserInfo {
   RGWUserInfo uinfo = {};
   obj_version user_version;
   rgw::sal::Attrs user_attrs;
+  std::list<RGWUserInfo> list_entries;
 };
 
 struct DBOpBucketInfo {
@@ -372,6 +373,7 @@ struct DBOps {
   std::shared_ptr<class InsertUserOp> InsertUser;
   std::shared_ptr<class RemoveUserOp> RemoveUser;
   std::shared_ptr<class GetUserOp> GetUser;
+  std::shared_ptr<class ListUsersOp> ListUsers;
   std::shared_ptr<class InsertBucketOp> InsertBucket;
   std::shared_ptr<class UpdateBucketOp> UpdateBucket;
   std::shared_ptr<class RemoveBucketOp> RemoveBucket;
@@ -944,6 +946,28 @@ class GetUserOp: virtual public DBOp {
         return fmt::format(Query, params.user_table,
             params.op.user.user_id);
       }
+    }
+};
+
+
+class ListUsersOp: virtual public DBOp {
+    static constexpr std::string_view Query = "SELECT \
+                          UserID, Tenant, NS, DisplayName, UserEmail, \
+                          AccessKeysID, AccessKeysSecret, AccessKeys, SwiftKeys,\
+                          SubUsers, Suspended, MaxBuckets, OpMask, UserCaps, Admin, \
+                          System, PlacementName, PlacementStorageClass, PlacementTags, \
+                          BucketQuota, TempURLKeys, UserQuota, Type, MfaIDs, AssumedRoleARN, \
+                          UserAttrs, UserVersion, UserVersionTag from '{}' where \
+                          UserID >= {} ORDER BY UserID ASC LIMIT {} ";
+
+  public:
+    virtual ~ListUsersOp() {}
+
+    static std::string Schema(DBOpPrepareParams &params) {
+      return fmt::format(Query,
+        params.user_table,
+        params.op.user.user_id,
+        params.op.list_max_count);
     }
 };
 
@@ -1717,6 +1741,11 @@ class DB {
         RGWObjVersionTracker *pobjv_tracker, RGWUserInfo* pold_info);
     int remove_user(const DoutPrefixProvider *dpp,
         RGWUserInfo& uinfo, RGWObjVersionTracker *pobjv_tracker);
+    int list_users(const DoutPrefixProvider *dpp,
+        const std::string& marker,
+        uint64_t max,
+        std::list<std::string>& keys,
+        bool *is_truncated);
     int get_account(const DoutPrefixProvider *dpp,
         const std::string& query_str, const std::string& query_str_val,
         RGWAccountInfo& ainfo, std::map<std::string, bufferlist> *pattrs,

--- a/src/rgw/driver/dbstore/common/dbstore.h
+++ b/src/rgw/driver/dbstore/common/dbstore.h
@@ -26,6 +26,12 @@ namespace rgw { namespace store {
 
 class DB;
 
+struct DBOpAccountInfo {
+  RGWAccountInfo info = {};
+  obj_version account_version;
+  rgw::sal::Attrs account_attrs;
+};
+
 struct DBOpUserInfo {
   RGWUserInfo uinfo = {};
   obj_version user_version;
@@ -122,6 +128,7 @@ struct DBOpInfo {
    * be able to query easily.
    *
    * XXX: Swift keys and subuser not supported for now */
+  DBOpAccountInfo account;
   DBOpUserInfo user;
   std::string query_str;
   DBOpBucketInfo bucket;
@@ -136,6 +143,7 @@ struct DBOpParams {
   CephContext *cct;
 
   /* Tables */
+  std::string account_table;
   std::string user_table;
   std::string bucket_table;
   std::string object_table;
@@ -162,6 +170,20 @@ struct DBOpParams {
  * These identifiers are used in prepare and bind statements
  * to get the right index of each param.
  */
+struct DBOpAccountPrepareInfo {
+  static constexpr const char* account_id = ":account_id";
+  static constexpr const char* tenant = ":tenant";
+  static constexpr const char* account_name = ":account_name";
+  static constexpr const char* email = ":email";
+  static constexpr const char* quota = ":quota";
+  static constexpr const char* bucket_quota = ":bucket_quota";
+  static constexpr const char* max_users = ":max_users";
+  static constexpr const char* max_roles = ":max_roles";
+  static constexpr const char* max_groups = ":max_groups";
+  static constexpr const char* max_buckets = ":max_buckets";
+  static constexpr const char* max_access_keys = ":max_access_keys";
+};
+
 struct DBOpUserPrepareInfo {
   static constexpr const char* user_id = ":user_id";
   static constexpr const char* tenant = ":tenant";
@@ -313,6 +335,7 @@ struct DBOpLCHeadPrepareInfo {
 };
 
 struct DBOpPrepareInfo {
+  DBOpAccountPrepareInfo account;
   DBOpUserPrepareInfo user;
   std::string_view query_str; // view into DBOpInfo::query_str
   DBOpBucketPrepareInfo bucket;
@@ -325,6 +348,7 @@ struct DBOpPrepareInfo {
 
 struct DBOpPrepareParams {
   /* Tables */
+  std::string account_table;
   std::string user_table;
   std::string bucket_table;
   std::string object_table;
@@ -342,6 +366,9 @@ struct DBOpPrepareParams {
 };
 
 struct DBOps {
+  std::shared_ptr<class InsertAccountOp> InsertAccount;
+  std::shared_ptr<class RemoveAccountOp> RemoveAccount;
+  std::shared_ptr<class GetAccountOp> GetAccount;
   std::shared_ptr<class InsertUserOp> InsertUser;
   std::shared_ptr<class RemoveUserOp> RemoveUser;
   std::shared_ptr<class GetUserOp> GetUser;
@@ -382,6 +409,30 @@ class ObjectOp {
 
 class DBOp {
   private:
+    static constexpr std::string_view CreateAccountTableQ =
+      /* Corresponds to RGWAccountInfo
+       *
+       * AccountID is made Primary key.
+       * If multiple tenants are stored in single .db handle, should
+       * make both (AccountID, Tenant) as Primary Key.
+       *
+       * XXX:
+       * - Quota stored as blob .. should be linked to quota table.
+       */
+      "CREATE TABLE IF NOT EXISTS '{}' (	\
+      AccountID TEXT NOT NULL UNIQUE,		\
+      Tenant TEXT ,		\
+      AccountName TEXT , \
+      Email TEXT ,	\
+      Quota BLOB ,	\
+      BucketQuota BLOB ,	\
+      MaxUsers INTEGER ,	\
+      MaxRoles INTEGER ,	\
+      MaxGroups INTEGER ,	\
+      MaxBuckets INTEGER ,	\
+      MaxAccessKeys INTEGER ,	\
+      PRIMARY KEY (AccountID) \n);";
+
     static constexpr std::string_view CreateUserTableQ =
       /* Corresponds to rgw::sal::User
        *
@@ -653,6 +704,9 @@ class DBOp {
 
     static std::string CreateTableSchema(std::string_view type,
                                          const DBOpParams *params) {
+      if (!type.compare("Account"))
+        return fmt::format(CreateAccountTableQ,
+            params->account_table);
       if (!type.compare("User"))
         return fmt::format(CreateUserTableQ,
             params->user_table);
@@ -703,6 +757,76 @@ class DBOp {
     virtual int Prepare(const DoutPrefixProvider *dpp, DBOpParams *params) { return 0; }
     virtual int Bind(const DoutPrefixProvider *dpp, DBOpParams *params) { return 0; }
     virtual int Execute(const DoutPrefixProvider *dpp, DBOpParams *params) { return 0; }
+};
+
+class InsertAccountOp : virtual public DBOp {
+  private:
+    static constexpr std::string_view Query = "INSERT OR REPLACE INTO '{}'	\
+                          (AccountID, Tenant, AccountName, Email, \
+                           Quota, BucketQuota, MaxUsers, MaxRoles, MaxGroups, \
+                           MaxBuckets, MaxAccessKeys) \
+                          VALUES ({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {});";
+
+  public:
+    virtual ~InsertAccountOp() {}
+
+    static std::string Schema(DBOpPrepareParams &params) {
+      return fmt::format(Query, params.account_table,
+          params.op.account.account_id, params.op.account.tenant,
+          params.op.account.account_name, params.op.account.email,
+          params.op.account.quota, params.op.account.bucket_quota,
+          params.op.account.max_users, params.op.account.max_roles,
+          params.op.account.max_groups, params.op.account.max_buckets,
+          params.op.account.max_access_keys);
+    }
+};
+
+class RemoveAccountOp: virtual public DBOp {
+  private:
+    static constexpr std::string_view Query =
+      "DELETE from '{}' where AccountID = {}";
+
+  public:
+    virtual ~RemoveAccountOp() {}
+
+    static std::string Schema(DBOpPrepareParams &params) {
+      return fmt::format(Query, params.account_table,
+          params.op.account.account_id);
+    }
+};
+
+class GetAccountOp: virtual public DBOp {
+  private:
+    static constexpr std::string_view Query = "SELECT \
+                          AccountID, Tenant, AccountName, Email, \
+                          Quota, BucketQuota, MaxUsers, MaxRoles, MaxGroups, \
+                          MaxBuckets, MaxAccessKeys from '{}' where AccountID = {}";
+
+    static constexpr std::string_view QueryByName = "SELECT \
+                          AccountID, Tenant, AccountName, Email, \
+                          Quota, BucketQuota, MaxUsers, MaxRoles, MaxGroups, \
+                          MaxBuckets, MaxAccessKeys from '{}' where AccountName = {}";
+
+    static constexpr std::string_view QueryByEmail = "SELECT \
+                          AccountID, Tenant, AccountName, Email, \
+                          Quota, BucketQuota, MaxUsers, MaxRoles, MaxGroups, \
+                          MaxBuckets, MaxAccessKeys from '{}' where Email = {}";
+
+  public:
+    virtual ~GetAccountOp() {}
+
+    static std::string Schema(DBOpPrepareParams &params) {
+      if (params.op.query_str == "name") {
+        return fmt::format(QueryByName, params.account_table,
+            params.op.account.account_name);
+      } else if (params.op.query_str == "email") {
+        return fmt::format(QueryByEmail, params.account_table,
+            params.op.account.email);
+      } else {
+        return fmt::format(Query, params.account_table,
+            params.op.account.account_id);
+      }
+    }
 };
 
 class InsertUserOp : virtual public DBOp {
@@ -1480,6 +1604,7 @@ class DB {
   private:
     const std::string db_name;
     rgw::sal::Driver* driver;
+    const std::string account_table;
     const std::string user_table;
     const std::string bucket_table;
     const std::string quota_table;
@@ -1501,6 +1626,7 @@ class DB {
 
   public:
     DB(std::string db_name, CephContext *_cct) : db_name(db_name),
+    account_table(db_name+"_account_table"),
     user_table(db_name+"_user_table"),
     bucket_table(db_name+"_bucket_table"),
     quota_table(db_name+"_quota_table"),
@@ -1512,6 +1638,7 @@ class DB {
     /*	DB() {}*/
 
     DB(CephContext *_cct) : db_name("default_db"),
+    account_table(db_name+"_account_table"),
     user_table(db_name+"_user_table"),
     bucket_table(db_name+"_bucket_table"),
     quota_table(db_name+"_quota_table"),
@@ -1524,6 +1651,7 @@ class DB {
 
     const std::string getDBname() { return db_name; }
     const std::string getDBfile() { return db_name + ".db"; }
+    const std::string getAccountTable() { return account_table; }
     const std::string getUserTable() { return user_table; }
     const std::string getBucketTable() { return bucket_table; }
     const std::string getQuotaTable() { return quota_table; }
@@ -1589,6 +1717,15 @@ class DB {
         RGWObjVersionTracker *pobjv_tracker, RGWUserInfo* pold_info);
     int remove_user(const DoutPrefixProvider *dpp,
         RGWUserInfo& uinfo, RGWObjVersionTracker *pobjv_tracker);
+    int get_account(const DoutPrefixProvider *dpp,
+        const std::string& query_str, const std::string& query_str_val,
+        RGWAccountInfo& ainfo, std::map<std::string, bufferlist> *pattrs,
+        RGWObjVersionTracker *pobjv_tracker);
+    int store_account(const DoutPrefixProvider *dpp,
+        const RGWAccountInfo& ainfo, bool exclusive, const std::map<std::string, bufferlist> *pattrs,
+        RGWObjVersionTracker *pobjv_tracker);
+    int remove_account(const DoutPrefixProvider *dpp,
+        const RGWAccountInfo &ainfo, RGWObjVersionTracker *pobjv_tracker);
     int get_bucket_info(const DoutPrefixProvider *dpp, const std::string& query_str,
         const std::string& query_str_val,
         RGWBucketInfo& info, rgw::sal::Attrs* pattrs, ceph::real_time* pmtime,

--- a/src/rgw/driver/dbstore/common/dbstore.h
+++ b/src/rgw/driver/dbstore/common/dbstore.h
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <iostream>
 #include <mutex>
+#include <filesystem>
 #include <condition_variable>
 #include "fmt/format.h"
 #include <map>
@@ -1627,6 +1628,7 @@ WRITE_CLASS_ENCODER(DBOLHInfo)
 class DB {
   private:
     const std::string db_name;
+    const std::string table_name_prefix;
     rgw::sal::Driver* driver;
     const std::string account_table;
     const std::string user_table;
@@ -1650,18 +1652,21 @@ class DB {
 
   public:
     DB(std::string db_name, CephContext *_cct) : db_name(db_name),
-    account_table(db_name+"_account_table"),
-    user_table(db_name+"_user_table"),
-    bucket_table(db_name+"_bucket_table"),
-    quota_table(db_name+"_quota_table"),
-    lc_head_table(db_name+"_lc_head_table"),
-    lc_entry_table(db_name+"_lc_entry_table"),
+    table_name_prefix(std::filesystem::path(db_name).filename()),
+    account_table(table_name_prefix + "_account_table"),
+    user_table(table_name_prefix + "_user_table"),
+    bucket_table(table_name_prefix + "_bucket_table"),
+    quota_table(table_name_prefix + "_quota_table"),
+    lc_head_table(table_name_prefix + "_lc_head_table"),
+    lc_entry_table(table_name_prefix + "_lc_entry_table"),
     cct(_cct),
     dp(_cct, ceph_subsys_rgw, "rgw DBStore backend: ")
   {}
     /*	DB() {}*/
 
     DB(CephContext *_cct) : db_name("default_db"),
+
+    table_name_prefix(db_name),
     account_table(db_name+"_account_table"),
     user_table(db_name+"_user_table"),
     bucket_table(db_name+"_bucket_table"),
@@ -1682,13 +1687,13 @@ class DB {
     const std::string getLCHeadTable() { return lc_head_table; }
     const std::string getLCEntryTable() { return lc_entry_table; }
     const std::string getObjectTable(std::string bucket) {
-      return db_name+"_"+bucket+"_object_table"; }
+      return table_name_prefix+"_"+bucket+"_object_table"; }
     const std::string getObjectDataTable(std::string bucket) {
-      return db_name+"_"+bucket+"_objectdata_table"; }
+      return table_name_prefix+"_"+bucket+"_objectdata_table"; }
     const std::string getObjectView(std::string bucket) {
-      return db_name+"_"+bucket+"_object_view"; }
+      return table_name_prefix+"_"+bucket+"_object_view"; }
     const std::string getObjectTrigger(std::string bucket) {
-      return db_name+"_"+bucket+"_object_trigger"; }
+      return table_name_prefix+"_"+bucket+"_object_trigger"; }
 
     std::map<std::string, class ObjectOp*> getObjectMap();
 

--- a/src/rgw/driver/dbstore/sqlite/sqliteDB.cc
+++ b/src/rgw/driver/dbstore/sqlite/sqliteDB.cc
@@ -157,8 +157,8 @@ int SQLiteDB::InitPrepareParams(const DoutPrefixProvider *dpp,
   if (!params)
     return -1;
 
-  if (params->user_table.empty()) {
-    params->user_table = getUserTable();
+  if (params->account_table.empty()) {
+    params->account_table = getAccountTable();
   }
   if (params->user_table.empty()) {
     params->user_table = getUserTable();
@@ -176,6 +176,7 @@ int SQLiteDB::InitPrepareParams(const DoutPrefixProvider *dpp,
     params->lc_head_table = getLCHeadTable();
   }
 
+  p_params.account_table = params->account_table;
   p_params.user_table = params->user_table;
   p_params.bucket_table = params->bucket_table;
   p_params.quota_table = params->quota_table;
@@ -216,6 +217,20 @@ static int list_callback(void *None, int argc, char **argv, char **aname)
   }
   return 0;
 }
+
+enum GetAccount {
+  AccountID = 0,
+  AccountTenant,
+  AccountName,
+  Email,
+  AccountQuota,
+  AccountBucketQuota,
+  MaxUsers,
+  MaxRoles,
+  MaxGroups,
+  AccountMaxBuckets,
+  MaxAccessKeys,
+};
 
 enum GetUser {
   UserID = 0,
@@ -358,6 +373,27 @@ enum GetLCHead {
   LCHeadMarker,
   LCHeadStartDate
 };
+
+static int list_account(const DoutPrefixProvider *dpp, DBOpInfo &op, sqlite3_stmt *stmt) {
+  if (!stmt)
+    return -1;
+
+  op.account.info.id = (const char*)sqlite3_column_text(stmt, AccountID);
+  op.account.info.tenant = (const char*)sqlite3_column_text(stmt, AccountTenant);
+  op.account.info.name = (const char*)sqlite3_column_text(stmt, AccountName);
+  op.account.info.email = (const char*)sqlite3_column_text(stmt, Email);
+
+  SQL_DECODE_BLOB_PARAM(dpp, stmt, AccountQuota, op.account.info.quota, sdb);
+  SQL_DECODE_BLOB_PARAM(dpp, stmt, AccountBucketQuota, op.account.info.bucket_quota, sdb);
+
+  op.account.info.max_users = sqlite3_column_int(stmt, MaxUsers);
+  op.account.info.max_roles = sqlite3_column_int(stmt, MaxRoles);
+  op.account.info.max_groups = sqlite3_column_int(stmt, MaxGroups);
+  op.account.info.max_buckets = sqlite3_column_int(stmt, AccountMaxBuckets);
+  op.account.info.max_access_keys = sqlite3_column_int(stmt, MaxAccessKeys);
+
+  return 0;
+}
 
 static int list_user(const DoutPrefixProvider *dpp, DBOpInfo &op, sqlite3_stmt *stmt) {
   if (!stmt)
@@ -588,6 +624,9 @@ static int list_lc_head(const DoutPrefixProvider *dpp, DBOpInfo &op, sqlite3_stm
 int SQLiteDB::InitializeDBOps(const DoutPrefixProvider *dpp)
 {
   (void)createTables(dpp);
+  dbops.InsertAccount = make_shared<SQLInsertAccount>(&this->db, this->getDBname(), cct);
+  dbops.RemoveAccount = make_shared<SQLRemoveAccount>(&this->db, this->getDBname(), cct);
+  dbops.GetAccount = make_shared<SQLGetAccount>(&this->db, this->getDBname(), cct);
   dbops.InsertUser = make_shared<SQLInsertUser>(&this->db, this->getDBname(), cct);
   dbops.RemoveUser = make_shared<SQLRemoveUser>(&this->db, this->getDBname(), cct);
   dbops.GetUser = make_shared<SQLGetUser>(&this->db, this->getDBname(), cct);
@@ -716,11 +755,15 @@ out:
 int SQLiteDB::createTables(const DoutPrefixProvider *dpp)
 {
   int ret = -1;
-  int cu = 0, cb = 0, cq = 0;
+  int ca = 0, cu = 0, cb = 0, cq = 0;
   DBOpParams params = {};
 
+  params.account_table = getAccountTable();
   params.user_table = getUserTable();
   params.bucket_table = getBucketTable();
+
+  if ((ca = createAccountTable(dpp, &params)))
+    goto out;
 
   if ((cu = createUserTable(dpp, &params)))
     goto out;
@@ -734,12 +777,30 @@ int SQLiteDB::createTables(const DoutPrefixProvider *dpp)
   ret = 0;
 out:
   if (ret) {
+    if (ca)
+      DeleteAccountTable(dpp, &params);
     if (cu)
       DeleteUserTable(dpp, &params);
     if (cb)
       DeleteBucketTable(dpp, &params);
     ldpp_dout(dpp, 0)<<"Creation of tables failed" << dendl;
   }
+
+  return ret;
+}
+
+int SQLiteDB::createAccountTable(const DoutPrefixProvider *dpp, DBOpParams *params)
+{
+  int ret = -1;
+  string schema;
+
+  schema = CreateTableSchema("Account", params);
+
+  ret = exec(dpp, schema.c_str(), NULL);
+  if (ret)
+    ldpp_dout(dpp, 0)<<"CreateAccountTable failed" << dendl;
+
+  ldpp_dout(dpp, 20)<<"CreateAccountTable succeeded" << dendl;
 
   return ret;
 }
@@ -881,6 +942,22 @@ int SQLiteDB::createLCTables(const DoutPrefixProvider *dpp)
     (void)DeleteLCEntryTable(dpp, &params);
   }
   ldpp_dout(dpp, 20)<<"CreateLCHeadTable succeeded" << dendl;
+
+  return ret;
+}
+
+int SQLiteDB::DeleteAccountTable(const DoutPrefixProvider *dpp, DBOpParams *params)
+{
+  int ret = -1;
+  string schema;
+
+  schema = DeleteTableSchema(params->account_table);
+
+  ret = exec(dpp, schema.c_str(), NULL);
+  if (ret)
+    ldpp_dout(dpp, 0)<<"DeleteAccountTable failed " << dendl;
+
+  ldpp_dout(dpp, 20)<<"DeleteAccountTable succeeded " << dendl;
 
   return ret;
 }
@@ -1067,6 +1144,174 @@ int SQLObjectOp::InitializeObjectOps(string db_name, const DoutPrefixProvider *d
   DeleteStaleObjectData = make_shared<SQLDeleteStaleObjectData>(sdb, db_name, cct);
 
   return 0;
+}
+
+int SQLInsertAccount::Prepare(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int ret = -1;
+  struct DBOpPrepareParams p_params = PrepareParams;
+
+  if (!*sdb) {
+    ldpp_dout(dpp, 0)<<"In SQLInsertAccount - no db" << dendl;
+    goto out;
+  }
+
+  InitPrepareParams(dpp, p_params, params);
+
+  SQL_PREPARE(dpp, p_params, sdb, stmt, ret, "PrepareInsertAccount");
+out:
+  return ret;
+}
+
+int SQLInsertAccount::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int index = -1;
+  int rc = 0;
+  struct DBOpPrepareParams p_params = PrepareParams;
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.account.account_id, sdb);
+  SQL_BIND_TEXT(dpp, stmt, index, params->op.account.info.id.c_str(), sdb);
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.account.tenant, sdb);
+  SQL_BIND_TEXT(dpp, stmt, index, params->op.account.info.tenant.c_str(), sdb);
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.account.account_name, sdb);
+  SQL_BIND_TEXT(dpp, stmt, index, params->op.account.info.name.c_str(), sdb);
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.account.email, sdb);
+  SQL_BIND_TEXT(dpp, stmt, index, params->op.account.info.email.c_str(), sdb);
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.account.quota, sdb);
+  SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.account.info.quota, sdb);
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.account.bucket_quota, sdb);
+  SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.account.info.bucket_quota, sdb);
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.account.max_users, sdb);
+  SQL_BIND_INT(dpp, stmt, index, params->op.account.info.max_users, sdb);
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.account.max_roles, sdb);
+  SQL_BIND_INT(dpp, stmt, index, params->op.account.info.max_roles, sdb);
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.account.max_groups, sdb);
+  SQL_BIND_INT(dpp, stmt, index, params->op.account.info.max_groups, sdb);
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.account.max_buckets, sdb);
+  SQL_BIND_INT(dpp, stmt, index, params->op.account.info.max_buckets, sdb);
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.account.max_access_keys, sdb);
+  SQL_BIND_INT(dpp, stmt, index, params->op.account.info.max_access_keys, sdb);
+
+out:
+  return rc;
+}
+
+int SQLInsertAccount::Execute(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int ret = -1;
+
+  SQL_EXECUTE(dpp, params, stmt, NULL);
+out:
+  return ret;
+}
+
+int SQLRemoveAccount::Prepare(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int ret = -1;
+  struct DBOpPrepareParams p_params = PrepareParams;
+
+  if (!*sdb) {
+    ldpp_dout(dpp, 0)<<"In SQLRemoveAccount - no db" << dendl;
+    goto out;
+  }
+
+  InitPrepareParams(dpp, p_params, params);
+
+  SQL_PREPARE(dpp, p_params, sdb, stmt, ret, "PrepareRemoveAccount");
+out:
+  return ret;
+}
+
+int SQLRemoveAccount::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int index = -1;
+  int rc = 0;
+  struct DBOpPrepareParams p_params = PrepareParams;
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.account.account_id, sdb);
+  SQL_BIND_TEXT(dpp, stmt, index, params->op.account.info.id.c_str(), sdb);
+
+out:
+  return rc;
+}
+
+int SQLRemoveAccount::Execute(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int ret = -1;
+
+  SQL_EXECUTE(dpp, params, stmt, NULL);
+out:
+  return ret;
+}
+
+int SQLGetAccount::Prepare(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int ret = -1;
+  struct DBOpPrepareParams p_params = PrepareParams;
+
+  if (!*sdb) {
+    ldpp_dout(dpp, 0)<<"In SQLGetAccount - no db" << dendl;
+    goto out;
+  }
+
+  InitPrepareParams(dpp, p_params, params);
+
+  if (params->op.query_str == "name") { 
+    SQL_PREPARE(dpp, p_params, sdb, name_stmt, ret, "PrepareGetAccount");
+  } else if (params->op.query_str == "email") { 
+    SQL_PREPARE(dpp, p_params, sdb, email_stmt, ret, "PrepareGetAccount");
+  } else { // by default by account_id
+    SQL_PREPARE(dpp, p_params, sdb, stmt, ret, "PrepareGetAccount");
+  }
+out:
+  return ret;
+}
+
+int SQLGetAccount::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int index = -1;
+  int rc = 0;
+  struct DBOpPrepareParams p_params = PrepareParams;
+
+  if (params->op.query_str == "name") { 
+    SQL_BIND_INDEX(dpp, name_stmt, index, p_params.op.account.account_name, sdb);
+    SQL_BIND_TEXT(dpp, name_stmt, index, params->op.account.info.name.c_str(), sdb);
+  } else if (params->op.query_str == "email") { 
+    SQL_BIND_INDEX(dpp, email_stmt, index, p_params.op.account.email, sdb);
+    SQL_BIND_TEXT(dpp, email_stmt, index, params->op.account.info.email.c_str(), sdb);
+  } else { // by default by account_id
+    SQL_BIND_INDEX(dpp, stmt, index, p_params.op.account.account_id, sdb);
+    SQL_BIND_TEXT(dpp, stmt, index, params->op.account.info.id.c_str(), sdb);
+  }
+
+out:
+  return rc;
+}
+
+int SQLGetAccount::Execute(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int ret = -1;
+
+  if (params->op.query_str == "name") { 
+    SQL_EXECUTE(dpp, params, name_stmt, list_account);
+  } else if (params->op.query_str == "email") { 
+    SQL_EXECUTE(dpp, params, email_stmt, list_account);
+  } else { // by default by account_id
+    SQL_EXECUTE(dpp, params, stmt, list_account);
+  }
+
+out:
+  return ret;
 }
 
 int SQLInsertUser::Prepare(const DoutPrefixProvider *dpp, struct DBOpParams *params)

--- a/src/rgw/driver/dbstore/sqlite/sqliteDB.cc
+++ b/src/rgw/driver/dbstore/sqlite/sqliteDB.cc
@@ -436,6 +436,7 @@ static int list_user(const DoutPrefixProvider *dpp, DBOpInfo &op, sqlite3_stmt *
   op.user.user_version.ver = sqlite3_column_int(stmt, UserVersion);
   op.user.user_version.tag = (const char*)sqlite3_column_text(stmt, UserVersionTag);
 
+  op.user.list_entries.push_back(op.user.uinfo);
   return 0;
 }
 
@@ -630,6 +631,7 @@ int SQLiteDB::InitializeDBOps(const DoutPrefixProvider *dpp)
   dbops.InsertUser = make_shared<SQLInsertUser>(&this->db, this->getDBname(), cct);
   dbops.RemoveUser = make_shared<SQLRemoveUser>(&this->db, this->getDBname(), cct);
   dbops.GetUser = make_shared<SQLGetUser>(&this->db, this->getDBname(), cct);
+  dbops.ListUsers = make_shared<SQLListUsers>(&this->db, this->getDBname(), cct);
   dbops.InsertBucket = make_shared<SQLInsertBucket>(&this->db, this->getDBname(), cct);
   dbops.UpdateBucket = make_shared<SQLUpdateBucket>(&this->db, this->getDBname(), cct);
   dbops.RemoveBucket = make_shared<SQLRemoveBucket>(&this->db, this->getDBname(), cct);
@@ -1550,6 +1552,48 @@ int SQLGetUser::Execute(const DoutPrefixProvider *dpp, struct DBOpParams *params
   } else { // by default by userid
     SQL_EXECUTE(dpp, params, stmt, list_user);
   }
+
+out:
+  return ret;
+}
+
+int SQLListUsers::Prepare(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int ret = -1;
+  struct DBOpPrepareParams p_params = PrepareParams;
+
+  if (!*sdb) {
+    ldpp_dout(dpp, 0)<<"In SQLListUsers - no db" << dendl;
+    goto out;
+  }
+
+  InitPrepareParams(dpp, p_params, params);
+
+  SQL_PREPARE(dpp, p_params, sdb, stmt, ret, "PrepareListUsers");
+out:
+  return ret;
+}
+
+int SQLListUsers::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int index = -1;
+  int rc = 0;
+  struct DBOpPrepareParams p_params = PrepareParams;
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.user_id, sdb);
+  SQL_BIND_TEXT(dpp, stmt, index, params->op.user.uinfo.user_id.id.c_str(), sdb);
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.list_max_count, sdb);
+  SQL_BIND_INT(dpp, stmt, index, params->op.list_max_count, sdb);
+out:
+  return rc;
+}
+
+int SQLListUsers::Execute(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int ret = -1;
+
+  SQL_EXECUTE(dpp, params, stmt, list_user);
 
 out:
   return ret;

--- a/src/rgw/driver/dbstore/sqlite/sqliteDB.cc
+++ b/src/rgw/driver/dbstore/sqlite/sqliteDB.cc
@@ -763,6 +763,7 @@ int SQLiteDB::createTables(const DoutPrefixProvider *dpp)
   params.account_table = getAccountTable();
   params.user_table = getUserTable();
   params.bucket_table = getBucketTable();
+  params.quota_table = getQuotaTable();
 
   if ((ca = createAccountTable(dpp, &params)))
     goto out;
@@ -785,6 +786,8 @@ out:
       DeleteUserTable(dpp, &params);
     if (cb)
       DeleteBucketTable(dpp, &params);
+    if (cq)
+      DeleteQuotaTable(dpp, &params);
     ldpp_dout(dpp, 0)<<"Creation of tables failed" << dendl;
   }
 

--- a/src/rgw/driver/dbstore/sqlite/sqliteDB.h
+++ b/src/rgw/driver/dbstore/sqlite/sqliteDB.h
@@ -196,6 +196,23 @@ class SQLGetUser : public SQLiteDB, public GetUserOp {
     int Bind(const DoutPrefixProvider *dpp, DBOpParams *params);
 };
 
+class SQLListUsers : public SQLiteDB, public ListUsersOp {
+  private:
+    sqlite3 **sdb = NULL;
+    sqlite3_stmt *stmt = NULL; // Prepared statement
+
+  public:
+    SQLListUsers(void **db, std::string db_name, CephContext *cct) : SQLiteDB((sqlite3 *)(*db), db_name, cct), sdb((sqlite3 **)db) {}
+    ~SQLListUsers() {
+      if (stmt)
+        sqlite3_finalize(stmt);
+    }
+    int Prepare(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int Execute(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int Bind(const DoutPrefixProvider *dpp, DBOpParams *params);
+};
+
+
 class SQLInsertBucket : public SQLiteDB, public InsertBucketOp {
   private:
     sqlite3 **sdb = NULL;

--- a/src/rgw/driver/dbstore/sqlite/sqliteDB.h
+++ b/src/rgw/driver/dbstore/sqlite/sqliteDB.h
@@ -45,6 +45,7 @@ class SQLiteDB : public DB, virtual public DBOp {
     /* default value matches with sqliteDB style */
 
     int createTables(const DoutPrefixProvider *dpp) override;
+    int createAccountTable(const DoutPrefixProvider *dpp, DBOpParams *params);
     int createBucketTable(const DoutPrefixProvider *dpp, DBOpParams *params);
     int createUserTable(const DoutPrefixProvider *dpp, DBOpParams *params);
     int createObjectTable(const DoutPrefixProvider *dpp, DBOpParams *params);
@@ -58,6 +59,7 @@ class SQLiteDB : public DB, virtual public DBOp {
 
     int createLCTables(const DoutPrefixProvider *dpp) override;
 
+    int DeleteAccountTable(const DoutPrefixProvider *dpp, DBOpParams *params);
     int DeleteBucketTable(const DoutPrefixProvider *dpp, DBOpParams *params);
     int DeleteUserTable(const DoutPrefixProvider *dpp, DBOpParams *params);
     int DeleteObjectTable(const DoutPrefixProvider *dpp, DBOpParams *params);
@@ -81,6 +83,60 @@ class SQLObjectOp : public ObjectOp {
     ~SQLObjectOp() {}
 
     int InitializeObjectOps(std::string db_name, const DoutPrefixProvider *dpp);
+};
+
+class SQLInsertAccount : public SQLiteDB, public InsertAccountOp {
+  private:
+    sqlite3 **sdb = NULL;
+    sqlite3_stmt *stmt = NULL; // Prepared statement
+
+  public:
+    SQLInsertAccount(void **db, std::string db_name, CephContext *cct) : SQLiteDB((sqlite3 *)(*db), db_name, cct), sdb((sqlite3 **)db) {}
+    ~SQLInsertAccount() {
+      if (stmt)
+        sqlite3_finalize(stmt);
+    }
+    int Prepare(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int Execute(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int Bind(const DoutPrefixProvider *dpp, DBOpParams *params);
+};
+
+class SQLRemoveAccount : public SQLiteDB, public RemoveAccountOp {
+  private:
+    sqlite3 **sdb = NULL;
+    sqlite3_stmt *stmt = NULL; // Prepared statement
+
+  public:
+    SQLRemoveAccount(void **db, std::string db_name, CephContext *cct) : SQLiteDB((sqlite3 *)(*db), db_name, cct), sdb((sqlite3 **)db) {}
+    ~SQLRemoveAccount() {
+      if (stmt)
+        sqlite3_finalize(stmt);
+    }
+    int Prepare(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int Execute(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int Bind(const DoutPrefixProvider *dpp, DBOpParams *params);
+};
+
+class SQLGetAccount : public SQLiteDB, public GetAccountOp {
+  private:
+    sqlite3 **sdb = NULL;
+    sqlite3_stmt *stmt = NULL; // Prepared statement
+    sqlite3_stmt *name_stmt = NULL; // Prepared statement to query by account name
+    sqlite3_stmt *email_stmt = NULL; // Prepared statement to query by email
+
+  public:
+    SQLGetAccount(void **db, std::string db_name, CephContext *cct) : SQLiteDB((sqlite3 *)(*db), db_name, cct), sdb((sqlite3 **)db) {}
+    ~SQLGetAccount() {
+      if (stmt)
+        sqlite3_finalize(stmt);
+      if (name_stmt)
+        sqlite3_finalize(name_stmt);
+      if (email_stmt)
+        sqlite3_finalize(email_stmt);
+    }
+    int Prepare(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int Execute(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int Bind(const DoutPrefixProvider *dpp, DBOpParams *params);
 };
 
 class SQLInsertUser : public SQLiteDB, public InsertUserOp {

--- a/src/rgw/driver/posix/bucket_cache.h
+++ b/src/rgw/driver/posix/bucket_cache.h
@@ -392,12 +392,13 @@ public:
 	  std::string ser_data;
 	  zpp::bits::out out(ser_data);
 	  struct timespec ts{ceph::real_clock::to_timespec(bde.meta.mtime)};
-	  auto errc =
-	    out(bde.key.name, bde.key.instance, /* XXX bde.key.ns, */
-		bde.ver.pool, bde.ver.epoch, bde.exists,
-		bde.meta.category, bde.meta.size, ts.tv_sec, ts.tv_nsec,
-		bde.meta.owner, bde.meta.owner_display_name, bde.meta.accounted_size,
-		bde.meta.storage_class, bde.meta.appendable, bde.meta.etag);
+          auto errc =
+              out(bde.key.name, bde.key.instance, /* XXX bde.key.ns, */
+                  bde.ver.pool, bde.ver.epoch, bde.exists, bde.meta.category,
+                  bde.meta.size, ts.tv_sec, ts.tv_nsec, bde.meta.owner,
+                  bde.meta.owner_display_name, bde.meta.accounted_size,
+                  bde.meta.storage_class, bde.meta.appendable, bde.meta.etag,
+                  bde.flags);
 	  /*std::cout << fmt::format("fill: bde.key.name: {}", bde.key.name)
 	    << std::endl;*/
 	  if (errc.code != std::errc{0}) {
@@ -449,12 +450,13 @@ public:
 	std::string ser_v{svv};
 	zpp::bits::in in_v(ser_v);
 	struct timespec ts;
-	errc =
-	  in_v(bde.key.name, bde.key.instance, /* bde.key.ns, */
-	       bde.ver.pool, bde.ver.epoch, bde.exists,
-	       bde.meta.category, bde.meta.size, ts.tv_sec, ts.tv_nsec,
-	       bde.meta.owner, bde.meta.owner_display_name, bde.meta.accounted_size,
-	       bde.meta.storage_class, bde.meta.appendable, bde.meta.etag);
+        errc = in_v(
+            bde.key.name, bde.key.instance, /* bde.key.ns, */
+            bde.ver.pool, bde.ver.epoch, bde.exists, bde.meta.category,
+            bde.meta.size, ts.tv_sec, ts.tv_nsec, bde.meta.owner,
+            bde.meta.owner_display_name, bde.meta.accounted_size,
+            bde.meta.storage_class, bde.meta.appendable, bde.meta.etag,
+            bde.flags);
 	if (errc.code != std::errc{0}) {
 	  abort();
 	}
@@ -535,12 +537,13 @@ public:
 	  std::string ser_data;
 	  zpp::bits::out out(ser_data);
 	  struct timespec ts{ceph::real_clock::to_timespec(bde.meta.mtime)};
-	  auto errc =
-	    out(bde.key.name, bde.key.instance, /* XXX bde.key.ns, */
-		bde.ver.pool, bde.ver.epoch, bde.exists,
-		bde.meta.category, bde.meta.size, ts.tv_sec, ts.tv_nsec,
-		bde.meta.owner, bde.meta.owner_display_name, bde.meta.accounted_size,
-		bde.meta.storage_class, bde.meta.appendable, bde.meta.etag);
+          auto errc =
+              out(bde.key.name, bde.key.instance, /* XXX bde.key.ns, */
+                  bde.ver.pool, bde.ver.epoch, bde.exists, bde.meta.category,
+                  bde.meta.size, ts.tv_sec, ts.tv_nsec, bde.meta.owner,
+                  bde.meta.owner_display_name, bde.meta.accounted_size,
+                  bde.meta.storage_class, bde.meta.appendable, bde.meta.etag,
+                  bde.flags);
 	  if (errc.code != std::errc{0}) {
 	    abort();
 	  }
@@ -595,7 +598,8 @@ public:
               bde.ver.pool, bde.ver.epoch, bde.exists, bde.meta.category,
               bde.meta.size, ts.tv_sec, ts.tv_nsec, bde.meta.owner,
               bde.meta.owner_display_name, bde.meta.accounted_size,
-              bde.meta.storage_class, bde.meta.appendable, bde.meta.etag);
+              bde.meta.storage_class, bde.meta.appendable, bde.meta.etag,
+              bde.flags);
       if (errc.code != std::errc{0}) {
         abort();
       }

--- a/src/rgw/driver/posix/bucket_cache.h
+++ b/src/rgw/driver/posix/bucket_cache.h
@@ -67,11 +67,21 @@ struct BucketCacheEntry : public cohort::lru::Object
 
 public:
   BucketCacheEntry(BucketCache<D, B>* bc, const std::string& name, uint64_t hk)
-    : bc(bc), name(name), hk(hk), flags(FLAG_NONE) {}
+    : bc(bc), name(name), env{nullptr}, hk(hk), flags(FLAG_NONE) {}
 
   void set_env(std::shared_ptr<LMDBSafe::MDBEnv>& _env, LMDBSafe::MDBDbi& _dbi) {
     env = _env;
     dbi = _dbi;
+  }
+
+  virtual ~BucketCacheEntry()
+  {
+    /* XXX depends on safe_link -- but I think on balance, built-in safe_link
+     * is preferable to a custom mechanism with likely the same cost */
+    if (name_hook.is_linked()) {
+      bc->cache.remove(hk, this, bucket_avl_cache::FLAG_NONE);
+    }
+    mdb_dbi_close(*env, dbi); // return db handle
   }
 
   inline bool deleted() const {
@@ -152,14 +162,12 @@ public:
 
 	//std::cout << fmt::format("reclaim {}!", name) << std::endl;
 	bc->un->remove_watch(name);
-#if 1
-	// depends on safe_link
+
+	// XXX depends on safe_link
 	if (! name_hook.is_linked()) {
 	  // this should not happen!
 	  abort();
 	}
-#endif
-	bc->cache.remove(hk, this, bucket_avl_cache::FLAG_NONE);
 
 	/* discard lmdb data associated with this bucket */
 	auto txn = env->getRWTransaction();
@@ -646,6 +654,7 @@ public:
       b->flags &= ~BucketCacheEntry<D, B>::FLAG_FILLED;
 
       ulk.unlock();
+      lru.unref(b, cohort::lru::FLAG_NONE);
     } /* b */
 
     return 0;

--- a/src/rgw/driver/posix/posixDB.cc
+++ b/src/rgw/driver/posix/posixDB.cc
@@ -71,11 +71,12 @@ int POSIXUserDB::Initialize(string logfile, int loglevel)
   DBOpParams params = {};
   RGWAccessKey key("0555b35654ad1656d804", "h7GhxuBLTrlhVUyxSPUKUV8r/2EI4ngqJxD7iBdBYLhwluN30JaT3Q==");
 
-  params.user_table = user_table;
-  params.bucket_table = bucket_table;
-  params.quota_table = quota_table;
-  params.lc_entry_table = lc_entry_table;
-  params.lc_head_table = lc_head_table;
+  params.user_table = getUserTable();
+  params.bucket_table = getBucketTable();
+  params.quota_table = getQuotaTable();
+  params.lc_entry_table = getLCEntryTable();
+  params.lc_head_table = getLCHeadTable();
+
   params.op.user.uinfo.display_name = "tester";
   params.op.user.uinfo.user_id.id = "test";
   params.op.user.uinfo.access_keys["default"] = key;

--- a/src/rgw/driver/posix/posixDB.cc
+++ b/src/rgw/driver/posix/posixDB.cc
@@ -108,5 +108,76 @@ int POSIXUserDB::Destroy(const DoutPrefixProvider *dpp)
   return 0;
 }
 
+int POSIXAccountDB::ProcessOp(const DoutPrefixProvider *dpp, string_view Op, DBOpParams *params) {
+  int ret = -1;
+  shared_ptr<class DBOp> db_op;
+
+  db_op = getDBOp(dpp, Op, params);
+
+  if (!db_op) {
+    ldpp_dout(dpp, 0)<<"No db_op found for Op("<<Op<<")" << dendl;
+    return ret;
+  }
+  ret = db_op->Execute(dpp, params);
+
+  if (ret) {
+    ldpp_dout(dpp, 0)<<"In Process op Execute failed for fop(" << Op << ")" << dendl;
+  } else {
+    ldpp_dout(dpp, 20)<<"Successfully processed fop(" << Op << ")" << dendl;
+  }
+
+  return ret;
+}
+
+int POSIXAccountDB::Initialize(string logfile, int loglevel)
+{
+  int ret = -1;
+  const DoutPrefixProvider *dpp = get_def_dpp();
+
+  if (!cct) {
+    cout << "Failed to Initialize. No ceph Context \n";
+    return -1;
+  }
+
+  if (loglevel > 0) {
+    cct->_conf->subsys.set_log_level(ceph_subsys_rgw, loglevel);
+  }
+  if (!logfile.empty()) {
+    cct->_log->set_log_file(logfile);
+    cct->_log->reopen_log_file();
+  }
+
+  db = openDB(dpp);
+
+  if (!db) {
+    ldpp_dout(dpp, 0) <<"Failed to open database " << dendl;
+    return ret;
+  }
+
+  ret = InitializeDBOps(dpp);
+
+  if (ret) {
+    ldpp_dout(dpp, 0) <<"InitializePOSIXAccountDBOps failed " << dendl;
+    closeDB(dpp);
+    db = NULL;
+    return ret;
+  }
+
+  ldpp_dout(dpp, 0) << "POSIXAccountDB successfully initialized - name:" \
+    << db_name << "" << dendl;
+
+  return ret;
+}
+
+int POSIXAccountDB::Destroy(const DoutPrefixProvider *dpp)
+{
+  DB::Destroy(dpp);
+
+  ldpp_dout(dpp, 20)<<"POSIXAccountDB successfully destroyed - name:" \
+    <<db_name << dendl;
+
+  return 0;
+}
+
 } } // namespace rgw::store
 

--- a/src/rgw/driver/posix/posixDB.h
+++ b/src/rgw/driver/posix/posixDB.h
@@ -28,6 +28,9 @@
 namespace rgw { namespace store {
 
 class POSIXUserDB;
+class POSIXAccountDB;
+
+struct POSIXAccountDBOpAccountInfo : DBOpAccountInfo {};
 
 struct POSIXUserDBOpUserInfo : DBOpUserInfo {};
 
@@ -38,6 +41,52 @@ struct POSIXUserDBOpUserPrepareInfo : DBOpUserPrepareInfo {};
 struct POSIXUserDBOpPrepareInfo : DBOpPrepareInfo {};
 
 struct POSIXUserDBOpPrepareParams : DBOpPrepareParams {};
+
+struct POSIXAccountDBOpInfo : DBOpInfo {};
+
+struct POSIXAccountDBOpPrepareInfo : DBOpPrepareInfo {};
+
+struct POSIXAccountDBOpPrepareParams : DBOpPrepareParams {};
+
+struct POSIXAccountDBOps : DBOps {};
+
+class POSIXAccountDBOp : public DBOp {
+  private:
+    static constexpr std::string_view CreateAccountTableQ =
+      /* Corresponds to RGWAccountInfo
+       *
+       * AccountID is made Primary key.
+       * If multiple tenants are stored in single .db handle, should
+       * make both (AccountID, Tenant) as Primary Key.
+       *
+       * XXX:
+       * - Quota stored as blob .. should be linked to quota table.
+       */
+      "CREATE TABLE IF NOT EXISTS '{}' (	\
+      AccountID TEXT NOT NULL UNIQUE,		\
+      Tenant TEXT ,		\
+      AccountName TEXT , \
+      Email TEXT ,	\
+      Quota BLOB ,	\
+      BucketQuota BLOB ,	\
+      MaxUsers INTEGER ,	\
+      MaxRoles INTEGER ,	\
+      MaxGroups INTEGER ,	\
+      MaxBuckets INTEGER ,	\
+      MaxAccessKeys INTEGER ,	\
+      PRIMARY KEY (AccountID) \n);";
+
+  public:
+    POSIXAccountDBOp() : DBOp() {}
+    virtual ~POSIXAccountDBOp() {}
+    std::mutex mtx; // to protect prepared stmt
+};
+
+class InsertPOSIXAccountOp : public SQLInsertAccount {};
+
+class RemovePOSIXAccountOp: public SQLRemoveAccount {};
+
+class GetPOSIXAccountOp: public SQLGetAccount {};
 
 struct POSIXUserDBOps : DBOps {};
 
@@ -128,6 +177,53 @@ class POSIXUserDB : public SQLiteDB {
 		dp(_cct, ceph_subsys_rgw, "rgw POSIXUserDBStore backend: ")
                 { DB::set_context(cct); }
     /* POSIXUserDB() {}*/
+
+    int Initialize(std::string logfile, int loglevel);
+    int ProcessOp(const DoutPrefixProvider *dpp, std::string_view Op, DBOpParams *params);
+    int Destroy(const DoutPrefixProvider *dpp);
+
+    CephContext* ctx() { return this->cct; }
+
+    virtual int InitPrepareParams(const DoutPrefixProvider *dpp,
+                                  DBOpPrepareParams &p_params,
+                                  DBOpParams* params) override { return 0; }
+    virtual int createLCTables(const DoutPrefixProvider *dpp) override { return 0; }
+
+    virtual int ListAllBuckets(const DoutPrefixProvider *dpp, DBOpParams *params) override { return 0; }
+    virtual int ListAllUsers(const DoutPrefixProvider *dpp, DBOpParams *params) override { return 0; }
+    virtual int ListAllObjects(const DoutPrefixProvider *dpp, DBOpParams *params) override { return 0; }
+};
+
+class POSIXAccountDB : public SQLiteDB {
+  private:
+    const std::string db_name;
+    const std::string account_table;
+    const std::string user_table;
+    const std::string bucket_table;
+    const std::string quota_table;
+    const std::string lc_head_table;
+    const std::string lc_entry_table;
+
+    rgw::sal::Driver* driver;
+
+  protected:
+    void *db;
+    CephContext *cct;
+    const DoutPrefix dp;
+    // Below mutex is to protect objectmap and other shared
+    // objects if any.
+    std::mutex mtx;
+
+  public:
+    struct DBOps dbops;
+
+    POSIXAccountDB(std::string db_name, CephContext *_cct) : SQLiteDB(db_name, _cct),
+		db_name(db_name),
+		account_table(db_name+"_account_table"),
+		user_table(db_name+"_user_table"),
+		cct(_cct),
+		dp(_cct, ceph_subsys_rgw, "rgw POSIXAccountDBStore backend: ")
+                { DB::set_context(cct); }
 
     int Initialize(std::string logfile, int loglevel);
     int ProcessOp(const DoutPrefixProvider *dpp, std::string_view Op, DBOpParams *params);

--- a/src/rgw/driver/posix/posixDB.h
+++ b/src/rgw/driver/posix/posixDB.h
@@ -151,12 +151,6 @@ class RemovePOSIXUserOp: public SQLRemoveUser {};
 class POSIXUserDB : public SQLiteDB {
   private:
     const std::string db_name;
-    const std::string user_table;
-    const std::string bucket_table;
-    const std::string quota_table;
-    const std::string lc_head_table;
-    const std::string lc_entry_table;
-
     rgw::sal::Driver* driver;
 
   protected:
@@ -172,7 +166,6 @@ class POSIXUserDB : public SQLiteDB {
 
     POSIXUserDB(std::string db_name, CephContext *_cct) : SQLiteDB(db_name, _cct),
 		db_name(db_name),
-		user_table(db_name+"_user_table"),
 		cct(_cct),
 		dp(_cct, ceph_subsys_rgw, "rgw POSIXUserDBStore backend: ")
                 { DB::set_context(cct); }

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -18,6 +18,7 @@
 #include <sys/stat.h>
 #include <sys/xattr.h>
 #include <unistd.h>
+#include <cstdint>
 #include "rgw_multi.h"
 #include "include/scope_guard.h"
 #include "common/Clock.h" // for ceph_clock_now()
@@ -145,7 +146,7 @@ static bool decode_attr(Attrs &attrs, const char *name, F &f) {
 
 static inline rgw_obj_key decode_obj_key(const char* fname)
 {
-  std::string dname, oname, ns;
+  std::string dname, oname, ns; // XXX ns is unused?
   dname = url_decode(fname);
   rgw_obj_key key;
   rgw_obj_key::parse_raw_oid(dname, &key);
@@ -433,7 +434,7 @@ int FSEnt::read_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs& at
   return get_x_attrs(y, dpp, get_fd(), attrs, get_name());
 }
 
-int FSEnt::fill_cache(const DoutPrefixProvider *dpp, optional_yield y, fill_cache_cb_t& cb)
+int FSEnt::fill_cache(const DoutPrefixProvider *dpp, optional_yield y, fill_cache_cb_t& cb, uint32_t flags)
 {
   rgw_bucket_dir_entry bde{};
 
@@ -449,7 +450,7 @@ int FSEnt::fill_cache(const DoutPrefixProvider *dpp, optional_yield y, fill_cach
     case ObjectType::VERSIONED:
       bde.flags = rgw_bucket_dir_entry::FLAG_VER;
       bde.exists = true;
-      if (!key.have_instance()) {
+      if (flags & FSEnt::FLAG_CURRENT) {
 	  bde.flags |= rgw_bucket_dir_entry::FLAG_CURRENT;
       }
       break;
@@ -1081,7 +1082,7 @@ int Directory::get_ent(const DoutPrefixProvider *dpp, optional_yield y, const st
 }
 
 int Directory::fill_cache(const DoutPrefixProvider *dpp, optional_yield y,
-                          fill_cache_cb_t &cb)
+                          fill_cache_cb_t &cb, uint32_t flags)
 {
   int ret = for_each(dpp, [this, &cb, &dpp, &y](const char *name) {
     std::unique_ptr<FSEnt> ent;
@@ -1097,7 +1098,7 @@ int Directory::fill_cache(const DoutPrefixProvider *dpp, optional_yield y,
 
     ent->stat(dpp); // Stat the object to get the type
 
-    ret = ent->fill_cache(dpp, y, cb);
+    ret = ent->fill_cache(dpp, y, cb, FSEnt::FLAG_NONE);
     if (ret < 0)
       return ret;
     return 0;
@@ -1180,54 +1181,6 @@ int Symlink::stat(const DoutPrefixProvider* dpp, bool force)
 
   exist = true;
   return fill_target(dpp, parent, get_name(), std::string(), target, ctx);
-}
-
-int Symlink::fill_cache(const DoutPrefixProvider *dpp, optional_yield y, fill_cache_cb_t& cb)
-{
-  rgw_bucket_dir_entry bde{};
-  int ret;
-
-  rgw_obj_key key = decode_obj_key(get_name());
-  key.get_index_key(&bde.key);
-  bde.ver.pool = 1;
-  bde.ver.epoch = 1;
-
-  bde.flags = rgw_bucket_dir_entry::FLAG_VER;
-  bde.exists = true;
-  bde.flags |= rgw_bucket_dir_entry::FLAG_CURRENT;
-
-  if (!target) {
-    ret = stat(dpp, /*force=*/false);
-    if (ret < 0)
-      return ret;
-  }
-
-  Attrs attrs;
-  ret = target->read_attrs(dpp, y, attrs);
-  if (ret < 0)
-    return ret;
-
-  POSIXOwner o;
-  ret = decode_owner(attrs, o);
-  if (ret < 0) {
-    bde.meta.owner = "unknown";
-    bde.meta.owner_display_name = "unknown";
-  } else {
-    bde.meta.owner = o.user.to_str();
-    bde.meta.owner_display_name = o.display_name;
-  }
-  bde.meta.category = RGWObjCategory::Main;
-  bde.meta.size = stx.stx_size;
-  bde.meta.accounted_size = stx.stx_size;
-  bde.meta.mtime = from_statx_timestamp(stx.stx_mtime);
-  bde.meta.storage_class = RGW_STORAGE_CLASS_STANDARD;
-  bde.meta.appendable = true;
-  bufferlist etag_bl;
-  if (rgw::sal::get_attr(attrs, RGW_ATTR_ETAG, etag_bl)) {
-    bde.meta.etag = etag_bl.to_str();
-  }
-
-  return cb(dpp, bde);
 }
 
 int Symlink::read_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs& attrs)
@@ -1384,13 +1337,13 @@ std::unique_ptr<File> MPDirectory::get_part_file(int partnum)
 }
 
 int MPDirectory::fill_cache(const DoutPrefixProvider *dpp, optional_yield y,
-                          fill_cache_cb_t &cb)
+                            fill_cache_cb_t &cb, uint32_t flags)
 {
-  int ret = FSEnt::fill_cache(dpp, y, cb);
+  int ret = FSEnt::fill_cache(dpp, y, cb, FSEnt::FLAG_NONE);
   if (ret < 0)
     return ret;
 
-  return Directory::fill_cache(dpp, y, cb);
+  return Directory::fill_cache(dpp, y, cb, FSEnt::FLAG_NONE);
 }
 
 int VersionedDirectory::open(const DoutPrefixProvider* dpp)
@@ -1796,8 +1749,11 @@ int VersionedDirectory::remove(const DoutPrefixProvider* dpp, optional_yield y, 
 }
 
 int VersionedDirectory::fill_cache(const DoutPrefixProvider *dpp, optional_yield y,
-                          fill_cache_cb_t &cb)
+                                   fill_cache_cb_t &cb, uint32_t flags)
 {
+  /* Fill cur_version */
+  stat(dpp, /*force=*/false);
+
   int ret = for_each(dpp, [this, &cb, &dpp, &y](const char *name) {
     std::unique_ptr<FSEnt> ent;
 
@@ -1812,9 +1768,17 @@ int VersionedDirectory::fill_cache(const DoutPrefixProvider *dpp, optional_yield
 
     ent->stat(dpp); // Stat the object to get the type
 
-    ret = ent->fill_cache(dpp, y, cb);
-    if (ret < 0)
-      return ret;
+    if (ent->get_type() != ObjectType::SYMLINK) {
+      uint32_t fill_flags =
+          (cur_version &&
+           (ent->get_name() == cur_version->get_name())) ?
+        FSEnt::FLAG_CURRENT :
+        FSEnt::FLAG_NONE;
+
+      ret = ent->fill_cache(dpp, y, cb, fill_flags);
+      if (ret < 0)
+        return ret;
+    }
     return 0;
   });
 
@@ -2347,7 +2311,7 @@ std::unique_ptr<Object> POSIXBucket::get_object(const rgw_obj_key& k)
 
 int POSIXObject::fill_cache(const DoutPrefixProvider *dpp, optional_yield y, fill_cache_cb_t& cb)
 {
-  return ent->fill_cache(dpp, y, cb);
+  return ent->fill_cache(dpp, y, cb, FSEnt::FLAG_NONE);
 }
 
 int POSIXDriver::mint_listing_entry(const std::string &bname,
@@ -2414,9 +2378,9 @@ std::unique_ptr<RGWRole> POSIXDriver::get_role(const RGWRoleInfo& info)
 }
 
 int POSIXBucket::fill_cache(const DoutPrefixProvider* dpp, optional_yield y,
-			  fill_cache_cb_t& cb)
+                            fill_cache_cb_t& cb)
 {
-return dir->fill_cache(dpp, y, cb);
+  return dir->fill_cache(dpp, y, cb, FSEnt::FLAG_NONE);
 }
 
 int POSIXBucket::list(const DoutPrefixProvider* dpp, ListParams& params,

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -3818,14 +3818,33 @@ int POSIXMultipartUpload::load(const DoutPrefixProvider *dpp, bool create)
 
 std::unique_ptr<rgw::sal::Object> POSIXMultipartUpload::get_meta_obj()
 {
+  std::unique_ptr<rgw::sal::Object> meta_obj{nullptr};
+
   load(nullptr);
+
   if (!shadow) {
     // This upload doesn't exist, but the API doesn't check this until it calls
     // on the *serializer*. So make a fake object in the parent bucket that
     // doesn't exist.  Put it in the MP namespace just in case.
-    return bucket->get_object(rgw_obj_key(get_meta(), std::string(), mp_ns));
+    meta_obj = bucket->get_object(rgw_obj_key(get_meta(), std::string(), mp_ns));
   }
-  return shadow->get_object(rgw_obj_key(get_meta(), std::string()));
+  meta_obj = shadow->get_object(rgw_obj_key(get_meta(), std::string()));
+
+  auto posix_meta_obj = static_cast<POSIXObject*>(meta_obj.get());
+  rgw::sal::Attrs attrs;
+  if (obj_retention) {
+    buffer::list obj_retention_bl;
+    obj_retention->encode(obj_retention_bl);
+    attrs[RGW_ATTR_OBJECT_RETENTION] = std::move(obj_retention_bl);
+  }
+  if (obj_legal_hold) {
+    buffer::list obj_legal_hold_bl;
+    obj_legal_hold->encode(obj_legal_hold_bl);
+    attrs[RGW_ATTR_OBJECT_LEGAL_HOLD] = std::move(obj_legal_hold_bl);
+  }
+  posix_meta_obj->set_attrs(attrs);
+
+  return meta_obj;
 }
 
 int POSIXMultipartUpload::init(const DoutPrefixProvider *dpp, optional_yield y,
@@ -3853,6 +3872,14 @@ int POSIXMultipartUpload::init(const DoutPrefixProvider *dpp, optional_yield y,
   }
 
   mp_obj.upload_info.cksum_type = cksum_type;
+  if (obj_retention) {
+    mp_obj.upload_info.obj_retention_exist = true;
+    mp_obj.upload_info.obj_retention = *obj_retention;
+  }
+  if (obj_legal_hold) {
+    mp_obj.upload_info.obj_legal_hold_exist = true;
+    mp_obj.upload_info.obj_legal_hold = *obj_legal_hold;
+  }
   mp_obj.upload_info.dest_placement = dest_placement;
   mp_obj.owner = owner;
 
@@ -4136,6 +4163,12 @@ int POSIXMultipartUpload::get_info(const DoutPrefixProvider *dpp, optional_yield
       }
     }
     *rule = &mp_obj.upload_info.dest_placement;
+    if (mp_obj.upload_info.obj_retention_exist) {
+      obj_retention = mp_obj.upload_info.obj_retention;
+    }
+    if (mp_obj.upload_info.obj_legal_hold_exist) {
+      obj_legal_hold = mp_obj.upload_info.obj_legal_hold;
+    }
   }
 
   return 0;

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -1971,9 +1971,15 @@ int POSIXDriver::initialize(CephContext *cct, const DoutPrefixProvider *dpp)
     }
   }
   ldpp_dout(dpp, 20) << "root_fd: " << root_dir->get_fd() << dendl;
+  quota_handler = RGWQuotaHandler::generate_handler(dpp, this, true);
 
   ldpp_dout(dpp, 20) << "SUCCESS" << dendl;
   return 0;
+}
+
+void POSIXDriver::finalize()
+{
+  RGWQuotaHandler::free_handler(quota_handler);
 }
 
 std::unique_ptr<User> POSIXDriver::get_user(const rgw_user &u)
@@ -2305,15 +2311,22 @@ int POSIXDriver::list_buckets(const DoutPrefixProvider* dpp, const rgw_owner& ow
       errno = 0;
       continue;
     }
-
+    std::unique_ptr<Bucket> bucket;
+    ret = load_bucket(dpp, rgw_bucket("", entry->d_name), &bucket, null_yield);
+    if (bucket->get_owner() != owner) {
+      continue;
+    }
     RGWBucketEnt ent;
     ent.bucket.name = url_decode(entry->d_name);
     ent.creation_time = ceph::real_clock::from_time_t(stx.stx_btime.tv_sec);
     // TODO: ent.size and ent.count
 
     result.buckets.push_back(std::move(ent));
-
     errno = 0;
+    if (result.buckets.size() == max){
+      result.next_marker = ent.bucket.marker;
+      break;
+    }
   }
   ret = errno;
   if (ret != 0) {
@@ -2477,6 +2490,116 @@ std::unique_ptr<RGWRole> POSIXDriver::get_role(const RGWRoleInfo& info)
 {
   RGWRole* p = nullptr;
   return std::unique_ptr<RGWRole>(p);
+}
+
+struct meta_list_handle {
+  std::string marker;
+  std::string section;
+
+  DIR *dir = nullptr;
+  long dpos = -1;
+
+  meta_list_handle(const std::string& _section, const std::string& _marker) {
+    marker = _marker;
+    section = _section;
+  }
+};
+
+int POSIXDriver::meta_list_keys_init(const DoutPrefixProvider *dpp,
+                                     const std::string& section,
+                                     const std::string& marker, void** phandle)
+{
+  meta_list_handle* stuff = new meta_list_handle(section, marker);
+  *phandle = (void *)stuff;
+  if (section == "bucket") {
+    int ret;
+    int dfd = copy_dir_fd(get_root_fd());
+    if (dfd == -1) {
+      ret = errno;
+      ldpp_dout(dpp, 0) << "ERROR: could not open root to list buckets: "
+                        << cpp_strerror(errno) << dendl;
+      return -ret;
+    }
+
+    stuff->dir = fdopendir(dfd);
+    if (stuff->dir == NULL) {
+      ret = errno;
+      ldpp_dout(dpp, 0) << "ERROR: could not open root to list buckets: "
+                        << cpp_strerror(ret) << dendl;
+      ::close(dfd);
+      return -ret;
+    }
+  }
+  return 0;
+  }
+
+int POSIXDriver::meta_list_keys_next(const DoutPrefixProvider *dpp, void* handle,
+                                     int max, std::list<std::string>& keys,
+                                     bool* truncated)
+{
+  meta_list_handle *h = static_cast<meta_list_handle *>(handle);
+  *truncated = false;
+  int ret;
+  keys.clear();
+  if (h->section == "user") {
+    ret = get_user_db()->list_users(dpp, h->marker, max, keys, truncated);
+    if (ret < 0) {
+      return ret;
+    }
+    if (keys.size() > 0) {
+      h->marker = *keys.rbegin();
+      if (std::cmp_equal(keys.size(),max)) {
+        *truncated = true;
+      }
+    }
+  } else if (h->section == "bucket") {
+    if (h->dpos != -1) {
+      seekdir(h->dir, h->dpos);
+    }
+    struct dirent* entry;
+    while ((entry = readdir(h->dir)) != NULL) {
+      if (entry->d_type == DT_UNKNOWN) {
+        struct statx stx;
+
+        ret = statx(get_root_fd(), entry->d_name, AT_SYMLINK_NOFOLLOW, STATX_ALL, &stx);
+        if (ret < 0) {
+          ret = errno;
+          ldpp_dout(dpp, 0) << "ERROR: could not stat object " << entry->d_name << ": "
+	                    << cpp_strerror(ret) << dendl;
+          return -ret;
+        }
+        if (!S_ISDIR(stx.stx_mode)) {
+        /* Not a bucket, skip it */
+          continue;
+        }
+      } else if (entry->d_type != DT_DIR) {
+        continue;
+      }
+      if (entry->d_name[0] == '.') {
+        /* Skip dotfiles */
+        continue;
+     }
+      keys.push_back(entry->d_name);
+      if (std::cmp_equal(keys.size(),max)) {
+        h->dpos = telldir(h->dir);
+        *truncated = true;
+        break;
+      }
+    }
+  }
+  return 0;
+}
+
+void POSIXDriver::meta_list_keys_complete(void* handle)
+{
+  if (handle) {
+    meta_list_handle *h = static_cast<meta_list_handle *>(handle);
+    if (h->section == "bucket") {
+      closedir(h->dir);
+    }
+    delete h;
+  }
+  return;
 }
 
 int POSIXBucket::fill_cache(const DoutPrefixProvider* dpp, optional_yield y,
@@ -2839,7 +2962,9 @@ int POSIXBucket::check_empty(const DoutPrefixProvider* dpp, optional_yield y)
 int POSIXBucket::check_quota(const DoutPrefixProvider *dpp, RGWQuota& quota, uint64_t obj_size,
 				optional_yield y, bool check_size_only)
 {
-    return 0;
+  return driver->get_quota_handler()->check_quota(dpp, info.owner, get_key(),
+                                                  quota, (check_size_only ? 0 : 1),
+                                                  obj_size, y);
 }
 
 int POSIXBucket::try_refresh_info(const DoutPrefixProvider* dpp, ceph::real_time* pmtime, optional_yield y)
@@ -3026,6 +3151,8 @@ int POSIXObject::delete_object(const DoutPrefixProvider* dpp,
     key.instance.clear();
     driver->get_bucket_cache()->remove_entry(dpp, b->get_name(), key);
   }
+  driver->get_quota_handler()->update_stats(b->get_owner(), b->get_key(),
+                                            -1, 0, state.accounted_size);
   return 0;
 }
 
@@ -4425,11 +4552,16 @@ int POSIXAtomicWriter::complete(size_t accounted_size, const std::string& etag,
                        uint32_t flags)
 {
   int ret;
+  uint64_t orig_size = 0;
+  auto exists = obj->check_exists(dpp);
+  if (exists) {
+    orig_size = obj->get_size();
+  }
 
   if (if_match) {
     if (strcmp(if_match, "*") == 0) {
       // test the object is existing
-      if (!obj->check_exists(dpp)) {
+      if (!exists) {
 	return -ERR_PRECONDITION_FAILED;
       }
     } else {
@@ -4445,7 +4577,7 @@ int POSIXAtomicWriter::complete(size_t accounted_size, const std::string& etag,
   if (if_nomatch) {
     if (strcmp(if_nomatch, "*") == 0) {
       // test the object is not existing
-      if (obj->check_exists(dpp)) {
+      if (!exists) {
 	return -ERR_PRECONDITION_FAILED;
       }
     } else {
@@ -4482,6 +4614,14 @@ int POSIXAtomicWriter::complete(size_t accounted_size, const std::string& etag,
     ldpp_dout(dpp, 20) << "ERROR: POSIXAtomicWriter failed writing temp file" << dendl;
     return ret;
   }
+
+  POSIXBucket *b = static_cast<POSIXBucket*>(obj->get_bucket());
+  if (!b) {
+      ldpp_dout(dpp, 0) << "ERROR: could not get bucket for " << obj->get_name() << dendl;
+      return -EINVAL;
+  }
+  driver->get_quota_handler()->update_stats(b->get_owner(), b->get_key(),
+                                            (exists ? 0 : 1), orig_size, accounted_size);
 
   return 0;
 }

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -2916,6 +2916,8 @@ int POSIXObject::delete_object(const DoutPrefixProvider* dpp,
 
   cls_rgw_obj_key key;
   get_key().get_index_key(&key);
+
+  /* XXXX we should get bucket cache once, ne? hint:  operate functor */
   driver->get_bucket_cache()->remove_entry(dpp, b->get_name(), key);
 
   if (!key.instance.empty() && !ent->exists()) {

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -3112,7 +3112,9 @@ int POSIXObject::load_obj_state(const DoutPrefixProvider* dpp, optional_yield y,
     return ret;
   }
 
-  return 0;
+  ret = get_obj_attrs(y, dpp);
+
+  return ret;
 }
 
 int POSIXObject::set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs,

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -2034,6 +2034,94 @@ int POSIXDriver::get_user_by_swift(const DoutPrefixProvider* dpp, const std::str
   return -ENOTSUP;
 }
 
+int POSIXDriver::load_account_by_id(const DoutPrefixProvider* dpp,
+				 optional_yield y,
+				 std::string_view id,
+				 RGWAccountInfo& info,
+				 Attrs& attrs,
+				 RGWObjVersionTracker& objv)
+{
+  RGWObjVersionTracker objv_tracker;
+
+  int ret = accountDB->get_account(dpp, std::string("account_id"), std::string(id), info, &attrs,
+      &objv_tracker);
+
+  if (ret < 0)
+    return ret;
+
+  objv = objv_tracker;
+  return 0;
+}
+
+int POSIXDriver::load_account_by_name(const DoutPrefixProvider* dpp,
+				 optional_yield y,
+				 std::string_view tenant,
+				 std::string_view name,
+				 RGWAccountInfo& info,
+				 Attrs& attrs,
+				 RGWObjVersionTracker& objv)
+{
+  RGWObjVersionTracker objv_tracker;
+
+  int ret = accountDB->get_account(dpp, std::string("name"), std::string(name), info, &attrs,
+      &objv_tracker);
+
+  if (ret < 0)
+    return ret;
+
+  objv = objv_tracker;
+  return 0;
+}
+
+int POSIXDriver::load_account_by_email(const DoutPrefixProvider* dpp,
+				  optional_yield y,
+				  std::string_view email,
+				  RGWAccountInfo& info,
+				  Attrs& attrs,
+				  RGWObjVersionTracker& objv)
+{
+  RGWObjVersionTracker objv_tracker;
+
+  int ret = accountDB->get_account(dpp, std::string("email"), std::string(email), info, &attrs,
+      &objv_tracker);
+
+  if (ret < 0)
+    return ret;
+
+  objv = objv_tracker;
+  return 0;
+}
+
+int POSIXDriver::store_account(const DoutPrefixProvider* dpp,
+			  optional_yield y, bool exclusive,
+			  const RGWAccountInfo& info,
+			  const RGWAccountInfo* old_info,
+			  const Attrs& attrs,
+			  RGWObjVersionTracker& objv)
+{
+  int ret = accountDB->store_account(dpp, info, exclusive, &attrs, &objv);
+
+  if (ret < 0)
+    return ret;
+
+  return 0;
+}
+
+int POSIXDriver::delete_account(const DoutPrefixProvider* dpp,
+			     optional_yield y,
+			     const RGWAccountInfo& info,
+			     RGWObjVersionTracker& objv)
+{
+  int ret = accountDB->remove_account(dpp, info, &objv);
+
+  if (ret < 0)
+    return ret;
+
+  return 0;
+}
+
+
+
 int POSIXDriver::load_owner_by_email(const DoutPrefixProvider* dpp,
 				    optional_yield y,
 				    std::string_view email,

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -3465,6 +3465,20 @@ int POSIXObject::link_temp_file(const DoutPrefixProvider *dpp, optional_yield y)
     return -EINVAL;
   }
 
+  ret = open(dpp);
+  if (ret < 0) {
+    ldpp_dout(dpp, 20)
+        << "ERROR: POSIXAtomicWriter failed opening file" << dendl;
+    return ret;
+  }
+
+  ret = stat(dpp);
+  if (ret < 0) {
+    ldpp_dout(dpp, 20)
+        << "ERROR: POSIXAtomicWriter failed closing file" << dendl;
+    return ret;
+  }
+
   fill_cache( nullptr, null_yield,
       [&](const DoutPrefixProvider *dpp, rgw_bucket_dir_entry &bde) -> int {
 	driver->get_bucket_cache()->add_entry(dpp, b->get_name(), bde);

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -1954,6 +1954,9 @@ int POSIXDriver::initialize(CephContext *cct, const DoutPrefixProvider *dpp)
       g_conf().get_val<int64_t>("rgw_posix_cache_partitions"),
       g_conf().get_val<int64_t>("rgw_posix_cache_lmdb_count")));
 
+  /* user info cache */
+  user_cache.set_max_size(dpp, g_conf().get_val<uint64_t>("rgw_posix_cache_max_users"));
+
   root_dir = std::make_unique<Directory>(base_path, nullptr, ctx());
   ret = root_dir->open(dpp);
   if (ret < 0) {
@@ -1989,6 +1992,17 @@ std::unique_ptr<User> POSIXDriver::get_user(const rgw_user &u)
 
 int POSIXDriver::get_user_by_access_key(const DoutPrefixProvider* dpp, const std::string& key, optional_yield y, std::unique_ptr<User>* user)
 {
+  {
+    UserCacheEntry ce;
+    if (user_cache.lookup_user_by_access_key(dpp, key, ce)) {
+      auto u = new POSIXUser(this, ce.info);
+      u->get_attrs() = ce.attrs;
+      u->get_version_tracker() = ce.objv_tracker;
+      user->reset(u);
+      return 0;
+    }
+  }
+
   RGWUserInfo uinfo;
   rgw::sal::Attrs attrs;
   RGWObjVersionTracker objv_tracker;
@@ -2007,6 +2021,8 @@ int POSIXDriver::get_user_by_access_key(const DoutPrefixProvider* dpp, const std
   u->get_attrs() = std::move(attrs);
   u->get_version_tracker() = objv_tracker;
   user->reset(u);
+
+  user_cache.insert_user(dpp, {uinfo, u->get_attrs(), objv_tracker});
   return 0;
 }
 
@@ -2031,6 +2047,8 @@ int POSIXDriver::get_user_by_email(const DoutPrefixProvider* dpp, const std::str
   u->get_attrs() = std::move(attrs);
   u->get_version_tracker() = objv_tracker;
   user->reset(u);
+
+  user_cache.insert_user(dpp, {uinfo, u->get_attrs(), objv_tracker});
   return 0;
 }
 
@@ -2380,10 +2398,34 @@ int POSIXBucket::create(const DoutPrefixProvider* dpp,
   return 0;
 }
 
+int POSIXUser::load_user_from_cache_or_db(const DoutPrefixProvider* dpp, bool& cache_hit)
+{
+  cache_hit = false;
+  UserCacheEntry ce;
+  if (driver->get_user_cache().lookup_user_by_uid(dpp, this->get_id().id, ce)) {
+    this->get_info() = std::move(ce.info);
+    this->get_attrs() = std::move(ce.attrs);
+    this->get_version_tracker() = std::move(ce.objv_tracker);
+    cache_hit = true;
+    return 0;
+  }
+
+  int ret = driver->get_user_db()->get_user(dpp, std::string("user_id"), this->get_id().id, this->get_info(), &(this->get_attrs()),
+        &(this->get_version_tracker()));
+  if (ret == 0) {
+    driver->get_user_cache().insert_user(dpp, {this->get_info(), this->get_attrs(), this->get_version_tracker()});
+  }
+  return ret;
+}
+
 int POSIXUser::read_attrs(const DoutPrefixProvider* dpp, optional_yield y)
 {
-  return driver->get_user_db()->get_user(dpp, std::string("user_id"), this->get_id().id, this->get_info(), &(this->get_attrs()),
-        &(this->get_version_tracker()));
+  bool cache_hit;
+  int ret = load_user_from_cache_or_db(dpp, cache_hit);
+  if (cache_hit) {
+    ldpp_dout(dpp, 21) << "UserCache: read_attrs: cache hit for uid=" << this->get_id().id << dendl;
+  }
+  return ret;
 }
 
 int POSIXUser::merge_and_store_attrs(const DoutPrefixProvider* dpp,
@@ -2393,24 +2435,40 @@ int POSIXUser::merge_and_store_attrs(const DoutPrefixProvider* dpp,
   for(auto& it : new_attrs) {
 	attrs[it.first] = it.second;
   }
+  this->get_attrs() = std::move(attrs);
 
   return store_user(dpp, y, false);
 }
 
 int POSIXUser::load_user(const DoutPrefixProvider* dpp, optional_yield y)
 {
-  return driver->get_user_db()->get_user(dpp, std::string("user_id"), this->get_id().id, this->get_info(), &(this->get_attrs()),
-           &(this->get_version_tracker()));
+  bool cache_hit;
+  int ret = load_user_from_cache_or_db(dpp, cache_hit);
+  if (cache_hit) {
+    ldpp_dout(dpp, 21) << "UserCache: load_user: cache hit for uid=" << this->get_id().id << dendl;
+  }
+  return ret;
 }
 
 int POSIXUser::store_user(const DoutPrefixProvider* dpp, optional_yield y, bool exclusive, RGWUserInfo* old_info)
 {
-  return driver->get_user_db()->store_user(dpp, this->get_info(), exclusive, &(this->get_attrs()), &(this->get_version_tracker()), old_info);
+  int ret = driver->get_user_db()->store_user(dpp, this->get_info(), exclusive, &(this->get_attrs()), &(this->get_version_tracker()), old_info);
+  if (ret == 0) {
+    driver->get_user_cache().invalidate_user(dpp, this->get_id().id);
+    driver->get_user_cache().insert_user(dpp, {this->get_info(), this->get_attrs(), this->get_version_tracker()});
+  }
+  return ret;
 }
 
 int POSIXUser::remove_user(const DoutPrefixProvider* dpp, optional_yield y)
 {
-  return driver->get_user_db()->remove_user(dpp, this->get_info(), &(this->get_version_tracker()));
+  int ret = driver->get_user_db()->remove_user(dpp, this->get_info(), &(this->get_version_tracker()));
+  if (ret == 0) {
+    driver->get_user_cache().invalidate_user(dpp, this->get_id().id);
+  } else {
+    ldpp_dout(dpp, 0) << "ERROR: failed to remove user uid=" << this->get_id().id << " ret=" << ret << dendl;
+  }
+  return ret;
 }
 
 int POSIXUser::verify_mfa(const std::string& mfa_str, bool* verified, const DoutPrefixProvider *dpp, optional_yield y)

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -754,6 +754,19 @@ int File::link_temp_file(const DoutPrefixProvider *dpp, optional_yield y, std::s
     return -ret;
   }
 
+  /* note that open() and stat() return already sign-reversed result codes */
+  ret = open(dpp);
+  if (ret < 0) {
+    ldpp_dout(dpp, 20) << "ERROR: POSIXAtomicWriter failed opening file" << dendl;
+    return ret;
+  }
+
+  ret = stat(dpp);
+  if (ret < 0) {
+    ldpp_dout(dpp, 20) << "ERROR: POSIXAtomicWriter failed closing file" << dendl;
+    return ret;
+  }
+
   return 0;
 }
 
@@ -4365,18 +4378,6 @@ int POSIXAtomicWriter::complete(size_t accounted_size, const std::string& etag,
   ret = obj->link_temp_file(rctx.dpp, rctx.y);
   if (ret < 0) {
     ldpp_dout(dpp, 20) << "ERROR: POSIXAtomicWriter failed writing temp file" << dendl;
-    return ret;
-  }
-
-  ret = obj->open(dpp);
-  if (ret < 0) {
-    ldpp_dout(rctx.dpp, 20) << "ERROR: POSIXAtomicWriter failed opening file" << dendl;
-    return ret;
-  }
-
-  ret = obj->stat(dpp);
-  if (ret < 0) {
-    ldpp_dout(rctx.dpp, 20) << "ERROR: POSIXAtomicWriter failed closing file" << dendl;
     return ret;
   }
 

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -4072,15 +4072,17 @@ int POSIXMultipartUpload::complete(const DoutPrefixProvider *dpp,
     attrs[RGW_ATTR_COMPRESSION] = tmp;
   }
 
-  POSIXManifest manifest;
-  manifest.multipart_part_count = total_parts;
-  buffer::list manifest_bl;
-  manifest.encode(manifest_bl);
-  attrs[RGW_POSIX_ATTR_MANIFEST] = manifest_bl;
+  {
+    POSIXManifest manifest;
+    manifest.multipart_part_count = total_parts;
+    buffer::list manifest_bl;
+    manifest.encode(manifest_bl);
+    attrs[RGW_POSIX_ATTR_MANIFEST] = std::move(manifest_bl);
 
-  ret = shadow->merge_and_store_attrs(dpp, attrs, y);
-  if (ret < 0) {
-    return ret;
+    ret = shadow->merge_and_store_attrs(dpp, attrs, y);
+    if (ret < 0) {
+      return ret;
+    }
   }
 
   // Rename to target_obj

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -3836,6 +3836,8 @@ int POSIXMultipartUpload::init(const DoutPrefixProvider *dpp, optional_yield y,
   }
 
   mp_obj.upload_info.cksum_type = cksum_type;
+  mp_obj.upload_info.cksum_flags = cksum_flags;
+
   if (obj_retention) {
     mp_obj.upload_info.obj_retention_exist = true;
     mp_obj.upload_info.obj_retention = *obj_retention;
@@ -3844,6 +3846,7 @@ int POSIXMultipartUpload::init(const DoutPrefixProvider *dpp, optional_yield y,
     mp_obj.upload_info.obj_legal_hold_exist = true;
     mp_obj.upload_info.obj_legal_hold = *obj_legal_hold;
   }
+
   mp_obj.upload_info.dest_placement = dest_placement;
   mp_obj.owner = owner;
 
@@ -4127,12 +4130,17 @@ int POSIXMultipartUpload::get_info(const DoutPrefixProvider *dpp, optional_yield
       }
     }
     *rule = &mp_obj.upload_info.dest_placement;
+
     if (mp_obj.upload_info.obj_retention_exist) {
       obj_retention = mp_obj.upload_info.obj_retention;
     }
     if (mp_obj.upload_info.obj_legal_hold_exist) {
       obj_legal_hold = mp_obj.upload_info.obj_legal_hold;
     }
+
+    /* no te olvides los cksum */
+    cksum_type = mp_obj.upload_info.cksum_type;
+    cksum_flags = mp_obj.upload_info.cksum_flags;
   }
 
   return 0;

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -35,6 +35,7 @@ const std::string ATTR_PREFIX = "user.X-RGW-";
 #define RGW_POSIX_ATTR_MPUPLOAD "POSIX-Multipart-Upload"
 #define RGW_POSIX_ATTR_OWNER "POSIX-Owner"
 #define RGW_POSIX_ATTR_OBJECT_TYPE "POSIX-Object-Type"
+#define RGW_POSIX_ATTR_MANIFEST "POSIX-Manifest"
 const std::string mp_ns = "multipart";
 const std::string MP_OBJ_PART_PFX = "part-";
 const std::string MP_OBJ_HEAD_NAME = MP_OBJ_PART_PFX + "00000";
@@ -3509,6 +3510,20 @@ int POSIXObject::POSIXReadOp::prepare(optional_yield y, const DoutPrefixProvider
     return -EINVAL;
   }
 
+  buffer::list manifest_bl;
+  if (source->get_attr(RGW_POSIX_ATTR_MANIFEST, manifest_bl)) {
+    POSIXManifest manifest;
+    auto iter = manifest_bl.cbegin();
+    try {
+      manifest.decode(iter);
+      if (manifest.multipart_part_count > 0) {
+        params.parts_count = manifest.multipart_part_count;
+      }
+    } catch (buffer::error& err) {
+      // pass
+    }
+  }
+
 #if 0 // WIP
   if (params.mod_ptr || params.unmod_ptr) {
     obj_time_weight src_weight;
@@ -4056,6 +4071,12 @@ int POSIXMultipartUpload::complete(const DoutPrefixProvider *dpp,
     encode(cs_info, tmp);
     attrs[RGW_ATTR_COMPRESSION] = tmp;
   }
+
+  POSIXManifest manifest;
+  manifest.multipart_part_count = total_parts;
+  buffer::list manifest_bl;
+  manifest.encode(manifest_bl);
+  attrs[RGW_POSIX_ATTR_MANIFEST] = manifest_bl;
 
   ret = shadow->merge_and_store_attrs(dpp, attrs, y);
   if (ret < 0) {

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -17,6 +17,7 @@
 
 #include "rgw_sal_filter.h"
 #include "rgw_sal_store.h"
+#include <cstdint>
 #include <memory>
 #include "common/dout.h"
 #include "bucket_cache.h"
@@ -106,6 +107,9 @@ protected:
   CephContext* ctx;
 
 public:
+  static constexpr uint32_t FLAG_NONE =      0x0;
+  static constexpr uint32_t FLAG_CURRENT =   0x2;
+
   FSEnt(std::string _name, Directory* _parent, CephContext* _ctx) : fname(_name), parent(_parent), ctx(_ctx) {}
   FSEnt(std::string _name, Directory* _parent, struct statx& _stx, CephContext* _ctx) : fname(_name), parent(_parent), exist(true), stx(_stx), stat_done(true), ctx(_ctx) {}
   FSEnt(const FSEnt& _e) :
@@ -138,7 +142,7 @@ public:
   virtual int copy(const DoutPrefixProvider *dpp, optional_yield y, Directory* dst_dir, const std::string& name) = 0;
   virtual int link_temp_file(const DoutPrefixProvider* dpp, optional_yield y, std::string target_fname) = 0;
   virtual std::unique_ptr<FSEnt> clone_base() = 0;
-  virtual int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb);
+  virtual int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb, uint32_t flags);
   virtual std::string get_cur_version() { return ""; };
 };
 
@@ -210,7 +214,7 @@ public:
   }
   virtual int copy(const DoutPrefixProvider *dpp, optional_yield y, Directory* dst_dir, const std::string& name) override;
   virtual int link_temp_file(const DoutPrefixProvider* dpp, optional_yield y, std::string target_fname) override;
-  virtual int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb) override;
+  virtual int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb, uint32_t flags) override;
 
   int get_ent(const DoutPrefixProvider *dpp, optional_yield y, const std::string& name, const std::string& version, std::unique_ptr<FSEnt>& ent);
 };
@@ -247,7 +251,6 @@ public:
     return std::make_unique<Symlink>(*this);
   }
   virtual int copy(const DoutPrefixProvider *dpp, optional_yield y, Directory* dst_dir, const std::string& name) override;
-  virtual int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb) override;
 };
 
 class MPDirectory : public Directory {
@@ -283,7 +286,7 @@ public:
   std::unique_ptr<MPDirectory> clone() {
     return std::make_unique<MPDirectory>(*this);
   }
-  virtual int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb) override;
+  virtual int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb, uint32_t flags) override;
 };
 
 class VersionedDirectory : public Directory {
@@ -344,7 +347,7 @@ public:
     return std::make_unique<VersionedDirectory>(*this);
   }
   virtual int copy(const DoutPrefixProvider *dpp, optional_yield y, Directory* dst_dir, const std::string& name) override;
-  virtual int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb) override;
+  virtual int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb, uint32_t flags) override;
 };
 
 std::string get_key_fname(rgw_obj_key& key, bool use_version);

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -968,6 +968,23 @@ private:
   int write_attrs(const DoutPrefixProvider *dpp, optional_yield y);
 }; /* POSIXBucket */
 
+struct POSIXManifest {
+  int64_t  multipart_part_count{-1};
+
+  void encode(bufferlist &bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(multipart_part_count, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator &bl) {
+    DECODE_START(1, bl);
+    decode(multipart_part_count, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(POSIXManifest);
+
 class POSIXObject : public StoreObject {
 public:
 private:

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -475,6 +475,7 @@ class POSIXDriver : public StoreDriver {
 protected:	
   CephContext *cct;
   std::unique_ptr<rgw::store::POSIXUserDB> userDB;
+  std::unique_ptr<rgw::store::POSIXAccountDB> accountDB;
   POSIXZone zone;
   std::unique_ptr<BucketCache> bucket_cache;
   std::string base_path;
@@ -491,6 +492,7 @@ public:
     auto db_full_path = std::filesystem::path(db_path) / db_name;
     
     userDB = std::make_unique<rgw::store::POSIXUserDB>(db_full_path.string(), cct);
+    accountDB = std::make_unique<rgw::store::POSIXAccountDB>(db_full_path.string(), cct);
   }
   virtual ~POSIXDriver() { }
 
@@ -518,32 +520,32 @@ public:
 				 std::string_view id,
 				 RGWAccountInfo& info,
 				 Attrs& attrs,
-				 RGWObjVersionTracker& objv) override { return -ENOTSUP; }
+				 RGWObjVersionTracker& objv) override;
   virtual int load_account_by_name(const DoutPrefixProvider* dpp,
 				 optional_yield y,
 				 std::string_view tenant,
 				 std::string_view name,
 				 RGWAccountInfo& info,
 				 Attrs& attrs,
-				 RGWObjVersionTracker& objv) override { return -ENOTSUP; }
+				 RGWObjVersionTracker& objv) override;
   virtual int load_account_by_email(const DoutPrefixProvider* dpp,
 				  optional_yield y,
 				  std::string_view email,
 				  RGWAccountInfo& info,
 				  Attrs& attrs,
-				  RGWObjVersionTracker& objv) override { return -ENOTSUP; }
+				  RGWObjVersionTracker& objv) override;
 
   virtual int store_account(const DoutPrefixProvider* dpp,
 			  optional_yield y, bool exclusive,
 			  const RGWAccountInfo& info,
 			  const RGWAccountInfo* old_info,
 			  const Attrs& attrs,
-			  RGWObjVersionTracker& objv) override { return -ENOTSUP; }
+			  RGWObjVersionTracker& objv) override;
 
   virtual int delete_account(const DoutPrefixProvider* dpp,
 			     optional_yield y,
 			     const RGWAccountInfo& info,
-			     RGWObjVersionTracker& objv) override { return -ENOTSUP; }
+			     RGWObjVersionTracker& objv) override;
 
   virtual int load_stats(const DoutPrefixProvider* dpp,
 			 optional_yield y,

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -17,6 +17,7 @@
 
 #include "rgw_sal_filter.h"
 #include "rgw_sal_store.h"
+#include "rgw_quota.h"
 #include <cstdint>
 #include <memory>
 #include "common/dout.h"
@@ -482,6 +483,7 @@ protected:
   std::unique_ptr<Directory> root_dir;
   int root_fd;
   RGWSyncModuleInstanceRef sync_module;
+  RGWQuotaHandler* quota_handler{nullptr};
 
 public:
   POSIXDriver(CephContext *_cct) : StoreDriver(), cct(_cct), zone(this)
@@ -708,9 +710,9 @@ public:
 			     std::map<rgw_user_bucket, rgw_usage_log_entry>& usage) override { return 0; }
   virtual int trim_all_usage(const DoutPrefixProvider *dpp, uint64_t start_epoch, uint64_t end_epoch, optional_yield y) override { return 0; }
   virtual int get_config_key_val(std::string name, bufferlist* bl) override { return -ENOTSUP; }
-  virtual int meta_list_keys_init(const DoutPrefixProvider *dpp, const std::string& section, const std::string& marker, void** phandle) override { return 0; }
-  virtual int meta_list_keys_next(const DoutPrefixProvider *dpp, void* handle, int max, std::list<std::string>& keys, bool* truncated) override { return 0; }
-  virtual void meta_list_keys_complete(void* handle) override { return; }
+  virtual int meta_list_keys_init(const DoutPrefixProvider *dpp, const std::string& section, const std::string& marker, void** phandle) override;
+  virtual int meta_list_keys_next(const DoutPrefixProvider *dpp, void* handle, int max, std::list<std::string>& keys, bool* truncated) override;
+  virtual void meta_list_keys_complete(void* handle) override;
   virtual std::string meta_get_marker(void* handle) override { return ""; }
   virtual int meta_remove(const DoutPrefixProvider* dpp, std::string& metadata_key, optional_yield y) override { return 0; }
   virtual const RGWSyncModuleInstanceRef& get_sync_module() override { return sync_module; }
@@ -771,7 +773,7 @@ public:
   virtual const std::string& get_compression_type(const rgw_placement_rule& rule) override;
   virtual bool valid_placement(const rgw_placement_rule& rule) override { return true; } 
 
-  virtual void finalize(void) override {}
+  virtual void finalize(void) override;
 
   virtual CephContext* ctx(void) override { return userDB->ctx(); }
 
@@ -788,6 +790,8 @@ public:
    * by inotify or similar */
   int mint_listing_entry(
     const std::string& bucket, rgw_bucket_dir_entry& bde /* OUT */);
+
+  RGWQuotaHandler* get_quota_handler() {return quota_handler;}
 };
 
 class POSIXNotification : public StoreNotification {

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -876,7 +876,7 @@ public:
     acls(_b.acls),
     ns(_b.ns)
     {
-      dir.reset(static_cast<Directory*>(_b.dir->clone().get()));
+      dir = _b.dir->clone_dir();
     }
 
   virtual ~POSIXBucket() { }

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -22,6 +22,7 @@
 #include <memory>
 #include "common/dout.h"
 #include "bucket_cache.h"
+#include "user_cache.h"
 #include "posixDB.h"
 
 namespace rgw { namespace sal {
@@ -479,6 +480,7 @@ protected:
   std::unique_ptr<rgw::store::POSIXAccountDB> accountDB;
   POSIXZone zone;
   std::unique_ptr<BucketCache> bucket_cache;
+  UserCache user_cache;
   std::string base_path;
   std::unique_ptr<Directory> root_dir;
   int root_fd;
@@ -785,6 +787,7 @@ public:
   Directory* get_root_dir() { return root_dir.get(); }
   const std::string& get_base_path() const { return base_path; }
   BucketCache* get_bucket_cache() { return bucket_cache.get(); }
+  UserCache& get_user_cache() { return user_cache; }
 
   /* called by BucketCache layer when a new object is discovered
    * by inotify or similar */
@@ -811,6 +814,7 @@ public:
 class POSIXUser : public StoreUser {
 private:
   POSIXDriver* driver;
+  int load_user_from_cache_or_db(const DoutPrefixProvider* dpp, bool& cache_hit);
 
 public:
   POSIXUser(POSIXDriver* _driver) :

--- a/src/rgw/driver/posix/user_cache.h
+++ b/src/rgw/driver/posix/user_cache.h
@@ -1,0 +1,172 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <list>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+#include "common/dout.h"
+#include "rgw_common.h"
+#include "rgw_sal_fwd.h"
+
+#define dout_subsys ceph_subsys_rgw
+
+namespace rgw::sal {
+
+struct UserCacheEntry {
+  RGWUserInfo info;
+  Attrs attrs;
+  RGWObjVersionTracker objv_tracker;
+};
+
+class UserCache {
+  struct LRUEntry {
+    std::string uid;
+    UserCacheEntry entry;
+  };
+
+  using lru_list_t = std::list<LRUEntry>;
+  using lru_iter_t = lru_list_t::iterator;
+
+  std::recursive_mutex mtx;
+  lru_list_t lru;
+  std::unordered_map<std::string, lru_iter_t> uid_to_lru_it; // user id -> LRU iterator
+  std::unordered_map<std::string, std::string> ak_to_uid; // access key -> user id
+  uint64_t lru_max_size;
+
+  
+  void lru_insert(const DoutPrefixProvider* dpp, const std::string& uid, const UserCacheEntry& entry) {
+    std::lock_guard l{mtx};
+    lru.emplace_front(LRUEntry{uid, entry});
+    uid_to_lru_it[uid] = lru.begin();
+    ldpp_dout(dpp, 30) << "UserCache: inserting user into LRU cache uid=" << uid << ", LRU size=" << lru.size()
+                       << ", user id to LRU iterator map size=" << uid_to_lru_it.size() << dendl;
+  }
+
+  void lru_evict(const DoutPrefixProvider* dpp) {
+    std::lock_guard l{mtx};
+    while (uid_to_lru_it.size() > lru_max_size) {
+      auto& evicted = lru.back();
+      // erase all access key mappings for evicted user
+      for (const auto& [ak, _] : evicted.entry.info.access_keys) {
+        ak_to_uid.erase(ak);
+      }
+      ldpp_dout(dpp, 30) << "UserCache: evicting user from LRU cache uid=" << evicted.uid << ", LRU size=" << lru.size()
+                         << ", access key to user id map size=" << ak_to_uid.size()
+                         << ", user id to LRU iterator map size=" << uid_to_lru_it.size() << dendl;
+      uid_to_lru_it.erase(evicted.uid);
+      lru.pop_back();
+    }
+  }
+
+  void lru_touch(const DoutPrefixProvider* dpp, lru_iter_t it) {
+    std::lock_guard l{mtx};
+    lru.splice(lru.begin(), lru, it);
+    ldpp_dout(dpp, 30) << "UserCache: touched user in LRU cache uid=" << it->uid << ", LRU size=" << lru.size() << dendl;
+  }
+
+
+public:
+  UserCache(uint64_t max_entries = 1000) : lru_max_size(max_entries) {}
+
+  void set_max_size(const DoutPrefixProvider* dpp, uint64_t max_entries) {
+    ldpp_dout(dpp, 30) << "UserCache: setting LRU max size to " << max_entries << dendl;
+    std::lock_guard l{mtx};
+    lru_max_size = max_entries;
+    lru_evict(dpp);
+  }
+  
+  void insert_user(const DoutPrefixProvider* dpp, const UserCacheEntry& entry) {
+    std::lock_guard l{mtx};
+    const auto& uid = entry.info.user_id.id;
+    
+    // if user already exists, replace entry and promote to front of LRU otherwise insert new entry into front of LRU
+    auto it = uid_to_lru_it.find(uid);
+    if (it != uid_to_lru_it.end()) {
+      // update existing: replace entry and promote
+      it->second->entry = entry;
+      lru_touch(dpp, it->second);
+    } else {
+      // insert new
+      lru_insert(dpp, uid, entry);
+    }
+    ldpp_dout(dpp, 30) << "UserCache: caching user uid=" << entry.info.user_id.id << ", LRU size=" << lru.size() << dendl;
+
+    // update access key -> user id mappings for this user
+    for (const auto& [ak, _] : entry.info.access_keys) {
+      ak_to_uid[ak] = uid;
+    }
+
+    lru_evict(dpp);
+  }
+
+  bool lookup_user_by_uid(const DoutPrefixProvider* dpp,
+                          const std::string& user_id,
+                          UserCacheEntry& out) {
+    std::lock_guard l{mtx};
+    auto uid_it = uid_to_lru_it.find(user_id);
+    if (uid_it == uid_to_lru_it.end()) {
+      ldpp_dout(dpp, 30) << "UserCache: lookup cached user by uid=" << user_id << " : not found" << dendl;
+      return false;
+    }
+    lru_touch(dpp, uid_it->second);
+    out = uid_it->second->entry;
+    ldpp_dout(dpp, 30) << "UserCache: lookup cached user by uid=" << user_id << " : found" << dendl;
+    return true;
+  }
+
+  bool lookup_user_by_access_key(const DoutPrefixProvider* dpp,
+                                 const std::string& key,
+                                 UserCacheEntry& out) {
+    std::lock_guard l{mtx};
+    auto ak_it = ak_to_uid.find(key);
+    if (ak_it == ak_to_uid.end()) {
+      ldpp_dout(dpp, 30) << "UserCache: lookup cached user by key=" << key << " : not found" << dendl;
+      return false;
+    }
+    auto uid_it = uid_to_lru_it.find(ak_it->second);
+    if (uid_it == uid_to_lru_it.end()) {
+      ldpp_dout(dpp, 30) << "UserCache: lookup cached user by key=" << key << " uid=" << ak_it->second << " : not found" << dendl;
+      return false;
+    }
+    lru_touch(dpp, uid_it->second);
+    out = uid_it->second->entry;
+    ldpp_dout(dpp, 30) << "UserCache: lookup cached user by key=" << key << " uid=" << ak_it->second << " : found" << dendl;
+    return true;
+  }
+
+  void invalidate_user(const DoutPrefixProvider* dpp, const std::string& user_id) {
+    ldpp_dout(dpp, 30) << "UserCache: invalidating cached user uid=" << user_id << dendl;
+    std::lock_guard l{mtx};
+    auto it = uid_to_lru_it.find(user_id);
+    // if user exists, remove from cache and erase all access key mappings for that user
+    if (it != uid_to_lru_it.end()) {
+      for (const auto& [ak, _] : it->second->entry.info.access_keys) {
+        ak_to_uid.erase(ak);
+      }
+      ldpp_dout(dpp, 30) << "UserCache: evicting user from LRU cache uid=" << it->second->entry.info.user_id.id << ", LRU size=" << lru.size()
+                         << ", access key to user id map size=" << ak_to_uid.size() << ", user id to LRU iterator map size=" << uid_to_lru_it.size() << dendl;
+      lru.erase(it->second);
+      uid_to_lru_it.erase(it);
+    }
+  }
+};
+
+} // namespace rgw::sal
+
+#undef dout_subsys

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -17,7 +17,9 @@
 
 #include "account.h"
 #include "buckets.h"
+#ifdef WITH_RADOSGW_RADOS
 #include "rgw_metadata_lister.h"
+#endif
 #include "rgw_reshard.h"
 #include "rgw_pubsub.h"
 
@@ -50,6 +52,7 @@ static constexpr size_t listing_max_entries = 1000;
 /*
  * The tenant_name is always returned on purpose. May be empty, of course.
  */
+#ifdef WITH_RADOSGW_RADOS
 static void parse_bucket(const string& bucket,
                          string *tenant_name,
                          string *bucket_name,
@@ -95,6 +98,7 @@ static void dump_multipart_index_results(std::list<rgw_obj_index_key>& objs,
     f->dump_string("object",  o.name);
   }
 }
+#endif
 
 void check_bad_owner_bucket_mapping(rgw::sal::Driver* driver,
                                     const rgw_owner& owner,
@@ -312,6 +316,7 @@ static void dump_bucket_usage(map<RGWObjCategory, RGWStorageStats>& stats, Forma
   formatter->close_section();
 }
 
+#ifdef WITH_RADOSGW_RADOS
 static void dump_index_check(map<RGWObjCategory, RGWStorageStats> existing_stats,
         map<RGWObjCategory, RGWStorageStats> calculated_stats,
         Formatter *formatter)
@@ -482,6 +487,7 @@ static int check_bad_index_multipart(rgw::sal::RadosStore* const rados_store,
 
   return 0;
 } // static ::check_bad_index_multipart
+#endif
 
 
 /**
@@ -496,6 +502,7 @@ static int check_bad_index_multipart(rgw::sal::RadosStore* const rados_store,
  * 'bucket check' operation over the /admin/bucket api, so we'll want
  * to address this in the future.
  */
+#ifdef WITH_RADOSGW_RADOS
 int RGWBucket::check_bad_index_multipart(rgw::sal::RadosStore* const rados_store,
 					 RGWBucketAdminOpState& op_state,
 					 RGWFormatterFlusher& flusher,
@@ -557,6 +564,7 @@ int RGWBucket::check_bad_index_multipart(rgw::sal::RadosStore* const rados_store
 
   return any_error;
 }
+#endif
 
 int RGWBucket::check_object_index(const DoutPrefixProvider *dpp, 
                                   RGWBucketAdminOpState& op_state,
@@ -616,6 +624,7 @@ int RGWBucket::check_object_index(const DoutPrefixProvider *dpp,
  * request left off by calling RGWRados::clear_olh. If the pending log is not
  * empty, we attempt to apply it.
  */
+#ifdef WITH_RADOSGW_RADOS
 static int check_index_olh(rgw::sal::RadosStore* const rados_store,
                            rgw::sal::Bucket* const bucket,
                            const DoutPrefixProvider *dpp,
@@ -701,6 +710,7 @@ static int check_index_olh(rgw::sal::RadosStore* const rados_store,
   flusher.flush();
   return 0;
 }
+#endif
 
 
 /**
@@ -714,6 +724,7 @@ static int check_index_olh(rgw::sal::RadosStore* const rados_store,
  * operation over the /admin/bucket api, so we'll want to address
  * this.
  */
+#ifdef WITH_RADOSGW_RADOS
 int RGWBucket::check_index_olh(rgw::sal::RadosStore* const rados_store,
                                const DoutPrefixProvider *dpp,
                                RGWBucketAdminOpState& op_state,
@@ -827,6 +838,7 @@ static int is_versioned_instance_listable(const DoutPrefixProvider *dpp,
   } while (result.is_truncated);
   return 0;
 }
+#endif
 
 /**
  * Loops over all instance entries in a bucket shard and finds ones with
@@ -840,6 +852,7 @@ static int is_versioned_instance_listable(const DoutPrefixProvider *dpp,
  * op_state.fix_index is true, we remove the object that is associated with the
  * instance entry.
  */
+#ifdef WITH_RADOSGW_RADOS
 static int check_index_unlinked(rgw::sal::RadosStore* const rados_store,
                                 rgw::sal::Bucket* const bucket,
                                 const DoutPrefixProvider *dpp,
@@ -997,6 +1010,7 @@ int RGWBucket::check_index_unlinked(rgw::sal::RadosStore* const rados_store,
   }
   return 0;
 }
+#endif
 
 int RGWBucket::check_index(const DoutPrefixProvider *dpp, optional_yield y,
         RGWBucketAdminOpState& op_state,
@@ -1149,6 +1163,7 @@ int RGWBucketAdminOp::dump_s3_policy(rgw::sal::Driver* driver, RGWBucketAdminOpS
   return 0;
 }
 
+#ifdef WITH_RADOSGW_RADOS
 int RGWBucketAdminOp::unlink(rgw::sal::Driver* driver, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp, optional_yield y, string *err)
 {
   rgw_owner owner;
@@ -1338,6 +1353,7 @@ int RGWBucketAdminOp::link(rgw::sal::Driver* driver, RGWBucketAdminOpState& op_s
 
   return 0;
 }
+#endif
 
 int RGWBucketAdminOp::chown(rgw::sal::Driver* driver, RGWBucketAdminOpState& op_state, const string& marker, const DoutPrefixProvider *dpp, optional_yield y, string *err)
 {
@@ -1351,6 +1367,7 @@ int RGWBucketAdminOp::chown(rgw::sal::Driver* driver, RGWBucketAdminOpState& op_
 
 }
 
+#ifdef WITH_RADOSGW_RADOS
 int RGWBucketAdminOp::check_index_olh(rgw::sal::RadosStore* store, RGWBucketAdminOpState& op_state,
                   RGWFormatterFlusher& flusher, const DoutPrefixProvider *dpp)
 {
@@ -1442,6 +1459,7 @@ int RGWBucketAdminOp::check_index(rgw::sal::Driver* driver,
 
   return 0;
 }
+#endif
 
 int RGWBucketAdminOp::remove_bucket(rgw::sal::Driver* driver, const rgw::SiteConfig& site,
                                     RGWBucketAdminOpState& op_state,
@@ -1976,6 +1994,7 @@ inline auto split_tenant(const std::string& bucket_name){
 }
 
 using bucket_instance_ls = std::vector<RGWBucketInfo>;
+#ifdef WITH_RADOSGW_RADOS
 void get_stale_instances(rgw::sal::Driver* driver, const std::string& bucket_name,
                          const vector<std::string>& lst,
                          bucket_instance_ls& stale_instances,
@@ -2160,6 +2179,7 @@ int RGWBucketAdminOp::clear_stale_instances(rgw::sal::Driver* driver,
 
   return process_stale_instances(driver, op_state, flusher, dpp, process_f, y);
 }
+#endif
 
 static int fix_single_bucket_lc(rgw::sal::Driver* driver,
                                 const std::string& tenant_name,
@@ -2353,6 +2373,7 @@ void RGWBucketCompleteInfo::decode_json(JSONObj *obj) {
   JSONDecoder::decode_json("attrs", attrs, obj);
 }
 
+#ifdef WITH_RADOSGW_RADOS
 class RGWBucketMetadataHandler : public RGWMetadataHandler {
  protected:
   librados::Rados& rados;
@@ -2467,6 +2488,7 @@ int RGWBucketMetadataHandler::put(std::string& entry, RGWMetadataObject* obj,
 
   return 0;
 }
+#endif
 
 int update_bucket_topic_mappings(const DoutPrefixProvider* dpp,
                                  const RGWBucketCompleteInfo* orig_bci,
@@ -2554,6 +2576,7 @@ int update_bucket_topic_mappings(const DoutPrefixProvider* dpp,
   return ret;
 }
 
+#ifdef WITH_RADOSGW_RADOS
 int RGWBucketMetadataHandler::remove(std::string& entry, RGWObjVersionTracker& objv_tracker,
                                      optional_yield y, const DoutPrefixProvider *dpp)
 {
@@ -2640,6 +2663,7 @@ static void get_md5_digest(const RGWBucketEntryPoint *be, string& md5_digest) {
 
    delete f;
 }
+#endif
 
 #define ARCHIVE_META_ATTR RGW_ATTR_PREFIX "zone.archive.info" 
 
@@ -2681,6 +2705,7 @@ struct archive_meta_info {
 };
 WRITE_CLASS_ENCODER(archive_meta_info)
 
+#ifdef WITH_RADOSGW_RADOS
 class RGWArchiveBucketMetadataHandler : public RGWBucketMetadataHandler {
  public:
   RGWArchiveBucketMetadataHandler(librados::Rados& rados,
@@ -2958,6 +2983,7 @@ int RGWBucketInstanceMetadataHandler::put(std::string& entry, RGWMetadataObject*
   // update related state on success
   return put_post(dpp, y, bci, old, objv_tracker);
 }
+#endif
 
 void init_default_bucket_layout(CephContext *cct, rgw::BucketLayout& layout,
 				const RGWZone& zone,
@@ -2985,6 +3011,7 @@ void init_default_bucket_layout(CephContext *cct, rgw::BucketLayout& layout,
   }
 }
 
+#ifdef WITH_RADOSGW_RADOS
 int RGWBucketInstanceMetadataHandler::put_prepare(
     const DoutPrefixProvider* dpp, optional_yield y,
     const std::string& entry, RGWBucketCompleteInfo& bci,
@@ -3187,7 +3214,6 @@ std::string RGWBucketInstanceMetadataHandler::get_marker(void *handle)
   return lister->get_marker();
 }
 
-
 class RGWArchiveBucketInstanceMetadataHandler : public RGWBucketInstanceMetadataHandler {
  public:
   using RGWBucketInstanceMetadataHandler::RGWBucketInstanceMetadataHandler;
@@ -3201,6 +3227,7 @@ class RGWArchiveBucketInstanceMetadataHandler : public RGWBucketInstanceMetadata
     return 0;
   }
 };
+#endif
 
 RGWBucketCtl::RGWBucketCtl(RGWSI_Zone *zone_svc,
                            RGWSI_Bucket *bucket_svc,
@@ -3230,6 +3257,7 @@ void RGWBucketCtl::init(RGWUserCtl *user_ctl,
     });
 }
 
+#ifdef WITH_RADOSGW_RADOS
 int RGWBucketCtl::read_bucket_entrypoint_info(const rgw_bucket& bucket,
                                               RGWBucketEntryPoint *info,
                                               optional_yield y, const DoutPrefixProvider *dpp,
@@ -3500,7 +3528,9 @@ static rgw_raw_obj get_owner_buckets_obj(RGWSI_User* svc_user,
         return rgwrados::account::get_buckets_obj(zone, account_id);
       }), owner);
 }
+#endif
 
+#ifdef WITH_RADOSGW_RADOS
 int RGWBucketCtl::link_bucket(librados::Rados& rados,
                               const rgw_owner& owner,
                               const rgw_bucket& bucket,
@@ -3569,7 +3599,9 @@ done_err:
   }
   return ret;
 }
+#endif
 
+#ifdef WITH_RADOSGW_RADOS
 int RGWBucketCtl::unlink_bucket(librados::Rados& rados, const rgw_owner& owner,
                                 const rgw_bucket& bucket, optional_yield y,
                                 const DoutPrefixProvider *dpp, bool update_entrypoint)
@@ -3605,6 +3637,7 @@ int RGWBucketCtl::unlink_bucket(librados::Rados& rados, const rgw_owner& owner,
   ep.linked = false;
   return svc.bucket->store_bucket_entrypoint_info(meta_key, ep, false, real_time(), &attrs, &ot, y, dpp);
 }
+#endif
 
 int RGWBucketCtl::read_bucket_stats(const rgw_bucket& bucket,
                                     RGWBucketEnt *result,
@@ -3620,6 +3653,7 @@ int RGWBucketCtl::read_buckets_stats(std::vector<RGWBucketEnt>& buckets,
   return svc.bucket->read_buckets_stats(buckets, y, dpp);
 }
 
+#ifdef WITH_RADOSGW_RADOS
 int RGWBucketCtl::sync_owner_stats(const DoutPrefixProvider *dpp,
                                    librados::Rados& rados,
                                    const rgw_owner& owner,
@@ -3648,6 +3682,7 @@ int RGWBucketCtl::sync_owner_stats(const DoutPrefixProvider *dpp,
       }), owner);
   return rgwrados::buckets::write_stats(dpp, y, rados, obj, *pent);
 }
+#endif
 
 int RGWBucketCtl::get_sync_policy_handler(std::optional<rgw_zone_id> zone,
                                           std::optional<rgw_bucket> bucket,
@@ -3692,6 +3727,7 @@ int RGWBucketCtl::bucket_imports_data(const rgw_bucket& bucket,
   return handler->bucket_imports_data();
 }
 
+#ifdef WITH_RADOSGW_RADOS
 auto create_bucket_metadata_handler(librados::Rados& rados,
                                     RGWSI_Bucket* svc_bucket,
                                     RGWBucketCtl* ctl_bucket)
@@ -3733,6 +3769,7 @@ auto create_archive_bucket_instance_metadata_handler(rgw::sal::Driver* driver,
                                                                    svc_bucket, svc_bi,
                                                                    svc_datalog);
 }
+#endif
 
 list<RGWBucketEntryPoint> RGWBucketEntryPoint::generate_test_instances()
 {

--- a/src/rgw/driver/rados/rgw_bucket.h
+++ b/src/rgw/driver/rados/rgw_bucket.h
@@ -31,7 +31,9 @@
 // define as static when RGWBucket implementation completes
 extern void rgw_get_buckets_obj(const rgw_user& user_id, std::string& buckets_obj_id);
 
+#ifdef WITH_RADOSGW_RADOS
 class RGWBucketMetadataHandler;
+#endif
 class RGWBucketInstanceMetadataHandler;
 class RGWUserCtl;
 class RGWBucketCtl;

--- a/src/rgw/driver/rados/rgw_metadata_lister.h
+++ b/src/rgw/driver/rados/rgw_metadata_lister.h
@@ -65,10 +65,12 @@ class RGWMetadataLister {
     return 0;
   }
 
+#ifdef WITH_RADOSGW_RADOS
   std::string get_marker()
   {
     std::string marker;
     listing.get_marker(&marker);
     return marker;
   }
+#endif
 };

--- a/src/rgw/driver/rados/rgw_obj_manifest.cc
+++ b/src/rgw/driver/rados/rgw_obj_manifest.cc
@@ -457,9 +457,10 @@ rgw_raw_obj rgw_obj_select::get_raw_obj(const RGWZoneGroup& zonegroup, const RGW
   return raw_obj;
 }
 
+#ifdef WITH_RADOSGW_RADOS 
 // returns true on success, false on failure
 bool RGWRados::get_obj_data_pool(const rgw_placement_rule& placement_rule, const rgw_obj& obj, rgw_pool *pool)
 {
   return rgw_get_obj_data_pool(svc.zone->get_zonegroup(), svc.zone->get_zone_params(), placement_rule, obj, pool);
 }
-
+#endif

--- a/src/rgw/driver/rados/rgw_user.cc
+++ b/src/rgw/driver/rados/rgw_user.cc
@@ -8,7 +8,9 @@
 #include "rgw_account.h"
 #include "rgw_bucket.h"
 #include "rgw_metadata.h"
+#ifdef WITH_RADOSGW_RADOS
 #include "rgw_metadata_lister.h"
+#endif
 #include "rgw_quota.h"
 #include "rgw_rest_iam.h" // validate_iam_user_name()
 
@@ -2692,6 +2694,7 @@ public:
   }
 };
 
+#ifdef WITH_RADOSGW_RADOS
 class RGWUserMetadataHandler : public RGWMetadataHandler {
   RGWSI_User *svc_user{nullptr};
  public:
@@ -2845,7 +2848,7 @@ std::string RGWUserMetadataHandler::get_marker(void *handle)
   auto lister = static_cast<RGWMetadataLister*>(handle);
   return lister->get_marker();
 }
-
+#endif
 
 RGWUserCtl::RGWUserCtl(RGWSI_Zone *zone_svc, RGWSI_User *user_svc)
 {
@@ -2975,11 +2978,13 @@ int RGWUserCtl::remove_info(const DoutPrefixProvider *dpp,
   return svc.user->remove_user_info(info, params.objv_tracker, y, dpp);
 }
 
+#ifdef WITH_RADOSGW_RADOS
 auto create_user_metadata_handler(RGWSI_User *user_svc)
     -> std::unique_ptr<RGWMetadataHandler>
 {
   return std::make_unique<RGWUserMetadataHandler>(user_svc);
 }
+#endif
 
 void rgw_user::dump(Formatter *f) const
 {

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -39,16 +39,20 @@ extern "C" {
 
 #include "include/util.h"
 
+#ifdef WITH_RADOSGW_RADOS
 #include "cls/rgw/cls_rgw_types.h"
 #include "cls/rgw/cls_rgw_client.h"
 #include "cls/2pc_queue/cls_2pc_queue_types.h"
 #include "cls/2pc_queue/cls_2pc_queue_client.h"
+#endif
 
 #include "include/utime.h"
 #include "include/str_list.h"
 
+#ifdef WITH_RADOSGW_RADOS
 #include "radosgw-admin/orphan.h"
 #include "radosgw-admin/sync_checkpoint.h"
+#endif
 
 #include "rgw/async_utils.h"
 
@@ -91,7 +95,9 @@ extern "C" {
 #include "services/svc_zone.h"
 
 #include "driver/rados/rgw_bucket.h"
+#ifdef WITH_RADOSGW_RADOS
 #include "driver/rados/rgw_sal_rados.h"
+#endif
 #include "driver/rados/rgw_bl_rados.h"
 
 #include <iomanip>
@@ -342,12 +348,14 @@ void usage()
   cout << "  reshardlog purge                 trim bucket resharding log\n";
   cout << "  sync error list                  list sync error\n";
   cout << "  sync error trim                  trim sync error\n";
+#ifdef WITH_RADOSGW_RADOS
   cout << "  mfa create                       create a new MFA TOTP token\n";
   cout << "  mfa list                         list MFA TOTP tokens\n";
   cout << "  mfa get                          show MFA TOTP token\n";
   cout << "  mfa remove                       delete MFA TOTP token\n";
   cout << "  mfa check                        check MFA TOTP token\n";
   cout << "  mfa resync                       re-sync MFA TOTP token\n";
+#endif
   cout << "  topic list                       list bucket notifications topics\n";
   cout << "  topic get                        get a bucket notifications topic\n";
   cout << "  topic rm                         remove a bucket notifications topic\n";
@@ -537,7 +545,9 @@ void usage()
   cout << "   --path-prefix                 path prefix for filtering roles\n";
   cout << "   --description                 Role description\n";
   cout << "   --policy-arn                  ARN of a managed policy\n";
+#ifdef WITH_RADOSGW_RADOS
   cout << "\nMFA options:\n";
+#endif
   cout << "   --totp-serial                 a string that represents the ID of a TOTP token\n";
   cout << "   --totp-seed                   the secret seed that is used to calculate the TOTP\n";
   cout << "   --totp-seconds                the time resolution that is being used for TOTP generation\n";
@@ -726,10 +736,13 @@ enum class OPT {
   KEY_RM,
   BUCKETS_LIST,
   BUCKET_LIMIT_CHECK,
+#ifdef WITH_RADOSGW_RADOS
   BUCKET_LINK,
   BUCKET_UNLINK,
+#endif
   BUCKET_LAYOUT,
   BUCKET_STATS,
+#ifdef WITH_RADOSGW_RADOS
   BUCKET_CHECK,
   BUCKET_CHECK_OLH,
   BUCKET_CHECK_UNLINKED,
@@ -741,22 +754,31 @@ enum class OPT {
   BUCKET_SYNC_RUN,
   BUCKET_SYNC_DISABLE,
   BUCKET_SYNC_ENABLE,
+#endif
   BUCKET_RM,
+#ifdef WITH_RADOSGW_RADOS
   BUCKET_REWRITE,
   BUCKET_RESHARD,
+#endif
   BUCKET_SET_MIN_SHARDS,
   BUCKET_CHOWN,
+#ifdef WITH_RADOSGW_RADOS
   BUCKET_RADOS_LIST,
+#endif
   BUCKET_SHARD_OBJECTS,
   BUCKET_OBJECT_SHARD,
+#ifdef WITH_RADOSGW_RADOS
   BUCKET_RESYNC_ENCRYPTED_MULTIPART,
+#endif
   BUCKET_LOGGING_FLUSH,
   BUCKET_LOGGING_INFO,
   BUCKET_LOGGING_LIST,
   POLICY,
+#ifdef WITH_RADOSGW_RADOS
   LOG_LIST,
   LOG_SHOW,
   LOG_RM,
+#endif
   USAGE_SHOW,
   USAGE_TRIM,
   USAGE_CLEAR,
@@ -764,21 +786,26 @@ enum class OPT {
   OBJECT_RM,
   OBJECT_UNLINK,
   OBJECT_STAT,
+#ifdef WITH_RADOSGW_RADOS
   OBJECT_MANIFEST,
   OBJECT_REWRITE,
   OBJECT_REINDEX,
+#endif
   OBJECTS_EXPIRE,
   OBJECTS_EXPIRE_STALE_LIST,
   OBJECTS_EXPIRE_STALE_RM,
+#ifdef WITH_RADOSGW_RADOS
   BI_GET,
   BI_PUT,
   BI_LIST,
   BI_PURGE,
   OLH_GET,
   OLH_READLOG,
+#endif
   QUOTA_SET,
   QUOTA_ENABLE,
   QUOTA_DISABLE,
+#ifdef WITH_RADOSGW_RADOS
   DEDUP_STATS,
   DEDUP_ESTIMATE,
   DEDUP_ABORT,
@@ -788,13 +815,18 @@ enum class OPT {
   DEDUP_THROTTLE,
   GC_LIST,
   GC_PROCESS,
+#endif
   LC_LIST,
   LC_GET,
+#ifdef WITH_RADOSGW_RADOS
   LC_PROCESS,
+#endif
   LC_RESHARD_FIX,
+#ifdef WITH_RADOSGW_RADOS
   ORPHANS_FIND,
   ORPHANS_FINISH,
   ORPHANS_LIST_JOBS,
+#endif
   RATELIMIT_GET,
   RATELIMIT_SET,
   RATELIMIT_ENABLE,
@@ -823,13 +855,16 @@ enum class OPT {
   ZONE_LIST,
   ZONE_RENAME,
   ZONE_DEFAULT,
+#ifdef WITH_RADOSGW_RADOS
   ZONE_PLACEMENT_ADD,
+#endif
   ZONE_PLACEMENT_MODIFY,
   ZONE_PLACEMENT_RM,
   ZONE_PLACEMENT_LIST,
   ZONE_PLACEMENT_GET,
   CAPS_ADD,
   CAPS_RM,
+#ifdef WITH_RADOSGW_RADOS
   METADATA_GET,
   METADATA_PUT,
   METADATA_RM,
@@ -844,6 +879,7 @@ enum class OPT {
   MDLOG_STATUS,
   SYNC_ERROR_LIST,
   SYNC_ERROR_TRIM,
+#endif
   SYNC_GROUP_CREATE,
   SYNC_GROUP_MODIFY,
   SYNC_GROUP_GET,
@@ -855,12 +891,14 @@ enum class OPT {
   SYNC_GROUP_PIPE_REMOVE,
   SYNC_POLICY_GET,
   BILOG_LIST,
+#ifdef WITH_RADOSGW_RADOS
   BILOG_TRIM,
   BILOG_STATUS,
   BILOG_AUTOTRIM,
   DATA_SYNC_STATUS,
   DATA_SYNC_INIT,
   DATA_SYNC_RUN,
+#endif
   DATALOG_LIST,
   DATALOG_STATUS,
   DATALOG_AUTOTRIM,
@@ -897,7 +935,9 @@ enum class OPT {
   GLOBAL_RATELIMIT_ENABLE,
   GLOBAL_RATELIMIT_DISABLE,
   SYNC_INFO,
+#ifdef WITH_RADOSGW_RADOS
   SYNC_STATUS,
+#endif
   ROLE_CREATE,
   ROLE_DELETE,
   ROLE_GET,
@@ -911,6 +951,7 @@ enum class OPT {
   ROLE_POLICY_DETACH,
   ROLE_POLICY_LIST_ATTACHED,
   ROLE_UPDATE,
+#ifdef WITH_RADOSGW_RADOS
   RESHARD_ADD,
   RESHARD_LIST,
   RESHARD_STATUS,
@@ -926,14 +967,17 @@ enum class OPT {
   RESHARD_STALE_INSTANCES_DELETE,
   RESHARDLOG_LIST,
   RESHARDLOG_PURGE,
+#endif
   PUBSUB_TOPIC_LIST,
   PUBSUB_TOPIC_GET,
   PUBSUB_TOPIC_RM,
   PUBSUB_NOTIFICATION_LIST,
   PUBSUB_NOTIFICATION_GET,
   PUBSUB_NOTIFICATION_RM,
+#ifdef WITH_RADOSGW_RADOS
   PUBSUB_TOPIC_STATS,
   PUBSUB_TOPIC_DUMP,
+#endif
   SCRIPT_PUT,
   SCRIPT_GET,
   SCRIPT_RM,
@@ -977,10 +1021,13 @@ static SimpleCmd::Commands all_cmds = {
   { "buckets list", OPT::BUCKETS_LIST },
   { "bucket list", OPT::BUCKETS_LIST },
   { "bucket limit check", OPT::BUCKET_LIMIT_CHECK },
+#ifdef WITH_RADOSGW_RADOS
   { "bucket link", OPT::BUCKET_LINK },
   { "bucket unlink", OPT::BUCKET_UNLINK },
+#endif
   { "bucket layout", OPT::BUCKET_LAYOUT },
   { "bucket stats", OPT::BUCKET_STATS },
+#ifdef WITH_RADOSGW_RADOS
   { "bucket check", OPT::BUCKET_CHECK },
   { "bucket check olh", OPT::BUCKET_CHECK_OLH },
   { "bucket check unlinked", OPT::BUCKET_CHECK_UNLINKED },
@@ -992,24 +1039,33 @@ static SimpleCmd::Commands all_cmds = {
   { "bucket sync run", OPT::BUCKET_SYNC_RUN },
   { "bucket sync disable", OPT::BUCKET_SYNC_DISABLE },
   { "bucket sync enable", OPT::BUCKET_SYNC_ENABLE },
+#endif
   { "bucket rm", OPT::BUCKET_RM },
+#ifdef WITH_RADOSGW_RADOS
   { "bucket rewrite", OPT::BUCKET_REWRITE },
   { "bucket reshard", OPT::BUCKET_RESHARD },
+#endif
   { "bucket set-min-shards", OPT::BUCKET_SET_MIN_SHARDS },
   { "bucket chown", OPT::BUCKET_CHOWN },
+#ifdef WITH_RADOSGW_RADOS
   { "bucket radoslist", OPT::BUCKET_RADOS_LIST },
   { "bucket rados list", OPT::BUCKET_RADOS_LIST },
+#endif
   { "bucket shard objects", OPT::BUCKET_SHARD_OBJECTS },
   { "bucket shard object", OPT::BUCKET_SHARD_OBJECTS },
   { "bucket object shard", OPT::BUCKET_OBJECT_SHARD },
+#ifdef WITH_RADOSGW_RADOS
   { "bucket resync encrypted multipart", OPT::BUCKET_RESYNC_ENCRYPTED_MULTIPART },
+#endif
   { "bucket logging flush", OPT::BUCKET_LOGGING_FLUSH },
   { "bucket logging info", OPT::BUCKET_LOGGING_INFO },
   { "bucket logging list", OPT::BUCKET_LOGGING_LIST },
   { "policy", OPT::POLICY },
+#ifdef WITH_RADOSGW_RADOS
   { "log list", OPT::LOG_LIST },
   { "log show", OPT::LOG_SHOW },
   { "log rm", OPT::LOG_RM },
+#endif
   { "usage show", OPT::USAGE_SHOW },
   { "usage trim", OPT::USAGE_TRIM },
   { "usage clear", OPT::USAGE_CLEAR },
@@ -1017,18 +1073,22 @@ static SimpleCmd::Commands all_cmds = {
   { "object rm", OPT::OBJECT_RM },
   { "object unlink", OPT::OBJECT_UNLINK },
   { "object stat", OPT::OBJECT_STAT },
+#ifdef WITH_RADOSGW_RADOS
   { "object manifest", OPT::OBJECT_MANIFEST },
   { "object rewrite", OPT::OBJECT_REWRITE },
   { "object reindex", OPT::OBJECT_REINDEX },
+#endif  
   { "objects expire", OPT::OBJECTS_EXPIRE },
   { "objects expire-stale list", OPT::OBJECTS_EXPIRE_STALE_LIST },
   { "objects expire-stale rm", OPT::OBJECTS_EXPIRE_STALE_RM },
+#ifdef WITH_RADOSGW_RADOS
   { "bi get", OPT::BI_GET },
   { "bi put", OPT::BI_PUT },
   { "bi list", OPT::BI_LIST },
   { "bi purge", OPT::BI_PURGE },
   { "olh get", OPT::OLH_GET },
   { "olh readlog", OPT::OLH_READLOG },
+#endif
   { "quota set", OPT::QUOTA_SET },
   { "quota enable", OPT::QUOTA_ENABLE },
   { "quota disable", OPT::QUOTA_DISABLE },
@@ -1036,6 +1096,7 @@ static SimpleCmd::Commands all_cmds = {
   { "ratelimit set", OPT::RATELIMIT_SET },
   { "ratelimit enable", OPT::RATELIMIT_ENABLE },
   { "ratelimit disable", OPT::RATELIMIT_DISABLE },
+#ifdef WITH_RADOSGW_RADOS
   { "dedup stats", OPT::DEDUP_STATS },
   { "dedup estimate", OPT::DEDUP_ESTIMATE },
   { "dedup abort", OPT::DEDUP_ABORT },
@@ -1046,14 +1107,19 @@ static SimpleCmd::Commands all_cmds = {
   { "dedup throttle", OPT::DEDUP_THROTTLE },
   { "gc list", OPT::GC_LIST },
   { "gc process", OPT::GC_PROCESS },
+#endif
   { "lc list", OPT::LC_LIST },
   { "lc get", OPT::LC_GET },
+#ifdef WITH_RADOSGW_RADOS
   { "lc process", OPT::LC_PROCESS },
+#endif
   { "lc reshard fix", OPT::LC_RESHARD_FIX },
+#ifdef WITH_RADOSGW_RADOS
   { "orphans find", OPT::ORPHANS_FIND },
   { "orphans finish", OPT::ORPHANS_FINISH },
   { "orphans list jobs", OPT::ORPHANS_LIST_JOBS },
   { "orphans list-jobs", OPT::ORPHANS_LIST_JOBS },
+#endif
   { "zonegroup add", OPT::ZONEGROUP_ADD },
   { "zonegroup create", OPT::ZONEGROUP_CREATE },
   { "zonegroup default", OPT::ZONEGROUP_DEFAULT },
@@ -1081,13 +1147,16 @@ static SimpleCmd::Commands all_cmds = {
   { "zones list", OPT::ZONE_LIST },
   { "zone rename", OPT::ZONE_RENAME },
   { "zone default", OPT::ZONE_DEFAULT },
+#ifdef WITH_RADOSGW_RADOS
   { "zone placement add", OPT::ZONE_PLACEMENT_ADD },
+#endif
   { "zone placement modify", OPT::ZONE_PLACEMENT_MODIFY },
   { "zone placement rm", OPT::ZONE_PLACEMENT_RM },
   { "zone placement list", OPT::ZONE_PLACEMENT_LIST },
   { "zone placement get", OPT::ZONE_PLACEMENT_GET },
   { "caps add", OPT::CAPS_ADD },
   { "caps rm", OPT::CAPS_RM },
+#ifdef WITH_RADOSGW_RADOS
   { "metadata get [*]", OPT::METADATA_GET },
   { "metadata put [*]", OPT::METADATA_PUT },
   { "metadata rm [*]", OPT::METADATA_RM },
@@ -1102,6 +1171,7 @@ static SimpleCmd::Commands all_cmds = {
   { "mdlog status", OPT::MDLOG_STATUS },
   { "sync error list", OPT::SYNC_ERROR_LIST },
   { "sync error trim", OPT::SYNC_ERROR_TRIM },
+#endif
   { "sync policy get", OPT::SYNC_POLICY_GET },
   { "sync group create", OPT::SYNC_GROUP_CREATE },
   { "sync group modify", OPT::SYNC_GROUP_MODIFY },
@@ -1113,12 +1183,14 @@ static SimpleCmd::Commands all_cmds = {
   { "sync group pipe modify", OPT::SYNC_GROUP_PIPE_MODIFY },
   { "sync group pipe remove", OPT::SYNC_GROUP_PIPE_REMOVE },
   { "bilog list", OPT::BILOG_LIST },
+#ifdef WITH_RADOSGW_RADOS
   { "bilog trim", OPT::BILOG_TRIM },
   { "bilog status", OPT::BILOG_STATUS },
   { "bilog autotrim", OPT::BILOG_AUTOTRIM },
   { "data sync status", OPT::DATA_SYNC_STATUS },
   { "data sync init", OPT::DATA_SYNC_INIT },
   { "data sync run", OPT::DATA_SYNC_RUN },
+#endif
   { "datalog list", OPT::DATALOG_LIST },
   { "datalog status", OPT::DATALOG_STATUS },
   { "datalog autotrim", OPT::DATALOG_AUTOTRIM },
@@ -1158,7 +1230,9 @@ static SimpleCmd::Commands all_cmds = {
   { "global ratelimit enable", OPT::GLOBAL_RATELIMIT_ENABLE },
   { "global ratelimit disable", OPT::GLOBAL_RATELIMIT_DISABLE },
   { "sync info", OPT::SYNC_INFO },
+#ifdef WITH_RADOSGW_RADOS
   { "sync status", OPT::SYNC_STATUS },
+#endif
   { "role create", OPT::ROLE_CREATE },
   { "role delete", OPT::ROLE_DELETE },
   { "role get", OPT::ROLE_GET },
@@ -1176,6 +1250,7 @@ static SimpleCmd::Commands all_cmds = {
   { "role policy detach", OPT::ROLE_POLICY_DETACH },
   { "role policy list attached", OPT::ROLE_POLICY_LIST_ATTACHED },
   { "role update", OPT::ROLE_UPDATE },
+#ifdef WITH_RADOSGW_RADOS
   { "reshard bucket", OPT::BUCKET_RESHARD },
   { "reshard add", OPT::RESHARD_ADD },
   { "reshard list", OPT::RESHARD_LIST },
@@ -1194,14 +1269,17 @@ static SimpleCmd::Commands all_cmds = {
   { "reshard stale delete", OPT::RESHARD_STALE_INSTANCES_DELETE },
   { "reshardlog list", OPT::RESHARDLOG_LIST},
   { "reshardlog purge", OPT::RESHARDLOG_PURGE},
+#endif
   { "topic list", OPT::PUBSUB_TOPIC_LIST },
   { "topic get", OPT::PUBSUB_TOPIC_GET },
   { "topic rm", OPT::PUBSUB_TOPIC_RM },
   { "notification list", OPT::PUBSUB_NOTIFICATION_LIST },
   { "notification get", OPT::PUBSUB_NOTIFICATION_GET },
   { "notification rm", OPT::PUBSUB_NOTIFICATION_RM },
+#ifdef WITH_RADOSGW_RADOS
   { "topic stats", OPT::PUBSUB_TOPIC_STATS },
   { "topic dump", OPT::PUBSUB_TOPIC_DUMP },
+#endif
   { "script put", OPT::SCRIPT_PUT },
   { "script get", OPT::SCRIPT_GET },
   { "script rm", OPT::SCRIPT_RM },
@@ -1284,6 +1362,7 @@ static void show_policy_arns(const boost::container::flat_set<std::string>& arns
   formatter->close_section();
 }
 
+#ifdef WITH_RADOSGW_RADOS
 static void show_reshard_status(
   const list<cls_rgw_bucket_instance_entry>& status, Formatter *formatter)
 {
@@ -1296,6 +1375,7 @@ static void show_reshard_status(
   formatter->close_section();
   formatter->flush(cout);
 }
+#endif
 
 static void show_topics_info_v2(const rgw_pubsub_topic& topic,
                                 const std::set<std::string>& subscribed_buckets,
@@ -1785,6 +1865,7 @@ int check_min_obj_stripe_size(rgw::sal::Driver* driver, rgw::sal::Object* obj, u
 }
 
 
+#ifdef WITH_RADOSGW_RADOS
 int check_obj_locator_underscore(rgw::sal::Object* obj, bool fix, bool remove_bad, Formatter *f) {
   f->open_object_section("object");
   f->open_object_section("key");
@@ -1826,7 +1907,9 @@ done:
 
   return 0;
 }
+#endif
 
+#ifdef WITH_RADOSGW_RADOS
 int check_obj_tail_locator_underscore(RGWBucketInfo& bucket_info, rgw_obj_key& key, bool fix, Formatter *f) {
   f->open_object_section("object");
   f->open_object_section("key");
@@ -1853,7 +1936,9 @@ int check_obj_tail_locator_underscore(RGWBucketInfo& bucket_info, rgw_obj_key& k
 
   return 0;
 }
+#endif
 
+#ifdef WITH_RADOSGW_RADOS
 int do_check_object_locator(const string& tenant_name, const string& bucket_name,
                             bool fix, bool remove_bad, Formatter *f)
 {
@@ -1926,6 +2011,7 @@ int do_check_object_locator(const string& tenant_name, const string& bucket_name
 
   return 0;
 }
+#endif
 
 /// search for a matching zone/zonegroup id and return a connection if found
 static boost::optional<RGWRESTConn> get_remote_conn(rgw::sal::RadosStore* driver,
@@ -2213,6 +2299,7 @@ static int update_period(rgw::sal::ConfigStore* cfgstore,
   return 0;
 }
 
+#ifdef WITH_RADOSGW_RADOS
 static int init_bucket_for_sync(const string& tenant, const string& bucket_name,
                                 const string& bucket_id,
 				std::unique_ptr<rgw::sal::Bucket>* bucket)
@@ -2225,6 +2312,7 @@ static int init_bucket_for_sync(const string& tenant, const string& bucket_name,
 
   return 0;
 }
+#endif
 
 static int do_period_pull(rgw::sal::ConfigStore* cfgstore,
                           RGWRESTConn *remote_conn, const string& url,
@@ -2301,6 +2389,7 @@ stringstream& push_ss(stringstream& ss, list<string>& l, int tab = 0)
   return ss;
 }
 
+#ifdef WITH_RADOSGW_RADOS
 static void get_md_sync_status(list<string>& status)
 {
   RGWMetaSyncStatusManager sync(static_cast<rgw::sal::RadosStore*>(driver), static_cast<rgw::sal::RadosStore*>(driver)->svc()->async_processor);
@@ -2679,6 +2768,7 @@ static void sync_status(Formatter *formatter)
 
   tab_dump("data sync", width, data_status);
 }
+#endif
 
 struct indented {
   int w; // indent width
@@ -2759,6 +2849,7 @@ struct bucket_source_sync_info {
   }
 };
 
+#ifdef WITH_RADOSGW_RADOS
 static int bucket_source_sync_status(const DoutPrefixProvider *dpp, rgw::sal::RadosStore* driver,
                                      const RGWZone& zone,
                                      const RGWZone& source, RGWRESTConn *conn,
@@ -2873,6 +2964,7 @@ static int bucket_source_sync_status(const DoutPrefixProvider *dpp, rgw::sal::Ra
   source_sync_info.shards_behind = std::move(shards_behind);
   return 0;
 }
+#endif
 
 void encode_json(const char *name, const RGWBucketSyncFlowManager::pipe_set& pset, Formatter *f)
 {
@@ -3043,6 +3135,7 @@ static int sync_info(std::optional<rgw_zone_id> opt_target_zone, std::optional<r
   return 0;
 }
 
+#ifdef WITH_RADOSGW_RADOS
 static int bucket_sync_info(rgw::sal::Driver* driver, const RGWBucketInfo& info,
                               std::ostream& out)
 {
@@ -3080,6 +3173,7 @@ static int bucket_sync_info(rgw::sal::Driver* driver, const RGWBucketInfo& info,
 
   return 0;
 }
+#endif
 
 struct bucket_sync_status_info {
   std::vector<bucket_source_sync_info> source_status_info;
@@ -3144,6 +3238,7 @@ struct bucket_sync_status_info {
 
 };
 
+#ifdef WITH_RADOSGW_RADOS
 static int bucket_sync_status(rgw::sal::Driver* driver, const RGWBucketInfo& info,
                               const rgw_zone_id& source_zone_id,
 			      std::optional<rgw_bucket>& opt_source_bucket,
@@ -3226,6 +3321,7 @@ static int bucket_sync_status(rgw::sal::Driver* driver, const RGWBucketInfo& inf
 
   return 0;
 }
+#endif
 
 static void parse_tier_config_param(const string& s, map<string, string, ltstr_nocase>& out)
 {
@@ -3261,6 +3357,7 @@ static void parse_tier_config_param(const string& s, map<string, string, ltstr_n
   }
 }
 
+#ifdef WITH_RADOSGW_RADOS
 static int check_pool_support_omap(const rgw_pool& pool)
 {
   librados::IoCtx io_ctx;
@@ -3278,6 +3375,7 @@ static int check_pool_support_omap(const rgw_pool& pool)
   io_ctx.close();
   return 0;
 }
+#endif
 
 int check_reshard_bucket_params(rgw::sal::Driver* driver,
 				const string& bucket_name,
@@ -3332,6 +3430,7 @@ int check_reshard_bucket_params(rgw::sal::Driver* driver,
   return 0;
 }
 
+#ifdef WITH_RADOSGW_RADOS
 static int scan_totp(CephContext *cct, ceph::real_time& now, rados::cls::otp::otp_info_t& totp, vector<string>& pins,
                      time_t *pofs)
 {
@@ -3401,6 +3500,7 @@ static int trim_sync_error_log(int shard_id, const string& marker, int delay_ms)
   }
   // unreachable
 }
+#endif
 
 static bool symmetrical_flow_opt(const string& opt)
 {
@@ -3759,9 +3859,11 @@ int main(int argc, const char **argv)
   list<string> tags;
   list<string> tags_add;
   list<string> tags_rm;
+#ifdef WITH_RADOSGW_RADOS
   int placement_inline_data = true;
   bool placement_inline_data_specified = false;
   bool format_arg_passed = false;
+#endif
 
   int64_t max_objects = -1;
   int64_t max_size = -1;
@@ -3771,8 +3873,10 @@ int main(int argc, const char **argv)
   int64_t max_delete_ops = 0;
   int64_t max_read_bytes = 0;
   int64_t max_write_bytes = 0;
+#ifdef WITH_RADOSGW_RADOS
   uint32_t max_bucket_index_ops = 0;
   uint32_t max_metadata_ops = 0;
+#endif
   bool have_max_objects = false;
   bool have_max_size = false;
   bool have_max_write_ops = false;
@@ -3781,12 +3885,14 @@ int main(int argc, const char **argv)
   bool have_max_delete_ops = false;
   bool have_max_write_bytes = false;
   bool have_max_read_bytes = false;
+#ifdef WITH_RADOSGW_RADOS
   bool have_max_bucket_index_ops = false;
   bool have_max_metadata_ops = false;
   std::string allow_bucket_list_file;
   std::string deny_bucket_list_file;
   std::string allow_storage_class_list_file;
   std::string deny_storage_class_list_file;
+#endif
   int include_all = false;
   int allow_unordered = false;
 
@@ -3800,9 +3906,11 @@ int main(int argc, const char **argv)
 
   int extra_info = false;
 
+#ifdef WITH_RADOSGW_RADOS
   uint64_t min_rewrite_size = 4 * 1024 * 1024;
   uint64_t max_rewrite_size = ULLONG_MAX;
   uint64_t min_rewrite_stripe_size = 0;
+#endif
 
   BIIndexType bi_index_type = BIIndexType::Plain;
   std::optional<log_type> opt_log_type;
@@ -3816,7 +3924,9 @@ int main(int argc, const char **argv)
   ceph::timespan min_age = std::chrono::hours(1);
   bool hide_progress = false;
   bool dump_keys = false;
+#ifdef WITH_RADOSGW_RADOS
   uint64_t orphan_stale_secs = (24 * 3600);
+#endif
   int detail = false;
 
   std::string val;
@@ -3835,8 +3945,10 @@ int main(int argc, const char **argv)
   boost::optional<string> index_pool;
   boost::optional<string> data_pool;
   boost::optional<string> data_extra_pool;
+#ifdef WITH_RADOSGW_RADOS
   rgw::BucketIndexType placement_index_type = rgw::BucketIndexType::Normal;
   bool index_type_specified = false;
+#endif
 
   boost::optional<std::string> compression_type;
 
@@ -3844,9 +3956,11 @@ int main(int argc, const char **argv)
   string totp_seed;
   string totp_seed_type = "hex";
   vector<string> totp_pin;
+#ifdef WITH_RADOSGW_RADOS
   int totp_seconds = 0;
   int totp_window = 0;
   int trim_delay_ms = 0;
+#endif
 
   string topic_name;
   string notification_id;
@@ -4036,12 +4150,14 @@ int main(int argc, const char **argv)
       // do nothing
     } else if (ceph_argparse_binary_flag(args, i, &commit, NULL, "--commit", (char*)NULL)) {
       // do nothing
+#ifdef WITH_RADOSGW_RADOS
     } else if (ceph_argparse_witharg(args, i, &val, "--min-rewrite-size", (char*)NULL)) {
       min_rewrite_size = (uint64_t)atoll(val.c_str());
     } else if (ceph_argparse_witharg(args, i, &val, "--max-rewrite-size", (char*)NULL)) {
       max_rewrite_size = (uint64_t)atoll(val.c_str());
     } else if (ceph_argparse_witharg(args, i, &val, "--min-rewrite-stripe-size", (char*)NULL)) {
       min_rewrite_stripe_size = (uint64_t)atoll(val.c_str());
+#endif
     } else if (ceph_argparse_witharg(args, i, &val, "--max-buckets", (char*)NULL)) {
       max_buckets = ceph::parse<int>(val);
       if (!max_buckets) {
@@ -4112,18 +4228,25 @@ int main(int argc, const char **argv)
       }
       have_max_write_bytes = true;
     } else if (ceph_argparse_witharg(args, i, &val, "--max-bucket-index-ops", (char*)NULL)) {
+#ifdef WITH_RADOSGW_RADOS
       max_bucket_index_ops = (int64_t)strict_strtoll(val.c_str(), 10, &err);
+#endif
       if (!err.empty()) {
 	cerr << "ERROR: failed to parse max bucket index ops: " << err << std::endl;
 	return EINVAL;
       }
+#ifdef WITH_RADOSGW_RADOS
       have_max_bucket_index_ops = true;
+#endif
     } else if (ceph_argparse_witharg(args, i, &val, "--max-metadata-ops", (char*)NULL)) {
+#ifdef WITH_RADOSGW_RADOS
       max_metadata_ops = (int64_t)strict_strtoll(val.c_str(), 10, &err);
+#endif
       if (!err.empty()) {
 	cerr << "ERROR: failed to parse max metadata ops: " << err << std::endl;
 	return EINVAL;
       }
+#ifdef WITH_RADOSGW_RADOS
       have_max_metadata_ops = true;
     } else if (ceph_argparse_witharg(args, i, &val, "--allow-bucket-list", (char*)NULL)) {
       allow_bucket_list_file = val;
@@ -4133,6 +4256,7 @@ int main(int argc, const char **argv)
       allow_storage_class_list_file = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--deny-storage-class-list", (char*)NULL)) {
       deny_storage_class_list_file = val;
+#endif
     } else if (ceph_argparse_witharg(args, i, &val, "--date", "--time", (char*)NULL)) {
       date = val;
       if (end_date.empty())
@@ -4162,12 +4286,14 @@ int main(int argc, const char **argv)
       }
     } else if (ceph_argparse_witharg(args, i, &val, "--min-age-hours", (char*)NULL)) {
       min_age = std::chrono::hours(atoi(val.c_str()));
+#ifdef WITH_RADOSGW_RADOS
     } else if (ceph_argparse_witharg(args, i, &val, "--orphan-stale-secs", (char*)NULL)) {
       orphan_stale_secs = (uint64_t)strict_strtoll(val.c_str(), 10, &err);
       if (!err.empty()) {
         cerr << "ERROR: failed to parse orphan stale secs: " << err << std::endl;
         return EINVAL;
       }
+#endif
     } else if (ceph_argparse_witharg(args, i, &val, "--shard-id", (char*)NULL)) {
       shard_id = (int)strict_strtol(val.c_str(), 10, &err);
       if (!err.empty()) {
@@ -4208,7 +4334,9 @@ int main(int argc, const char **argv)
       new_bucket_name = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--format", (char*)NULL)) {
       format = val;
+#ifdef WITH_RADOSGW_RADOS
       format_arg_passed = true;
+#endif
     } else if (ceph_argparse_witharg(args, i, &val, "--categories", (char*)NULL)) {
       string cat_str = val;
       list<string> cat_list;
@@ -4257,8 +4385,10 @@ int main(int argc, const char **argv)
       hide_progress = true;
     } else if (ceph_argparse_flag(args, i, "--dump-keys", (char*)NULL)) {
       dump_keys = true;
+#ifdef WITH_RADOSGW_RADOS
     } else if (ceph_argparse_binary_flag(args, i, &placement_inline_data, NULL, "--placement-inline-data", (char*)NULL)) {
       placement_inline_data_specified = true;
+#endif
      // do nothing
     } else if (ceph_argparse_witharg(args, i, &val, "--caps", (char*)NULL)) {
       caps = val;
@@ -4375,6 +4505,7 @@ int main(int argc, const char **argv)
       data_pool = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--data-extra-pool", (char*)NULL)) {
       data_extra_pool = val;
+#ifdef WITH_RADOSGW_RADOS
     } else if (ceph_argparse_witharg(args, i, &val, "--placement-index-type", (char*)NULL)) {
       if (val == "normal") {
         placement_index_type = rgw::BucketIndexType::Normal;
@@ -4388,6 +4519,7 @@ int main(int argc, const char **argv)
         }
       }
       index_type_specified = true;
+#endif
     } else if (ceph_argparse_witharg(args, i, &val, "--compression", (char*)NULL)) {
       compression_type = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--role-name", (char*)NULL)) {
@@ -4416,12 +4548,14 @@ int main(int argc, const char **argv)
       totp_seed = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--totp-seed-type", (char*)NULL)) {
       totp_seed_type = val;
+#ifdef WITH_RADOSGW_RADOS
     } else if (ceph_argparse_witharg(args, i, &val, "--totp-seconds", (char*)NULL)) {
       totp_seconds = atoi(val.c_str());
     } else if (ceph_argparse_witharg(args, i, &val, "--totp-window", (char*)NULL)) {
       totp_window = atoi(val.c_str());
     } else if (ceph_argparse_witharg(args, i, &val, "--trim-delay-ms", (char*)NULL)) {
       trim_delay_ms = atoi(val.c_str());
+#endif
     } else if (ceph_argparse_witharg(args, i, &val, "--topic", (char*)NULL)) {
       topic_name = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--notification-id", (char*)NULL)) {
@@ -4570,12 +4704,14 @@ int main(int argc, const char **argv)
     /* some commands may have an optional extra param */
     if (!extra_args.empty()) {
       switch (opt_cmd) {
+#ifdef WITH_RADOSGW_RADOS
         case OPT::METADATA_GET:
         case OPT::METADATA_PUT:
         case OPT::METADATA_RM:
         case OPT::METADATA_LIST:
           metadata_key = extra_args[0];
           break;
+#endif
         default:
           break;
       }
@@ -4604,7 +4740,10 @@ int main(int argc, const char **argv)
 			 OPT::ZONE_CREATE, OPT::ZONE_DELETE,
 			 OPT::ZONE_GET, OPT::ZONE_SET, OPT::ZONE_RENAME,
 			 OPT::ZONE_LIST, OPT::ZONE_MODIFY, OPT::ZONE_DEFAULT,
-			 OPT::ZONE_PLACEMENT_ADD, OPT::ZONE_PLACEMENT_RM,
+#ifdef WITH_RADOSGW_RADOS
+			 OPT::ZONE_PLACEMENT_ADD, 
+#endif
+			 OPT::ZONE_PLACEMENT_RM,
 			 OPT::ZONE_PLACEMENT_MODIFY, OPT::ZONE_PLACEMENT_LIST,
 			 OPT::ZONE_PLACEMENT_GET,
 			 OPT::REALM_CREATE,
@@ -4632,6 +4771,7 @@ int main(int argc, const char **argv)
 			 OPT::BUCKET_LIMIT_CHECK,
 			 OPT::BUCKET_LAYOUT,
 			 OPT::BUCKET_STATS,
+#ifdef WITH_RADOSGW_RADOS
 			 OPT::BUCKET_SYNC_CHECKPOINT,
 			 OPT::BUCKET_SYNC_INFO,
 			 OPT::BUCKET_SYNC_STATUS,
@@ -4640,8 +4780,10 @@ int main(int argc, const char **argv)
 			 OPT::BUCKET_OBJECT_SHARD,
 			 OPT::LOG_LIST,
 			 OPT::LOG_SHOW,
+#endif
 			 OPT::USAGE_SHOW,
 			 OPT::OBJECT_STAT,
+#ifdef WITH_RADOSGW_RADOS
 			 OPT::OBJECT_MANIFEST,
 			 OPT::BI_GET,
 			 OPT::BI_LIST,
@@ -4655,8 +4797,11 @@ int main(int argc, const char **argv)
 			 OPT::DEDUP_RESUME,
 			 OPT::DEDUP_THROTTLE,
 			 OPT::GC_LIST,
+#endif
 			 OPT::LC_LIST,
+#ifdef WITH_RADOSGW_RADOS
 			 OPT::ORPHANS_LIST_JOBS,
+#endif
 			 OPT::ZONEGROUP_GET,
 			 OPT::ZONEGROUP_LIST,
 			 OPT::ZONEGROUP_PLACEMENT_LIST,
@@ -4665,17 +4810,21 @@ int main(int argc, const char **argv)
 			 OPT::ZONE_LIST,
 			 OPT::ZONE_PLACEMENT_LIST,
 			 OPT::ZONE_PLACEMENT_GET,
+#ifdef WITH_RADOSGW_RADOS
 			 OPT::METADATA_GET,
 			 OPT::METADATA_LIST,
 			 OPT::METADATA_SYNC_STATUS,
 			 OPT::MDLOG_LIST,
 			 OPT::MDLOG_STATUS,
 			 OPT::SYNC_ERROR_LIST,
+#endif
 			 OPT::SYNC_GROUP_GET,
 			 OPT::SYNC_POLICY_GET,
 			 OPT::BILOG_LIST,
+#ifdef WITH_RADOSGW_RADOS
 			 OPT::BILOG_STATUS,
 			 OPT::DATA_SYNC_STATUS,
+#endif
 			 OPT::DATALOG_LIST,
 			 OPT::DATALOG_SEMAPHORE_LIST,
 			 OPT::DATALOG_STATUS,
@@ -4687,40 +4836,50 @@ int main(int argc, const char **argv)
 			 OPT::PERIOD_GET_CURRENT,
 			 OPT::PERIOD_LIST,
 			 OPT::GLOBAL_QUOTA_GET,
-       OPT::GLOBAL_RATELIMIT_GET,
+		     OPT::GLOBAL_RATELIMIT_GET,
 			 OPT::SYNC_INFO,
+#ifdef WITH_RADOSGW_RADOS
 			 OPT::SYNC_STATUS,
+#endif
 			 OPT::ROLE_GET,
 			 OPT::ROLE_LIST,
 			 OPT::ROLE_POLICY_LIST,
 			 OPT::ROLE_POLICY_GET,
 			 OPT::ROLE_POLICY_LIST_ATTACHED,
+#ifdef WITH_RADOSGW_RADOS
 			 OPT::RESHARD_LIST,
 			 OPT::RESHARD_STATUS,
+#endif			 
 			 OPT::PUBSUB_TOPIC_LIST,
        OPT::PUBSUB_NOTIFICATION_LIST,
 			 OPT::PUBSUB_TOPIC_GET,
        OPT::PUBSUB_NOTIFICATION_GET,
+#ifdef WITH_RADOSGW_RADOS
        OPT::PUBSUB_TOPIC_STATS  ,
        OPT::PUBSUB_TOPIC_DUMP  ,
+#endif
 			 OPT::SCRIPT_GET,
        OPT::RESTORE_STATUS,
        OPT::RESTORE_LIST,
     };
 
     std::set<OPT> gc_ops_list = {
+#ifdef WITH_RADOSGW_RADOS
 			 OPT::GC_LIST,
 			 OPT::GC_PROCESS,
+#endif
 			 OPT::OBJECT_RM,
 			 OPT::BUCKET_RM,  // --purge-objects
 			 OPT::USER_RM,    // --purge-data
 			 OPT::OBJECTS_EXPIRE,
 			 OPT::OBJECTS_EXPIRE_STALE_RM,
+#ifdef WITH_RADOSGW_RADOS
 			 OPT::LC_PROCESS,
        OPT::BUCKET_SYNC_RUN,
        OPT::DATA_SYNC_RUN,
        OPT::BUCKET_REWRITE,
        OPT::OBJECT_REWRITE
+#endif
     };
 
     raw_storage_op = (raw_storage_ops_list.find(opt_cmd) != raw_storage_ops_list.end() ||
@@ -4799,17 +4958,21 @@ int main(int argc, const char **argv)
                           && opt_cmd != OPT::ROLE_POLICY_DETACH
                           && opt_cmd != OPT::ROLE_POLICY_LIST_ATTACHED
                           && opt_cmd != OPT::ROLE_UPDATE
+#ifdef WITH_RADOSGW_RADOS
                           && opt_cmd != OPT::RESHARD_ADD
                           && opt_cmd != OPT::RESHARD_CANCEL
                           && opt_cmd != OPT::RESHARD_STATUS
+#endif			  
                           && opt_cmd != OPT::PUBSUB_TOPIC_LIST
                           && opt_cmd != OPT::PUBSUB_NOTIFICATION_LIST
                           && opt_cmd != OPT::PUBSUB_TOPIC_GET
                           && opt_cmd != OPT::PUBSUB_NOTIFICATION_GET
                           && opt_cmd != OPT::PUBSUB_TOPIC_RM
                           && opt_cmd != OPT::PUBSUB_NOTIFICATION_RM
+#ifdef WITH_RADOSGW_RADOS
                           && opt_cmd != OPT::PUBSUB_TOPIC_STATS
                           && opt_cmd != OPT::PUBSUB_TOPIC_DUMP
+#endif
 			  && opt_cmd != OPT::SCRIPT_PUT
 			  && opt_cmd != OPT::SCRIPT_GET
 			  && opt_cmd != OPT::SCRIPT_RM
@@ -6664,7 +6827,9 @@ int main(int argc, const char **argv)
 	}
       }
       break;
+#ifdef WITH_RADOSGW_RADOS
     case OPT::ZONE_PLACEMENT_ADD:
+#endif
     case OPT::ZONE_PLACEMENT_MODIFY:
     case OPT::ZONE_PLACEMENT_RM:
       {
@@ -6688,6 +6853,7 @@ int main(int argc, const char **argv)
 	  return -ret;
 	}
 
+#ifdef WITH_RADOSGW_RADOS
         if (opt_cmd == OPT::ZONE_PLACEMENT_ADD ||
 	    opt_cmd == OPT::ZONE_PLACEMENT_MODIFY) {
 	  RGWZoneGroup zonegroup;
@@ -6760,7 +6926,9 @@ int main(int argc, const char **argv)
                  << "' does not support omap" << std::endl;
              return ret;
           }
-        } else if (opt_cmd == OPT::ZONE_PLACEMENT_RM) {
+        } else 
+#endif
+	    if (opt_cmd == OPT::ZONE_PLACEMENT_RM) {
           if (!opt_storage_class ||
               opt_storage_class->empty()) {
             zone.placement_pools.erase(placement_id);
@@ -6838,10 +7006,16 @@ int main(int argc, const char **argv)
                                         OPT::USER_MODIFY, OPT::USER_ENABLE,
                                         OPT::USER_SUSPEND, OPT::SUBUSER_CREATE,
                                         OPT::SUBUSER_MODIFY, OPT::SUBUSER_RM,
+#ifdef WITH_RADOSGW_RADOS
                                         OPT::BUCKET_LINK, OPT::BUCKET_UNLINK,
-                                        OPT::BUCKET_CHOWN, OPT::METADATA_PUT,
-                                        OPT::METADATA_RM, OPT::MFA_CREATE,
+#endif
+                                        OPT::BUCKET_CHOWN, 
+#ifdef WITH_RADOSGW_RADOS
+                                        OPT::METADATA_PUT,
+                                        OPT::METADATA_RM,
+				       	                OPT::MFA_CREATE,
                                         OPT::MFA_REMOVE, OPT::MFA_RESYNC,
+#endif
                                         OPT::CAPS_ADD, OPT::CAPS_RM,
                                         OPT::ROLE_CREATE, OPT::ROLE_DELETE,
                                         OPT::ROLE_POLICY_PUT, OPT::ROLE_POLICY_DELETE,
@@ -7719,6 +7893,7 @@ int main(int argc, const char **argv)
     } /* have bucket_name */
   } /* OPT::BUCKETS_LIST */
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::BUCKET_RADOS_LIST) {
     RGWRadosList lister(static_cast<rgw::sal::RadosStore*>(driver),
 			max_concurrent_ios, orphan_stale_secs, tenant);
@@ -7747,6 +7922,7 @@ int main(int argc, const char **argv)
       return -ret;
     }
   }
+#endif
 
   if (opt_cmd == OPT::BUCKET_LAYOUT) {
     if (bucket_name.empty()) {
@@ -7788,6 +7964,7 @@ int main(int argc, const char **argv)
     }
   }
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::BUCKET_LINK) {
     bucket_op.set_bucket_id(bucket_id);
     bucket_op.set_new_bucket_name(new_bucket_name);
@@ -7806,6 +7983,7 @@ int main(int argc, const char **argv)
       return -r;
     }
   }
+#endif
 
   if (opt_cmd == OPT::BUCKET_SHARD_OBJECTS) {
     const auto prefix = opt_prefix ? *opt_prefix : "obj"s;
@@ -7870,6 +8048,7 @@ int main(int argc, const char **argv)
     formatter->flush(cout);
   }
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::BUCKET_RESYNC_ENCRYPTED_MULTIPART) {
     // repair logic for replication of encrypted multipart uploads:
     // https://tracker.ceph.com/issues/46062
@@ -7910,6 +8089,7 @@ int main(int argc, const char **argv)
     formatter->flush(cout);
     return 0;
   }
+#endif
 
   if (opt_cmd == OPT::BUCKET_CHOWN) {
     if (bucket_name.empty()) {
@@ -8018,6 +8198,7 @@ int main(int argc, const char **argv)
     return 0;
   }
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::BUCKET_LOGGING_LIST) {
     if (bucket_name.empty()) {
       cerr << "ERROR: bucket not specified" << std::endl;
@@ -8200,6 +8381,7 @@ next:
       }
     }
   }
+#endif
 
   if (opt_cmd == OPT::USAGE_SHOW) {
     uint64_t start_epoch = 0;
@@ -8295,6 +8477,7 @@ next:
   }
 
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::OLH_GET || opt_cmd == OPT::OLH_READLOG) {
     if (bucket_name.empty()) {
       cerr << "ERROR: bucket not specified" << std::endl;
@@ -8535,6 +8718,7 @@ next:
       }
     }
   }
+#endif
 
   if (opt_cmd == OPT::OBJECT_PUT) {
     if (bucket_name.empty()) {
@@ -8593,6 +8777,7 @@ next:
     }
   }
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::OBJECT_REWRITE) {
     if (bucket_name.empty()) {
       cerr << "ERROR: bucket not specified" << std::endl;
@@ -8709,6 +8894,7 @@ next:
       } // while
     }
   } // OPT::OBJECT_REINDEX
+#endif
 
   if (opt_cmd == OPT::OBJECTS_EXPIRE) {
     if (!driver->process_expired_objects(dpp(), null_yield)) {
@@ -8733,6 +8919,7 @@ next:
     }
   }
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::BUCKET_REWRITE) {
     if (bucket_name.empty()) {
       cerr << "ERROR: bucket not specified" << std::endl;
@@ -9081,6 +9268,7 @@ next:
       return -ret;
     }
   } // OPT_RESHARD_CANCEL
+#endif
 
   if (opt_cmd == OPT::BUCKET_SET_MIN_SHARDS) {
     if (bucket_name.empty()) {
@@ -9235,6 +9423,7 @@ next:
     formatter->flush(cout);
   } // OPT::OBJECT_STAT
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::OBJECT_MANIFEST) {
     int ret = init_bucket(tenant, bucket_name, bucket_id, &bucket);
     if (ret < 0) {
@@ -9324,7 +9513,9 @@ next:
     formatter->close_section(); // outer
     formatter->flush(cout);
   } // OPT::OBJECT_MANIFEST
+#endif
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::BUCKET_CHECK) {
     if (check_head_obj_locator) {
       if (bucket_name.empty()) {
@@ -9358,6 +9549,7 @@ next:
     }
     RGWBucketAdminOp::check_index_unlinked(store, bucket_op, stream_flusher, dpp());
   }
+#endif
 
   if (opt_cmd == OPT::BUCKET_RM) {
     if (!inconsistent_index) {
@@ -9372,6 +9564,7 @@ next:
     }
   }
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::DEDUP_STATS    ||
       opt_cmd == OPT::DEDUP_ESTIMATE ||
       opt_cmd == OPT::DEDUP_ABORT    ||
@@ -9542,6 +9735,7 @@ next:
       return 1;
     }
   }
+#endif
 
   if (opt_cmd == OPT::LC_LIST) {
     formatter->open_array_section("lifecycle_list");
@@ -9611,6 +9805,7 @@ next:
     formatter->flush(cout);
   }
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::LC_PROCESS) {
     if ((! bucket_name.empty()) ||
 	(! bucket_id.empty())) {
@@ -9629,6 +9824,7 @@ next:
       return 1;
     }
   }
+#endif
 
   if (opt_cmd == OPT::LC_RESHARD_FIX) {
     ret = RGWBucketAdminOp::fix_lc_shards(driver, bucket_op, stream_flusher, dpp(), null_yield);
@@ -9638,6 +9834,7 @@ next:
 
   }
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::ORPHANS_FIND) {
     if (!yes_i_really_mean_it) {
       cerr << "this command is now deprecated; please consider using the rgw-orphan-list tool; "
@@ -9744,6 +9941,7 @@ next:
     formatter->close_section();
     formatter->flush(cout);
   }
+#endif
 
   if (opt_cmd == OPT::USER_CHECK) {
     check_bad_owner_bucket_mapping(driver, user->get_id(),
@@ -9948,6 +10146,7 @@ next:
     return 0;
   }
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::METADATA_GET) {
     int ret = static_cast<rgw::sal::RadosStore*>(driver)->ctl()->meta.mgr->get(metadata_key, formatter.get(), null_yield, dpp());
     if (ret < 0) {
@@ -9979,8 +10178,12 @@ next:
       return -ret;
     }
   }
+#endif
 
-  if (opt_cmd == OPT::METADATA_LIST ||
+  if (
+#ifdef WITH_RADOSGW_RADOS
+      opt_cmd == OPT::METADATA_LIST ||
+#endif
       opt_cmd == OPT::USER_LIST ||
       opt_cmd == OPT::ACCOUNT_LIST) {
     if (opt_cmd == OPT::USER_LIST) {
@@ -10055,6 +10258,7 @@ next:
     driver->meta_list_keys_complete(handle);
   }
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::MDLOG_LIST) {
     if (!start_date.empty()) {
       std::cerr << "start-date not allowed." << std::endl;
@@ -10234,11 +10438,13 @@ next:
       return -ret;
     }
   }
+#endif
 
   if (opt_cmd == OPT::SYNC_INFO) {
     sync_info(opt_effective_zone_id, opt_bucket, zone_formatter.get());
   }
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::SYNC_STATUS) {
     sync_status(formatter.get());
   }
@@ -10804,6 +11010,7 @@ next:
       }
     }
   }
+#endif
 
   if (opt_cmd == OPT::SYNC_GROUP_CREATE ||
       opt_cmd == OPT::SYNC_GROUP_MODIFY) {
@@ -11139,6 +11346,7 @@ next:
     show_result(sync_policy, zone_formatter.get(), cout);
   }
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::BILOG_TRIM) {
     if (bucket_name.empty()) {
       cerr << "ERROR: bucket not specified" << std::endl;
@@ -11457,6 +11665,7 @@ next:
       std::cout << "No empty generations." << std::endl;
     }
   }
+#endif
 
   bool quota_op = (opt_cmd == OPT::QUOTA_SET || opt_cmd == OPT::QUOTA_ENABLE || opt_cmd == OPT::QUOTA_DISABLE);
 
@@ -11574,6 +11783,7 @@ next:
     }
   }
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::MFA_CREATE) {
     rados::cls::otp::otp_info_t config;
 
@@ -11926,6 +12136,7 @@ next:
       return -ret;
     }
   }
+#endif
 
   if (opt_cmd == OPT::PUBSUB_NOTIFICATION_LIST) {
     if (bucket_name.empty()) {
@@ -12152,6 +12363,7 @@ next:
     }
   }
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::PUBSUB_TOPIC_STATS) {
     if (topic_name.empty()) {
       cerr << "ERROR: topic name was not provided (via --topic)" << std::endl;
@@ -12249,6 +12461,7 @@ next:
     formatter->close_section();
     formatter->flush(cout);
   }
+#endif
 
   if (opt_cmd == OPT::SCRIPT_PUT) {
     if (!str_script_ctx) {

--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1506,11 +1506,8 @@ namespace rgw {
     if (factory == nullptr) {
       return false;
     }
-    /* make sure the reclaiming object is the same partition with newobject factory,
-     * then we can recycle the object, and replace with newobject */
-    if (!fs->fh_cache.is_same_partition(factory->fhk.fh_hk.object, fh.fh_hk.object)) {
-      return false;
-    }
+    /* XXXX seems like we should use a flag rather than is_linked(),
+     * as we now depend on safe_link mode */
     /* in the non-delete case, handle may still be in handle table */
     if (fh_hook.is_linked()) {
       /* in this case, we are being called from a context which holds

--- a/src/rgw/rgw_file_int.h
+++ b/src/rgw/rgw_file_int.h
@@ -1070,7 +1070,7 @@ namespace rgw {
 	/* LATCHED, LOCKED */
 	if (! (flags & RGWFileHandle::FLAG_LOCK))
 	  fh->mtx.unlock(); /* ! LOCKED */
-      }
+      } /* fh */
       lat.lock->unlock(); /* !LATCHED */
       get<0>(fhr) = fh;
       if (fh) {

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -7589,6 +7589,10 @@ void RGWCompleteMultipart::execute(optional_yield y)
   }
 
   upload = s->bucket->get_multipart_upload(s->object->get_name(), upload_id);
+
+  rgw_placement_rule* dest_placement;
+  op_ret = upload->get_info(this, s->yield, &dest_placement);
+
   ldpp_dout(this, 16) <<
     fmt::format("INFO: {}->get_multipart_upload for obj {}, {} cksum_type {}",
 		s->bucket->get_name(),
@@ -7596,8 +7600,6 @@ void RGWCompleteMultipart::execute(optional_yield y)
 		(!!upload) ? to_string(upload->cksum_type) : "nil")
 		<< dendl;
 
-  rgw_placement_rule* dest_placement;
-  op_ret = upload->get_info(this, s->yield, &dest_placement);
   if (op_ret < 0) {
     /* XXX this fails consistently when !checksum */
     ldpp_dout(this, 0) <<

--- a/src/test/rgw/test_rgw_posix_driver.cc
+++ b/src/test/rgw/test_rgw_posix_driver.cc
@@ -1097,7 +1097,7 @@ public:
         }
       }
     }
-
+    quota_handler = RGWQuotaHandler::generate_handler(env->dpp, this, false);
     /* ordered listing cache */
     bucket_cache.reset(new BucketCache(
         this, base_path, cache_base, 100, 3, 3, 3));


### PR DESCRIPTION
Every S3 request calls get_user() at least twice, each of which acquires a global std::mutex protecting SQLite prepared statements. Under high concurrency (e.g. rgw_thread_pool_size=512), this single lock serializes all request processing and causes a a higher lock contention compared to for example 12 threads.

Add a mutex-protected user LRU cache in POSIXDriver that serves repeated lookups from memory. The cache is populated on first DB hit and invalidated on store_user/remove_user.

Benchmark (4K PUT, 100K objects, 256 buckets, hsbench 512 clients):
```
  Before: 512 threads =  3,578 IO/s  (avg lat 142ms)
          12  threads =  6,068 IO/s  (avg lat  84ms)

  After:  512 threads = 19,299 IO/s  (avg lat  26ms)  5.4x
          12  threads =  9,962 IO/s  (avg lat  51ms)  1.6x
```

The perf improvement comes from caches reduced lock hold duration compared to SQLite operation.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
