### PR TITLE
mgr/cephadm: Add tunable to set log level for ceph-volume

### DIFF
--- a/src/pybind/mgr/cephadm/ceph_volume.py
+++ b/src/pybind/mgr/cephadm/ceph_volume.py
@@ -74,7 +74,7 @@ class CephVolume:
                 - A list of strings representing the standard error output of the command.
                 - An integer representing the return code of the command execution.
         """
-        cmd: List[str] = ['--']
+        cmd: List[str] = ['--', '--log-level', self.mgr.ceph_volume_log_level]
         cmd.extend(command)
         result = await CephadmServe(self.mgr)._run_cephadm(
             hostname, 'osd', 'ceph-volume',
@@ -99,7 +99,7 @@ class CephVolume:
             Dict[str, Any]: The result of the command execution as a dictionary parsed from
                             the JSON output.
         """
-        cmd: List[str] = ['--']
+        cmd: List[str] = ['--', '--log-level', self.mgr.ceph_volume_log_level]
         cmd.extend(command)
         result = await CephadmServe(self.mgr)._run_cephadm_json(
             hostname, 'osd', 'ceph-volume',

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -530,6 +530,14 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                  'When enabled, cephadm and bash commands are validated and executed via '
                  'the secure invoker wrapper.'
         ),
+        Option(
+            'ceph_volume_log_level',
+            type='str',
+            default='debug',
+            enum_allowed=['debug', 'info', 'warning', 'error', 'critical'],
+            desc='Change log level for ceph-volume commands.'
+            'executed by cephadm',
+        ),
     ]
     for image in DefaultImages:
         MODULE_OPTIONS.append(Option(image.key, default=image.image_ref, desc=image.desc))
@@ -633,6 +641,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             self.default_cephadm_command_timeout = 0
             self.cephadm_log_destination = ''
             self.oob_default_addr = ''
+            self.ceph_volume_log_level = 'debug'
             self.ssh_keepalive_interval = 0
             self.ssh_keepalive_count_max = 0
             self.sudo_hardening = False
@@ -3314,7 +3323,7 @@ Then run the following:
                     f"OSD{'s' if len(active_osds) > 1 else ''}"
                     f" ({', '.join(active_osds)}). Use 'ceph orch osd rm' first.")
 
-        cv_args = ['--', 'lvm', 'zap', '--destroy', path]
+        cv_args = ['--', '--log-level', self.ceph_volume_log_level, 'lvm', 'zap', '--destroy', path]
         with self.async_timeout_handler(host, f'cephadm ceph-volume {" ".join(cv_args)}'):
             out, err, code = self.wait_async(CephadmServe(self)._run_cephadm(
                 host, 'osd', 'ceph-volume', cv_args, error_ok=True))

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -401,24 +401,24 @@ class CephadmServe:
     def _refresh_host_devices(self, host: str) -> Optional[str]:
         with_lsm = self.mgr.device_enhanced_scan
         list_all = self.mgr.inventory_list_all
-        inventory_args = ['--', 'inventory',
+        inventory_args = ['--', '--log-level', self.mgr.ceph_volume_log_level,
+                          'inventory',
                           '--format=json-pretty',
                           '--filter-for-batch']
         if with_lsm:
             inventory_args.insert(-1, "--with-lsm")
         if list_all:
             inventory_args.insert(-1, "--list-all")
-
         try:
             try:
-                with self.mgr.async_timeout_handler(host, 'cephadm ceph-volume -- inventory'):
+                with self.mgr.async_timeout_handler(host, f'cephadm ceph-volume -- --log-level {self.mgr.ceph_volume_log_level} inventory'):
                     devices = self.mgr.wait_async(self._run_cephadm_json(
                         host, 'osd', 'ceph-volume', inventory_args, log_output=self.mgr.log_refresh_metadata))
             except OrchestratorError as e:
                 if 'unrecognized arguments: --filter-for-batch' in str(e):
                     rerun_args = inventory_args.copy()
                     rerun_args.remove('--filter-for-batch')
-                    with self.mgr.async_timeout_handler(host, 'cephadm ceph-volume -- inventory'):
+                    with self.mgr.async_timeout_handler(host, f'cephadm ceph-volume -- --log-level {self.mgr.ceph_volume_log_level} inventory'):
                         devices = self.mgr.wait_async(self._run_cephadm_json(
                             host, 'osd', 'ceph-volume', rerun_args, log_output=self.mgr.log_refresh_metadata))
                 else:

--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -132,6 +132,7 @@ class OSDService(CephService):
             host, 'osd', 'ceph-volume',
             [
                 '--',
+                '--log-level', self.mgr.ceph_volume_log_level,
                 'lvm', 'list',
                 '--format', 'json',
             ])
@@ -184,6 +185,7 @@ class OSDService(CephService):
             host, 'osd', 'ceph-volume',
             [
                 '--',
+                '--log-level', self.mgr.ceph_volume_log_level,
                 'raw', 'list',
                 '--format', 'json',
             ])
@@ -337,7 +339,7 @@ class OSDService(CephService):
 
                 # get preview data from ceph-volume
                 for cmd in cmds:
-                    with self.mgr.async_timeout_handler(host, f'cephadm ceph-volume -- {cmd}'):
+                    with self.mgr.async_timeout_handler(host, f'cephadm ceph-volume -- --log-level {self.mgr.ceph_volume_log_level} {cmd}'):
                         out, err, code = self.mgr.wait_async(self._run_ceph_volume_command(host, cmd))
                     if out:
                         try:
@@ -403,7 +405,7 @@ class OSDService(CephService):
         })
 
         split_cmd = cmd.split(' ')
-        _cmd = ['--config-json', '-', '--']
+        _cmd = ['--config-json', '-', '--', '--log-level', self.mgr.ceph_volume_log_level]
         _cmd.extend(split_cmd)
         out, err, code = await CephadmServe(self.mgr)._run_cephadm(
             host, 'osd', 'ceph-volume',
@@ -588,7 +590,7 @@ class RemoveUtil(object):
     def zap_osd(self, osd: "OSD") -> str:
         "Zaps all devices that are associated with an OSD"
         if osd.hostname is not None:
-            cmd = ['--', 'lvm', 'zap', '--osd-id', str(osd.osd_id)]
+            cmd = ['--', '--log-level', self.mgr.ceph_volume_log_level, 'lvm', 'zap', '--osd-id', str(osd.osd_id)]
             if osd.replace_block:
                 cmd.append('--replace-block')
             if osd.replace_db:

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -136,11 +136,11 @@ def with_osd_daemon(cephadm_module: CephadmOrchestrator, _run_cephadm, host: str
         [host]).stdout == f"Created osd(s) 1 on host '{host}'"
     assert _run_cephadm.mock_calls == [
         mock.call(host, 'osd', 'ceph-volume',
-                  ['--', 'lvm', 'list', '--format', 'json'],
+                  ['--', '--log-level', 'debug', 'lvm', 'list', '--format', 'json'],
                   no_fsid=False, error_ok=False, image='', log_output=True, use_current_daemon_image=False),
         mock.call(host, f'osd.{osd_id}', ['_orch', 'deploy'], [], stdin=mock.ANY, error_ok=True, use_current_daemon_image=False),
         mock.call(host, 'osd', 'ceph-volume',
-                  ['--', 'raw', 'list', '--format', 'json'],
+                  ['--', '--log-level', 'debug', 'raw', 'list', '--format', 'json'],
                   no_fsid=False, error_ok=False, image='', log_output=True, use_current_daemon_image=False),
     ]
     dd = cephadm_module.cache.get_daemon(f'osd.{osd_id}', host=host)
@@ -1168,17 +1168,17 @@ class TestCephadm(object):
 
             _run_cephadm.assert_any_call(
                 'test', 'osd', 'ceph-volume',
-                ['--config-json', '-', '--', 'lvm', 'batch',
-                    '--no-auto', '/dev/sdb', '--objectstore', 'bluestore',
-                    '--yes', '--no-systemd'],
+                ['--config-json', '-', '--', '--log-level', 'debug', 'lvm',
+                    'batch', '--no-auto', '/dev/sdb', '--objectstore',
+                    'bluestore', '--no-systemd'],
                 env_vars=['CEPH_VOLUME_OSDSPEC_AFFINITY=foo'], error_ok=True,
                 stdin='{"config": "", "keyring": ""}')
             _run_cephadm.assert_any_call(
-                'test', 'osd', 'ceph-volume', ['--', 'lvm', 'list', '--format', 'json'],
+                'test', 'osd', 'ceph-volume', ['--', '--log-level', 'debug', 'lvm', 'list', '--format', 'json'],
                 image='', no_fsid=False, error_ok=False, log_output=True, use_current_daemon_image=False
             )
             _run_cephadm.assert_any_call(
-                'test', 'osd', 'ceph-volume', ['--', 'raw', 'list', '--format', 'json'],
+                'test', 'osd', 'ceph-volume', ['--', '--log-level', 'debug', 'raw', 'list', '--format', 'json'],
                 image='', no_fsid=False, error_ok=False, log_output=True, use_current_daemon_image=False
             )
 
@@ -1214,7 +1214,7 @@ class TestCephadm(object):
 
             _run_cephadm.assert_any_call(
                 'test', 'osd', 'ceph-volume',
-                ['--config-json', '-', '--', 'lvm', 'batch',
+                ['--config-json', '-', '--', '--log-level', 'debug', 'lvm', 'batch',
                     '--no-auto', '/dev/sdb', '--db-devices', '/dev/sdc',
                     '--wal-devices', '/dev/sdd', '--objectstore', 'bluestore',
                     '--yes', '--no-systemd'],
@@ -1222,11 +1222,11 @@ class TestCephadm(object):
                 error_ok=True, stdin='{"config": "", "keyring": ""}',
             )
             _run_cephadm.assert_any_call(
-                'test', 'osd', 'ceph-volume', ['--', 'lvm', 'list', '--format', 'json'],
+                'test', 'osd', 'ceph-volume', ['--', '--log-level', 'debug', 'lvm', 'list', '--format', 'json'],
                 image='', no_fsid=False, error_ok=False, log_output=True, use_current_daemon_image=False
             )
             _run_cephadm.assert_any_call(
-                'test', 'osd', 'ceph-volume', ['--', 'raw', 'list', '--format', 'json'],
+                'test', 'osd', 'ceph-volume', ['--', '--log-level', 'debug', 'raw', 'list', '--format', 'json'],
                 image='', no_fsid=False, error_ok=False, log_output=True, use_current_daemon_image=False
             )
 
@@ -2645,10 +2645,10 @@ Traceback (most recent call last):
 
             assert _run_cephadm.mock_calls == [
                 mock.call('test', 'osd', 'ceph-volume',
-                          ['--', 'inventory', '--format=json-pretty', '--filter-for-batch'], image='',
+                          ['--', '--log-level', 'debug', 'inventory', '--format=json-pretty', '--filter-for-batch'], image='',
                           no_fsid=False, error_ok=False, log_output=False, use_current_daemon_image=False),
                 mock.call('test', 'osd', 'ceph-volume',
-                          ['--', 'inventory', '--format=json-pretty'], image='',
+                          ['--', '--log-level', 'debug', 'inventory', '--format=json-pretty'], image='',
                           no_fsid=False, error_ok=False, log_output=False, use_current_daemon_image=False),
             ]
 


### PR DESCRIPTION
This commit introduces a new configuration option to allow users to set a specific logging verbosity for the ceph-volume component.

Fixes: https://tracker.ceph.com/issues/73725

Signed-off-by: Vivek Maurya



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
