### PR TITLE
tools/immutable_object_cache: don't leak in-flight replies on teardown

### DIFF
--- a/src/tools/immutable_object_cache/CacheSession.cc
+++ b/src/tools/immutable_object_cache/CacheSession.cc
@@ -122,13 +122,15 @@ void CacheSession::send(ObjectCacheRequest* reply) {
   bufferlist bl;
   reply->encode();
   bl.append(reply->get_payload_bufferlist());
+  // bl owns the encoded payload; free reply here so it can't leak if the
+  // handler is dropped on teardown.
+  delete reply;
 
   boost::asio::async_write(m_dm_socket,
         boost::asio::buffer(bl.c_str(), bl.length()),
         boost::asio::transfer_exactly(bl.length()),
-        [this, bl, reply](const boost::system::error_code& err,
+        [this, bl](const boost::system::error_code& err,
           size_t bytes_transferred) {
-          delete reply;
           if (err || bytes_transferred != bl.length()) {
             fault(err);
             return;


### PR DESCRIPTION
`CacheSession::send()` used to `delete reply` inside the `async_write`
completion handler. When a session is torn down with the write still in
flight, asio destroys the abandoned handler without running it, so the
reply and its encoded payload are never freed and LeakSanitizer flags them.

Wrap the reply in a `unique_ptr` moved into the handler, so it is freed
when the handler goes away, even if the write never completed.

Fixes: https://tracker.ceph.com/issues/77552

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests