### PR TITLE
crimson/os/seastore/random_block_manager/avlallocator: avoid directly modifying avl_set elements

### DIFF
--- a/src/crimson/os/seastore/random_block_manager/avlallocator.cc
+++ b/src/crimson/os/seastore/random_block_manager/avlallocator.cc
@@ -46,30 +46,32 @@ void AvlAllocator::_remove_from_tree(rbm_abs_addr start, rbm_abs_addr size)
   bool left_over = (rs->start != start);
   bool right_over = (rs->end != end);
 
+  auto range = extent_range_t{rs->start, rs->end};
   _extent_size_tree_rm(*rs);
+  auto insert_pos = extent_tree.erase_and_dispose(rs, dispose_rs{});
 
   if (left_over && right_over) {
-    auto old_right_end = rs->end;
-    auto insert_pos = rs;
-    ceph_assert(insert_pos != extent_tree.end());
-    ++insert_pos;
-    rs->end = start;
+    auto prange = new extent_range_t(range);
+    auto old_right_end = prange->end;
+    prange->end = start;
 
     auto r = new extent_range_t{end, old_right_end};
-    extent_tree.insert_before(insert_pos, *r);
-    extent_size_tree.insert(*r);
-    available_size += r->length();
-    _extent_size_tree_try_insert(*rs);
+    insert_pos = extent_tree.insert_before(insert_pos, *r);
+    extent_tree.insert_before(insert_pos, *prange);
+    _extent_size_tree_try_insert(*r);
+    _extent_size_tree_try_insert(*prange);
   } else if (left_over) {
+    auto prange = new extent_range_t(range);
     assert(is_aligned(start, block_size));
-    rs->end = start;
-    _extent_size_tree_try_insert(*rs);
+    prange->end = start;
+    extent_tree.insert_before(insert_pos, *prange);
+    _extent_size_tree_try_insert(*prange);
   } else if (right_over) {
+    auto prange = new extent_range_t(range);
     assert(is_aligned(end, block_size));
-    rs->start = end;
-    _extent_size_tree_try_insert(*rs);
-  } else {
-    extent_tree.erase_and_dispose(rs, dispose_rs{});
+    prange->start = end;
+    extent_tree.insert_before(insert_pos, *prange);
+    _extent_size_tree_try_insert(*prange);
   }
 }
 
@@ -135,24 +137,29 @@ void AvlAllocator::_add_to_tree(rbm_abs_addr start, rbm_abs_addr size)
   bool merge_after = (rs_after != extent_tree.end() && rs_after->start == end);
 
   if (merge_before && merge_after) {
+    auto range = new extent_range_t{rs_before->start, rs_after->end};
     _extent_size_tree_rm(*rs_before);
     _extent_size_tree_rm(*rs_after);
-    rs_after->start = rs_before->start;
-    extent_tree.erase_and_dispose(rs_before, dispose_rs{});
-    _extent_size_tree_try_insert(*rs_after);
+    rs_after = extent_tree.erase_and_dispose(rs_before, dispose_rs{});
+    auto insert_pos = extent_tree.erase_and_dispose(rs_after, dispose_rs{});
+    _extent_size_tree_try_insert(*range);
+    extent_tree.insert_before(insert_pos, *range);
   } else if (merge_before) {
+    auto range = new extent_range_t{rs_before->start, end};
     _extent_size_tree_rm(*rs_before);
-    rs_before->end = end;
-    _extent_size_tree_try_insert(*rs_before);
+    _extent_size_tree_try_insert(*range);
+    auto insert_pos = extent_tree.erase_and_dispose(rs_before, dispose_rs{});
+    extent_tree.insert_before(insert_pos, *range);
   } else if (merge_after) {
+    auto range = new extent_range_t{start, rs_after->end};
     _extent_size_tree_rm(*rs_after);
-    rs_after->start = start;
-    _extent_size_tree_try_insert(*rs_after);
+    _extent_size_tree_try_insert(*range);
+    auto insert_pos = extent_tree.erase_and_dispose(rs_after, dispose_rs{});
+    extent_tree.insert_before(insert_pos, *range);
   } else {
     auto r = new extent_range_t{start, end};
     extent_tree.insert(*r);
-    extent_size_tree.insert(*r);
-    available_size += r->length();
+    _extent_size_tree_try_insert(*r);
   }
 }
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/77549
Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
