### PR TITLE
os/bluestore: Skip unconfigured allocators in free-score

### DIFF
--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -234,9 +234,11 @@ void super_dump(
   delete fs;
 }
 
-void inferring_bluefs_devices(vector<string>& devs, std::string& path)
+void inferring_bluefs_devices(vector<string>& devs, std::string& path, bool verbose = true)
 {
-  cout << "inferring bluefs devices from bluestore path" << std::endl;
+  if (verbose) {
+    cout << "inferring bluefs devices from bluestore path" << std::endl;
+  }
   for (auto fn : {"block", "block.wal", "block.db"}) {
     string p = path + "/" + fn;
     struct stat st;
@@ -1273,8 +1275,24 @@ int main(int argc, char **argv)
       cerr << "error from cold_open: " << cpp_strerror(r) << std::endl;
       exit(EXIT_FAILURE);
     }
+    
+    // Device inference is sufficient here, as
+    // cold_open() has already initialized the allocators.
+    vector<string> present_devs;
+    inferring_bluefs_devices(present_devs, path, false);
+    auto device_present = [&](const string& alloc_name) {
+      string suffix = (alloc_name == "bluefs-wal") ? "block.wal" :
+                      (alloc_name == "bluefs-db")  ? "block.db"  : "block";
+      return std::any_of(present_devs.begin(), present_devs.end(),
+                         [&](const string& dev) {
+                           return dev.ends_with(suffix);
+                         });
+    };
 
     for (auto alloc_name : allocs_name) {
+      if (!device_present(alloc_name)) {
+        continue;
+      }	    
       ceph::bufferlist in, out;
       ostringstream err;
       int r = admin_socket->execute_command(


### PR DESCRIPTION
The free-score command queries all BlueFS allocators (block, bluefs-db, and bluefs-wal) even when some devices are not configured for an OSD, resulting in unnecessary query failures. Use inferring_bluefs_devices() to detect the BlueFS devices present under the OSD path and query only their corresponding allocators, so fragmentation scores are reported only for configured devices without unnecessary error messages.

Fixes: https://tracker.ceph.com/issues/77462

**Test results:**
**Test Case 1: OSD deployed with only Data device**
```
[root@manya-test-0 /]# ceph-bluestore-tool free-score --path /var/lib/ceph/8775816c-8745-11f1-80a5-525400863160/osd.0
block:
{
    "fragmentation_score": 2.4795592183013068e-05
}

```

**Test Case 2: OSD deployed with Data + DB  devices**
```
[root@manya-test-0 /]# ceph-bluestore-tool free-score --path /var/lib/ceph/8775816c-8745-11f1-80a5-525400863160/osd.1
block:
{
    "fragmentation_score": 2.2194734544009199e-06
}

bluefs-db:
{
    "fragmentation_score": 9.3238755176527598e-05
}

```

**Test Case 3: OSD deployed with Data + DB + WAL devices**

```
[root@manya-test-0 /]# ceph-bluestore-tool free-score --path /var/lib/ceph/8775816c-8745-11f1-80a5-525400863160/osd.2
block:
{
    "fragmentation_score": 1.2330414354017335e-06
}

bluefs-db:
{
    "fragmentation_score": 9.3171943483155473e-05
}

bluefs-wal:
{
    "fragmentation_score": 0
}

```
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
