### PR TITLE
cmake/boost: load context Jamfile before passing context-impl to b2

### DIFF
--- a/cmake/modules/BuildBoost.cmake
+++ b/cmake/modules/BuildBoost.cmake
@@ -144,15 +144,23 @@ function(do_build_boost root_dir version)
   if(WITH_BOOST_VALGRIND)
     list(APPEND b2 valgrind=on)
   endif()
+  set(b2_targets headers stage)
+  set(b2_install_targets install)
   if(WITH_ASAN)
     list(APPEND b2 context-impl=ucontext)
+    # `context-impl` is declared in libs/context/build/Jamfile.v2; the headers/stage
+    # and install targets never load it, so b2 aborts with `unknown feature
+    # "<context-impl>"`. Name the context project as a target so its Jamfile loads
+    # the feature first.
+    list(PREPEND b2_targets libs/context/build)
+    list(PREPEND b2_install_targets libs/context/build)
   endif()
   set(build_command
-    ${b2} headers stage
+    ${b2} ${b2_targets}
     #"--buildid=ceph" # changes lib names--can omit for static
     ${boost_features})
   set(install_command
-    ${b2} install)
+    ${b2} ${b2_install_targets})
   if(EXISTS "${PROJECT_SOURCE_DIR}/src/boost/bootstrap.sh")
     check_boost_version("${PROJECT_SOURCE_DIR}/src/boost" ${version})
     set(source_dir


### PR DESCRIPTION
With `WITH_ASAN`, b2 runs as `b2 context-impl=ucontext headers stage`
and `b2 context-impl=ucontext install`. The `context-impl` feature is
declared in `libs/context/build/Jamfile.v2`, which neither the
headers/stage nor the install targets load, so b2 aborts with:

```
error: unknown feature "<context-impl>"
```
log: https://github.com/sunyuechi/ceph-ci/actions/runs/27857218437

Name the context project (`libs/context/build`) as a target in both
commands so its Jamfile loads the feature before the build request is
expanded.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests