### PR TITLE
rgw/cls: Enhance cmpomap to enable its use for CAS operations

### DIFF
--- a/src/cls/cmpomap/client.cc
+++ b/src/cls/cmpomap/client.cc
@@ -56,6 +56,28 @@ int cmp_set_vals(librados::ObjectWriteOperation& op,
   return 0;
 }
 
+int cmp_set_vals2(librados::ObjectWriteOperation& op,
+                 Mode mode, Op comparison, ComparisonMap cmp_values,
+                 ValueMap set_values,
+                 std::optional<ceph::bufferlist> default_value)
+{
+  if (cmp_values.size() > max_keys || set_values.size() > max_keys) {
+    return -E2BIG;
+  }
+  cmp_set_vals2_op call;
+  call.mode = mode;
+  call.comparison = comparison;
+  call.cmp_values = std::move(cmp_values);
+  call.set_values = std::move(set_values);
+  call.default_value = std::move(default_value);
+
+  bufferlist in;
+  encode(call, in);
+  op.exec(method::cmp_set_vals2, in);
+  return 0;
+}
+
+
 int cmp_rm_keys(librados::ObjectWriteOperation& op,
                 Mode mode, Op comparison, ComparisonMap values)
 {
@@ -70,6 +92,27 @@ int cmp_rm_keys(librados::ObjectWriteOperation& op,
   bufferlist in;
   encode(call, in);
   op.exec(method::cmp_rm_keys, in);
+  return 0;
+}
+
+int cmp_rm_keys2(librados::ObjectWriteOperation& op,
+                Mode mode, Op comparison, ComparisonMap cmp_values,
+                KeySet rm_keys,
+                std::optional<ceph::bufferlist> default_value)
+{
+  if (cmp_values.size() > max_keys || rm_keys.size() > max_keys) {
+    return -E2BIG;
+  }
+  cmp_rm_keys2_op call;
+  call.mode = mode;
+  call.comparison = comparison;
+  call.cmp_values = std::move(cmp_values);
+  call.rm_keys = std::move(rm_keys);
+  call.default_value = std::move(default_value);
+
+  bufferlist in;
+  encode(call, in);
+  op.exec(method::cmp_rm_keys2, in);
   return 0;
 }
 

--- a/src/cls/cmpomap/client.h
+++ b/src/cls/cmpomap/client.h
@@ -42,6 +42,17 @@ static constexpr uint32_t max_keys = 1000;
                                Mode mode, Op comparison, ComparisonMap values,
                                std::optional<ceph::bufferlist> default_value);
 
+/// process all of the omap value comparisons according to the same rules as
+/// cmpxattr(). If all key/value pairs for comparison purpose compare successfully,
+/// the key/value pairs for overwritten are overwritten. For comparisons with
+/// Mode::U64, failure to decode an input value is reported as -EINVAL. An empty
+/// stored value is compared as 0, while decode failure of a stored value is treated
+/// as an unsuccessful comparison and is not reported as an error.
+[[nodiscard]] int cmp_set_vals2(librados::ObjectWriteOperation& writeop,
+                                Mode mode, Op comparison, ComparisonMap cmp_values,
+                                ValueMap set_values,
+                                std::optional<ceph::bufferlist> default_value);
+
 /// process each of the omap value comparisons according to the same rules as
 /// cmpxattr(). any key/value pairs that compare successfully are removed. for
 /// comparisons with Mode::U64, failure to decode an input value is reported as
@@ -51,6 +62,16 @@ static constexpr uint32_t max_keys = 1000;
 [[nodiscard]] int cmp_rm_keys(librados::ObjectWriteOperation& writeop,
                               Mode mode, Op comparison, ComparisonMap values);
 
+/// process all of the omap value comparisons according to the same rules as
+/// cmpxattr(). If all key/value pairs for comparison purpose compare successfully,
+/// the key set for deletion are deleted. For comparisons with
+/// Mode::U64, failure to decode an input value is reported as -EINVAL. An empty
+/// stored value is compared as 0, while decode failure of a stored value is treated
+/// as an unsuccessful comparison and is not reported as an error.
+[[nodiscard]] int cmp_rm_keys2(librados::ObjectWriteOperation& writeop,
+                               Mode mode, Op comparison, ComparisonMap cmp_values,
+                               KeySet rm_keys,
+                               std::optional<ceph::bufferlist> default_value);
 
 // bufferlist factories for comparison values
 inline ceph::bufferlist string_buffer(std::string_view value) {

--- a/src/cls/cmpomap/ops.h
+++ b/src/cls/cmpomap/ops.h
@@ -74,6 +74,36 @@ inline void decode(cmp_set_vals_op& o, ceph::bufferlist::const_iterator& bl)
   DECODE_FINISH(bl);
 }
 
+struct cmp_set_vals2_op {
+  Mode mode;
+  Op comparison;
+  ComparisonMap cmp_values;
+  std::optional<ceph::bufferlist> default_value;
+  ValueMap set_values;
+};
+
+inline void encode(const cmp_set_vals2_op& o, ceph::bufferlist& bl, uint64_t f=0)
+{
+  ENCODE_START(1, 1, bl);
+  encode(o.mode, bl);
+  encode(o.comparison, bl);
+  encode(o.cmp_values, bl);
+  encode(o.default_value, bl);
+  encode(o.set_values, bl);
+  ENCODE_FINISH(bl);
+}
+
+inline void decode(cmp_set_vals2_op& o, ceph::bufferlist::const_iterator& bl)
+{
+  DECODE_START(1, bl);
+  decode(o.mode, bl);
+  decode(o.comparison, bl);
+  decode(o.cmp_values, bl);
+  decode(o.default_value, bl);
+  decode(o.set_values, bl);
+  DECODE_FINISH(bl);
+}
+
 struct cmp_rm_keys_op {
   Mode mode;
   Op comparison;
@@ -98,13 +128,45 @@ inline void decode(cmp_rm_keys_op& o, ceph::bufferlist::const_iterator& bl)
   DECODE_FINISH(bl);
 }
 
+struct cmp_rm_keys2_op {
+  Mode mode;
+  Op comparison;
+  ComparisonMap cmp_values;
+  std::optional<ceph::bufferlist> default_value;
+  KeySet rm_keys;
+};
+
+inline void encode(const cmp_rm_keys2_op& o, ceph::bufferlist& bl, uint64_t f=0)
+{
+  ENCODE_START(1, 1, bl);
+  encode(o.mode, bl);
+  encode(o.comparison, bl);
+  encode(o.cmp_values, bl);
+  encode(o.default_value, bl);
+  encode(o.rm_keys, bl);
+  ENCODE_FINISH(bl);
+}
+
+inline void decode(cmp_rm_keys2_op& o, ceph::bufferlist::const_iterator& bl)
+{
+  DECODE_START(1, bl);
+  decode(o.mode, bl);
+  decode(o.comparison, bl);
+  decode(o.cmp_values, bl);
+  decode(o.default_value, bl);
+  decode(o.rm_keys, bl);
+  DECODE_FINISH(bl);
+}
+
 struct ClassId {
   static constexpr auto name = "cmpomap";
 };
 namespace method {
 constexpr auto cmp_vals = ClsMethod<RdTag, ClassId>("cmp_vals");
 constexpr auto cmp_set_vals = ClsMethod<RdWrTag, ClassId>("cmp_set_vals");
+constexpr auto cmp_set_vals2 = ClsMethod<RdWrTag, ClassId>("cmp_set_vals2");
 constexpr auto cmp_rm_keys = ClsMethod<RdWrTag, ClassId>("cmp_rm_keys");
+constexpr auto cmp_rm_keys2 = ClsMethod<RdWrTag, ClassId>("cmp_rm_keys2");
 }
 
 } // namespace cls::cmpomap

--- a/src/cls/cmpomap/server.cc
+++ b/src/cls/cmpomap/server.cc
@@ -13,6 +13,7 @@
  */
 
 #include "objclass/objclass.h"
+#include <inttypes.h>
 #include "ops.h"
 
 CLS_VER(1,0)
@@ -50,11 +51,12 @@ static int compare_values_u64(Op op, uint64_t lhs, const bufferlist& value)
       return -EIO;
     }
   }
+  CLS_LOG(20, "%s() compare %zu vs %zu", __func__, lhs, rhs);
   return compare_values(op, lhs, rhs);
 }
 
-static int compare_value(Mode mode, Op op, const bufferlist& input,
-                         const bufferlist& value)
+static int compare_values_by_mode(Mode mode, Op op, const bufferlist& input,
+                          const bufferlist& value)
 {
   switch (mode) {
   case Mode::String:
@@ -74,6 +76,41 @@ static int compare_value(Mode mode, Op op, const bufferlist& input,
   default:
     return -EINVAL;
   }
+}
+
+static int compare_all_values_by_mode(Mode mode, Op op,
+                                      const ComparisonMap& input_values,
+                                      ValueMap& values,
+                                      std::optional<ceph::bufferlist> default_value)
+{
+  auto v = values.cbegin();
+  for (const auto& [key, input] : input_values) {
+    bufferlist value;
+    if (v != values.end() && v->first == key) {
+      value = std::move(v->second);
+      CLS_LOG(20, "%s() comparing key=%s mode=%d op=%d", __func__,
+              key.c_str(), (int)mode, (int)op);
+      ++v;
+    } else if (!default_value) {
+      CLS_LOG(10, "%s() missing key=%s without default", __func__, key.c_str());
+      return -ECANCELED;
+    } else {
+      CLS_LOG(10, "%s() missing key=%s with default", __func__, key.c_str());
+      value = *default_value;
+    }
+
+    int r = compare_values_by_mode(mode, op, input, value);
+    if (r == -EIO) {
+      r = 0; // treat EIO as a failed comparison
+    }
+    if (r <= 0) {
+      // unsuccessful comparison
+      CLS_LOG(10, "%s() failed to compare key=%s r=%d", __func__,
+              key.c_str(), r);
+      return r;
+    }
+  }
+  return 1;
 }
 
 static int cmp_vals(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
@@ -119,7 +156,7 @@ static int cmp_vals(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
               key.c_str(), (int)op.mode, (int)op.comparison);
     }
 
-    r = compare_value(op.mode, op.comparison, input, value);
+    r = compare_values_by_mode(op.mode, op.comparison, input, value);
     if (r < 0) {
       CLS_LOG(10, "cmp_vals() failed to compare key=%s r=%d", key.c_str(), r);
       return r;
@@ -178,7 +215,7 @@ static int cmp_set_vals(cls_method_context_t hctx, bufferlist *in, bufferlist *o
               key.c_str(), (int)op.mode, (int)op.comparison);
     }
 
-    r = compare_value(op.mode, op.comparison, input, value);
+    r = compare_values_by_mode(op.mode, op.comparison, input, value);
     if (r == -EIO) {
       r = 0; // treat EIO as a failed comparison
     }
@@ -218,6 +255,50 @@ static int cmp_set_vals(cls_method_context_t hctx, bufferlist *in, bufferlist *o
   return cls_cxx_map_set_vals(hctx, &values);
 }
 
+static int cmp_set_vals2(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
+{
+  cmp_set_vals2_op op;
+  try {
+    auto p = in->cbegin();
+    decode(op, p);
+  } catch (const buffer::error&) {
+    CLS_LOG(1, "ERROR: %s(): failed to decode input", __func__);
+    return -EINVAL;
+  }
+
+  // collect the keys we need to read
+  std::set<std::string> keys;
+  for (const auto& kv : op.cmp_values) {
+    keys.insert(kv.first);
+  }
+
+  // read the values for each key to compare
+  std::map<std::string, bufferlist> values;
+  int r = cls_cxx_map_get_vals_by_keys(hctx, keys, &values);
+  if (r < 0) {
+    CLS_LOG(4, "ERROR: %s() failed to read values r=%d", __func__, r);
+    return r;
+  }
+
+  r = compare_all_values_by_mode(op.mode, op.comparison, op.cmp_values, values, op.default_value);
+  if (r <= 0) {
+    if (r == 0) {
+      return -ECANCELED;
+    }
+    return r;
+  }
+
+  // Successful comparison, update values
+  r = cls_cxx_map_set_vals(hctx, &op.set_values);
+  if (r < 0) {
+    CLS_LOG(10, "%s() failed to overwrite keys count=%zu r=%d", __func__,
+            op.set_values.size(), r);
+    return r;
+  }
+  CLS_LOG(20, "%s() overwriting count=%zu", __func__, op.set_values.size());
+  return 0;
+}
+
 static int cmp_rm_keys(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
 {
   cmp_rm_keys_op op;
@@ -255,7 +336,7 @@ static int cmp_rm_keys(cls_method_context_t hctx, bufferlist *in, bufferlist *ou
     const bufferlist& value = v->second;
     ++v;
 
-    r = compare_value(op.mode, op.comparison, input, value);
+    r = compare_values_by_mode(op.mode, op.comparison, input, value);
     if (r == -EIO) {
       r = 0; // treat EIO as a failed comparison
     }
@@ -282,6 +363,50 @@ static int cmp_rm_keys(cls_method_context_t hctx, bufferlist *in, bufferlist *ou
   return 0;
 }
 
+static int cmp_rm_keys2(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
+{
+  cmp_rm_keys2_op op;
+  try {
+    auto p = in->cbegin();
+    decode(op, p);
+  } catch (const buffer::error&) {
+    CLS_LOG(1, "ERROR: %s(): failed to decode input", __func__);
+    return -EINVAL;
+  }
+
+  // collect the keys we need to read
+  std::set<std::string> keys;
+  for (const auto& kv : op.cmp_values) {
+    keys.insert(kv.first);
+  }
+
+  // read the values for each key to compare
+  std::map<std::string, bufferlist> values;
+  int r = cls_cxx_map_get_vals_by_keys(hctx, keys, &values);
+  if (r < 0) {
+    CLS_LOG(4, "ERROR: %s() failed to read values r=%d", __func__, r);
+    return r;
+  }
+
+  r = compare_all_values_by_mode(op.mode, op.comparison, op.cmp_values, values, op.default_value);
+  if (r <= 0) {
+    if (r == 0) {
+      return -ECANCELED;
+    }
+    return r;
+  }
+
+  // Successful comparison, remove keys
+  r = cls_cxx_map_remove_keys(hctx, op.rm_keys);
+  if (r < 0) {
+    CLS_LOG(10, "%s() failed to remove keys count=%zu r=%d", __func__,
+            op.rm_keys.size(), r);
+    return r;
+  }
+  CLS_LOG(20, "%s() removed keys count=%zu", __func__, op.rm_keys.size());
+  return 0;
+}
+
 CLS_INIT(cmpomap)
 {
   CLS_LOG(1, "Loaded cmpomap class!");
@@ -289,13 +414,17 @@ CLS_INIT(cmpomap)
   cls_handle_t h_class;
   cls_method_handle_t h_cmp_vals;
   cls_method_handle_t h_cmp_set_vals;
+  cls_method_handle_t h_cmp_set_vals2;
   cls_method_handle_t h_cmp_rm_keys;
+  cls_method_handle_t h_cmp_rm_keys2;
 
   using namespace cls::cmpomap;
   cls_register(ClassId::name, &h_class);
   ClassRegistrar<ClassId> cls(h_class);
 
-  cls.register_cxx_method(method::cmp_vals,     cmp_vals,     &h_cmp_vals);
-  cls.register_cxx_method(method::cmp_set_vals, cmp_set_vals, &h_cmp_set_vals);
-  cls.register_cxx_method(method::cmp_rm_keys,  cmp_rm_keys,  &h_cmp_rm_keys);
+  cls.register_cxx_method(method::cmp_vals,      cmp_vals,      &h_cmp_vals);
+  cls.register_cxx_method(method::cmp_set_vals,  cmp_set_vals,  &h_cmp_set_vals);
+  cls.register_cxx_method(method::cmp_set_vals2, cmp_set_vals2, &h_cmp_set_vals2);
+  cls.register_cxx_method(method::cmp_rm_keys,   cmp_rm_keys,   &h_cmp_rm_keys);
+  cls.register_cxx_method(method::cmp_rm_keys2,  cmp_rm_keys2,  &h_cmp_rm_keys2);
 }

--- a/src/cls/cmpomap/types.h
+++ b/src/cls/cmpomap/types.h
@@ -40,5 +40,7 @@ enum class Op : uint8_t {
 
 /// mapping of omap keys to value comparisons
 using ComparisonMap = boost::container::flat_map<std::string, ceph::bufferlist>;
+using ValueMap = std::map<std::string, bufferlist>; // Identical to what is used in cls_cxx_map_set_vals
+using KeySet = std::set<std::string>;
 
 } // namespace cls::cmpomap

--- a/src/crimson/osd/objclass.cc
+++ b/src/crimson/osd/objclass.cc
@@ -442,6 +442,13 @@ int cls_cxx_map_remove_key(cls_method_context_t hctx, const string &key)
   return execute_osd_op(hctx, op);
 }
 
+int cls_cxx_map_remove_keys(cls_method_context_t hctx, const std::set<std::string> &keys)
+{
+  OSDOp op{CEPH_OSD_OP_OMAPRMKEYS};
+  encode(keys, op.indata);
+  return execute_osd_op(hctx, op);
+}
+
 int cls_cxx_list_watchers(cls_method_context_t hctx,
                           obj_list_watch_response_t *watchers)
 {

--- a/src/objclass/objclass.h
+++ b/src/objclass/objclass.h
@@ -123,6 +123,7 @@ extern int cls_cxx_map_set_vals(cls_method_context_t hctx,
                                 const std::map<std::string, ceph::buffer::list> *map);
 extern int cls_cxx_map_write_header(cls_method_context_t hctx, ceph::buffer::list *inbl);
 extern int cls_cxx_map_remove_key(cls_method_context_t hctx, const std::string &key);
+extern int cls_cxx_map_remove_keys(cls_method_context_t hctx, const std::set<std::string> &keys);
 /* remove keys in the range [key_begin, key_end) */
 extern int cls_cxx_map_remove_range(cls_method_context_t hctx,
                                     const std::string& key_begin,

--- a/src/osd/objclass.cc
+++ b/src/osd/objclass.cc
@@ -588,6 +588,20 @@ int cls_cxx_map_remove_key(cls_method_context_t hctx, const string &key)
   return (*pctx)->pg->do_osd_ops(*pctx, ops);
 }
 
+int cls_cxx_map_remove_keys(cls_method_context_t hctx, const set<string> &keys)
+{
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
+  vector<OSDOp> ops(1);
+  OSDOp& op = ops[0];
+  bufferlist& update_bl = op.indata;
+
+  encode(keys, update_bl);
+
+  op.op.op = CEPH_OSD_OP_OMAPRMKEYS;
+
+  return (*pctx)->pg->do_osd_ops(*pctx, ops);
+}
+
 int cls_cxx_list_watchers(cls_method_context_t hctx,
 			  obj_list_watch_response_t *watchers)
 {

--- a/src/test/cls_cmpomap/test_cls_cmpomap.cc
+++ b/src/test/cls_cmpomap/test_cls_cmpomap.cc
@@ -52,6 +52,24 @@ class CmpOmap : public ::testing::Test {
  protected:
   librados::IoCtx& ioctx = RadosEnv::ioctx;
 
+  // Generic helper to wrap operation setup and execution
+  // Handles common pattern of: build operation -> check return -> execute with flags
+  template<typename OpType, typename Func, typename... Args>
+  int execute_op(const std::string& oid, Func&& func,
+                 bool need_returnvec, Args&&... args)
+  {
+    OpType op;
+    int ret = func(op, std::forward<Args>(args)...);
+    if (ret < 0) {
+      return ret;
+    }
+    if (need_returnvec) {
+      return ioctx.operate(oid, &op, librados::OPERATION_RETURNVEC);
+    } else {
+      return ioctx.operate(oid, &op);
+    }
+  }
+
   int do_cmp_vals(const std::string& oid, Mode mode,
                   Op comparison, ComparisonMap values,
                   std::optional<bufferlist> def = std::nullopt)
@@ -69,24 +87,36 @@ class CmpOmap : public ::testing::Test {
                       Op comparison, ComparisonMap values,
                       std::optional<bufferlist> def = std::nullopt)
   {
-    librados::ObjectWriteOperation op;
-    int ret = cmp_set_vals(op, mode, comparison,
-                           std::move(values), std::move(def));
-    if (ret < 0) {
-      return ret;
-    }
-    return ioctx.operate(oid, &op);
+    return execute_op<librados::ObjectWriteOperation>(
+      oid, cmp_set_vals, false, mode, comparison,
+      std::move(values), std::move(def));
   }
 
   int do_cmp_rm_keys(const std::string& oid, Mode mode,
                      Op comparison, ComparisonMap values)
   {
-    librados::ObjectWriteOperation op;
-    int ret = cmp_rm_keys(op, mode, comparison, std::move(values));
-    if (ret < 0) {
-      return ret;
-    }
-    return ioctx.operate(oid, &op);
+    return execute_op<librados::ObjectWriteOperation>(
+      oid, cmp_rm_keys, false, mode, comparison, std::move(values));
+  }
+
+  int do_cmp_set_vals2(const std::string& oid, Mode mode,
+                       Op comparison, ComparisonMap cmp_values,
+                       std::map<std::string, bufferlist> set_values,
+                       std::optional<bufferlist> def = std::nullopt)
+  {
+    return execute_op<librados::ObjectWriteOperation>(
+      oid, cmp_set_vals2, false, mode, comparison,
+      std::move(cmp_values), std::move(set_values), std::move(def));
+  }
+
+  int do_cmp_rm_keys2(const std::string& oid, Mode mode,
+                      Op comparison, ComparisonMap cmp_values,
+                      std::set<std::string> rm_keys,
+                      std::optional<bufferlist> def = std::nullopt)
+  {
+    return execute_op<librados::ObjectWriteOperation>(
+      oid, cmp_rm_keys2, false, mode, comparison,
+      std::move(cmp_values), std::move(rm_keys), std::move(def));
   }
 
   int get_vals(const std::string& oid, std::map<std::string, bufferlist>* vals)
@@ -715,6 +745,748 @@ TEST_F(CmpOmap, cmp_rm_keys_u64_empty)
     EXPECT_EQ(vals.count("lt"), 1);
     EXPECT_EQ(vals.count("lte"), 1);
   }
+}
+
+// ============================================================================
+// Tests for cmp_set_vals2
+// ============================================================================
+
+TEST_F(CmpOmap, cmp_set_vals2_basic_success)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  // Set up initial values
+  ASSERT_EQ(ioctx.omap_set(oid, {{"cmp_key", u64_buffer(10)}}), 0);
+
+  // Compare cmp_key==10, if true set set_key=20
+  std::map<std::string, bufferlist> set_vals = {{"set_key", u64_buffer(20)}};
+  ASSERT_EQ(do_cmp_set_vals2(oid, Mode::U64, Op::EQ, 
+                             {{"cmp_key", u64_buffer(10)}},
+                             std::move(set_vals)), 0);
+
+  // Verify results
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), 0);
+  ASSERT_EQ(vals.size(), 2);
+  EXPECT_EQ(vals["cmp_key"], u64_buffer(10));
+  EXPECT_EQ(vals["set_key"], u64_buffer(20));
+}
+
+TEST_F(CmpOmap, cmp_set_vals2_comparison_fails)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  // Set up initial values
+  ASSERT_EQ(ioctx.omap_set(oid, {{"cmp_key", u64_buffer(10)}}), 0);
+
+  // Compare cmp_key==20 (should fail), don't set set_key
+  std::map<std::string, bufferlist> set_vals = {{"set_key", u64_buffer(20)}};
+  ASSERT_EQ(do_cmp_set_vals2(oid, Mode::U64, Op::EQ,
+                             {{"cmp_key", u64_buffer(20)}},
+                             std::move(set_vals)), -ECANCELED);
+
+  // Verify set_key was not created
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), 0);
+  ASSERT_EQ(vals.size(), 1);
+  EXPECT_EQ(vals.count("set_key"), 0);
+}
+
+TEST_F(CmpOmap, cmp_set_vals2_disjoint_keys)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  // Set up initial values - comparison keys are completely separate from set keys
+  ASSERT_EQ(ioctx.omap_set(oid, {{"cmp_key1", u64_buffer(10)},
+                                  {"cmp_key2", u64_buffer(20)},
+                                  {"existing_data", u64_buffer(100)}}), 0);
+
+  // Compare cmp_key1 and cmp_key2, but set completely different keys
+  std::map<std::string, bufferlist> set_vals = {
+    {"new_key1", u64_buffer(200)},
+    {"new_key2", u64_buffer(300)}
+  };
+  ASSERT_EQ(do_cmp_set_vals2(oid, Mode::U64, Op::GT,
+                             {{"cmp_key1", u64_buffer(15)},
+                              {"cmp_key2", u64_buffer(25)}},
+                             std::move(set_vals)), 0);
+
+  // Verify: cmp keys unchanged, new keys created, existing data unchanged
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), 0);
+  ASSERT_EQ(vals.size(), 5);
+  EXPECT_EQ(vals["cmp_key1"], u64_buffer(10));  // unchanged
+  EXPECT_EQ(vals["cmp_key2"], u64_buffer(20));  // unchanged
+  EXPECT_EQ(vals["existing_data"], u64_buffer(100));  // unchanged
+  EXPECT_EQ(vals["new_key1"], u64_buffer(200));  // newly created
+  EXPECT_EQ(vals["new_key2"], u64_buffer(300));  // newly created
+}
+
+TEST_F(CmpOmap, cmp_set_vals2_partial_overlap)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  // Test case where some keys overlap between cmp and set
+  ASSERT_EQ(ioctx.omap_set(oid, {{"key1", u64_buffer(10)},
+                                  {"key2", u64_buffer(20)},
+                                  {"key3", u64_buffer(30)}}), 0);
+
+  // Compare key1 and key2, set key2 and key3
+  std::map<std::string, bufferlist> set_vals = {
+    {"key2", u64_buffer(99)},  // overwrite key2
+    {"key3", u64_buffer(88)}   // overwrite key3
+  };
+  ASSERT_EQ(do_cmp_set_vals2(oid, Mode::U64, Op::LTE,
+                             {{"key1", u64_buffer(5)},
+                              {"key2", u64_buffer(15)}},
+                             std::move(set_vals)), 0);
+
+  // Verify results
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), 0);
+  ASSERT_EQ(vals.size(), 3);
+  EXPECT_EQ(vals["key1"], u64_buffer(10));  // unchanged (only compared)
+  EXPECT_EQ(vals["key2"], u64_buffer(99));  // changed (compared and set)
+  EXPECT_EQ(vals["key3"], u64_buffer(88));  // changed (only set)
+}
+
+TEST_F(CmpOmap, cmp_set_vals2_compare_one_set_many)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  // Use case: check a single condition, update many values atomically
+  ASSERT_EQ(ioctx.omap_set(oid, {{"lock_flag", u64_buffer(0)}}), 0);
+
+  // If lock_flag==0 (unlocked), set multiple config values
+  std::map<std::string, bufferlist> set_vals = {
+    {"config1", u64_buffer(100)},
+    {"config2", u64_buffer(200)},
+    {"config3", u64_buffer(300)},
+    {"config4", u64_buffer(400)}
+  };
+  ASSERT_EQ(do_cmp_set_vals2(oid, Mode::U64, Op::EQ,
+                             {{"lock_flag", u64_buffer(0)}},
+                             std::move(set_vals)), 0);
+
+  // Verify all configs were set
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), 0);
+  ASSERT_EQ(vals.size(), 5);
+  EXPECT_EQ(vals["lock_flag"], u64_buffer(0));  // unchanged
+  EXPECT_EQ(vals["config1"], u64_buffer(100));
+  EXPECT_EQ(vals["config2"], u64_buffer(200));
+  EXPECT_EQ(vals["config3"], u64_buffer(300));
+  EXPECT_EQ(vals["config4"], u64_buffer(400));
+}
+
+TEST_F(CmpOmap, cmp_set_vals2_compare_many_set_one)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  // Use case: check multiple preconditions before single update
+  ASSERT_EQ(ioctx.omap_set(oid, {{"version", u64_buffer(5)},
+                                  {"state", u64_buffer(1)},
+                                  {"permission", u64_buffer(7)},
+                                  {"result", u64_buffer(0)}}), 0);
+
+  // Only update result if all preconditions are met
+  std::map<std::string, bufferlist> set_vals = {{"result", u64_buffer(42)}};
+  ASSERT_EQ(do_cmp_set_vals2(oid, Mode::U64, Op::LTE,
+                             {{"version", u64_buffer(5)},
+                              {"state", u64_buffer(1)},
+                              {"permission", u64_buffer(4)}},
+                             std::move(set_vals)), 0);
+
+  // Verify only result changed
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), 0);
+  ASSERT_EQ(vals.size(), 4);
+  EXPECT_EQ(vals["version"], u64_buffer(5));
+  EXPECT_EQ(vals["state"], u64_buffer(1));
+  EXPECT_EQ(vals["permission"], u64_buffer(7));
+  EXPECT_EQ(vals["result"], u64_buffer(42));  // only this changed
+}
+
+TEST_F(CmpOmap, cmp_set_vals2_multiple_comparisons_all_pass)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  // Set up initial values
+  ASSERT_EQ(ioctx.omap_set(oid, {{"cmp1", u64_buffer(10)},
+                                  {"cmp2", u64_buffer(20)}}), 0);
+
+  // Compare both keys, set multiple values if all pass
+  std::map<std::string, bufferlist> set_vals = {{"set1", u64_buffer(100)},
+                                                 {"set2", u64_buffer(200)}};
+  ASSERT_EQ(do_cmp_set_vals2(oid, Mode::U64, Op::LTE,
+                             {{"cmp1", u64_buffer(5)},
+                              {"cmp2", u64_buffer(15)}},
+                             std::move(set_vals)), 0);
+
+  // Verify all values
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), 0);
+  ASSERT_EQ(vals.size(), 4);
+  EXPECT_EQ(vals["set1"], u64_buffer(100));
+  EXPECT_EQ(vals["set2"], u64_buffer(200));
+}
+
+TEST_F(CmpOmap, cmp_set_vals2_multiple_comparisons_one_fails)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  // Set up initial values
+  ASSERT_EQ(ioctx.omap_set(oid, {{"cmp1", u64_buffer(10)},
+                                  {"cmp2", u64_buffer(20)}}), 0);
+
+  // One comparison fails, so no values should be set
+  std::map<std::string, bufferlist> set_vals = {{"set1", u64_buffer(100)}};
+  ASSERT_EQ(do_cmp_set_vals2(oid, Mode::U64, Op::LT,
+                             {{"cmp1", u64_buffer(5)},   // passes: 5 < 10
+                              {"cmp2", u64_buffer(25)}}, // fails: 25 < 20
+                             std::move(set_vals)), -ECANCELED);
+
+  // Verify set_vals were not applied
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), 0);
+  ASSERT_EQ(vals.size(), 2);
+  EXPECT_EQ(vals.count("set1"), 0);
+}
+
+TEST_F(CmpOmap, cmp_set_vals2_with_default_value)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  ASSERT_EQ(ioctx.create(oid, true), 0);
+
+  // Compare against nonexistent key with default value
+  std::map<std::string, bufferlist> set_vals = {{"set_key", u64_buffer(99)}};
+  bufferlist def = u64_buffer(0);
+  ASSERT_EQ(do_cmp_set_vals2(oid, Mode::U64, Op::EQ,
+                             {{"missing_key", u64_buffer(0)}},
+                             std::move(set_vals), def), 0);
+
+  // Verify set_key was created
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), 0);
+  ASSERT_EQ(vals.size(), 1);
+  EXPECT_EQ(vals["set_key"], u64_buffer(99));
+}
+
+TEST_F(CmpOmap, cmp_set_vals2_missing_key_no_default)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+
+  // Compare against nonexistent key without default - should fail
+  std::map<std::string, bufferlist> set_vals = {{"set_key", u64_buffer(99)}};
+  ASSERT_EQ(do_cmp_set_vals2(oid, Mode::U64, Op::EQ,
+                             {{"missing_key", u64_buffer(0)}},
+                             std::move(set_vals)), -ECANCELED);
+
+  // Verify nothing was set
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), -ENOENT);
+}
+
+TEST_F(CmpOmap, cmp_set_vals2_string_mode)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  ASSERT_EQ(ioctx.omap_set(oid, {{"cmp_key", string_buffer("aaa")}}), 0);
+
+  // Compare string, set if match
+  std::map<std::string, bufferlist> set_vals = {{"set_key", string_buffer("zzz")}};
+  ASSERT_EQ(do_cmp_set_vals2(oid, Mode::String, Op::EQ,
+                             {{"cmp_key", string_buffer("aaa")}},
+                             std::move(set_vals)), 0);
+
+  // Verify
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), 0);
+  EXPECT_EQ(vals["set_key"], string_buffer("zzz"));
+}
+
+TEST_F(CmpOmap, cmp_set_vals2_overwrite_existing)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  ASSERT_EQ(ioctx.omap_set(oid, {{"cmp_key", u64_buffer(10)},
+                                  {"set_key", u64_buffer(5)}}), 0);
+
+  // Overwrite existing set_key if comparison passes
+  std::map<std::string, bufferlist> set_vals = {{"set_key", u64_buffer(50)}};
+  ASSERT_EQ(do_cmp_set_vals2(oid, Mode::U64, Op::EQ,
+                             {{"cmp_key", u64_buffer(10)}},
+                             std::move(set_vals)), 0);
+
+  // Verify overwrite
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), 0);
+  EXPECT_EQ(vals["set_key"], u64_buffer(50));
+}
+
+TEST_F(CmpOmap, cmp_set_vals2_u64_invalid_input)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  ASSERT_EQ(ioctx.create(oid, true), 0);
+
+  // Invalid input value for U64 mode
+  std::map<std::string, bufferlist> set_vals = {{"set_key", u64_buffer(1)}};
+  bufferlist def = u64_buffer(0);
+  bufferlist invalid = string_buffer("invalid"); // invalid number
+  EXPECT_EQ(do_cmp_set_vals2(oid, Mode::U64, Op::EQ,
+                             {{"key", invalid}},
+                             std::move(set_vals), def), -EINVAL);
+}
+
+TEST_F(CmpOmap, cmp_set_vals2_at_max_keys)
+{
+  ComparisonMap cmp_vals;
+  std::map<std::string, bufferlist> set_vals;
+  for (uint32_t i = 0; i < max_keys; i++) {
+    cmp_vals.emplace(std::to_string(i), u64_buffer(i));
+    set_vals.emplace(std::to_string(i+max_keys), u64_buffer(i));
+  }
+  librados::ObjectWriteOperation op;
+  EXPECT_EQ(cmp_set_vals2(op, Mode::U64, Op::GTE, std::move(cmp_vals),
+                          std::move(set_vals), std::nullopt), 0);
+}
+
+TEST_F(CmpOmap, cmp_set_vals2_over_max_keys_cmp)
+{
+  ComparisonMap cmp_vals;
+  std::map<std::string, bufferlist> set_vals = {{"set1", u64_buffer(1)}};
+  for (uint32_t i = 0; i < max_keys + 1; i++) {
+    cmp_vals.emplace(std::to_string(i), u64_buffer(i));
+  }
+  librados::ObjectWriteOperation op;
+  EXPECT_EQ(cmp_set_vals2(op, Mode::U64, Op::LTE, std::move(cmp_vals),
+                          std::move(set_vals), std::nullopt), -E2BIG);
+}
+
+TEST_F(CmpOmap, cmp_set_vals2_over_max_keys_set)
+{
+  ComparisonMap cmp_vals = {{"cmp1", u64_buffer(1)}};
+  std::map<std::string, bufferlist> set_vals;
+  for (uint32_t i = 0; i < max_keys + 1; i++) {
+    set_vals.emplace(std::to_string(i), u64_buffer(i));
+  }
+  librados::ObjectWriteOperation op;
+  EXPECT_EQ(cmp_set_vals2(op, Mode::U64, Op::LTE, std::move(cmp_vals),
+                          std::move(set_vals), std::nullopt), -E2BIG);
+}
+
+TEST_F(CmpOmap, cmp_set_vals2_empty_cmp_values)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  ASSERT_EQ(ioctx.create(oid, true), 0);
+
+  // Empty comparison map should always succeed
+  ComparisonMap empty_cmp;
+  std::map<std::string, bufferlist> set_vals = {
+    {"key1", u64_buffer(100)},
+    {"key2", u64_buffer(200)}
+  };
+  ASSERT_EQ(do_cmp_set_vals2(oid, Mode::U64, Op::EQ,
+                             std::move(empty_cmp),
+                             std::move(set_vals)), 0);
+
+  // Verify values were set
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), 0);
+  ASSERT_EQ(vals.size(), 2);
+  EXPECT_EQ(vals["key1"], u64_buffer(100));
+  EXPECT_EQ(vals["key2"], u64_buffer(200));
+}
+
+TEST_F(CmpOmap, cmp_set_vals2_empty_cmp_values_with_existing)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  ASSERT_EQ(ioctx.omap_set(oid, {{"existing", u64_buffer(42)}}), 0);
+
+  // Empty comparison map with existing data
+  ComparisonMap empty_cmp;
+  std::map<std::string, bufferlist> set_vals = {{"new_key", u64_buffer(99)}};
+  ASSERT_EQ(do_cmp_set_vals2(oid, Mode::U64, Op::EQ,
+                             std::move(empty_cmp),
+                             std::move(set_vals)), 0);
+
+  // Verify both keys exist
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), 0);
+  ASSERT_EQ(vals.size(), 2);
+  EXPECT_EQ(vals["existing"], u64_buffer(42));
+  EXPECT_EQ(vals["new_key"], u64_buffer(99));
+}
+
+TEST_F(CmpOmap, cmp_set_vals2_empty_cmp_values_overwrite)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  ASSERT_EQ(ioctx.omap_set(oid, {{"key1", u64_buffer(10)}}), 0);
+
+  // Empty comparison map, overwrite existing key
+  ComparisonMap empty_cmp;
+  std::map<std::string, bufferlist> set_vals = {{"key1", u64_buffer(50)}};
+  ASSERT_EQ(do_cmp_set_vals2(oid, Mode::U64, Op::EQ,
+                             std::move(empty_cmp),
+                             std::move(set_vals)), 0);
+
+  // Verify key was overwritten
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), 0);
+  EXPECT_EQ(vals["key1"], u64_buffer(50));
+}
+
+// ============================================================================
+// Tests for cmp_rm_keys2
+// ============================================================================
+
+TEST_F(CmpOmap, cmp_rm_keys2_basic_success)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  // Set up initial values
+  ASSERT_EQ(ioctx.omap_set(oid, {{"cmp_key", u64_buffer(10)},
+                                  {"rm_key", u64_buffer(20)}}), 0);
+
+  // Compare cmp_key==10, if true remove rm_key
+  ASSERT_EQ(do_cmp_rm_keys2(oid, Mode::U64, Op::EQ,
+                            {{"cmp_key", u64_buffer(10)}},
+                            {"rm_key"}), 0);
+
+  // Verify rm_key was removed
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), 0);
+  ASSERT_EQ(vals.size(), 1);
+  EXPECT_EQ(vals.count("cmp_key"), 1);
+  EXPECT_EQ(vals.count("rm_key"), 0);
+}
+
+TEST_F(CmpOmap, cmp_rm_keys2_comparison_fails)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  // Set up initial values
+  ASSERT_EQ(ioctx.omap_set(oid, {{"cmp_key", u64_buffer(10)},
+                                  {"rm_key", u64_buffer(20)}}), 0);
+
+  // Compare fails, don't remove
+  ASSERT_EQ(do_cmp_rm_keys2(oid, Mode::U64, Op::EQ,
+                            {{"cmp_key", u64_buffer(99)}},
+                            {"rm_key"}), -ECANCELED);
+
+  // Verify rm_key still exists
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), 0);
+  ASSERT_EQ(vals.size(), 2);
+  EXPECT_EQ(vals.count("rm_key"), 1);
+}
+
+TEST_F(CmpOmap, cmp_rm_keys2_disjoint_keys)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  // Compare one set of keys, remove a completely different set
+  ASSERT_EQ(ioctx.omap_set(oid, {{"guard1", u64_buffer(10)},
+                                  {"guard2", u64_buffer(20)},
+                                  {"data1", u64_buffer(100)},
+                                  {"data2", u64_buffer(200)},
+                                  {"keep", u64_buffer(999)}}), 0);
+
+  // Check guard conditions, then remove data keys (not guard keys)
+  ASSERT_EQ(do_cmp_rm_keys2(oid, Mode::U64, Op::GTE,
+                            {{"guard1", u64_buffer(15)},
+                             {"guard2", u64_buffer(25)}},
+                            {"data1", "data2"}), 0);
+
+  // Verify: guards untouched, data removed, keep untouched
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), 0);
+  ASSERT_EQ(vals.size(), 3);
+  EXPECT_EQ(vals.count("guard1"), 1);  // unchanged
+  EXPECT_EQ(vals.count("guard2"), 1);  // unchanged
+  EXPECT_EQ(vals.count("keep"), 1);    // unchanged
+  EXPECT_EQ(vals.count("data1"), 0);   // removed
+  EXPECT_EQ(vals.count("data2"), 0);   // removed
+}
+
+TEST_F(CmpOmap, cmp_rm_keys2_partial_overlap)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  // Some keys are both compared and removed
+  ASSERT_EQ(ioctx.omap_set(oid, {{"key1", u64_buffer(10)},
+                                  {"key2", u64_buffer(20)},
+                                  {"key3", u64_buffer(30)}}), 0);
+
+  // Compare key1 and key2, but remove key2 and key3
+  ASSERT_EQ(do_cmp_rm_keys2(oid, Mode::U64, Op::GT,
+                            {{"key1", u64_buffer(15)},
+                             {"key2", u64_buffer(25)}},
+                            {"key2", "key3"}), 0);
+
+  // Verify: key1 kept (only compared), key2 and key3 removed
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), 0);
+  ASSERT_EQ(vals.size(), 1);
+  EXPECT_EQ(vals.count("key1"), 1);  // kept
+  EXPECT_EQ(vals.count("key2"), 0);  // removed (was compared and removed)
+  EXPECT_EQ(vals.count("key3"), 0);  // removed (only removed)
+}
+
+TEST_F(CmpOmap, cmp_rm_keys2_compare_one_remove_many)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  // Use case: check single flag, cleanup many temporary keys
+  ASSERT_EQ(ioctx.omap_set(oid, {{"cleanup_flag", u64_buffer(1)},
+                                  {"temp1", u64_buffer(1)},
+                                  {"temp2", u64_buffer(2)},
+                                  {"temp3", u64_buffer(3)},
+                                  {"temp4", u64_buffer(4)},
+                                  {"permanent", u64_buffer(999)}}), 0);
+
+  // If cleanup_flag==1, remove all temp keys
+  ASSERT_EQ(do_cmp_rm_keys2(oid, Mode::U64, Op::EQ,
+                            {{"cleanup_flag", u64_buffer(1)}},
+                            {"temp1", "temp2", "temp3", "temp4"}), 0);
+
+  // Verify: cleanup_flag and permanent remain, temps removed
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), 0);
+  ASSERT_EQ(vals.size(), 2);
+  EXPECT_EQ(vals.count("cleanup_flag"), 1);
+  EXPECT_EQ(vals.count("permanent"), 1);
+  EXPECT_EQ(vals.count("temp1"), 0);
+  EXPECT_EQ(vals.count("temp2"), 0);
+  EXPECT_EQ(vals.count("temp3"), 0);
+  EXPECT_EQ(vals.count("temp4"), 0);
+}
+
+TEST_F(CmpOmap, cmp_rm_keys2_compare_many_remove_one)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  // Use case: check multiple conditions before removing critical key
+  ASSERT_EQ(ioctx.omap_set(oid, {{"check1", u64_buffer(1)},
+                                  {"check2", u64_buffer(2)},
+                                  {"check3", u64_buffer(3)},
+                                  {"critical_lock", u64_buffer(123)}}), 0);
+
+  // Only remove lock if all checks pass
+  ASSERT_EQ(do_cmp_rm_keys2(oid, Mode::U64, Op::LTE,
+                            {{"check1", u64_buffer(1)},
+                             {"check2", u64_buffer(2)},
+                             {"check3", u64_buffer(3)}},
+                            {"critical_lock"}), 0);
+
+  // Verify: checks remain, lock removed
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), 0);
+  ASSERT_EQ(vals.size(), 3);
+  EXPECT_EQ(vals.count("check1"), 1);
+  EXPECT_EQ(vals.count("check2"), 1);
+  EXPECT_EQ(vals.count("check3"), 1);
+  EXPECT_EQ(vals.count("critical_lock"), 0);  // only this removed
+}
+
+TEST_F(CmpOmap, cmp_rm_keys2_multiple_removes)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  // Set up initial values
+  ASSERT_EQ(ioctx.omap_set(oid, {{"cmp_key", u64_buffer(10)},
+                                  {"rm1", u64_buffer(20)},
+                                  {"rm2", u64_buffer(30)},
+                                  {"keep", u64_buffer(40)}}), 0);
+
+  // Remove multiple keys
+  ASSERT_EQ(do_cmp_rm_keys2(oid, Mode::U64, Op::GT,
+                            {{"cmp_key", u64_buffer(20)}},
+                            {"rm1", "rm2"}), 0);
+
+  // Verify
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), 0);
+  ASSERT_EQ(vals.size(), 2);
+  EXPECT_EQ(vals.count("cmp_key"), 1);
+  EXPECT_EQ(vals.count("keep"), 1);
+  EXPECT_EQ(vals.count("rm1"), 0);
+  EXPECT_EQ(vals.count("rm2"), 0);
+}
+
+TEST_F(CmpOmap, cmp_rm_keys2_multiple_comparisons)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  ASSERT_EQ(ioctx.omap_set(oid, {{"cmp1", u64_buffer(10)},
+                                  {"cmp2", u64_buffer(20)},
+                                  {"rm_key", u64_buffer(30)}}), 0);
+
+  // All comparisons must pass
+  ASSERT_EQ(do_cmp_rm_keys2(oid, Mode::U64, Op::LTE,
+                            {{"cmp1", u64_buffer(5)},
+                             {"cmp2", u64_buffer(15)}},
+                            {"rm_key"}), 0);
+
+  // Verify
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), 0);
+  EXPECT_EQ(vals.count("rm_key"), 0);
+}
+
+TEST_F(CmpOmap, cmp_rm_keys2_one_comparison_fails)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  ASSERT_EQ(ioctx.omap_set(oid, {{"cmp1", u64_buffer(10)},
+                                  {"cmp2", u64_buffer(20)},
+                                  {"rm_key", u64_buffer(30)}}), 0);
+
+  // One fails, so nothing is removed
+  ASSERT_EQ(do_cmp_rm_keys2(oid, Mode::U64, Op::LT,
+                            {{"cmp1", u64_buffer(5)},   // passes
+                             {"cmp2", u64_buffer(25)}}, // fails
+                            {"rm_key"}), -ECANCELED);
+
+  // Verify rm_key still exists
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), 0);
+  EXPECT_EQ(vals.count("rm_key"), 1);
+}
+
+TEST_F(CmpOmap, cmp_rm_keys2_with_default)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  ASSERT_EQ(ioctx.omap_set(oid, {{"rm_key", u64_buffer(10)}}), 0);
+
+  // Compare nonexistent key with default
+  bufferlist def = u64_buffer(0);
+  ASSERT_EQ(do_cmp_rm_keys2(oid, Mode::U64, Op::EQ,
+                            {{"missing", u64_buffer(0)}},
+                            {"rm_key"}, def), 0);
+
+  // Verify removal
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), 0);
+  ASSERT_EQ(vals.size(), 0); // Key deleted
+}
+
+TEST_F(CmpOmap, cmp_rm_keys2_missing_key_no_default)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  ASSERT_EQ(ioctx.omap_set(oid, {{"rm_key", u64_buffer(10)}}), 0);
+
+  // Compare nonexistent key without default - fails
+  ASSERT_EQ(do_cmp_rm_keys2(oid, Mode::U64, Op::EQ,
+                            {{"missing", u64_buffer(0)}},
+                            {"rm_key"}), -ECANCELED);
+
+  // Verify not removed
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), 0);
+  EXPECT_EQ(vals.count("rm_key"), 1);
+}
+
+TEST_F(CmpOmap, cmp_rm_keys2_string_mode)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  ASSERT_EQ(ioctx.omap_set(oid, {{"cmp_key", string_buffer("test")},
+                                  {"rm_key", string_buffer("data")}}), 0);
+
+  ASSERT_EQ(do_cmp_rm_keys2(oid, Mode::String, Op::EQ,
+                            {{"cmp_key", string_buffer("test")}},
+                            {"rm_key"}), 0);
+
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), 0);
+  EXPECT_EQ(vals.count("rm_key"), 0);
+}
+
+TEST_F(CmpOmap, cmp_rm_keys2_remove_nonexistent_key)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  ASSERT_EQ(ioctx.omap_set(oid, {{"cmp_key", u64_buffer(10)}}), 0);
+
+  // Try to remove nonexistent key - should succeed (no-op)
+  ASSERT_EQ(do_cmp_rm_keys2(oid, Mode::U64, Op::EQ,
+                            {{"cmp_key", u64_buffer(10)}},
+                            {"nonexistent"}), 0);
+}
+
+TEST_F(CmpOmap, cmp_rm_keys2_at_max_keys)
+{
+  ComparisonMap cmp_vals;
+  std::set<std::string> rm_keys;
+  for (uint32_t i = 0; i < max_keys; i++) {
+    cmp_vals.emplace(std::to_string(i), u64_buffer(i));
+    rm_keys.insert(std::to_string(i+max_keys));
+  }
+  librados::ObjectWriteOperation op;
+  EXPECT_EQ(cmp_rm_keys2(op, Mode::U64, Op::LTE, std::move(cmp_vals),
+                         std::move(rm_keys), std::nullopt), 0);
+}
+
+TEST_F(CmpOmap, cmp_rm_keys2_over_max_keys_cmp)
+{
+  ComparisonMap cmp_vals;
+  std::set<std::string> rm_keys = {"rm1"};
+  for (uint32_t i = 0; i < max_keys + 1; i++) {
+    cmp_vals.emplace(std::to_string(i), u64_buffer(i));
+  }
+  librados::ObjectWriteOperation op;
+  EXPECT_EQ(cmp_rm_keys2(op, Mode::U64, Op::LTE, std::move(cmp_vals),
+                         std::move(rm_keys), std::nullopt), -E2BIG);
+}
+
+TEST_F(CmpOmap, cmp_rm_keys2_over_max_keys_rm)
+{
+  ComparisonMap cmp_vals = {{"cmp1", u64_buffer(1)}};
+  std::set<std::string> rm_keys;
+  for (uint32_t i = 0; i < max_keys + 1; i++) {
+    rm_keys.insert(std::to_string(i));
+  }
+  librados::ObjectWriteOperation op;
+  EXPECT_EQ(cmp_rm_keys2(op, Mode::U64, Op::LTE, std::move(cmp_vals),
+                         std::move(rm_keys), std::nullopt), -E2BIG);
+}
+
+TEST_F(CmpOmap, cmp_rm_keys2_empty_cmp_values)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  ASSERT_EQ(ioctx.omap_set(oid, {{"key1", u64_buffer(10)},
+                                  {"key2", u64_buffer(20)},
+                                  {"key3", u64_buffer(30)}}), 0);
+
+  // Empty comparison map should always succeed
+  ComparisonMap empty_cmp;
+  ASSERT_EQ(do_cmp_rm_keys2(oid, Mode::U64, Op::EQ,
+                            std::move(empty_cmp),
+                            {"key1", "key2"}), 0);
+
+  // Verify key1 and key2 were removed, key3 remains
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), 0);
+  ASSERT_EQ(vals.size(), 1);
+  EXPECT_EQ(vals.count("key1"), 0);
+  EXPECT_EQ(vals.count("key2"), 0);
+  EXPECT_EQ(vals.count("key3"), 1);
+}
+
+TEST_F(CmpOmap, cmp_rm_keys2_empty_cmp_values_remove_all)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  ASSERT_EQ(ioctx.omap_set(oid, {{"key1", u64_buffer(10)},
+                                  {"key2", u64_buffer(20)}}), 0);
+
+  // Empty comparison map, remove all keys
+  ComparisonMap empty_cmp;
+  ASSERT_EQ(do_cmp_rm_keys2(oid, Mode::U64, Op::EQ,
+                            std::move(empty_cmp),
+                            {"key1", "key2"}), 0);
+
+  // Verify all keys were removed
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), 0);
+  ASSERT_EQ(vals.size(), 0);
+}
+
+TEST_F(CmpOmap, cmp_rm_keys2_empty_cmp_values_remove_nonexistent)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  ASSERT_EQ(ioctx.omap_set(oid, {{"existing", u64_buffer(42)}}), 0);
+
+  // Empty comparison map, try to remove nonexistent key (should succeed as no-op)
+  ComparisonMap empty_cmp;
+  ASSERT_EQ(do_cmp_rm_keys2(oid, Mode::U64, Op::EQ,
+                            std::move(empty_cmp),
+                            {"nonexistent"}), 0);
+
+  // Verify existing key still there
+  std::map<std::string, bufferlist> vals;
+  ASSERT_EQ(get_vals(oid, &vals), 0);
+  ASSERT_EQ(vals.size(), 1);
+  EXPECT_EQ(vals.count("existing"), 1);
 }
 
 } // namespace cls::cmpomap


### PR DESCRIPTION
1. Add two new client functions to enable the use of separate key/values for comparison and modification. One for setting values and the other for deletion.

2. Add an omap operation for CLS to delete a batch of keys, instead of just a single key.

3. Add unit tests for the new cmpomap client functions, generated by Copilot with model Claude Sonnet 4.5

Fixes: https://tracker.ceph.com/issues/76622

Reported-by: Yixin Jin <yjin77@yahoo.ca>


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
