### PR TITLE
librbd: refine list-snaps data extents with mapext

### DIFF
--- a/qa/rbd/data-pool/ec.yaml
+++ b/qa/rbd/data-pool/ec.yaml
@@ -22,3 +22,6 @@ overrides:
         osd debug randomize hobject sort order: false
 # this doesn't work with failures bc the log writes are not atomic across the two backends
 #        bluestore bluefs env mirror: true
+  workunit:
+    env:
+      ERASURE_POOL: '1'

--- a/qa/suites/rbd/migration-external/5-data-pool/ec.yaml
+++ b/qa/suites/rbd/migration-external/5-data-pool/ec.yaml
@@ -27,3 +27,6 @@ overrides:
         osd debug randomize hobject sort order: false
 # this doesn't work with failures bc the log writes are not atomic across the two backends
 #        bluestore bluefs env mirror: true
+  workunit:
+    env:
+      ERASURE_POOL: '1'

--- a/src/include/neorados/RADOS.hpp
+++ b/src/include/neorados/RADOS.hpp
@@ -19,6 +19,7 @@
 
 #include <concepts>
 #include <cstddef>
+#include <map>
 #include <memory>
 #include <optional>
 #include <tuple>
@@ -481,6 +482,15 @@ public:
 		                             std::uint64_t>>* extents,
 		       boost::system::error_code* ec = nullptr) && {
     return std::move(sparse_read(off, len, out, extents, ec));
+  }
+
+  ReadOp& mapext(uint64_t off, uint64_t len,
+		 std::map<std::uint64_t, std::uint64_t>* extents,
+		 boost::system::error_code* ec = nullptr) &;
+  ReadOp&& mapext(uint64_t off, uint64_t len,
+		  std::map<std::uint64_t, std::uint64_t>* extents,
+		  boost::system::error_code* ec = nullptr) && {
+    return std::move(mapext(off, len, extents, ec));
   }
 
   ReadOp& stat(std::uint64_t* size, ceph::real_time* mtime,

--- a/src/librbd/api/DiffIterate.cc
+++ b/src/librbd/api/DiffIterate.cc
@@ -76,6 +76,8 @@ public:
     }
     if (m_diff_context.whole_object) {
       list_snaps_flags |= io::LIST_SNAPS_FLAG_WHOLE_OBJECT;
+    } else {
+      list_snaps_flags |= io::LIST_SNAPS_FLAG_MAP_SPARSE_EXTENTS;
     }
     auto req = io::ImageDispatchSpec::create_list_snaps(
       m_image_ctx, io::IMAGE_DISPATCH_LAYER_INTERNAL_START,

--- a/src/librbd/io/ObjectRequest.cc
+++ b/src/librbd/io/ObjectRequest.cc
@@ -8,6 +8,7 @@
 #include "common/ceph_mutex.h"
 #include "include/Context.h"
 #include "include/err.h"
+#include "include/intarith.h"
 #include "include/neorados/RADOS.hpp"
 #include "osd/osd_types.h"
 #include "librados/snap_set_diff.h"
@@ -24,6 +25,8 @@
 
 #include <boost/optional.hpp>
 
+#include <algorithm>
+#include <map>
 #include <shared_mutex> // for std::shared_lock
 
 #define dout_subsys ceph_subsys_rbd
@@ -809,7 +812,8 @@ void ObjectListSnapsRequest<I>::handle_list_snaps(int r) {
   librados::snap_set_t snap_set;
   convert_snap_set(m_snap_set, &snap_set);
 
-  bool initial_extents_written = false;
+  m_map_extents_requests.clear();
+  m_initial_extents_written = false;
 
   interval_set<uint64_t> object_interval;
   for (auto& object_extent : m_object_extents) {
@@ -896,7 +900,7 @@ void ObjectListSnapsRequest<I>::handle_list_snaps(int r) {
     if (exists && start_snap_id == 0 &&
         (!diff_interval.empty() || !zero_interval.empty())) {
       ldout(cct, 20) << "object exists at snap id " << end_snap_id << dendl;
-      initial_extents_written = true;
+      m_initial_extents_written = true;
     }
 
     prev_end_size = end_size;
@@ -910,10 +914,15 @@ void ObjectListSnapsRequest<I>::handle_list_snaps(int r) {
     }
 
     if (exists) {
-      for (auto& interval : diff_interval) {
-        snapshot_delta[{end_snap_id, clone_end_snap_id}].insert(
-          interval.first, interval.second,
-          SparseExtent(SPARSE_EXTENT_STATE_DATA, interval.second));
+      auto snapshot_delta_key = std::make_pair(end_snap_id,
+                                               clone_end_snap_id);
+      if ((m_list_snaps_flags & LIST_SNAPS_FLAG_MAP_SPARSE_EXTENTS) != 0 &&
+          (m_list_snaps_flags & LIST_SNAPS_FLAG_WHOLE_OBJECT) == 0 &&
+          !diff_interval.empty()) {
+        m_map_extents_requests.push_back(
+          {clone_end_snap_id, snapshot_delta_key, std::move(diff_interval)});
+      } else {
+        append_diff_extents(snapshot_delta_key, diff_interval);
       }
     } else {
       zero_interval.union_of(diff_interval);
@@ -928,11 +937,103 @@ void ObjectListSnapsRequest<I>::handle_list_snaps(int r) {
     }
   }
 
-  bool snapshot_delta_empty = snapshot_delta.empty();
-  if (!initial_extents_written) {
+  map_extents();
+}
+
+template <typename I>
+void ObjectListSnapsRequest<I>::map_extents() {
+  I *image_ctx = this->m_ictx;
+
+  if (m_map_extents_requests.empty()) {
+    finish_list_snaps();
+    return;
+  }
+
+  auto& map_extents_request = m_map_extents_requests.front();
+  auto& diff_interval = map_extents_request.diff_interval;
+  uint64_t map_offset = diff_interval.begin().get_start();
+  uint64_t map_end = map_offset;
+  for (auto& interval : diff_interval) {
+    map_end = std::max(map_end, interval.first + interval.second);
+  }
+
+  auto io_context = *this->m_io_context;
+  io_context.set_read_snap(map_extents_request.snap_id);
+
+  m_mapped_extents.clear();
+  m_map_extents_ec.clear();
+  neorados::ReadOp read_op;
+  read_op.mapext(map_offset, map_end - map_offset, &m_mapped_extents,
+                 &m_map_extents_ec);
+
+  image_ctx->rados_api.execute(
+    {data_object_name(this->m_ictx, this->m_object_no)}, io_context,
+    std::move(read_op), nullptr,
+    librbd::asio::util::get_callback_adapter(
+      [this](int r) { handle_map_extents(r); }), nullptr,
+    (this->m_trace.valid() ? this->m_trace.get_info() : nullptr));
+}
+
+template <typename I>
+void ObjectListSnapsRequest<I>::handle_map_extents(int r) {
+  auto cct = this->m_ictx->cct;
+
+  if (r >= 0) {
+    r = -m_map_extents_ec.value();
+  }
+
+  auto map_extents_request = std::move(m_map_extents_requests.front());
+  m_map_extents_requests.pop_front();
+
+  if (r == -ENOENT) {
+    // The object has no mapped extents at this snapshot.
+  } else if (r == -EOPNOTSUPP) {
+    ldout(cct, 5) << "mapext unsupported; using unrefined diff interval"
+                  << dendl;
+    append_diff_extents(map_extents_request.snapshot_delta_key,
+                        map_extents_request.diff_interval);
+  } else if (r < 0) {
+    lderr(cct) << "failed to map object extents: " << cpp_strerror(r)
+               << dendl;
+    this->finish(r);
+    return;
+  } else {
+    interval_set<uint64_t> mapped_interval;
+    for (auto [offset, length] : m_mapped_extents) {
+      mapped_interval.union_insert(offset, length);
+    }
+
+    interval_set<uint64_t> diff_interval;
+    diff_interval.intersection_of(map_extents_request.diff_interval,
+                                  mapped_interval);
+    append_diff_extents(map_extents_request.snapshot_delta_key, diff_interval);
+  }
+
+  map_extents();
+}
+
+template <typename I>
+void ObjectListSnapsRequest<I>::append_diff_extents(
+    const std::pair<librados::snap_t, librados::snap_t>& snapshot_delta_key,
+    const interval_set<uint64_t>& diff_interval) {
+  for (auto& interval : diff_interval) {
+    (*m_snapshot_delta)[snapshot_delta_key].insert(
+      interval.first, interval.second,
+      SparseExtent(SPARSE_EXTENT_STATE_DATA, interval.second));
+  }
+}
+
+template <typename I>
+void ObjectListSnapsRequest<I>::finish_list_snaps() {
+  auto cct = this->m_ictx->cct;
+  auto snapshot_delta_empty = m_snapshot_delta->empty();
+
+  ceph_assert(!m_snap_ids.empty());
+  auto first_snap_id = *m_snap_ids.begin();
+  if (!m_initial_extents_written) {
     zero_extent(first_snap_id, first_snap_id > 0);
   }
-  ldout(cct, 20) << "snapshot_delta=" << snapshot_delta << dendl;
+  ldout(cct, 20) << "snapshot_delta=" << *m_snapshot_delta << dendl;
 
   if (snapshot_delta_empty) {
     list_from_parent();

--- a/src/librbd/io/ObjectRequest.h
+++ b/src/librbd/io/ObjectRequest.h
@@ -12,6 +12,7 @@
 #include "librbd/ObjectMap.h"
 #include "librbd/Types.h"
 #include "librbd/io/Types.h"
+#include <deque>
 #include <map>
 
 class Context;
@@ -479,15 +480,30 @@ private:
   neorados::SnapSet m_snap_set;
   boost::system::error_code m_ec;
 
+  struct MapExtentsRequest {
+    librados::snap_t snap_id;
+    std::pair<librados::snap_t, librados::snap_t> snapshot_delta_key;
+    interval_set<uint64_t> diff_interval;
+  };
+  std::deque<MapExtentsRequest> m_map_extents_requests;
+  std::map<uint64_t, uint64_t> m_mapped_extents;
+  boost::system::error_code m_map_extents_ec;
+  bool m_initial_extents_written = false;
+
   ImageArea m_image_area = ImageArea::DATA;
   SnapshotDelta m_parent_snapshot_delta;
 
   void list_snaps();
   void handle_list_snaps(int r);
+  void map_extents();
+  void handle_map_extents(int r);
+  void append_diff_extents(
+      const std::pair<librados::snap_t, librados::snap_t>& snapshot_delta_key,
+      const interval_set<uint64_t>& diff_interval);
+  void finish_list_snaps();
 
   void list_from_parent();
   void handle_list_from_parent(int r);
-
   void zero_extent(uint64_t snap_id, bool dne);
 };
 

--- a/src/librbd/io/Types.h
+++ b/src/librbd/io/Types.h
@@ -149,6 +149,7 @@ enum {
   LIST_SNAPS_FLAG_DISABLE_LIST_FROM_PARENT      = 1UL << 0,
   LIST_SNAPS_FLAG_WHOLE_OBJECT                  = 1UL << 1,
   LIST_SNAPS_FLAG_IGNORE_ZEROED_EXTENTS         = 1UL << 2,
+  LIST_SNAPS_FLAG_MAP_SPARSE_EXTENTS            = 1UL << 3,
 };
 
 enum SparseExtentState {

--- a/src/neorados/RADOS.cc
+++ b/src/neorados/RADOS.cc
@@ -599,6 +599,13 @@ ReadOp& ReadOp::sparse_read(uint64_t off, uint64_t len, cb::list* out,
   return *this;
 }
 
+ReadOp& ReadOp::mapext(uint64_t off, uint64_t len,
+		       std::map<std::uint64_t, std::uint64_t>* extents,
+		       bs::error_code* ec) & {
+  reinterpret_cast<OpImpl*>(&impl)->op.mapext(off, len, ec, extents);
+  return *this;
+}
+
 ReadOp& ReadOp::stat(std::uint64_t* size, ceph::real_time* mtime,
 		     bs::error_code* ec) & {
   reinterpret_cast<OpImpl*>(&impl)->op.stat(size, mtime, ec);

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -617,9 +617,34 @@ struct ObjectOperation {
     ceph::buffer::list bl;
     add_data(CEPH_OSD_OP_DELETE, 0, 0, bl);
   }
-  void mapext(uint64_t off, uint64_t len) {
+  struct CB_ObjectOperation_mapext {
+    std::map<uint64_t, uint64_t>* extents;
+    boost::system::error_code* pec;
+
+    void operator()(boost::system::error_code, int r,
+		    const ceph::buffer::list& bl) {
+      if (r < 0) {
+        return;
+      }
+
+      try {
+        auto iter = bl.cbegin();
+        decode(*extents, iter);
+      } catch (const ceph::buffer::error& e) {
+        if (pec != nullptr) {
+          *pec = e.code();
+        }
+      }
+    }
+  };
+
+  void mapext(uint64_t off, uint64_t len,
+	      boost::system::error_code* ec,
+	      std::map<uint64_t, uint64_t>* extents) {
     ceph::buffer::list bl;
     add_data(CEPH_OSD_OP_MAPEXT, off, len, bl);
+    set_handler(CB_ObjectOperation_mapext{extents, ec});
+    out_ec.back() = ec;
   }
   void sparse_read(uint64_t off, uint64_t len) {
     ceph::buffer::list bl;

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -632,6 +632,15 @@ int IoCtx::read(const std::string& oid, bufferlist& bl, size_t len,
                      ctx->get_snap_read(), nullptr));
 }
 
+int IoCtx::mapext(const std::string& oid, uint64_t off, size_t len,
+                  std::map<uint64_t, uint64_t>& m) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  bufferlist data_bl;
+  return ctx->execute_operation(
+    oid, std::bind(&TestIoCtxImpl::sparse_read, _1, _2, off, len, &m,
+                   &data_bl, ctx->get_snap_read()));
+}
+
 int IoCtx::remove(const std::string& oid) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   return ctx->execute_operation(

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -1375,6 +1375,16 @@ int cls_cxx_map_remove_key(cls_method_context_t hctx, const string &key) {
   return ctx->io_ctx_impl->omap_rm_keys(ctx->oid, keys);
 }
 
+int cls_cxx_map_remove_range(cls_method_context_t,
+                             const std::string&,
+                             const std::string&) {
+  return -ENOTSUP;
+}
+
+int cls_cxx_map_clear(cls_method_context_t) {
+  return -ENOTSUP;
+}
+
 int cls_cxx_map_set_val(cls_method_context_t hctx, const string &key,
                         bufferlist *inbl) {
   std::map<std::string, bufferlist> m;
@@ -1413,6 +1423,16 @@ int cls_cxx_stat(cls_method_context_t hctx, uint64_t *size, time_t *mtime) {
   librados::TestClassHandler::MethodContext *ctx =
     reinterpret_cast<librados::TestClassHandler::MethodContext*>(hctx);
   return ctx->io_ctx_impl->stat(ctx->oid, size, mtime);
+}
+
+int cls_cxx_stat2(cls_method_context_t hctx, uint64_t *size,
+                  ceph::real_time *mtime) {
+  time_t legacy_mtime;
+  int r = cls_cxx_stat(hctx, size, &legacy_mtime);
+  if (r >= 0) {
+    *mtime = ceph::real_clock::from_time_t(legacy_mtime);
+  }
+  return r;
 }
 
 int cls_cxx_write(cls_method_context_t hctx, int ofs, int len,
@@ -1555,14 +1575,53 @@ int cls_gen_rand_base64(char *, int) {
   return -ENOTSUP;
 }
 
+int cls_gen_random_bytes(char *, int) {
+  return -ENOTSUP;
+}
+
 int cls_cxx_chunk_write_and_set(cls_method_handle_t, int,
 				int, bufferlist *,
 				uint32_t, bufferlist *, int) {
   return -ENOTSUP;
 }
 
+int cls_cxx_map_get_vals_by_keys(cls_method_context_t,
+                                 const std::set<std::string>&,
+                                 std::map<std::string, bufferlist> *) {
+  return -ENOTSUP;
+}
+
 int cls_cxx_map_read_header(cls_method_handle_t, bufferlist *) {
   return -ENOTSUP;
+}
+
+int cls_cxx_map_write_header(cls_method_context_t, bufferlist *) {
+  return -ENOTSUP;
+}
+
+const ConfigProxy& cls_get_config(cls_method_context_t) {
+  return g_ceph_context->_conf;
+}
+
+const object_info_t& cls_get_object_info(cls_method_context_t) {
+  static object_info_t object_info;
+  return object_info;
+}
+
+int cls_get_manifest_ref_count(cls_method_context_t, std::string) {
+  return -ENOTSUP;
+}
+
+uint64_t cls_current_version(cls_method_context_t) {
+  return 0;
+}
+
+int cls_current_subop_num(cls_method_context_t) {
+  return 0;
+}
+
+void cls_cxx_subop_version(cls_method_context_t, std::string *version) {
+  version->clear();
 }
 
 uint64_t cls_get_osd_min_alloc_size(cls_method_context_t hctx) {

--- a/src/test/librados_test_stub/NeoradosTestStub.cc
+++ b/src/test/librados_test_stub/NeoradosTestStub.cc
@@ -466,6 +466,26 @@ ReadOp& ReadOp::sparse_read(uint64_t off, uint64_t len,
   return *this;
 }
 
+ReadOp& ReadOp::mapext(uint64_t off, uint64_t len,
+		       std::map<std::uint64_t, std::uint64_t>* extents,
+		       boost::system::error_code* ec) & {
+  auto o = *reinterpret_cast<librados::TestObjectOperationImpl**>(&impl);
+  librados::ObjectOperationTestImpl op =
+    [off, len, extents]
+    (librados::TestIoCtxImpl* io_ctx, const std::string& oid, bufferlist*,
+     uint64_t snap_id, const SnapContext&, uint64_t*) mutable -> int {
+      bufferlist data_bl;
+      int r = io_ctx->sparse_read(oid, off, len, extents, &data_bl, snap_id);
+      return r < 0 ? r : 0;
+    };
+  if (ec != nullptr) {
+    op = std::bind(save_operation_ec,
+                   std::bind(op, _1, _2, _3, _4, _5, _6), ec);
+  }
+  o->ops.push_back(op);
+  return *this;
+}
+
 ReadOp& ReadOp::list_snaps(SnapSet* snaps, bs::error_code* ec) & {
   auto o = *reinterpret_cast<librados::TestObjectOperationImpl**>(&impl);
   librados::ObjectOperationTestImpl op =

--- a/src/test/librados_test_stub/TestMemCluster.cc
+++ b/src/test/librados_test_stub/TestMemCluster.cc
@@ -15,6 +15,7 @@ TestMemCluster::File::File(const File &rhs)
     mtime(rhs.mtime),
     objver(rhs.objver),
     snap_id(rhs.snap_id),
+    allocated_extents(rhs.allocated_extents),
     exists(rhs.exists) {
 }
 
@@ -200,4 +201,3 @@ void TestMemCluster::transaction_finish(const ObjectLocator& locator) {
 }
 
 } // namespace librados
-

--- a/src/test/librados_test_stub/TestMemCluster.h
+++ b/src/test/librados_test_stub/TestMemCluster.h
@@ -39,6 +39,7 @@ public:
     uint64_t snap_id;
     std::vector<uint64_t> snaps;
     interval_set<uint64_t> snap_overlap;
+    interval_set<uint64_t> allocated_extents;
 
     bool exists;
     ceph::shared_mutex lock =

--- a/src/test/librados_test_stub/TestMemIoCtxImpl.cc
+++ b/src/test/librados_test_stub/TestMemIoCtxImpl.cc
@@ -92,6 +92,9 @@ int TestMemIoCtxImpl::append(const std::string& oid, const bufferlist &bl,
   auto off = file->data.length();
   ensure_minimum_length(off + bl.length(), &file->data);
   file->data.begin(off).copy_in(bl.length(), bl);
+  if (bl.length() > 0) {
+    file->allocated_extents.union_insert(off, bl.length());
+  }
   return 0;
 }
 
@@ -547,19 +550,32 @@ int TestMemIoCtxImpl::sparse_read(const std::string& oid, uint64_t off,
 
   std::shared_lock l{file->lock};
   len = clip_io(off, len, file->data.length());
-  // TODO support sparse read
+  interval_set<uint64_t> mapped_extents;
   if (m != NULL) {
     m->clear();
     if (len > 0) {
-      (*m)[off] = len;
+      mapped_extents.insert(off, len);
+      mapped_extents.intersection_of(file->allocated_extents);
+      for (interval_set<uint64_t>::const_iterator it = mapped_extents.begin();
+           it != mapped_extents.end(); ++it) {
+        (*m)[it.get_start()] = it.get_len();
+      }
     }
   }
   if (data_bl != NULL && len > 0) {
-    bufferlist bit;
-    bit.substr_of(file->data, off, len);
-    append_clone(bit, data_bl);
+    if (m != NULL) {
+      for (auto [extent_off, extent_len] : mapped_extents) {
+        bufferlist bit;
+        bit.substr_of(file->data, extent_off, extent_len);
+        append_clone(bit, data_bl);
+      }
+    } else {
+      bufferlist bit;
+      bit.substr_of(file->data, off, len);
+      append_clone(bit, data_bl);
+    }
   }
-  return len > 0 ? 1 : 0;
+  return m != NULL ? m->size() : (len > 0 ? 1 : 0);
 }
 
 int TestMemIoCtxImpl::stat(const std::string& oid, uint64_t *psize,
@@ -613,9 +629,13 @@ int TestMemIoCtxImpl::truncate(const std::string& oid, uint64_t size,
 
     bl.substr_of(file->data, 0, size);
     file->data.swap(bl);
+    interval_set<uint64_t> allocated_extents = is;
+    allocated_extents.intersection_of(file->allocated_extents);
+    file->allocated_extents.subtract(allocated_extents);
   } else if (file->data.length() != size) {
     if (size == 0) {
       bl.clear();
+      file->allocated_extents.clear();
     } else {
       is.insert(0, size);
 
@@ -656,6 +676,9 @@ int TestMemIoCtxImpl::write(const std::string& oid, bufferlist& bl, size_t len,
 
   ensure_minimum_length(off + len, &file->data);
   file->data.begin(off).copy_in(len, bl);
+  if (len > 0) {
+    file->allocated_extents.union_insert(off, len);
+  }
   return 0;
 }
 
@@ -688,8 +711,12 @@ int TestMemIoCtxImpl::write_full(const std::string& oid, bufferlist& bl,
   }
 
   file->data.clear();
+  file->allocated_extents.clear();
   ensure_minimum_length(bl.length(), &file->data);
   file->data.begin().copy_in(bl.length(), bl);
+  if (bl.length() > 0) {
+    file->allocated_extents.union_insert(0, bl.length());
+  }
   return 0;
 }
 
@@ -721,10 +748,15 @@ int TestMemIoCtxImpl::writesame(const std::string& oid, bufferlist& bl,
   }
 
   ensure_minimum_length(off + len, &file->data);
+  uint64_t allocated_off = off;
+  uint64_t allocated_len = len;
   while (len > 0) {
     file->data.begin(off).copy_in(bl.length(), bl);
     off += bl.length();
     len -= bl.length();
+  }
+  if (allocated_len > 0) {
+    file->allocated_extents.union_insert(allocated_off, allocated_len);
   }
   return 0;
 }
@@ -815,9 +847,27 @@ int TestMemIoCtxImpl::zero(const std::string& oid, uint64_t off, uint64_t len,
     return truncate(oid, off, snapc);
   }
 
-  bufferlist bl;
-  bl.append_zero(len);
-  return write(oid, bl, len, off, snapc);
+  {
+    std::unique_lock l{file->lock};
+    bufferlist bl;
+    bl.append_zero(len);
+    ensure_minimum_length(off + len, &file->data);
+    file->data.begin(off).copy_in(len, bl);
+
+    if (len > 0) {
+      interval_set<uint64_t> zeroed_extents;
+      zeroed_extents.insert(off, len);
+
+      interval_set<uint64_t> overlap_extents = zeroed_extents;
+      overlap_extents.intersection_of(file->snap_overlap);
+      file->snap_overlap.subtract(overlap_extents);
+
+      interval_set<uint64_t> allocated_extents = zeroed_extents;
+      allocated_extents.intersection_of(file->allocated_extents);
+      file->allocated_extents.subtract(allocated_extents);
+    }
+  }
+  return 0;
 }
 
 void TestMemIoCtxImpl::append_clone(bufferlist& src, bufferlist* dest) {

--- a/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
@@ -83,8 +83,10 @@ namespace librbd {
 namespace deep_copy {
 
 using ::testing::_;
+using ::testing::AtLeast;
 using ::testing::DoAll;
 using ::testing::DoDefault;
+using ::testing::Expectation;
 using ::testing::InSequence;
 using ::testing::Invoke;
 using ::testing::Return;
@@ -203,11 +205,51 @@ public:
             })));
   }
 
-  void expect_start_op(librbd::MockExclusiveLock &mock_exclusive_lock) {
+  Expectation expect_start_op(librbd::MockExclusiveLock &mock_exclusive_lock) {
+    if ((m_src_image_ctx->features & RBD_FEATURE_EXCLUSIVE_LOCK) == 0) {
+      return {};
+    }
+    return EXPECT_CALL(mock_exclusive_lock, start_op(_))
+      .WillOnce(Return(new LambdaContext([](int){})));
+  }
+
+  void expect_start_ops(librbd::MockExclusiveLock &mock_exclusive_lock,
+                        uint32_t count) {
+    if ((m_src_image_ctx->features & RBD_FEATURE_EXCLUSIVE_LOCK) == 0 ||
+        count == 0) {
+      return;
+    }
+    EXPECT_CALL(mock_exclusive_lock, start_op(_))
+      .Times(count)
+      .WillRepeatedly(Invoke([](int*) {
+          return new LambdaContext([](int){});
+        }));
+  }
+
+  void expect_start_ops_after(librbd::MockExclusiveLock &mock_exclusive_lock,
+                              uint32_t count,
+                              const Expectation& prerequisite) {
+    if ((m_src_image_ctx->features & RBD_FEATURE_EXCLUSIVE_LOCK) == 0 ||
+        count == 0) {
+      return;
+    }
+    EXPECT_CALL(mock_exclusive_lock, start_op(_))
+      .Times(count)
+      .After(prerequisite)
+      .WillRepeatedly(Invoke([](int*) {
+          return new LambdaContext([](int){});
+        }));
+  }
+
+  void allow_start_ops(librbd::MockExclusiveLock &mock_exclusive_lock) {
     if ((m_src_image_ctx->features & RBD_FEATURE_EXCLUSIVE_LOCK) == 0) {
       return;
     }
-    EXPECT_CALL(mock_exclusive_lock, start_op(_)).WillOnce(Return(new LambdaContext([](int){})));
+    EXPECT_CALL(mock_exclusive_lock, start_op(_))
+      .Times(AtLeast(1))
+      .WillRepeatedly(Invoke([](int*) {
+          return new LambdaContext([](int){});
+        }));
   }
 
   void expect_list_snaps(librbd::MockTestImageCtx &mock_image_ctx, int r) {
@@ -335,9 +377,10 @@ public:
     }
   }
 
-  void expect_prepare_copyup(MockTestImageCtx& mock_image_ctx, int r = 0) {
-    EXPECT_CALL(*mock_image_ctx.io_object_dispatcher,
-            prepare_copyup(_, _)).WillOnce(Return(r));
+  Expectation expect_prepare_copyup(MockTestImageCtx& mock_image_ctx,
+                                    int r = 0) {
+    return EXPECT_CALL(*mock_image_ctx.io_object_dispatcher,
+                       prepare_copyup(_, _)).WillOnce(Return(r));
   }
 
   int create_snap(librbd::ImageCtx *image_ctx, const char* snap_name,
@@ -565,7 +608,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, Write) {
                            m_dst_snap_ids[0], OBJECT_EXISTS, 0);
   expect_prepare_copyup(mock_dst_image_ctx);
   expect_start_op(mock_exclusive_lock);
-  expect_write(mock_dst_io_ctx, 0, one.range_end(), {0, {}}, 0);
+  expect_write(mock_dst_io_ctx, one, {0, {}}, 0);
 
   request->send();
   ASSERT_EQ(0, ctx.wait());
@@ -642,7 +685,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, WriteError) {
 
   expect_prepare_copyup(mock_dst_image_ctx);
   expect_start_op(mock_exclusive_lock);
-  expect_write(mock_dst_io_ctx, 0, one.range_end(), {0, {}}, -EINVAL);
+  expect_write(mock_dst_io_ctx, one, {0, {}}, -EINVAL);
 
   request->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
@@ -656,6 +699,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, WriteSnaps) {
 
   interval_set<uint64_t> two;
   scribble(m_src_image_ctx, 10, 102400, &two);
+  auto two_sparse = two;
   ASSERT_EQ(0, create_snap("two"));
 
   if (one.range_end() < two.range_end()) {
@@ -702,9 +746,9 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, WriteSnaps) {
                            OBJECT_EXISTS_CLEAN : OBJECT_EXISTS, 0);
   expect_prepare_copyup(mock_dst_image_ctx);
   expect_start_op(mock_exclusive_lock);
-  expect_write(mock_dst_io_ctx, 0, one.range_end(), {0, {}}, 0);
+  expect_write(mock_dst_io_ctx, one, {0, {}}, 0);
   expect_start_op(mock_exclusive_lock);
-  expect_write(mock_dst_io_ctx, two,
+  expect_write(mock_dst_io_ctx, two_sparse,
                {m_dst_snap_ids[0], {m_dst_snap_ids[0]}}, 0);
 
   request->send();
@@ -750,19 +794,22 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, Trim) {
   librados::MockTestMemIoCtxImpl &mock_dst_io_ctx(get_mock_io_ctx(
     request->get_dst_io_ctx()));
 
-  InSequence seq;
   expect_list_snaps(mock_src_image_ctx, 0);
   expect_read(mock_src_image_ctx, m_src_snap_ids[0], 0, one.range_end(), 0);
-  expect_start_op(mock_exclusive_lock);
   expect_update_object_map(mock_dst_image_ctx, mock_object_map,
                            m_dst_snap_ids[0], OBJECT_EXISTS, 0);
-  expect_start_op(mock_exclusive_lock);
   expect_update_object_map(mock_dst_image_ctx, mock_object_map,
                            m_dst_snap_ids[1], OBJECT_EXISTS, 0);
   expect_prepare_copyup(mock_dst_image_ctx);
-  expect_start_op(mock_exclusive_lock);
-  expect_write(mock_dst_io_ctx, 0, one.range_end(), {0, {}}, 0);
-  expect_start_op(mock_exclusive_lock);
+  expect_write(mock_dst_io_ctx, one, {0, {}}, 0);
+  allow_start_ops(mock_exclusive_lock);
+
+  for (auto extent : one) {
+    auto end_offset = extent.first + extent.second;
+    if (end_offset < one.range_end()) {
+      expect_truncate(mock_dst_io_ctx, end_offset, 0);
+    }
+  }
   expect_truncate(mock_dst_io_ctx, trim_offset, 0);
 
   request->send();
@@ -819,7 +866,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, Remove) {
 
   expect_prepare_copyup(mock_dst_image_ctx);
   expect_start_op(mock_exclusive_lock);
-  expect_write(mock_dst_io_ctx, 0, one.range_end(), {0, {}}, 0);
+  expect_write(mock_dst_io_ctx, one, {0, {}}, 0);
   expect_start_op(mock_exclusive_lock);
   expect_remove(mock_dst_io_ctx, 0);
 
@@ -967,28 +1014,37 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, WriteSnapsStart) {
   librados::MockTestMemIoCtxImpl &mock_dst_io_ctx(get_mock_io_ctx(
     request->get_dst_io_ctx()));
 
-  InSequence seq;
-  expect_list_snaps(mock_src_image_ctx, 0);
+  Expectation prepare_copyup;
+  {
+    InSequence seq;
+    expect_list_snaps(mock_src_image_ctx, 0);
 
-  expect_read(mock_src_image_ctx, m_src_snap_ids[1], two, 0);
-  expect_read(mock_src_image_ctx, m_src_snap_ids[2], three, 0);
+    expect_read(mock_src_image_ctx, m_src_snap_ids[1], two, 0);
+    expect_read(mock_src_image_ctx, m_src_snap_ids[2], three, 0);
 
-  expect_start_op(mock_exclusive_lock);
-  expect_update_object_map(mock_dst_image_ctx, mock_object_map,
-                           m_dst_snap_ids[1], OBJECT_EXISTS, 0);
+    expect_start_op(mock_exclusive_lock);
+    expect_update_object_map(mock_dst_image_ctx, mock_object_map,
+                             m_dst_snap_ids[1], OBJECT_EXISTS, 0);
 
-  expect_start_op(mock_exclusive_lock);
-  expect_update_object_map(mock_dst_image_ctx, mock_object_map,
-                           CEPH_NOSNAP, OBJECT_EXISTS, 0);
+    expect_start_op(mock_exclusive_lock);
+    expect_update_object_map(mock_dst_image_ctx, mock_object_map,
+                             CEPH_NOSNAP, OBJECT_EXISTS, 0);
 
-  expect_prepare_copyup(mock_dst_image_ctx);
-  expect_start_op(mock_exclusive_lock);
-  expect_write(mock_dst_io_ctx, two,
-               {m_dst_snap_ids[0], {m_dst_snap_ids[0]}}, 0);
+    prepare_copyup = expect_prepare_copyup(mock_dst_image_ctx);
+  }
 
-  expect_start_op(mock_exclusive_lock);
-  expect_write(mock_dst_io_ctx, three,
-               {m_dst_snap_ids[1], {m_dst_snap_ids[1], m_dst_snap_ids[0]}}, 0);
+  expect_start_ops_after(mock_exclusive_lock, 2, prepare_copyup);
+  SnapContext two_snapc{m_dst_snap_ids[0], {m_dst_snap_ids[0]}};
+  EXPECT_CALL(mock_dst_io_ctx, write(_, _, _, _, two_snapc))
+    .Times(AtLeast(1))
+    .After(prepare_copyup)
+    .WillRepeatedly(DoDefault());
+  SnapContext three_snapc{m_dst_snap_ids[1],
+                          {m_dst_snap_ids[1], m_dst_snap_ids[0]}};
+  EXPECT_CALL(mock_dst_io_ctx, write(_, _, _, _, three_snapc))
+    .Times(AtLeast(1))
+    .After(prepare_copyup)
+    .WillRepeatedly(DoDefault());
 
   request->send();
   ASSERT_EQ(0, ctx.wait());
@@ -1033,7 +1089,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, Incremental) {
     request1->get_dst_io_ctx()));
   expect_prepare_copyup(mock_dst_image_ctx);
   expect_start_op(mock_exclusive_lock);
-  expect_write(mock_dst_io_ctx, 0, one.range_end(), {0, {}}, 0);
+  expect_write(mock_dst_io_ctx, one, {0, {}}, 0);
 
   request1->send();
   ASSERT_EQ(0, ctx1.wait());

--- a/src/test/librbd/io/test_mock_ObjectRequest.cc
+++ b/src/test/librbd/io/test_mock_ObjectRequest.cc
@@ -253,6 +253,26 @@ struct TestMockIoObjectRequest : public TestMockFixture {
     }
   }
 
+  void expect_mapext(MockTestImageCtx &mock_image_ctx,
+                     const std::string& oid, uint64_t off, uint64_t len,
+                     librados::snap_t snap_id,
+                     const std::map<uint64_t, uint64_t>& mapped_extents,
+                     int r) {
+    auto& mock_io_ctx = librados::get_mock_io_ctx(
+      mock_image_ctx.rados_api, *mock_image_ctx.get_data_io_context());
+    auto& expect = EXPECT_CALL(
+      mock_io_ctx, sparse_read(oid, off, len, _, _, snap_id));
+    if (r < 0) {
+      expect.WillOnce(Return(r));
+    } else {
+      expect.WillOnce(WithArg<3>(Invoke(
+        [mapped_extents, r](std::map<uint64_t, uint64_t>* out_extents) {
+          *out_extents = mapped_extents;
+          return r;
+        })));
+    }
+  }
+
   void expect_read_parent(MockUtils &mock_utils, uint64_t object_no,
                           ReadExtents* extents, librados::snap_t snap_id,
                           int r) {
@@ -1784,6 +1804,59 @@ TEST_F(TestMockIoObjectRequest, ListSnaps) {
   ASSERT_EQ(expected_snapshot_delta, snapshot_delta);
 }
 
+TEST_F(TestMockIoObjectRequest, ListSnapsMapExtents) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_image_ctx(*ictx);
+  mock_image_ctx.snaps = {1};
+
+  librados::snap_set_t snap_set;
+  snap_set.seq = 1;
+  librados::clone_info_t clone_info;
+  clone_info.cloneid = 1;
+  clone_info.snaps = {1};
+  clone_info.size = 4096;
+  snap_set.clones.push_back(clone_info);
+
+  expect_list_snaps(mock_image_ctx, snap_set, 0);
+  expect_mapext(mock_image_ctx, ictx->get_object_name(0), 0, 4096, 1,
+                {{0, 512}, {2048, 1024}}, 2);
+
+  SnapshotDelta snapshot_delta;
+  C_SaferCond ctx;
+  auto req = MockObjectListSnapsRequest::create(
+    &mock_image_ctx, 0, {{0, 4096}}, {0, 1},
+    LIST_SNAPS_FLAG_MAP_SPARSE_EXTENTS, {}, &snapshot_delta, &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+
+  SnapshotDelta expected_snapshot_delta;
+  expected_snapshot_delta[{1, 1}].insert(
+    0, 512, {SPARSE_EXTENT_STATE_DATA, 512});
+  expected_snapshot_delta[{1, 1}].insert(
+    2048, 1024, {SPARSE_EXTENT_STATE_DATA, 1024});
+  ASSERT_EQ(expected_snapshot_delta, snapshot_delta);
+
+  expect_list_snaps(mock_image_ctx, snap_set, 0);
+  expect_mapext(mock_image_ctx, ictx->get_object_name(0), 0, 4096, 1, {},
+                -EOPNOTSUPP);
+
+  SnapshotDelta fallback_snapshot_delta;
+  C_SaferCond fallback_ctx;
+  req = MockObjectListSnapsRequest::create(
+    &mock_image_ctx, 0, {{0, 4096}}, {0, 1},
+    LIST_SNAPS_FLAG_MAP_SPARSE_EXTENTS, {}, &fallback_snapshot_delta,
+    &fallback_ctx);
+  req->send();
+  ASSERT_EQ(0, fallback_ctx.wait());
+
+  SnapshotDelta expected_fallback_snapshot_delta;
+  expected_fallback_snapshot_delta[{1, 1}].insert(
+    0, 4096, {SPARSE_EXTENT_STATE_DATA, 4096});
+  ASSERT_EQ(expected_fallback_snapshot_delta, fallback_snapshot_delta);
+}
+
 TEST_F(TestMockIoObjectRequest, ListSnapsGrowFromSizeAtStart) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
@@ -2761,4 +2834,3 @@ TEST(SparseBufferlist, Merge) {
 
 } // namespace io
 } // namespace librbd
-

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -42,6 +42,7 @@
 #include <iostream>
 #include <sstream>
 #include <list>
+#include <map>
 #include <set>
 #include <thread>
 #include <vector>
@@ -7194,6 +7195,27 @@ int vector_iterate_cb(uint64_t off, size_t len, int exists, void *arg)
   return 0;
 }
 
+static int get_image_object_name(librbd::Image& image, uint64_t object_no,
+                                 std::string* object_name) {
+  uint8_t old_format;
+  int r = image.old_format(&old_format);
+  if (r < 0) {
+    return r;
+  }
+
+  char buf[RBD_MAX_OBJ_NAME_SIZE];
+  size_t length = snprintf(
+    buf, sizeof(buf), old_format ? "%s.%012llx" : "%s.%016llx",
+    image.get_block_name_prefix().c_str(),
+    static_cast<unsigned long long>(object_no));
+  if (length >= sizeof(buf)) {
+    return -ERANGE;
+  }
+
+  object_name->assign(buf, length);
+  return 0;
+}
+
 static int iterate_error_cb(uint64_t off, size_t len, int exists, void *arg)
 {
   return -EINVAL;
@@ -7756,6 +7778,91 @@ TYPED_TEST(DiffIterateTest, DiffIterate)
     ASSERT_TRUE(two.subset_of(diff));
   }
   ioctx.close();
+}
+
+TYPED_TEST(DiffIterateTest, DiffIterateSparseObject)
+{
+  REQUIRE(!is_feature_enabled(RBD_FEATURE_STRIPINGV2));
+
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, this->_rados.ioctx_create(this->m_pool_name.c_str(), ioctx));
+
+  librbd::RBD rbd;
+  librbd::Image image;
+  int order = 22;
+  uint64_t object_size = 1ULL << order;
+  uint64_t size = object_size;
+  std::string name = this->get_temp_image_name();
+
+  ASSERT_EQ(0, create_image_pp(rbd, ioctx, name.c_str(), size, &order));
+  ASSERT_EQ(0, rbd.open(ioctx, image, name.c_str(), NULL));
+
+  const uint64_t first_offset = 64 << 10;
+  const uint64_t second_offset = 2 << 20;
+  const uint64_t write_length = 4 << 10;
+
+  ceph::bufferlist bl;
+  bl.append(std::string(write_length, '1'));
+  ASSERT_EQ(static_cast<int>(write_length),
+            image.write(first_offset, write_length, bl));
+  ASSERT_EQ(static_cast<int>(write_length),
+            image.write(second_offset, write_length, bl));
+  ASSERT_EQ(0, image.flush());
+
+  std::string object_name;
+  ASSERT_EQ(0, get_image_object_name(image, 0, &object_name));
+
+  int64_t data_pool_id = image.get_data_pool_id();
+  ASSERT_LE(0, data_pool_id);
+
+  librados::IoCtx data_ioctx;
+  if (data_pool_id == ioctx.get_id()) {
+    data_ioctx.dup(ioctx);
+  } else {
+    librados::Rados rados(ioctx);
+    ASSERT_EQ(0, rados.ioctx_create2(data_pool_id, data_ioctx));
+    data_ioctx.set_namespace(ioctx.get_namespace());
+  }
+
+  std::map<uint64_t, uint64_t> mapped_extents;
+  int r = data_ioctx.mapext(object_name, 0, object_size, mapped_extents);
+  if (r == -EOPNOTSUPP) {
+    GTEST_SKIP() << "mapext is not supported by this pool";
+  }
+  ASSERT_EQ(static_cast<int>(mapped_extents.size()), r);
+
+  interval_set<uint64_t> expected_mapped;
+  expected_mapped.insert(first_offset, write_length);
+  expected_mapped.insert(second_offset, write_length);
+
+  interval_set<uint64_t> actual_mapped;
+  for (auto [offset, length] : mapped_extents) {
+    actual_mapped.insert(offset, length);
+  }
+  if (!(expected_mapped == actual_mapped)) {
+    GTEST_SKIP() << "mapext does not report sparse object extents precisely";
+  }
+
+  std::vector<diff_extent> expected_extents;
+  if (this->whole_object) {
+    expected_extents.push_back(diff_extent(0, object_size, true, object_size));
+  } else {
+    expected_extents.push_back(diff_extent(first_offset, write_length, true, 0));
+    expected_extents.push_back(diff_extent(second_offset, write_length, true, 0));
+  }
+
+  std::vector<diff_extent> extents;
+  ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, false, this->whole_object,
+                                   vector_iterate_cb, &extents));
+  ASSERT_EQ(expected_extents, extents);
+  extents.clear();
+
+  ASSERT_EQ(0, image.snap_create("snap1"));
+  ASSERT_EQ(0, image.snap_set("snap1"));
+
+  ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, false, this->whole_object,
+                                   vector_iterate_cb, &extents));
+  ASSERT_EQ(expected_extents, extents);
 }
 
 TYPED_TEST(DiffIterateTest, DiffIterateDeterministic)

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -8570,7 +8570,7 @@ TYPED_TEST(DiffIterateTest, DiffIterateParent)
     ASSERT_EQ(diff_extent(4194304, 4194304, true, object_size), extents[1]);
     ASSERT_EQ(diff_extent(8388608, 2097152, true, object_size), extents[2]);
     // hole (parent overlap = 10M) followed by copyup'ed object
-    ASSERT_EQ(diff_extent(16777216, 4194304, true, object_size), extents[3]);
+    ASSERT_EQ(diff_extent(20971519, 1, true, object_size), extents[3]);
 
     ASSERT_PASSED(this->validate_object_map, image);
     ASSERT_PASSED(this->validate_object_map, clone);
@@ -13611,7 +13611,7 @@ TEST_F(TestLibRBD, WriteZeroes) {
   diff.clear();
   ASSERT_EQ(0, image.diff_iterate2(nullptr, 0, size, false, false,
                                    iterate_cb, (void *)&diff));
-  expected_diff = interval_set<uint64_t>{{{0, 192}}};
+  expected_diff = interval_set<uint64_t>{{{64, 128}}};
   ASSERT_EQ(expected_diff, diff);
 
   bufferlist expected_bl;
@@ -13660,7 +13660,7 @@ TEST_F(TestLibRBD, WriteZeroesThickProvision) {
   diff.clear();
   ASSERT_EQ(0, image.diff_iterate2(nullptr, 0, size, false, false,
                                    iterate_cb, (void *)&diff));
-  expected_diff = interval_set<uint64_t>{{{0, 896}}};
+  expected_diff = interval_set<uint64_t>{{{0, 128}, {384, 512}}};
   ASSERT_EQ(expected_diff, diff);
 
   // prepend with write-same
@@ -13669,7 +13669,7 @@ TEST_F(TestLibRBD, WriteZeroesThickProvision) {
   diff.clear();
   ASSERT_EQ(0, image.diff_iterate2(nullptr, 0, size, false, false,
                                    iterate_cb, (void *)&diff));
-  expected_diff = interval_set<uint64_t>{{{0, 1536}}};
+  expected_diff = interval_set<uint64_t>{{{0, 128}, {384, 1152}}};
   ASSERT_EQ(expected_diff, diff);
 
   // write-same with append
@@ -13678,7 +13678,7 @@ TEST_F(TestLibRBD, WriteZeroesThickProvision) {
   diff.clear();
   ASSERT_EQ(0, image.diff_iterate2(nullptr, 0, size, false, false,
                                    iterate_cb, (void *)&diff));
-  expected_diff = interval_set<uint64_t>{{{0, 2176}}};
+  expected_diff = interval_set<uint64_t>{{{0, 128}, {384, 1792}}};
   ASSERT_EQ(expected_diff, diff);
 
   // prepend + write-same + append
@@ -13687,7 +13687,7 @@ TEST_F(TestLibRBD, WriteZeroesThickProvision) {
   diff.clear();
   ASSERT_EQ(0, image.diff_iterate2(nullptr, 0, size, false, false,
                                    iterate_cb, (void *)&diff));
-  expected_diff = interval_set<uint64_t>{{{0, 2944}}};
+  expected_diff = interval_set<uint64_t>{{{0, 128}, {384, 2560}}};
 
   // write-same
   ASSERT_EQ(1024, image.write_zeroes(
@@ -13695,7 +13695,7 @@ TEST_F(TestLibRBD, WriteZeroesThickProvision) {
   diff.clear();
   ASSERT_EQ(0, image.diff_iterate2(nullptr, 0, size, false, false,
                                    iterate_cb, (void *)&diff));
-  expected_diff = interval_set<uint64_t>{{{0, 4096}}};
+  expected_diff = interval_set<uint64_t>{{{0, 128}, {384, 2560}, {3072, 1024}}};
 
   bufferlist expected_bl;
   expected_bl.append_zero(size);

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -84,6 +84,10 @@ using std::chrono::seconds;
     ASSERT_TRUE(passed);          \
   } while(0)
 
+static inline bool accurate_diff_supported() {
+  return getenv("ERASURE_POOL") == nullptr;
+}
+
 void register_test_librbd() {
 }
 
@@ -7406,6 +7410,9 @@ private:
     uint64_t extent_len = whole_object ?
       round_up_to(object_off + len, block_size) :
       round_up_to(object_off + len, block_size) - extent_off;
+    if (!accurate_diff_supported()) {
+      extent_len = round_up_to(object_off + len, block_size);
+    }
 
     rbd_image_info_t info;
     ASSERT_EQ(0, rbd_stat(image, &info, sizeof(info)));
@@ -7435,8 +7442,12 @@ private:
     ASSERT_EQ(0, rbd_diff_iterate2(image, NULL, 0, size, true, whole_object,
                                    vector_iterate_cb, &extents));
     ASSERT_EQ(1u, extents.size());
-    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
-              extents[0]);
+    if (!accurate_diff_supported()) {
+      ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+    } else {
+      ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+                extents[0]);
+    }
     extents.clear();
 
     ASSERT_EQ(0, rbd_snap_create(image, "snap2"));
@@ -7445,10 +7456,15 @@ private:
     ASSERT_EQ(0, rbd_diff_iterate2(image, NULL, 0, size, true, whole_object,
                                    vector_iterate_cb, &extents));
     ASSERT_EQ(2u, extents.size());
-    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
-              extents[0]);
-    ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
-              extents[1]);
+    if (!accurate_diff_supported()) {
+      ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+      ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    } else {
+      ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+                extents[0]);
+      ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
+                extents[1]);
+    }
     extents.clear();
 
     ASSERT_EQ(0, rbd_snap_create(image, "snap3"));
@@ -7457,28 +7473,42 @@ private:
     ASSERT_EQ(0, rbd_diff_iterate2(image, NULL, 0, size, true, whole_object,
                                    vector_iterate_cb, &extents));
     ASSERT_EQ(2u, extents.size());
-    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
-              extents[0]);
-    ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
-              extents[1]);
+    if (!accurate_diff_supported()) {
+      ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+      ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    } else {
+      ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+                extents[0]);
+      ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
+                extents[1]);
+    }
     extents.clear();
 
     // 2. snap1 -> HEAD
     ASSERT_EQ(0, rbd_diff_iterate2(image, "snap1", 0, size, true, whole_object,
                                    vector_iterate_cb, &extents));
     ASSERT_EQ(2u, extents.size());
-    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
-              extents[0]);
-    ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
-              extents[1]);
+    if (!accurate_diff_supported()) {
+      ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+      ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    } else {
+      ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+                extents[0]);
+      ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
+                extents[1]);
+    }
     extents.clear();
 
     // 3. snap2 -> HEAD
     ASSERT_EQ(0, rbd_diff_iterate2(image, "snap2", 0, size, true, whole_object,
                                    vector_iterate_cb, &extents));
     ASSERT_EQ(1u, extents.size());
-    ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
-              extents[0]);
+    if (!accurate_diff_supported()) {
+      ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[0]);
+    } else {
+      ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
+                extents[0]);
+    }
     extents.clear();
 
     // 4. snap3 -> HEAD
@@ -7493,28 +7523,42 @@ private:
     ASSERT_EQ(0, rbd_diff_iterate2(image, NULL, 0, size, true, whole_object,
                                    vector_iterate_cb, &extents));
     ASSERT_EQ(2u, extents.size());
-    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
-              extents[0]);
-    ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
-              extents[1]);
+    if (!accurate_diff_supported()) {
+      ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+      ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    } else {
+      ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+                extents[0]);
+      ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
+                extents[1]);
+    }
     extents.clear();
 
     // 6. snap1 -> snap3
     ASSERT_EQ(0, rbd_diff_iterate2(image, "snap1", 0, size, true, whole_object,
                                    vector_iterate_cb, &extents));
     ASSERT_EQ(2u, extents.size());
-    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
-              extents[0]);
-    ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
-              extents[1]);
+    if (!accurate_diff_supported()) {
+      ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+      ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    } else {
+      ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+                extents[0]);
+      ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
+                extents[1]);
+    }
     extents.clear();
 
     // 7. snap2 -> snap3
     ASSERT_EQ(0, rbd_diff_iterate2(image, "snap2", 0, size, true, whole_object,
                                    vector_iterate_cb, &extents));
     ASSERT_EQ(1u, extents.size());
-    ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
-              extents[0]);
+    if (!accurate_diff_supported()) {
+      ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[0]);
+    } else {
+      ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
+                extents[0]);
+    }
     extents.clear();
 
     // 8. snap3 -> snap3
@@ -7529,16 +7573,24 @@ private:
     ASSERT_EQ(0, rbd_diff_iterate2(image, NULL, 0, size, true, whole_object,
                                    vector_iterate_cb, &extents));
     ASSERT_EQ(1u, extents.size());
-    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
-              extents[0]);
+    if (!accurate_diff_supported()) {
+      ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+    } else {
+      ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+                extents[0]);
+    }
     extents.clear();
 
     // 10. snap1 -> snap2
     ASSERT_EQ(0, rbd_diff_iterate2(image, "snap1", 0, size, true, whole_object,
                                    vector_iterate_cb, &extents));
     ASSERT_EQ(1u, extents.size());
-    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
-              extents[0]);
+    if (!accurate_diff_supported()) {
+      ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+    } else {
+      ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+                extents[0]);
+    }
     extents.clear();
 
     // 11. snap2 -> snap2
@@ -7587,6 +7639,9 @@ private:
     uint64_t extent_len = whole_object ?
       round_up_to(object_off + len, block_size) :
       round_up_to(object_off + len, block_size) - extent_off;
+    if (!accurate_diff_supported()) {
+      extent_len = round_up_to(object_off + len, block_size);
+    }
 
     librbd::image_info_t info;
     ASSERT_EQ(0, image.stat(info, sizeof(info)));
@@ -7617,8 +7672,12 @@ private:
     ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, whole_object,
                                      vector_iterate_cb, &extents));
     ASSERT_EQ(1u, extents.size());
-    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
-              extents[0]);
+    if (!accurate_diff_supported()) {
+      ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+    } else {
+      ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+                extents[0]);
+    }
     extents.clear();
 
     ASSERT_EQ(0, image.snap_create("snap2"));
@@ -7627,10 +7686,15 @@ private:
     ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, whole_object,
                                      vector_iterate_cb, &extents));
     ASSERT_EQ(2u, extents.size());
-    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
-              extents[0]);
-    ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
-              extents[1]);
+    if (!accurate_diff_supported()) {
+      ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+      ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    } else {
+      ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+                extents[0]);
+      ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
+                extents[1]);
+    }
     extents.clear();
 
     ASSERT_EQ(0, image.snap_create("snap3"));
@@ -7639,28 +7703,42 @@ private:
     ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, whole_object,
                                      vector_iterate_cb, &extents));
     ASSERT_EQ(2u, extents.size());
-    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
-              extents[0]);
-    ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
-              extents[1]);
+    if (!accurate_diff_supported()) {
+      ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+      ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    } else {
+      ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+                extents[0]);
+      ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
+                extents[1]);
+    }
     extents.clear();
 
     // 2. snap1 -> HEAD
     ASSERT_EQ(0, image.diff_iterate2("snap1", 0, size, true, whole_object,
                                      vector_iterate_cb, &extents));
     ASSERT_EQ(2u, extents.size());
-    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
-              extents[0]);
-    ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
-              extents[1]);
+    if (!accurate_diff_supported()) {
+      ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+      ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    } else {
+      ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+                extents[0]);
+      ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
+                extents[1]);
+    }
     extents.clear();
 
     // 3. snap2 -> HEAD
     ASSERT_EQ(0, image.diff_iterate2("snap2", 0, size, true, whole_object,
                                      vector_iterate_cb, &extents));
     ASSERT_EQ(1u, extents.size());
-    ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
-              extents[0]);
+    if (!accurate_diff_supported()) {
+      ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[0]);
+    } else {
+      ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
+                extents[0]);
+    }
     extents.clear();
 
     // 4. snap3 -> HEAD
@@ -7675,28 +7753,42 @@ private:
     ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, whole_object,
                                      vector_iterate_cb, &extents));
     ASSERT_EQ(2u, extents.size());
-    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
-              extents[0]);
-    ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
-              extents[1]);
+    if (!accurate_diff_supported()) {
+      ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+      ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    } else {
+      ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+                extents[0]);
+      ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
+                extents[1]);
+    }
     extents.clear();
 
     // 6. snap1 -> snap3
     ASSERT_EQ(0, image.diff_iterate2("snap1", 0, size, true, whole_object,
                                      vector_iterate_cb, &extents));
     ASSERT_EQ(2u, extents.size());
-    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
-              extents[0]);
-    ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
-              extents[1]);
+    if (!accurate_diff_supported()) {
+      ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+      ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    } else {
+      ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+                extents[0]);
+      ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
+                extents[1]);
+    }
     extents.clear();
 
     // 7. snap2 -> snap3
     ASSERT_EQ(0, image.diff_iterate2("snap2", 0, size, true, whole_object,
                                      vector_iterate_cb, &extents));
     ASSERT_EQ(1u, extents.size());
-    ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
-              extents[0]);
+    if (!accurate_diff_supported()) {
+      ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[0]);
+    } else {
+      ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
+                extents[0]);
+    }
     extents.clear();
 
     // 8. snap3 -> snap3
@@ -7711,16 +7803,24 @@ private:
     ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, whole_object,
                                      vector_iterate_cb, &extents));
     ASSERT_EQ(1u, extents.size());
-    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
-              extents[0]);
+    if (!accurate_diff_supported()) {
+      ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+    } else {
+      ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+                extents[0]);
+    }
     extents.clear();
 
     // 10. snap1 -> snap2
     ASSERT_EQ(0, image.diff_iterate2("snap1", 0, size, true, whole_object,
                                      vector_iterate_cb, &extents));
     ASSERT_EQ(1u, extents.size());
-    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
-              extents[0]);
+    if (!accurate_diff_supported()) {
+      ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+    } else {
+      ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+                extents[0]);
+    }
     extents.clear();
 
     // 11. snap2 -> snap2

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -7401,7 +7401,11 @@ private:
     uint64_t off1 = 0;
     uint64_t off2 = 4 << 20;
     uint64_t size = 20 << 20;
-    uint64_t extent_len = round_up_to(object_off + len, block_size);
+    uint64_t extent_off = whole_object ? 0 :
+      round_down_to(object_off, block_size);
+    uint64_t extent_len = whole_object ?
+      round_up_to(object_off + len, block_size) :
+      round_up_to(object_off + len, block_size) - extent_off;
 
     rbd_image_info_t info;
     ASSERT_EQ(0, rbd_stat(image, &info, sizeof(info)));
@@ -7431,7 +7435,8 @@ private:
     ASSERT_EQ(0, rbd_diff_iterate2(image, NULL, 0, size, true, whole_object,
                                    vector_iterate_cb, &extents));
     ASSERT_EQ(1u, extents.size());
-    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+              extents[0]);
     extents.clear();
 
     ASSERT_EQ(0, rbd_snap_create(image, "snap2"));
@@ -7440,8 +7445,10 @@ private:
     ASSERT_EQ(0, rbd_diff_iterate2(image, NULL, 0, size, true, whole_object,
                                    vector_iterate_cb, &extents));
     ASSERT_EQ(2u, extents.size());
-    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
-    ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+              extents[0]);
+    ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
+              extents[1]);
     extents.clear();
 
     ASSERT_EQ(0, rbd_snap_create(image, "snap3"));
@@ -7450,23 +7457,28 @@ private:
     ASSERT_EQ(0, rbd_diff_iterate2(image, NULL, 0, size, true, whole_object,
                                    vector_iterate_cb, &extents));
     ASSERT_EQ(2u, extents.size());
-    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
-    ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+              extents[0]);
+    ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
+              extents[1]);
     extents.clear();
 
     // 2. snap1 -> HEAD
     ASSERT_EQ(0, rbd_diff_iterate2(image, "snap1", 0, size, true, whole_object,
                                    vector_iterate_cb, &extents));
     ASSERT_EQ(2u, extents.size());
-    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
-    ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+              extents[0]);
+    ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
+              extents[1]);
     extents.clear();
 
     // 3. snap2 -> HEAD
     ASSERT_EQ(0, rbd_diff_iterate2(image, "snap2", 0, size, true, whole_object,
                                    vector_iterate_cb, &extents));
     ASSERT_EQ(1u, extents.size());
-    ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[0]);
+    ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
+              extents[0]);
     extents.clear();
 
     // 4. snap3 -> HEAD
@@ -7481,23 +7493,28 @@ private:
     ASSERT_EQ(0, rbd_diff_iterate2(image, NULL, 0, size, true, whole_object,
                                    vector_iterate_cb, &extents));
     ASSERT_EQ(2u, extents.size());
-    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
-    ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+              extents[0]);
+    ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
+              extents[1]);
     extents.clear();
 
     // 6. snap1 -> snap3
     ASSERT_EQ(0, rbd_diff_iterate2(image, "snap1", 0, size, true, whole_object,
                                    vector_iterate_cb, &extents));
     ASSERT_EQ(2u, extents.size());
-    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
-    ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+              extents[0]);
+    ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
+              extents[1]);
     extents.clear();
 
     // 7. snap2 -> snap3
     ASSERT_EQ(0, rbd_diff_iterate2(image, "snap2", 0, size, true, whole_object,
                                    vector_iterate_cb, &extents));
     ASSERT_EQ(1u, extents.size());
-    ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[0]);
+    ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
+              extents[0]);
     extents.clear();
 
     // 8. snap3 -> snap3
@@ -7512,14 +7529,16 @@ private:
     ASSERT_EQ(0, rbd_diff_iterate2(image, NULL, 0, size, true, whole_object,
                                    vector_iterate_cb, &extents));
     ASSERT_EQ(1u, extents.size());
-    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+              extents[0]);
     extents.clear();
 
     // 10. snap1 -> snap2
     ASSERT_EQ(0, rbd_diff_iterate2(image, "snap1", 0, size, true, whole_object,
                                    vector_iterate_cb, &extents));
     ASSERT_EQ(1u, extents.size());
-    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+              extents[0]);
     extents.clear();
 
     // 11. snap2 -> snap2
@@ -7563,7 +7582,11 @@ private:
     uint64_t off1 = 8 << 20;
     uint64_t off2 = 16 << 20;
     uint64_t size = 20 << 20;
-    uint64_t extent_len = round_up_to(object_off + len, block_size);
+    uint64_t extent_off = whole_object ? 0 :
+      round_down_to(object_off, block_size);
+    uint64_t extent_len = whole_object ?
+      round_up_to(object_off + len, block_size) :
+      round_up_to(object_off + len, block_size) - extent_off;
 
     librbd::image_info_t info;
     ASSERT_EQ(0, image.stat(info, sizeof(info)));
@@ -7594,7 +7617,8 @@ private:
     ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, whole_object,
                                      vector_iterate_cb, &extents));
     ASSERT_EQ(1u, extents.size());
-    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+              extents[0]);
     extents.clear();
 
     ASSERT_EQ(0, image.snap_create("snap2"));
@@ -7603,8 +7627,10 @@ private:
     ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, whole_object,
                                      vector_iterate_cb, &extents));
     ASSERT_EQ(2u, extents.size());
-    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
-    ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+              extents[0]);
+    ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
+              extents[1]);
     extents.clear();
 
     ASSERT_EQ(0, image.snap_create("snap3"));
@@ -7613,23 +7639,28 @@ private:
     ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, whole_object,
                                      vector_iterate_cb, &extents));
     ASSERT_EQ(2u, extents.size());
-    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
-    ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+              extents[0]);
+    ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
+              extents[1]);
     extents.clear();
 
     // 2. snap1 -> HEAD
     ASSERT_EQ(0, image.diff_iterate2("snap1", 0, size, true, whole_object,
                                      vector_iterate_cb, &extents));
     ASSERT_EQ(2u, extents.size());
-    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
-    ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+              extents[0]);
+    ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
+              extents[1]);
     extents.clear();
 
     // 3. snap2 -> HEAD
     ASSERT_EQ(0, image.diff_iterate2("snap2", 0, size, true, whole_object,
                                      vector_iterate_cb, &extents));
     ASSERT_EQ(1u, extents.size());
-    ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[0]);
+    ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
+              extents[0]);
     extents.clear();
 
     // 4. snap3 -> HEAD
@@ -7644,23 +7675,28 @@ private:
     ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, whole_object,
                                      vector_iterate_cb, &extents));
     ASSERT_EQ(2u, extents.size());
-    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
-    ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+              extents[0]);
+    ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
+              extents[1]);
     extents.clear();
 
     // 6. snap1 -> snap3
     ASSERT_EQ(0, image.diff_iterate2("snap1", 0, size, true, whole_object,
                                      vector_iterate_cb, &extents));
     ASSERT_EQ(2u, extents.size());
-    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
-    ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+              extents[0]);
+    ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
+              extents[1]);
     extents.clear();
 
     // 7. snap2 -> snap3
     ASSERT_EQ(0, image.diff_iterate2("snap2", 0, size, true, whole_object,
                                      vector_iterate_cb, &extents));
     ASSERT_EQ(1u, extents.size());
-    ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[0]);
+    ASSERT_EQ(diff_extent(off2 + extent_off, extent_len, true, object_size),
+              extents[0]);
     extents.clear();
 
     // 8. snap3 -> snap3
@@ -7675,14 +7711,16 @@ private:
     ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, whole_object,
                                      vector_iterate_cb, &extents));
     ASSERT_EQ(1u, extents.size());
-    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+              extents[0]);
     extents.clear();
 
     // 10. snap1 -> snap2
     ASSERT_EQ(0, image.diff_iterate2("snap1", 0, size, true, whole_object,
                                      vector_iterate_cb, &extents));
     ASSERT_EQ(1u, extents.size());
-    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+    ASSERT_EQ(diff_extent(off1 + extent_off, extent_len, true, object_size),
+              extents[0]);
     extents.clear();
 
     // 11. snap2 -> snap2


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/77542
Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
