### PR TITLE
mds: fix crash in _eval_stray_remote when stray inode nlink is 0

### DIFF
--- a/qa/tasks/cephfs/test_strays.py
+++ b/qa/tasks/cephfs/test_strays.py
@@ -1051,3 +1051,77 @@ touch pin/placeholder
         self.wait_until_equal(
         lambda: len(self.fs.rank_tell(["dump", "stray"])),
         expect_val=NUM_DIRS, timeout=60, period=1)
+
+    def test_kill_after_unlink_finish(self):
+        """
+        That MDS recovery does not crash in _eval_stray_remote when a
+        stale dentry on disk points to a stray inode with nlink == 0.
+
+        The MDS is killed via mds_kill_after_unlink_finish right after
+        _unlink_local_finish commits nlink=0 and moves the inode to the
+        stray directory, but before CDir::commit writes the directory
+        omap to RADOS.  On recovery, journal replay restores nlink=0
+        and the stray location, but stale dentry entries persist on disk
+        (omap not yet updated).  When these stale entries are loaded
+        during dirfrag fetch, they trigger eval_remote / _eval_stray_remote
+        on an inode with nlink == 0, which previously asserted nlink >= 1.
+
+        Tracker: https://tracker.ceph.com/issues/62663
+        """
+
+        # Create test files
+        self.mount_a.run_shell(["mkdir", "kill_unlink_test"])
+        self.mount_a.write_n_mb("kill_unlink_test/file_a", 1)
+
+        # Flush journal to ensure everything is on disk
+        self.fs.mds_asok(["flush", "journal"])
+
+        # Get rank info for later core dump cleanup
+        status = self.fs.status()
+        rank0 = self.fs.get_rank(rank=0, status=status)
+
+        # Set runtime-only kill config (lost on MDS crash, so restart
+        # picks up the default false).
+        self.fs.mds_asok(['config', 'set',
+                          'mds_kill_after_unlink_finish', "true"])
+
+        # Unlink the file: nlink drops to 0, inode goes to stray,
+        # _unlink_local_finish commits and then ceph_abort_msg() fires.
+        # Use wait=False because the MDS will crash and the command
+        # won't complete.
+        self.mount_a.run_shell([
+            "rm", "-f", "kill_unlink_test/file_a"], wait=False)
+
+        # Wait for the MDS to finish crashing
+        time.sleep(10)
+
+        # Clean up the core dump left by the crash
+        self.delete_mds_coredump(rank0['name'])
+
+        # Restart the MDS.  The runtime kill config was lost during the
+        # crash, so the MDS will boot normally.  During recovery:
+        #   1. Journal replay restores nlink=0, inode in stray
+        #   2. Dirfrag fetch loads stale dentry from RADOS omap
+        #   3. link_remote → eval_remote → _eval_stray_remote
+        #   4. Fixed code returns early on nlink==0 instead of crashing
+        self.fs.mds_restart()
+        time.sleep(5)
+        self.fs.wait_for_daemons()
+
+        # Verify the filesystem is functional after recovery:
+        # create new files and verify they exist
+        self.mount_a.run_shell(["mkdir", "kill_unlink_recovery"])
+        self.mount_a.write_n_mb("kill_unlink_recovery/recovery_test", 1)
+        ls_out = set(self.mount_a.ls("kill_unlink_recovery/"))
+        self.assertIn("recovery_test", ls_out)
+
+        # Verify stale strays are eventually purged
+        self.wait_until_equal(
+            lambda: self.get_mdc_stat("num_strays"),
+            expect_val=0,
+            timeout=60
+        )
+
+        # Cleanup
+        self.mount_a.run_shell(["rm", "-rf", "kill_unlink_test"])
+        self.mount_a.run_shell(["rm", "-rf", "kill_unlink_recovery"])

--- a/qa/tasks/cephfs/test_strays.py
+++ b/qa/tasks/cephfs/test_strays.py
@@ -1125,3 +1125,114 @@ touch pin/placeholder
         # Cleanup
         self.mount_a.run_shell(["rm", "-rf", "kill_unlink_test"])
         self.mount_a.run_shell(["rm", "-rf", "kill_unlink_recovery"])
+
+    def test_kill_after_unlink_finish_hardlink(self):
+        """
+        That MDS recovery handles stale type-'L' remote dentries on disk
+        after a hardlinked file is unlinked and the MDS crashes.
+
+        Unlike the simple unlink case (which leaves a stale type-'I'
+        primary dentry that is gracefully skipped as a duplicate inode),
+        a hardlinked file leaves a stale type-'L' remote dentry which
+        directly triggers link_remote -> eval_remote -> _eval_stray_remote
+        during dirfrag fetch.
+
+        A single crash cannot produce both a stale type-'L' entry and
+        nlink == 0 (the kill point fires after each individual unlink),
+        so this test uses two crash cycles:
+
+        Cycle 1: unlink primary (nlink 2->1), crash -> recovery loads
+        type-'L' stale dentry, _eval_stray_remote(nlink=1) is called;
+        verify the MDS did not crash and FS is healthy.
+
+        Cycle 2: unlink the remaining link (nlink 1->0), crash ->
+        recovery purges the nlink=0 stray and verifies FS health.
+        """
+
+        # Create test file and hardlink
+        self.mount_a.run_shell(["mkdir", "kill_unlink_hl_test"])
+        self.mount_a.write_n_mb("kill_unlink_hl_test/file_a", 1)
+        self.mount_a.run_shell([
+            "ln", "kill_unlink_hl_test/file_a",
+            "kill_unlink_hl_test/file_a_link"])
+
+        # Flush journal to ensure everything is on disk
+        self.fs.mds_asok(["flush", "journal"])
+
+        # Get rank info for later core dump cleanup
+        status = self.fs.status()
+        rank0 = self.fs.get_rank(rank=0, status=status)
+
+        # == Cycle 1: unlink primary (nlink 2->1), crash ==
+        self.fs.mds_asok(['config', 'set',
+                          'mds_kill_after_unlink_finish', "true"])
+
+        self.mount_a.run_shell([
+            "rm", "-f", "kill_unlink_hl_test/file_a"], wait=False)
+
+        # Wait for the MDS to finish crashing
+        time.sleep(10)
+
+        # Clean up the core dump left by the crash
+        self.delete_mds_coredump(rank0['name'])
+
+        # Restart the MDS.  During recovery:
+        #  1. Journal replay: nlink=1, inode in stray (file_a was primary)
+        #  2. Dirfrag fetch loads stale type-'L' dentry for file_a_link
+        #  3. link_remote -> eval_remote -> _eval_stray_remote(nlink=1)
+        #  4. MDS reintegrates: file_a_link becomes the new primary
+        self.fs.mds_restart()
+        time.sleep(5)
+        self.fs.wait_for_daemons()
+
+        # Verify FS is functional after cycle 1 recovery: the MDS did
+        # not crash when loading the stale type-'L' OMAP entry during
+        # dirfrag fetch, and the surviving hardlink is still accessible.
+        # (reintegration may not have completed yet in vstart_runner,
+        # but that's fine — the primary goal is verifying no crash in
+        # _eval_stray_remote during recovery.)
+        self.mount_a.run_shell(["mkdir", "kill_unlink_hl_verify"])
+        self.mount_a.write_n_mb("kill_unlink_hl_verify/verify_file", 1)
+        ls_out = set(self.mount_a.ls("kill_unlink_hl_verify/"))
+        self.assertIn("verify_file", ls_out)
+        self.mount_a.run_shell(["rm", "-rf", "kill_unlink_hl_verify"])
+        self.fs.mds_asok(["flush", "journal"])
+
+        # == Cycle 2: unlink remaining primary (nlink 1->0), crash ==
+        self.fs.mds_asok(['config', 'set',
+                          'mds_kill_after_unlink_finish', "true"])
+
+        self.mount_a.run_shell([
+            "rm", "-f", "kill_unlink_hl_test/file_a_link"], wait=False)
+
+        # Wait for the MDS to finish crashing
+        time.sleep(10)
+
+        # Clean up the core dump left by the crash
+        self.delete_mds_coredump(rank0['name'])
+
+        # Restart the MDS.  During recovery:
+        #  1. Journal replay: nlink=0, inode in stray
+        #  2. Dirfrag fetch loads stale type-'I' dentry -> duplicate
+        #     inode, gracefully skipped
+        #  3. _eval_stray purge path cleans up the stray
+        self.fs.mds_restart()
+        time.sleep(5)
+        self.fs.wait_for_daemons()
+
+        # Verify the filesystem is functional after cycle 2 recovery
+        self.mount_a.run_shell(["mkdir", "kill_unlink_hl_recovery"])
+        self.mount_a.write_n_mb("kill_unlink_hl_recovery/recovery_test", 1)
+        ls_out = set(self.mount_a.ls("kill_unlink_hl_recovery/"))
+        self.assertIn("recovery_test", ls_out)
+
+        # Verify all strays are eventually purged
+        self.wait_until_equal(
+            lambda: self.get_mdc_stat("num_strays"),
+            expect_val=0,
+            timeout=60
+        )
+
+        # Cleanup
+        self.mount_a.run_shell(["rm", "-rf", "kill_unlink_hl_test"])
+        self.mount_a.run_shell(["rm", "-rf", "kill_unlink_hl_recovery"])

--- a/qa/tasks/cephfs/test_strays.py
+++ b/qa/tasks/cephfs/test_strays.py
@@ -1092,8 +1092,10 @@ touch pin/placeholder
         self.mount_a.run_shell([
             "rm", "-f", "kill_unlink_test/file_a"], wait=False)
 
-        # Wait for the MDS to finish crashing
-        time.sleep(10)
+        # Wait for the MDS to finish crashing.  The coredump is fully
+        # written before the rank is marked failed, so this also makes
+        # the subsequent delete_mds_coredump() deterministic.
+        self.fs.wait_for_death()
 
         # Clean up the core dump left by the crash
         self.delete_mds_coredump(rank0['name'])
@@ -1170,8 +1172,10 @@ touch pin/placeholder
         self.mount_a.run_shell([
             "rm", "-f", "kill_unlink_hl_test/file_a"], wait=False)
 
-        # Wait for the MDS to finish crashing
-        time.sleep(10)
+        # Wait for the MDS to finish crashing.  The coredump is fully
+        # written before the rank is marked failed, so this also makes
+        # the subsequent delete_mds_coredump() deterministic.
+        self.fs.wait_for_death()
 
         # Clean up the core dump left by the crash
         self.delete_mds_coredump(rank0['name'])
@@ -1205,8 +1209,10 @@ touch pin/placeholder
         self.mount_a.run_shell([
             "rm", "-f", "kill_unlink_hl_test/file_a_link"], wait=False)
 
-        # Wait for the MDS to finish crashing
-        time.sleep(10)
+        # Wait for the MDS to finish crashing.  The coredump is fully
+        # written before the rank is marked failed, so this also makes
+        # the subsequent delete_mds_coredump() deterministic.
+        self.fs.wait_for_death()
 
         # Clean up the core dump left by the crash
         self.delete_mds_coredump(rank0['name'])

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -1209,7 +1209,10 @@ class LogStream(object):
         pass
 
     def __del__(self):
-        self._write()
+        try:
+            self._write()
+        except Exception:
+            pass
 
 
 class InteractiveFailureResult(unittest.TextTestResult):

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -698,6 +698,8 @@ class LocalCephFSMount():
         log.info('Ready to start {}...'.format(type(self).__name__))
 
     def is_blocked(self):
+        if not hasattr(self, 'addr') or self.addr is None:
+            return False
         self.fs = LocalFilesystem(self.ctx, name=self.cephfs_name)
 
         output = self.fs.mon_manager.raw_cluster_cmd(args='osd blocklist ls')

--- a/src/common/options/mds.yaml.in
+++ b/src/common/options/mds.yaml.in
@@ -1233,6 +1233,19 @@ options:
     are flushed to the pool.
     (for testing only).
   with_legacy: true
+- name: mds_kill_after_unlink_finish
+  type: bool
+  level: dev
+  default: false
+  services:
+  - mds
+  fmt_desc: MDS will crash after _unlink_local_finish commits the unlink but
+    before CDir::commit has written the directory omap to RADOS.
+    This reproduces the crash in _eval_stray_remote when a stale remote
+    dentry on disk is loaded after MDS recovery and triggers reintegration
+    of an nlink==0 stray inode (tracker 62663).
+    (for developers only).
+  with_legacy: true
 - name: mds_inject_skip_replaying_inotable
   type: bool
   level: dev

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -8788,14 +8788,16 @@ void Server::_unlink_local_finish(const MDRequestRef& mdr,
   // This reproduces the stale remote dentry crash in _eval_stray_remote
   // on recovery (tracker 62663).
   //
-  // Test procedure:
+  // Test procedure (hardlink scenario):
   //   1. set mds_kill_after_unlink_finish = true
   //   2. create a file with primary + remote hardlinks (nlink >= 2)
-  //   3. unlink all hardlinks (nlink drops to 0)
-  //   4. the last unlink triggers this assertion; MDS crashes
-  //   5. restart MDS → journal replay restores nlink=0 + stray location
-  //   6. stale remote dentry on disk triggers eval_remote →
-  //      _eval_stray_remote → fixed code handles nlink==0 without crash
+  //   3. unlink the primary → nlink drops to 1, MDS crashes
+  //   4. restart MDS → journal replay restores nlink=1 + stray location,
+  //      stale type-'L' remote dentry on disk triggers eval_remote →
+  //      _eval_stray_remote(nlink=1) → reintegrates; FS is healthy
+  //   5. set mds_kill_after_unlink_finish = true again
+  //   6. unlink the remaining primary link → nlink drops to 0, MDS crashes
+  //   7. restart MDS → nlink=0 stray is purged; verify FS functional
   if (unlikely(g_conf()->mds_kill_after_unlink_finish)) {
     ceph_abort_msg(
         "mds_kill_after_unlink_finish is set; "

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -8780,6 +8780,28 @@ void Server::_unlink_local_finish(const MDRequestRef& mdr,
     // might be elegible for purge.
     mdcache->notify_stray(straydn);
   }
+
+  // Dev config injection point: crash the MDS after the unlink journal
+  // callback has committed nlink and moved the inode to the stray dir,
+  // but before CDir::commit has written the directory omap to RADOS.
+  // This reproduces the stale remote dentry crash in _eval_stray_remote
+  // on recovery (tracker 62663).
+  //
+  // Test procedure:
+  //   1. set mds_kill_after_unlink_finish = true
+  //   2. create a file with primary + remote hardlinks (nlink >= 2)
+  //   3. unlink all hardlinks (nlink drops to 0)
+  //   4. the last unlink triggers this assertion; MDS crashes
+  //   5. restart MDS → journal replay restores nlink=0 + stray location
+  //   6. stale remote dentry on disk triggers eval_remote →
+  //      _eval_stray_remote → fixed code handles nlink==0 without crash
+  if (unlikely(g_conf()->mds_kill_after_unlink_finish)) {
+    ceph_abort_msg(
+        "mds_kill_after_unlink_finish is set; "
+        "the nlink==0 commit was applied and the MDS will now crash. "
+        "On recovery, any stale remote dentries still on disk will "
+        "trigger the _eval_stray_remote path to verify the fix.");
+  }
 }
 
 bool Server::_rmdir_prepare_witness(const MDRequestRef& mdr, mds_rank_t who, vector<CDentry*>& trace, CDentry *straydn)

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -8767,19 +8767,20 @@ void Server::_unlink_local_finish(const MDRequestRef& mdr,
   // bump pop
   mds->balancer->hit_dir(dn->get_dir(), META_POP_IWR);
 
-  // reply
-  respond_to_request(mdr, 0);
-  
-  // removing a new dn?
-  dn->get_dir()->try_remove_unlinked_dn(dn);
-
   // clean up ?
-  // respond_to_request() drops locks. So stray reintegration can race with us.
+  // evaluate stray before dropping locks to avoid racing with
+  // concurrent link/unlink requests that may modify nlink.
   if (straydn && !straydn->get_projected_linkage()->is_null()) {
     // Tip off the MDCache that this dentry is a stray that
     // might be elegible for purge.
     mdcache->notify_stray(straydn);
   }
+
+  // reply
+  respond_to_request(mdr, 0);
+
+  // removing a new dn?
+  dn->get_dir()->try_remove_unlinked_dn(dn);
 
   // Dev config injection point: crash the MDS after the unlink journal
   // callback has committed nlink and moved the inode to the stray dir,
@@ -9715,17 +9716,18 @@ void Server::_rename_finish(const MDRequestRef& mdr, CDentry *srcdn, CDentry *de
 
   ceph_assert(g_conf()->mds_kill_rename_at != 7);
 
+  // clean up?
+  // evaluate stray before dropping locks to avoid racing with
+  // concurrent link/unlink requests that may modify nlink.
+  if (straydn && !straydn->get_projected_linkage()->is_null()) {
+    mdcache->notify_stray(straydn);
+  }
+
   // reply
   respond_to_request(mdr, 0);
 
   if (need_eval)
     mds->locker->eval(in, CEPH_CAP_LOCKS, true);
-
-  // clean up?
-  // respond_to_request() drops locks. So stray reintegration can race with us.
-  if (straydn && !straydn->get_projected_linkage()->is_null()) {
-    mdcache->notify_stray(straydn);
-  }
 }
 
 

--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -498,11 +498,17 @@ bool StrayManager::_eval_stray(CDentry *dn)
       mds->mdcache->clear_dirty_bits_for_stray(in);
 
       if (!in->remote_parents.empty()) {
-	// unlink any stale remote snap dentry.
+	// unlink any stale remote dentries (both snap and non-snap).
+	// When nlink == 0, the inode has been fully deleted and all
+	// remote parents are stale.  Snap dentries are created during
+	// snapshot operations; non-snap dentries may remain from
+	// incomplete hardlink cleanup (e.g. after MDS failover).
 	for (auto it = in->remote_parents.begin(); it != in->remote_parents.end(); ) {
 	  CDentry *remote_dn = *it;
 	  ++it;
-	  ceph_assert(remote_dn->last != CEPH_NOSNAP);
+	  dout(10) << __func__ << ": unlinking stale remote "
+	           << (remote_dn->last != CEPH_NOSNAP ? "snap " : "")
+	           << "dentry " << *remote_dn << dendl;
 	  remote_dn->unlink_remote(remote_dn->get_linkage());
 	}
       }

--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -629,8 +629,27 @@ void StrayManager::_eval_stray_remote(CDentry *stray_dn, CDentry *remote_dn)
   CDentry::linkage_t *stray_dnl = stray_dn->get_projected_linkage();
   ceph_assert(stray_dnl->is_primary());
   CInode *stray_in = stray_dnl->get_inode();
-  ceph_assert(stray_in->get_inode()->nlink >= 1);
+  ceph_assert(stray_in->get_inode()->nlink >= 0);
   ceph_assert(stray_in->last == CEPH_NOSNAP);
+
+  if (stray_in->get_inode()->nlink == 0) {
+    /*
+     * When nlink reaches 0, the inode has been fully deleted and is
+     * pending purge from the stray directory.  Any remote parents that
+     * still point here are stale dentries that haven't been cleaned
+     * up yet (e.g. after an MDS failover, stale remote dentries may
+     * still reside on disk and get loaded during dirfrag fetch).
+     *
+     * We must NOT attempt to reintegrate a stray with nlink == 0,
+     * because reintegration assumes at least one valid hard link
+     * remains.  Instead, just return; the normal _eval_stray path
+     * will handle cleanup when it processes this inode via the
+     * nlink == 0 purge path.
+     */
+    dout(10) << __func__ << ": stray inode " << *stray_in
+             << " nlink == 0, skipping reintegration" << dendl;
+    return;
+  }
 
   /* If no remote_dn hinted, pick one arbitrarily */
   if (remote_dn == NULL) {

--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -475,7 +475,7 @@ bool StrayManager::_eval_stray(CDentry *dn)
   }
 
   // purge?
-  if (in->get_inode()->nlink == 0) {
+  if (in->get_inode()->nlink <= 0) {
     // past snaprealm parents imply snapped dentry remote links.
     // only important for directories.  normal file data snaps are handled
     // by the object store.
@@ -499,7 +499,7 @@ bool StrayManager::_eval_stray(CDentry *dn)
 
       if (!in->remote_parents.empty()) {
 	// unlink any stale remote dentries (both snap and non-snap).
-	// When nlink == 0, the inode has been fully deleted and all
+	// When nlink <= 0, the inode has been fully deleted and all
 	// remote parents are stale.  Snap dentries are created during
 	// snapshot operations; non-snap dentries may remain from
 	// incomplete hardlink cleanup (e.g. after MDS failover).
@@ -635,10 +635,9 @@ void StrayManager::_eval_stray_remote(CDentry *stray_dn, CDentry *remote_dn)
   CDentry::linkage_t *stray_dnl = stray_dn->get_projected_linkage();
   ceph_assert(stray_dnl->is_primary());
   CInode *stray_in = stray_dnl->get_inode();
-  ceph_assert(stray_in->get_inode()->nlink >= 0);
   ceph_assert(stray_in->last == CEPH_NOSNAP);
 
-  if (stray_in->get_inode()->nlink == 0) {
+  if (stray_in->get_inode()->nlink <= 0) {
     /*
      * When nlink reaches 0, the inode has been fully deleted and is
      * pending purge from the stray directory.  Any remote parents that
@@ -646,14 +645,14 @@ void StrayManager::_eval_stray_remote(CDentry *stray_dn, CDentry *remote_dn)
      * up yet (e.g. after an MDS failover, stale remote dentries may
      * still reside on disk and get loaded during dirfrag fetch).
      *
-     * We must NOT attempt to reintegrate a stray with nlink == 0,
+     * We must NOT attempt to reintegrate a stray with nlink <= 0,
      * because reintegration assumes at least one valid hard link
      * remains.  Instead, just return; the normal _eval_stray path
      * will handle cleanup when it processes this inode via the
-     * nlink == 0 purge path.
+     * nlink <= 0 purge path.
      */
     dout(10) << __func__ << ": stray inode " << *stray_in
-             << " nlink == 0, skipping reintegration" << dendl;
+             << " nlink <= 0, skipping reintegration" << dendl;
     return;
   }
 

--- a/src/tools/cephfs/DataScan.cc
+++ b/src/tools/cephfs/DataScan.cc
@@ -1271,6 +1271,13 @@ int DataScan::scan_links()
 
   map<dirfrag_t, set<string>> to_remove;
 
+  // Track inodes that are in stray directories with nlink == 0.
+  // Remote dentries pointing to these inodes are stale leftover
+  // hardlinks that were not cleaned up before an MDS crash; they
+  // must be removed so the MDS can start without hitting the
+  // _eval_stray_remote nlink >= 1 assertion.
+  std::set<inodeno_t> stale_stray_inodes;
+
   enum {
     SCAN_INOS = 1,
     CHECK_LINK,
@@ -1346,6 +1353,11 @@ int DataScan::scan_links()
             inodeno_t ino = inode.inode->ino;
 
 	    if (step == SCAN_INOS) {
+	      // Record inodes that are in stray dirs with nlink == 0.
+	      // Remote dentries pointing to these inodes are stale and
+	      // will be cleaned up during the CHECK_LINK step.
+	      if (MDS_INO_IS_STRAY(dir_ino) && inode.inode->nlink == 0)
+		stale_stray_inodes.insert(ino);
 	      if (used_inos.contains(ino, 1)) {
 		dup_primaries.emplace(
                   std::piecewise_construct, std::forward_as_tuple(ino),
@@ -1474,6 +1486,14 @@ int DataScan::scan_links()
                 dentry_key_t dn_key(CEPH_NOSNAP, dname.c_str());
                 dn_key.encode(key);
                 to_remove[dirfrag_t(dir_ino, frag_id)].insert(key);
+              } else if (stale_stray_inodes.count(ino)) {
+                derr << "Stale remote dentry 0x" << std::hex << dir_ino
+                     << std::dec << "/" << dname << ", ino " << ino
+                     << " is in stray dir with nlink 0" << dendl;
+                std::string key;
+                dentry_key_t dn_key(CEPH_NOSNAP, dname.c_str());
+                dn_key.encode(key);
+                to_remove[dirfrag_t(dir_ino, frag_id)].insert(key);
               }
             }
           } else {
@@ -1516,7 +1536,9 @@ int DataScan::scan_links()
   used_inos.clear();
 
   dout(10) << "processing " << dup_primaries.size() << " dup_primaries, "
-           << remote_links.size() << " remote_links" << dendl;
+           << remote_links.size() << " remote_links, "
+           << stale_stray_inodes.size() << " stale stray inodes (nlink 0)"
+           << dendl;
 
   for (auto& p : dup_primaries) {
 

--- a/src/tools/cephfs/DataScan.cc
+++ b/src/tools/cephfs/DataScan.cc
@@ -1353,10 +1353,10 @@ int DataScan::scan_links()
             inodeno_t ino = inode.inode->ino;
 
 	    if (step == SCAN_INOS) {
-	      // Record inodes that are in stray dirs with nlink == 0.
+	      // Record inodes that are in stray dirs with nlink <= 0.
 	      // Remote dentries pointing to these inodes are stale and
 	      // will be cleaned up during the CHECK_LINK step.
-	      if (MDS_INO_IS_STRAY(dir_ino) && inode.inode->nlink == 0)
+	      if (MDS_INO_IS_STRAY(dir_ino) && inode.inode->nlink <= 0)
 		stale_stray_inodes.insert(ino);
 	      if (used_inos.contains(ino, 1)) {
 		dup_primaries.emplace(


### PR DESCRIPTION
During MDS failover, stale remote dentries on disk may be loaded via
_omap_fetched->_load_dentry->link_remote, which triggers eval_remote.
When the linked inode's primary dentry is in the stray directory,
_eval_stray_remote is called, but it incorrectly asserts nlink >= 1.

A stray inode can legitimately have nlink == 0 (fully deleted, pending
purge) while stale remote dentries still point to it.  Instead of
asserting, skip reintegration when nlink == 0 and let _eval_stray
handle the cleanup via the normal purge path.

Fixes: https://tracker.ceph.com/issues/62663





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
