### PR TITLE
mon: allow setting/unsetting multiple OSD flags in one command

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -1400,7 +1400,8 @@ Usage::
 
     ceph osd scrub <who>
 
-Subcommand ``set`` sets cluster-wide <flag> by updating OSD map.
+Subcommand ``set`` sets cluster-wide <flag> by updating the OSD map. More than
+one flag may be given in a single command, separated by spaces.
 The ``full`` flag is not honored anymore since the Mimic release, and
 ``ceph osd set full`` is not supported in the Octopus release.
 
@@ -1408,7 +1409,7 @@ Usage::
 
     ceph osd set pause|noup|nodown|noout|noin|nobackfill|norebalance|
     norecover|noscrub|nodeep-scrub|notieragent|nosnaptrim|
-    pglog_hardlimit|noautoscale
+    pglog_hardlimit|noautoscale [<flag>...]
 
 Subcommand ``setcrushmap`` sets CRUSH map from input file.
 
@@ -1495,13 +1496,14 @@ Usage::
 
     ceph osd unpause
 
-Subcommand ``unset`` unsets cluster-wide <flag> by updating OSD map.
+Subcommand ``unset`` unsets cluster-wide <flag> by updating the OSD map. More
+than one flag may be given in a single command, separated by spaces.
 
 Usage::
 
     ceph osd unset pause|noup|nodown|noout|noin|nobackfill|norebalance|
     norecover|noscrub|nodeep-scrub|notieragent|nosnaptrim|
-    noautoscale
+    noautoscale [<flag>...]
 
 
 pg

--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -538,6 +538,18 @@ following commands:
    ceph osd set <flag>
    ceph osd unset <flag>
 
+More than one flag may be given in a single command, separated by spaces. This
+is useful when preparing for maintenance, because the flags then take effect
+together in one OSD map update rather than one per command:
+
+.. prompt:: bash #
+
+   ceph osd set noout nobackfill norebalance
+   ceph osd unset noout nobackfill norebalance
+
+If any of the named flags is not recognized, the command is rejected and none of
+them are applied.
+
 OSD_FLAGS
 _________
 

--- a/doc/rados/troubleshooting/troubleshooting-osd.rst
+++ b/doc/rados/troubleshooting/troubleshooting-osd.rst
@@ -966,8 +966,11 @@ temporarily freezing their states:
 
 .. prompt:: bash
 
-   ceph osd set noup      # prevent OSDs from getting marked up
-   ceph osd set nodown    # prevent OSDs from getting marked down
+   ceph osd set noup nodown
+
+``noup`` prevents OSDs from getting marked ``up``, and ``nodown`` prevents OSDs
+from getting marked ``down``. Naming both flags in a single command applies them
+together in one OSD map update.
 
 These flags are recorded in the osdmap:
 
@@ -977,14 +980,13 @@ These flags are recorded in the osdmap:
 
 ::
 
-   flags no-up,no-down
+   flags noup,nodown
 
 You can clear these flags with:
 
 .. prompt:: bash
 
-   ceph osd unset noup
-   ceph osd unset nodown
+   ceph osd unset noup nodown
 
 Two other flags are available, ``noin`` and ``noout``, which prevent booting
 OSDs from being marked ``in`` (allocated data) or protect OSDs from eventually

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1583,6 +1583,19 @@ function test_mon_osd()
   done
   expect_false ceph osd set bogus
   expect_false ceph osd unset bogus
+  # multiple flags can be set/unset in a single command
+  ceph osd set norecover nobackfill norebalance
+  ceph osd dump | grep flags | grep norecover
+  ceph osd dump | grep flags | grep nobackfill
+  ceph osd dump | grep flags | grep norebalance
+  ceph osd unset norecover nobackfill norebalance
+  ! ceph osd dump | grep flags | grep norecover || exit 1
+  ! ceph osd dump | grep flags | grep nobackfill || exit 1
+  ! ceph osd dump | grep flags | grep norebalance || exit 1
+  # a single invalid flag rejects the whole command without applying any
+  expect_false ceph osd set noout bogus
+  ! ceph osd dump | grep flags | grep noout || exit 1
+  expect_false ceph osd unset noout bogus
   for f in sortbitwise recover_deletes require_jewel_osds \
 	  require_kraken_osds
   do

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -116,6 +116,62 @@ function check_response()
 	fi
 }
 
+# Send a mon command as raw JSON and require that the monitor rejects it with
+# the given errno and message. This bypasses the CLI's client-side argument
+# validation, which is the only way to reach handler paths that a well-formed
+# command line cannot express.
+function expect_raw_mon_command_error()
+{
+	local cmdjson=$1
+	local expected_ret=$2
+	local expected_msg=$3
+
+	python3 - "$cmdjson" "$expected_ret" "$expected_msg" << 'EOF'
+import rados, sys
+
+cmdjson, expected_ret, expected_msg = sys.argv[1:4]
+cluster = rados.Rados(conffile="")
+cluster.connect()
+try:
+    ret, _, err = cluster.mon_command(cmdjson, b"")
+finally:
+    cluster.shutdown()
+if ret != int(expected_ret):
+    print("return code invalid: got %d, expected %s" % (ret, expected_ret),
+          file=sys.stderr)
+    sys.exit(1)
+if expected_msg not in err:
+    print("Didn't find %s in %r" % (expected_msg, err), file=sys.stderr)
+    sys.exit(1)
+EOF
+}
+
+# The same, for a raw JSON mon command that is expected to succeed.
+function expect_raw_mon_command_ok()
+{
+	local cmdjson=$1
+	local expected_msg=$2
+
+	python3 - "$cmdjson" "$expected_msg" << 'EOF'
+import rados, sys
+
+cmdjson, expected_msg = sys.argv[1:3]
+cluster = rados.Rados(conffile="")
+cluster.connect()
+try:
+    ret, _, err = cluster.mon_command(cmdjson, b"")
+finally:
+    cluster.shutdown()
+if ret != 0:
+    print("return code invalid: got %d, expected 0 (%s)" % (ret, err),
+          file=sys.stderr)
+    sys.exit(1)
+if expected_msg not in err:
+    print("Didn't find %s in %r" % (expected_msg, err), file=sys.stderr)
+    sys.exit(1)
+EOF
+}
+
 function get_config_value_or_die()
 {
   local target config_opt raw val
@@ -1583,6 +1639,81 @@ function test_mon_osd()
   done
   expect_false ceph osd set bogus
   expect_false ceph osd unset bogus
+
+  # a single flag reports in the singular, as it always has
+  ceph osd set noout 2> $TMPFILE
+  check_response "noout is set"
+  ceph osd unset noout 2> $TMPFILE
+  check_response "noout is unset"
+
+  # several flags can be named in one command, and all of them are applied
+  ceph osd set norecover nobackfill norebalance 2> $TMPFILE
+  check_response "nobackfill,norebalance,norecover are set"
+  ceph osd dump | grep flags | grep norecover
+  ceph osd dump | grep flags | grep nobackfill
+  ceph osd dump | grep flags | grep norebalance
+  ceph osd unset norecover nobackfill norebalance 2> $TMPFILE
+  check_response "nobackfill,norebalance,norecover are unset"
+  ! ceph osd dump | grep flags | grep norecover || exit 1
+  ! ceph osd dump | grep flags | grep nobackfill || exit 1
+  ! ceph osd dump | grep flags | grep norebalance || exit 1
+
+  # "pause" is one name covering two flag bits, so it too reports in the plural
+  ceph osd set pause 2> $TMPFILE
+  check_response "pauserd,pausewr are set"
+  ceph osd unset pause 2> $TMPFILE
+  check_response "pauserd,pausewr are unset"
+
+  # naming a flag more than once is not an error and applies it once
+  ceph osd set noout noout 2> $TMPFILE
+  check_response "noout is set"
+  ceph osd unset noout
+
+  # a name that is not a flag at all is refused by the argument parser, before
+  # the command reaches the monitor, and none of the command is applied
+  expect_false ceph osd set noout bogus 2> $TMPFILE || return 1
+  check_response "EINVAL: invalid command"
+  ! ceph osd dump | grep flags | grep noout || exit 1
+  expect_false ceph osd unset noout bogus 2> $TMPFILE || return 1
+  check_response "EINVAL: invalid command"
+
+  # "full" gets past the argument parser but is refused by the monitor, so it
+  # exercises the monitor's own validation, both on its own and alongside a
+  # flag that would otherwise have been applied
+  expect_false ceph osd set full 2> $TMPFILE || return 1
+  check_response "EINVAL: unrecognized flag 'full'"
+  expect_false ceph osd set noout full 2> $TMPFILE || return 1
+  check_response "EINVAL: unrecognized flag 'full'"
+  ! ceph osd dump | grep flags | grep noout || exit 1
+  expect_false ceph osd unset noout full 2> $TMPFILE || return 1
+  check_response "EINVAL: unrecognized flag 'full'"
+
+  # the monitor rejects a flag it does not know even when the argument parser
+  # would never have let it through, and applies nothing when it does
+  expect_raw_mon_command_error '{"prefix": "osd set", "key": ["noout", "bogus"]}' \
+    -22 "unrecognized flag 'bogus'"
+  ! ceph osd dump | grep flags | grep noout || exit 1
+  expect_raw_mon_command_error '{"prefix": "osd unset", "key": ["noout", "bogus"]}' \
+    -22 "unrecognized flag 'bogus'"
+
+  # at least one flag is required. the argument parser rejects an empty flag
+  # list up front, and the monitor rejects one that reaches it anyway
+  expect_false ceph osd set 2> $TMPFILE || return 1
+  check_response "expected at least 1"
+  expect_false ceph osd unset 2> $TMPFILE || return 1
+  check_response "expected at least 1"
+  expect_raw_mon_command_error '{"prefix": "osd set", "key": []}' \
+    -22 "no flags specified"
+  expect_raw_mon_command_error '{"prefix": "osd unset", "key": []}' \
+    -22 "no flags specified"
+
+  # callers that build the command themselves rather than going through the
+  # argument parser pass a bare string, not a list, and must keep working
+  expect_raw_mon_command_ok '{"prefix": "osd set", "key": "noout"}' "noout is set"
+  ceph osd dump | grep flags | grep noout
+  expect_raw_mon_command_ok '{"prefix": "osd unset", "key": "noout"}' "noout is unset"
+  ! ceph osd dump | grep flags | grep noout || exit 1
+
   for f in sortbitwise recover_deletes require_jewel_osds \
 	  require_kraken_osds
   do

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -887,14 +887,14 @@ COMMAND("osd erasure-code-profile ls",
 COMMAND("osd set "
 	"name=key,type=CephChoices,strings=full|pause|noup|nodown|"
 	"noout|noin|nobackfill|norebalance|norecover|noscrub|nodeep-scrub|"
-	"notieragent|nosnaptrim|pglog_hardlimit|noautoscale "
+	"notieragent|nosnaptrim|pglog_hardlimit|noautoscale,n=N "
         "name=yes_i_really_mean_it,type=CephBool,req=false",
-	"set <key>", "osd", "rw")
+	"set <key> [<key>...]", "osd", "rw")
 COMMAND("osd unset "
 	"name=key,type=CephChoices,strings=full|pause|noup|nodown|"\
 	"noout|noin|nobackfill|norebalance|norecover|noscrub|nodeep-scrub|"
-	"notieragent|nosnaptrim|noautoscale",
-	"unset <key>", "osd", "rw")
+	"notieragent|nosnaptrim|noautoscale,n=N",
+	"unset <key> [<key>...]", "osd", "rw")
 COMMAND("osd require-osd-release "\
 	"name=release,type=CephChoices,strings=octopus|pacific|quincy|reef|squid|tentacle|umbrella "
         "name=yes_i_really_mean_it,type=CephBool,req=false",

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -8576,6 +8576,29 @@ int OSDMonitor::prepare_new_pool(string& name,
   return 0;
 }
 
+namespace {
+// Map a flag name accepted by both "osd set" and "osd unset" to its
+// OSDMap flag bit(s). Returns 0 for names that need special handling
+// (e.g. pglog_hardlimit) or are not recognized.
+int osdmap_flag_from_name(std::string_view name)
+{
+  if (name == "pause")        return CEPH_OSDMAP_PAUSERD | CEPH_OSDMAP_PAUSEWR;
+  if (name == "noup")         return CEPH_OSDMAP_NOUP;
+  if (name == "nodown")       return CEPH_OSDMAP_NODOWN;
+  if (name == "noout")        return CEPH_OSDMAP_NOOUT;
+  if (name == "noin")         return CEPH_OSDMAP_NOIN;
+  if (name == "nobackfill")   return CEPH_OSDMAP_NOBACKFILL;
+  if (name == "norebalance")  return CEPH_OSDMAP_NOREBALANCE;
+  if (name == "norecover")    return CEPH_OSDMAP_NORECOVER;
+  if (name == "noscrub")      return CEPH_OSDMAP_NOSCRUB;
+  if (name == "nodeep-scrub") return CEPH_OSDMAP_NODEEP_SCRUB;
+  if (name == "notieragent")  return CEPH_OSDMAP_NOTIERAGENT;
+  if (name == "nosnaptrim")   return CEPH_OSDMAP_NOSNAPTRIM;
+  if (name == "noautoscale")  return CEPH_OSDMAP_NOAUTOSCALE;
+  return 0;
+}
+}
+
 bool OSDMonitor::prepare_set_flag(MonOpRequestRef op, int flag)
 {
   op->mark_osdmon_event(__func__);
@@ -12366,90 +12389,66 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     bool sure = false;
     cmd_getval(cmdmap, "yes_i_really_mean_it", sure);
 
-    string key;
-    cmd_getval(cmdmap, "key", key);
-    if (key == "pause")
-      return prepare_set_flag(op, CEPH_OSDMAP_PAUSERD | CEPH_OSDMAP_PAUSEWR);
-    else if (key == "noup")
-      return prepare_set_flag(op, CEPH_OSDMAP_NOUP);
-    else if (key == "nodown")
-      return prepare_set_flag(op, CEPH_OSDMAP_NODOWN);
-    else if (key == "noout")
-      return prepare_set_flag(op, CEPH_OSDMAP_NOOUT);
-    else if (key == "noin")
-      return prepare_set_flag(op, CEPH_OSDMAP_NOIN);
-    else if (key == "nobackfill")
-      return prepare_set_flag(op, CEPH_OSDMAP_NOBACKFILL);
-    else if (key == "norebalance")
-      return prepare_set_flag(op, CEPH_OSDMAP_NOREBALANCE);
-    else if (key == "norecover")
-      return prepare_set_flag(op, CEPH_OSDMAP_NORECOVER);
-    else if (key == "noscrub")
-      return prepare_set_flag(op, CEPH_OSDMAP_NOSCRUB);
-    else if (key == "nodeep-scrub")
-      return prepare_set_flag(op, CEPH_OSDMAP_NODEEP_SCRUB);
-    else if (key == "notieragent")
-      return prepare_set_flag(op, CEPH_OSDMAP_NOTIERAGENT);
-    else if (key == "nosnaptrim")
-      return prepare_set_flag(op, CEPH_OSDMAP_NOSNAPTRIM);
-    else if (key == "pglog_hardlimit") {
-      if (!osdmap.get_num_up_osds() && !sure) {
-        ss << "Not advisable to continue since no OSDs are up. Pass "
-           << "--yes-i-really-mean-it if you really wish to continue.";
-        err = -EPERM;
-        goto reply_no_propose;
-      }
-      // The release check here is required because for OSD_PGLOG_HARDLIMIT,
-      // we are reusing a jewel feature bit that was retired in luminous.
-      if (osdmap.require_osd_release >= ceph_release_t::luminous &&
-         (HAVE_FEATURE(osdmap.get_up_osd_features(), OSD_PGLOG_HARDLIMIT)
-          || sure)) {
-	return prepare_set_flag(op, CEPH_OSDMAP_PGLOG_HARDLIMIT);
+    vector<string> keys;
+    cmd_getval(cmdmap, "key", keys);
+
+    // accumulate all requested flags so several can be set in a single
+    // command; validate every key before changing anything
+    int flags = 0;
+    for (const auto& key : keys) {
+      if (int flag = osdmap_flag_from_name(key); flag) {
+	flags |= flag;
+      } else if (key == "pglog_hardlimit") {
+	if (!osdmap.get_num_up_osds() && !sure) {
+	  ss << "Not advisable to continue since no OSDs are up. Pass "
+	     << "--yes-i-really-mean-it if you really wish to continue.";
+	  err = -EPERM;
+	  goto reply_no_propose;
+	}
+	// The release check here is required because for OSD_PGLOG_HARDLIMIT,
+	// we are reusing a jewel feature bit that was retired in luminous.
+	if (osdmap.require_osd_release >= ceph_release_t::luminous &&
+	   (HAVE_FEATURE(osdmap.get_up_osd_features(), OSD_PGLOG_HARDLIMIT)
+	    || sure)) {
+	  flags |= CEPH_OSDMAP_PGLOG_HARDLIMIT;
+	} else {
+	  ss << "not all up OSDs have OSD_PGLOG_HARDLIMIT feature";
+	  err = -EPERM;
+	  goto reply_no_propose;
+	}
       } else {
-	ss << "not all up OSDs have OSD_PGLOG_HARDLIMIT feature";
-	err = -EPERM;
+	ss << "unrecognized flag '" << key << "'";
+	err = -EINVAL;
 	goto reply_no_propose;
       }
-    } else if (key == "noautoscale") {
-      return prepare_set_flag(op, CEPH_OSDMAP_NOAUTOSCALE);
-    } else {
-      ss << "unrecognized flag '" << key << "'";
-      err = -EINVAL;
     }
+    if (!flags) {
+      ss << "no flags specified";
+      err = -EINVAL;
+      goto reply_no_propose;
+    }
+    return prepare_set_flag(op, flags);
 
   } else if (prefix == "osd unset") {
-    string key;
-    cmd_getval(cmdmap, "key", key);
-    if (key == "pause")
-      return prepare_unset_flag(op, CEPH_OSDMAP_PAUSERD | CEPH_OSDMAP_PAUSEWR);
-    else if (key == "noup")
-      return prepare_unset_flag(op, CEPH_OSDMAP_NOUP);
-    else if (key == "nodown")
-      return prepare_unset_flag(op, CEPH_OSDMAP_NODOWN);
-    else if (key == "noout")
-      return prepare_unset_flag(op, CEPH_OSDMAP_NOOUT);
-    else if (key == "noin")
-      return prepare_unset_flag(op, CEPH_OSDMAP_NOIN);
-    else if (key == "nobackfill")
-      return prepare_unset_flag(op, CEPH_OSDMAP_NOBACKFILL);
-    else if (key == "norebalance")
-      return prepare_unset_flag(op, CEPH_OSDMAP_NOREBALANCE);
-    else if (key == "norecover")
-      return prepare_unset_flag(op, CEPH_OSDMAP_NORECOVER);
-    else if (key == "noscrub")
-      return prepare_unset_flag(op, CEPH_OSDMAP_NOSCRUB);
-    else if (key == "nodeep-scrub")
-      return prepare_unset_flag(op, CEPH_OSDMAP_NODEEP_SCRUB);
-    else if (key == "notieragent")
-      return prepare_unset_flag(op, CEPH_OSDMAP_NOTIERAGENT);
-    else if (key == "nosnaptrim")
-      return prepare_unset_flag(op, CEPH_OSDMAP_NOSNAPTRIM);
-    else if (key == "noautoscale")
-      return prepare_unset_flag(op, CEPH_OSDMAP_NOAUTOSCALE);
-    else {
-      ss << "unrecognized flag '" << key << "'";
-      err = -EINVAL;
+    vector<string> keys;
+    cmd_getval(cmdmap, "key", keys);
+
+    int flags = 0;
+    for (const auto& key : keys) {
+      if (int flag = osdmap_flag_from_name(key); flag) {
+	flags |= flag;
+      } else {
+	ss << "unrecognized flag '" << key << "'";
+	err = -EINVAL;
+	goto reply_no_propose;
+      }
     }
+    if (!flags) {
+      ss << "no flags specified";
+      err = -EINVAL;
+      goto reply_no_propose;
+    }
+    return prepare_unset_flag(op, flags);
 
   } else if (prefix == "osd require-osd-release") {
     string release;

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -8579,6 +8579,61 @@ int OSDMonitor::prepare_new_pool(string& name,
   return 0;
 }
 
+namespace {
+// Map a flag name accepted by both "osd set" and "osd unset" to its
+// OSDMap flag bit(s). Returns 0 for names that need special handling
+// (e.g. pglog_hardlimit) or are not recognized.
+int osdmap_flag_from_name(std::string_view name)
+{
+  if (name == "pause")        return CEPH_OSDMAP_PAUSERD | CEPH_OSDMAP_PAUSEWR;
+  if (name == "noup")         return CEPH_OSDMAP_NOUP;
+  if (name == "nodown")       return CEPH_OSDMAP_NODOWN;
+  if (name == "noout")        return CEPH_OSDMAP_NOOUT;
+  if (name == "noin")         return CEPH_OSDMAP_NOIN;
+  if (name == "nobackfill")   return CEPH_OSDMAP_NOBACKFILL;
+  if (name == "norebalance")  return CEPH_OSDMAP_NOREBALANCE;
+  if (name == "norecover")    return CEPH_OSDMAP_NORECOVER;
+  if (name == "noscrub")      return CEPH_OSDMAP_NOSCRUB;
+  if (name == "nodeep-scrub") return CEPH_OSDMAP_NODEEP_SCRUB;
+  if (name == "notieragent")  return CEPH_OSDMAP_NOTIERAGENT;
+  if (name == "nosnaptrim")   return CEPH_OSDMAP_NOSNAPTRIM;
+  if (name == "noautoscale")  return CEPH_OSDMAP_NOAUTOSCALE;
+  return 0;
+}
+
+// Agree the verb in a completion message with the number of flag names
+// OSDMap::get_flag_string() will render, so that a single flag reads
+// "noout is set" and several read "nobackfill,noout are set". Note that
+// "pause" is itself two bits and so is plural.
+const char* flag_verb(int flags)
+{
+  return (flags & (flags - 1)) ? "are" : "is";
+}
+
+// Collect the flag names given to "osd set" or "osd unset".
+//
+// Now that "key" is declared n=N the CLI sends a list, but callers that build
+// the command themselves send a bare string, and they predate this: the
+// pg_autoscaler and dashboard mgr modules, and ceph_test_rados_io_sequence via
+// OSDSetRequest. cmd_getval() matches the variant's type exactly, so asking for
+// a vector<string> would fail all of those with "bad or missing field 'key'".
+// Accept either shape instead. An empty result is left for the caller to reject.
+std::vector<std::string> osdmap_flag_keys(const cmdmap_t& cmdmap)
+{
+  std::vector<std::string> keys;
+  auto i = cmdmap.find("key");
+  if (i == cmdmap.end()) {
+    return keys;
+  }
+  if (auto* list = boost::get<std::vector<std::string>>(&i->second); list) {
+    keys = *list;
+  } else if (auto* one = boost::get<std::string>(&i->second); one) {
+    keys.push_back(*one);
+  }
+  return keys;
+}
+} // anonymous namespace
+
 bool OSDMonitor::prepare_set_flag(MonOpRequestRef op, int flag)
 {
   op->mark_osdmon_event(__func__);
@@ -8586,7 +8641,7 @@ bool OSDMonitor::prepare_set_flag(MonOpRequestRef op, int flag)
   if (pending_inc.new_flags < 0)
     pending_inc.new_flags = osdmap.get_flags();
   pending_inc.new_flags |= flag;
-  ss << OSDMap::get_flag_string(flag) << " is set";
+  ss << OSDMap::get_flag_string(flag) << " " << flag_verb(flag) << " set";
   wait_for_commit(op, new Monitor::C_Command(mon, op, 0, ss.str(),
 						    get_last_committed() + 1));
   return true;
@@ -8599,7 +8654,7 @@ bool OSDMonitor::prepare_unset_flag(MonOpRequestRef op, int flag)
   if (pending_inc.new_flags < 0)
     pending_inc.new_flags = osdmap.get_flags();
   pending_inc.new_flags &= ~flag;
-  ss << OSDMap::get_flag_string(flag) << " is unset";
+  ss << OSDMap::get_flag_string(flag) << " " << flag_verb(flag) << " unset";
   wait_for_commit(op, new Monitor::C_Command(mon, op, 0, ss.str(),
 						    get_last_committed() + 1));
   return true;
@@ -12369,90 +12424,70 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     bool sure = false;
     cmd_getval(cmdmap, "yes_i_really_mean_it", sure);
 
-    string key;
-    cmd_getval(cmdmap, "key", key);
-    if (key == "pause")
-      return prepare_set_flag(op, CEPH_OSDMAP_PAUSERD | CEPH_OSDMAP_PAUSEWR);
-    else if (key == "noup")
-      return prepare_set_flag(op, CEPH_OSDMAP_NOUP);
-    else if (key == "nodown")
-      return prepare_set_flag(op, CEPH_OSDMAP_NODOWN);
-    else if (key == "noout")
-      return prepare_set_flag(op, CEPH_OSDMAP_NOOUT);
-    else if (key == "noin")
-      return prepare_set_flag(op, CEPH_OSDMAP_NOIN);
-    else if (key == "nobackfill")
-      return prepare_set_flag(op, CEPH_OSDMAP_NOBACKFILL);
-    else if (key == "norebalance")
-      return prepare_set_flag(op, CEPH_OSDMAP_NOREBALANCE);
-    else if (key == "norecover")
-      return prepare_set_flag(op, CEPH_OSDMAP_NORECOVER);
-    else if (key == "noscrub")
-      return prepare_set_flag(op, CEPH_OSDMAP_NOSCRUB);
-    else if (key == "nodeep-scrub")
-      return prepare_set_flag(op, CEPH_OSDMAP_NODEEP_SCRUB);
-    else if (key == "notieragent")
-      return prepare_set_flag(op, CEPH_OSDMAP_NOTIERAGENT);
-    else if (key == "nosnaptrim")
-      return prepare_set_flag(op, CEPH_OSDMAP_NOSNAPTRIM);
-    else if (key == "pglog_hardlimit") {
-      if (!osdmap.get_num_up_osds() && !sure) {
-        ss << "Not advisable to continue since no OSDs are up. Pass "
-           << "--yes-i-really-mean-it if you really wish to continue.";
-        err = -EPERM;
+    vector<string> keys = osdmap_flag_keys(cmdmap);
+
+    // accumulate all requested flags so several can be set in a single
+    // command; validate every key before changing anything
+    int flags = 0;
+    for (const auto& key : keys) {
+      if (int flag = osdmap_flag_from_name(key); flag) {
+        flags |= flag;
+      } else if (key == "pglog_hardlimit") {
+        if (!osdmap.get_num_up_osds() && !sure) {
+          ss << "Not advisable to continue since no OSDs are up. Pass "
+             << "--yes-i-really-mean-it if you really wish to continue.";
+          err = -EPERM;
+          goto reply_no_propose;
+        }
+        // The release check here is required because for OSD_PGLOG_HARDLIMIT,
+        // we are reusing a jewel feature bit that was retired in luminous.
+        if (osdmap.require_osd_release >= ceph_release_t::luminous &&
+           (HAVE_FEATURE(osdmap.get_up_osd_features(), OSD_PGLOG_HARDLIMIT)
+            || sure)) {
+          flags |= CEPH_OSDMAP_PGLOG_HARDLIMIT;
+        } else {
+          ss << "not all up OSDs have OSD_PGLOG_HARDLIMIT feature";
+          err = -EPERM;
+          goto reply_no_propose;
+        }
+      } else {
+        ss << "unrecognized flag '" << key << "'";
+        err = -EINVAL;
         goto reply_no_propose;
       }
-      // The release check here is required because for OSD_PGLOG_HARDLIMIT,
-      // we are reusing a jewel feature bit that was retired in luminous.
-      if (osdmap.require_osd_release >= ceph_release_t::luminous &&
-         (HAVE_FEATURE(osdmap.get_up_osd_features(), OSD_PGLOG_HARDLIMIT)
-          || sure)) {
-	return prepare_set_flag(op, CEPH_OSDMAP_PGLOG_HARDLIMIT);
-      } else {
-	ss << "not all up OSDs have OSD_PGLOG_HARDLIMIT feature";
-	err = -EPERM;
-	goto reply_no_propose;
-      }
-    } else if (key == "noautoscale") {
-      return prepare_set_flag(op, CEPH_OSDMAP_NOAUTOSCALE);
-    } else {
-      ss << "unrecognized flag '" << key << "'";
-      err = -EINVAL;
     }
+    // "key" is declared n=N, so a client using the CLI cannot get here with an
+    // empty list. The monitor does not validate arguments against the command
+    // descriptor though (Monitor::handle_command only resolves the prefix and
+    // checks caps), so a hand-crafted mon_command still can. Reject it instead
+    // of proposing an OSD map update that changes nothing.
+    if (!flags) {
+      ss << "no flags specified";
+      err = -EINVAL;
+      goto reply_no_propose;
+    }
+    return prepare_set_flag(op, flags);
 
   } else if (prefix == "osd unset") {
-    string key;
-    cmd_getval(cmdmap, "key", key);
-    if (key == "pause")
-      return prepare_unset_flag(op, CEPH_OSDMAP_PAUSERD | CEPH_OSDMAP_PAUSEWR);
-    else if (key == "noup")
-      return prepare_unset_flag(op, CEPH_OSDMAP_NOUP);
-    else if (key == "nodown")
-      return prepare_unset_flag(op, CEPH_OSDMAP_NODOWN);
-    else if (key == "noout")
-      return prepare_unset_flag(op, CEPH_OSDMAP_NOOUT);
-    else if (key == "noin")
-      return prepare_unset_flag(op, CEPH_OSDMAP_NOIN);
-    else if (key == "nobackfill")
-      return prepare_unset_flag(op, CEPH_OSDMAP_NOBACKFILL);
-    else if (key == "norebalance")
-      return prepare_unset_flag(op, CEPH_OSDMAP_NOREBALANCE);
-    else if (key == "norecover")
-      return prepare_unset_flag(op, CEPH_OSDMAP_NORECOVER);
-    else if (key == "noscrub")
-      return prepare_unset_flag(op, CEPH_OSDMAP_NOSCRUB);
-    else if (key == "nodeep-scrub")
-      return prepare_unset_flag(op, CEPH_OSDMAP_NODEEP_SCRUB);
-    else if (key == "notieragent")
-      return prepare_unset_flag(op, CEPH_OSDMAP_NOTIERAGENT);
-    else if (key == "nosnaptrim")
-      return prepare_unset_flag(op, CEPH_OSDMAP_NOSNAPTRIM);
-    else if (key == "noautoscale")
-      return prepare_unset_flag(op, CEPH_OSDMAP_NOAUTOSCALE);
-    else {
-      ss << "unrecognized flag '" << key << "'";
-      err = -EINVAL;
+    vector<string> keys = osdmap_flag_keys(cmdmap);
+
+    int flags = 0;
+    for (const auto& key : keys) {
+      if (int flag = osdmap_flag_from_name(key); flag) {
+        flags |= flag;
+      } else {
+        ss << "unrecognized flag '" << key << "'";
+        err = -EINVAL;
+        goto reply_no_propose;
+      }
     }
+    // see the note on the "osd set" branch above
+    if (!flags) {
+      ss << "no flags specified";
+      err = -EINVAL;
+      goto reply_no_propose;
+    }
+    return prepare_unset_flag(op, flags);
 
   } else if (prefix == "osd require-osd-release") {
     string release;


### PR DESCRIPTION
`ceph osd set` and `ceph osd unset` only accepted a single flag per invocation, so an operator preparing for maintenance had to run one command per flag:

```
ceph osd set noout
ceph osd set nobackfill
ceph osd set norebalance
```

Passing several at once failed with a confusing parser error (`nobackfill not one of 'true', 'false'`) because the extra words were matched against the optional `yes_i_really_mean_it` boolean.

This makes both commands accept one or more flags (`n=N`). The handler validates every flag first and applies them as a single OSD map update, so either all of the requested flags are set/unset or, if any flag is invalid, none are and the command is rejected. The per-flag name-to-bit mapping that was duplicated between the two handlers is pulled into a small helper.

A single flag still behaves exactly as before, and the completion message now agrees its verb with the number of flag names it reports, so one flag reads `noout is set` while several read `nobackfill,noout are set`.

### Compatibility with callers that build the command themselves

Declaring the argument `n=N` changes the JSON the monitor receives from `"key": "noout"` to `"key": ["noout"]`. The CLI adapts on its own, but callers that assemble the command directly do not, and `cmd_getval()` matches the variant type exactly. Reading only a `vector<string>` would have failed all of these with `-EINVAL "bad or missing field 'key'"`:

- `pg_autoscaler/module.py`, which backs `ceph osd pool set/unset noautoscale`
- `dashboard/controllers/osd.py` `_update_flags()`, behind the OSD Flags page
- `test/pybind/test_rados.py`, six sites, each asserting `eq(r, 0)`
- `ceph_test_rados_io_sequence`, via `OSDSetRequest` which holds `key` as a `std::string`

The pg_autoscaler case fails silently, since it does not check the return value: `ceph osd pool set noautoscale` would report success without setting the flag. Both shapes are therefore accepted, which keeps those callers working untouched.

## Testing

Besides the added `cephtool/test.sh` cases, verified on a vstart cluster:

- `ceph osd set norecover nobackfill norebalance` sets all three in one command, `ceph osd unset` clears several at once
- a single flag behaves exactly as before, and `pause` reports both of its bits
- an invalid flag anywhere in the list rejects the whole command and applies none of them
- `pglog_hardlimit` combined with another flag still honors its feature/release guard
- an empty flag list is rejected by the CLI up front and by the monitor when sent as a raw `mon_command`
- a flag passed as a bare string still works, and `ceph osd pool set/unset noautoscale` round-trips correctly
- the six `test_rados.py` tests that pass `key` as a bare string pass

Tracker: https://tracker.ceph.com/issues/77397

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
- Component impact
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
- Tests (select at least one)
  - [x] Includes integration test(s)
