### PR TITLE
squid: rgw/kafka: add mTLS client certificate authentication (fixes #67427)

### DIFF
--- a/doc/radosgw/notifications.rst
+++ b/doc/radosgw/notifications.rst
@@ -305,9 +305,6 @@ Request parameters:
   - "broker": Messages are considered "delivered" if acked by the broker. (This
     is the default.)
 
- - ``kafka-brokers``: A comma-separated list of ``host:port`` of Kafka brokers:
-   these brokers (may contain a broker which is defined in Kafka URI) will be
-   added to Kafka URI to support sending notifications to a Kafka cluster.
  - ``ssl-certificate-location``: The path to a PEM-encoded client certificate
    file to present to the Kafka broker for mutual TLS (mTLS) authentication.
    This enables certificate-based client identity and must be used together

--- a/doc/radosgw/notifications.rst
+++ b/doc/radosgw/notifications.rst
@@ -194,6 +194,9 @@ updating, use the name of an existing topic and different endpoint values).
    [&Attributes.entry.16.key=user-name&Attributes.entry.16.value=<user-name-string>]
    [&Attributes.entry.17.key=password&Attributes.entry.17.value=<password-string>]
    [&Attributes.entry.18.key=kafka-brokers&Attributes.entry.18.value=<kafka-broker-list>]
+   [&Attributes.entry.19.key=ssl-certificate-location&Attributes.entry.19.value=<file path>]
+   [&Attributes.entry.20.key=ssl-key-location&Attributes.entry.20.value=<file path>]
+   [&Attributes.entry.21.key=ssl-key-password&Attributes.entry.21.value=<password-string>]
 
 Request parameters:
 
@@ -302,7 +305,25 @@ Request parameters:
   - "broker": Messages are considered "delivered" if acked by the broker. (This
     is the default.)
 
- - kafka-brokers: A command-separated list of host:port of kafka brokers. These brokers (may contain a broker which is defined in kafka uri) will be added to kafka uri to support sending notifcations to a kafka cluster.
+ - ``kafka-brokers``: A comma-separated list of ``host:port`` of Kafka brokers:
+   these brokers (may contain a broker which is defined in Kafka URI) will be
+   added to Kafka URI to support sending notifications to a Kafka cluster.
+ - ``ssl-certificate-location``: The path to a PEM-encoded client certificate
+   file to present to the Kafka broker for mutual TLS (mTLS) authentication.
+   This enables certificate-based client identity and must be used together
+   with ``ssl-key-location`` and ``use-ssl=true``. Specifying only one of
+   ``ssl-certificate-location`` or ``ssl-key-location`` will cause the
+   connection to fail.
+ - ``ssl-key-location``: The path to a PEM-encoded private key file
+   corresponding to the client certificate specified in
+   ``ssl-certificate-location``.
+ - ``ssl-key-password``: The password for the client private key, if the key
+   file is encrypted. This is optional and only required when the private key
+   is password-protected.
+
+   The same security considerations in place for this parameter as
+   for ``user``/``password``: it should be provided over HTTPS or
+   ``rgw_allow_notification_secrets_in_cleartext`` must be set to "true".
 
 .. note::
 
@@ -554,32 +575,39 @@ The response has the following format:
 
 Valid AttributeName that can be passed:
 
-  - push-endpoint: This is the URI of an endpoint to send push notifications to.
-  - OpaqueData: Opaque data is set in the topic configuration and added to all
-    notifications that are triggered by the topic.
-  - persistent: This indicates whether notifications to this endpoint are
-    persistent (=asynchronous) or not persistent. (This is "false" by default.)
-  - time_to_live: This will limit the time (in seconds) to retain the notifications.
-  - max_retries: This will limit the max retries before expiring notifications.
-  - retry_sleep_duration: This will control the frequency of retrying the notifications.
-  - Policy: This will control who can access the topic other than owner of the topic.
-  - verify-ssl: This indicates whether the server certificates must be validated by
-    the client. This is "true" by default.
-  - ``use-ssl``: If this is set to "true", a secure connection is used to
-    connect to the broker. This is "false" by default.
-  - cloudevents: This indicates whether the HTTP header should contain
-    attributes according to the `S3 CloudEvents Spec`_. 
-  - amqp-exchange: The exchanges must exist and must be able to route messages
-    based on topics.
-  - amqp-ack-level: No end2end acknowledgement is required. Messages may persist in the
-    broker before being delivered to their final destinations. 
-  - ``ca-location``: If this is provided and a secure connection is used, the
-    specified CA will be used instead of the default CA to authenticate the
-    broker. 
-  - mechanism: may be provided together with user/password (default: ``PLAIN``).
-  - kafka-ack-level: No end2end acknowledgement is required. Messages may persist in the
-    broker before being delivered to their final destinations. 
-  - kafka-brokers: Set endpoint with broker(s) as a comma-separated list of host or host:port (default port 9092).
+- ``push-endpoint``: This is the URI of an endpoint to send push notifications to.
+- ``OpaqueData``: Opaque data is set in the topic configuration and added to all
+  notifications that are triggered by the topic.
+- ``persistent``: This indicates whether notifications to this endpoint are
+  persistent (=asynchronous) or not persistent. (This is "false" by default.)
+- ``time_to_live``: This will limit the time (in seconds) to retain the notifications.
+- ``max_retries``: This will limit the max retries before expiring notifications.
+- ``retry_sleep_duration``: This will control the frequency of retrying the notifications.
+- ``Policy``: This will control who can access the topic other than owner of the topic.
+- ``verify-ssl``: This indicates whether the server certificates must be validated by
+  the client. This is "true" by default.
+- ``use-ssl``: If this is set to "true", a secure connection is used to
+  connect to the broker. This is "false" by default.
+- ``cloudevents``: This indicates whether the HTTP header should contain
+  attributes according to the `S3 CloudEvents Spec`_.
+- ``amqp-exchange``: The exchanges must exist and must be able to route messages
+  based on topics.
+- ``amqp-ack-level``: No end2end acknowledgement is required. Messages may persist in the
+  broker before being delivered to their final destinations.
+- ``ca-location``: If this is provided and a secure connection is used, the
+  specified CA will be used instead of the default CA to authenticate the
+  broker.
+- ``mechanism``: May be provided together with ``user``/``password`` (default: ``PLAIN``)
+- ``kafka-ack-level``: No end2end acknowledgement is required. Messages may persist in the
+  broker before being delivered to their final destinations.
+- ``kafka-brokers``: Set endpoint with broker(s) as a comma-separated list of
+  ``host`` or ``host:port`` (default port 9092).
+- ``ssl-certificate-location``: Path to a PEM-encoded client certificate for mTLS
+  authentication to the Kafka broker. Must be provided together with
+  ``ssl-key-location``; specifying only one will cause the connection to fail.
+- ``ssl-key-location``: Path to a PEM-encoded private key corresponding to the
+  client certificate. Must be provided together with ``ssl-certificate-location``.
+- ``ssl-key-password``: Password for an encrypted private key (optional).
 
 Notifications
 ~~~~~~~~~~~~~

--- a/src/rgw/driver/rados/rgw_pubsub_push.cc
+++ b/src/rgw/driver/rados/rgw_pubsub_push.cc
@@ -292,7 +292,10 @@ public:
            conn_id, _endpoint, get_bool(args, "use-ssl", false),
            get_bool(args, "verify-ssl", true), args.get_optional("ca-location"),
            args.get_optional("mechanism"), args.get_optional("user-name"),
-           args.get_optional("password"), args.get_optional("kafka-brokers"))) {
+           args.get_optional("password"), args.get_optional("kafka-brokers"),
+           args.get_optional("ssl-certificate-location"),
+           args.get_optional("ssl-key-location"),
+           args.get_optional("ssl-key-password"))) {
      throw configuration_error("Kafka: failed to create connection to: " +
                                _endpoint);
    }

--- a/src/rgw/rgw_kafka.cc
+++ b/src/rgw/rgw_kafka.cc
@@ -73,13 +73,29 @@ connection_id_t::connection_id_t(
     const std::string& _password,
     const boost::optional<const std::string&>& _ca_location,
     const boost::optional<const std::string&>& _mechanism,
-    bool _ssl)
-    : broker(_broker), user(_user), password(_password), ssl(_ssl) {
+    bool _ssl,
+    bool _verify_ssl,
+    const boost::optional<const std::string&>& _ssl_certificate,
+    const boost::optional<const std::string&>& _ssl_key,
+    const boost::optional<const std::string&>& _ssl_key_password
+  )
+    : broker(_broker), user(_user), password(_password), ssl(_ssl),
+      verify_ssl(_verify_ssl) {
+
   if (_ca_location.has_value()) {
     ca_location = _ca_location.get();
   }
   if (_mechanism.has_value()) {
     mechanism = _mechanism.get();
+  }
+  if (_ssl_certificate.has_value()) {
+    ssl_certificate = _ssl_certificate.get();
+  }
+  if (_ssl_key.has_value()) {
+    ssl_key = _ssl_key.get();
+  }
+  if (_ssl_key_password.has_value()) {
+    ssl_key_password = _ssl_key_password.get();
   }
 }
 
@@ -88,7 +104,11 @@ connection_id_t::connection_id_t(
 bool operator==(const connection_id_t& lhs, const connection_id_t& rhs) {
   return lhs.broker == rhs.broker && lhs.user == rhs.user &&
          lhs.password == rhs.password && lhs.ca_location == rhs.ca_location &&
-         lhs.mechanism == rhs.mechanism && lhs.ssl == rhs.ssl;
+         lhs.mechanism == rhs.mechanism && lhs.ssl == rhs.ssl &&
+         lhs.verify_ssl == rhs.verify_ssl &&
+         lhs.ssl_certificate == rhs.ssl_certificate &&
+         lhs.ssl_key == rhs.ssl_key &&
+         lhs.ssl_key_password == rhs.ssl_key_password;
 }
 
 struct connection_id_hasher {
@@ -100,11 +120,13 @@ struct connection_id_hasher {
     boost::hash_combine(h, k.ca_location);
     boost::hash_combine(h, k.mechanism);
     boost::hash_combine(h, k.ssl);
+    boost::hash_combine(h, k.verify_ssl);
+    boost::hash_combine(h, k.ssl_certificate);
+    boost::hash_combine(h, k.ssl_key);
     return h;
   }
 };
 
-std::string to_string(const connection_id_t& id) {
   return id.broker + ":" + id.user;
 }
 
@@ -161,6 +183,9 @@ struct connection_t {
   const std::string user;
   const std::string password;
   const boost::optional<std::string> mechanism;
+  const boost::optional<std::string> ssl_certificate;
+  const boost::optional<std::string> ssl_key;
+  const boost::optional<std::string> ssl_key_password;
   utime_t timestamp = ceph_clock_now();
 
   // cleanup of all internal connection resource
@@ -193,8 +218,12 @@ struct connection_t {
   // ctor for setting immutable values
   connection_t(CephContext* _cct, const std::string& _broker, bool _use_ssl, bool _verify_ssl, 
           const boost::optional<const std::string&>& _ca_location,
-          const std::string& _user, const std::string& _password, const boost::optional<const std::string&>& _mechanism) :
-      cct(_cct), broker(_broker), use_ssl(_use_ssl), verify_ssl(_verify_ssl), ca_location(_ca_location), user(_user), password(_password), mechanism(_mechanism) {}                                                                                                                                                        
+          const std::string& _user, const std::string& _password, const boost::optional<const std::string&>& _mechanism,
+          const boost::optional<const std::string&>& _ssl_certificate,
+          const boost::optional<const std::string&>& _ssl_key,
+          const boost::optional<const std::string&>& _ssl_key_password) :
+      cct(_cct), broker(_broker), use_ssl(_use_ssl), verify_ssl(_verify_ssl), ca_location(_ca_location), user(_user), password(_password), mechanism(_mechanism),
+      ssl_certificate(_ssl_certificate), ssl_key(_ssl_key), ssl_key_password(_ssl_key_password) {}                                                                                                                                                        
 
   // dtor also destroys the internals
   ~connection_t() {
@@ -315,6 +344,23 @@ bool new_producer(connection_t* conn) {
       ldout(conn->cct, 20) << "Kafka connect: successfully configured CA location" << dendl;
     } else {
       ldout(conn->cct, 20) << "Kafka connect: using default CA location" << dendl;
+    }
+    if (rd_kafka_conf_set(conf.get(), "enable.ssl.certificate.verification",
+                          conn->verify_ssl ? "true" : "false",
+                          errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK) {
+      goto conf_error;
+    }
+    if (conn->ssl_certificate) {
+      if (rd_kafka_conf_set(conf.get(), "ssl.certificate.location", conn->ssl_certificate->c_str(), errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK) goto conf_error;
+      ldout(conn->cct, 20) << "Kafka connect: successfully configured client certificate location" << dendl;
+    }
+    if (conn->ssl_key) {
+      if (rd_kafka_conf_set(conf.get(), "ssl.key.location", conn->ssl_key->c_str(), errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK) goto conf_error;
+      ldout(conn->cct, 20) << "Kafka connect: successfully configured client key location" << dendl;
+    }
+    if (conn->ssl_key_password) {
+      if (rd_kafka_conf_set(conf.get(), "ssl.key.password", conn->ssl_key_password->c_str(), errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK) goto conf_error;
+      ldout(conn->cct, 20) << "Kafka connect: successfully configured client key password" << dendl;
     }
     // Note: when librdkafka.1.0 is available the following line could be uncommented instead of the callback setting call
     // if (rd_kafka_conf_set(conn->conf, "enable.ssl.certificate.verification", "0", errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK) goto conf_error;
@@ -590,14 +636,17 @@ public:
 
   // connect to a broker, or reuse an existing connection if already connected
   bool connect(connection_id_t& conn_id,
-          const std::string& url, 
-          bool use_ssl,
-          bool verify_ssl,
-          boost::optional<const std::string&> ca_location,
-          boost::optional<const std::string&> mechanism,
-          boost::optional<const std::string&> topic_user_name,
-          boost::optional<const std::string&> topic_password,
-          boost::optional<const std::string&> brokers) {
+               const std::string& url,
+               bool use_ssl,
+               bool verify_ssl,
+               boost::optional<const std::string&> ca_location,
+               boost::optional<const std::string&> mechanism,
+               boost::optional<const std::string&> topic_user_name,
+               boost::optional<const std::string&> topic_password,
+               boost::optional<const std::string&> brokers,
+               boost::optional<const std::string&> ssl_certificate,
+               boost::optional<const std::string&> ssl_key,
+               boost::optional<const std::string&> ssl_key_password) {
     if (stopped) {
       ldout(cct, 1) << "Kafka connect: manager is stopped" << dendl;
       return false;
@@ -635,13 +684,20 @@ public:
       return false;
     }
 
+    // ssl_certificate and ssl_key must both be provided for mTLS
+    if (ssl_certificate.has_value() != ssl_key.has_value()) {
+      ldout(cct, 1) << "Kafka connect: both ssl_certificate and ssl_key must be provided for mTLS (got only "
+                    << (ssl_certificate.has_value() ? "ssl_certificate" : "ssl_key") << ")" << dendl;
+      return false;
+    }
+
     if (brokers.has_value()) {
       broker_list.append(",");
       broker_list.append(brokers.get());
     }
 
     connection_id_t tmp_id(broker_list, user, password, ca_location, mechanism,
-                           use_ssl);
+                           use_ssl, verify_ssl, ssl_certificate, ssl_key, ssl_key_password);
     std::lock_guard lock(connections_lock);
     const auto it = connections.find(tmp_id);
     // note that ssl vs. non-ssl connection to the same host are two separate connections
@@ -660,7 +716,7 @@ public:
       return false;
     }
 
-    auto conn = std::make_unique<connection_t>(cct, broker_list, use_ssl, verify_ssl, ca_location, user, password, mechanism);
+    auto conn = std::make_unique<connection_t>(cct, broker_list, use_ssl, verify_ssl, ca_location, user, password, mechanism, ssl_certificate, ssl_key, ssl_key_password);
     if (!new_producer(conn.get())) {
       ldout(cct, 10) << "Kafka connect: producer creation failed in new connection" << dendl;
       return false;
@@ -779,11 +835,15 @@ bool connect(connection_id_t& conn_id,
              boost::optional<const std::string&> mechanism,
              boost::optional<const std::string&> user_name,
              boost::optional<const std::string&> password,
-             boost::optional<const std::string&> brokers) {
+             boost::optional<const std::string&> brokers,
+             boost::optional<const std::string&> ssl_certificate,
+             boost::optional<const std::string&> ssl_key,
+             boost::optional<const std::string&> ssl_key_password) {
   std::shared_lock lock(s_manager_mutex);
   if (!s_manager) return false;
   return s_manager->connect(conn_id, url, use_ssl, verify_ssl, ca_location,
-                            mechanism, user_name, password, brokers);
+                            mechanism, user_name, password, brokers,
+                            ssl_certificate, ssl_key, ssl_key_password);
 }
 
 int publish(const connection_id_t& conn_id,

--- a/src/rgw/rgw_kafka.cc
+++ b/src/rgw/rgw_kafka.cc
@@ -636,17 +636,17 @@ public:
 
   // connect to a broker, or reuse an existing connection if already connected
   bool connect(connection_id_t& conn_id,
-               const std::string& url,
-               bool use_ssl,
-               bool verify_ssl,
-               boost::optional<const std::string&> ca_location,
-               boost::optional<const std::string&> mechanism,
-               boost::optional<const std::string&> topic_user_name,
-               boost::optional<const std::string&> topic_password,
-               boost::optional<const std::string&> brokers,
-               boost::optional<const std::string&> ssl_certificate,
-               boost::optional<const std::string&> ssl_key,
-               boost::optional<const std::string&> ssl_key_password) {
+          const std::string& url,
+          bool use_ssl,
+          bool verify_ssl,
+          boost::optional<const std::string&> ca_location,
+          boost::optional<const std::string&> mechanism,
+          boost::optional<const std::string&> topic_user_name,
+          boost::optional<const std::string&> topic_password,
+          boost::optional<const std::string&> brokers,
+          boost::optional<const std::string&> ssl_certificate,
+          boost::optional<const std::string&> ssl_key,
+          boost::optional<const std::string&> ssl_key_password) {
     if (stopped) {
       ldout(cct, 1) << "Kafka connect: manager is stopped" << dendl;
       return false;

--- a/src/rgw/rgw_kafka.h
+++ b/src/rgw/rgw_kafka.h
@@ -28,6 +28,9 @@ struct connection_id_t {
   std::string password;
   std::string ca_location;
   std::string mechanism;
+  std::string ssl_certificate;
+  std::string ssl_key;
+  std::string ssl_key_password;
   bool ssl = false;
   connection_id_t() = default;
   connection_id_t(const std::string& _broker,
@@ -35,7 +38,11 @@ struct connection_id_t {
                   const std::string& _password,
                   const boost::optional<const std::string&>& _ca_location,
                   const boost::optional<const std::string&>& _mechanism,
-                  bool _ssl);
+                  bool _ssl,
+                  bool _verify_ssl,
+                  const boost::optional<const std::string&>& _ssl_certificate,
+                  const boost::optional<const std::string&>& _ssl_key,
+                  const boost::optional<const std::string&>& _ssl_key_password);
 };
 
 std::string to_string(const connection_id_t& id);
@@ -49,7 +56,10 @@ bool connect(connection_id_t& conn_id,
              boost::optional<const std::string&> mechanism,
              boost::optional<const std::string&> user_name,
              boost::optional<const std::string&> password,
-             boost::optional<const std::string&> brokers);
+             boost::optional<const std::string&> brokers,
+             boost::optional<const std::string&> ssl_certificate,
+             boost::optional<const std::string&> ssl_key,
+             boost::optional<const std::string&> ssl_key_password);
 
 // publish a message over a connection that was already created
 int publish(const connection_id_t& conn_id,

--- a/src/rgw/rgw_rest_pubsub.cc
+++ b/src/rgw/rgw_rest_pubsub.cc
@@ -77,6 +77,17 @@ bool validate_and_update_endpoint_secret(rgw_pubsub_dest& dest, CephContext *cct
       return false;
     }
   }
+
+  // check for mTLS key password - also a secret that requires secure transport
+  auto ssl_key_password = args.get_optional("ssl-key-password");
+  if (ssl_key_password.has_value() && !ssl_key_password->empty()) {
+    dest.stored_secret = true;
+    if (!verify_transport_security(cct, *ri.env)) {
+      message = "Topic contains secrets that must be transmitted over a secure transport";
+      return false;
+    }
+  }
+
   return true;
 }
 
@@ -789,7 +800,8 @@ class RGWPSSetTopicAttributesOp : public RGWOp {
       static constexpr std::initializer_list<const char*> args = {
           "verify-ssl",    "use-ssl",         "ca-location", "amqp-ack-level",
           "amqp-exchange", "kafka-ack-level", "mechanism",   "cloudevents",
-          "user-name",     "password"};
+          "user-name",     "password",
+          "ssl-certificate-location", "ssl-key-location", "ssl-key-password"};
       if (std::find(args.begin(), args.end(), attribute_name) != args.end()) {
         replace_str(attribute_name, s->info.args.get("AttributeValue"));
         return 0;


### PR DESCRIPTION
Backport of #68771  to squid.

Cherry-pick of 591d8ac3748.
Fixes: https://tracker.ceph.com/issues/67427


