### PR TITLE
client: force mtime override on write under SHARED caps

### DIFF
--- a/qa/tasks/cephfs/test_misc.py
+++ b/qa/tasks/cephfs/test_misc.py
@@ -528,6 +528,77 @@ class TestMisc(CephFSTestCase):
         self.assertEqual(ce.exception.exitstatus, 1)
 
 
+    def test_write_overrides_futuristic_mtime(self):
+        """
+        Ensure a data write operation unconditionally overwrites a user-set
+        futuristic mtime/ctime with the current real clock, even in multi-client
+        environments where CEPH_CAP_FILE_EXCL is revoked.
+        """
+        test_dir = "test_futuristic_mtime_dir"
+        test_file = f"{test_dir}/target.bin"
+
+        # Use Client 1 (mount_a) to create the base directory and file
+        self.mount_a.run_shell(["mkdir", "-p", test_dir])
+        self.mount_a.touch(test_file)
+
+        # Explicitly push the file's mtime 25 hours into the future
+        log.info("Setting file mtime 25 hours into the future")
+        self.mount_a.run_shell(["touch", "-m", "-d", "+25 hours", test_file])
+
+        # Verify the file is actually set in the future before continuing
+        future_mtime = int(self.mount_a.run_shell(["stat", "-c", "%Y",
+                                                   test_file]).stdout.getvalue().strip())
+        current_time = int(self.mount_a.run_shell(["date",
+                                                   "+%s"]).stdout.getvalue().strip())
+        self.assertTrue(future_mtime > current_time,
+                        "Setup error: File mtime is not in the future.")
+
+        # Read the file from Client 2 (mount_b) to break Client 1's exclusive
+        # caps (EXCL)
+        log.info("Opening file on client_b to force cap downgrade"
+                 "(revoking EXCL) on client_a")
+        proc_b = self.mount_b.run_shell(["cat", test_file], wait=False)
+
+        # Wait briefly for cap transitions to settle across MDS/clients
+        time.sleep(2)
+
+        # Perform a data write operation via Client 1 (mount_a)
+        log.info("Executing write on client_a while working under"
+                 "shared capabilities")
+        self.mount_a.run_shell(["sh", "-c", f"echo 'payload' >> {test_file}"])
+
+        # Gather the post-write modification time metrics
+        log.info("Gathering post-write metadata metrics from client_a")
+        post_mtime = int(self.mount_a.run_shell(["stat", "-c", "%Y",
+                                                 test_file]).stdout.getvalue().strip())
+
+        # Refresh current time gauge
+        final_current_time = int(self.mount_a.run_shell(["date", "+%s"
+                                                         ]).stdout.getvalue().strip())
+
+        # Clean up background process contexts safely with a maximum 30-second timeout
+        try:
+            proc_b.wait(timeout=30)
+        except Exception as e:
+            log.warning(f"Background proc_b did not exit cleanly within timeout: {e}")
+        self.mount_a.run_shell(["rm", "-rf", test_dir])
+
+        # Final Assertion Checklist
+        log.info(f"Future mtime: {future_mtime} | Post-write mtime: {post_mtime}"
+                 f" | Current system time: {final_current_time}")
+
+        # The post-write mtime should no longer be stuck in the future.
+        # It must be within a safe delta (e.g., 10 seconds) of the current real
+        # system clock time.
+        # A strict match post_mtime == final_current_time would cause false failures.
+        self.assertLessEqual(
+            post_mtime,
+            final_current_time + 10,
+            "REGRESSION DETECTED: The futuristic mtime remained stuck after a "
+            "write operation because metadata caps were not dirtied or forced "
+            "backward to the real clock."
+        )
+
 @classhook('_add_session_client_evictions')
 class TestSessionClientEvict(CephFSTestCase):
     CLIENTS_REQUIRED = 3

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12759,6 +12759,19 @@ int64_t Client::_write(Fh *f, int64_t offset, uint64_t size, bufferlist bl,
     return r;
 
   put_cap_ref(in, CEPH_CAP_AUTH_SHARED);
+  /* A data write operation must unconditionally overwrite a futuristic mtime
+   * with the current clock time. When multiple clients hold file
+   * handles open, exclusive capabilities (EXCL) are revoked. This fix forces
+   * the client to actively advance the time and dirty the write capabilities
+   * even under shared write execution.
+   */
+  utime_t now = ceph_clock_now();
+  if (in->mtime > now || (in->caps_issued() & CEPH_CAP_FILE_EXCL)) {
+    in->mtime = now;
+    in->ctime = now;
+    in->mark_caps_dirty(CEPH_CAP_FILE_WR);
+  }
+
   if (size > 0) {
     r = clear_suid_sgid(in, f->actor_perms);
     if (r < 0) {


### PR DESCRIPTION
This PR addresses issues where file metadata updates were incorrectly optimised away or skipped by the client when exclusive capabilities (CEPH_CAP_FILE_EXCL) were lost or downgraded to SHARED caps in multi-client scenarios.

* **Force mtime override on write**: Fixes a regression where standard data write operations (_write) failed to override a futuristic mtime if the client's EXCL capabilities were revoked. The client now actively updates mtime to the current clock time and dirties CEPH_CAP_FILE_WR under shared write execution.

* **QA Tests**: Added dedicated regression test cases in the test suite to validate distributed metadata propagation under SHARED cap constraints.

Fixes: https://tracker.ceph.com/issues/71622

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
