### PR TITLE
tentacle: rgw/restore: run shard hash through HASH_PRIME

### DIFF
--- a/src/rgw/rgw_restore.cc
+++ b/src/rgw/rgw_restore.cc
@@ -209,7 +209,7 @@ std::ostream& Restore::gen_prefix(std::ostream& out) const
 int Restore::choose_oid(const RestoreEntry& e) {
   int index;
   const auto& name = e.bucket.name + e.obj_key.name + e.obj_key.instance;
-  index = ((ceph_str_hash_linux(name.data(), name.size())) % max_objs);
+  index = ((ceph_str_hash_linux(name.data(), name.size())) % HASH_PRIME % max_objs);
   return static_cast<int>(index);
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77529

---

backport of https://github.com/ceph/ceph/pull/69373
parent tracker: https://tracker.ceph.com/issues/77286

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh