### PR TITLE
tools/rados: add benchmarking for OSD rollback operation

### DIFF
--- a/qa/suites/smoke/basic/tasks/test/rados_bench_write_rollback_read.yaml
+++ b/qa/suites/smoke/basic/tasks/test/rados_bench_write_rollback_read.yaml
@@ -1,0 +1,61 @@
+overrides:
+  ceph:
+    conf:
+      global:
+        ms inject delay max: 1
+        ms inject delay probability: 0.005
+        ms inject delay type: osd
+        ms inject internal delays: 0.002
+        ms inject socket failures: 2500
+        mon client directed command retry: 5
+tasks:
+- ceph:
+    fs: xfs
+    log-ignorelist:
+      - overall HEALTH_
+      - \(OSDMAP_FLAGS\)
+      - \(OSD_
+      - \(PG_
+      - \(POOL_
+      - \(CACHE_POOL_
+      - \(SMALLER_PGP_NUM\)
+      - \(OBJECT_
+      - \(SLOW_OPS\)
+      - \(TOO_FEW_PGS\)
+      - \(OSD_SLOW_PING_TIME
+      - slow request
+- thrashosds:
+    chance_pgnum_grow: 2
+    chance_pgnum_shrink: 2
+    chance_pgpnum_fix: 1
+    timeout: 1200
+- exec:
+    client.0:
+      - sudo ceph osd pool create benchpool 64
+      - sudo ceph osd pool application enable benchpool rados
+- full_sequential:
+  - radosbench:
+      clients: [client.0]
+      time: 150
+      pool: benchpool
+      create_pool: false
+      cleanup: false
+  - radosbench:
+      clients: [client.0]
+      time: 150
+      type: rollback
+      rollback_snap: snap_0
+      skip_write: true
+      pool: benchpool
+      create_pool: false
+      cleanup: false
+  - radosbench:
+      clients: [client.0]
+      time: 150
+      type: seq
+      skip_write: true
+      pool: benchpool
+      create_pool: false
+- exec:
+    client.0:
+      - sudo ceph osd pool rm benchpool benchpool --yes-i-really-really-mean-it

--- a/qa/tasks/radosbench.py
+++ b/qa/tasks/radosbench.py
@@ -33,7 +33,9 @@ def task(ctx, config):
           m: 1
           crush-failure-domain: osd
         cleanup: false (defaults to true)
-        type: <write|seq|rand> (defaults to write)
+        type: <write|seq|rand|rollback> (defaults to write)
+        rollback_snap: <snapshot> (to be used with runtype `rollback`)
+        skip_write: skip write for seq|rand|rollback run type (defaults to `false`)
     example:
 
     tasks:
@@ -51,6 +53,7 @@ def task(ctx, config):
     testdir = teuthology.get_testdir(ctx)
     manager = ctx.managers['ceph']
     runtype = config.get('type', 'write')
+    skip_write = config.get('skip_write', False)
 
     create_pool = config.get('create_pool', True)
     for role in config.get(
@@ -75,6 +78,10 @@ def task(ctx, config):
         if config.get('write-omap', False):
             write_to_omap = ['--write-omap']
             log.info('omap writes')
+        rollback_snap = []
+        snap = config.get('rollback_snap', None)
+        if snap:
+            rollback_snap = ['--snap', snap]
 
         pool = config.get('pool', 'data')
         if create_pool:
@@ -91,7 +98,7 @@ def task(ctx, config):
             objectsize = ['--object-size', str(osize)]
         size = ['-b', str(config.get('size', 65536))]
         # If doing a reading run then populate data
-        if runtype != "write":
+        if runtype != "write" and not skip_write:
             proc = remote.run(
                 args=[
                     "/bin/sh", "-c",
@@ -110,6 +117,7 @@ def task(ctx, config):
             logger=log.getChild('radosbench.{id}'.format(id=id_)),
             wait=True
             )
+        if runtype != "write":
             size = []
             objectsize = []
 
@@ -126,7 +134,7 @@ def task(ctx, config):
                           + size + objectsize +
                           ['-p' , pool,
                           'bench', str(config.get('time', 360)), runtype,
-                          ] + write_to_omap + cleanup).format(tdir=testdir),
+                          ] + write_to_omap + rollback_snap + cleanup).format(tdir=testdir),
                 ],
             logger=log.getChild('radosbench.{id}'.format(id=id_)),
             stdin=run.PIPE,

--- a/src/common/obj_bencher.cc
+++ b/src/common/obj_bencher.cc
@@ -36,41 +36,34 @@ using std::string;
 using std::unique_lock;
 using std::unique_ptr;
 
-const std::string BENCH_LASTRUN_METADATA = "benchmark_last_metadata";
-const std::string BENCH_PREFIX = "benchmark_data";
-const std::string BENCH_OBJ_NAME = BENCH_PREFIX + "_%s_%d_object%d";
-
-static char cached_hostname[30] = {0};
+static std::string cached_hostname;
 int cached_pid = 0;
 
 static std::string generate_object_prefix_nopid() {
-  if (cached_hostname[0] == 0) {
-    gethostname(cached_hostname, sizeof(cached_hostname)-1);
-    cached_hostname[sizeof(cached_hostname)-1] = 0;
+  if (cached_hostname.empty()) {
+    cached_hostname = ceph::bench::get_local_hostname();
   }
 
-  std::ostringstream oss;
-  oss << BENCH_PREFIX << "_" << cached_hostname;
-  return oss.str();
+  return ceph::bench::generate_object_prefix_nopid(cached_hostname);
 }
 
 static std::string generate_object_prefix(int pid = 0) {
+  if (cached_hostname.empty()) {
+    cached_hostname = ceph::bench::get_local_hostname();
+  }
   if (pid)
     cached_pid = pid;
   else if (!cached_pid)
     cached_pid = getpid();
 
-  std::ostringstream oss;
-  oss << generate_object_prefix_nopid() << "_" << cached_pid;
-  return oss.str();
+  return ceph::bench::generate_object_prefix(cached_hostname, cached_pid);
 }
 
 // this is 8x faster than previous impl based on chained, deduped functions call
 static std::string generate_object_name_fast(int objnum, int pid = 0)
 {
-  if (cached_hostname[0] == 0) {
-	gethostname(cached_hostname, sizeof(cached_hostname)-1);
-	cached_hostname[sizeof(cached_hostname)-1] = 0;
+  if (cached_hostname.empty()) {
+    cached_hostname = ceph::bench::get_local_hostname();
   }
 
   if (pid)
@@ -78,10 +71,7 @@ static std::string generate_object_name_fast(int objnum, int pid = 0)
   else if (!cached_pid)
 	cached_pid = getpid();
 
-  char name[512];
-  int n = snprintf(&name[0], sizeof(name),  BENCH_OBJ_NAME.c_str(), cached_hostname, cached_pid, objnum);
-  ceph_assert(n > 0 && n < (int)sizeof(name));
-  return std::string(&name[0], (size_t)n);
+  return ceph::bench::generate_object_name_fast(cached_hostname, cached_pid, objnum);
 }
 
 static void sanitize_object_contents (bench_data *data, size_t length) {
@@ -322,6 +312,10 @@ int ObjBencher::aio_bench(
     r = rand_read_bench(secondsToRun, num_ops, num_objects, concurrentios, prev_pid, no_verify);
     if (r != 0) goto out;
   }
+  else if (OP_ROLLBACK == operation) {
+    r = rollback_bench(secondsToRun, num_ops, num_objects, concurrentios, prev_pid);
+    if (r != 0) goto out;
+  }
 
   if (OP_WRITE == operation && cleanup) {
     r = fetch_bench_metadata(run_name_meta, &op_size, &object_size,
@@ -385,15 +379,8 @@ int ObjBencher::fetch_bench_metadata(const std::string& metadata_file,
     }
     return r;
   }
-  auto p = object_data.cbegin();
-  decode(*object_size, p);
-  decode(*num_ops, p);
-  decode(*prevPid, p);
-  if (!p.end()) {
-    decode(*op_size, p);
-  } else {
-    *op_size = *object_size;
-  }
+  ceph::bench::decode_bench_metadata(object_data, object_size, num_ops, prevPid, op_size);
+
   unsigned ops_per_object = 1;
   // make sure *op_size value is reasonable
   if (*op_size > 0 && *object_size > *op_size) {
@@ -412,11 +399,11 @@ int ObjBencher::write_bench(int secondsToRun,
 
   if (!formatter) {
     out(cout) << "Maintaining " << concurrentios << " concurrent writes of "
-	      << data.op_size << " bytes to objects of size "
-	      << data.object_size << " for up to "
-	      << secondsToRun << " seconds or "
-	      << max_objects << " objects"
-	      << std::endl;
+              << data.op_size << " bytes to objects of size "
+              << data.object_size << " for up to "
+              << secondsToRun << " seconds or "
+              << max_objects << " objects"
+              << std::endl;
   } else {
     formatter->dump_format("concurrent_ios", "%d", concurrentios);
     formatter->dump_format("object_size", "%d", data.object_size);
@@ -424,6 +411,7 @@ int ObjBencher::write_bench(int secondsToRun,
     formatter->dump_format("seconds_to_run", "%d", secondsToRun);
     formatter->dump_format("max_objects", "%d", max_objects);
   }
+
   bufferlist* newContents = 0;
 
   std::string prefix = prev_pid ? generate_object_prefix(prev_pid) : generate_object_prefix();
@@ -470,7 +458,7 @@ int ObjBencher::write_bench(int secondsToRun,
     if (r < 0)
       goto ERR;
     r = aio_write(name[i], i, *contents[i], data.op_size,
-		  data.op_size * (i % writes_per_object));
+                    data.op_size * (i % writes_per_object));
     if (r < 0) {
       goto ERR;
     }
@@ -634,13 +622,200 @@ int ObjBencher::write_bench(int secondsToRun,
     formatter->dump_format("min_latency", "%f", data.min_latency);
   }
   //write object size/number data for read benchmarks
-  encode(data.object_size, b_write);
-  encode(data.finished, b_write);
-  encode(prev_pid ? prev_pid : getpid(),  b_write);
-  encode(data.op_size, b_write);
-
+  ceph::bench::encode_bench_metadata(&b_write, data.object_size, data.finished,
+                        prev_pid ? prev_pid : getpid(), data.op_size);
   // persist meta-data for further cleanup or read
   sync_write(run_name_meta, b_write, sizeof(int)*3);
+
+  completions_done();
+
+  return 0;
+
+ ERR:
+  locker.lock();
+  data.done = 1;
+  locker.unlock();
+  pthread_join(print_thread, NULL);
+  return r;
+}
+
+int ObjBencher::rollback_bench(int secondsToRun,
+                               int num_ops, int num_objects,
+                               int concurrentios, int prev_pid) {
+  if (concurrentios <= 0)
+    return -EINVAL;
+
+  if (!formatter) {
+    out(cout) << "Maintaining " << concurrentios << " concurrent rollbacks of "
+              << data.object_size << " for up to "
+              << secondsToRun << " seconds"
+              << std::endl;
+  } else {
+    formatter->dump_format("concurrent_ios", "%d", concurrentios);
+    formatter->dump_format("object_size", "%d", data.object_size);
+    formatter->dump_format("seconds_to_run", "%d", secondsToRun);
+  }
+
+  std::string prefix = prev_pid ? generate_object_prefix(prev_pid) : generate_object_prefix();
+  if (!formatter)
+    out(cout) << "Object prefix: " << prefix << std::endl;
+  else
+    formatter->dump_string("object_prefix", prefix);
+
+  std::vector<string> name(concurrentios);
+  std::string newName;
+  int r = 0;
+  bufferlist b_write;
+  lock_cond lc(&lock);
+  double total_latency = 0;
+  std::vector<mono_time> start_times(concurrentios);
+  mono_time stopTime;
+  std::chrono::duration<double> timePassed;
+
+  r = completions_init(concurrentios);
+
+  //set up object names so I can start them together
+  for (int i = 0; i<concurrentios; ++i) {
+    name[i] = generate_object_name_fast(i);
+  }
+
+  pthread_t print_thread;
+
+  pthread_create(&print_thread, NULL, ObjBencher::status_printer, (void *)this);
+  std::unique_lock locker{lock};
+  data.finished = 0;
+  data.start_time = mono_clock::now();
+  locker.unlock();
+  for (int i = 0; i<concurrentios; ++i) {
+    start_times[i] = mono_clock::now();
+    r = create_completion(i, _aio_cb, (void *)&lc);
+    if (r < 0)
+      goto ERR;
+    r = aio_rollback(name[i], i);
+    if (r < 0) {
+      goto ERR;
+    }
+    locker.lock();
+    ++data.started;
+    ++data.in_flight;
+    locker.unlock();
+  }
+
+  //keep on adding new writes as old ones complete until we've passed minimum time
+  int slot;
+
+  //don't need locking for reads because other thread doesn't write
+
+  stopTime = data.start_time + std::chrono::seconds(secondsToRun);
+  slot = 0;
+  locker.lock();
+  while (data.finished < data.started) {
+    bool found = false;
+    while (1) {
+      int old_slot = slot;
+      do {
+        if (completion_is_done(slot)) {
+            found = true;
+            break;
+        }
+        slot++;
+        if (slot == concurrentios) {
+          slot = 0;
+        }
+      } while (slot != old_slot);
+      if (found)
+        break;
+      lc.cond.wait(locker);
+    }
+    locker.unlock();
+
+    completion_wait(slot);
+    locker.lock();
+    r = completion_ret(slot);
+    if (r != 0) {
+      locker.unlock();
+      goto ERR;
+    }
+    data.cur_latency = mono_clock::now() - start_times[slot];
+    total_latency += data.cur_latency.count();
+    if (data.cur_latency.count() > data.max_latency) {
+      data.max_latency = data.cur_latency.count();
+    }
+    if (data.cur_latency.count() < data.min_latency) {
+      data.min_latency = data.cur_latency.count();
+    }
+    ++data.finished;
+    double delta = data.cur_latency.count() - data.avg_latency;
+    data.avg_latency = total_latency / data.finished;
+    data.latency_diff_sum += delta * (data.cur_latency.count() - data.avg_latency);
+    --data.in_flight;
+    locker.unlock();
+    release_completion(slot);
+
+    if (!secondsToRun || mono_clock::now() >= stopTime || num_ops < data.started) {
+      locker.lock();
+      continue;
+    }
+
+    start_times[slot] = mono_clock::now();
+    r = create_completion(slot, _aio_cb, &lc);
+    if (r < 0)
+      goto ERR;
+    r = aio_rollback(name[slot], slot);
+    if (r < 0) {
+      goto ERR;
+    }
+    locker.lock();
+    ++data.started;
+    ++data.in_flight;
+  }
+  locker.unlock();
+
+  timePassed = mono_clock::now() - data.start_time;
+  locker.lock();
+  data.done = true;
+  locker.unlock();
+
+  pthread_join(print_thread, NULL);
+
+  double iops_stddev;
+  double latency_stddev;
+  if (data.idata.iops_cycles > 1) {
+    iops_stddev = std::sqrt(data.idata.iops_diff_sum / (data.idata.iops_cycles - 1));
+  } else {
+    iops_stddev = 0;
+  }
+  if (data.finished > 1) {
+    latency_stddev = std::sqrt(data.latency_diff_sum / (data.finished - 1));
+  } else {
+    latency_stddev = 0;
+  }
+
+  if (!formatter) {
+    out(cout) << "Total time run:         " << timePassed.count() << std::endl
+       << "Total rollbacks made:      " << data.finished << std::endl
+       << "Object size:            " << data.object_size << std::endl
+       << "Average IOPS:           " << (int)(data.finished/timePassed.count()) << std::endl
+       << "Stddev IOPS:            " << iops_stddev << std::endl
+       << "Max IOPS:               " << data.idata.max_iops << std::endl
+       << "Min IOPS:               " << data.idata.min_iops << std::endl
+       << "Average Latency(s):     " << data.avg_latency << std::endl
+       << "Stddev Latency(s):      " << latency_stddev << std::endl
+       << "Max latency(s):         " << data.max_latency << std::endl
+       << "Min latency(s):         " << data.min_latency << std::endl;
+  } else {
+    formatter->dump_format("total_time_run", "%f", timePassed.count());
+    formatter->dump_format("total_writes_made", "%d", data.finished);
+    formatter->dump_format("object_size", "%d", data.object_size);
+    formatter->dump_format("average_iops", "%d", (int)(data.finished/timePassed.count()));
+    formatter->dump_format("stddev_iops", "%d", iops_stddev);
+    formatter->dump_format("max_iops", "%d", data.idata.max_iops);
+    formatter->dump_format("min_iops", "%d", data.idata.min_iops);
+    formatter->dump_format("average_latency", "%f", data.avg_latency);
+    formatter->dump_format("stddev_latency", "%f", latency_stddev);
+    formatter->dump_format("max_latency", "%f", data.max_latency);
+    formatter->dump_format("min_latency", "%f", data.min_latency);
+  }
 
   completions_done();
 

--- a/src/common/obj_bencher.h
+++ b/src/common/obj_bencher.h
@@ -63,6 +63,7 @@ struct bench_data {
 const int OP_WRITE     = 1;
 const int OP_SEQ_READ  = 2;
 const int OP_RAND_READ = 3;
+const int OP_ROLLBACK  = 4;
 
 // Object is composed of <oid,namespace>
 typedef std::pair<std::string, std::string> Object;
@@ -86,6 +87,7 @@ protected:
   int write_bench(int secondsToRun, int concurrentios, const std::string& run_name_meta, unsigned max_objects, int prev_pid);
   int seq_read_bench(int secondsToRun, int num_ops, int num_objects, int concurrentios, int writePid, bool no_verify=false);
   int rand_read_bench(int secondsToRun, int num_ops, int num_objects, int concurrentios, int writePid, bool no_verify=false);
+  int rollback_bench(int secondsToRun, int num_ops, int num_objects, int concurrentios, int prev_pid);
 
   int clean_up(int num_objects, int prevPid, int concurrentios);
   bool more_objects_matching_prefix(const std::string& prefix, std::list<Object>* name);
@@ -106,6 +108,7 @@ protected:
   virtual int sync_read(const std::string& oid, bufferlist& bl, size_t len) = 0;
   virtual int sync_write(const std::string& oid, bufferlist& bl, size_t len) = 0;
   virtual int sync_remove(const std::string& oid) = 0;
+  virtual int aio_rollback(const std::string& oid, int slot) = 0;
 
   virtual bool get_objects(std::list< std::pair<std::string, std::string> >* objects, int num) = 0;
   virtual void set_namespace(const std::string&) {}
@@ -133,5 +136,87 @@ public:
   int clean_up_slow(const std::string& prefix, int concurrentios);
 };
 
+const std::string BENCH_LASTRUN_METADATA = "benchmark_last_metadata";
+const std::string BENCH_PREFIX = "benchmark_data";
+const std::string BENCH_OBJ_NAME = BENCH_PREFIX + "_%s_%d_object%d";
+
+namespace ceph::bench {
+  inline std::string generate_object_prefix_nopid(const std::string &base_prefix,
+                                                  const std::string &hostname) {
+    std::string name;
+    name.reserve(base_prefix.size() + 1 + hostname.size());
+    name.append(base_prefix);
+    name.append("_");
+    name.append(hostname);
+    return name;
+  }
+  inline std::string generate_object_prefix_nopid(const std::string &hostname) {
+    return ceph::bench::generate_object_prefix_nopid(BENCH_PREFIX, hostname);
+  }
+
+  inline std::string generate_object_prefix(const std::string &base_prefix,
+                                            const std::string &hostname, int pid) {
+    std::string name;
+    name.reserve(base_prefix.size() + 1 + hostname.size() + 11);
+    name.append(base_prefix);
+    name.append("_");
+    name.append(hostname);
+    name.append("_");
+    name.append(std::to_string(pid));
+    return name;
+  }
+  inline std::string generate_object_prefix(const std::string &hostname, int pid) {
+    return ceph::bench::generate_object_prefix(BENCH_PREFIX, hostname, pid);
+  }
+
+  inline std::string generate_object_name_fast(const std::string &base_prefix,
+                                               const std::string &hostname,
+                                               int pid, int index) {
+    std::string name;
+    name.reserve(base_prefix.size() + 1 + hostname.size() + 1 + 11 + 7 + 20);
+    name.append(base_prefix);
+    name.append("_");
+    name.append(hostname);
+    name.append("_");
+    name.append(std::to_string(pid));
+    name.append("_object");
+    name.append(std::to_string(index));
+    return name;
+  }
+  inline std::string generate_object_name_fast(const std::string &hostname,
+                                               int pid, int index) {
+    return ceph::bench::generate_object_name_fast(BENCH_PREFIX, hostname, pid, index);
+  }
+
+  inline std::string get_local_hostname() {
+    char hostname[256];
+    if (gethostname(hostname, sizeof(hostname)) < 0) {
+      return "localhost";
+    }
+    return std::string(hostname);
+  }
+
+  inline void decode_bench_metadata(const bufferlist &bl, uint64_t *object_size,
+                                    int *num_ops, int *prev_pid, uint64_t *op_size) {
+    using ceph::decode;
+    auto p = bl.cbegin();
+    decode(*object_size, p);
+    decode(*num_ops, p);
+    decode(*prev_pid, p);
+    if (!p.end()) {
+      decode(*op_size, p);
+    } else {
+      *op_size = *object_size;
+    }
+  }
+  inline void encode_bench_metadata(bufferlist *bl, uint64_t object_size,
+                                    int num_ops, int prev_pid, uint64_t op_size) {
+    using ceph::encode;
+    encode(object_size, *bl);
+    encode(num_ops, *bl);
+    encode(prev_pid, *bl);
+    encode(op_size, *bl);
+  }
+} // namespace ceph::bench
 
 #endif

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -131,7 +131,7 @@ void usage(ostream& out)
 "   rollback <obj-name> <snap-name>  roll back object to snap <snap-name>\n"
 "\n"
 "   listsnaps <obj-name>             list the snapshots of this object\n"
-"   bench <seconds> write|seq|rand [-t concurrent_operations] [--no-cleanup] [--run-name run_name] [--no-hints] [--reuse-bench]\n"
+"   bench <seconds> write|seq|rand|rollback [-t concurrent_operations] [--no-cleanup] [--run-name run_name] [--no-hints] [--reuse-bench]\n"
 "                                    default is 16 concurrent IOs and 4 MB ops\n"
 "                                    default is to clean up after write benchmark\n"
 "                                    default run-name is 'benchmark_last_metadata'\n"
@@ -266,6 +266,8 @@ void usage(ostream& out)
 "        read or write contents to the omap\n"
 "   --xattr | write-xattr (deprecated)\n"
 "        read or write contents to the extended attributes\n"
+"   --mutate-percent=N\n"
+"        percentage of live objects to modify before a rollback benchmark (0-100, default: 50)\n"
 "\n"
 "LOAD GEN OPTIONS:\n"
 "   --num-objects                    total number of objects\n"
@@ -1090,6 +1092,8 @@ class RadosBencher : public ObjBencher {
   bool iterator_valid;
   OpDest destination;
   omap_read_params_t omap_read;
+  bool rollback_mode = false;
+  snap_t rollback_snapid = CEPH_NOSNAP;
 
 protected:
   int completions_init(int concurrentios) override {
@@ -1168,6 +1172,12 @@ protected:
     return io_ctx.aio_operate(oid, completions[slot], &op);
   }
 
+  int aio_rollback(const std::string& oid, int slot) {
+    librados::ObjectWriteOperation op;
+    op.snap_rollback(rollback_snapid);
+    return io_ctx.aio_operate(oid, completions[slot], &op);
+  }
+
   int aio_remove(const std::string& oid, int slot) override {
     return io_ctx.aio_remove(oid, completions[slot]);
   }
@@ -1233,6 +1243,97 @@ public:
   }
   void set_omap_read_patams(const omap_read_params_t& omap_read_params) {
     omap_read = omap_read_params;
+  }
+
+  int prepare_rollback_environment(const char* snapname, int64_t mutate_percent,
+                                   const std::string &run_name) {
+    if (!snapname) {
+      return -EINVAL;
+    }
+
+    int ret = io_ctx.snap_create(snapname);
+    if (ret < 0) {
+      return ret;
+    }
+
+    io_ctx.snap_set_read(CEPH_NOSNAP);
+    if (mutate_percent > 0) {
+      // Handle the default fallback run name if the user didn't
+      // specify --run-name
+      std::string meta_obj = run_name.empty() ? BENCH_LASTRUN_METADATA : run_name;
+      bufferlist metadata_bl;
+
+      int ret = io_ctx.read(meta_obj, metadata_bl, 4096, 0);
+      if (ret < 0) {
+        cerr << "error: unable to read benchmark metadata from object '" << meta_obj
+             << "': " << cpp_strerror(ret) << std::endl;
+        cerr << "hint: make sure you have run a 'write' benchmark with '--no-cleanup' using the same --run-name before running rollback." << std::endl;
+        return ret;
+      }
+
+      uint64_t object_size = 0;
+      int num_ops = 0;
+      int prev_pid = 0;
+      uint64_t op_size = 0;
+
+      try {
+        ceph::bench::decode_bench_metadata(metadata_bl, &object_size, &num_ops, &prev_pid, &op_size);
+      } catch (const ceph::buffer::error& e) {
+        cerr << "error: failed to decode benchmark metadata from '" << meta_obj
+             << "': " << e.what() << std::endl;
+        return -EINVAL;
+      }
+
+      std::string hostname = ceph::bench::get_local_hostname();
+      std::string object_prefix = ceph::bench::generate_object_prefix(hostname, prev_pid);
+      cout << "Successfully decoded metadata. Target object prefix resolved: '" << object_prefix << "'" << std::endl;
+
+      cout << "Modifying " << mutate_percent << "% of live objects matching '"
+           << object_prefix << "' to build divergence..." << std::endl;
+      try {
+        librados::NObjectIterator i = io_ctx.nobjects_begin();
+        const librados::NObjectIterator i_end = io_ctx.nobjects_end();
+        int modified_count = 0;
+        int total_bench_objects = 0;
+
+        for (; i != i_end; ++i) {
+          if (i->get_oid().find(object_prefix) == std::string::npos) {
+            continue;
+          }
+          total_bench_objects++;
+
+          if (ceph::util::generate_random_number(0, 99) < mutate_percent) {
+            cout << "Mutating " << i->get_oid() << std::endl;
+            bufferlist bl;
+            bl.append("post_snapshot_divergent_bench_payload");
+            io_ctx.set_namespace(i->get_nspace());
+            io_ctx.locator_set_key(i->get_locator());
+            int w_ret = io_ctx.write_full(i->get_oid(), bl);
+            if (w_ret == 0) {
+              modified_count++;
+            }
+          }
+        }
+        cout << "Found " << total_bench_objects << " total objects matching run name '" << object_prefix << "'." << std::endl;
+        cout << "Successfully dirtied/diverged " << modified_count << " objects." << std::endl;
+      } catch (...) {
+        return -EIO;
+      }
+    }
+
+    cout << "Starting snapshot rollback benchmark metric evaluation..." << std::endl;
+    return 0;
+  }
+
+  void set_rollback(bool rollback, snap_t snapid) {
+    cout << "Setting rollback snap-id: " << snapid << std::endl;
+    rollback_mode = rollback;
+    rollback_snapid = snapid;
+    if (rollback) {
+      // Clear any read-snapshot context on the io_ctx to ensure
+      // object discovery iterates over the live head objects
+      io_ctx.snap_set_read(CEPH_NOSNAP);
+    }
   }
 };
 
@@ -1951,6 +2052,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
   uint64_t max_backlog = 0;
   uint64_t target_throughput = 0;
   int64_t read_percent = -1;
+  int64_t mutate_percent = -1;
   uint64_t num_objs = 0;
   int run_length = 0;
 
@@ -2096,6 +2198,16 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
   i = opts.find("read-percent");
   if (i != opts.end()) {
     if (rados_sistrtoll(i, &read_percent)) {
+      return -EINVAL;
+    }
+  }
+  i = opts.find("mutate-percent");
+  if (i != opts.end()) {
+    if (rados_sistrtoll(i, &mutate_percent)) {
+      return -EINVAL;
+    }
+    if (mutate_percent < 0 || mutate_percent > 100) {
+      cerr << "error: --mutate-percent must be an integer value between 0 and 100" << std::endl;
       return -EINVAL;
     }
   }
@@ -2315,8 +2427,11 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
       cerr << "pool name must be specified with --snap" << std::endl;
       return 1;
     }
+    bool is_rollback_bench = (!nargs.empty() &&
+                              strcmp(nargs[0], "bench") == 0 &&
+                              nargs.size() >= 3 && strcmp(nargs[2], "rollback") == 0);
     ret = io_ctx.snap_lookup(snapname, &snapid);
-    if (ret < 0) {
+    if (ret < 0 && !is_rollback_bench) {
       cerr << "error looking up snap '" << snapname << "': " << cpp_strerror(ret) << std::endl;
       return 1;
     }
@@ -3396,6 +3511,8 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
       operation = OP_SEQ_READ;
     else if (strcmp(nargs[2], "rand") == 0)
       operation = OP_RAND_READ;
+    else if (strcmp(nargs[2], "rollback") == 0)
+      operation = OP_ROLLBACK;
     else {
       usage(cerr);
       return 1;
@@ -3417,6 +3534,16 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
       return 1;
     }
     RadosBencher bencher(g_ceph_context, rados, io_ctx);
+    if (operation == OP_ROLLBACK) {
+      cout << "Preparing snapshot environment..." << std::endl;
+      ret = bencher.prepare_rollback_environment(snapname, mutate_percent, run_name);
+      if (ret < 0) {
+        cerr << "Failed to prepare rollback environment: " << cpp_strerror(ret) << std::endl;
+        return ret;
+      }
+      io_ctx.snap_lookup(snapname, &snapid);
+      bencher.set_rollback(true, snapid);
+    }
     bencher.set_show_time(show_time);
     bencher.set_destination(static_cast<OpDest>(bench_dest));
     bencher.set_omap_read_patams(omap_read);
@@ -4323,6 +4450,8 @@ int main(int argc, const char **argv)
       opts["dest-obj"] = "true";
     } else if (ceph_argparse_flag(args, i, "--xattr", (char*)nullptr)) {
       opts["dest-xattr"] = "true";
+    } else if (ceph_argparse_witharg(args, i, &val, "--mutate-percent", (char*)nullptr)) {
+      opts["mutate-percent"] = val;
     } else if (ceph_argparse_flag(args, i, "--with-clones", (char*)nullptr)) {
       opts["with-clones"] = "true";
     } else if (ceph_argparse_witharg(args, i, &val, "--omap-read-start-after", (char*)nullptr)) {


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
