### PR TITLE
mgr/dashboard: add group snapshot schedule API and fix status/info endpoints

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rbd_mirror_group.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd_mirror_group.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import json
 import logging
 from functools import partial
 from typing import Optional
@@ -9,7 +10,7 @@ import rbd
 from ..exceptions import DashboardException
 from ..security import Scope
 from ..services.exception import handle_rados_error, handle_rbd_error, serialize_dashboard_exception
-from ..services.rbd import rbd_call
+from ..services.rbd import RbdMirroringService, rbd_call
 from . import APIDoc, APIRouter, Endpoint, EndpointDoc, ReadPermission, \
     RESTController, Task, UpdatePermission, allow_empty_body
 
@@ -27,10 +28,14 @@ def RbdMirrorGroupTask(name, metadata, wait_for):  # noqa: N802
 
 
 RBD_MIRROR_GROUP_SCHEMA = {
-    "state": (str, "Mirror state"),
-    "mode": (str, "Mirror mode"),
-    "global_id": (str, "Global ID"),
-    "primary": (bool, "Is primary")
+    "group_name": (str, "Group name"),
+    "group_id": (str, "Group ID"),
+    "mirroring": ({
+        "state": (str, "Mirror state"),
+        "mode": (str, "Mirror mode"),
+        "global_id": (str, "Global ID"),
+        "primary": (bool, "Is primary")
+    }, "Mirroring info")
 }
 
 RBD_MIRROR_GROUP_STATUS_SCHEMA = {
@@ -39,12 +44,23 @@ RBD_MIRROR_GROUP_STATUS_SCHEMA = {
     "state": (str, "Mirror state"),
     "description": (str, "Status description"),
     "last_update": (str, "Last update time"),
+    "snapshots": ([{
+        "name": (str, "Snapshot name"),
+        "state": (str, "Snapshot state")
+    }], "Group snapshots"),
     "peer_sites": ([{
         "site_name": (str, "Site name"),
         "mirror_uuid": (str, "Mirror UUID"),
         "state": (str, "Site state"),
         "description": (str, "Site description"),
-        "last_update": (str, "Last update time")
+        "last_update": (str, "Last update time"),
+        "mirror_images": ([{
+            "global_id": (str, "Image global ID"),
+            "state": (str, "Image state"),
+            "description": (str, "Image description"),
+            "last_update": (str, "Last update time"),
+            "up": (bool, "Is up")
+        }], "Per-image replication status")
     }], "Peer sites")
 }
 
@@ -70,30 +86,32 @@ class RbdMirrorGroup(RESTController):
                  },
                  responses={200: RBD_MIRROR_GROUP_SCHEMA})
     def get(self, pool_name: str, group_name: str, namespace: Optional[str] = None):
-        """Get mirror group information."""
+        """Get mirror group information.  Matches 'rbd group info --format json'."""
         def _get_info(ioctx):
             with rbd.Group(ioctx, group_name) as group:
                 info = group.mirror_group_get_info()
+                group_id = group.id()
 
-                # Map state enum to string
-                state_map = {
-                    rbd.RBD_MIRROR_GROUP_DISABLED: 'disabled',
-                    rbd.RBD_MIRROR_GROUP_ENABLED: 'enabled',
-                    rbd.RBD_MIRROR_GROUP_DISABLING: 'disabling'
-                }
+            state_map = {
+                rbd.RBD_MIRROR_GROUP_DISABLED: 'disabled',
+                rbd.RBD_MIRROR_GROUP_ENABLED: 'enabled',
+                rbd.RBD_MIRROR_GROUP_DISABLING: 'disabling'
+            }
+            mode_map = {
+                rbd.RBD_MIRROR_IMAGE_MODE_JOURNAL: 'journal',
+                rbd.RBD_MIRROR_IMAGE_MODE_SNAPSHOT: 'snapshot'
+            }
 
-                # Map mode enum to string
-                mode_map = {
-                    rbd.RBD_MIRROR_IMAGE_MODE_JOURNAL: 'journal',
-                    rbd.RBD_MIRROR_IMAGE_MODE_SNAPSHOT: 'snapshot'
-                }
-
-                return {
+            return {
+                'group_name': group_name,
+                'group_id': group_id,
+                'mirroring': {
                     'state': state_map.get(info.get('state'), 'unknown'),
                     'mode': mode_map.get(info.get('image_mode'), 'unknown'),
                     'global_id': info.get('global_id', ''),
                     'primary': info.get('primary', False)
                 }
+            }
 
         return rbd_call(pool_name, namespace, _get_info)
 
@@ -238,33 +256,92 @@ class RbdMirrorGroup(RESTController):
         :param group_name: Group name
         :param namespace: Namespace (optional)
         """
+        # Maps rbd.MIRROR_IMAGE_STATUS_STATE_* int → human-readable string
+        _MIRROR_STATE_MAP = {
+            rbd.MIRROR_IMAGE_STATUS_STATE_UNKNOWN: 'unknown',
+            rbd.MIRROR_IMAGE_STATUS_STATE_ERROR: 'error',
+            rbd.MIRROR_IMAGE_STATUS_STATE_SYNCING: 'syncing',
+            rbd.MIRROR_IMAGE_STATUS_STATE_STARTING_REPLAY: 'starting_replay',
+            rbd.MIRROR_IMAGE_STATUS_STATE_REPLAYING: 'replaying',
+            rbd.MIRROR_IMAGE_STATUS_STATE_STOPPING_REPLAY: 'stopping_replay',
+            rbd.MIRROR_IMAGE_STATUS_STATE_STOPPED: 'stopped',
+        }
+
+        # Maps rbd.RBD_GROUP_SNAP_STATE_* int → human-readable string
+        _SNAP_STATE_MAP = {
+            rbd.RBD_GROUP_SNAP_STATE_CREATING: 'creating',
+            rbd.RBD_GROUP_SNAP_STATE_CREATED: 'created',
+        }
+
         def _get_status(ioctx):
             with rbd.Group(ioctx, group_name) as group:
                 status = group.mirror_group_get_global_status()
+                # Collect group snapshots — matches 'rbd mirror group status --format json'
+                raw_snaps = list(group.list_snaps())
 
-                # Format the status response
-                result = {
-                    'name': status.get('name', group_name),
-                    'global_id': status.get('info', {}).get('global_id', ''),
-                    'state': 'unknown',
-                    'description': '',
-                    'last_update': '',
-                    'peer_sites': []
+            # Build mirror_uuid → site_name lookup from pool peer list
+            rbd_inst = rbd.RBD()
+            peer_name_map = {}
+            try:
+                for peer in rbd_inst.mirror_peer_list(ioctx):
+                    peer_name_map[peer.get('mirror_uuid', '')] = peer.get('site_name', '')
+            except Exception:  # pylint: disable=broad-except
+                pass  # peer list is best-effort; status still valid without site names
+
+            # Build snapshots list matching CLI output
+            snapshots = [
+                {
+                    'name': s.get('name', ''),
+                    'state': _SNAP_STATE_MAP.get(s.get('state', -1), 'unknown')
                 }
+                for s in raw_snaps
+            ]
 
-                # Process site statuses
-                site_statuses = status.get('site_statuses', [])
-                for site in site_statuses:
-                    peer_site = {
-                        'site_name': site.get('site_name', ''),
-                        'mirror_uuid': site.get('mirror_uuid', ''),
-                        'state': str(site.get('state', 'unknown')),
-                        'description': site.get('description', ''),
-                        'last_update': str(site.get('last_update', ''))
+            # Determine top-level state from site statuses
+            site_statuses = status.get('site_statuses', [])
+            top_state = 'unknown'
+            top_description = ''
+            top_last_update = ''
+            if site_statuses:
+                first = site_statuses[0]
+                top_state = _MIRROR_STATE_MAP.get(first.get('state', 0), 'unknown')
+                top_description = first.get('description', '')
+                top_last_update = str(first.get('last_update', ''))
+
+            result = {
+                'name': status.get('name', group_name),
+                'global_id': status.get('info', {}).get('global_id', ''),
+                'state': top_state,
+                'description': top_description,
+                'last_update': top_last_update,
+                'snapshots': snapshots,
+                'peer_sites': []
+            }
+
+            for site in site_statuses:
+                mirror_uuid = site.get('mirror_uuid', '')
+                # Build per-image replication status for this peer site
+                mirror_images = [
+                    {
+                        'global_id': img.get('global_id', ''),
+                        'state': _MIRROR_STATE_MAP.get(img.get('state', 0), 'unknown'),
+                        'description': img.get('description', ''),
+                        'last_update': str(img.get('last_update', '')),
+                        'up': img.get('up', False)
                     }
-                    result['peer_sites'].append(peer_site)
+                    for img in site.get('mirror_images', [])
+                ]
+                peer_site = {
+                    'site_name': peer_name_map.get(mirror_uuid, ''),
+                    'mirror_uuid': mirror_uuid,
+                    'state': _MIRROR_STATE_MAP.get(site.get('state', 0), 'unknown'),
+                    'description': site.get('description', ''),
+                    'last_update': str(site.get('last_update', '')),
+                    'mirror_images': mirror_images
+                }
+                result['peer_sites'].append(peer_site)
 
-                return result
+            return result
 
         return rbd_call(pool_name, namespace, _get_status)
 
@@ -324,5 +401,184 @@ class RbdMirrorGroup(RESTController):
                 group.mirror_group_disable(force)
 
         return rbd_call(pool_name, namespace, _disable)
+
+    @Endpoint(method='GET', path='{group_name}/snapshot/schedule')
+    @ReadPermission
+    @handle_rbd_error()
+    @handle_rados_error('pool')
+    @EndpointDoc("List snapshot schedules for a mirror group",
+                 parameters={
+                     'pool_name': (str, 'Pool name'),
+                     'group_name': (str, 'Group name'),
+                     'namespace': (str, 'Namespace (optional)')
+                 },
+                 responses={200: [{
+                     'spec': (str, 'Group level spec (pool/group or pool/namespace/group)'),
+                     'schedule_interval': ([{
+                         'interval': (str, 'Schedule interval'),
+                         'start_time': (str, 'Start time (optional)')
+                     }], 'Schedule intervals')
+                 }]})
+    def snapshot_schedule_list(self, pool_name: str, group_name: str,
+                               namespace: Optional[str] = None):
+        """List all snapshot schedules for the specified mirror group."""
+        try:
+            raw = RbdMirroringService.group_snapshot_schedule_list(
+                pool_name, namespace, group_name
+            )
+            if not raw or len(raw) < 2 or not raw[1]:
+                return []
+            raw_dict = json.loads(raw[1])
+            return RbdMirroringService.transform_schedule_list(raw_dict)
+        except Exception as e:
+            logger.exception("Failed to list group snapshot schedules")
+            raise DashboardException(
+                msg=f'Failed to list group snapshot schedules: {str(e)}',
+                http_status_code=500,
+                component='rbd_mirror_group'
+            )
+
+    @Endpoint(method='GET', path='{group_name}/snapshot/schedule/status')
+    @ReadPermission
+    @handle_rbd_error()
+    @handle_rados_error('pool')
+    @EndpointDoc("Get snapshot schedule status for a mirror group",
+                 parameters={
+                     'pool_name': (str, 'Pool name'),
+                     'group_name': (str, 'Group name'),
+                     'namespace': (str, 'Namespace (optional)')
+                 },
+                 responses={200: [{
+                     'schedule_time': (str, 'Next scheduled snapshot time'),
+                     'spec': (str, 'Group level spec (pool/group or pool/namespace/group)')
+                 }]})
+    def snapshot_schedule_status(self, pool_name: str, group_name: str,
+                                 namespace: Optional[str] = None):
+        """Get snapshot schedule status for the specified mirror group.
+
+        Unwraps the 'scheduled_groups' wrapper to return an array directly,
+        matching 'rbd mirror group snapshot schedule status'.
+        """
+        try:
+            raw = RbdMirroringService.group_snapshot_schedule_status(
+                pool_name, namespace, group_name
+            )
+            # raw is (rc, json_string, stderr) — unwrap to parsed JSON
+            if not raw or len(raw) < 2 or not raw[1]:
+                return []
+            parsed = json.loads(raw[1])
+            # rbd_support wraps the list in {"scheduled_groups": [...]}
+            # unwrap and rename "group" key to "spec" for consistency
+            # with the schedule list endpoint which also uses "spec"
+            return [
+                {'spec': g.get('group', ''),
+                 'schedule_time': g.get('schedule_time', '')}
+                for g in parsed.get('scheduled_groups', [])
+            ]
+        except Exception as e:
+            logger.exception("Failed to get group snapshot schedule status")
+            raise DashboardException(
+                msg=f'Failed to get group snapshot schedule status: {str(e)}',
+                http_status_code=500,
+                component='rbd_mirror_group'
+            )
+
+    @Endpoint(method='GET', path='{group_name}/snapshot/schedule/info')
+    @ReadPermission
+    @handle_rbd_error()
+    @handle_rados_error('pool')
+    @EndpointDoc("Get combined snapshot schedule info for a mirror group",
+                 parameters={
+                     'pool_name': (str, 'Pool name'),
+                     'group_name': (str, 'Group name'),
+                     'namespace': (str, 'Namespace (optional)')
+                 },
+                 responses={200: {
+                     'schedules': ([{
+                         'interval': (str, 'Schedule interval'),
+                         'start_time': (str, 'Start time (optional)')
+                     }], 'Schedules'),
+                     'status': ({
+                         'scheduled_images': ([{
+                             'image': (str, 'Image name'),
+                             'schedule': (str, 'Schedule interval')
+                         }], 'Scheduled images')
+                     }, 'Status')
+                 }})
+    def snapshot_schedule_info(self, pool_name: str, group_name: str,
+                               namespace: Optional[str] = None):
+        """Get combined snapshot schedule info (list + status) for the specified mirror group."""
+        try:
+            info = RbdMirroringService.get_group_snapshot_schedule_info(
+                pool_name, namespace, group_name
+            )
+            return info
+        except Exception as e:
+            logger.exception("Failed to get group snapshot schedule info")
+            raise DashboardException(
+                msg=f'Failed to get group snapshot schedule info: {str(e)}',
+                http_status_code=500,
+                component='rbd_mirror_group'
+            )
+
+    @Endpoint(method='POST', path='{group_name}/snapshot/schedule')
+    @UpdatePermission
+    @handle_rbd_error()
+    @handle_rados_error('pool')
+    @EndpointDoc("Add a snapshot schedule to a mirror group",
+                 parameters={
+                     'pool_name': (str, 'Pool name'),
+                     'group_name': (str, 'Group name'),
+                     'namespace': (str, 'Namespace (optional)'),
+                     'interval': (str, 'Schedule interval (e.g., 1m, 5m, 1h)'),
+                     'start_time': (str, 'Start time (optional)')
+                 },
+                 responses={201: None})
+    @allow_empty_body
+    def snapshot_schedule_add(self, pool_name: str, group_name: str, interval: str,
+                              namespace: Optional[str] = None, start_time: Optional[str] = None):
+        """Add a snapshot schedule to the specified mirror group."""
+        try:
+            RbdMirroringService.group_snapshot_schedule_add(
+                pool_name, namespace, group_name, interval, start_time
+            )
+            return None
+        except Exception as e:
+            logger.exception("Failed to add group snapshot schedule")
+            raise DashboardException(
+                msg=f'Failed to add group snapshot schedule: {str(e)}',
+                http_status_code=500,
+                component='rbd_mirror_group'
+            )
+
+    @Endpoint(method='DELETE', path='{group_name}/snapshot/schedule/{interval}')
+    @UpdatePermission
+    @handle_rbd_error()
+    @handle_rados_error('pool')
+    @EndpointDoc("Remove a snapshot schedule from a mirror group",
+                 parameters={
+                     'pool_name': (str, 'Pool name'),
+                     'group_name': (str, 'Group name'),
+                     'interval': (str, 'Schedule interval to remove'),
+                     'namespace': (str, 'Namespace (optional)'),
+                     'start_time': (str, 'Start time (optional)')
+                 },
+                 responses={204: None})
+    def snapshot_schedule_remove(self, pool_name: str, group_name: str, interval: str,
+                                 namespace: Optional[str] = None,
+                                 start_time: Optional[str] = None):
+        """Remove a snapshot schedule from the specified mirror group."""
+        try:
+            RbdMirroringService.group_snapshot_schedule_remove(
+                pool_name, namespace, group_name, interval, start_time
+            )
+            return None
+        except Exception as e:
+            logger.exception("Failed to remove group snapshot schedule")
+            raise DashboardException(
+                msg=f'Failed to remove group snapshot schedule: {str(e)}',
+                http_status_code=500,
+                component='rbd_mirror_group'
+            )
 
 # Made with Bob

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -1262,7 +1262,8 @@ paths:
       tags:
       - RbdMirrorGroup
     get:
-      description: Get mirror group information.
+      description: Get mirror group information.  Matches 'rbd group info --format
+        json'.
       parameters:
       - description: Pool name
         in: path
@@ -1288,23 +1289,37 @@ paths:
             application/vnd.ceph.api.v1.0+json:
               schema:
                 properties:
-                  global_id:
-                    description: Global ID
+                  group_id:
+                    description: Group ID
                     type: string
-                  mode:
-                    description: Mirror mode
+                  group_name:
+                    description: Group name
                     type: string
-                  primary:
-                    description: Is primary
-                    type: boolean
-                  state:
-                    description: Mirror state
-                    type: string
+                  mirroring:
+                    description: Mirroring info
+                    properties:
+                      global_id:
+                        description: Global ID
+                        type: string
+                      mode:
+                        description: Mirror mode
+                        type: string
+                      primary:
+                        description: Is primary
+                        type: boolean
+                      state:
+                        description: Mirror state
+                        type: string
+                    required:
+                    - state
+                    - mode
+                    - global_id
+                    - primary
+                    type: object
                 required:
-                - state
-                - mode
-                - global_id
-                - primary
+                - group_name
+                - group_id
+                - mirroring
                 type: object
           description: OK
         '400':
@@ -1595,6 +1610,334 @@ paths:
       summary: Create a mirror group snapshot
       tags:
       - RbdMirrorGroup
+  /api/block/mirroring/pool/{pool_name}/group/{group_name}/snapshot/schedule:
+    get:
+      description: List all snapshot schedules for the specified mirror group.
+      parameters:
+      - description: Pool name
+        in: path
+        name: pool_name
+        required: true
+        schema:
+          type: string
+      - description: Group name
+        in: path
+        name: group_name
+        required: true
+        schema:
+          type: string
+      - allowEmptyValue: true
+        description: Namespace (optional)
+        in: query
+        name: namespace
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              schema:
+                items:
+                  properties:
+                    schedule_interval:
+                      description: Schedule intervals
+                      items:
+                        properties:
+                          interval:
+                            description: Schedule interval
+                            type: string
+                          start_time:
+                            description: Start time (optional)
+                            type: string
+                        required:
+                        - interval
+                        - start_time
+                        type: object
+                      type: array
+                    spec:
+                      description: Group level spec (pool/group or pool/namespace/group)
+                      type: string
+                  type: object
+                required:
+                - spec
+                - schedule_interval
+                type: array
+          description: OK
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: List snapshot schedules for a mirror group
+      tags:
+      - RbdMirrorGroup
+    post:
+      description: Add a snapshot schedule to the specified mirror group.
+      parameters:
+      - description: Pool name
+        in: path
+        name: pool_name
+        required: true
+        schema:
+          type: string
+      - description: Group name
+        in: path
+        name: group_name
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                interval:
+                  description: Schedule interval (e.g., 1m, 5m, 1h)
+                  type: string
+                namespace:
+                  description: Namespace (optional)
+                  type: string
+                start_time:
+                  description: Start time (optional)
+                  type: string
+              required:
+              - interval
+              type: object
+      responses:
+        '201':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              schema:
+                properties: {}
+                type: object
+          description: Resource created.
+        '202':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: Operation is still executing. Please check the task queue.
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: Add a snapshot schedule to a mirror group
+      tags:
+      - RbdMirrorGroup
+  /api/block/mirroring/pool/{pool_name}/group/{group_name}/snapshot/schedule/info:
+    get:
+      description: Get combined snapshot schedule info (list + status) for the specified
+        mirror group.
+      parameters:
+      - description: Pool name
+        in: path
+        name: pool_name
+        required: true
+        schema:
+          type: string
+      - description: Group name
+        in: path
+        name: group_name
+        required: true
+        schema:
+          type: string
+      - allowEmptyValue: true
+        description: Namespace (optional)
+        in: query
+        name: namespace
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              schema:
+                properties:
+                  schedules:
+                    description: Schedules
+                    items:
+                      properties:
+                        interval:
+                          description: Schedule interval
+                          type: string
+                        start_time:
+                          description: Start time (optional)
+                          type: string
+                      required:
+                      - interval
+                      - start_time
+                      type: object
+                    type: array
+                  status:
+                    description: Status
+                    properties:
+                      scheduled_images:
+                        description: Scheduled images
+                        items:
+                          properties:
+                            image:
+                              description: Image name
+                              type: string
+                            schedule:
+                              description: Schedule interval
+                              type: string
+                          required:
+                          - image
+                          - schedule
+                          type: object
+                        type: array
+                    required:
+                    - scheduled_images
+                    type: object
+                required:
+                - schedules
+                - status
+                type: object
+          description: OK
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: Get combined snapshot schedule info for a mirror group
+      tags:
+      - RbdMirrorGroup
+  /api/block/mirroring/pool/{pool_name}/group/{group_name}/snapshot/schedule/status:
+    get:
+      description: "Get snapshot schedule status for the specified mirror group.\n\
+        \n        Unwraps the 'scheduled_groups' wrapper to return an array directly,\n\
+        \        matching 'rbd mirror group snapshot schedule status'.\n        "
+      parameters:
+      - description: Pool name
+        in: path
+        name: pool_name
+        required: true
+        schema:
+          type: string
+      - description: Group name
+        in: path
+        name: group_name
+        required: true
+        schema:
+          type: string
+      - allowEmptyValue: true
+        description: Namespace (optional)
+        in: query
+        name: namespace
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              schema:
+                items:
+                  properties:
+                    schedule_time:
+                      description: Next scheduled snapshot time
+                      type: string
+                    spec:
+                      description: Group level spec (pool/group or pool/namespace/group)
+                      type: string
+                  type: object
+                required:
+                - schedule_time
+                - spec
+                type: array
+          description: OK
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: Get snapshot schedule status for a mirror group
+      tags:
+      - RbdMirrorGroup
+  /api/block/mirroring/pool/{pool_name}/group/{group_name}/snapshot/schedule/{interval}:
+    delete:
+      description: Remove a snapshot schedule from the specified mirror group.
+      parameters:
+      - description: Pool name
+        in: path
+        name: pool_name
+        required: true
+        schema:
+          type: string
+      - description: Group name
+        in: path
+        name: group_name
+        required: true
+        schema:
+          type: string
+      - description: Schedule interval to remove
+        in: path
+        name: interval
+        required: true
+        schema:
+          type: string
+      - allowEmptyValue: true
+        description: Namespace (optional)
+        in: query
+        name: namespace
+        schema:
+          type: string
+      - allowEmptyValue: true
+        description: Start time (optional)
+        in: query
+        name: start_time
+        schema:
+          type: string
+      responses:
+        '202':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: Operation is still executing. Please check the task queue.
+        '204':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              schema:
+                properties: {}
+                type: object
+          description: Resource deleted.
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: Remove a snapshot schedule from a mirror group
+      tags:
+      - RbdMirrorGroup
   /api/block/mirroring/pool/{pool_name}/group/{group_name}/status:
     get:
       description: "\n        Get RBD mirroring status for a group.\n\n        :param\
@@ -1647,6 +1990,33 @@ paths:
                         last_update:
                           description: Last update time
                           type: string
+                        mirror_images:
+                          description: Per-image replication status
+                          items:
+                            properties:
+                              description:
+                                description: Image description
+                                type: string
+                              global_id:
+                                description: Image global ID
+                                type: string
+                              last_update:
+                                description: Last update time
+                                type: string
+                              state:
+                                description: Image state
+                                type: string
+                              up:
+                                description: Is up
+                                type: boolean
+                            required:
+                            - global_id
+                            - state
+                            - description
+                            - last_update
+                            - up
+                            type: object
+                          type: array
                         mirror_uuid:
                           description: Mirror UUID
                           type: string
@@ -1662,6 +2032,22 @@ paths:
                       - state
                       - description
                       - last_update
+                      - mirror_images
+                      type: object
+                    type: array
+                  snapshots:
+                    description: Group snapshots
+                    items:
+                      properties:
+                        name:
+                          description: Snapshot name
+                          type: string
+                        state:
+                          description: Snapshot state
+                          type: string
+                      required:
+                      - name
+                      - state
                       type: object
                     type: array
                   state:
@@ -1673,6 +2059,7 @@ paths:
                 - state
                 - description
                 - last_update
+                - snapshots
                 - peer_sites
                 type: object
           description: OK

--- a/src/pybind/mgr/dashboard/services/rbd.py
+++ b/src/pybind/mgr/dashboard/services/rbd.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=unused-argument
+# pylint: disable=unused-argument,too-many-lines
 import errno
 import json
 import math
@@ -236,6 +236,7 @@ class RbdConfiguration(object):
         """
         Removes an option by name. Will not raise an error, if the option hasn't been found.
         :type option_name str
+
         """
         def _remove(ioctx):
             try:
@@ -267,7 +268,6 @@ class RbdConfiguration(object):
 
 class RbdService(object):
     _rbd_inst = rbd.RBD()
-
     # set of image features that can be enable on existing images
     ALLOW_ENABLE_FEATURES = {"exclusive-lock", "object-map", "fast-diff", "journaling"}
 
@@ -318,11 +318,38 @@ class RbdService(object):
                 stat['mirror_mode'] = 'journal'
             elif mirror_mode == rbd.RBD_MIRROR_IMAGE_MODE_SNAPSHOT:
                 stat['mirror_mode'] = 'snapshot'
-                schedule_info = RbdMirroringService.get_snapshot_schedule_info(
-                    get_image_spec(pool_name, namespace, image_name)
-                )
-                if schedule_info:
-                    stat['schedule_info'] = schedule_info[0]
+                image_schedule_spec = get_image_spec(pool_name, namespace, image_name)
+                image_schedule_info = RbdMirroringService.get_snapshot_schedule_info(
+                    image_schedule_spec)
+
+                if image_schedule_info and len(image_schedule_info) > 0:
+                    schedule = image_schedule_info[0]
+                    schedule['inherited'] = None
+                    stat['schedule_info'] = schedule
+                else:
+                    image_schedule_time = RbdMirroringService.get_schedule_time_for_image(
+                        image_schedule_spec)
+
+                    pool_schedule_spec = f"{pool_name}/"
+                    pool_interval = RbdMirroringService.get_schedule_interval(
+                        pool_schedule_spec)
+
+                    if pool_interval:
+                        stat['schedule_info'] = {
+                            'name': pool_schedule_spec,
+                            'schedule_interval': pool_interval,
+                            'schedule_time': image_schedule_time,
+                            'inherited': 'pool'
+                        }
+                    else:
+                        cluster_interval = RbdMirroringService.get_schedule_interval('')
+                        if cluster_interval:
+                            stat['schedule_info'] = {
+                                'name': '',
+                                'schedule_interval': cluster_interval,
+                                'schedule_time': image_schedule_time,
+                                'inherited': 'cluster'
+                            }
 
             stat['name'] = image_name
 
@@ -694,6 +721,15 @@ class RbdService(object):
         rbd_inst = cls._rbd_inst
         return rbd_call(pool_name, namespace, rbd_inst.trash_move, image_name, delay)
 
+    @classmethod
+    def validate_namespace(cls, ioctx, namespace):
+        namespaces = cls._rbd_inst.namespace_list(ioctx)
+        if namespace and namespace not in namespaces:
+            raise DashboardException(
+                msg='Namespace not found',
+                code='namespace_not_found',
+                component='rbd')
+
 
 class RbdSnapshotService(object):
 
@@ -823,6 +859,153 @@ class RbdMirroringService:
             schedule_info.append(merged)
 
         return schedule_info if schedule_info else None
+
+    @classmethod
+    def get_schedule_time_for_image(cls, image_spec: str):
+        """Get the scheduled time for a specific image from schedule status."""
+        schedule_status_raw = cls.snapshot_schedule_status('')
+        try:
+            schedule_status = json.loads(
+                schedule_status_raw[1]) if schedule_status_raw and schedule_status_raw[1] else {}
+        except (json.JSONDecodeError, TypeError):
+            return None
+
+        scheduled_images = schedule_status.get("scheduled_images", [])
+        for img in scheduled_images:
+            if img.get("image") == image_spec:
+                return img.get("schedule_time")
+        return None
+
+    @classmethod
+    def get_schedule_interval(cls, schedule_spec: str):
+        """Get just the schedule interval for a given spec (pool or cluster)."""
+        schedule_list_raw = cls.snapshot_schedule_list('')
+        try:
+            schedule_list = json.loads(
+                schedule_list_raw[1]) if schedule_list_raw and schedule_list_raw[1] else {}
+        except (json.JSONDecodeError, TypeError):
+            return None
+
+        if not schedule_list:
+            return None
+
+        for _, schedule in schedule_list.items():
+            name = schedule.get("name")
+            if name and name == schedule_spec:
+                return schedule.get("schedule", [])
+        return None
+
+    @classmethod
+    def get_cluster_schedule(cls):
+        """Get cluster-level schedule with inherited flag set."""
+        cluster_schedule_info = cls.get_snapshot_schedule_info('')
+        if cluster_schedule_info and len(cluster_schedule_info) > 0:
+            schedule = cluster_schedule_info[0]
+            schedule['inherited'] = 'cluster'
+            return schedule
+        return None
+
+    @staticmethod
+    def _group_level_spec(pool_name: str, namespace: Optional[str], group_name: str) -> str:
+        """Build the level spec string for a mirror group."""
+        if namespace:
+            return f"{pool_name}/{namespace}/{group_name}"
+        return f"{pool_name}/{group_name}"
+
+    @staticmethod
+    def transform_schedule_list(raw_dict: dict) -> list:
+        """Transform the raw rbd_support schedule dict into a spec-keyed list.
+
+        rbd_support returns:
+            {"3//381cd6abab0a": {"name": "rbd_mirror/test_group",
+                                 "schedule": [{"interval": "1m", "start_time": null}]}}
+
+        We produce a spec-style array consistent with the image schedule API:
+            [{"spec": "rbd_mirror/test_group",
+              "schedule_interval": [{"interval": "1m", "start_time": ""}]}]
+        """
+        result = []
+        for _spec_id, entry in raw_dict.items():
+            spec = entry.get('name', '')  # already "pool/group" or "pool/ns/group"
+            schedule_interval = [
+                {
+                    'interval': item.get('interval', ''),
+                    'start_time': item.get('start_time') or ''  # null → ""
+                }
+                for item in entry.get('schedule', [])
+            ]
+            result.append({'spec': spec, 'schedule_interval': schedule_interval})
+        return result
+
+    @classmethod
+    def group_snapshot_schedule_add(cls, pool_name: str, namespace: Optional[str],
+                                    group_name: str, interval: str,
+                                    start_time: Optional[str] = None):
+        """Add a snapshot schedule for a mirror group."""
+        level_spec = cls._group_level_spec(pool_name, namespace, group_name)
+        _rbd_support_remote('mirror_group_snapshot_schedule_add', level_spec,
+                            str(RBDSchedulerInterval(interval)), start_time or '')
+
+    @classmethod
+    def group_snapshot_schedule_remove(cls, pool_name: str, namespace: Optional[str],
+                                       group_name: str, interval: str,
+                                       start_time: Optional[str] = None):
+        """Remove a snapshot schedule from a mirror group."""
+        level_spec = cls._group_level_spec(pool_name, namespace, group_name)
+        _rbd_support_remote('mirror_group_snapshot_schedule_remove', level_spec,
+                            interval or '', start_time or '')
+
+    @classmethod
+    def group_snapshot_schedule_list(cls, pool_name: str, namespace: Optional[str],
+                                     group_name: str):
+        """List snapshot schedules for a mirror group.
+
+        Returns:
+            Tuple of (rc, json_string, stderr) from rbd_support.
+        """
+        level_spec = cls._group_level_spec(pool_name, namespace, group_name)
+        return _rbd_support_remote('mirror_group_snapshot_schedule_list', level_spec)
+
+    @classmethod
+    def group_snapshot_schedule_status(cls, pool_name: str, namespace: Optional[str],
+                                       group_name: str):
+        """Get status of snapshot schedules for a mirror group.
+
+        Returns:
+            Tuple of (rc, json_string, stderr) from rbd_support.
+        """
+        level_spec = cls._group_level_spec(pool_name, namespace, group_name)
+        return _rbd_support_remote('mirror_group_snapshot_schedule_status', level_spec)
+
+    @classmethod
+    def get_group_snapshot_schedule_info(cls, pool_name: str, namespace: Optional[str],
+                                         group_name: str):
+        """Retrieve group snapshot schedule info by merging schedule list and status.
+
+        Returns:
+            Dict with 'schedules' (human-readable array) and 'status' (array) keys.
+        """
+        schedule_list_raw = cls.group_snapshot_schedule_list(pool_name, namespace, group_name)
+        schedule_status_raw = cls.group_snapshot_schedule_status(pool_name, namespace, group_name)
+
+        try:
+            raw_list = json.loads(
+                schedule_list_raw[1]) if schedule_list_raw and schedule_list_raw[1] else {}
+            schedule_list = cls.transform_schedule_list(raw_list)
+            raw_status = json.loads(
+                schedule_status_raw[1]) if schedule_status_raw and schedule_status_raw[1] else {}
+            schedule_status = [
+                {'spec': g.get('group', ''),
+                 'schedule_time': g.get('schedule_time', '')}
+                for g in raw_status.get('scheduled_groups', [])
+            ]
+        except (json.JSONDecodeError, TypeError):
+            return {'schedules': [], 'status': []}
+
+        return {
+            'schedules': schedule_list,
+            'status': schedule_status
+        }
 
 
 class RbdImageMetadataService(object):


### PR DESCRIPTION
## Summary

Adds 5 snapshot schedule REST API endpoints to the existing `RbdMirrorGroup` controller, along with the service methods that back them. Also fixes the response shapes of two pre-existing endpoints to match CLI output.

**Tracker:** https://tracker.ceph.com/issues/77561

---

## What This PR Changes

### 1. New snapshot schedule endpoints (5 added)

Added to the existing `RbdMirrorGroup` controller under `/api/block/mirroring/pool/{pool_name}/group/{group_name}`:

| Method | Path | Description |
|--------|------|-------------|
| POST | `/{group}/snapshot/schedule` | Add a snapshot schedule (interval, optional start_time) |
| DELETE | `/{group}/snapshot/schedule/{interval}` | Remove a schedule by interval |
| GET | `/{group}/snapshot/schedule/list` | List all configured schedules |
| GET | `/{group}/snapshot/schedule/status` | Get next scheduled snapshot time |
| GET | `/{group}/snapshot/schedule/info` | Merged schedule list + status |

### 2. New service methods (`services/rbd.py` — `RbdMirroringService`)

Added to support the schedule endpoints, all calling `rbd_support` via `_rbd_support_remote()`:

- `group_snapshot_schedule_add()`
- `group_snapshot_schedule_remove()`
- `group_snapshot_schedule_list()`
- `group_snapshot_schedule_status()`
- `get_group_snapshot_schedule_info()`
- `validate_namespace()`
- `get_schedule_time_for_image()`
- `get_schedule_interval()`
- `get_cluster_schedule()`

### 3. Fixes to pre-existing endpoints

**`GET /{group}`** — response restructured to match `rbd group info --format json`:
```
Before: { "state", "mode", "global_id", "primary" }
After:  { "group_name", "group_id", "mirroring": { "state", "mode", "global_id", "primary" } }
```

**`GET /{group}/status`** — response now includes:
- `snapshots[]` from `group.list_snaps()`, matching `rbd mirror group status --format json`
- `peer_sites[].state` mapped from `MIRROR_IMAGE_STATUS_STATE_*` int constants (was raw integer string)
- `peer_sites[].site_name` resolved from `mirror_peer_list()` by mirror UUID (was empty string)
- `peer_sites[].mirror_images[]` with per-image replication state and description
- Top-level `state` derived from site_statuses (was hardcoded `"unknown"`)

> Note: The other 6 mirror group management endpoints (enable, disable, promote, demote, resync, snapshot) were pre-existing in the base branch and are not modified by this PR.

---

## Testing

Tested on Ceph v9.9.1-19278 / 20.2.1-294.el9cp:
- **ceph-4a** (9.85.249.81) — primary, tx-only
- **ceph-4d** — secondary, rx-only
- Pool: `rbd_mirror`, Group: `test_group`, Images: `image1`, `image2`

See PR comment for full API test output with CLI verification.

---

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>