### PR TITLE
rgw: add RGWObjCategory::MultiPart to separate multipart parts from completed objects in bucket stats

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1037,3 +1037,13 @@ can be configured using the `rgw` option `rgw_bucket_persistent_notif_num_shards
   https://docs.ceph.com/en/latest/radosgw/notifications/
 
 Relevant tracker: https://tracker.ceph.com/issues/71677
+
+* RGW: Multipart upload part heads are now tracked under a new
+  ``rgw.multipart`` category in bucket stats, separate from completed
+  objects (``rgw.main``). This makes ``radosgw-admin bucket stats``
+  and the ``X-RGW-Object-Count`` header on HEAD Bucket more accurate:
+  in-progress or abandoned multipart parts no longer inflate the
+  object count. Existing in-progress uploads retain the old category
+  until they complete or abort.
+
+  Relevant tracker: https://tracker.ceph.com/issues/77509

--- a/qa/workunits/rgw/test_rgw_multipart_category.py
+++ b/qa/workunits/rgw/test_rgw_multipart_category.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+
+import logging as log
+import json
+from common import exec_cmd, create_user, boto_connect
+from botocore.config import Config
+from botocore.exceptions import ClientError
+
+"""
+Tests that multipart upload part heads are tracked under the
+rgw.multipart category in bucket stats, separate from completed
+objects (rgw.main), and that quota enforcement still counts them.
+"""
+
+USER = 'mpart-cat-tester'
+DISPLAY_NAME = 'Multipart Category Testing'
+ACCESS_KEY = 'MPARTCAT1TESTKEY00001'
+SECRET_KEY = 'mpartcat1testsecretkey000000001'
+
+PART_SIZE = 5 * 1024 * 1024  # 5 MiB (S3 minimum part size)
+
+
+def get_bucket_stats(bucket_name):
+    out = exec_cmd(f'radosgw-admin bucket stats --bucket {bucket_name}')
+    return json.loads(out)
+
+
+def get_category(stats, category):
+    return stats['usage'].get(category, {})
+
+
+def assert_category(stats, category, num_objects, label=''):
+    cat = get_category(stats, category)
+    actual = cat.get('num_objects', 0)
+    assert actual == num_objects, \
+        f'{label}: expected {category}.num_objects={num_objects}, got {actual}'
+
+
+def cleanup_bucket(connection, bucket_name):
+    try:
+        s3client = connection.meta.client
+        response = s3client.list_multipart_uploads(Bucket=bucket_name)
+        for upload in response.get('Uploads', []):
+            s3client.abort_multipart_upload(
+                Bucket=bucket_name, Key=upload['Key'],
+                UploadId=upload['UploadId'])
+        connection.Bucket(bucket_name).objects.all().delete()
+        connection.Bucket(bucket_name).delete()
+    except Exception:
+        pass
+
+
+def test_category_tracking(connection):
+    """Verify multipart parts appear under rgw.multipart, not rgw.main."""
+    bucket_name = 'mpart-cat-bucket'
+    cleanup_bucket(connection, bucket_name)
+    connection.create_bucket(Bucket=bucket_name)
+    s3client = connection.meta.client
+
+    # TESTCASE 'empty bucket has no stats'
+    log.debug('TEST: empty bucket has no stats\n')
+    stats = get_bucket_stats(bucket_name)
+    assert_category(stats, 'rgw.main', 0, 'empty bucket')
+
+    # TESTCASE 'incomplete multipart parts appear under rgw.multipart'
+    log.debug('TEST: incomplete multipart parts appear under rgw.multipart\n')
+    part_body = b'x' * PART_SIZE
+
+    response = s3client.create_multipart_upload(Bucket=bucket_name, Key='incomplete-obj')
+    upload_id = response['UploadId']
+
+    for part_num in (1, 2):
+        s3client.upload_part(
+            Bucket=bucket_name, Key='incomplete-obj',
+            UploadId=upload_id, PartNumber=part_num, Body=part_body)
+
+    stats = get_bucket_stats(bucket_name)
+    assert_category(stats, 'rgw.main', 0, 'after upload parts')
+    assert_category(stats, 'rgw.multipart', 2, 'after upload parts')
+    assert_category(stats, 'rgw.multimeta', 1, 'after upload parts')
+
+    response = s3client.list_objects_v2(Bucket=bucket_name)
+    assert response['KeyCount'] == 0, f'expected 0 listed objects, got {response["KeyCount"]}'
+
+    # TESTCASE 'complete multipart moves parts to rgw.main'
+    log.debug('TEST: complete multipart moves parts to rgw.main\n')
+    parts_list = s3client.list_parts(
+        Bucket=bucket_name, Key='incomplete-obj', UploadId=upload_id)
+    parts = [{'ETag': p['ETag'], 'PartNumber': p['PartNumber']}
+             for p in parts_list['Parts']]
+
+    s3client.complete_multipart_upload(
+        Bucket=bucket_name, Key='incomplete-obj',
+        UploadId=upload_id,
+        MultipartUpload={'Parts': parts})
+
+    stats = get_bucket_stats(bucket_name)
+    assert_category(stats, 'rgw.main', 1, 'after complete')
+    assert_category(stats, 'rgw.multipart', 0, 'after complete')
+    assert_category(stats, 'rgw.multimeta', 0, 'after complete')
+
+    # TESTCASE 'abort multipart cleans up rgw.multipart entries'
+    log.debug('TEST: abort multipart cleans up rgw.multipart entries\n')
+    response = s3client.create_multipart_upload(
+        Bucket=bucket_name, Key='aborted-obj')
+    upload_id2 = response['UploadId']
+
+    s3client.upload_part(
+        Bucket=bucket_name, Key='aborted-obj',
+        UploadId=upload_id2, PartNumber=1, Body=part_body)
+
+    stats = get_bucket_stats(bucket_name)
+    assert_category(stats, 'rgw.main', 1, 'before abort')
+    assert_category(stats, 'rgw.multipart', 1, 'before abort')
+    assert_category(stats, 'rgw.multimeta', 1, 'before abort')
+
+    s3client.abort_multipart_upload(Bucket=bucket_name, Key='aborted-obj', UploadId=upload_id2)
+
+    stats = get_bucket_stats(bucket_name)
+    assert_category(stats, 'rgw.main', 1, 'after abort')
+    assert_category(stats, 'rgw.multipart', 0, 'after abort')
+    assert_category(stats, 'rgw.multimeta', 0, 'after abort')
+
+    cleanup_bucket(connection, bucket_name)
+    log.debug('test_category_tracking PASSED\n')
+
+
+def test_quota_enforcement(connection):
+    """Verify multipart parts count against bucket and user quotas."""
+    bucket1 = 'mpart-quota-1'
+    bucket2 = 'mpart-quota-2'
+    s3client = connection.meta.client
+    part_body = b'x' * PART_SIZE
+
+    cleanup_bucket(connection, bucket1)
+    cleanup_bucket(connection, bucket2)
+
+    # bucket quota: 15 MB (3 x 5MB parts), user quota: 25 MB (5 x 5MB parts)
+    exec_cmd(f'radosgw-admin quota set --quota-scope=bucket --uid={USER} --max-size=15728640')
+    exec_cmd(f'radosgw-admin quota set --quota-scope=user --uid={USER} --max-size=26214400')
+    exec_cmd(f'radosgw-admin quota enable --quota-scope=bucket --uid={USER}')
+    exec_cmd(f'radosgw-admin quota enable --quota-scope=user --uid={USER}')
+
+    try:
+        connection.create_bucket(Bucket=bucket1)
+        connection.create_bucket(Bucket=bucket2)
+
+        # TESTCASE 'bucket quota: 4th part exceeds 15 MB bucket limit'
+        log.debug('TEST: bucket quota rejects part that exceeds limit\n')
+        mpu1 = s3client.create_multipart_upload(Bucket=bucket1, Key='obj1')
+        uid1 = mpu1['UploadId']
+
+        for i in range(1, 4):
+            s3client.upload_part(Bucket=bucket1, Key='obj1', UploadId=uid1,
+                                 PartNumber=i, Body=part_body)
+
+        try:
+            s3client.upload_part(Bucket=bucket1, Key='obj1', UploadId=uid1,
+                                 PartNumber=4, Body=part_body)
+            assert False, 'part 4 should have been rejected by bucket quota'
+        except ClientError as e:
+            assert e.response['Error']['Code'] == 'QuotaExceeded', \
+                f'expected QuotaExceeded, got {e.response["Error"]["Code"]}'
+
+        response = s3client.list_objects_v2(Bucket=bucket1)
+        assert response['KeyCount'] == 0, 'bucket1 should have no completed objects'
+
+        stats = get_bucket_stats(bucket1)
+        assert_category(stats, 'rgw.main', 0, 'bucket1 quota')
+        assert_category(stats, 'rgw.multipart', 3, 'bucket1 quota')
+
+        # TESTCASE 'user quota: 3rd part in bucket2 exceeds 25 MB user limit'
+        log.debug('TEST: user quota rejects part that exceeds limit\n')
+        mpu2 = s3client.create_multipart_upload(Bucket=bucket2, Key='obj2')
+        uid2 = mpu2['UploadId']
+
+        # 15 MB already used in bucket1; user quota is 25 MB
+        for i in range(1, 3):
+            s3client.upload_part(Bucket=bucket2, Key='obj2', UploadId=uid2,
+                                 PartNumber=i, Body=part_body)
+
+        try:
+            s3client.upload_part(Bucket=bucket2, Key='obj2', UploadId=uid2,
+                                 PartNumber=3, Body=part_body)
+            assert False, 'part 3 should have been rejected by user quota'
+        except ClientError as e:
+            assert e.response['Error']['Code'] == 'QuotaExceeded', \
+                f'expected QuotaExceeded, got {e.response["Error"]["Code"]}'
+
+        response = s3client.list_objects_v2(Bucket=bucket2)
+        assert response['KeyCount'] == 0, 'bucket2 should have no completed objects'
+
+        stats = get_bucket_stats(bucket2)
+        assert_category(stats, 'rgw.main', 0, 'bucket2 quota')
+        assert_category(stats, 'rgw.multipart', 2, 'bucket2 quota')
+
+    finally:
+        cleanup_bucket(connection, bucket1)
+        cleanup_bucket(connection, bucket2)
+        exec_cmd(f'radosgw-admin quota disable --quota-scope=bucket --uid={USER}')
+        exec_cmd(f'radosgw-admin quota disable --quota-scope=user --uid={USER}')
+
+    log.debug('test_quota_enforcement PASSED\n')
+
+
+def main():
+    create_user(USER, DISPLAY_NAME, ACCESS_KEY, SECRET_KEY)
+
+    # ensure quotas are disabled before category tracking tests
+    exec_cmd(f'radosgw-admin quota disable --quota-scope=bucket --uid={USER}')
+    exec_cmd(f'radosgw-admin quota disable --quota-scope=user --uid={USER}')
+
+    connection = boto_connect(ACCESS_KEY, SECRET_KEY, Config(retries={
+        'total_max_attempts': 1,
+    }))
+
+    test_category_tracking(connection)
+    test_quota_enforcement(connection)
+
+    log.debug('All multipart category tests passed\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -140,6 +140,7 @@ std::string_view to_string(RGWObjCategory c)
     case RGWObjCategory::Shadow: return "rgw.shadow";
     case RGWObjCategory::MultiMeta: return "rgw.multimeta";
     case RGWObjCategory::CloudTiered: return "rgw.cloudtiered";
+    case RGWObjCategory::MultiPart: return "rgw.multipart";
     default: return "unknown";
   }
 }

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -194,6 +194,8 @@ enum class RGWObjCategory : uint8_t {
   MultiMeta = 3,  // b-i entries for multipart upload metadata objs
 
   CloudTiered = 4, // b-i entries which are tiered to external cloud
+
+  MultiPart = 5,   // b-i entries for multipart upload part head objs
 };
 
 std::string_view to_string(RGWObjCategory c);

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -189,8 +189,7 @@ enum class RGWObjCategory : uint8_t {
 
   Main      = 1,  // b-i entries for standard objs
 
-  Shadow    = 2,  // presumably intended for multipart shadow
-                  // uploads; not currently used in the codebase
+  Shadow    = 2,  // unused, reserved for backward compatibility
 
   MultiMeta = 3,  // b-i entries for multipart upload metadata objs
 

--- a/src/rgw/driver/rados/rgw_putobj_processor.cc
+++ b/src/rgw/driver/rados/rgw_putobj_processor.cc
@@ -557,6 +557,7 @@ int MultipartObjectProcessor::complete(
   obj_op.meta.mtime = mtime;
   obj_op.meta.owner = owner;
   obj_op.meta.bucket_owner = bucket_info.owner;
+  obj_op.meta.category = RGWObjCategory::MultiPart;
   obj_op.meta.delete_at = delete_at;
   obj_op.meta.zones_trace = zones_trace;
   obj_op.meta.modify_tail = true;

--- a/src/test/cls_rgw/test_cls_rgw_stats.cc
+++ b/src/test/cls_rgw/test_cls_rgw_stats.cc
@@ -552,7 +552,7 @@ void simulator::complete_multipart(const operation& op)
           << " size=" << part_size << dendl;
     } else {
       rgw_bucket_dir_entry_meta meta;
-      meta.category = op.meta.category;
+      meta.category = RGWObjCategory::MultiPart;
       meta.size = meta.accounted_size = part_size;
 
       int r = index_complete(ioctx, oid, part_key, op.tag, op.type,

--- a/src/test/rgw/s3-tests/s3tests/functional/test_s3.py
+++ b/src/test/rgw/s3-tests/s3tests/functional/test_s3.py
@@ -1129,6 +1129,40 @@ def test_head_bucket_usage():
 
 @pytest.mark.fails_on_aws
 @pytest.mark.fails_on_dbstore
+def test_head_bucket_usage_multipart_incomplete():
+    bucket_name = get_new_bucket()
+    client = get_client()
+
+    # initiate a multipart upload and upload 2 parts without completing
+    response = client.create_multipart_upload(Bucket=bucket_name, Key='mpu-obj')
+    upload_id = response['UploadId']
+    part_body = 'x' * (5 * 1024 * 1024)
+    for part_num in (1, 2):
+        client.upload_part(Bucket=bucket_name, Key='mpu-obj',
+                           UploadId=upload_id, PartNumber=part_num,
+                           Body=part_body)
+
+    # HEAD bucket with read-stats should show 0 objects: incomplete
+    # multipart parts are not counted as user-visible objects.
+    def add_read_stats_param(request, **kwargs):
+        request.params['read-stats'] = 'true'
+
+    client.meta.events.register('request-created.s3.HeadBucket', add_read_stats_param)
+    client.meta.events.register('after-call.s3.HeadBucket', get_http_response)
+    client.head_bucket(Bucket=bucket_name)
+    hdrs = http_response['headers']
+    assert hdrs['X-RGW-Object-Count'] == '0'
+
+    # ListObjects should also return nothing
+    response = client.list_objects_v2(Bucket=bucket_name)
+    assert response['KeyCount'] == 0
+
+    # cleanup
+    client.abort_multipart_upload(Bucket=bucket_name, Key='mpu-obj',
+                                  UploadId=upload_id)
+
+@pytest.mark.fails_on_aws
+@pytest.mark.fails_on_dbstore
 def test_bucket_list_unordered():
     # boto3.set_stream_logger(name='botocore')
     keys_in = ['ado', 'bot', 'cob', 'dog', 'emu', 'fez', 'gnu', 'hex',


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/77509.
s3-tests: https://github.com/ceph/s3-tests/pull/759

### Testing

Create a bucket, initiate a multipart upload, upload 3 parts, and do **not** complete or abort:

Getting bucket stats

Before
```json
{
  "usage": {
    "rgw.main": {
      "size": 15728640,
      "size_actual": 15728640,
      "num_objects": 3
    },
    "rgw.multimeta": {
      "size": 0,
      "size_actual": 0,
      "num_objects": 1
    }
  }
}
```

After
```json
{
  "usage": {
    "rgw.main": {
      "num_objects": 0
    },
    "rgw.multipart": {
      "num_objects": 3,
      "size_actual": 15728640
    },
    "rgw.multimeta": {
      "num_objects": 1
    }
  }
}
```

and `X-RGW-Object-Count: 0` on HEAD Bucket (since it reads only `RGWObjCategory::Main`). Clients can now distinguish:
- **`rgw.main`** completed, user-visible objects
- **`rgw.multipart`** in-progress or abandoned multipart part heads (storage consumed but not yet assembled)
- **`rgw.multimeta`** active multipart upload sessions

### Backward Compatibility

- `RGWObjCategory` is serialized as `uint8_t` via `ceph::encode()`. Value 5 encodes/decodes transparently.
- Old RGW reading new data: `to_string()` returns `"unknown"` for unrecognized values. Bucket stats would show an `"unknown"` section: cosmetic, not broken.
- Mixed cluster during rolling upgrade: parts split between Main (old RGWs) and MultiPart (new RGWs). Temporary inconsistency, not a safety issue.
- Existing in-progress uploads retain `Main` until they complete or abort. `bucket check` and reshard preserve existing categories — they do not re-derive them.

### Scope

Only the rados driver is affected. Other drivers (dbstore, posix, daos, motr) handle multipart parts differentl: dbstore stores parts via `add_mp_part()` in a separate table, not as bucket index entries with categories.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
