### PR TITLE
tentacle: upgrade rocksdb submodule to v7.10.2 to address CVE-2022-23476

### DIFF
--- a/src/kv/rocksdb_cache/BinnedLRUCache.cc
+++ b/src/kv/rocksdb_cache/BinnedLRUCache.cc
@@ -160,9 +160,9 @@ void BinnedLRUCacheShard::EraseUnRefEntries() {
 
 void BinnedLRUCacheShard::ApplyToAllCacheEntries(
   const std::function<void(const rocksdb::Slice& key,
-                           void* value,
+                           rocksdb::Cache::ObjectPtr value,
                            size_t charge,
-                           DeleterFn)>& callback,
+                           const rocksdb::Cache::CacheItemHelper* helper)>& callback,
   bool thread_safe)
 {
   if (thread_safe) {
@@ -170,7 +170,7 @@ void BinnedLRUCacheShard::ApplyToAllCacheEntries(
   }
   table_.ApplyToAllCacheEntries(
     [callback](BinnedLRUHandle* h) {
-      callback(h->key(), h->value, h->charge, h->deleter);
+      callback(h->key(), h->value, h->charge, h->helper);
     });
   if (thread_safe) {
     mutex_.unlock();
@@ -419,16 +419,17 @@ bool BinnedLRUCacheShard::Release(rocksdb::Cache::Handle* handle, bool force_era
   return last_reference;
 }
 
-rocksdb::Status BinnedLRUCacheShard::Insert(const rocksdb::Slice& key, uint32_t hash, void* value,
+rocksdb::Status BinnedLRUCacheShard::Insert(const rocksdb::Slice& key, uint32_t hash,
+                             rocksdb::Cache::ObjectPtr value,
+                             const rocksdb::Cache::CacheItemHelper* helper,
                              size_t charge,
-                             DeleterFn deleter,
                              rocksdb::Cache::Handle** handle, rocksdb::Cache::Priority priority) {
   auto e = new BinnedLRUHandle();
   rocksdb::Status s;
   BinnedLRUHandle* deleted = nullptr;
 
   e->value = value;
-  e->deleter = deleter;
+  e->helper = helper;
   e->charge = charge;
   e->key_length = key.size();
   e->key_data = new char[e->key_length];
@@ -560,10 +561,11 @@ std::string BinnedLRUCacheShard::GetPrintableOptions() const {
   return std::string(buffer);
 }
 
-DeleterFn BinnedLRUCacheShard::GetDeleter(rocksdb::Cache::Handle* h) const
+const rocksdb::Cache::CacheItemHelper*
+BinnedLRUCacheShard::GetCacheItemHelper(rocksdb::Cache::Handle* h) const
 {
   auto* handle = reinterpret_cast<BinnedLRUHandle*>(h);
-  return handle->deleter;
+  return handle->helper;
 }
 
 #undef dout_context
@@ -701,7 +703,7 @@ const CacheShard* BinnedLRUCache::GetShard(int shard) const {
   return reinterpret_cast<CacheShard*>(&shards_[shard]);
 }
 
-void* BinnedLRUCache::Value(Handle* handle) {
+rocksdb::Cache::ObjectPtr BinnedLRUCache::Value(Handle* handle) {
   return reinterpret_cast<const BinnedLRUHandle*>(handle)->value;
 }
 
@@ -720,12 +722,11 @@ void BinnedLRUCache::DisownData() {
 #endif  // !__SANITIZE_ADDRESS__
 }
 
-#if (ROCKSDB_MAJOR >= 7 || (ROCKSDB_MAJOR == 6 && ROCKSDB_MINOR >= 22))
-DeleterFn BinnedLRUCache::GetDeleter(Handle* handle) const
+const rocksdb::Cache::CacheItemHelper*
+BinnedLRUCache::GetCacheItemHelper(Handle* handle) const
 {
-  return reinterpret_cast<const BinnedLRUHandle*>(handle)->deleter;
+  return reinterpret_cast<const BinnedLRUHandle*>(handle)->helper;
 }
-#endif
 
 size_t BinnedLRUCache::TEST_GetLRUSize() {
   size_t lru_size_of_all_shards = 0;

--- a/src/kv/rocksdb_cache/BinnedLRUCache.h
+++ b/src/kv/rocksdb_cache/BinnedLRUCache.h
@@ -58,8 +58,8 @@ std::shared_ptr<rocksdb::Cache> NewBinnedLRUCache(
 
 struct BinnedLRUHandle {
   std::shared_ptr<uint64_t> age_bin;
-  void* value;
-  DeleterFn deleter;
+  rocksdb::Cache::ObjectPtr value;
+  const rocksdb::Cache::CacheItemHelper* helper;
   BinnedLRUHandle* next_hash;
   BinnedLRUHandle* next;
   BinnedLRUHandle* prev;
@@ -121,8 +121,8 @@ struct BinnedLRUHandle {
 
   void Free() {
     ceph_assert((refs == 1 && InCache()) || (refs == 0 && !InCache()));
-    if (deleter) {
-      (*deleter)(key(), value);
+    if (helper && helper->del_cb) {
+      (*helper->del_cb)(value, /*allocator=*/nullptr);
     }
     delete[] key_data;
     delete this;
@@ -240,9 +240,10 @@ class alignas(CACHE_LINE_SIZE) BinnedLRUCacheShard : public CacheShard {
   void SetHighPriPoolRatio(double high_pri_pool_ratio);
 
   // Like Cache methods, but with an extra "hash" parameter.
-  virtual rocksdb::Status Insert(const rocksdb::Slice& key, uint32_t hash, void* value,
+  virtual rocksdb::Status Insert(const rocksdb::Slice& key, uint32_t hash,
+                        rocksdb::Cache::ObjectPtr value,
+                        const rocksdb::Cache::CacheItemHelper* helper,
                         size_t charge,
-                        DeleterFn deleter,
                         rocksdb::Cache::Handle** handle,
                         rocksdb::Cache::Priority priority) override;
   virtual rocksdb::Cache::Handle* Lookup(const rocksdb::Slice& key, uint32_t hash) override;
@@ -260,16 +261,17 @@ class alignas(CACHE_LINE_SIZE) BinnedLRUCacheShard : public CacheShard {
 
   virtual void ApplyToAllCacheEntries(
     const std::function<void(const rocksdb::Slice& key,
-                             void* value,
+                             rocksdb::Cache::ObjectPtr value,
                              size_t charge,
-                             DeleterFn)>& callback,
+                             const rocksdb::Cache::CacheItemHelper* helper)>& callback,
     bool thread_safe) override;
 
   virtual void EraseUnRefEntries() override;
 
   virtual std::string GetPrintableOptions() const override;
 
-  virtual DeleterFn GetDeleter(rocksdb::Cache::Handle* handle) const override;
+  virtual const rocksdb::Cache::CacheItemHelper* GetCacheItemHelper(
+      rocksdb::Cache::Handle* handle) const override;
 
   void TEST_GetLRUList(BinnedLRUHandle** lru, BinnedLRUHandle** lru_low_pri);
 
@@ -382,13 +384,12 @@ class BinnedLRUCache : public ShardedCache {
   virtual const char* Name() const override { return "BinnedLRUCache"; }
   virtual CacheShard* GetShard(int shard) override;
   virtual const CacheShard* GetShard(int shard) const override;
-  virtual void* Value(Handle* handle) override;
+  virtual rocksdb::Cache::ObjectPtr Value(Handle* handle) override;
   virtual size_t GetCharge(Handle* handle) const override;
   virtual uint32_t GetHash(Handle* handle) const override;
   virtual void DisownData() override;
-#if (ROCKSDB_MAJOR >= 7 || (ROCKSDB_MAJOR == 6 && ROCKSDB_MINOR >= 22))
-  virtual DeleterFn GetDeleter(Handle* handle) const override;
-#endif
+  virtual const rocksdb::Cache::CacheItemHelper* GetCacheItemHelper(
+      Handle* handle) const override;
   //  Retrieves number of elements in LRU, for unit test purpose only
   size_t TEST_GetLRUSize();
   // Sets the high pri pool ratio

--- a/src/kv/rocksdb_cache/ShardedCache.cc
+++ b/src/kv/rocksdb_cache/ShardedCache.cc
@@ -43,15 +43,23 @@ void ShardedCache::SetStrictCapacityLimit(bool strict_capacity_limit) {
   strict_capacity_limit_ = strict_capacity_limit;
 }
 
-rocksdb::Status ShardedCache::Insert(const rocksdb::Slice& key, void* value, size_t charge,
-                            DeleterFn deleter,
+rocksdb::Status ShardedCache::Insert(const rocksdb::Slice& key,
+                            rocksdb::Cache::ObjectPtr value,
+                            const rocksdb::Cache::CacheItemHelper* helper,
+                            size_t charge,
                             rocksdb::Cache::Handle** handle, Priority priority) {
   uint32_t hash = HashSlice(key);
   return GetShard(Shard(hash))
-      ->Insert(key, hash, value, charge, deleter, handle, priority);
+      ->Insert(key, hash, value, helper, charge, handle, priority);
 }
 
-rocksdb::Cache::Handle* ShardedCache::Lookup(const rocksdb::Slice& key, rocksdb::Statistics* /*stats*/) {
+rocksdb::Cache::Handle* ShardedCache::Lookup(const rocksdb::Slice& key,
+                            const rocksdb::Cache::CacheItemHelper* /*helper*/,
+                            rocksdb::Cache::CreateContext* /*create_context*/,
+                            Priority /*priority*/, bool /*wait*/,
+                            rocksdb::Statistics* /*stats*/) {
+  // Secondary cache is not supported by BinnedLRUCache, so the helper,
+  // create_context, priority, wait, and stats arguments are ignored here.
   uint32_t hash = HashSlice(key);
   return GetShard(Shard(hash))->Lookup(key, hash);
 }
@@ -109,36 +117,25 @@ size_t ShardedCache::GetPinnedUsage() const {
   return usage;
 }
 
-#if (ROCKSDB_MAJOR >= 7 || (ROCKSDB_MAJOR == 6 && ROCKSDB_MINOR >= 22))
-DeleterFn ShardedCache::GetDeleter(Handle* handle) const
+const rocksdb::Cache::CacheItemHelper* ShardedCache::GetCacheItemHelper(
+    Handle* handle) const
 {
   uint32_t hash = GetHash(handle);
-  return GetShard(Shard(hash))->GetDeleter(handle);
+  return GetShard(Shard(hash))->GetCacheItemHelper(handle);
 }
 
 void ShardedCache::ApplyToAllEntries(
-    const std::function<void(const rocksdb::Slice& key, void* value, size_t charge,
-                             DeleterFn deleter)>& callback,
-    const ApplyToAllEntriesOptions& opts)
+    const std::function<void(const rocksdb::Slice& key,
+                             rocksdb::Cache::ObjectPtr value,
+                             size_t charge,
+                             const rocksdb::Cache::CacheItemHelper* helper)>& callback,
+    const ApplyToAllEntriesOptions& /*opts*/)
 {
   int num_shards = 1 << num_shard_bits_;
   for (int s = 0; s < num_shards; s++) {
     GetShard(s)->ApplyToAllCacheEntries(callback, true /* thread_safe */);
   }
 }
-#else
-void ShardedCache::ApplyToAllCacheEntries(void (*callback)(void*, size_t),
-                                          bool thread_safe) {
-  int num_shards = 1 << num_shard_bits_;
-  for (int s = 0; s < num_shards; s++) {
-    GetShard(s)->ApplyToAllCacheEntries(
-      [callback](const rocksdb::Slice&, void* value, size_t charge, DeleterFn) {
-        callback(value, charge);
-      },
-      thread_safe);
-  }
-}
-#endif
 
 void ShardedCache::EraseUnRefEntries() {
   int num_shards = 1 << num_shard_bits_;

--- a/src/kv/rocksdb_cache/ShardedCache.h
+++ b/src/kv/rocksdb_cache/ShardedCache.h
@@ -26,18 +26,18 @@
 
 namespace rocksdb_cache {
 
-using DeleterFn = void (*)(const rocksdb::Slice& key, void* value);
-
 // Single cache shard interface.
 class CacheShard {
  public:
   CacheShard() = default;
   virtual ~CacheShard() = default;
 
-  virtual rocksdb::Status Insert(const rocksdb::Slice& key, uint32_t hash, void* value,
+  virtual rocksdb::Status Insert(const rocksdb::Slice& key, uint32_t hash,
+                                 rocksdb::Cache::ObjectPtr value,
+                                 const rocksdb::Cache::CacheItemHelper* helper,
                                  size_t charge,
-                                 DeleterFn deleter,
-                                 rocksdb::Cache::Handle** handle, rocksdb::Cache::Priority priority) = 0;
+                                 rocksdb::Cache::Handle** handle,
+                                 rocksdb::Cache::Priority priority) = 0;
   virtual rocksdb::Cache::Handle* Lookup(const rocksdb::Slice& key, uint32_t hash) = 0;
   virtual bool Ref(rocksdb::Cache::Handle* handle) = 0;
   virtual bool Release(rocksdb::Cache::Handle* handle, bool force_erase = false) = 0;
@@ -48,13 +48,14 @@ class CacheShard {
   virtual size_t GetPinnedUsage() const = 0;
   virtual void ApplyToAllCacheEntries(
     const std::function<void(const rocksdb::Slice& key,
-                             void* value,
+                             rocksdb::Cache::ObjectPtr value,
                              size_t charge,
-                             DeleterFn)>& callback,
+                             const rocksdb::Cache::CacheItemHelper* helper)>& callback,
     bool thread_safe) = 0;
   virtual void EraseUnRefEntries() = 0;
   virtual std::string GetPrintableOptions() const { return ""; }
-  virtual DeleterFn GetDeleter(rocksdb::Cache::Handle* handle) const = 0;
+  virtual const rocksdb::Cache::CacheItemHelper* GetCacheItemHelper(
+      rocksdb::Cache::Handle* handle) const = 0;
 };
 
 // Generic cache interface which shards cache by hash of keys. 2^num_shard_bits
@@ -67,15 +68,22 @@ class ShardedCache : public rocksdb::Cache, public PriorityCache::PriCache {
   // rocksdb::Cache
   virtual const char* Name() const override = 0;
   using rocksdb::Cache::Insert;
-  virtual rocksdb::Status Insert(const rocksdb::Slice& key, void* value, size_t charge,
-                                 DeleterFn,
-                                 rocksdb::Cache::Handle** handle, Priority priority) override;
+  virtual rocksdb::Status Insert(const rocksdb::Slice& key,
+                                 rocksdb::Cache::ObjectPtr value,
+                                 const rocksdb::Cache::CacheItemHelper* helper,
+                                 size_t charge,
+                                 rocksdb::Cache::Handle** handle,
+                                 Priority priority) override;
   using rocksdb::Cache::Lookup;
-  virtual rocksdb::Cache::Handle* Lookup(const rocksdb::Slice& key, rocksdb::Statistics* stats) override;
+  virtual rocksdb::Cache::Handle* Lookup(const rocksdb::Slice& key,
+                                         const rocksdb::Cache::CacheItemHelper* helper,
+                                         rocksdb::Cache::CreateContext* create_context,
+                                         Priority priority, bool wait,
+                                         rocksdb::Statistics* stats) override;
   virtual bool Ref(rocksdb::Cache::Handle* handle) override;
   using rocksdb::Cache::Release;
   virtual bool Release(rocksdb::Cache::Handle* handle, bool force_erase = false) override;
-  virtual void* Value(Handle* handle) override = 0;
+  virtual rocksdb::Cache::ObjectPtr Value(Handle* handle) override = 0;
   virtual void Erase(const rocksdb::Slice& key) override;
   virtual uint64_t NewId() override;
   virtual void SetCapacity(size_t capacity) override;
@@ -85,20 +93,16 @@ class ShardedCache : public rocksdb::Cache, public PriorityCache::PriCache {
   virtual size_t GetUsage() const override;
   virtual size_t GetUsage(rocksdb::Cache::Handle* handle) const override;
   virtual size_t GetPinnedUsage() const override;
-  virtual size_t GetCharge(Handle* handle) const = 0;
-#if (ROCKSDB_MAJOR >= 7 || (ROCKSDB_MAJOR == 6 && ROCKSDB_MINOR >= 22))
-  virtual DeleterFn GetDeleter(Handle* handle) const override;
-#endif
+  virtual size_t GetCharge(Handle* handle) const override = 0;
+  virtual const rocksdb::Cache::CacheItemHelper* GetCacheItemHelper(
+      Handle* handle) const override;
   virtual void DisownData() override = 0;
-#if (ROCKSDB_MAJOR >= 7 || (ROCKSDB_MAJOR == 6 && ROCKSDB_MINOR >= 22))
   virtual void ApplyToAllEntries(
-      const std::function<void(const rocksdb::Slice& key, void* value, size_t charge,
-                               DeleterFn deleter)>& callback,
+      const std::function<void(const rocksdb::Slice& key,
+                               rocksdb::Cache::ObjectPtr value,
+                               size_t charge,
+                               const rocksdb::Cache::CacheItemHelper* helper)>& callback,
       const ApplyToAllEntriesOptions& opts) override;
-#else
-  virtual void ApplyToAllCacheEntries(void (*callback)(void*, size_t),
-                                      bool thread_safe) override;
-#endif
   virtual void EraseUnRefEntries() override;
   virtual std::string GetPrintableOptions() const override;
   virtual CacheShard* GetShard(int shard) = 0;


### PR DESCRIPTION
Tentacle backport of https://github.com/ceph/ceph/pull/69106


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
