### PR TITLE
cephadm: fix silent ignore of manual actions on unmanaged services

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3108,7 +3108,86 @@ Then run the following:
         self._daemon_action_set_image(action, image, d.daemon_type, d.daemon_id)
 
         self.log.info(f'Schedule {action} daemon {daemon_name}')
-        return self._schedule_daemon_action(daemon_name, action)
+        msg = self._schedule_daemon_action(daemon_name, action)
+        svc_name = d.service_name()
+        if (svc_name in self.spec_store
+                and self.spec_store[svc_name].spec
+                and self.spec_store[svc_name].spec.unmanaged):
+            msg += self._unmanaged_daemon_action_warning(action, d)
+        return msg
+
+    def _unmanaged_daemon_action_warning(self, action: str, d: 'DaemonDescription') -> str:
+        """Return a warning string when an action is run on an unmanaged daemon.
+
+        Unmanaged services skip _apply_service() entirely, so some spec changes
+        cannot be applied by per-daemon actions.  This method detects those gaps
+        and tells the user exactly what will not be applied and how to fix it.
+
+        Only called when the service is already known to be unmanaged.
+        """
+        if action not in ('restart', 'reconfig', 'redeploy'):
+            return ''
+        svc_name = d.service_name()
+        if svc_name not in self.spec_store:
+            return ''
+        spec = self.spec_store[svc_name].spec
+        if not spec:
+            return ''
+
+        set_managed_workaround = (
+            f'\n    To apply: ceph orch set-managed {svc_name}'
+            f'\n              ceph orch redeploy {svc_name}'
+            f'\n              ceph orch set-unmanaged {svc_name}'
+        )
+
+        # restart: nothing from the spec is applied — always warn
+        if action == 'restart':
+            return (
+                f'\nNOTE: {svc_name} is unmanaged. restart only restarts the'
+                f' process with its current configuration — no spec changes are'
+                f' applied. To apply spec changes run:'
+                f'\n  ceph orch daemon redeploy {d.name()}'
+            )
+
+        # reconfig and redeploy: report specific gaps
+        gaps = []
+
+        # reconfig does not rewrite unit.run — container args are not applied
+        if action == 'reconfig':
+            if (d.extra_container_args or []) != (spec.extra_container_args or []):
+                gaps.append(
+                    f'  - extra_container_args changed'
+                    f'\n    To apply: ceph orch daemon redeploy {d.name()}'
+                )
+            if (d.extra_entrypoint_args or []) != (spec.extra_entrypoint_args or []):
+                gaps.append(
+                    f'  - extra_entrypoint_args changed'
+                    f'\n    To apply: ceph orch daemon redeploy {d.name()}'
+                )
+
+        # port changes require _apply_service() slot logic — not possible per-daemon
+        new_ports = spec.get_port_start()
+        if new_ports and new_ports != (d.ports or []):
+            gaps.append(
+                f'  - port: spec={new_ports}, running={d.ports}'
+                + set_managed_workaround
+            )
+
+        # spec.config dict is written by _apply_service_config() inside
+        # _apply_service() — skipped entirely for unmanaged services
+        if spec.config:
+            gaps.append(
+                f'  - config entries: {", ".join(spec.config.keys())}'
+                + set_managed_workaround
+            )
+
+        if not gaps:
+            return ''
+        return (
+            f'\nNOTE: {svc_name} is unmanaged. The following spec changes'
+            f' will NOT be applied by {action}:\n'
+            + '\n'.join(gaps)
+        )
 
     def daemon_is_self(self, daemon_type: str, daemon_id: str) -> bool:
         return daemon_type == 'mgr' and daemon_id == self.get_mgr_id()

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1149,82 +1149,106 @@ class CephadmServe:
                 # in this iteration to avoid looking up stale daemon entries.
                 continue
 
+            # For unmanaged services: skip automatic reconciliation entirely.
+            # However, if a manual action (restart/redeploy) was explicitly scheduled
+            # by the user, honour it and fall through to the shared execution block below.
             if spec and spec.unmanaged:
-                continue
-
-            if dd.daemon_type == 'agent':
-                try:
-                    self.mgr.agent_helpers._check_agent(dd.hostname)
-                except Exception as e:
-                    self.log.debug(
-                        f'Agent {dd.name()} could not be checked in _check_daemons: {e}')
-                continue
-
-            # These daemon types require additional configs after creation
-            if dd.daemon_type in REQUIRES_POST_ACTIONS:
-                daemons_post[dd.daemon_type].append(dd)
-
-            svc_type = daemon_type_to_service(dd.daemon_type)
-            svc_obj = service_registry.get_service(svc_type)
-            if svc_obj.get_active_daemon(
-               self.mgr.cache.get_daemons_by_service(dd.service_name())).daemon_id == dd.daemon_id:
-                dd.is_active = True
-            else:
-                dd.is_active = False
-
-            deps = svc_obj.sorted_dependencies(self.mgr, spec, dd.daemon_type)
-            last_deps, last_config = self.mgr.cache.get_daemon_last_config_deps(
-                dd.hostname, dd.name())
-            if last_deps is None:
-                last_deps = []
-            action = scheduled_action = (
-                self.mgr.cache.get_scheduled_daemon_action(
+                action = scheduled_action = self.mgr.cache.get_scheduled_daemon_action(
                     dd.hostname, dd.name()
                 )
-            )
-            if not last_config:
-                self.log.info('Reconfiguring %s (unknown last config time)...' % (
-                    dd.name()))
-                action = 'reconfig'
-            elif spec is not None and hasattr(spec, 'extra_container_args') and dd.extra_container_args != spec.extra_container_args:
-                self.log.debug(
-                    f'{dd.name()} container cli args {dd.extra_container_args} -> {spec.extra_container_args}')
-                self.log.info(f'Redeploying {dd.name()}, (container cli args changed) . . .')
-                dd.extra_container_args = spec.extra_container_args
-                action = 'redeploy'
-            elif spec is not None and hasattr(spec, 'extra_entrypoint_args') and dd.extra_entrypoint_args != spec.extra_entrypoint_args:
-                self.log.info(f'Redeploying {dd.name()}, (entrypoint args changed) . . .')
-                self.log.debug(
-                    f'{dd.name()} daemon entrypoint args {dd.extra_entrypoint_args} -> {spec.extra_entrypoint_args}')
-                dd.extra_entrypoint_args = spec.extra_entrypoint_args
-                action = 'redeploy'
-            else:
-                # method uses new action enum type
-                _scheduled_action = utils.Action.create(scheduled_action)
-                _action = svc_obj.choose_next_action(
-                    _scheduled_action,
-                    dd.daemon_type,
-                    spec,
-                    curr_deps=deps,
-                    last_deps=last_deps,
+                if not action:
+                    continue
+                # Sync container-level args from the spec only for redeploy.
+                # restart and reconfig do not rewrite unit.run, so syncing here
+                # for those actions would make the daemon cache lie about what
+                # the running container actually has.  Only redeploy rewrites
+                # unit.run and can therefore honour the updated args.
+                if action == 'redeploy':
+                    if hasattr(spec, 'extra_container_args'):
+                        dd.extra_container_args = spec.extra_container_args
+                    if hasattr(spec, 'extra_entrypoint_args'):
+                        dd.extra_entrypoint_args = spec.extra_entrypoint_args
+                self.log.info(
+                    f'Executing scheduled action {action} for unmanaged daemon {dd.name()}'
                 )
-                if _action is not _scheduled_action:
-                    self.log.info(
-                        (
-                            'Daemon %s chose new action %s (was %s)'
-                            ' (deps: %r, last_deps: %r)'
-                        ),
-                        dd.name(),
-                        _action,
-                        _scheduled_action,
-                        deps,
-                        last_deps,
+            else:
+                # ignore daemons for deleted services
+                if dd.service_name() in self.mgr.spec_store.spec_deleted:
+                    continue
+
+                if dd.daemon_type == 'agent':
+                    try:
+                        self.mgr.agent_helpers._check_agent(dd.hostname)
+                    except Exception as e:
+                        self.log.debug(
+                            f'Agent {dd.name()} could not be checked in _check_daemons: {e}')
+                    continue
+
+                # These daemon types require additional configs after creation
+                if dd.daemon_type in REQUIRES_POST_ACTIONS:
+                    daemons_post[dd.daemon_type].append(dd)
+
+                svc_type = daemon_type_to_service(dd.daemon_type)
+                svc_obj = service_registry.get_service(svc_type)
+                if svc_obj.get_active_daemon(
+                   self.mgr.cache.get_daemons_by_service(dd.service_name())).daemon_id == dd.daemon_id:
+                    dd.is_active = True
+                else:
+                    dd.is_active = False
+
+                deps = svc_obj.sorted_dependencies(self.mgr, spec, dd.daemon_type)
+                last_deps, last_config = self.mgr.cache.get_daemon_last_config_deps(
+                    dd.hostname, dd.name())
+                if last_deps is None:
+                    last_deps = []
+                action = scheduled_action = (
+                    self.mgr.cache.get_scheduled_daemon_action(
+                        dd.hostname, dd.name()
                     )
-                    # convert back to legacy str type
-                    action = str(_action)
-            action = _ceph_service_next_action(
-                action, dd.daemon_type, dd.name(), self.mgr, last_config
-            )
+                )
+                if not last_config:
+                    self.log.info('Reconfiguring %s (unknown last config time)...' % (
+                        dd.name()))
+                    action = 'reconfig'
+                elif spec is not None and hasattr(spec, 'extra_container_args') and dd.extra_container_args != spec.extra_container_args:
+                    self.log.debug(
+                        f'{dd.name()} container cli args {dd.extra_container_args} -> {spec.extra_container_args}')
+                    self.log.info(f'Redeploying {dd.name()}, (container cli args changed) . . .')
+                    dd.extra_container_args = spec.extra_container_args
+                    action = 'redeploy'
+                elif spec is not None and hasattr(spec, 'extra_entrypoint_args') and dd.extra_entrypoint_args != spec.extra_entrypoint_args:
+                    self.log.info(f'Redeploying {dd.name()}, (entrypoint args changed) . . .')
+                    self.log.debug(
+                        f'{dd.name()} daemon entrypoint args {dd.extra_entrypoint_args} -> {spec.extra_entrypoint_args}')
+                    dd.extra_entrypoint_args = spec.extra_entrypoint_args
+                    action = 'redeploy'
+                else:
+                    # method uses new action enum type
+                    _scheduled_action = utils.Action.create(scheduled_action)
+                    _action = svc_obj.choose_next_action(
+                        _scheduled_action,
+                        dd.daemon_type,
+                        spec,
+                        curr_deps=deps,
+                        last_deps=last_deps,
+                    )
+                    if _action is not _scheduled_action:
+                        self.log.info(
+                            (
+                                'Daemon %s chose new action %s (was %s)'
+                                ' (deps: %r, last_deps: %r)'
+                            ),
+                            dd.name(),
+                            _action,
+                            _scheduled_action,
+                            deps,
+                            last_deps,
+                        )
+                        # convert back to legacy str type
+                        action = str(_action)
+                action = _ceph_service_next_action(
+                    action, dd.daemon_type, dd.name(), self.mgr, last_config
+                )
 
             if action:
                 if scheduled_action == 'redeploy' and action == 'reconfig':


### PR DESCRIPTION
cephadm: fix silent ignore of manual actions on unmanaged services

Before this fix, running `ceph orch daemon restart/redeploy/reconfig` on an unmanaged daemon printed "Scheduled..." but silently did nothing. The unconditional `continue` in _check_daemons() discarded all scheduled actions for unmanaged services.

The unmanaged flag is meant to prevent *automatic* reconciliation, not to block explicit manual actions. If a user runs `ceph orch daemon redeploy`, they are explicitly taking control and expecting the action to happen.

The correct workflow for controlled rolling restarts (e.g. tracker to update the configuration without touching any daemon, then manually redeploy each daemon at the right time. This was previously broken because the redeploy was silently ignored.

Fix _check_daemons() to execute scheduled manual actions for unmanaged daemons. The managed reconciliation path is moved into an `else` block and is entirely unchanged. Container args are synced from spec to the daemon cache only on `redeploy` — restart and reconfig do not rewrite unit.run, so syncing for those actions would leave the daemon cache showing spec values while the running container uses old values, with no reconciliation loop to correct the divergence for unmanaged services.

Note: some spec changes still cannot be applied via per-daemon actions since they require _apply_service() which is intentionally skipped for unmanaged services: port changes, spec.config dict entries, and placement changes. The workaround for these is set-managed, wait for reconciliation, then set-unmanaged.

To make these limitations visible, add _unmanaged_daemon_action_warning() which appends a note to the command output describing what will not be applied and how to fix it. restart always shows the note. reconfig and redeploy show it only when gaps are detected (port changed, config entries set, container args changed for reconfig).

Test: TODO
Changes:

serve.py - _check_daemons():
- Replace unconditional `continue` for unmanaged services with a check for a scheduled manual action. If no action is scheduled, skip as before. If an action is scheduled, execute it and skip only the automatic reconciliation logic (moved into `else` block, unchanged).
- Sync extra_container_args and extra_entrypoint_args from spec to daemon cache only when action == 'redeploy', not for restart or reconfig, to keep the cache honest about what the running container actually has.

module.py - daemon_action():
- After scheduling the action, check if the service is unmanaged and if so, append the output of _unmanaged_daemon_action_warning().

module.py - new _unmanaged_daemon_action_warning():
- restart: always returns a note that no spec changes are applied and suggests `ceph orch daemon redeploy <daemon>`.
- reconfig: reports extra_container_args/extra_entrypoint_args changes (not applied, requires redeploy), port changes and config dict entries (require set-managed workaround).
- redeploy: reports port changes and config dict entries (require set-managed workaround).
- Returns empty string when no gaps are detected or for managed services - zero impact on existing managed service behavior.

Fixes: https://tracker.ceph.com/issues/76767
Signed-off-by: Yael Azulay <yazulay@redhat.com>

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
