### PR TITLE
mgr/dashboard: Disable multisite Action dropdown for read-only user

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-details/rgw-multisite-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-details/rgw-multisite-details.component.html
@@ -53,6 +53,7 @@
       dropDownOnly="Actions"
       [dropDownOnlyBtnColor]="'tertiary'"
       [dropDownOnlyOffset]="{ x: 45, y: 0 }"
+      [disabled]="disableActions"
     >
     </cd-table-actions>
   </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-details/rgw-multisite-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-details/rgw-multisite-details.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 
 import { SharedModule } from '~/app/shared/shared.module';
 
@@ -10,6 +11,11 @@ import { configureTestBed } from '~/testing/unit-test-helper';
 import { NgbNavModule, NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 import { RgwMultisiteRealmFormComponent } from '../rgw-multisite-realm-form/rgw-multisite-realm-form.component';
+import { TableActionsComponent } from '~/app/shared/datatable/table-actions/table-actions.component';
+import { Icons } from '~/app/shared/enum/icons.enum';
+import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
+import { Permission, Permissions } from '~/app/shared/models/permissions';
+import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 
 describe('RgwMultisiteDetailsComponent', () => {
   let component: RgwMultisiteDetailsComponent;
@@ -54,6 +60,96 @@ describe('RgwMultisiteDetailsComponent', () => {
       info: entity,
       defaultsInfo: component.defaultsInfo,
       multisiteInfo: component.multisiteInfo
+    });
+  });
+
+  describe('disableActions', () => {
+    it('should return true when rgw.create is false', () => {
+      component.permissions = new Permissions({ rgw: ['read'] });
+      expect(component.disableActions).toBe(true);
+    });
+
+    it('should return false when rgw.create is true', () => {
+      component.permissions = new Permissions({ rgw: ['read', 'create'] });
+      expect(component.disableActions).toBe(false);
+    });
+  });
+
+  describe('multisite create table actions', () => {
+    const createFixture = (rgwPermissions: string[]) => {
+      spyOn(TestBed.inject(AuthStorageService), 'getPermissions').and.returnValue(
+        new Permissions({ rgw: rgwPermissions, 'config-opt': ['read'] })
+      );
+      const testFixture = TestBed.createComponent(RgwMultisiteDetailsComponent);
+      testFixture.detectChanges();
+      return testFixture;
+    };
+
+    const getMultisiteTableActions = (
+      testFixture: ComponentFixture<RgwMultisiteDetailsComponent>
+    ): TableActionsComponent =>
+      testFixture.debugElement.query(By.css('cd-table-actions.multisite-actions'))
+        .componentInstance;
+
+    it('should pass disabled=true to TableActionsComponent when rgw.create is false', () => {
+      const testFixture = createFixture(['read']);
+      const tableActions = getMultisiteTableActions(testFixture);
+      const button = testFixture.debugElement.query(
+        By.css('cd-table-actions.multisite-actions button.cds--btn--tertiary')
+      );
+
+      expect(testFixture.componentInstance.disableActions).toBe(true);
+      expect(tableActions.disabled).toBe(true);
+      expect(button.nativeElement.disabled).toBe(true);
+    });
+
+    it('should pass disabled=false to TableActionsComponent when rgw.create is true', () => {
+      const testFixture = createFixture(['read', 'create']);
+      const tableActions = getMultisiteTableActions(testFixture);
+      const button = testFixture.debugElement.query(
+        By.css('cd-table-actions.multisite-actions button.cds--btn--tertiary')
+      );
+
+      expect(testFixture.componentInstance.disableActions).toBe(false);
+      expect(tableActions.disabled).toBe(false);
+      expect(button.nativeElement.disabled).toBe(false);
+    });
+  });
+
+  describe('TableActionsComponent disabled input', () => {
+    const createTableActionsFixture = (disabled: boolean) => {
+      const tableActionsFixture = TestBed.createComponent(TableActionsComponent);
+      const tableActionsComponent = tableActionsFixture.componentInstance;
+      tableActionsComponent.permission = new Permission(['create']);
+      tableActionsComponent.dropDownOnly = 'Actions';
+      tableActionsComponent.dropDownOnlyBtnColor = 'tertiary';
+      tableActionsComponent.tableActions = [
+        { permission: 'create', icon: Icons.add, name: 'Create Realm', click: () => undefined }
+      ];
+      tableActionsComponent.selection = new CdTableSelection();
+      tableActionsComponent.disabled = disabled;
+      tableActionsFixture.detectChanges();
+      return tableActionsFixture;
+    };
+
+    const getDropdownTriggerButton = (
+      tableActionsFixture: ComponentFixture<TableActionsComponent>
+    ) => tableActionsFixture.debugElement.query(By.css('button.cds--btn--tertiary'));
+
+    it('should disable the trigger button when disabled is true', () => {
+      const tableActionsFixture = createTableActionsFixture(true);
+      const button = getDropdownTriggerButton(tableActionsFixture);
+
+      expect(tableActionsFixture.componentInstance.disabled).toBe(true);
+      expect(button.nativeElement.disabled).toBe(true);
+    });
+
+    it('should enable the trigger button when disabled is false', () => {
+      const tableActionsFixture = createTableActionsFixture(false);
+      const button = getDropdownTriggerButton(tableActionsFixture);
+
+      expect(tableActionsFixture.componentInstance.disabled).toBe(false);
+      expect(button.nativeElement.disabled).toBe(false);
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-details/rgw-multisite-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-details/rgw-multisite-details.component.ts
@@ -125,6 +125,10 @@ export class RgwMultisiteDetailsComponent extends CdForm implements OnDestroy, O
   MODULE_NAME = 'rgw';
   NAVIGATE_TO = '/rgw/multisite';
 
+  get disableActions(): boolean {
+    return !this.permissions?.rgw?.create;
+  }
+
   constructor(
     private modalService: ModalService,
     private timerService: TimerService,

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-actions/table-actions.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-actions/table-actions.component.html
@@ -94,6 +94,7 @@
   <button
     [cdsButton]="dropDownOnlyBtnColor"
     type="button"
+    [disabled]="disabled"
   >
     <span i18n>{{ dropDownOnly }}</span>
     <svg

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-actions/table-actions.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-actions/table-actions.component.ts
@@ -31,6 +31,8 @@ export class TableActionsComponent implements OnChanges, OnInit {
   dropDownOnly?: string;
   @Input()
   primaryDropDown = false;
+  @Input()
+  disabled: boolean = false;
 
   currentAction?: CdTableAction;
   // Array with all visible actions


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/77570
Signed-off-by: Devika Babrekar <devika.babrekar@ibm.com>


<img width="3840" height="1987" alt="image" src="https://github.com/user-attachments/assets/f609ac6e-e5c1-4c5b-805c-9f40e20f5114" />

How to test:
1. Create read-only user from user management page.
2. Go-to: Object -> Multi-site -> Configuration tab
3. Observe that, Actions dropdown is disabled


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
