### PR TITLE
cmake: define BOOST_USE_UCONTEXT tree-wide under ASan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -817,6 +817,17 @@ else()
   include(BuildBoost)
   build_boost(1.87
     COMPONENTS ${BOOST_COMPONENTS} ${BOOST_HEADER_COMPONENTS})
+  if(WITH_ASAN)
+    # Boost.Context is built ucontext-only here (context-impl=ucontext); define
+    # the matching backend tree-wide so every Boost.Context/Coroutine2 consumer
+    # agrees on it, instead of relying on per-target propagation that is easy to miss.
+    # Except riscv64: its ASan mis-handles ucontext, so it keeps fcontext.
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "riscv")
+      add_compile_definitions(BOOST_USE_ASAN)
+    else()
+      add_compile_definitions(BOOST_USE_ASAN BOOST_USE_UCONTEXT)
+    endif()
+  endif()
 endif()
 include_directories(BEFORE SYSTEM ${Boost_INCLUDE_DIRS})
 add_library(Boost::asio INTERFACE IMPORTED)

--- a/cmake/modules/BuildBoost.cmake
+++ b/cmake/modules/BuildBoost.cmake
@@ -146,7 +146,8 @@ function(do_build_boost root_dir version)
   endif()
   set(b2_targets headers stage)
   set(b2_install_targets install)
-  if(WITH_ASAN)
+  # Except riscv64: its ASan mis-handles ucontext, so it keeps fcontext.
+  if(WITH_ASAN AND NOT (CMAKE_SYSTEM_PROCESSOR MATCHES "riscv"))
     list(APPEND b2 context-impl=ucontext)
     # `context-impl` is declared in libs/context/build/Jamfile.v2; the headers/stage
     # and install targets never load it, so b2 aborts with `unknown feature
@@ -262,10 +263,8 @@ macro(build_boost version)
       set_target_properties(Boost::${c} PROPERTIES
         INTERFACE_COMPILE_DEFINITIONS "BOOST_USE_VALGRIND")
     endif()
-    if((c MATCHES "context") AND (WITH_ASAN))
-      set_target_properties(Boost::${c} PROPERTIES
-        INTERFACE_COMPILE_DEFINITIONS "BOOST_USE_ASAN;BOOST_USE_UCONTEXT")
-    endif()
+    # ASan's BOOST_USE_ASAN/BOOST_USE_UCONTEXT are defined tree-wide in the
+    # top-level CMakeLists.txt, not per-target.
     list(APPEND Boost_LIBRARIES ${Boost_${upper_c}_LIBRARY})
   endforeach()
   foreach(c ${Boost_BUILD_COMPONENTS})


### PR DESCRIPTION
Under `WITH_ASAN` Boost.Context is built ucontext-only, so consumers that
include its headers without linking `Boost::context` (e.g. libosd) were
still built for the fcontext backend and broke the link:

```
mold: error: undefined symbol: boost::context::detail::make_fcontext
```

Define the backend tree-wide so every consumer agrees on it.

riscv64's ASan runtime mis-handles `makecontext`/`swapcontext`, so the
ucontext fiber backend reports false-positive heap-buffer-overflows on
fiber switch that can't be suppressed. So exclude it.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests