### PR TITLE
librbd: fix use-after-free releasing object map locks in deep copy

### DIFF
--- a/src/librbd/DeepCopyRequest.cc
+++ b/src/librbd/DeepCopyRequest.cc
@@ -197,36 +197,38 @@ void DeepCopyRequest<I>::handle_copy_image(int r) {
 
 template <typename I>
 void DeepCopyRequest<I>::send_copy_object_map() {
-  m_dst_image_ctx->owner_lock.lock_shared();
-  m_dst_image_ctx->image_lock.lock_shared();
+  // local ref so the unlocks don't touch 'this', which rollback() may free
+  I &dst_image_ctx = *m_dst_image_ctx;
+  dst_image_ctx.owner_lock.lock_shared();
+  dst_image_ctx.image_lock.lock_shared();
 
-  if (!m_dst_image_ctx->test_features(RBD_FEATURE_OBJECT_MAP,
-                                      m_dst_image_ctx->image_lock)) {
-    m_dst_image_ctx->image_lock.unlock_shared();
-    m_dst_image_ctx->owner_lock.unlock_shared();
+  if (!dst_image_ctx.test_features(RBD_FEATURE_OBJECT_MAP,
+                                   dst_image_ctx.image_lock)) {
+    dst_image_ctx.image_lock.unlock_shared();
+    dst_image_ctx.owner_lock.unlock_shared();
     send_copy_metadata();
     return;
   }
   if (m_src_snap_id_end == CEPH_NOSNAP) {
-    m_dst_image_ctx->image_lock.unlock_shared();
-    m_dst_image_ctx->owner_lock.unlock_shared();
+    dst_image_ctx.image_lock.unlock_shared();
+    dst_image_ctx.owner_lock.unlock_shared();
     send_refresh_object_map();
     return;
   }
 
-  ceph_assert(m_dst_image_ctx->object_map != nullptr);
+  ceph_assert(dst_image_ctx.object_map != nullptr);
 
   ldout(m_cct, 20) << dendl;
 
   Context *finish_op_ctx = nullptr;
   int r;
-  if (m_dst_image_ctx->exclusive_lock != nullptr) {
-    finish_op_ctx = m_dst_image_ctx->exclusive_lock->start_op(&r);
+  if (dst_image_ctx.exclusive_lock != nullptr) {
+    finish_op_ctx = dst_image_ctx.exclusive_lock->start_op(&r);
   }
   if (finish_op_ctx == nullptr) {
     lderr(m_cct) << "lost exclusive lock" << dendl;
-    m_dst_image_ctx->image_lock.unlock_shared();
-    m_dst_image_ctx->owner_lock.unlock_shared();
+    dst_image_ctx.image_lock.unlock_shared();
+    dst_image_ctx.owner_lock.unlock_shared();
     finish(r);
     return;
   }
@@ -238,9 +240,9 @@ void DeepCopyRequest<I>::send_copy_object_map() {
     });
   ceph_assert(m_snap_seqs->count(m_src_snap_id_end) > 0);
   librados::snap_t copy_snap_id = (*m_snap_seqs)[m_src_snap_id_end];
-  m_dst_image_ctx->object_map->rollback(copy_snap_id, ctx);
-  m_dst_image_ctx->image_lock.unlock_shared();
-  m_dst_image_ctx->owner_lock.unlock_shared();
+  dst_image_ctx.object_map->rollback(copy_snap_id, ctx);
+  dst_image_ctx.image_lock.unlock_shared();
+  dst_image_ctx.owner_lock.unlock_shared();
 }
 
 template <typename I>


### PR DESCRIPTION
`DeepCopyRequest::send_copy_object_map()` holds the destination image's `owner_lock` and `image_lock` (shared), issues an asynchronous `object_map->rollback()`, and then releases the two locks through `m_dst_image_ctx`.  The rollback callback drives the rest of the request to completion (`handle_copy_object_map()` ... `finish()` -> `put()`) on other threads.  That path needs `image_lock`, so it only proceeds once this method releases it, and can then run to completion and free '`this`' before the following `owner_lock.unlock_shared()` executes, dereferencing the freed `DeepCopyRequest`.

ASan reported this as a heap-use-after-free in
`TestImageReplayer.StartReplayAndWrite`: the object was freed on the finisher thread (`handle_copy_metadata()` -> `finish()`) while the io_context thread was still in send_copy_object_map().

The destination image ctx outlives the request, so operate through a local reference to it and release the locks through that reference rather than through '`this`', as
operation/`SnapshotRollbackRequest::send_rollback_object_map()` already does.

Keep the explicit `lock_shared()`/`unlock_shared()` calls rather than scoped std::shared_lock guards: unlike
operation/`SnapshotRollbackRequest::send_rollback_object_map()`, `send_copy_object_map()` has four exit paths (`send_copy_metadata()`, `send_refresh_object_map()`, `finish()`, and the object map rollback), each of which must release the locks before running a different continuation, so RAII guards would push that continuation out of the locked scope and read less clearly than unlocking at each exit.

Fixes: https://tracker.ceph.com/issues/77551





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
