### PR TITLE
mgr/MMgrReport: default-initialize PerfCounterType members

### DIFF
--- a/src/messages/MMgrReport.h
+++ b/src/messages/MMgrReport.h
@@ -32,13 +32,13 @@ public:
   std::string path;
   std::string description;
   std::string nick;
-  enum perfcounter_type_d type;
+  enum perfcounter_type_d type = PERFCOUNTER_NONE;
 
   // For older clients that did not send priority, pretend everything
   // is "useful" so that mgr plugins filtering on prio will get some
   // data (albeit probably more than they wanted)
   uint8_t priority = PerfCountersBuilder::PRIO_USEFUL;
-  enum unit_t unit;
+  enum unit_t unit = UNIT_NONE;
 
   void encode(ceph::buffer::list &bl) const
   {


### PR DESCRIPTION
`readable.sh` can fail decoding pre-v3 corpus objects that predate the
`unit` field:

```
**** reencode of .../objects/PerfCounterType/... resulted in a different dump ****
7c7
<     "unit": 36
---
>     "unit": 101
```

ci: https://github.com/sunyuechi/ceph-ci/actions/runs/27833755001

For `struct_v < 3` the `unit` field is never decoded and had no in-class
default, so it read indeterminate memory and differed between the two
ceph-dencoder processes `readable.sh` compares. Default it to `UNIT_NONE`.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests