### PR TITLE
crimson/os/seastore/transaction_manager: refresh `indirect_cursor` after the `direct_cursor` is removed in `TM::_remove()`

### DIFF
--- a/src/crimson/os/seastore/lba/lba_btree_node.cc
+++ b/src/crimson/os/seastore/lba/lba_btree_node.cc
@@ -135,6 +135,7 @@ base_iertr::future<> LBACursor::refresh()
 
   modifications = leaf->modifications;
   iter = leaf->lower_bound(get_laddr());
+  assert(iter == leaf->end() || iter.get_key() == get_laddr());
   assert(is_viewable());
 }
 

--- a/src/crimson/os/seastore/lba/lba_btree_node.cc
+++ b/src/crimson/os/seastore/lba/lba_btree_node.cc
@@ -87,60 +87,55 @@ LBALeafNode::internal_const_iterator_t LBALeafNode::insert(
 base_iertr::future<> LBACursor::refresh()
 {
   LOG_PREFIX(LBACursor::refresh);
-  return with_btree<lba::LBABtree>(
-    ctx.cache,
-    ctx,
-    [this, FNAME, c=ctx](auto &btree) {
-    c.trans.cursor_stats.num_refresh_parent_total++;
 
-    if (!parent->is_valid()) {
-      c.trans.cursor_stats.num_refresh_invalid_parent++;
-      SUBTRACET(
-	seastore_lba,
-	"cursor {} parent is invalid, re-search from scratch",
-	 c.trans, *this);
-      return btree.lower_bound(c, this->get_laddr()
-      ).si_then([this](lba::LBABtree::iterator it) {
-	assert(this->get_laddr() == it.get_key());
-	iter = LBALeafNode::iterator(
-	  it.get_leaf_node().get(),
-	  it.get_leaf_pos());
-	auto leaf = it.get_leaf_node();
-	parent = leaf;
-	modifications = leaf->modifications;
-      });
-    }
-    assert(parent->is_stable() ||
-      parent->is_pending_in_trans(c.trans.get_trans_id()));
-    auto leaf = parent->cast<lba::LBALeafNode>();
-    if (leaf->is_pending_in_trans(c.trans.get_trans_id())) {
-      if (leaf->modified_since(modifications)) {
-	c.trans.cursor_stats.num_refresh_modified_viewable_parent++;
-      } else {
-	// no need to refresh
-	return base_iertr::now();
-      }
-    } else {
-      auto [viewable, l] = leaf->resolve_transaction(c.trans, get_laddr());
-	SUBTRACET(seastore_lba, "cursor: {} viewable: {}",
-	  c.trans, *this, viewable);
-      if (!viewable) {
-	leaf = l;
-	c.trans.cursor_stats.num_refresh_unviewable_parent++;
-	parent = leaf;
-      } else {
-	assert(leaf.get() == l.get());
-	assert(leaf->is_stable());
-	return base_iertr::now();
-      }
-    }
+  auto btree = co_await get_btree<LBABtree>(ctx.cache, ctx);
+  ctx.trans.cursor_stats.num_refresh_parent_total++;
 
+  if (!parent->is_valid()) {
+    ctx.trans.cursor_stats.num_refresh_invalid_parent++;
+    SUBTRACET(
+      seastore_lba,
+      "cursor {} parent is invalid, re-search from scratch",
+       ctx.trans, *this);
+    lba::LBABtree::iterator it = co_await btree.lower_bound(
+      ctx, this->get_laddr());
+    assert(this->get_laddr() == it.get_key());
+    iter = LBALeafNode::iterator(
+      it.get_leaf_node().get(),
+      it.get_leaf_pos());
+    auto leaf = it.get_leaf_node();
+    parent = leaf;
     modifications = leaf->modifications;
-    iter = leaf->lower_bound(get_laddr());
-    assert(is_viewable());
+    co_return;
+  }
+  assert(parent->is_stable() ||
+    parent->is_pending_in_trans(ctx.trans.get_trans_id()));
+  auto leaf = parent->cast<lba::LBALeafNode>();
+  if (leaf->is_pending_in_trans(ctx.trans.get_trans_id())) {
+    if (leaf->modified_since(modifications)) {
+      ctx.trans.cursor_stats.num_refresh_modified_viewable_parent++;
+    } else {
+      // no need to refresh
+      co_return;
+    }
+  } else {
+    auto [viewable, l] = leaf->resolve_transaction(ctx.trans, get_laddr());
+      SUBTRACET(seastore_lba, "cursor: {} viewable: {}",
+        ctx.trans, *this, viewable);
+    if (!viewable) {
+      leaf = l;
+      ctx.trans.cursor_stats.num_refresh_unviewable_parent++;
+      parent = leaf;
+    } else {
+      assert(leaf.get() == l.get());
+      assert(leaf->is_stable());
+      co_return;
+    }
+  }
 
-    return base_iertr::now();
-  });
+  modifications = leaf->modifications;
+  iter = leaf->lower_bound(get_laddr());
+  assert(is_viewable());
 }
 
 }

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -331,6 +331,12 @@ TransactionManager::_remove(
     indirect_cursor = co_await lba_manager->update_mapping_refcount(
       t, mapping.indirect_cursor, -1);
     co_await mapping.direct_cursor->refresh();
+    if (unlikely(indirect_cursor->get_key() ==
+          mapping.direct_cursor->get_key())) {
+      // indirect_cursor points to the same mapping as direct_cursor,
+      // no need to keep it
+      indirect_cursor.reset();
+    }
   }
 
   DEBUGT("removing direct mapping {}~0x{:x} refcount={} -- offset={}",
@@ -344,6 +350,10 @@ TransactionManager::_remove(
 
   LBACursorRef direct_cursor = co_await lba_manager->update_mapping_refcount(
     t, mapping.direct_cursor, -1);
+
+  if (indirect_cursor) {
+    co_await indirect_cursor->refresh();
+  }
 
   auto ret = co_await resolve_cursor_to_mapping(
     t,


### PR DESCRIPTION
Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
