### PR TITLE
mgr/dashboard: fix bind address regression from CherryPy isolation

### DIFF
--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -209,6 +209,7 @@ class CherryPyConfig(object):
         self._url_prefix = prepare_url_prefix(self.get_module_option(  # type: ignore
             'url_prefix', default=''))
 
+        bind_addr = server_addr
         if server_addr in ['::', '0.0.0.0']:
             server_addr = self.get_mgr_ip()  # type: ignore
         base_url = build_url(
@@ -217,7 +218,7 @@ class CherryPyConfig(object):
             port=server_port,
         )
         uri = f'{base_url}{self.url_prefix}/'
-        return uri, (server_addr, server_port), ssl_info, config
+        return uri, (bind_addr, server_port), ssl_info, config
 
     def await_configuration(self):
         """

--- a/src/pybind/mgr/dashboard/tests/test_settings.py
+++ b/src/pybind/mgr/dashboard/tests/test_settings.py
@@ -2,11 +2,13 @@
 
 import errno
 import unittest
+from unittest.mock import MagicMock
 
 from mgr_module import ERROR_MSG_EMPTY_INPUT_FILE
 
 from .. import settings
 from ..controllers.settings import Settings as SettingsController
+from ..module import CherryPyConfig
 from ..settings import Settings, handle_option_command
 from ..tests import ControllerTestCase, KVStoreMockMixin
 
@@ -124,6 +126,33 @@ class SettingsTest(unittest.TestCase, KVStoreMockMixin):
 
         self.assertEqual(str(ctx.exception),
                          "type object 'Options' has no attribute 'NON_EXISTENT_OPTION'")
+
+    def _setup_cherrypy_config(self, server_addr, server_port):
+        obj = CherryPyConfig()
+        config_map = {
+            'server_addr': server_addr,
+            'ssl': False,
+            'server_port': server_port
+        }
+        obj.get_localized_module_option = MagicMock(
+            side_effect=lambda key, default=None: config_map.get(key, default))
+        obj.get_mgr_ip = MagicMock(return_value='192.168.1.10')
+        obj.get_module_option = MagicMock(return_value='')
+        obj.get_mgr_id = MagicMock(return_value='test')
+        obj.module_name = 'dashboard'
+        obj.log = MagicMock()
+        obj.update_cherrypy_config = MagicMock()
+        return obj
+
+    def test_wildcard_bind_addr_preserved(self):
+        obj = self._setup_cherrypy_config('::', 8080)
+        _, bind_addr, _, _ = obj._configure()  # pylint: disable=protected-access
+        self.assertEqual(bind_addr, ('::', 8080))
+
+    def test_wildcard_bind_addr_preserved_ipv4(self):
+        obj = self._setup_cherrypy_config('0.0.0.0', 8443)
+        _, bind_addr, _, _ = obj._configure()  # pylint: disable=protected-access
+        self.assertEqual(bind_addr, ('0.0.0.0', 8443))
 
 
 class SettingsControllerTest(ControllerTestCase, KVStoreMockMixin):


### PR DESCRIPTION
The CherryPy isolation refactor (PR #67227) accidentally changed the dashboard bind address from wildcard (*:8443) to mon_ip:8443. The get_mgr_ip() replacement was originally only for URI generation, but the refactor passed the mutated address to CherryPyMgr.mount() as the actual socket bind address.

This breaks the management gateway when its VIP is not on the same interface as mon_ip, as the dashboard becomes unreachable on other interfaces.

Preserve the original wildcard address for binding and only use get_mgr_ip() for the advertised URI.

Fixes: https://tracker.ceph.com/issues/77491





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
