### PR TITLE
umbrella: rgw/restore: run shard hash through HASH_PRIME

### DIFF
--- a/src/rgw/rgw_restore.cc
+++ b/src/rgw/rgw_restore.cc
@@ -266,7 +266,7 @@ std::ostream& Restore::gen_prefix(std::ostream& out) const
 int Restore::choose_oid(const RestoreEntry& e) {
   int index;
   const auto& name = e.bucket.name + e.obj_key.name + e.obj_key.instance;
-  index = ((ceph_str_hash_linux(name.data(), name.size())) % max_objs);
+  index = ((ceph_str_hash_linux(name.data(), name.size())) % HASH_PRIME % max_objs);
   return static_cast<int>(index);
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77528

---

backport of https://github.com/ceph/ceph/pull/69373
parent tracker: https://tracker.ceph.com/issues/77286

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh



## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests
