### PR TITLE
Fix datalog tests

### DIFF
--- a/src/test/neorados/common_tests.h
+++ b/src/test/neorados/common_tests.h
@@ -44,6 +44,7 @@
 
 #include "include/neorados/RADOS.hpp"
 
+#include "common/async/context_pool.h"
 #include "common/dout.h"
 
 #include "gtest/gtest.h"
@@ -161,8 +162,8 @@ class CoroTest : public testing::Test {
 private:
   std::exception_ptr eptr;
 protected:
-  boost::asio::io_context asio_context; ///< The context on which the
-					///  coroutine runs.
+  ceph::async::io_context_pool asio_pool{3};
+  boost::asio::io_context& asio_context = asio_pool.get_io_context();
 public:
   /// Final override that does nothing. Actual setup code should go in CoSetUp
   void SetUp() override final { };
@@ -208,22 +209,27 @@ public:
     boost::asio::co_spawn(
       asio_context,
       [](CoroTest* t) -> boost::asio::awaitable<void> {
-	co_await t->CoSetUp();
+	try {
+	  co_await t->CoSetUp();
+	} catch (...) {
+	  t->eptr = std::current_exception();
+	  co_return;
+	}
 	try {
 	  co_await t->CoTestBody();
 	} catch (...) {
 	  t->eptr = std::current_exception();
 	}
-	co_await t->CoTearDown();
-	if (t->eptr) {
-	  std::rethrow_exception(t->eptr);
+	try {
+	  co_await t->CoTearDown();
+	} catch (...) {
+	  if (!t->eptr) t->eptr = std::current_exception();
 	}
 	co_return;
       }(this),
-      [](std::exception_ptr e) {
-	if (e) std::rethrow_exception(e);
-      });
-    asio_context.run();
+      boost::asio::detached);
+    asio_pool.finish();
+    if (eptr) std::rethrow_exception(eptr);
   }
 };
 

--- a/src/test/rgw/test_datalog.cc
+++ b/src/test/rgw/test_datalog.cc
@@ -38,61 +38,14 @@ namespace ss = neorados::cls::sem_set;
 
 using neorados::WriteOp;
 
-class DataLogTestBase : public CoroTest {
+class DataLogTestBase : public NeoRadosTest {
 private:
-  const std::string prefix_{std::string{"test framework "} +
-			    testing::UnitTest::GetInstance()->
-			    current_test_info()->name() +
-			    std::string{": "}};
-
-  std::optional<neorados::RADOS> rados_;
-  neorados::IOContext pool_;
-  const std::string pool_name_ = get_temp_pool_name(
-    testing::UnitTest::GetInstance()->current_test_info()->name());
-  std::unique_ptr<DoutPrefix> dpp_;
-
-  boost::asio::awaitable<uint64_t> create_pool() {
-    co_return co_await ::create_pool(rados(), pool_name(),
-				     boost::asio::use_awaitable);
-  }
-
-  boost::asio::awaitable<void> clean_pool() {
-    co_await rados().delete_pool(pool().get_pool(),
-				boost::asio::use_awaitable);
-  }
-
   virtual asio::awaitable<std::unique_ptr<RGWDataChangesLog>>
   create_datalog() = 0;
 
 protected:
 
   std::unique_ptr<RGWDataChangesLog> datalog;
-
-  neorados::RADOS& rados() noexcept { return *rados_; }
-  const std::string& pool_name() const noexcept { return pool_name_; }
-  const neorados::IOContext& pool() const noexcept { return pool_; }
-  std::string_view prefix() const noexcept { return prefix_; }
-  const DoutPrefixProvider* dpp() const noexcept { return dpp_.get(); }
-  auto execute(std::string_view oid, neorados::WriteOp&& op,
-	       std::uint64_t* ver = nullptr) {
-    return rados().execute(oid, pool(), std::move(op),
-			   boost::asio::use_awaitable, ver);
-  }
-  auto execute(std::string_view oid, neorados::ReadOp&& op,
-	       std::uint64_t* ver = nullptr) {
-    return rados().execute(oid, pool(), std::move(op), nullptr,
-			   boost::asio::use_awaitable, ver);
-  }
-  auto execute(std::string_view oid, neorados::WriteOp&& op,
-	       neorados::IOContext ioc, std::uint64_t* ver = nullptr) {
-    return rados().execute(oid, std::move(ioc), std::move(op),
-			   boost::asio::use_awaitable, ver);
-  }
-  auto execute(std::string_view oid, neorados::ReadOp&& op,
-	       neorados::IOContext ioc, std::uint64_t* ver = nullptr) {
-    return rados().execute(oid, std::move(ioc), std::move(op), nullptr,
-			   boost::asio::use_awaitable, ver);
-  }
 
   asio::awaitable<void>
   read_all_sems(int index,
@@ -186,22 +139,17 @@ protected:
 
 public:
 
-  /// \brief Create RADOS handle and pool for the test
   boost::asio::awaitable<void> CoSetUp() override {
-    rados_ = co_await neorados::RADOS::Builder{}
-      .build(asio_context, boost::asio::use_awaitable);
-    dpp_ = std::make_unique<DoutPrefix>(rados().cct(), 0, prefix().data());
-    pool_.set_pool(co_await create_pool());
+    co_await NeoRadosTest::CoSetUp();
     datalog = co_await create_datalog();
     co_return;
   }
 
   ~DataLogTestBase() override = default;
 
-  /// \brief Delete pool used for testing
   boost::asio::awaitable<void> CoTearDown() override {
     co_await datalog->async_shutdown();
-    co_await clean_pool();
+    co_await NeoRadosTest::CoTearDown();
     co_return;
   }
 };

--- a/src/test/rgw/test_log_backing.cc
+++ b/src/test/rgw/test_log_backing.cc
@@ -165,6 +165,7 @@ CORO_TEST_F(LogBacking, GenerationSingle, NeoRadosTest) {
       co_await lg->empty_to(dpp(), 0);
     }, sys::system_error);
 
+  lg->shutdown();
   lg.reset();
 
   lg = co_await logback_generations::init<generations>(
@@ -185,6 +186,7 @@ CORO_TEST_F(LogBacking, GenerationSingle, NeoRadosTest) {
   EXPECT_EQ(log_type::omap, lg->got_entries[1].type);
   EXPECT_FALSE(lg->got_entries[1].pruned);
 
+  lg->shutdown();
   lg.reset();
 
   lg = co_await logback_generations::init<generations>(
@@ -203,6 +205,7 @@ CORO_TEST_F(LogBacking, GenerationSingle, NeoRadosTest) {
 
   EXPECT_EQ(0, *lg->tail);
 
+  lg->shutdown();
   lg.reset();
 
   lg = co_await logback_generations::init<generations>(


### PR DESCRIPTION
test/rgw: fix datalog tests

Test ceph_test_datalog and unittest_log_backing don't work at least since commit a9d718331c7 (rgw/datalog: Remove use of 'detached' in `rgw_log_backing` watch). They deadlock when the only available thread issues a blocking call and no one processes the callbacks.

To fix this an option to add more worker threads is added and used for the two test.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
