### PR TITLE
test/librbd: split unittest_librbd into parallel ctest jobs

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -659,14 +659,16 @@ if(WITH_FIO)
 endif()
 
 if(WITH_RBD)
-  # Run rbd-unit-tests separate so they an run in parallel
+  # Run rbd-unit-tests separate so they can run in parallel.
   # For values see: src/include/rbd/features.h
-  add_ceph_test(run-rbd-unit-tests-N.sh   ${CMAKE_CURRENT_SOURCE_DIR}/run-rbd-unit-tests.sh N)
-  add_ceph_test(run-rbd-unit-tests-0.sh   ${CMAKE_CURRENT_SOURCE_DIR}/run-rbd-unit-tests.sh 0)
-  add_ceph_test(run-rbd-unit-tests-1.sh   ${CMAKE_CURRENT_SOURCE_DIR}/run-rbd-unit-tests.sh 1)
-  add_ceph_test(run-rbd-unit-tests-61.sh  ${CMAKE_CURRENT_SOURCE_DIR}/run-rbd-unit-tests.sh 61)
-  add_ceph_test(run-rbd-unit-tests-109.sh ${CMAKE_CURRENT_SOURCE_DIR}/run-rbd-unit-tests.sh 109)
-  add_ceph_test(run-rbd-unit-tests-127.sh ${CMAKE_CURRENT_SOURCE_DIR}/run-rbd-unit-tests.sh 127)
+  # Each feature is split into parallel ctest jobs; the encryption flatten
+  # cases dominate, so they get their own job per feature and the rest another.
+  foreach(features N 0 1 61 109 127)
+    add_ceph_test(run-rbd-unit-tests-${features}.sh
+      ${CMAKE_CURRENT_SOURCE_DIR}/run-rbd-unit-tests.sh ${features} "*-EncryptedFlattenTest*")
+    add_ceph_test(run-rbd-unit-tests-${features}-encryption.sh
+      ${CMAKE_CURRENT_SOURCE_DIR}/run-rbd-unit-tests.sh ${features} "EncryptedFlattenTest*")
+  endforeach()
   if(FREEBSD)
     add_ceph_test(rbd-ggate.sh ${CMAKE_CURRENT_SOURCE_DIR}/rbd-ggate.sh)
   endif(FREEBSD)

--- a/src/test/run-rbd-unit-tests.sh
+++ b/src/test/run-rbd-unit-tests.sh
@@ -15,6 +15,15 @@ GTEST_FILTER+=":TestLibRBD.ConcurrentOperations"
 # https://tracker.ceph.com/issues/70847
 GTEST_FILTER+=":TestMigration.Stress*"
 
+# Optional 2nd arg: a gtest filter so the suite can be split across parallel
+# ctest jobs. Each job still runs its cases serially (in-process order matters).
+if [ -n "${2:-}" ]; then
+  case "$2" in
+    *-*) GTEST_FILTER="${2}:${GTEST_FILTER#-}" ;;  # shard already opens a '-' negative section
+    *)   GTEST_FILTER="${2}${GTEST_FILTER}" ;;     # positive-only shard; GTEST_FILTER opens the negative section
+  esac
+fi
+
 # exclude tests that are prone to sporadic failures
 export GTEST_FILTER
 
@@ -22,11 +31,11 @@ if [ $# = 0 ]; then
   # mimic the old behaviour
   TESTS='0 1 61 109 127'
   unset RBD_FEATURES; unittest_librbd
-elif [ $# = 1 -a "${1}" = N ] ; then
+elif [ "${1}" = N ] ; then
   # new style no feature request
   unset RBD_FEATURES; unittest_librbd
-else 
-  TESTS="$*"
+else
+  TESTS="$1"
 fi
 
 for i in ${TESTS}


### PR DESCRIPTION
`run-rbd-unit-tests.sh` runs `unittest_librbd` once per `RBD_FEATURES`
value, each running its whole gtest suite serially in one process, so the
slowest feature combinations dominate `make check` wall-clock.

Case-level parallelism (e.g. gtest-parallel) doesn't work: many cases
implicitly depend on in-process execution order and fail when run as
isolated single-case processes.

Parallelize at the process level instead. The script now takes an optional
gtest filter so a run can be split across several ctest jobs running as
separate parallel processes, while each job still runs its own cases
serially. The encryption flatten cases dominate, so they get their own job
per feature and everything else runs as another.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests