### PR TITLE
doc: add AGENTS.md navigation guides across codebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,8 @@ Assisted-by: AI-tool-or-model [optional-tooling]
 ```
 
 ### Commit Structure and PR Preparation
+Read `SubmittingPatches.rst` in the repository root for the full guide on commit titles, commit messages, PR format, and backport procedures. **Exception**: the `Signed-off-by` instructions in that document apply to human developers only — AI agents MUST NOT add S-o-b tags (see above).
+
 During development, commit regularly so progress is preserved. Working commits do not need to be polished.
 
 When asked to prepare for a PR, restructure commits to tell a **story for human reviewers**: preparatory refactoring first, then tests/reproducers, then the main fix, then cleanup. Each commit should be reviewable in isolation. Never mix unrelated changes. A simple fix can be one commit; a complex feature may need several. Pushing a PR is always a human decision.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,229 @@
+# Ceph Codebase Navigation Guide
+
+## Project Overview
+
+Ceph is a distributed storage system providing three storage interfaces on a single unified cluster: **object storage** (RADOS/RGW), **block storage** (RBD), and **file storage** (CephFS). The cluster is managed by a set of daemons:
+
+- **MON** (Monitor) — maintains cluster consensus via Paxos, manages cluster maps (OSDMap, MonMap, MDSMap, FSMap)
+- **OSD** (Object Storage Daemon) — stores objects, handles replication/erasure-coding, recovery, scrubbing
+- **MDS** (Metadata Server) — manages the CephFS filesystem namespace
+- **RGW** (RADOS Gateway) — provides S3 and Swift-compatible HTTP object storage APIs
+- **MGR** (Manager) — hosts Python plugin modules for monitoring, orchestration, and management
+
+The codebase is primarily C++20 with Python for management tooling. The build system is CMake.
+
+## Repository Layout
+
+| Directory | Purpose |
+|-----------|---------|
+| `src/` | All source code — daemons, libraries, and tools |
+| `qa/` | Integration test suites (Teuthology) and standalone test scripts |
+| `doc/` | Sphinx documentation (user-facing and developer) |
+| `cmake/` | CMake build modules and dependency finders |
+| `monitoring/` | Grafana dashboards, Prometheus alert rules, SNMP MIBs |
+| `container/` | Container/Docker build configurations |
+| `debian/` | Debian/Ubuntu packaging |
+| `systemd/` | systemd unit files |
+| `examples/` | Example configurations |
+| `man/` | Man pages |
+| `admin/` | Administration utilities |
+
+## Source Code Map (`src/`)
+
+| Directory | What It Is | Guide |
+|-----------|-----------|-------|
+| `src/osd/` | Object Storage Daemon — PGs, replication, EC, peering, recovery | [AGENTS.md](src/osd/AGENTS.md) |
+| `src/mon/` | Monitor — Paxos consensus, cluster state management | [AGENTS.md](src/mon/AGENTS.md) |
+| `src/mds/` | Metadata Server — CephFS namespace, distributed locking | [AGENTS.md](src/mds/AGENTS.md) |
+| `src/rgw/` | RADOS Gateway — S3/Swift HTTP API (largest subsystem) | [AGENTS.md](src/rgw/AGENTS.md) |
+| `src/mgr/` | Manager — Python plugin host, metrics, orchestration | [AGENTS.md](src/mgr/AGENTS.md) |
+| `src/crimson/` | Next-gen async OSD using Seastar framework | [AGENTS.md](src/crimson/AGENTS.md) |
+| `src/librados/` | RADOS client library (C and C++ API) | [AGENTS.md](src/librados/AGENTS.md) |
+| `src/librbd/` | RBD (block device) client library | [AGENTS.md](src/librbd/AGENTS.md) |
+| `src/common/` | Core shared utilities (bufferlist, mutexes, formatters, config) | [AGENTS.md](src/common/AGENTS.md) |
+| `src/include/` | Shared headers (encoding, types, Context, feature bits) | [AGENTS.md](src/include/AGENTS.md) |
+| `src/msg/` | Messaging layer (async networking, protocol v1/v2) | [AGENTS.md](src/msg/AGENTS.md) |
+| `src/os/` | ObjectStore abstraction (BlueStore, MemStore) | [AGENTS.md](src/os/AGENTS.md) |
+| `src/crush/` | CRUSH placement algorithm | [AGENTS.md](src/crush/AGENTS.md) |
+| `src/erasure-code/` | Erasure coding plugin framework | [AGENTS.md](src/erasure-code/AGENTS.md) |
+| `src/cls/` | Server-side RADOS classes (custom object ops on OSD) | [AGENTS.md](src/cls/AGENTS.md) |
+| `src/pybind/mgr/` | Python manager modules (dashboard, cephadm, etc.) | [AGENTS.md](src/pybind/mgr/AGENTS.md) |
+| `src/tools/` | CLI tools (crushtool, osdmaptool, rados, rbd) | [AGENTS.md](src/tools/AGENTS.md) |
+| `src/test/` | C++ unit tests (GTest/GMock) | [AGENTS.md](src/test/AGENTS.md) |
+| `qa/` | Integration tests (Teuthology suites, standalone scripts) | [AGENTS.md](qa/AGENTS.md) |
+| `src/client/` | CephFS FUSE client | |
+| `src/osdc/` | Client-side Objecter — sends OSD operations | |
+| `src/neorados/` | New async RADOS API (boost::asio) | |
+| `src/auth/` | Authentication (CephX) | |
+| `src/kv/` | Key-value store abstraction (RocksDB wrapper) | |
+| `src/global/` | Global initialization and signal handling | |
+| `src/log/` | Logging infrastructure | |
+| `src/compressor/` | Compression plugins (zstd, snappy, lz4, zlib) | |
+| `src/blk/` | Block device abstraction | |
+| `src/messages/` | 176 message type headers (one per inter-daemon message) | |
+| `src/cephadm/` | Container-based cluster deployment tool | |
+| `src/ceph-volume/` | LVM-based OSD provisioning tool | |
+
+### Vendored Third-Party (do NOT modify)
+`src/rocksdb/`, `src/seastar/`, `src/fmt/`, `src/zstd/`, `src/xxHash/`, `src/BLAKE3/`, `src/arrow/`, `src/googletest/`, `src/json_spirit/`, `src/spdk/`, `src/isa-l/`, `src/c-ares/`, `src/utf8proc/`, `src/dmclock/`, `src/lss/`, `src/breakpad/`, `src/jaegertracing/`, `src/s3select/`, `src/qatlib/`, `src/qatzip/`, `src/uadk/`, `src/libkmip/`, `src/blkin/`
+
+## Daemon Entry Points
+
+| Daemon | Source File | Binary |
+|--------|-----------|--------|
+| OSD | `src/ceph_osd.cc` | `ceph-osd` |
+| Monitor | `src/ceph_mon.cc` | `ceph-mon` |
+| MDS | `src/ceph_mds.cc` | `ceph-mds` |
+| Manager | `src/ceph_mgr.cc` | `ceph-mgr` |
+| RGW | `src/rgw/rgw_main.cc` | `radosgw` |
+| Crimson OSD | `src/crimson/osd/main.cc` | `crimson-osd` |
+
+## Build System
+
+```bash
+./install-deps.sh              # Install build prerequisites
+./do_cmake.sh                  # Configure (creates build/ directory)
+cd build && ninja              # Build (or make -jN)
+./run-make-check.sh            # Full build + unit tests
+```
+
+- CMake modules in `cmake/modules/` handle dependency detection
+- Config options defined in YAML files under `src/common/options/` (e.g., `osd.yaml.in`, `rgw.yaml.in`)
+- `compile_commands.json` in the repo root or build dir for IDE/clangd integration
+
+## Coding Conventions
+
+Based on the project's `CodingStyle` file:
+
+- **Indentation**: 2 spaces, no tabs
+- **Functions**: `snake_case()` (not CamelCase)
+- **Classes**: `CamelCase` for full classes; `lower_case_t` for simple structs
+- **Members**: `m_` prefix or no prefix (not trailing `_`)
+- **Constants/Enums**: `UPPER_CASE`
+- **Conditionals**: always use braces, body on next line
+- **Parameters**: inputs first, then outputs. Use `const&` for inputs, pointers for outputs
+- **Constructors**: mark single-arg constructors `explicit`
+- **Header guards**: `#pragma once` is acceptable
+- **Python**: PEP-8
+- **Commit messages**: `subsystem: imperative description` (e.g., `osd: fix PG creation race`). The human developer must add a `Signed-off-by:` line — never generate one as an AI.
+
+## Rules for AI Coding Agents
+
+### Code Formatting
+The repository has a `.clang-format` file at the project root. **All new and modified C++ code must conform to this format.** Key points from the config:
+- Based on Google style with Ceph-specific overrides
+- C++20 standard
+- 2-space indentation, no tabs
+- Column limit: 80 (soft), penalty-based line breaking
+- Braces: opening brace on same line for classes/structs/control, but **after newline for function definitions**
+- Pointer/reference alignment: left (`int* p`, not `int *p`)
+- Constructor initializer lists: break after colon, one per line if they don't fit
+- Includes are sorted and regrouped by category (local, project, boost, system)
+
+When writing new code, follow these formatting rules. When editing existing code, format only the lines you change.
+
+### Do Not Reformat Existing Code
+**Never make whitespace-only or style-only changes to code you are not otherwise modifying.** Reformatting untouched code causes unnecessary git conflicts with other developers' branches. If you see poorly formatted existing code, leave it alone unless you are already making functional changes to those specific lines.
+
+### Minimize Diff Noise
+Keep diffs clean and minimal:
+- Only change lines that are necessary for the functional change
+- Do not re-indent surrounding code blocks unless the change requires it
+- Do not reorganize includes in files where you are only changing a few lines
+- Do not add or remove blank lines in code you are not modifying
+
+### Comments
+Comments should explain **why**, not **what**. Assume developers have AI tools to explain what code does.
+
+**Good:** edge cases, non-obvious invariants, workarounds for specific bugs, constraints from other subsystems.
+**Bad:** narrating code line by line, changelog-style ("NOW does X"), describing the current task/PR ("Added for the backfill fix"). When in doubt, leave the comment out.
+
+### Documentation
+If your change affects user-visible behavior (CLI commands, config options, APIs, admin operations), you **must** update the corresponding documentation in `doc/`. Documentation in `doc/` is for **users and operators**, not developers. It should:
+- Cover use cases for advanced users and administrators
+- Explain what changed, how to use it, and any migration steps
+- Use practical examples showing real commands and expected output
+- Not include internal implementation details, code structure explanations, or developer notes
+
+Developer-facing information belongs in code comments, commit messages, or `doc/dev/` — not in the user-facing docs.
+
+### Design Documents
+Complex changes and major new features **must** include a design document in `doc/dev/`. An agent may be asked to write or iterate on a design document — editing it based on human developer feedback is expected and encouraged during the design phase.
+
+However, once implementation begins, the design document becomes the agreed specification. **Never modify a design document during implementation without explicit user permission.** If implementation reveals a design flaw, stop and raise it with the user rather than silently changing the design to match what you built.
+
+### Git Commit Standards
+
+#### Sign-off
+All commits must include a `Signed-off-by` line. **Only the human developer may add this line — never generate or insert a `Signed-off-by` line as an AI.** The sign-off is the developer's personal assertion of DCO compliance and cannot be delegated to or fabricated by a tool.
+
+#### AI Attribution
+All AI-generated or AI-assisted code must include an `Assisted-by` tag so human reviewers know which parts of the change need careful scrutiny. Include the AI tool or model used, and any automated tooling that contributed to the change.
+
+```
+Assisted-by: AI-tool-or-model [optional-tooling]
+```
+
+The human developer takes full responsibility for DCO compliance, licensing, and correctness, and must add their own `Signed-off-by: Developer Name <developer@example.com>` line before committing.
+
+### Commit Structure and PR Preparation
+During development, commit regularly so progress is preserved. Working commits do not need to be polished.
+
+When asked to prepare for a PR, restructure commits to tell a **story for human reviewers**: preparatory refactoring first, then tests/reproducers, then the main fix, then cleanup. Each commit should be reviewable in isolation. Never mix unrelated changes. A simple fix can be one commit; a complex feature may need several. Pushing a PR is always a human decision.
+
+### Build and Test
+- **Build**: `cd build && ninja` (never use `make`). **Never clean the build directory without explicit user permission.**
+- **Test**: `cd build && ninja osd_unittests` — baseline mandatory check. If unsure whether to skip, ask the user.
+
+### Agent Workflow
+1. Understand the code before modifying it — use `compile_commands.json` with clangd if available
+2. Write code following `.clang-format` and `CodingStyle` — format only lines you change
+3. Build with `ninja`, run `osd_unittests`, never clean without permission
+4. Add an `Assisted-by` tag to commit messages — the human developer must add their own `Signed-off-by`; never generate one
+
+## Navigation Quick Reference
+
+| If you need to... | Look in... |
+|---|---|
+| Add a config option | `src/common/options/*.yaml.in` |
+| Add a CLI command | `src/mon/MonCommands.h` (mon) or mgr module `@CLICommand` |
+| Add a new message type | `src/messages/` + register constant in `src/include/ceph_fs.h` |
+| Understand data placement | `src/crush/CrushWrapper.h` |
+| Understand PG operations | `src/osd/PrimaryLogPG.cc` |
+| Add a mgr module | Copy `src/pybind/mgr/hello/` |
+| Add a RADOS class | Copy `src/cls/hello/` |
+| Understand serialization | `src/include/encoding.h` (`ENCODE_START`/`ENCODE_FINISH`) |
+| Understand the wire protocol | `src/msg/async/ProtocolV2.h` |
+| Work on BlueStore | `src/os/bluestore/BlueStore.h` |
+| Debug an ObjectStore offline | `src/tools/ceph_objectstore_tool.cc` |
+
+## Key Interdependencies
+
+```
+                    ┌──────────┐
+                    │  common/ │  (used by everything)
+                    │ include/ │
+                    └────┬─────┘
+                         │
+              ┌──────────┼──────────┐
+              │          │          │
+         ┌────▼───┐ ┌───▼────┐ ┌──▼───┐
+         │  msg/  │ │  os/   │ │crush/│
+         └───┬────┘ └───┬────┘ └──┬───┘
+             │          │         │
+    ┌────────┼──────────┼─────────┘
+    │        │          │
+┌───▼──┐ ┌──▼──┐ ┌────▼───┐ ┌─────┐
+│ osd/ │ │mon/ │ │  mds/  │ │mgr/ │
+└──┬───┘ └─────┘ └────────┘ └─────┘
+   │
+   │  ┌──────────┐  ┌──────────┐  ┌──────┐
+   └──│erasure-  │  │librados/ │  │ rgw/ │
+      │code/     │  └────┬─────┘  └──┬───┘
+      └──────────┘       │           │
+                    ┌────▼─────┐     │
+                    │ librbd/  │◄────┘
+                    └──────────┘
+```
+
+Note: `rgw/` depends on `librados/` (not on `os/` or `crush/` directly). `librados/` depends on `msg/`, `os/`, and `crush/` transitively, but `rgw/` does not.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,15 +107,8 @@ The repository has a `.clang-format` file at the project root. **All new and mod
 
 When writing new code, follow `.clang-format`. When editing existing code, format only the lines you change.
 
-### Do Not Reformat Existing Code
-**Never make whitespace-only or style-only changes to code you are not otherwise modifying.** Reformatting untouched code causes unnecessary git conflicts with other developers' branches. If you see poorly formatted existing code, leave it alone unless you are already making functional changes to those specific lines.
-
-### Minimize Diff Noise
-Keep diffs clean and minimal:
-- Only change lines that are necessary for the functional change
-- Do not re-indent surrounding code blocks unless the change requires it
-- Do not reorganize includes in files where you are only changing a few lines
-- Do not add or remove blank lines in code you are not modifying
+### Minimal Diffs
+Only change lines necessary for the functional change. Never make whitespace-only, style-only, or include-reordering changes to code you are not otherwise modifying — it causes git conflicts with other branches.
 
 ### Comments
 Comments should explain **why**, not **what**. Assume developers have AI tools to explain what code does.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,9 @@ cd build && ninja              # Build (or make -jN)
 
 ## Coding Conventions
 
+### Licensing Headers
+New source files must include an `SPDX-License-Identifier` header. Ceph is primarily licensed under LGPL-2.1 or LGPL-3 (see `COPYING`). Use: `// SPDX-License-Identifier: LGPL-2.1-only OR LGPL-3.0-only`
+
 Based on the project's `CodingStyle` file:
 
 - **Indentation**: 2 spaces, no tabs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ The codebase is primarily C++23 with Python for management tooling. The build sy
 | `src/ceph-volume/` | LVM-based OSD provisioning tool | |
 
 ### Vendored Third-Party (do NOT modify)
-`src/rocksdb/`, `src/seastar/`, `src/fmt/`, `src/zstd/`, `src/xxHash/`, `src/BLAKE3/`, `src/arrow/`, `src/googletest/`, `src/json_spirit/`, `src/spdk/`, `src/isa-l/`, `src/c-ares/`, `src/utf8proc/`, `src/dmclock/`, `src/lss/`, `src/breakpad/`, `src/jaegertracing/`, `src/s3select/`, `src/qatlib/`, `src/qatzip/`, `src/uadk/`, `src/libkmip/`, `src/blkin/`
+Directories listed in `.gitmodules` are external repos vendored as git submodules. Never edit files inside them.
 
 ## Daemon Entry Points
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Ceph is a distributed storage system providing three storage interfaces on a sin
 - **RGW** (RADOS Gateway) — provides S3 and Swift-compatible HTTP object storage APIs
 - **MGR** (Manager) — hosts Python plugin modules for monitoring, orchestration, and management
 
-The codebase is primarily C++20 with Python for management tooling. The build system is CMake.
+The codebase is primarily C++23 with Python for management tooling. The build system is CMake.
 
 ## Repository Layout
 
@@ -96,18 +96,8 @@ cd build && ninja              # Build (or make -jN)
 ### Licensing Headers
 New source files must include an `SPDX-License-Identifier` header. Ceph is primarily licensed under LGPL-2.1 or LGPL-3 (see `COPYING`). Use: `// SPDX-License-Identifier: LGPL-2.1-only OR LGPL-3.0-only`
 
-Based on the project's `CodingStyle` file:
+Read and follow the `CodingStyle` file in the repository root — it is the single source of truth for naming, indentation, braces, and parameter conventions. Do not rely on summaries; read the file directly so you pick up any updates.
 
-- **Indentation**: 2 spaces, no tabs
-- **Functions**: `snake_case()` (not CamelCase)
-- **Classes**: `CamelCase` for full classes; `lower_case_t` for simple structs
-- **Members**: `m_` prefix or no prefix (not trailing `_`)
-- **Constants/Enums**: `UPPER_CASE`
-- **Conditionals**: always use braces, body on next line
-- **Parameters**: inputs first, then outputs. Use `const&` for inputs, pointers for outputs
-- **Constructors**: mark single-arg constructors `explicit`
-- **Header guards**: `#pragma once` is acceptable
-- **Python**: PEP-8
 - **Commit messages**: `subsystem: imperative description` (e.g., `osd: fix PG creation race`). AI agents **MUST NOT** add `Signed-off-by` tags — only humans can certify DCO compliance.
 
 ## Rules for AI Coding Agents
@@ -115,7 +105,7 @@ Based on the project's `CodingStyle` file:
 ### Code Formatting
 The repository has a `.clang-format` file at the project root. **All new and modified C++ code must conform to this format.** Key points from the config:
 - Based on Google style with Ceph-specific overrides
-- C++20 standard
+- C++23 standard
 - 2-space indentation, no tabs
 - Column limit: 80 (soft), penalty-based line breaking
 - Braces: opening brace on same line for classes/structs/control, but **after newline for function definitions**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,17 +103,9 @@ Read and follow the `CodingStyle` file in the repository root — it is the sing
 ## Rules for AI Coding Agents
 
 ### Code Formatting
-The repository has a `.clang-format` file at the project root. **All new and modified C++ code must conform to this format.** Key points from the config:
-- Based on Google style with Ceph-specific overrides
-- C++23 standard
-- 2-space indentation, no tabs
-- Column limit: 80 (soft), penalty-based line breaking
-- Braces: opening brace on same line for classes/structs/control, but **after newline for function definitions**
-- Pointer/reference alignment: left (`int* p`, not `int *p`)
-- Constructor initializer lists: break after colon, one per line if they don't fit
-- Includes are sorted and regrouped by category (local, project, boost, system)
+The repository has a `.clang-format` file at the project root. **All new and modified C++ code must conform to this format.** Read the `.clang-format` file directly for the authoritative formatting rules — do not rely on summaries, which can drift out of date.
 
-When writing new code, follow these formatting rules. When editing existing code, format only the lines you change.
+When writing new code, follow `.clang-format`. When editing existing code, format only the lines you change.
 
 ### Do Not Reformat Existing Code
 **Never make whitespace-only or style-only changes to code you are not otherwise modifying.** Reformatting untouched code causes unnecessary git conflicts with other developers' branches. If you see poorly formatted existing code, leave it alone unless you are already making functional changes to those specific lines.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,31 +201,13 @@ When asked to prepare for a PR, restructure commits to tell a **story for human 
 
 ## Key Interdependencies
 
-```
-                    ┌──────────┐
-                    │  common/ │  (used by everything)
-                    │ include/ │
-                    └────┬─────┘
-                         │
-              ┌──────────┼──────────┐
-              │          │          │
-         ┌────▼───┐ ┌───▼────┐ ┌──▼───┐
-         │  msg/  │ │  os/   │ │crush/│
-         └───┬────┘ └───┬────┘ └──┬───┘
-             │          │         │
-    ┌────────┼──────────┼─────────┘
-    │        │          │
-┌───▼──┐ ┌──▼──┐ ┌────▼───┐ ┌─────┐
-│ osd/ │ │mon/ │ │  mds/  │ │mgr/ │
-└──┬───┘ └─────┘ └────────┘ └─────┘
-   │
-   │  ┌──────────┐  ┌──────────┐  ┌──────┐
-   └──│erasure-  │  │librados/ │  │ rgw/ │
-      │code/     │  └────┬─────┘  └──┬───┘
-      └──────────┘       │           │
-                    ┌────▼─────┐     │
-                    │ librbd/  │◄────┘
-                    └──────────┘
-```
-
-Note: `rgw/` depends on `librados/` (not on `os/` or `crush/` directly). `librados/` depends on `msg/`, `os/`, and `crush/` transitively, but `rgw/` does not.
+- **`common/`, `include/`** — foundational libraries used by everything
+- **`msg/`**, **`os/`**, **`crush/`** — infrastructure layer; depends on `common/`/`include/`
+- **`osd/`** — depends on `msg/`, `os/`, `crush/`, `erasure-code/`
+- **`mon/`** — depends on `msg/`, `os/`, `crush/`
+- **`mds/`** — depends on `msg/`, `os/`, `crush/`
+- **`mgr/`** — depends on `msg/`, `common/`
+- **`librados/`** — RADOS client library; depends on `msg/`, `common/` (talks to OSDs/MONs over the network, does not link `os/` or `crush/` directly)
+- **`rgw/`** — depends on `librados/` (not on `os/` or `crush/` directly)
+- **`librbd/`** — depends on `librados/`
+- **`erasure-code/`** — plugin framework used by `osd/`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,7 @@ Based on the project's `CodingStyle` file:
 - **Constructors**: mark single-arg constructors `explicit`
 - **Header guards**: `#pragma once` is acceptable
 - **Python**: PEP-8
-- **Commit messages**: `subsystem: imperative description` (e.g., `osd: fix PG creation race`). The human developer must add a `Signed-off-by:` line — never generate one as an AI.
+- **Commit messages**: `subsystem: imperative description` (e.g., `osd: fix PG creation race`). AI agents **MUST NOT** add `Signed-off-by` tags — only humans can certify DCO compliance.
 
 ## Rules for AI Coding Agents
 
@@ -155,16 +155,18 @@ However, once implementation begins, the design document becomes the agreed spec
 ### Git Commit Standards
 
 #### Sign-off
-All commits must include a `Signed-off-by` line. **Only the human developer may add this line — never generate or insert a `Signed-off-by` line as an AI.** The sign-off is the developer's personal assertion of DCO compliance and cannot be delegated to or fabricated by a tool.
+All commits must include a `Signed-off-by` line, but **AI agents MUST NOT add `Signed-off-by` tags.** Only humans can legally certify the Developer Certificate of Origin (DCO). The human submitter is responsible for:
+- Reviewing all AI-generated code
+- Ensuring compliance with licensing requirements
+- Adding their own `Signed-off-by` tag to certify the DCO
+- Taking full responsibility for the contribution
 
 #### AI Attribution
-All AI-generated or AI-assisted code must include an `Assisted-by` tag so human reviewers know which parts of the change need careful scrutiny. Include the AI tool or model used, and any automated tooling that contributed to the change.
+All AI-generated or AI-assisted code must include an `Assisted-by` tag so human reviewers know which parts of the change need careful scrutiny.
 
 ```
 Assisted-by: AI-tool-or-model [optional-tooling]
 ```
-
-The human developer takes full responsibility for DCO compliance, licensing, and correctness, and must add their own `Signed-off-by: Developer Name <developer@example.com>` line before committing.
 
 ### Commit Structure and PR Preparation
 During development, commit regularly so progress is preserved. Working commits do not need to be polished.
@@ -179,7 +181,7 @@ When asked to prepare for a PR, restructure commits to tell a **story for human 
 1. Understand the code before modifying it — use `compile_commands.json` with clangd if available
 2. Write code following `.clang-format` and `CodingStyle` — format only lines you change
 3. Build with `ninja`, run `osd_unittests`, never clean without permission
-4. Add an `Assisted-by` tag to commit messages — the human developer must add their own `Signed-off-by`; never generate one
+4. Add an `Assisted-by` tag to commit messages — **never** add a `Signed-off-by` tag; only the human developer may do so
 
 ## Navigation Quick Reference
 

--- a/PR_MEMORY_69576.md
+++ b/PR_MEMORY_69576.md
@@ -19,3 +19,9 @@
 - **Action**: Replaced ASCII box diagram with text-based dependency list. Fixed incorrect dependencies: rgw depends on librados (not os/crush directly, not librbd). ASCII diagrams are unreliable for LLM parsing.
 - **Commit**: `doc: AGENTS.md: replace ASCII diagram with text dependency list`
 - **Status**: Done
+
+### 4. Mention radosgw-admin and librgw in Purpose (yuvalif)
+- **Comment ID**: 3436356957
+- **Action**: Added brief mention of radosgw-admin and librgw to the Purpose section of src/rgw/AGENTS.md. They were already in the Key Files table but not immediately visible.
+- **Commit**: `doc: src/rgw/AGENTS.md: mention radosgw-admin and librgw in Purpose`
+- **Status**: Done

--- a/PR_MEMORY_69576.md
+++ b/PR_MEMORY_69576.md
@@ -37,3 +37,9 @@
 - **Action**: Replaced duplicated coding style bullet list with a directive to read CodingStyle directly. Fixed C++20 → C++23 throughout.
 - **Commit**: `doc: AGENTS.md: reference CodingStyle file instead of duplicating rules`
 - **Status**: Done
+
+### 7. Reference .clang-format instead of duplicating (JonBailey1993)
+- **Comment ID**: 3472990076
+- **Action**: Replaced duplicated .clang-format summary with directive to read the file directly.
+- **Commit**: `doc: AGENTS.md: reference .clang-format instead of duplicating rules`
+- **Status**: Done

--- a/PR_MEMORY_69576.md
+++ b/PR_MEMORY_69576.md
@@ -25,3 +25,9 @@
 - **Action**: Added brief mention of radosgw-admin and librgw to the Purpose section of src/rgw/AGENTS.md. They were already in the Key Files table but not immediately visible.
 - **Commit**: `doc: src/rgw/AGENTS.md: mention radosgw-admin and librgw in Purpose`
 - **Status**: Done
+
+### 5. SPDX-License-Identifier guidance (mmgaggle)
+- **Comment ID**: 3443367898
+- **Action**: Added SPDX header guidance to Coding Conventions section. New files should include SPDX-License-Identifier with LGPL-2.1-only OR LGPL-3.0-only.
+- **Commit**: `doc: AGENTS.md: add SPDX-License-Identifier guidance for new files`
+- **Status**: Done

--- a/PR_MEMORY_69576.md
+++ b/PR_MEMORY_69576.md
@@ -7,3 +7,9 @@
 - **Action**: Strengthened S-o-b language throughout AGENTS.md. AI agents MUST NOT add S-o-b tags. Aligned with Linux kernel policy. Removed all phrasing that implied AI could add S-o-b with human approval.
 - **Commit**: `doc: AGENTS.md: strengthen Signed-off-by prohibition for AI agents`
 - **Status**: Done
+
+### 2. RGW test location clarification (yuvalif)
+- **Comment ID**: 3436278802
+- **Action**: Added notes to qa/AGENTS.md about RGW test split: src/test/rgw has unit+standalone tests, qa/ has setup code only, most RGW tests in separate s3-tests repo.
+- **Commit**: `doc: qa/AGENTS.md: clarify RGW test locations`
+- **Status**: Done

--- a/PR_MEMORY_69576.md
+++ b/PR_MEMORY_69576.md
@@ -1,0 +1,9 @@
+# PR #69576 Review Comment Tracker
+
+## Addressed Comments
+
+### 1. Signed-off-by prohibition (gregsfortytwo, idryomov, mmgaggle)
+- **Comment IDs**: 3435928954, 3435936055, 3435938377, 3435940296, 3444260301, 3443383484, 3444072359
+- **Action**: Strengthened S-o-b language throughout AGENTS.md. AI agents MUST NOT add S-o-b tags. Aligned with Linux kernel policy. Removed all phrasing that implied AI could add S-o-b with human approval.
+- **Commit**: `doc: AGENTS.md: strengthen Signed-off-by prohibition for AI agents`
+- **Status**: Done

--- a/PR_MEMORY_69576.md
+++ b/PR_MEMORY_69576.md
@@ -43,3 +43,9 @@
 - **Action**: Replaced duplicated .clang-format summary with directive to read the file directly.
 - **Commit**: `doc: AGENTS.md: reference .clang-format instead of duplicating rules`
 - **Status**: Done
+
+### 8. Reference SubmittingPatches.rst for commit format (JonBailey1993)
+- **Comment ID**: 3473082793
+- **Action**: Added reference to SubmittingPatches.rst for commit/PR formatting, with explicit exception that S-o-b instructions apply to humans only.
+- **Commit**: `doc: AGENTS.md: reference SubmittingPatches.rst for commit format`
+- **Status**: Done

--- a/PR_MEMORY_69576.md
+++ b/PR_MEMORY_69576.md
@@ -61,3 +61,13 @@
 - **Action**: Merged "Do Not Reformat Existing Code" and "Minimize Diff Noise" into a single concise "Minimal Diffs" section.
 - **Commit**: `doc: AGENTS.md: merge redundant diff noise sections`
 - **Status**: Done
+
+### 11. epuertat discussion comments (reply-only, no code changes)
+- **Comment IDs**: 3491689297, 3492977242, 3493066431, 3493097856, 3493106070, 3493224031, 3493264995, 3493336056, 3493377514
+- **Action**: Replied to each with reasoning. These are architectural suggestions (SKILLs, token optimization, per-language style files, prompt compression) that are valid future direction but out of scope for this PR. Some concerns were already addressed by prior commits (CodingStyle/SubmittingPatches.rst references).
+- **Status**: Replied
+
+### 12. SPDX header conflict (epuertat vs mmgaggle)
+- **Comment IDs**: 3491704611, 3493484136 (epuertat pushback) vs 3443367898 (mmgaggle request)
+- **Action**: Flagged conflicting reviewer feedback on GitHub. epuertat questions team agreement and notes Ceph is single-license. mmgaggle originally requested the addition. Needs PR author decision.
+- **Status**: Flagged for human decision

--- a/PR_MEMORY_69576.md
+++ b/PR_MEMORY_69576.md
@@ -55,3 +55,9 @@
 - **Action**: Replaced enumerated vendored directory list with a short reference to .gitmodules. Saves tokens, avoids staleness.
 - **Commit**: `doc: AGENTS.md: replace vendored list with .gitmodules reference`
 - **Status**: Done
+
+### 10. Merge redundant diff noise sections (epuertat)
+- **Comment ID**: 3493322339
+- **Action**: Merged "Do Not Reformat Existing Code" and "Minimize Diff Noise" into a single concise "Minimal Diffs" section.
+- **Commit**: `doc: AGENTS.md: merge redundant diff noise sections`
+- **Status**: Done

--- a/PR_MEMORY_69576.md
+++ b/PR_MEMORY_69576.md
@@ -49,3 +49,9 @@
 - **Action**: Added reference to SubmittingPatches.rst for commit/PR formatting, with explicit exception that S-o-b instructions apply to humans only.
 - **Commit**: `doc: AGENTS.md: reference SubmittingPatches.rst for commit format`
 - **Status**: Done
+
+### 9. Replace vendored list with .gitmodules reference (epuertat)
+- **Comment ID**: 3493093553
+- **Action**: Replaced enumerated vendored directory list with a short reference to .gitmodules. Saves tokens, avoids staleness.
+- **Commit**: `doc: AGENTS.md: replace vendored list with .gitmodules reference`
+- **Status**: Done

--- a/PR_MEMORY_69576.md
+++ b/PR_MEMORY_69576.md
@@ -31,3 +31,9 @@
 - **Action**: Added SPDX header guidance to Coding Conventions section. New files should include SPDX-License-Identifier with LGPL-2.1-only OR LGPL-3.0-only.
 - **Commit**: `doc: AGENTS.md: add SPDX-License-Identifier guidance for new files`
 - **Status**: Done
+
+### 6. Reference CodingStyle instead of duplicating + C++23 fix (JonBailey1993)
+- **Comment IDs**: 3472907006, 3472980119
+- **Action**: Replaced duplicated coding style bullet list with a directive to read CodingStyle directly. Fixed C++20 → C++23 throughout.
+- **Commit**: `doc: AGENTS.md: reference CodingStyle file instead of duplicating rules`
+- **Status**: Done

--- a/PR_MEMORY_69576.md
+++ b/PR_MEMORY_69576.md
@@ -13,3 +13,9 @@
 - **Action**: Added notes to qa/AGENTS.md about RGW test split: src/test/rgw has unit+standalone tests, qa/ has setup code only, most RGW tests in separate s3-tests repo.
 - **Commit**: `doc: qa/AGENTS.md: clarify RGW test locations`
 - **Status**: Done
+
+### 3. Fix dependency graph + replace ASCII diagram (yuvalif, JonBailey1993/Bob)
+- **Comment ID**: 3436325550 (yuvalif), external feedback from JonBailey1993
+- **Action**: Replaced ASCII box diagram with text-based dependency list. Fixed incorrect dependencies: rgw depends on librados (not os/crush directly, not librbd). ASCII diagrams are unreliable for LLM parsing.
+- **Commit**: `doc: AGENTS.md: replace ASCII diagram with text dependency list`
+- **Status**: Done

--- a/qa/AGENTS.md
+++ b/qa/AGENTS.md
@@ -4,6 +4,11 @@
 
 The `qa/` directory contains Ceph's integration testing infrastructure. There are two main approaches: **Teuthology** (distributed cluster testing on real or virtual machines) and **standalone tests** (shell scripts that run on a single node using vstart clusters). Unit tests are separate — see [../src/test/AGENTS.md](../src/test/AGENTS.md).
 
+**Important notes on test locations:**
+- `src/test/rgw/` contains both unit tests and standalone tests. The standalone tests there are also the tests run in Teuthology — the code under `qa/` for RGW is setup/orchestration code, not the test logic itself.
+- The majority of RGW tests live in the separate **[s3-tests](https://github.com/ceph/s3-tests)** repository under the Ceph GitHub org.
+- Other subsystems may have similar splits — check subsystem-specific AGENTS.md files for details.
+
 ## Key Files and Directories
 
 ### Standalone Tests

--- a/qa/AGENTS.md
+++ b/qa/AGENTS.md
@@ -1,0 +1,114 @@
+# qa/ — Integration Testing Infrastructure
+
+## Purpose
+
+The `qa/` directory contains Ceph's integration testing infrastructure. There are two main approaches: **Teuthology** (distributed cluster testing on real or virtual machines) and **standalone tests** (shell scripts that run on a single node using vstart clusters). Unit tests are separate — see [../src/test/AGENTS.md](../src/test/AGENTS.md).
+
+## Key Files and Directories
+
+### Standalone Tests
+| Path | Purpose |
+|------|---------|
+| `standalone/` | Shell-based tests that run on a single node using vstart clusters |
+| `standalone/ceph-helpers.sh` | ~80KB utility library — functions for starting/stopping daemons, waiting for cluster health, creating pools, etc. All standalone tests source this. |
+
+### Teuthology Suites
+| Path | Purpose |
+|------|---------|
+| `suites/` | Test suite definitions (YAML-based). Each suite is a directory tree; YAML fragments are composed to create test configurations. |
+| `tasks/` | Python task implementations (~134 files). Each task is a Python class that teuthology executes on test nodes. |
+| `workunits/` | Self-contained test scripts that run on test nodes (assume a running cluster). |
+| `clusters/` | Predefined cluster configurations (YAML) specifying node count and roles. |
+| `config/` | Test configuration fragments. |
+| `overrides/` | Configuration overrides for test matrix generation. |
+| `distros/` | Distribution-specific test configurations. |
+| `machine_types/` | Machine type configurations for test infrastructure. |
+
+### Major Test Suites (`suites/`)
+| Suite | Tests |
+|---|---|
+| `rados/` | Core RADOS object storage (28 subdirectories) |
+| `rbd/` | RBD block device (22 subdirectories) |
+| `rgw/` | RGW S3/Swift gateway (24 subdirectories) |
+| `fs/` / `cephfs/` | CephFS filesystem (28 subdirectories) |
+| `crimson-rados/` | Crimson OSD |
+| `smoke/` | Quick smoke tests |
+| `upgrade/` | Cluster upgrade tests |
+| `perf-basic/` | Performance benchmarks |
+| `nvmeof/` | NVMe-oF gateway tests |
+
+### Key Task Files (`tasks/`)
+| File | Purpose |
+|------|---------|
+| `ceph.py` | Core cluster control — start/stop daemons, health checks |
+| `cephadm.py` | Container-based deployment testing |
+| `ceph_test_case.py` | Base test class for Python-based tests |
+| `cephfs/` | CephFS-specific tasks (60 modules) |
+
+## Patterns and Idioms
+
+### Standalone Test Pattern
+```bash
+#!/bin/bash
+source $(dirname $0)/../ceph-helpers.sh
+
+function run() {
+    local dir=$1
+    shift
+    setup $dir || return 1
+
+    run_mon $dir a || return 1
+    run_osd $dir 0 || return 1
+    run_osd $dir 1 || return 1
+    run_osd $dir 2 || return 1
+
+    wait_for_clean || return 1
+
+    # ... test logic ...
+
+    teardown $dir || return 1
+}
+
+main my-test "$@"
+```
+
+### Teuthology Suite Composition
+YAML fragments in the suite directory tree are composed to create test configurations:
+- Single test: `suites/foo/test.yaml`
+- Combined tests: `suites/foo/bar/+` (combines fragments a.yaml, b.yaml, c.yaml)
+- Test matrix: `suites/foo/%` (creates all combinations)
+- Random selection: `suites/foo/$` (picks one randomly)
+
+### Teuthology Task Pattern
+```python
+from teuthology.task import Task
+
+class MyTask(Task):
+    def setup(self):
+        # Cluster setup
+        pass
+
+    def begin(self):
+        # Run test
+        pass
+
+    def end(self):
+        # Cleanup
+        pass
+```
+
+## Navigation Hints
+
+- To write a quick single-node test: create a shell script under `standalone/` using `ceph-helpers.sh`
+- To understand the `ceph-helpers.sh` API: read the function list at the top of the file
+- To add a teuthology test: create a YAML suite definition under `suites/` and implement tasks in `tasks/`
+- To run standalone tests locally: `qa/standalone/<category>/test_name.sh`
+- To understand how teuthology composes tests: look at the directory structure under any suite
+
+## Gotchas
+
+- `ceph-helpers.sh` is ~80KB and central to all standalone tests. Changes to it can break many tests.
+- Teuthology suites generate a combinatorial matrix of tests. A seemingly small change to a suite definition can produce hundreds of additional test runs.
+- Workunits assume a running cluster. They do not set up or tear down clusters themselves.
+- Standalone tests create temporary vstart clusters. They need the Ceph binaries to be built and available in PATH.
+- Some QA tests are very long-running (hours). Check the suite's estimated run time before launching.

--- a/src/cls/AGENTS.md
+++ b/src/cls/AGENTS.md
@@ -1,0 +1,69 @@
+# src/cls/ — RADOS Classes
+
+## Purpose
+
+RADOS classes (cls) are **server-side plugins** that execute atomically on OSD nodes alongside RADOS operations. Each class provides domain-specific operations that run close to the data — avoiding round-trips between client and OSD. For example, `cls_rbd` manages RBD image metadata, `cls_rgw` manages bucket indices, and `cls_lock` provides distributed locking.
+
+Classes register methods via the `objclass` API (`src/objclass/objclass.h`). Server-side code operates only on the local object — it cannot access the network or other objects.
+
+## Key Files
+
+Each class follows the same directory structure:
+- `cls_<name>.cc` — server-side implementation (runs on OSD)
+- `cls_<name>_client.cc/h` — client-side helper library (used by librados callers)
+- `cls_<name>_types.h/cc` — shared type definitions
+- `cls_<name>_ops.h` — operation definitions
+
+The `objclass` API is defined in:
+- `src/objclass/objclass.h` — stable C API for writing class methods
+
+## Directory Structure (Class Implementations)
+
+| Subdirectory | Purpose | Used By |
+|---|---|---|
+| `rbd/` | RBD image metadata (headers, snapshots, object map, mirroring) | librbd |
+| `rgw/` | RGW bucket index operations | RGW |
+| `rgw_gc/` | RGW garbage collection | RGW |
+| `lock/` | Distributed object locking | librbd, RGW |
+| `log/` | Append-only log on objects | RGW (metadata log) |
+| `journal/` | Journaling support | librbd mirroring |
+| `refcount/` | Reference counting on objects | RGW |
+| `queue/` | Object-based queue | RGW notifications |
+| `2pc_queue/` | Two-phase commit queue | RGW notifications |
+| `fifo/` | FIFO queue on objects | RGW |
+| `cas/` | Content-addressable storage (chunk dedup) | Dedup feature |
+| `cmpomap/` | Compare omap values atomically | Various |
+| `numops/` | Numeric operations on object data | Various |
+| `otp/` | One-time password | RGW MFA |
+| `user/` | User metadata storage | RGW |
+| `version/` | Object versioning | Various |
+| `sem_set/` | Semaphore set | Various |
+| `cephfs/` | CephFS-specific operations | MDS |
+| `lua/` | Lua scripting engine | User-defined classes |
+| `hello/` | **Example/template class** — copy this to create new classes | Documentation |
+| `sdk/` | SDK examples | Documentation |
+| `timeindex/` | Time-indexed operations | Various |
+
+## Patterns and Idioms
+
+### Writing a Class
+Copy `hello/` as a template. Server-side methods receive `cls_method_context_t hctx` and use `cls_cxx_*` functions (`cls_cxx_read`, `cls_cxx_write`, `cls_cxx_map_get_val`, etc.) to operate on the local object. Methods are registered in `__cls_init()` via `cls_register_cxx_method()`. Client-side helpers wrap `ioctx.exec()` calls. See `src/objclass/objclass.h` for the full server-side API.
+
+## Dependencies
+
+API defined in `src/objclass/objclass.h`. Client helpers use `librados`. Classes loaded by OSD via `src/osd/ClassHandler.h`.
+
+## Navigation Hints
+
+- To create a new RADOS class, copy the `hello/` directory structure
+- To understand how a specific cls method works, read the server-side `.cc` file
+- To call a cls method from client code, use the `cls_<name>_client.h` helpers
+- To understand how the OSD loads and executes classes, see `src/osd/ClassHandler.h/cc`
+
+## Gotchas
+
+- Server-side code **cannot access the network**. It can only read/write the local object via `cls_cxx_*` functions.
+- Server-side code runs atomically — the entire method completes or fails as one operation.
+- The client-side helpers and server-side implementation must use the same encoding format. Keep type definitions in the shared `_types.h` file.
+- `cls_rbd` is the most complex class — it manages the full RBD image metadata schema. Changes to it affect RBD format compatibility.
+- Classes are loaded as shared libraries by the OSD. Build system registration is in `src/cls/CMakeLists.txt`.

--- a/src/common/AGENTS.md
+++ b/src/common/AGENTS.md
@@ -1,0 +1,123 @@
+# src/common/ — Shared Utilities
+
+## Purpose
+
+The `common/` directory is the shared utility library used by every Ceph subsystem. It contains ~330+ files providing core infrastructure: configuration management, threading primitives, serialization helpers, data structures, logging, performance counters, cryptography, and more.
+
+Almost every `.cc` file in Ceph includes something from `common/`. When looking for a utility function, check here first before writing a new one.
+
+## Key Files
+
+### Configuration
+| File | Role |
+|------|------|
+| `options/` | YAML config option definitions (`osd.yaml.in`, `rgw.yaml.in`, etc.) |
+| `options/build_options.cc` | Compiled config option registry |
+| `config.cc/h` | Config parsing and management |
+| `ceph_context.cc/h` | `CephContext` — the global context object holding config, logging, perf counters |
+| `config_cacher.h` | Thread-safe config value caching |
+
+### Threading and Synchronization
+| File | Role |
+|------|------|
+| `ceph_mutex.h` | Mutex wrappers with optional lockdep checking in debug builds |
+| `WorkQueue.h` | Thread pool work queue (ThreadPool + WorkQueue) |
+| `Finisher.h/cc` | Callback completion queue — runs `Context` callbacks in a dedicated thread |
+| `Timer.h/cc` | `SafeTimer` — schedule callbacks after a delay |
+| `AsyncReserver.h` | Async reservation system (used for backfill/recovery slot management) |
+| `Throttle.h/cc` | Rate limiting / backpressure (token bucket) |
+| `Cond.h` | Condition variable wrapper |
+| `RWLock.h` | Reader-writer lock wrapper |
+
+### Data Structures
+| File | Role |
+|------|------|
+| `hobject.h/cc` | `hobject_t` and `ghobject_t` — hash-based object identifiers |
+| `Formatter.h/cc` | Output formatting base class |
+| `JSONFormatter.h` | JSON output formatting |
+| `XMLFormatter.h` | XML output formatting |
+| `HTMLFormatter.h` | HTML output formatting |
+| `TableFormatter.h` | Table output formatting |
+| `PrioritizedQueue.h` | Priority queue with strict and proportional queues |
+| `PriorityCache.h` | Priority-based cache manager |
+| `cohort_lru.h` | Thread-safe LRU cache |
+| `RefCountedObj.h` | Intrusive reference-counted base class |
+
+### Logging
+| File | Role |
+|------|------|
+| `dout.h` | `dout(level)` / `dendl` macros |
+| `subsys.h` | Logging subsystem definitions (ceph_subsys_osd, etc.) |
+| `LogClient.h/cc` | Centralized log message forwarding to MON |
+| `LogEntry.h` | Log entry structure |
+
+### Performance
+| File | Role |
+|------|------|
+| `perf_counters.h/cc` | Performance counter infrastructure (counters viewable via admin socket) |
+| `TrackedOp.h/cc` | Operation tracking with slow-op warnings |
+| `HeartbeatMap.h/cc` | Thread heartbeat monitoring |
+| `admin_socket.h/cc` | Unix socket for runtime introspection |
+
+### Crypto and Checksums
+| File | Role |
+|------|------|
+| `ceph_crypto.h/cc` | Cryptographic function wrappers |
+| `Checksummer.h` | Checksum computation (crc32c, xxhash) |
+| `CDC.h` / `FastCDC.h` / `FixedCDC.h` | Content-defined chunking for deduplication |
+
+### Other Utilities
+| File | Role |
+|------|------|
+| `ceph_argparse.h/cc` | Command-line argument parsing |
+| `common_init.h/cc` | Daemon initialization sequence |
+| `BackTrace.h/cc` | Stack trace capture |
+| `SubProcess.h/cc` | Child process management |
+| `armor.h/cc` | Base64 encoding/decoding |
+| `blkdev.h/cc` | Block device utility functions |
+| `PluginRegistry.h/cc` | Generic plugin loading framework |
+| `EventTrace.h/cc` | LTTng/USDT tracing |
+
+## Directory Structure
+
+| Subdirectory | Contents |
+|---|---|
+| `options/` | YAML config option definitions and build scripts |
+| `async/` | Async completion utilities |
+| `io_exerciser/` | I/O pattern testing utilities |
+| `json/` | JSON parsing helpers |
+
+## Patterns and Idioms
+
+### CephContext
+Every daemon and library creates a `CephContext` (usually abbreviated `cct`). It holds configuration, the logging subsystem, and perf counters. Almost every class receives `cct` as a constructor parameter. Access config values via `cct->_conf->get_val<T>("name")` or the config observer pattern.
+
+### Finisher Pattern
+Use `Finisher::queue(Context*)` when a callback needs to run on a dedicated thread rather than the caller's.
+
+### Mutex Guidelines
+Use `ceph::mutex` / `ceph::make_mutex("name")` instead of `std::mutex` — enables lockdep checking in debug builds.
+
+### TrackedOp
+Long-running operations should inherit from `TrackedOp` for automatic slow-op warnings.
+
+## Dependencies
+
+Foundational library — depends on `include/`, `log/`, and external libraries (boost, fmt, openssl). Everything else depends on `common/`.
+
+## Navigation Hints
+
+- Need to add a config option? Edit the appropriate YAML file in `options/` (e.g., `osd.yaml.in` for OSD options)
+- Need a thread pool? Use `WorkQueue.h` (or `ShardedThreadPool` for sharded work)
+- Need to format output (JSON/XML/table)? Use `Formatter.h` and its subclasses
+- Need rate limiting? Use `Throttle.h`
+- Need an operation timer? Use `TrackedOp.h`
+- Need a perf counter? See `perf_counters.h` and look at existing examples
+
+## Gotchas
+
+- `hobject_t` hash ordering is critical for PG splitting and CRUSH. Never change hash functions.
+- `bufferlist` is defined in `include/buffer.h`, not in `common/`. But `common/` has the buffer instrumentation.
+- Not everything in `common/` is widely used. Some utilities are only used by one or two subsystems.
+- `Finisher` callbacks run on the Finisher's thread. If your callback acquires locks, beware of deadlocks with the caller.
+- `SafeTimer` callbacks run with the timer's lock held. Keep them short or dispatch to a Finisher.

--- a/src/crimson/AGENTS.md
+++ b/src/crimson/AGENTS.md
@@ -1,0 +1,111 @@
+# src/crimson/ — Next-Generation Async OSD (Seastar)
+
+## Purpose
+
+Crimson is the next-generation OSD implementation built on the **Seastar** asynchronous framework. It provides a run-to-completion, shard-per-core concurrency model — no mutexes, no thread pools, no blocking I/O. Each CPU core runs an independent reactor with its own event loop.
+
+Crimson is under active development and is **not yet production-ready**. It shares some code with the classic OSD (PeeringState, PGLog, OSDMap, CRUSH) but reimplements the I/O path, networking, and storage layers using Seastar futures.
+
+## Key Files
+
+### OSD Core (`osd/`)
+| File | Role |
+|------|------|
+| `osd/osd.h/cc` | Crimson OSD daemon — initialization, map handling, PG management. |
+| `osd/main.cc` | Crimson OSD entry point (`crimson-osd` binary). |
+| `osd/pg.h/cc` | Crimson PG — async PG implementation using futures. |
+| `osd/pg_backend.h/cc` | Abstract backend for Crimson PG I/O. |
+| `osd/replicated_backend.h/cc` | Replicated pool I/O using Seastar futures. |
+| `osd/ec_backend.h/cc` | Erasure code backend for Crimson. |
+| `osd/osd_operation.h/cc` | Operation tracking and scheduling for Crimson ops. |
+| `osd/ops_executer.h/cc` | Executes RADOS operations within Crimson. |
+| `osd/object_context.h/cc` | Object context management (replaces classic ObjectContext). |
+| `osd/recovery_backend.h/cc` | Recovery implementation using futures. |
+
+### Common Utilities (`common/`)
+| File | Role |
+|------|------|
+| `common/errorator.h` | **Errorator** — type-safe error handling replacing exceptions. Core Crimson pattern. |
+| `common/interruptible_future.h` | Interruptible futures — can be cancelled when PG interval changes. |
+| `common/gated.h` | Gate for tracking outstanding operations. |
+| `common/operation.h` | Operation tracking framework. |
+
+### Storage (`os/`)
+| File | Role |
+|------|------|
+| `os/seastore/` | **SeaStore** — new object store optimized for NVMe, fully async. |
+| `os/alienstore/` | **AlienStore** — bridge to run classic BlueStore inside Crimson (wraps blocking calls). |
+| `os/cyanstore/` | **CyanStore** — in-memory store for testing. |
+
+### Networking (`net/`)
+| File | Role |
+|------|------|
+| `net/Messenger.h` | Crimson Messenger built on Seastar networking. |
+| `net/Connection.h` | Crimson async connection. |
+
+## Directory Structure
+
+| Subdirectory | Contents |
+|---|---|
+| `osd/` | Crimson OSD implementation (async PG, backends, operations) |
+| `os/seastore/` | SeaStore — new async object store for NVMe |
+| `os/alienstore/` | Bridge to classic BlueStore |
+| `os/cyanstore/` | In-memory testing store |
+| `common/` | Crimson-specific utilities (errorator, interruptible_future, etc.) |
+| `net/` | Seastar networking layer |
+| `mon/` | Crimson monitor client |
+| `mgr/` | Crimson manager client |
+| `auth/` | Crimson auth handlers |
+| `admin/` | Admin socket for Crimson |
+| `tools/` | Crimson-specific tools |
+
+## Patterns and Idioms
+
+### Errorator
+Type-safe error handling that replaces exceptions (which are expensive in Seastar):
+```cpp
+using read_errorator = crimson::errorator<
+  crimson::ct_error::enoent,
+  crimson::ct_error::input_output_error>;
+
+read_errorator::future<bufferlist> read(...);
+```
+The return type statically encodes which errors can occur. Callers must handle all error cases.
+
+### Interruptible Futures
+Most PG operations use `interruptible_future` instead of plain `seastar::future`. These can be interrupted when a PG interval change invalidates ongoing work:
+```cpp
+using interruptible_future = crimson::interruptible::interruptible_future<IOInterruptCondition>;
+```
+
+### Shared Code with Classic OSD
+Crimson shares these components with the classic OSD:
+- `PeeringState` — peering state machine
+- `PGLog` — operation log
+- `OSDMap` / `CRUSHWrapper` — placement
+- `osd_types.h` — type definitions
+
+But the I/O path, threading model, and storage layer are completely different.
+
+### No Blocking Allowed
+Crimson code must never block. No `std::mutex`, no `std::condition_variable`, no blocking I/O. Everything is expressed as `seastar::future<>` chains. AlienStore exists specifically to wrap classic BlueStore's blocking calls in a separate thread pool.
+
+## Dependencies
+
+Uses `src/seastar/` (vendored Seastar framework). Shares `osd/PeeringState.h`, `osd/osd_types.h`, `osd/OSDMap.h`, `crush/` with the classic OSD. Uses non-blocking parts of `common/` and `include/`.
+
+## Navigation Hints
+
+- To understand the Crimson I/O path: `osd/ops_executer.cc` → `pg_backend.cc` → `replicated_backend.cc`
+- To understand SeaStore: start at `os/seastore/seastore.h`
+- To understand errorator: read `common/errorator.h` — it's the foundation of all Crimson error handling
+- To understand how classic code is bridged: see `os/alienstore/`
+
+## Gotchas
+
+- **Never add blocking code** to Crimson. No `std::mutex`, `std::condition_variable`, `sleep()`, blocking I/O, or standard library threading headers.
+- `seastar::future<>` vs `crimson::interruptible_future<>` — most PG operations use the interruptible variant. Using the wrong one can cause hangs or missed interruptions.
+- Crimson is not production-ready. Expect incomplete features and active churn.
+- SeaStore is experimental. AlienStore (wrapping BlueStore) is the practical storage backend for Crimson testing.
+- Errorator requires explicit error type listing at compile time. Adding a new error type to a function signature can cascade through many callers.
+- Seastar's shard-per-core model means each core has its own copy of state. Cross-core communication uses `seastar::submit_to()`.

--- a/src/crush/AGENTS.md
+++ b/src/crush/AGENTS.md
@@ -1,0 +1,64 @@
+# src/crush/ — CRUSH Placement Algorithm
+
+## Purpose
+
+CRUSH (Controlled Replication Under Scalable Hashing) is Ceph's data placement algorithm. It deterministically maps objects to OSDs using a hierarchical cluster topology (racks, hosts, devices) and configurable placement rules. CRUSH avoids centralized lookup tables — any node can compute placement given the CRUSH map.
+
+The core algorithm is implemented in C (`mapper.c`, `crush.c`, `hash.c`) for performance. A C++ wrapper (`CrushWrapper`) provides the high-level API used by the rest of Ceph.
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `CrushWrapper.h/cc` | C++ wrapper around the C CRUSH code. Primary API for all CRUSH operations: rule creation, bucket management, placement computation. |
+| `mapper.c/h` | Core CRUSH mapping algorithm in C — `crush_do_rule()` computes placement |
+| `crush.c/h` | CRUSH data structures: buckets, rules, weights (C code) |
+| `hash.c/h` | CRUSH hash functions (rjenkins) — deterministic and stable |
+| `builder.c/h` | Programmatic CRUSH map construction (add buckets, items, adjust weights) |
+| `CrushCompiler.h/cc` | Text-format CRUSH map compiler/decompiler (human-readable format) |
+| `CrushTester.h/cc` | CRUSH map testing — simulate placement and measure distribution |
+| `CrushTreeDumper.h` | Dump CRUSH hierarchy as tree for visualization |
+| `CrushLocation.h/cc` | OSD location detection (reads `crush_location` from config or hardware) |
+| `types.h` | CRUSH type definitions |
+| `grammar.h` | Parser grammar for CRUSH map text format |
+
+## Patterns and Idioms
+
+### Placement Computation
+```cpp
+// Map object to OSDs:
+vector<int> osds;
+crush.do_rule(rule_id, x, osds, num_replicas, weights);
+// x is typically pg_id.ps() (placement seed)
+```
+
+### CRUSH Rule Structure
+Rules are sequences of steps:
+1. `take(root)` — select a starting bucket
+2. `chooseleaf_firstn(N, type)` — choose N leaves of the given type (e.g., host)
+3. `emit` — output the selected devices
+
+### Bucket Types
+- `uniform` — all items same weight
+- `list` — linked list (legacy)
+- `tree` — balanced binary tree
+- `straw` / `straw2` — straw-drawing (default, fairest distribution)
+
+## Dependencies
+
+Self-contained — depends only on `include/`. Used by `osd/`, `mon/`, `osdc/`, `crimson/`.
+
+## Navigation Hints
+
+- To understand how pools map to CRUSH rules, see `OSDMap::_pg_to_up_acting_osds()`
+- To modify CRUSH placement behavior, start with `mapper.c:crush_do_rule()`
+- To add a new bucket type, modify `crush.h` and `mapper.c`
+- To test CRUSH distribution, use `crushtool --test` (source in `src/tools/crushtool.cc`)
+
+## Gotchas
+
+- **Hash stability is critical**: changing hash functions changes data placement across the entire cluster, causing massive data migration. Never modify `hash.c` without understanding the full impact.
+- CRUSH rules are order-sensitive. The sequence of steps (take, choose, emit) defines behavior.
+- The C code uses raw pointers and manual memory management. The C++ `CrushWrapper` handles ownership.
+- `straw2` is the recommended bucket algorithm. `straw` (v1) has known fairness issues with weight changes.
+- CRUSH weights are in units of 0x10000 (65536 = 1.0 TiB). Integer arithmetic, not floating point.

--- a/src/erasure-code/AGENTS.md
+++ b/src/erasure-code/AGENTS.md
@@ -1,0 +1,85 @@
+# src/erasure-code/ — Erasure Coding Framework
+
+## Purpose
+
+This directory provides the pluggable erasure coding (EC) framework. It defines the `ErasureCodeInterface` that all EC plugins implement, plus a base class with shared utilities and a plugin loader. Multiple EC algorithms are available as subdirectory plugins, each optimized for different use cases.
+
+Erasure coding splits data into `k` data chunks and generates `m` coding (parity) chunks. Any `k` of the `k+m` chunks can reconstruct the original data, providing storage efficiency compared to replication.
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `ErasureCodeInterface.h` | Pure virtual interface — defines `encode()`, `decode()`, `minimum_to_decode()`, chunk mapping |
+| `ErasureCode.h/cc` | Base class with shared utility methods (chunk size calculations, default implementations) |
+| `ErasureCodePlugin.h/cc` | Plugin loading infrastructure (`ErasureCodePluginRegistry`) |
+
+## Directory Structure (Plugins)
+
+| Subdirectory | Algorithm | Best For |
+|---|---|---|
+| `jerasure/` | Reed-Solomon via Jerasure library | Default plugin, general purpose |
+| `isa/` | Intel ISA-L optimized Reed-Solomon | Intel CPUs with SIMD (fastest) |
+| `lrc/` | Locally Repairable Codes | Reducing recovery network traffic (adds local parity groups) |
+| `clay/` | CLAY codes | Optimal repair bandwidth (minimum data transfer for single-chunk repair) |
+| `shec/` | Shingled Erasure Code | Reduced parity overhead |
+| `consistency/` | Consistency checking | Testing/verification |
+
+## Patterns and Idioms
+
+### Plugin Registration
+Each plugin registers itself via `ErasureCodePluginRegistry`:
+```cpp
+ErasureCodePluginRegistry::instance().add("jerasure", new ErasureCodePluginJerasure());
+```
+
+### Core Interface
+```cpp
+// Encode: k data chunks → k+m chunks (data + coding)
+int encode(const set<int> &want_to_encode,
+           const bufferlist &in,
+           map<int, bufferlist> *encoded);
+
+// Decode: any k chunks → reconstruct missing chunks
+int decode(const set<int> &want_to_read,
+           const map<int, bufferlist> &chunks,
+           map<int, bufferlist> *decoded);
+
+// What chunks are needed to read a given set?
+int minimum_to_decode(const set<int> &want_to_read,
+                      const set<int> &available,
+                      map<int, vector<pair<int,int>>> *minimum);
+```
+
+### Profile Configuration
+EC plugins are configured via a profile (key-value map):
+```
+plugin=jerasure technique=reed_sol_van k=4 m=2
+```
+
+## OSD-Side EC Backends
+
+This directory provides the codec plugins. The OSD-side I/O path that *uses* these codecs has two implementations (see `src/osd/AGENTS.md` for details):
+
+- **FastEC** (`src/osd/ECBackend.cc`, `ECCommon.cc`) — the active development target. All new work should target FastEC unless explicitly told otherwise.
+- **Classic/Legacy EC** (`src/osd/ECBackendL.cc`, `ECCommonL.cc`) — original implementation, kept for stability. Likely to be deleted. Do not add features here.
+
+`src/osd/ECSwitch.h` selects between them at runtime based on pool configuration.
+
+## Dependencies
+
+Uses `include/`, `common/`. Used by `src/osd/ECBackend.cc` and `src/osd/ECCommon.cc`.
+
+## Navigation Hints
+
+- To understand how the OSD uses EC, see `src/osd/ECBackend.h` (FastEC) or `src/osd/ECBackendL.h` (legacy)
+- To add a new EC plugin, create a new subdirectory following the `jerasure/` pattern
+- To test EC behavior, use `ceph_erasure_code_benchmark` (in `src/test/erasure-code/`)
+- EC pool configuration is managed by OSDMonitor — see `src/mon/OSDMonitor.cc`
+
+## Gotchas
+
+- EC chunk ordering matters. Chunk 0..k-1 are data, k..k+m-1 are coding. The mapping between chunks and OSD shards is defined by `shard_id_t`.
+- The `minimum_to_decode()` method is critical for read optimization — it tells the OSD which shards to read from to minimize I/O.
+- ISA-L (`isa/`) requires Intel CPUs. On non-Intel hardware, jerasure is used automatically.
+- CLAY codes minimize repair bandwidth but have higher encode/decode CPU cost.

--- a/src/include/AGENTS.md
+++ b/src/include/AGENTS.md
@@ -1,0 +1,104 @@
+# src/include/ — Shared Header Files
+
+## Purpose
+
+The `include/` directory contains fundamental header files used across all Ceph subsystems. This is where core type definitions, the serialization framework, the `bufferlist` data container, callback infrastructure, protocol constants, and public API headers live.
+
+When you see a type like `epoch_t`, `bufferlist`, `Context`, or `hobject_t` and need to understand it, look here first.
+
+## Key Files
+
+### Serialization
+| File | Role |
+|------|------|
+| `encoding.h` | The `ENCODE_START`/`ENCODE_FINISH`/`DECODE_START`/`DECODE_FINISH` macros and `WRITE_CLASS_ENCODER`. This is the primary serialization framework. |
+| `denc.h` | `DENC` — a newer, more efficient serialization framework. Types that use it get zero-copy decoding. Used for hot-path types. |
+
+### Data Containers
+| File | Role |
+|------|------|
+| `buffer.h` | `bufferlist`, `bufferptr`, `buffer::list::iterator` — the universal data container in Ceph |
+| `buffer_fwd.h` | Forward declarations for buffer types |
+
+### Callbacks
+| File | Role |
+|------|------|
+| `Context.h` | `Context` base class (async callback), `C_SaferCond` (sync waiter), `LambdaContext`. Every async completion in Ceph uses this. |
+
+### Type Definitions
+| File | Role |
+|------|------|
+| `types.h` | Common typedefs: `epoch_t`, `version_t`, `tid_t`, `snapid_t`, `ceph_tid_t` |
+| `ceph_fs.h` | On-wire protocol constants, `MSG_*` message type numbers, inode/dentry flags |
+| `ceph_features.h` | Feature bit definitions for version negotiation between daemons |
+| `CompatSet.h` | Feature compatibility sets for on-disk format versioning |
+| `rados.h` | RADOS operation constants (`CEPH_OSD_OP_READ`, `CEPH_OSD_OP_WRITE`, etc.) |
+| `ceph_hash.h` | Hash functions for object naming (rjenkins) |
+| `msgr.h` | Messenger constants and address types |
+| `neorados/RADOS.hpp` | New async RADOS API header |
+
+### Data Structures
+| File | Role |
+|------|------|
+| `interval_set.h` | Set of non-overlapping intervals — used for tracking extent ranges |
+| `elist.h` | Embeddable (intrusive) doubly-linked list |
+| `mempool.h` | Memory pool tracking — categorizes memory usage by subsystem |
+| `compact_map.h` / `compact_set.h` | Space-efficient map/set for small collections |
+| `btree_map.h` | B-tree based map (from `cpp-btree/`) |
+| `filepath.h` | CephFS path representation |
+
+### Public API Headers
+| Subdirectory | Contents |
+|---|---|
+| `rados/` | `librados.h`, `librados.hpp` — public RADOS API |
+| `rbd/` | `librbd.h`, `librbd.hpp` — public RBD API |
+| `cephfs/` | `libcephfs.h`, `ceph_ll_client.h` — public CephFS API |
+
+## Patterns and Idioms
+
+### Encoding/Decoding
+Every on-wire and on-disk structure uses versioned encoding defined in `encoding.h`:
+```cpp
+void encode(bufferlist& bl) const {
+  ENCODE_START(2, 1, bl);  // (current_version, compat_version, bufferlist)
+  encode(field1, bl);
+  encode(field2, bl);
+  encode(field3, bl);      // added in v2
+  ENCODE_FINISH(bl);
+}
+void decode(bufferlist::const_iterator& p) {
+  DECODE_START(2, p);
+  decode(field1, p);
+  decode(field2, p);
+  if (struct_v >= 2) {
+    decode(field3, p);     // v2 addition — guarded for backwards compat
+  }
+  DECODE_FINISH(p);
+}
+WRITE_CLASS_ENCODER(MyType)
+```
+When adding a field, bump the version and guard the decode with `if (struct_v >= N)`. `denc.h` provides a newer zero-copy variant for performance-critical types — don't mix both for the same type.
+
+### bufferlist
+`bufferlist` is a scatter-gather list of memory buffers — the universal data container. Not contiguous: `bl.c_str()` may copy. Use iterators for decoding: `auto it = bl.cbegin(); decode(obj, it)`.
+
+### Context Callbacks
+`Context` (in `Context.h`) is the async callback base class. Use `LambdaContext` for lambdas, `C_SaferCond` for synchronous waiting.
+
+## Dependencies
+
+Most fundamental layer — depends only on external libraries (boost, fmt). Everything in `src/` depends on `include/`.
+
+## Navigation Hints
+
+- Need to find a message type constant? Search `ceph_fs.h` for `MSG_` or `msgr.h` for `CEPH_MSG_`
+- Need to understand what RADOS ops exist? See `rados.h` for `CEPH_OSD_OP_*`
+- Need to check feature compatibility? See `ceph_features.h`
+- Need to understand the encode/decode version for a type? Find its `ENCODE_START` call
+
+## Gotchas
+
+- `encoding.h` vs `denc.h`: most types use `encoding.h`. `denc.h` is for performance-critical types that benefit from bounded-size encoding. Don't mix them for the same type.
+- `bufferlist` is NOT a contiguous buffer. Operations that assume contiguity (e.g., casting to a char*) require `bl.c_str()` which may copy.
+- Feature bits in `ceph_features.h` are a limited resource. New features should prefer capability negotiation over adding feature bits.
+- `MSG_*` constants must be unique. When adding a new message type, choose the next available number.

--- a/src/librados/AGENTS.md
+++ b/src/librados/AGENTS.md
@@ -1,0 +1,55 @@
+# src/librados/ — RADOS Client Library
+
+## Purpose
+
+`librados` provides the C and C++ client API for RADOS object storage. Applications use it to create pools, read/write objects, manage snapshots, and perform atomic operations. Internally, it wraps the **Objecter** (`src/osdc/Objecter.h`), which handles the actual OSD communication, OSDMap management, and request routing.
+
+This library is used by RGW, RBD, CephFS clients, and any external application that needs direct RADOS access.
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `librados_cxx.cc` | C++ API implementation (`librados::Rados`, `librados::IoCtx`). |
+| `librados_c.cc` | C API implementation (`rados_t`, `rados_ioctx_t`). |
+| `RadosClient.h/cc` | Internal client implementation — manages connections, MonClient, Objecter. |
+| `IoCtxImpl.h/cc` | I/O context (pool handle) implementation — per-pool state and operations. |
+| `AioCompletionImpl.h/cc` | Async I/O completion implementation. |
+| `ObjectOperationImpl.h/cc` | Object operation builder implementation. |
+| `ListObjectImpl.h/cc` | Object listing/enumeration implementation. |
+| `librados_util.h/cc` | Internal utility functions. |
+| `snap_set_diff.h/cc` | Snapshot set difference calculation. |
+
+### Related Files (outside this directory)
+| File | Role |
+|------|------|
+| `osdc/Objecter.h/cc` | The RADOS request engine — maps operations to OSDs, handles retries, manages OSDMap. |
+| `neorados/RADOS.hpp` | New async RADOS API using boost::asio (modern replacement). |
+| `include/rados/librados.h` | Public C API header. |
+| `include/rados/librados.hpp` | Public C++ API header. |
+
+## Patterns and Idioms
+
+### Core Patterns
+- **Sync**: `ioctx.write("obj", bl, len, offset)`
+- **Async**: create `AioCompletion`, call `ioctx.aio_write(...)`, wait/poll
+- **Compound ops**: batch multiple operations atomically via `ObjectWriteOperation`/`ObjectReadOperation`
+- **Lifecycle**: `Rados::init()` → `connect()` → `ioctx_create(pool)` → operations → cleanup
+
+## Dependencies
+
+Core dependency is `osdc/Objecter.h` (the actual request engine). Also uses `mon/MonClient.h`, `msg/`, `common/`. Public API in `include/rados/`.
+
+## Navigation Hints
+
+- To understand how a RADOS operation reaches an OSD: `IoCtxImpl::operate()` → `Objecter::mutate()` → `Objecter::_op_submit()` → sends `MOSDOp` to the primary OSD
+- To add a new RADOS operation: add the op constant to `include/rados.h`, add builder method to the `ObjectOperation` class, implement in `OSD::do_osd_ops()`
+- For the new async API, see `src/neorados/RADOS.hpp`
+
+## Gotchas
+
+- `librados` is the C/C++ wrapper. The actual networking and routing logic is in `osdc/Objecter`, not here.
+- The C API (`librados.h`) and C++ API (`librados.hpp`) are separate wrappers around the same `RadosClient` implementation.
+- `neorados` is the modern replacement API. New internal Ceph code should prefer it over the classic `librados` API.
+- Pool handles (`IoCtx`) are not thread-safe. Create one per thread or protect with external synchronization.
+- The Objecter automatically handles OSD failures and OSDMap changes (re-routing operations to new primaries).

--- a/src/librbd/AGENTS.md
+++ b/src/librbd/AGENTS.md
@@ -1,0 +1,86 @@
+# src/librbd/ — RBD Client Library
+
+## Purpose
+
+The `librbd` library provides RADOS Block Device (RBD) functionality — virtual block devices stored as striped objects in RADOS. It supports snapshots, cloning, journaling (for mirroring), encryption, image groups, live migration, and client-side caching.
+
+The library uses an **async request pattern** where operations are `AsyncRequest` subclasses with internal state machines. The central object is `ImageCtx`, which holds all state for an open RBD image.
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `ImageCtx.h/cc` | Central context object for an open RBD image. Holds pointers to all subsystems. |
+| `internal.h/cc` | Core operations: create, open, close, resize, snap_create, flatten, etc. |
+| `Operations.h/cc` | High-level image operation wrappers. |
+| `ImageState.h/cc` | Image state machine (open, close, refresh). |
+| `ImageWatcher.h/cc` | Watch/notify for image-level events (resize, snap, lock changes). |
+| `ExclusiveLock.h/cc` | Exclusive lock management — ensures single-writer semantics. |
+| `Journal.h/cc` | Image journal — records all mutations for mirroring. |
+| `MirroringWatcher.h/cc` | Mirroring state change notifications. |
+| `ObjectMap.h/cc` | Object existence bitmap — tracks which RADOS objects exist for fast reads. |
+| `Types.h/cc` | RBD type definitions. |
+| `Utils.h/cc` | Utility functions. |
+| `AsioEngine.h/cc` | Boost.Asio based executor for async operations. |
+
+## Directory Structure
+
+| Subdirectory | Contents |
+|---|---|
+| `io/` | I/O path — read, write, discard, flush, copy-on-write |
+| `operation/` | Image-level operations (resize, snap_create, flatten, rename) |
+| `image/` | Image lifecycle management (open, close, refresh) |
+| `mirror/` | Mirroring operations (enable, disable, promote, demote) |
+| `cache/` | Client-side caching (including persistent writeback cache) |
+| `crypto/` | Image encryption (LUKS1, LUKS2) |
+| `journal/` | Journal implementation for mirroring |
+| `object_map/` | Object existence map operations |
+| `managed_lock/` | Distributed lock management internals |
+| `exclusive_lock/` | Exclusive lock state machine |
+| `deep_copy/` | Image deep copy operations |
+| `migration/` | Live image migration |
+| `trash/` | Trash (deferred deletion) management |
+| `watcher/` | Watch/notify base framework |
+| `group/` | Image group (consistency group) operations |
+| `api/` | Public API implementation |
+| `plugin/` | Plugin framework (e.g., cache plugins) |
+
+## Patterns and Idioms
+
+### Async Request Pattern
+Most operations are implemented as `AsyncRequest` subclasses with state machines:
+```cpp
+class MyRequest : public AsyncRequest<ImageCtx> {
+  void send() override;      // Start the operation
+  // Internal states call each other via Context callbacks
+};
+```
+
+### Context Callbacks
+All async operations use `Context` callbacks for completion. State transitions within a request chain contexts together.
+
+### ImageCtx
+The central hub — holds configuration, I/O engine, journal, lock state, object map, and caching layer. Almost every class in librbd receives an `ImageCtx*`.
+
+### Object Striping
+RBD images are striped across multiple RADOS objects. Each object holds `object_size` bytes (default 4MB). Object names follow the pattern `rbd_data.<image_id>.<object_number>`.
+
+## Dependencies
+
+Uses `librados/` for RADOS I/O, `common/`, `cls/rbd/` (metadata), `cls/lock/` (locking), `journal/` (mirroring). Public API in `include/rbd/`.
+
+## Navigation Hints
+
+- To understand the read/write path: see `io/ImageDispatchSpec.h` → `io/ObjectDispatch.h` → `io/ObjectRequest.h`
+- To understand snapshotting: see `operation/SnapshotCreateRequest.h`
+- To understand cloning (copy-on-write): see `io/CopyupRequest.h`
+- To understand mirroring: see `mirror/` and `journal/`
+- To add a new image operation: create an `AsyncRequest` subclass in `operation/`
+
+## Gotchas
+
+- The async request pattern means operations span many callbacks. Tracing a single operation requires following the chain of `Context::complete()` calls through multiple states.
+- `ImageCtx` is not thread-safe by itself. Access is coordinated through the exclusive lock and image-level locks.
+- RBD uses `cls_rbd` (server-side class) heavily for metadata operations. Client-side helpers are in `cls/rbd/cls_rbd_client.h`.
+- The journal is optional — it's only enabled when mirroring is active. But when enabled, every write goes through the journal.
+- Object map is also optional. When enabled, it must be kept in sync with actual object existence.

--- a/src/mds/AGENTS.md
+++ b/src/mds/AGENTS.md
@@ -1,0 +1,85 @@
+# src/mds/ — Metadata Server
+
+## Purpose
+
+The MDS (Metadata Server) manages the CephFS filesystem namespace. It maintains an in-memory metadata cache of inodes, dentries, and directory fragments, provides distributed locking for concurrent access, and journals all metadata mutations for crash recovery.
+
+The MDS uses a **hierarchical metadata cache** built from `CInode` (inode), `CDentry` (directory entry), and `CDir` (directory fragment) objects. For multi-MDS scaling, the namespace is partitioned into **subtrees**, each owned by one MDS rank. Subtrees can be migrated between MDS ranks for load balancing.
+
+Client access is controlled through a **capability (cap)** system — clients receive read/write/exclusive capabilities on inodes, which the MDS grants and revokes to maintain consistency.
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `MDSDaemon.h/cc` | Daemon process lifecycle — startup, shutdown, signal handling. |
+| `MDSRank.h/cc` | Per-rank MDS logic. Central coordinator for all subsystems. A daemon process runs one rank. |
+| `MDCache.h/cc` | The metadata cache — manages CInode/CDir/CDentry tree, discovery, replication, migration. Largest file (~15K lines). |
+| `Server.h/cc` | Handles client requests — lookups, creates, unlinks, renames, setattr, etc. |
+| `Locker.h/cc` | Distributed lock manager — cap grants/revocations, file locks, scatter locks (~6K lines). |
+| `CInode.h/cc` | Inode cache entry. Holds inode metadata, lock state, capabilities. |
+| `CDir.h/cc` | Directory fragment cache entry. Directories can be split into fragments for parallelism. |
+| `CDentry.h/cc` | Dentry (name→inode link) cache entry. |
+| `MDLog.h/cc` | Metadata journal management — writing and trimming log segments. |
+| `MDBalancer.h/cc` | Load balancing across MDS ranks — decides when/what to migrate. |
+| `Migrator.h/cc` | Subtree/metadata migration protocol between MDS ranks. |
+| `SessionMap.h/cc` | Client session tracking and persistence. |
+| `Beacon.h/cc` | MDS→Monitor heartbeat reporting. |
+| `SnapRealm.h/cc` | Snapshot realm management (snapshot hierarchy). |
+| `SnapServer.h/cc` / `SnapClient.h/cc` | Snapshot ID allocation and distribution. |
+| `StrayManager.h/cc` | Orphaned/stray inode cleanup (purging). |
+| `Capability.h/cc` | Client capability grant/revoke structures. |
+| `Mutation.h/cc` | Metadata mutation tracking. |
+| `MDSAuthCaps.h/cc` | MDS authorization/capability checking. |
+| `SimpleLock.h` / `ScatterLock.h` / `LocalLock.h` | Lock type implementations. |
+| `locks.h` | Lock state machine definitions — all lock type state transitions. |
+
+## Directory Structure
+
+| Subdirectory | Contents |
+|---|---|
+| `events/` | Journal event types: `EUpdate`, `ESession`, `EMetaBlob`, `EExport`, `EFragment`, etc. |
+| `balancers/` | Load balancing policy implementations (Lua-based, e.g., `greedyspill.lua`) |
+
+## Patterns and Idioms
+
+### Metadata Mutation Flow
+1. Client request arrives at `Server::handle_client_request()`
+2. Path traversal via `MDCache::path_traverse()` discovers/loads inodes
+3. Locks acquired via `Locker::acquire_locks()`
+4. Mutation journaled: create `EUpdate` with `EMetaBlob` → `MDLog::submit_entry()`
+5. On journal flush: apply changes to in-memory cache
+6. Reply to client
+
+### Lock Types
+- `SimpleLock` — basic read/write/exclusive lock (most metadata)
+- `ScatterLock` — aggregation lock for distributed counters (e.g., directory stats that are updated by multiple clients)
+- `LocalLock` — lock with no remote replication (local-only state)
+
+Each lock type has a state machine defined in `locks.h`.
+
+### Capability (Cap) System
+Clients receive capabilities granting permission to cache metadata locally (read, write, buffer, exclusive). The Locker manages cap grants and revocations. See `Capability.h` for the cap types.
+
+### Directory Fragmentation
+Directories can be split into fragments (`frag_t`) for parallel access across MDS ranks. `CDir` represents one fragment. See `frag_t` in `include/ceph_frag.h`.
+
+## Dependencies
+
+Uses `common/`, `msg/`, `osdc/` (Objecter for RADOS I/O), `include/`. Key messages: `MClientRequest`, `MClientCaps`, `MDirUpdate`.
+
+## Navigation Hints
+
+- To understand how a specific client operation (e.g., `mkdir`) is handled: search for it in `Server.cc` (e.g., `Server::handle_client_mkdir()`)
+- To understand the lock state transitions: read `locks.h` for the state tables
+- To understand cap revocation: start at `Locker::issue_caps()` and `Locker::revoke_stale_caps()`
+- To understand subtree migration: start at `Migrator::export_dir()` and `Migrator::import_dir()`
+- To add a new journal event type: create a new class in `events/`, register in `LogEvent.h`
+
+## Gotchas
+
+- `MDCache.cc` is massive (~15K lines). When working on specific features, focus on the relevant methods rather than reading the whole file.
+- `Locker.cc` is ~6K lines of cap/lock state transitions. The locking model is intricate and easy to break.
+- `frag_t` (directory fragmentation) uses a bitwise prefix scheme. Understanding it is necessary for any work on directory operations.
+- CInode/CDentry/CDir use intrusive reference counting. Be careful with ownership — don't hold raw pointers across async operations.
+- Multi-MDS setups add significant complexity around subtree management and migration.

--- a/src/mgr/AGENTS.md
+++ b/src/mgr/AGENTS.md
@@ -1,0 +1,73 @@
+# src/mgr/ — Manager Daemon
+
+## Purpose
+
+The Manager daemon (ceph-mgr) hosts Python plugin modules that provide cluster monitoring, orchestration, CLI commands, and management features. The C++ code in this directory handles the daemon lifecycle, Python module loading, GIL management, and bridges between Python modules and the cluster's C++ infrastructure.
+
+The actual module implementations (dashboard, cephadm, prometheus, pg_autoscaler, etc.) live in `src/pybind/mgr/` — see [../pybind/mgr/AGENTS.md](../pybind/mgr/AGENTS.md). This directory contains only the C++ hosting infrastructure.
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `Mgr.h/cc` | Main active manager daemon class. |
+| `MgrStandby.h/cc` | Standby manager — waits for promotion to active. |
+| `DaemonServer.h/cc` | Handles connections from other daemons, routes commands, collects reports. |
+| `ActivePyModules.h/cc` | Manages active Python module instances — dispatches notifications, health checks. |
+| `StandbyPyModules.h/cc` | Manages Python modules while in standby mode. |
+| `PyModule.h/cc` | Wrapper for a single Python module — loading, initialization. |
+| `PyModuleRegistry.h/cc` | Discovery and loading of all Python modules from the filesystem. |
+| `BaseMgrModule.h/cc` | C++ base class exposed to Python — defines the `ceph_module` C extension interface. |
+| `BaseMgrStandbyModule.h/cc` | C++ base for standby-mode Python module interface. |
+| `Gil.h/cc` | Python GIL management utilities — `SafeThreadState`, `GilGuard`. Critical for thread safety. |
+| `MgrClient.h/cc` | Client-side MGR connection — used by other daemons to send perf stats and reports. |
+| `ClusterState.h/cc` | Cached cluster state (OSDMap, health, PGMap) for Python modules. |
+| `DaemonState.h/cc` | Per-daemon state tracking (perf counters, health). |
+| `ServiceMap.h/cc` | Service discovery — tracks registered services (RGW, iSCSI, NFS, etc.). |
+| `PyFormatter.h/cc` | Bridge between Ceph's Formatter classes and Python objects. |
+| `PyOSDMap.h/cc` | OSDMap exposed to Python. |
+| `MgrCommands.h` | Command definitions for the manager itself. |
+
+## Patterns and Idioms
+
+### GIL Management
+The most critical pattern in this subsystem. C++ and Python code run on different threads, and the Python GIL must be managed carefully:
+
+```cpp
+// Acquire GIL before calling Python:
+Gil gil(py_module->pMyThreadState);
+// ... call Python ...
+// GIL released when `gil` goes out of scope
+```
+
+Always acquire the GIL before calling into Python, release before calling into C++. See `Gil.h` for `SafeThreadState` and `GilGuard`.
+
+### Module Commands
+Python modules define commands via:
+- `COMMANDS` class attribute (older pattern, list of command descriptors)
+- `@CLICommand` decorator (newer pattern, annotated methods)
+
+Commands are registered with the manager, which routes CLI requests to the appropriate module.
+
+### Python Module Lifecycle
+1. `PyModuleRegistry` scans `src/pybind/mgr/` for modules (directories with `module.py`)
+2. `PyModule` wraps each module, loading its Python class
+3. `ActivePyModules` instantiates and runs modules when the mgr is active
+4. Modules receive notifications (map changes, daemon reports) via callbacks
+
+## Dependencies
+
+Uses `common/`, `msg/`, `mon/` (MonClient), `osd/OSDMap.h`, embedded CPython. Module code is in `src/pybind/mgr/`.
+
+## Navigation Hints
+
+- To understand how a CLI command reaches a Python module: `DaemonServer::handle_command()` → `ActivePyModules::handle_command()`
+- To understand how Python modules access cluster state: see `BaseMgrModule.cc` for the `ceph_module` methods exposed to Python
+- To add a new module: create a new directory under `src/pybind/mgr/` following the `hello/` template
+- To understand perf counter collection: see `DaemonServer::handle_report()`
+
+## Gotchas
+
+- **GIL deadlocks** are a real risk. The most common pattern: holding a C++ lock, acquiring GIL, calling Python code that tries to call back into C++ and acquire the same lock.
+- Manager has active/standby HA. Only the active manager runs Python modules at full functionality.
+- `Py*` wrappers expose C++ objects to Python with manual reference counting — be careful with ownership.

--- a/src/mon/AGENTS.md
+++ b/src/mon/AGENTS.md
@@ -1,0 +1,75 @@
+# src/mon/ — Monitor Daemon
+
+## Purpose
+
+The Monitor daemon maintains cluster consensus and manages all cluster state maps. A Ceph cluster typically runs 3-5 monitors that use the **Paxos** consensus algorithm to agree on cluster state. Each type of cluster state (OSDMap, MonMap, MDSMap, AuthMap, etc.) is managed by a dedicated **PaxosService** subclass.
+
+The monitor handles leader election, processes state change proposals (e.g., OSD up/down, pool creation, auth key management), and distributes updated maps to all cluster participants.
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `Monitor.h/cc` | Main daemon class. Holds PaxosService instances, handles election, message dispatch, admin commands. |
+| `Paxos.h/cc` | Core Paxos consensus algorithm implementation. |
+| `PaxosService.h/cc` | Base class for all monitor services. Defines the `preprocess_query()` / `prepare_update()` lifecycle. |
+| `Elector.h/cc` | Monitor leader election protocol. |
+| `ElectionLogic.h/cc` | Election algorithm logic (separated from networking). |
+| `OSDMonitor.h/cc` | Manages OSDMap — processes OSD state changes, pool creation/deletion, CRUSH rule changes. Largest PaxosService. |
+| `MDSMonitor.h/cc` | Manages MDSMap/FSMap — MDS rank assignment, filesystem status. |
+| `AuthMonitor.h/cc` | Manages authentication keys and capabilities (CephX). |
+| `MgrMonitor.h/cc` | Manages MgrMap — active/standby manager status. |
+| `ConfigMonitor.h/cc` | Centralized configuration store — distributes config to daemons. |
+| `HealthMonitor.h/cc` | Aggregates health checks from all services. |
+| `LogMonitor.h/cc` | Cluster log management. |
+| `KVMonitor.h/cc` | Generic KV metadata store. |
+| `MonMap.h/cc` | Monitor cluster membership map. |
+| `PGMap.h/cc` | Aggregated PG statistics (used for `ceph status` output). |
+| `MonCommands.h` | CLI command definitions — macro-based DSL defining all `ceph` CLI commands handled by the monitor. |
+| `MonClient.h/cc` | Client-side monitor connection (used by all daemons to subscribe to maps). |
+| `Session.h/cc` | Monitor session tracking. |
+| `MonOpRequest.h/cc` | Monitor operation request wrapper. |
+
+## Patterns and Idioms
+
+### PaxosService Lifecycle
+All PaxosService subclasses follow the same pattern:
+
+1. **`preprocess_query()`** — read-only check. Can answer immediately without Paxos (e.g., returning current state). Return `true` if handled, `false` if it needs Paxos.
+2. **`prepare_update()`** — propose a state change through Paxos. Stages the change in a pending buffer.
+3. Paxos commits → `update_from_paxos()` is called on all monitors to apply the committed state.
+
+When adding a new monitor command or state change, follow this pattern exactly.
+
+### MonCommands DSL
+CLI commands are defined in `MonCommands.h` using a macro-based DSL:
+```cpp
+COMMAND("osd pool create "
+        "name=pool,type=CephString "
+        "name=pg_num,type=CephInt,range=0",
+        "create pool",
+        "osd", "rw")
+```
+Each entry defines: command syntax, help text, module, and permissions.
+
+### Map Versioning
+Every cluster map has a monotonically increasing `epoch_t` version. The monitor stores all versions (for clients that need to catch up). Map trimming removes old versions based on configurable retention.
+
+## Dependencies
+
+Uses `common/`, `msg/`, `auth/`, `kv/` (RocksDB), `include/`. References map types from `osd/OSDMap.h` and `mds/FSMap.h`.
+
+## Navigation Hints
+
+- To add a new `ceph` CLI command: add the command definition to `MonCommands.h`, then implement handling in the appropriate PaxosService's `preprocess_query()` or `prepare_update()`
+- To understand how OSD state changes propagate: follow `OSDMonitor::prepare_update()` → `OSDMonitor::encode_pending()` → Paxos commit → `OSDMonitor::update_from_paxos()`
+- To understand election: `Elector.cc` handles the messaging, `ElectionLogic.cc` has the algorithm
+- To understand how daemons subscribe to maps: see `MonClient.h/cc`
+
+## Gotchas
+
+- `MonCommands.h` uses a macro-based DSL that can be confusing. The command string format is positional — parameter names and types must match exactly.
+- The monitor stores ALL versions of cluster maps. This means unbounded disk growth if trimming is misconfigured.
+- `OSDMonitor` is by far the largest PaxosService. It handles pools, CRUSH rules, OSD state, and device classes — all in one service.
+- The monitor's `MonitorDBStore` is a different KV store from the OSD's `KeyValueDB`. They both wrap RocksDB but have different schemas.
+- `PGMap` is populated from OSD reports and aggregated by the monitor. It is NOT a Paxos-managed map — it's updated out-of-band.

--- a/src/msg/AGENTS.md
+++ b/src/msg/AGENTS.md
@@ -1,0 +1,72 @@
+# src/msg/ — Messaging Layer
+
+## Purpose
+
+The `msg/` directory implements Ceph's network communication framework. All inter-daemon and client-daemon communication flows through the Messenger abstraction. The primary implementation is `AsyncMessenger`, which provides asynchronous, event-driven networking with support for two wire protocols: v1 (legacy) and v2 (msgr2, with encryption and compression).
+
+Daemons implement the `Dispatcher` interface to receive messages. The messaging layer handles connection lifecycle, authentication, message serialization, and flow control.
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `Messenger.h/cc` | Abstract base class. Daemons create a Messenger, bind to an address, add dispatchers, and start it. |
+| `Message.h/cc` | Base class for all messages. Provides encode/decode, priority, routing. |
+| `MessageRef.h` | `MessageRef` — reference-counted message pointer (`boost::intrusive_ptr<Message>`) |
+| `Dispatcher.h` | Interface that daemons implement to handle incoming messages (`ms_dispatch()`, `ms_handle_connect()`, etc.) |
+| `Connection.h/cc` | Represents a connection to a peer. Used to send messages and track connection state. |
+| `DispatchQueue.h/cc` | Queues messages for delivery to dispatchers |
+| `Policy.h` | Connection policies (lossy, lossless, stateful, stateless) |
+| `SimplePolicyMessenger.h` | Convenience base for messengers with simple per-type policies |
+| `msg_types.h/cc` | `entity_addr_t`, `entity_name_t`, `entity_inst_t` — network address and identity types |
+| `compressor_registry.h/cc` | On-wire message compression configuration |
+
+## Directory Structure
+
+| Subdirectory | Contents |
+|---|---|
+| `async/` | Asynchronous messenger implementation (the production messenger) |
+
+### async/ Key Files
+| File | Role |
+|------|------|
+| `AsyncMessenger.h/cc` | Production async messenger — event-loop based, one worker thread per connection set |
+| `AsyncConnection.h/cc` | Per-connection state machine and I/O |
+| `Protocol.h/cc` | Base class for wire protocols |
+| `ProtocolV1.h/cc` | Legacy wire protocol (being phased out) |
+| `ProtocolV2.h/cc` | Modern msgr2 protocol with encryption, compression, and multiplexing |
+| `frames_v2.h/cc` | Protocol v2 frame format definitions |
+| `Event.h/cc` | Event loop abstraction |
+| `EventEpoll.h/cc` | Linux epoll backend |
+| `EventKqueue.h/cc` | macOS/BSD kqueue backend |
+| `PosixStack.h/cc` | POSIX socket networking stack |
+| `Stack.h/cc` | Network stack abstraction |
+| `crypto_onwire.h/cc` | On-wire encryption (AES-GCM) |
+| `compression_onwire.h/cc` | On-wire compression |
+| `rdma/` | RDMA transport (optional) |
+| `dpdk/` | DPDK transport (optional) |
+
+## Patterns and Idioms
+
+### Core Patterns
+- **Sending**: `messenger->connect_to(type, addr)->send_message(new MFoo(...))`
+- **Receiving**: daemons implement `Dispatcher::ms_dispatch2()` and switch on `m->get_type()` (MSG_* constants)
+- **Downcasting**: use `ref_cast<MType>(m)` — messages are reference-counted via `MessageRef`, never `delete` them
+- **Connection policies**: `lossy` (may drop, e.g., heartbeats), `lossless` (reliable, e.g., client-to-OSD), `stateless`
+
+## Dependencies
+
+Uses `include/`, `common/`, `auth/` (connection handshake), `compressor/` (on-wire compression).
+
+## Navigation Hints
+
+- To trace how a specific message is handled, find its `MSG_*` constant (in `include/ceph_fs.h` or `include/msgr.h`), then grep for it in the target daemon's dispatch method
+- To understand the wire format, read `async/frames_v2.h` for msgr2
+- To add a new message type, create a header in `src/messages/`, assign a `MSG_*` constant, and add handling in the relevant daemon's dispatcher
+
+## Gotchas
+
+- Protocol v1 is legacy and being phased out. New features should target v2 only.
+- `AsyncMessenger` uses worker threads with event loops. Blocking in a dispatch handler blocks that worker — use Finishers or thread pools for heavy work.
+- Connection failures trigger `ms_handle_reset()` / `ms_handle_remote_reset()` callbacks. Daemons must handle these to clean up state.
+- Messages carry a `ref_t` (intrusive pointer). Once dispatched, the message is owned by the handler — don't store raw pointers to messages without taking a reference.

--- a/src/os/AGENTS.md
+++ b/src/os/AGENTS.md
@@ -1,0 +1,67 @@
+# src/os/ — ObjectStore Abstraction
+
+## Purpose
+
+The `os/` directory defines the `ObjectStore` abstract interface — the contract for all on-disk object storage in Ceph. Every OSD stores its data through this interface. The production implementation is **BlueStore** (`bluestore/`); **MemStore** (`memstore/`) exists for testing.
+
+The ObjectStore API provides atomic transactions, collection (PG) management, object read/write, extended attributes, and omap (key-value per object) operations.
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `ObjectStore.h` | Abstract base class defining the full storage interface. This is the contract that all backends implement. |
+| `Transaction.h` | `ObjectStore::Transaction` — atomic batch of mutations (write, setattr, omap_setkeys, clone, etc.) |
+
+## Directory Structure
+
+| Subdirectory | Contents |
+|---|---|
+| `bluestore/` | BlueStore — production backend, stores data directly on raw block devices. See [bluestore/AGENTS.md](bluestore/AGENTS.md) |
+| `memstore/` | MemStore — in-memory backend for unit tests. `MemStore.h/cc`, `PageSet.h` |
+| `fs/` | Filesystem metadata utilities |
+
+## Patterns and Idioms
+
+### Transaction Model
+All storage mutations are batched into a `Transaction`:
+```cpp
+ObjectStore::Transaction t;
+t.write(coll, oid, offset, length, bl);
+t.setattr(coll, oid, "attr_name", val_bl);
+t.omap_setkeys(coll, oid, keys);
+store->queue_transaction(ch, std::move(t), on_applied, on_committed);
+```
+
+Transactions are atomic — either all operations apply or none do. The `on_committed` callback fires when the transaction is durable.
+
+### Collections
+A `coll_t` represents a collection, which maps 1:1 to a Placement Group. Objects belong to exactly one collection.
+
+### Object Naming
+Objects are identified by `ghobject_t` (which contains a `hobject_t` plus generation and shard_id for EC). The ObjectStore maps these to its internal storage format.
+
+### Read Path
+```cpp
+store->read(ch, oid, offset, length, &bl);
+store->getattr(ch, oid, "attr_name", &val_bl);
+store->omap_get_values(ch, oid, keys, &out);
+```
+
+## Dependencies
+
+Uses `include/`, `common/`. BlueStore additionally uses `kv/` (RocksDB) and `blk/` (block device).
+
+## Navigation Hints
+
+- To understand what operations a Transaction supports, read `Transaction.h`
+- To understand how BlueStore implements storage, see [bluestore/AGENTS.md](bluestore/AGENTS.md)
+- To understand how the OSD uses ObjectStore, see `src/osd/PrimaryLogPG.cc` (specifically `do_osd_ops()`)
+- For testing, use `MemStore` — it requires no disk setup
+
+## Gotchas
+
+- `ObjectStore` implementations must guarantee transaction atomicity. This is non-trivial for BlueStore (which uses a WAL).
+- The `ch` parameter (collection handle) must be obtained via `open_collection()` before use. It caches metadata.
+- `queue_transaction` is asynchronous. The callbacks fire on a separate thread.
+- There used to be a FileStore backend (deprecated, removed). Some old comments may reference it.

--- a/src/os/bluestore/AGENTS.md
+++ b/src/os/bluestore/AGENTS.md
@@ -1,0 +1,79 @@
+# src/os/bluestore/ — BlueStore
+
+## Purpose
+
+BlueStore is Ceph's **production object store backend**. It stores data directly on raw block devices, bypassing the filesystem layer entirely. It uses **RocksDB** for metadata (via a thin filesystem called BlueFS), and pluggable allocators for managing free space on the block device.
+
+The architecture layers: objects (onodes) → blobs → extents on disk. Each object has metadata (onode) stored in RocksDB, which points to blobs that reference disk extents where the actual data lives.
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `BlueStore.h/cc` | Main implementation (~30K lines). Inherits from `ObjectStore`. Contains all CRUD operations, cache management, GC, and transaction handling. |
+| `BlueFS.h/cc` | Minimal filesystem for RocksDB — manages WAL and SST files on raw block device. |
+| `bluestore_types.h/cc` | Core on-disk types: `bluestore_onode_t`, `bluestore_blob_t`, `bluestore_extent_ref_map_t`, `bluestore_pextent_t`. |
+| `bluefs_types.h/cc` | BlueFS on-disk format types. |
+| `Allocator.h/cc` | Free-space allocator interface. |
+| `AvlAllocator.h/cc` | AVL tree-based allocator. |
+| `BitmapAllocator.h/cc` | Bitmap-based allocator. |
+| `BtreeAllocator.h/cc` | B-tree allocator. |
+| `Btree2Allocator.h/cc` | Second-generation B-tree allocator. |
+| `HybridAllocator.h/cc` | Hybrid allocator (combines strategies). |
+| `StupidAllocator.h/cc` | Simple first-fit allocator (legacy, still used). |
+| `FreelistManager.h/cc` | Persistent free-space tracking (survives restarts). |
+| `Writer.h/cc` | Write path optimization. |
+| `Compression.h/cc` | Compression integration (selects and applies compressor). |
+| `bluestore_tool.cc` | `ceph-bluestore-tool` — offline debugging and repair tool. |
+
+## Patterns and Idioms
+
+### Onode → Blob → Extent Hierarchy
+```
+Onode (per-object metadata in RocksDB)
+  └── Blob (chunk of data, possibly compressed/checksummed)
+       └── PExtent (physical extent on block device: offset + length)
+```
+
+- **Onode**: metadata for one object. Stored in RocksDB. Points to blobs.
+- **Blob**: a contiguous chunk of object data. May be compressed, checksummed, shared (for clones).
+- **PExtent** (`bluestore_pextent_t`): physical location on disk (offset + length).
+
+### Write Strategies
+- **Direct write**: for large writes — data written directly to allocated extents.
+- **Deferred write**: for small overwrites — data written to WAL first, then applied later. Avoids read-modify-write of large blocks.
+
+### Transaction Handling
+1. Caller creates `ObjectStore::Transaction` with operations
+2. BlueStore stages the transaction: allocates space, prepares RocksDB batch
+3. Data written to block device
+4. RocksDB metadata updated atomically
+5. Completion callbacks fired
+
+### Cache Management
+BlueStore maintains two caches:
+- **Onode cache**: recently accessed object metadata
+- **Buffer cache**: recently read data blocks
+Both are size-limited and configurable via `bluestore_cache_size`.
+
+## Dependencies
+
+Implements `os/ObjectStore.h`. Uses `kv/` (RocksDB), `blk/` (block devices), `common/`, `include/`.
+
+## Navigation Hints
+
+- To understand how a write is handled: search for `BlueStore::_do_write()` in `BlueStore.cc`
+- To understand how data is read: search for `BlueStore::read()` in `BlueStore.cc`
+- To understand allocator behavior: read the allocator you're interested in (default is usually `BitmapAllocator` or `StupidAllocator`)
+- To understand BlueFS (RocksDB filesystem): `BlueFS.h/cc`
+- To debug BlueStore issues: use `ceph-bluestore-tool` (source in `bluestore_tool.cc`)
+- For offline fsck: `ceph-bluestore-tool fsck`
+
+## Gotchas
+
+- `BlueStore.cc` is ~30K lines — one of the largest files in Ceph. Search by function name rather than reading linearly.
+- BlueStore writes directly to raw block devices. A bug in allocation or extent mapping can corrupt all data on the device.
+- The deferred write mechanism adds complexity to the write path. Small writes have a different code path from large writes.
+- BlueFS and BlueStore share the same block device but manage different regions. Understanding the boundary is important for space management.
+- Allocator choice affects performance characteristics. Different allocators have different fragmentation and speed trade-offs.
+- The onode/blob/extent model means that reading a single byte of object data may require: RocksDB lookup → extent map resolution → block device read → decompression. Understanding this chain is necessary for performance work.

--- a/src/osd/AGENTS.md
+++ b/src/osd/AGENTS.md
@@ -1,0 +1,90 @@
+# src/osd/ — Object Storage Daemon
+
+## Purpose
+
+The OSD (Object Storage Daemon) is the core data storage daemon in Ceph. Each OSD process manages one or more storage devices and is responsible for storing objects, handling replication and erasure coding, recovery, scrubbing, and serving client I/O.
+
+The OSD manages **Placement Groups (PGs)** — the fundamental unit of data distribution. Each PG is a logical group of objects that maps to a set of OSDs via CRUSH. The OSD implements a layered architecture: the OSD daemon handles map processing, messaging, and heartbeats; PG handles peering, state management, and recovery coordination; PGBackend (ReplicatedBackend or ECBackend) handles the specifics of replication vs. erasure coding; and the ObjectStore handles on-disk persistence.
+
+The peering state machine (boost::statechart-based) is one of the most complex parts of the codebase. It determines which OSDs have authoritative copies of a PG and brings them into sync.
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `OSD.h/cc` | Main daemon class. Message dispatch, OSDMap processing, heartbeats, PG lifecycle. |
+| `PG.h/cc` | Base Placement Group class. Peering state management, recovery coordination. |
+| `PrimaryLogPG.h/cc` | Primary PG implementation. Handles client ops via `do_op()`/`do_osd_ops()`, executes RADOS operations. The main workhorse. |
+| `PeeringState.h/cc` | Peering state machine (boost::statechart). States: Reset, Started, Primary, Stray, Peering, Active, etc. |
+| `PGBackend.h/cc` | Abstract backend interface for PG I/O operations. |
+| `ReplicatedBackend.h/cc` | Replicated pool I/O — sends writes to all replicas. |
+| `ECBackend.h/cc` | Erasure code pool I/O — encodes data into chunks, distributes to shards. |
+| `ECCommon.h/cc` | Shared EC utilities. |
+| `ECUtil.h/cc` | EC chunk/stripe calculations. |
+| `OSDMap.h/cc` | Cluster topology map. Pool properties, PG-to-OSD mapping, OSD states. Used by many subsystems, not just OSD. |
+| `osd_types.h/cc` | Core type definitions: `pg_t`, `spg_t`, `hobject_t`, `ghobject_t`, `eversion_t`, `pg_info_t`, etc. |
+| `PGLog.h/cc` | PG operation log — tracks recent operations for recovery. |
+| `SnapMapper.h/cc` | Mapping between snapshots and clone objects. |
+| `Session.h/cc` | Client session management. |
+| `Watch.h/cc` | Object watch/notify mechanism (used by RBD). |
+| `OpRequest.h/cc` | Operation request wrapper with tracking. |
+| `ClassHandler.h/cc` | Loads and executes RADOS class (cls) methods. |
+| `osd_perf_counters.h` | Performance counter definitions. |
+
+## Directory Structure
+
+| Subdirectory | Contents |
+|---|---|
+| `scrubber/` | Scrubbing subsystem — data integrity verification. See [scrubber/AGENTS.md](scrubber/AGENTS.md) |
+| `scheduler/` | Op scheduling with mClock QoS (`mClockScheduler.h/cc`) |
+
+## Patterns and Idioms
+
+### PG Lock Ordering
+The OSD has strict lock ordering to avoid deadlocks. The general rule is: PG lock → shard lock → OSD-level locks. See comments in `OSD.h` for the full ordering.
+
+### Operation Dispatch Flow
+1. Client sends `MOSDOp` message
+2. `OSD::ms_dispatch()` → `OSD::dispatch_op_fast()` → enqueue on PG's op queue
+3. PG dequeues → `PrimaryLogPG::do_op()` → `PrimaryLogPG::do_osd_ops()` executes the RADOS ops
+4. For writes: create `ObjectStore::Transaction`, submit to ObjectStore, replicate to secondaries
+
+### Peering State Machine
+PG peering uses boost::statechart with states defined in `PeeringState.h`. Key states:
+- `Reset` → initial or recovery from failure
+- `Peering` → discovering which OSDs have data, choosing authoritative log
+- `Active` → PG is serving I/O
+- `Recovery` → missing objects being recovered from peers
+
+### EC Backend Architecture
+There are two EC implementations, switched at runtime by `ECSwitch.h`:
+
+- **FastEC** (optimized): `ECBackend.cc`, `ECCommon.cc`, `ECExtentCache.cc`, `ECTransaction.cc`, `ECUtil.cc` — the current active development target. All new EC work should go here unless explicitly told otherwise.
+- **Classic/Legacy EC**: `ECBackendL.cc`, `ECCommonL.cc`, `ECExtentCacheL.cc`, `ECTransactionL.cc`, `ECUtilL.cc` — the original implementation, kept for stability while FastEC matures. Likely to be deleted in the future. Do not add features to these files.
+
+`ECSwitch` delegates to one or the other based on pool configuration (`allows_ecoptimizations()`). Related shared files: `ECMsgTypes.h/cc` (message types), `ECTypes.h` (shared types), `ECListener.h` (PG callback interface), `ECInject.h/cc` (error injection for testing), `ECOmapJournal.h/cc` (omap journaling).
+
+### Object Identifiers
+- `hobject_t` — hash-ordered object identifier (pool, hash, key, oid, snap, namespace)
+- `ghobject_t` — extends `hobject_t` with `generation` and `shard_id` for EC objects
+- `pg_t` — placement group identifier (pool, seed)
+- `spg_t` — sharded PG identifier (pg_t + shard_id)
+
+## Dependencies
+
+Uses `os/` (ObjectStore), `msg/` (Messenger), `crush/`, `erasure-code/`, `cls/`, `common/`, `include/`. Key messages: `MOSDOp`, `MOSDRepOp`, `MOSDPGInfo`, `MOSDPGLog`.
+
+## Navigation Hints
+
+- To understand how a client read/write is processed, start at `PrimaryLogPG::do_op()` → `do_osd_ops()`
+- To understand peering, start at `PeeringState.h` and follow the state transitions
+- To understand recovery, look at `PrimaryLogPG::start_recovery_ops()` and the RecoveryBackend classes
+- To understand EC encode/decode, start at `ECBackend::handle_sub_write()` and `ECUtil.h`
+- To add a new RADOS operation, add the op constant to `include/rados.h`, then implement in `PrimaryLogPG::do_osd_ops()`
+
+## Gotchas
+
+- `OSDMap` is NOT only used by the OSD. Monitors, MDS, clients, and librbd all use it. Changes to OSDMap affect the entire cluster.
+- The peering state machine is extremely complex (~40 states). Modifying it without understanding the full state graph will introduce subtle bugs.
+- `hobject_t` vs. `ghobject_t`: ghobject_t adds generation/shard_id for EC objects. Most internal OSD code uses `ghobject_t`.
+- `PrimaryLogPG::do_osd_ops()` is very large. Individual op implementations are in the giant switch statement — search by `CEPH_OSD_OP_*` constant.

--- a/src/osd/scrubber/AGENTS.md
+++ b/src/osd/scrubber/AGENTS.md
@@ -1,0 +1,63 @@
+# src/osd/scrubber/ — Scrubbing Subsystem
+
+## Purpose
+
+The scrubbing subsystem verifies data integrity by comparing object replicas (or EC shards) across OSDs. It detects and can repair data corruption, bitrot, and metadata inconsistencies. Scrubbing operates at the PG level — each PG is independently scheduled and scrubbed.
+
+There are two scrub modes:
+- **Shallow scrub**: compares metadata (size, attributes, omap) across replicas
+- **Deep scrub**: additionally reads and checksums all object data
+
+The scrub lifecycle is managed by a **boost::statechart state machine** that coordinates chunk-by-chunk scanning across the primary and replica OSDs.
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `pg_scrubber.h/cc` | Per-PG scrubber implementation — owns the scrub state machine and coordinates the scrub process. |
+| `scrub_machine.h/cc` | Scrub state machine (boost::statechart). States: NotActive, NewChunk, WaitPushes, WaitLastUpdate, BuildMap, WaitReplicas, WaitDigestUpdate, etc. |
+| `scrub_backend.h/cc` | Comparison logic — compares replica maps to detect inconsistencies and determine repairs. |
+| `osd_scrub.h/cc` | OSD-level scrub coordination — manages the scrub queue across all PGs on this OSD. |
+| `osd_scrub_sched.h/cc` | Scrub scheduling queue — determines which PGs to scrub and when. |
+| `scrub_reservations.h/cc` | Replica reservation management — reserves scrub slots on replica OSDs before starting. |
+| `scrub_resources.h/cc` | Resource limiting — controls how many PGs can scrub concurrently. |
+| `scrub_job.h/cc` | Scrub job definition — encapsulates a single scrub task's parameters and state. |
+| `ScrubStore.h/cc` | Persistent storage of scrub errors (stored as objects in the PG). |
+| `PrimaryLogScrub.h/cc` | Integration with PrimaryLogPG — bridges the PG and scrubber. |
+
+## Patterns and Idioms
+
+### Scrub State Machine Flow
+1. **NotActive** → scrub scheduled, PG enters scrub mode
+2. **NewChunk** → select next chunk of objects to scrub
+3. **WaitPushes** → wait for any pending recovery pushes
+4. **WaitLastUpdate** → wait for outstanding writes to complete
+5. **BuildMap** → primary builds scrub map for its chunk
+6. **WaitReplicas** → request and wait for replica scrub maps
+7. **WaitDigestUpdate** → compare maps, repair if needed
+8. Loop back to NewChunk until all objects are scrubbed
+
+### Reservation Protocol
+Before scrubbing, the primary must reserve scrub slots on all replica OSDs. This prevents too many concurrent scrubs from overloading the cluster. Reservations are managed by `scrub_reservations.h/cc`.
+
+### Chunk-Based Processing
+Objects are scrubbed in chunks (configurable size) to avoid holding PG locks for too long and to allow interleaving with regular I/O.
+
+## Dependencies
+
+Uses `osd/PG.h`, `osd/PrimaryLogPG.h`, `os/ObjectStore.h`, `common/`. Key messages: `MOSDRepScrub`, `MOSDRepScrubMap`.
+
+## Navigation Hints
+
+- To understand the scrub lifecycle: read the state machine in `scrub_machine.h`
+- To understand how replicas are compared: see `scrub_backend.cc`
+- To understand scheduling policy: see `osd_scrub_sched.cc`
+- To modify scrub behavior: likely need to change both the state machine and the backend
+
+## Gotchas
+
+- The state machine is complex with many states and transitions. Drawing the state diagram helps when making changes.
+- Scrub interacts with recovery, backfill, and client I/O. Changes to scrub timing can affect cluster performance.
+- Deep scrub reads all data — it can generate significant I/O load. The scheduling system throttles this.
+- Scrub errors are stored persistently. The error reporting and repair path is separate from the detection path.
+- The reservation system prevents scrub storms but can also delay necessary scrubs if many PGs need scrubbing simultaneously.

--- a/src/pybind/mgr/AGENTS.md
+++ b/src/pybind/mgr/AGENTS.md
@@ -1,0 +1,65 @@
+# src/pybind/mgr/ — Python Manager Modules
+
+## Purpose
+
+This directory contains the Python modules that run inside the Manager daemon (ceph-mgr). There are 50+ modules providing web UI, monitoring, orchestration, CLI commands, and various management features. Each module is a directory containing a `module.py` (or equivalent) that defines a class inheriting from `MgrModule`.
+
+The C++ hosting infrastructure for these modules is in `src/mgr/` — see [../../mgr/AGENTS.md](../../mgr/AGENTS.md).
+
+## Key Files (Framework)
+
+| File | Role |
+|------|------|
+| `mgr_module.py` | `MgrModule` base class — defines the full interface for modules (options, commands, health checks, notifications, etc.). Read this first. |
+| `mgr_util.py` | Shared utility functions used across modules. |
+| `object_format.py` | Output formatting utilities (JSON, YAML, text). |
+
+## Module Directory
+
+### Key Modules
+| Module | Purpose |
+|---|---|
+| `dashboard/` | Web UI (Angular frontend + Python REST backend). Largest module, has its own build system. |
+| `cephadm/` | Container-based cluster deployment and lifecycle management. |
+| `orchestrator/` | Orchestrator abstraction layer (interface for cephadm/rook). |
+| `prometheus/` | Prometheus metrics exporter. |
+| `balancer/` | PG balancer — distributes PGs evenly across OSDs. |
+| `pg_autoscaler/` | Automatic PG count management. |
+| `volumes/` | CephFS volume/subvolume management. |
+| `rbd_support/` | RBD management commands. |
+| `hello/` | **Template module** — copy this to create new modules. |
+
+There are 50+ modules total. Browse the directory listing for the full set.
+
+## Patterns and Idioms
+
+### Module Structure
+Every module has a class inheriting `MgrModule` (defined in `mgr_module.py`). Use `hello/` as a template. Key patterns:
+- **Commands**: use `@CLICommand` decorator (preferred) or `COMMANDS` class attribute (older)
+- **Cluster state**: `self.get_osdmap()`, `self.get('health')`, `self.get('pg_summary')`
+- **Health checks**: `self.set_health_checks({...})`
+- **Config**: `self.get_module_option('name')` / `self.set_module_option('name', val)`
+- **Continuous service**: implement `serve()` with `self.event.wait()` for interruptible sleeping (not `time.sleep()`)
+
+## Dependencies
+
+- `mgr_module.py` — the MgrModule base class (in this directory)
+- `src/mgr/` — C++ hosting infrastructure
+- Various Python standard library and third-party packages
+
+## Navigation Hints
+
+- To create a new module: copy `hello/` and modify
+- To understand the MgrModule API: read `mgr_module.py` — it has comprehensive docstrings
+- To add a CLI command to an existing module: use the `@CLICommand` decorator
+- To expose a health check: use `self.set_health_checks()`
+- To understand the dashboard: see `dashboard/` (it has its own frontend build system using Angular)
+- To understand orchestrator interface: read `orchestrator/_interface.py`
+
+## Gotchas
+
+- **Dashboard** is by far the largest module. It has its own Angular frontend, build system, and REST API framework. Treat it as a sub-project.
+- Modules run in the Manager daemon's Python interpreter. Thread safety with the C++ GIL layer is handled by the hosting code, but be careful with multi-threaded Python code within a module.
+- `serve()` runs in its own thread. Use `self.event.wait()` for interruptible sleeping — do not use `time.sleep()`.
+- Module config options persist in the monitor store. Changes are visible cluster-wide.
+- Not all modules are enabled by default. Check `ceph mgr module ls` for active modules.

--- a/src/rgw/AGENTS.md
+++ b/src/rgw/AGENTS.md
@@ -6,6 +6,8 @@ The RADOS Gateway (RGW) provides S3-compatible and Swift-compatible HTTP object 
 
 RGW supports multisite replication, IAM policies, server-side encryption, lifecycle management, bucket notifications (Kafka, AMQP), and many S3 features. The SAL abstraction allows pluggable storage backends beyond RADOS.
 
+The subsystem also includes **`radosgw-admin`** (CLI tool for bucket, user, zone, and key management) and **`librgw`** (embeddable C API for embedding RGW in other processes).
+
 ## Key Files
 
 ### Core

--- a/src/rgw/AGENTS.md
+++ b/src/rgw/AGENTS.md
@@ -1,0 +1,112 @@
+# src/rgw/ — RADOS Gateway
+
+## Purpose
+
+The RADOS Gateway (RGW) provides S3-compatible and Swift-compatible HTTP object storage APIs on top of RADOS. It is the **largest subsystem** in Ceph (~360 files). The architecture is layered: HTTP frontend (Boost.Beast/Asio) → REST operation routing → **Storage Abstraction Layer (SAL)** → backend driver (usually RADOS).
+
+RGW supports multisite replication, IAM policies, server-side encryption, lifecycle management, bucket notifications (Kafka, AMQP), and many S3 features. The SAL abstraction allows pluggable storage backends beyond RADOS.
+
+## Key Files
+
+### Core
+| File | Role |
+|------|------|
+| `rgw_main.cc` / `rgw_appmain.cc` | Daemon startup and initialization. |
+| `rgw_process.cc/h` | Request processing pipeline. |
+| `rgw_rest.cc/h` | REST request routing — maps HTTP method + URL to handler class. |
+| `rgw_op.cc/h` | Base operation classes (`RGWOp` and subclasses for GET, PUT, DELETE, etc.). |
+| `rgw_common.h/cc` | Common definitions, utilities, error codes. |
+| `librgw.cc` | Embeddable RGW library (`librgw`) — C API for embedding RGW in other processes. |
+| `radosgw-admin/` | `radosgw-admin` CLI tool — bucket, user, zone, and key management commands. |
+
+### S3/Swift Protocol
+| File | Role |
+|------|------|
+| `rgw_rest_s3.cc/h` | S3 API implementation — all S3-specific request/response handling. |
+| `rgw_rest_swift.cc/h` | Swift API implementation. |
+| `rgw_auth.h/cc` | Authentication framework (pluggable auth engines). |
+| `rgw_auth_s3.h/cc` | S3 signature verification (v2 and v4 signing). |
+| `rgw_acl.h/cc` / `rgw_acl_s3.h/cc` | Access control list implementation. |
+| `rgw_iam_policy.h/cc` | IAM policy evaluation engine. |
+
+### Storage Abstraction Layer
+| File | Role |
+|------|------|
+| `rgw_sal.h` | SAL interface — `rgw::sal::Driver`, `rgw::sal::Bucket`, `rgw::sal::Object`. All storage goes through this. |
+| `rgw_sal_fwd.h` | Forward declarations for SAL types. |
+
+### Features
+| File | Role |
+|------|------|
+| `rgw_bucket.h/cc` | Bucket operations. |
+| `rgw_user.h/cc` | User management. |
+| `rgw_lc.h/cc` | Lifecycle management (expiration, transitions). |
+| `rgw_sync.h/cc` / `rgw_data_sync.cc` | Multisite data sync engine. |
+| `rgw_crypt.h/cc` | Server-side encryption (SSE-S3, SSE-KMS, SSE-C). |
+| `rgw_compression.h/cc` | Object compression. |
+| `rgw_coroutine.h/cc` | Legacy coroutine framework for async operations. |
+| `rgw_cache.h/cc` | Object caching layer. |
+| `rgw_bucket_logging.h/cc` | Bucket access logging. |
+
+## Directory Structure
+
+| Subdirectory | Contents |
+|---|---|
+| `driver/rados/` | RADOS backend for SAL — the production backend (~127 files). |
+| `driver/posix/` | POSIX filesystem backend for SAL. |
+| `driver/d4n/` | D4N (Data for Nodes) caching backend. |
+| `driver/daos/` | DAOS backend. |
+| `driver/dbstore/` | Database-backed store (SQLite). |
+| `driver/motr/` | Motr backend. |
+| `services/` | Service layer (`svc_*`) — modular backend-agnostic services (zone, user, bucket, quota, etc.). |
+| `radosgw-admin/` | `radosgw-admin` CLI tool source. |
+| `librgw.cc` | Embeddable RGW library entry point — see also `include/rados/librgw.h`. |
+
+## Patterns and Idioms
+
+### SAL (Storage Abstraction Layer)
+All storage operations go through the SAL interface:
+- `rgw::sal::Driver` — top-level driver (create bucket, get user, etc.)
+- `rgw::sal::Bucket` — bucket operations (list objects, get/set attrs)
+- `rgw::sal::Object` — object operations (read, write, delete)
+
+New features should use SAL interfaces, not talk directly to RADOS.
+
+### REST Operation Dispatch
+Each S3/Swift operation has a handler class inheriting from `RGWOp`:
+1. HTTP request arrives at frontend
+2. `rgw_rest.cc` matches URL pattern → selects `RGWHandler` subclass
+3. Handler creates appropriate `RGWOp` subclass
+4. `RGWOp::execute()` performs the operation via SAL
+
+### Service Layer
+Services in `services/` provide modular, backend-agnostic functionality:
+- `svc_zone.h/cc` — zone/realm/period management
+- `svc_user.h/cc` — user metadata
+- `svc_bucket.h/cc` — bucket metadata
+- `svc_mdlog.h/cc` — metadata change log
+- `svc_datalog.h/cc` — data change log
+
+### Coroutines
+Legacy async operations (especially multisite sync) use `RGWCoroutine`. New async code should prefer boost::asio coroutines.
+
+## Dependencies
+
+Uses `librados/` for RADOS I/O, `common/`, `include/`. Key RADOS classes: `cls_rgw`, `cls_rgw_gc`, `cls_log`, `cls_lock`, `cls_user`.
+
+## Navigation Hints
+
+- To understand how a specific S3 API call is handled: search for its handler class in `rgw_rest_s3.cc` (e.g., `RGWPutObj_ObjStore_S3`)
+- To add a new S3 operation: create handler in `rgw_rest_s3.cc`, create `RGWOp` subclass in `rgw_op.cc`
+- To understand multisite sync: start at `driver/rados/rgw_data_sync.cc`
+- To understand the RADOS backend: look in `driver/rados/`
+- To understand IAM policy evaluation: see `rgw_iam_policy.cc`
+
+## Gotchas
+
+- Almost all files have the `rgw_` prefix. The sheer number makes grep noisy — use the SAL/driver/services layering to narrow your search.
+- Multisite sync is extremely complex. The data sync engine uses coroutines extensively and spans many files.
+- The SAL interface is relatively new. Some code still bypasses SAL and talks directly to RADOS. This is being cleaned up — new code must use SAL.
+- `rgw_rest_s3.cc` is very large. Search by S3 operation name to find the relevant handler.
+- RGW uses its own HTTP server (Beast/Asio frontend), not the Ceph Messenger. Networking patterns differ from other daemons.
+- See `MAINTAINERS.md` in this directory for RGW-specific maintainer contacts.

--- a/src/test/AGENTS.md
+++ b/src/test/AGENTS.md
@@ -1,0 +1,61 @@
+# src/test/ — C++ Unit Tests
+
+## Purpose
+
+This directory contains C++ unit tests using the **Google Test (GTest)** and **Google Mock (GMock)** frameworks. Tests generally mirror the source tree structure — tests for subsystem `foo` are in `test/foo/`.
+
+## Organization
+
+### Test File Naming
+- `test_*.cc` — standalone tests
+- `unittest_*.cc` — unit tests linked against GTest
+- Test files are registered in `CMakeLists.txt` via `add_ceph_test()` or `add_ceph_unittest()`
+
+### Major Test Subdirectories
+| Subdirectory | Tests For |
+|---|---|
+| `osd/` | OSD, PG, PGBackend, PGLog, EC, peering |
+| `mon/` | Monitor, Paxos, PGMap |
+| `mds/` | MDS metadata operations |
+| `msgr/` | Messaging layer |
+| `crimson/` | Crimson async engine |
+| `librados/` | RADOS client library |
+| `librbd/` | RBD image library |
+| `client/` | CephFS client |
+| `objectstore/` | BlueStore and ObjectStore |
+| `erasure-code/` | Erasure coding plugins |
+| `compressor/` | Compression plugins |
+| `encoding/` | Encoding roundtrip tests |
+| `common/` | Common utilities |
+| `cls_rbd/`, `cls_lock/`, `cls_log/`, `cls_rgw/`, etc. | RADOS class tests |
+| `journal/` | RBD journal tests |
+| `admin_socket/` | Admin socket tests |
+| `cli/` | CLI output tests |
+
+## Building and Running Tests
+
+```bash
+cd build && ninja unittest_foo && ./bin/unittest_foo   # Build and run one test
+GTEST_FILTER="Suite.Name" ./bin/unittest_foo           # Filter test cases
+ctest -j$(nproc)                                       # Run all registered tests
+```
+
+## Patterns and Idioms
+
+Standard GTest/GMock. Tests use `TEST_F` with fixture classes. Register in `CMakeLists.txt` via `add_ceph_unittest()`. Many tests use `MemStore` (in-memory ObjectStore) to avoid disk I/O.
+
+## Navigation Hints
+
+- To find tests for a specific subsystem: look in `test/<subsystem>/`
+- To add a new test: create a `test_*.cc` or `unittest_*.cc` file in the appropriate subdirectory and register it in `CMakeLists.txt`
+- To understand test fixtures for OSD tests: see `test/osd/` for PGBackend and PGLog test fixtures
+- For encoding roundtrip tests: see `test/encoding/`
+- For integration-level tests: see `qa/` ([../../qa/AGENTS.md](../../qa/AGENTS.md))
+
+## Gotchas
+
+- Some tests require a running cluster or specific hardware. These are typically skipped in unit test runs and handled by the QA infrastructure instead.
+- Test binaries are built in `build/bin/`. Use `ninja <test_name>` to build a specific test without building everything.
+- `run-make-check.sh` does a full build plus tests. It's slow — for iterative development, build and run individual tests.
+- Some tests use `GTEST_SKIP()` for conditional execution. Check test output for skipped tests.
+- The `cls_*` test directories test both the server-side class code and the client-side helper libraries.

--- a/src/tools/AGENTS.md
+++ b/src/tools/AGENTS.md
@@ -1,0 +1,64 @@
+# src/tools/ — CLI Tools
+
+## Purpose
+
+This directory contains the source code for Ceph's command-line tools — used for cluster administration, debugging, and offline manipulation of data stores. Some tools operate on a running cluster; others operate directly on offline data structures.
+
+## Key Files
+
+### Map and Configuration Tools
+| File | Tool Binary | Purpose |
+|------|------------|---------|
+| `crushtool.cc` | `crushtool` | Compile, decompile, test, and simulate CRUSH maps |
+| `monmaptool.cc` | `monmaptool` | Create and edit monitor maps |
+| `osdmaptool.cc` | `osdmaptool` | Create, edit, and test OSD maps |
+| `ceph_conf.cc` | `ceph-conf` | Query ceph.conf configuration values |
+| `ceph_authtool.cc` | `ceph-authtool` | Create and manage CephX authentication keys |
+
+### Offline Store Tools
+| File | Tool Binary | Purpose |
+|------|------------|---------|
+| `ceph_objectstore_tool.cc/h` | `ceph-objectstore-tool` | Offline ObjectStore manipulation — import/export objects, repair metadata, list PGs |
+| `ceph_monstore_tool.cc` | `ceph-monstore-tool` | Offline monitor store manipulation — inspect and modify monitor database |
+| `ceph_kvstore_tool.cc` | `ceph-kvstore-tool` | RocksDB key-value store inspection and manipulation |
+| `kvstore_tool.h/cc` | (library) | Shared KV store tool logic |
+
+### Recovery and Repair
+| File | Tool Binary | Purpose |
+|------|------------|---------|
+| `rebuild_mondb.h/cc` | (library) | Monitor database reconstruction from OSD data |
+| `RadosDump.h/cc` | (library) | RADOS object dumping utilities |
+
+### Client CLI Tools (subdirectories)
+| Subdirectory | Tool Binary | Purpose |
+|---|---|---|
+| `rados/` | `rados` | RADOS object storage CLI — put/get/bench/pool management |
+| `rbd/` | `rbd` | RBD image management CLI — create/map/snap/mirror |
+| `cephfs/` | `cephfs-top`, `cephfs-mirror` | CephFS monitoring and mirroring tools |
+| `rbd_mirror/` | `rbd-mirror` | RBD mirror daemon — replicates images between clusters |
+| `rbd_nbd/` | `rbd-nbd` | Map RBD images as NBD devices |
+| `rbd_wnbd/` | `rbd-wnbd` | Map RBD images as Windows block devices |
+| `immutable_object_cache/` | `ceph-immutable-object-cache` | Shared read-only cache daemon |
+| `ceph-dencoder/` | `ceph-dencoder` | Encoding/decoding test tool — roundtrip test all serializable types |
+| `neorados/` | `neorados` | New RADOS CLI using the neorados API |
+
+### Other Tools
+| File | Tool Binary | Purpose |
+|------|------------|---------|
+| `psim.cc` | `psim` | Placement group simulator — test PG distribution |
+| `scratchtoolpp.cc` | `scratchtoolpp` | RADOS test/scratch tool |
+
+## Navigation Hints
+
+- To work on the `rados` CLI: see `rados/rados.cc`
+- To work on the `rbd` CLI: see `rbd/rbd.cc`
+- To understand offline OSD repair: see `ceph_objectstore_tool.cc`
+- To test encoding compatibility: use `ceph-dencoder` (source in `ceph-dencoder/`)
+- To simulate CRUSH placement: use `crushtool --test`
+
+## Gotchas
+
+- `ceph_objectstore_tool` directly opens the OSD's ObjectStore. The OSD must be stopped first — running it on a live OSD will corrupt data.
+- `ceph-dencoder` is used in encoding compatibility tests. Adding a new encoded type requires registering it with the dencoder.
+- The `rados` and `rbd` CLI tools have many subcommands implemented across multiple source files in their subdirectories.
+- The RBD mirror daemon (`rbd_mirror/`) is a long-running daemon, not just a CLI tool, despite living in `tools/`.


### PR DESCRIPTION
Add 22 AGENTS.md files at strategic locations throughout the Ceph repository to help AI coding agents navigate the codebase effectively. Each file documents subsystem purpose, key files, patterns, dependencies, and gotchas.

Root AGENTS.md includes AI agent rules covering code formatting, commit standards, documentation requirements, and build workflow.

It is intentionally brief, to avoid excessive token usage.  I have tried to make it factual for now and not opinionated - with the expectation that component owners will tweak there own versions of it. 

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
