### PR TITLE
build,test: fix issues surfaced by tests after enabling ASan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -460,6 +460,10 @@ if(ALLOCATOR)
   elseif(NOT ALLOCATOR STREQUAL "libc")
     message(FATAL_ERROR "Unsupported allocator selected: ${ALLOCATOR}")
   endif()
+elseif(WITH_ASAN)
+  # Force libc: tcmalloc/jemalloc still export operator new/delete even when the
+  # sanitizer shadows malloc, so sanitizer-allocated memory is freed via tcmalloc and SIGSEGVs.
+  set(ALLOCATOR "libc")
 else(ALLOCATOR)
   find_package(gperftools 2.6.2)
   set(HAVE_LIBTCMALLOC ${gperftools_FOUND})

--- a/qa/lsan.supp
+++ b/qa/lsan.supp
@@ -67,3 +67,11 @@ leak:^RAND_priv_bytes_ex
 # OpenSSL per-thread error stack/strings, freed only by OPENSSL_thread_stop.
 leak:^ossl_err_get_state_int
 leak:^ERR_add_error_vdata
+
+# unittest-seastore stops the seastar reactor (SeastarRunner, on its own thread)
+# without draining its pending tasks, so a few cached extents those tasks still
+# held are leaked at shutdown. Three anchors for the three seastore subsystems
+# they come from.
+leak:crimson::os::seastore::Cache::
+leak:crimson::os::seastore::omap_manager
+leak:crimson::os::seastore::FixedKVBtree

--- a/qa/lsan.supp
+++ b/qa/lsan.supp
@@ -48,3 +48,22 @@ leak:^ceph::ErasureCodePluginRegistry::load
 # SQLite internal allocations
 # These are indirect leaks from SQLite's internal memory management
 leak:libsqlite3.so
+
+# boost.thread main-thread TLS; freed only when a boost-created thread exits, so
+# still reachable at exit. Benign.
+leak:boost::detail::make_external_thread_data
+
+# OpenSSL one-time init; ForkDeathTest children _exit() without OPENSSL_cleanup.
+leak:^OPENSSL_init_crypto
+
+# Still-reachable OpenSSL / libcryptsetup state with no API to free at exit;
+# seen in the librbd encryption and migration unittests under ASan.
+#
+# libcryptsetup OpenSSL cipher/per-thread state that survives crypt_free().
+leak:libcryptsetup
+# OpenSSL DRBG global state, freed only by OPENSSL_cleanup (never called here).
+leak:^RAND_bytes_ex
+leak:^RAND_priv_bytes_ex
+# OpenSSL per-thread error stack/strings, freed only by OPENSSL_thread_stop.
+leak:^ossl_err_get_state_int
+leak:^ERR_add_error_vdata

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -510,6 +510,11 @@ if(WITH_CRIMSON)
     "-Wno-attributes"
     "-Wno-pessimizing-move"
     "-Wno-address-of-packed-member")
+  if(WITH_ASAN)
+    # As built here (RelWithDebInfo) seastar keeps its own allocator, which
+    # ASan calls via dlsym before init, crashing every test before main().
+    target_compile_definitions(seastar PUBLIC SEASTAR_DEFAULT_ALLOCATOR)
+  endif()
   add_subdirectory(crimson)
   add_dependencies(crimson-osd erasure_code)
 endif()

--- a/src/test/encoding/readable.sh
+++ b/src/test/encoding/readable.sh
@@ -24,9 +24,16 @@ fi
 
 # ASAN builds need setarch -R to disable ASLR so each process can find a
 # contiguous 16+ TB shadow memory region. See https://clang.llvm.org/docs/AddressSanitizer.html
+# Use bare `setarch -R` (no arch): the arch-qualified form also sets the
+# personality, which fails where setarch can't (e.g. riscv64). Check it works
+# before wrapping, and just run ceph-dencoder unwrapped if it doesn't.
 if ldd $(command -v $CEPH_DENCODER) 2>/dev/null | grep -q libasan; then
-  echo "ASAN build detected: wrapping ceph-dencoder with 'setarch \$(uname -m) -R'"
-  CEPH_DENCODER="setarch $(uname -m) -R $CEPH_DENCODER"
+  if setarch -R true >/dev/null 2>&1; then
+    echo "ASAN build detected: wrapping ceph-dencoder with 'setarch -R'"
+    CEPH_DENCODER="setarch -R $CEPH_DENCODER"
+  else
+    echo "ASAN build detected but 'setarch -R' is unavailable; running ceph-dencoder without ASLR disable"
+  fi
 fi
 
 myversion=$($CEPH_DENCODER version)

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -64,6 +64,14 @@ if [ -e CMakeCache.txt ]; then
     CEPH_ROOT=$(get_cmake_variable ceph_SOURCE_DIR)
     CEPH_BUILD_DIR=`pwd`
     [ -z "$MGR_PYTHON_PATH" ] && MGR_PYTHON_PATH=$CEPH_ROOT/src/pybind/mgr
+
+    # Point the sanitizers at the in-tree suppression files so vstart daemons
+    # ignore the same still-reachable third-party leaks AddCephTest.cmake suppresses for
+    # unittests. Without this `ceph-mon --mkfs` aborts on LeakSanitizer.
+    if [ "$(get_cmake_variable WITH_ASAN)" = "ON" ]; then
+        [ -z "$ASAN_OPTIONS" ] && export ASAN_OPTIONS="suppressions=$CEPH_ROOT/qa/asan.supp,detect_odr_violation=0"
+        [ -z "$LSAN_OPTIONS" ] && export LSAN_OPTIONS="suppressions=$CEPH_ROOT/qa/lsan.supp,print_suppressions=0"
+    fi
 fi
 
 # use CEPH_BUILD_ROOT to vstart from a 'make install'


### PR DESCRIPTION
- cmake: force the libc allocator when WITH_ASAN is set. tcmalloc/jemalloc
  still export the global operator new/delete, so sanitizer-allocated memory
  is freed through tcmalloc and SIGSEGVs (e.g. seastar coroutine frames).
  Define SEASTAR_DEFAULT_ALLOCATOR under WITH_ASAN. Otherwise
  seastar's own allocator is called via dlsym before init and crashes every
  crimson unittest before main().
- test/encoding: probe `setarch -R` and drop the arch argument, which also
  sets the personality and fails on e.g. riscv64; fall back to running
  ceph-dencoder unwrapped.
- tools/immutable_object_cache: hold in-flight replies in a shared_ptr so
  they aren't leaked when the session is torn down mid-write.
- vstart: export ASAN_OPTIONS/LSAN_OPTIONS suppressions on WITH_ASAN builds,
  matching AddCephTest.cmake, so ceph-mon --mkfs doesn't abort.
- qa/lsan.supp: suppress still-reachable leaks from third-party libs
  (boost.thread TLS, OpenSSL init, libcryptsetup).

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
