### PR TITLE
compressor/zstd: validate decompression and fix DStream leak

### DIFF
--- a/src/compressor/zstd/ZstdCompressor.h
+++ b/src/compressor/zstd/ZstdCompressor.h
@@ -19,6 +19,8 @@
 #define ZSTD_STATIC_LINKING_ONLY
 #include <zstd.h>
 
+#include <limits>
+
 #include "include/buffer.h"
 #include "include/encoding.h"
 #include "compressor/Compressor.h"
@@ -28,6 +30,11 @@ class ZstdCompressor : public Compressor {
   ZstdCompressor(CephContext *cct) : Compressor(COMP_ALG_ZSTD, "zstd"), cct(cct) {}
 
   int compress(const ceph::buffer::list &src, ceph::buffer::list &dst, std::optional<int32_t> &compressor_message) override {
+    // the decompressed length is stored as a uint32_t prefix, so a source
+    // larger than that cannot be round-tripped
+    if (src.length() > std::numeric_limits<uint32_t>::max()) {
+      return -EINVAL;
+    }
     ZSTD_CCtx *s = ZSTD_createCCtx();
     if (!s) {
       return -ENOMEM;
@@ -90,7 +97,7 @@ class ZstdCompressor : public Compressor {
 		 ceph::buffer::list &dst,
 		 std::optional<int32_t> compressor_message) override {
     if (compressed_len < 4) {
-      return -1;
+      return -EINVAL;
     }
     compressed_len -= 4;
     uint32_t dst_len;
@@ -102,19 +109,48 @@ class ZstdCompressor : public Compressor {
     outbuf.size = dstptr.length();
     outbuf.pos = 0;
     ZSTD_DStream *s = ZSTD_createDStream();
-    ZSTD_initDStream(s);
+    if (!s) {
+      return -ENOMEM;
+    }
+    size_t res = ZSTD_initDStream(s);
+    if (ZSTD_isError(res)) {
+      ZSTD_freeDStream(s);
+      return -EINVAL;
+    }
+    // tracks the return of the last ZSTD_decompressStream() call; a non-zero
+    // value after all input is consumed means the frame was truncated
+    size_t left_in_frame = 0;
     while (compressed_len > 0) {
       if (p.end()) {
-	return -1;
+	ZSTD_freeDStream(s);
+	return -EINVAL;
       }
       ZSTD_inBuffer_s inbuf;
       inbuf.pos = 0;
       inbuf.size = p.get_ptr_and_advance(compressed_len,
 					 (const char**)&inbuf.src);
-      ZSTD_decompressStream(s, &outbuf, &inbuf);
       compressed_len -= inbuf.size;
+      size_t r = ZSTD_decompressStream(s, &outbuf, &inbuf);
+      if (ZSTD_isError(r)) {
+	ZSTD_freeDStream(s);
+	return -EINVAL;
+      }
+      // zstd must consume the whole input chunk. If it stopped early the
+      // output buffer filled up, which means the decoded-length prefix
+      // understated the real size: a corrupt or inconsistent frame.
+      if (inbuf.pos != inbuf.size) {
+	ZSTD_freeDStream(s);
+	return -EINVAL;
+      }
+      left_in_frame = r;
     }
     ZSTD_freeDStream(s);
+
+    // the frame must have ended exactly when the input ran out, and must have
+    // produced exactly the number of bytes promised by the length prefix
+    if (left_in_frame != 0 || outbuf.pos != dst_len) {
+      return -EINVAL;
+    }
 
     dst.append(dstptr, 0, outbuf.pos);
     return 0;

--- a/src/test/compressor/test_compression.cc
+++ b/src/test/compressor/test_compression.cc
@@ -457,6 +457,81 @@ TEST(ZlibCompressor, zlib_isal_compatibility)
 }
 #endif
 
+// Tracker #77334: ZstdCompressor::decompress() used to ignore the
+// ZSTD_decompressStream() return value and the consumed-input count, so a
+// corrupt or truncated frame returned success with silently truncated/garbage
+// output. These cases must now fail with a negative error code.
+TEST(ZstdCompressor, decompress_rejects_corruption)
+{
+  CompressorRef zstd = Compressor::create(g_ceph_context, "zstd");
+  ASSERT_TRUE(zstd);
+
+  // compressible payload so the frame has several bytes to corrupt
+  bufferlist orig;
+  for (int i = 0; i < 256; ++i) {
+    orig.append("the quick brown fox jumps over the lazy dog\n");
+  }
+
+  std::optional<int32_t> compressor_message;
+  bufferlist compressed;
+  ASSERT_EQ(0, zstd->compress(orig, compressed, compressor_message));
+  // sanity: the happy path still round-trips
+  {
+    bufferlist after;
+    ASSERT_EQ(0, zstd->decompress(compressed, after, compressor_message));
+    ASSERT_TRUE(orig.contents_equal(after));
+  }
+
+  // the on-disk layout is a 4-byte little-endian decompressed-length prefix
+  // followed by the raw zstd frame
+  const std::string blob = compressed.to_str();
+  ASSERT_GT(blob.size(), 4u);
+  const std::string frame = blob.substr(4);
+
+  auto make_input = [](uint32_t dst_len, const std::string& body) {
+    bufferlist bl;
+    using ceph::encode;
+    encode(dst_len, bl);
+    bl.append(body.data(), body.size());
+    return bl;
+  };
+
+  // 1) truncated frame: the decoder must not report success with partial output
+  {
+    bufferlist bad = make_input(orig.length(), frame.substr(0, frame.size() - 4));
+    bufferlist after;
+    std::optional<int32_t> msg;
+    EXPECT_LT(zstd->decompress(bad, after, msg), 0);
+  }
+
+  // 2) length prefix smaller than the real output: zstd stops consuming input
+  //    once the undersized output buffer fills
+  {
+    bufferlist bad = make_input(orig.length() / 2, frame);
+    bufferlist after;
+    std::optional<int32_t> msg;
+    EXPECT_LT(zstd->decompress(bad, after, msg), 0);
+  }
+
+  // 3) length prefix larger than the real output: the frame ends before the
+  //    promised number of bytes is produced
+  {
+    bufferlist bad = make_input(orig.length() + 4096, frame);
+    bufferlist after;
+    std::optional<int32_t> msg;
+    EXPECT_LT(zstd->decompress(bad, after, msg), 0);
+  }
+
+  // 4) garbage body of a plausible length must not be accepted as a valid frame
+  {
+    std::string junk(frame.size(), '\xa5');
+    bufferlist bad = make_input(orig.length(), junk);
+    bufferlist after;
+    std::optional<int32_t> msg;
+    EXPECT_LT(zstd->decompress(bad, after, msg), 0);
+  }
+}
+
 TEST(CompressionPlugin, all)
 {
   CompressorRef compressor;


### PR DESCRIPTION
`ZstdCompressor::decompress()` ignores the return of `ZSTD_decompressStream()` and assumes every input chunk is fully consumed. So a corrupt, truncated, or inconsistent zstd frame returns success (0) with silently truncated or garbage output, and callers (BlueStore, RGW, OSD message decompression) can't tell good data from bad. Same class of silent-corruption problem as the 2020 lz4 bug. The `compress()` path right above it already checks every libzstd return; `decompress()` just never got the same treatment. Reported by a user auditing the zstd path before turning it on in production (#77334).

What changed in `decompress()`:
- check `ZSTD_createDStream()` for NULL (`-ENOMEM`) and `ZSTD_initDStream()` for an error, matching `compress()`
- check the `ZSTD_decompressStream()` return with `ZSTD_isError()`
- require zstd to consume the whole input chunk. If it stops early the output buffer filled up, which means the decoded-length prefix understated the real size: a corrupt or inconsistent frame
- after the loop, require the frame to have ended and to have produced exactly the byte count the length prefix promised
- free the DStream on the mid-loop early-return that used to leak it, and return `-EINVAL`/`-ENOMEM` instead of a bare `-1`

`compress()` also gets a guard against a source bigger than the `uint32_t` length prefix can hold, which would otherwise truncate silently and make the data impossible to decompress.

New unit test compresses a payload and feeds truncated, under-sized-prefix, over-sized-prefix, and garbage variants to `decompress()`, each has to fail with a negative code now instead of returning 0.

`unittest_compression` passes all 92 tests, including every zstd round-trip and the new corruption case.

Tracker: https://tracker.ceph.com/issues/77334

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
- Component impact
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes unit test(s)
