### PR TITLE
cmake: make GTEST_PARALLEL_COMMAND visible to all test directories

### DIFF
--- a/cmake/modules/AddCephTest.cmake
+++ b/cmake/modules/AddCephTest.cmake
@@ -73,8 +73,11 @@ if(WITH_GTEST_PARALLEL)
       BUILD_COMMAND ""
       INSTALL_COMMAND "")
     add_dependencies(tests gtest-parallel_ext)
+    # CACHE INTERNAL: the set() runs only in the first directory to create the
+    # target, so a plain variable would be invisible to PARALLEL tests elsewhere.
     set(GTEST_PARALLEL_COMMAND
-      ${Python3_EXECUTABLE} ${gtest_parallel_source_dir}/gtest-parallel)
+      ${Python3_EXECUTABLE} ${gtest_parallel_source_dir}/gtest-parallel
+      CACHE INTERNAL "command to run a gtest binary through gtest-parallel")
   endif()
 endif()
 


### PR DESCRIPTION
`GTEST_PARALLEL_COMMAND` was set as an ordinary variable inside the
`if(NOT TARGET gtest-parallel_ext)` guard, so it only existed in the first
directory that `include()`s AddCephTest (src/common/options). Later includes
skip the guarded block and leave it empty, so PARALLEL unittests under
src/test silently ran serially.

Promote it to `CACHE INTERNAL` so it is visible across all directories
regardless of include order.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests