### PR TITLE
rgw/posix: hold the avl partition lock across the recycle insert

### DIFF
--- a/qa/workunits/rgw/test_librgw_file.sh
+++ b/qa/workunits/rgw/test_librgw_file.sh
@@ -74,4 +74,10 @@ ceph_test_librgw_file_gp ${K} --delete
 echo "phase 6.1"
 ceph_test_librgw_file_rename ${K} --create
 
+# lru replacement and large (ish) directory listing
+echo "phase 7.1"
+ceph_test_librgw_file_chunksim ${K} --create --num_objs=10000 --verbose
+echo "phase 7.2"
+ceph_test_librgw_file_chunksim ${K} --num_objs=10000 --verbose
+
 exit 0

--- a/src/common/cohort_lru.h
+++ b/src/common/cohort_lru.h
@@ -154,6 +154,10 @@ namespace cohort {
 	for (int ix = 0; ix < n_lanes; ++ix, ++lane_ix) {
 	  Lane& lane = qlane[lane_ix % n_lanes];
           std::unique_lock lane_lock{lane.lock};
+	  // only evict when this lane exceeds capacity (otherwise may evict an entry that is still in use)
+	  if (lane.q.size() <= lane_hiwat) {
+	    continue;
+	  }
           if (lane.q.empty()) {
             continue;
           }

--- a/src/common/cohort_lru.h
+++ b/src/common/cohort_lru.h
@@ -220,36 +220,43 @@ namespace cohort {
 	  Lane& lane = lane_of(o);
 	  lane.lock.lock();
 	  refcnt = o->lru_refcnt.load();
-	  if (unlikely(refcnt == 0)) {
-	    Object::Queue::iterator it =
-	      Object::Queue::s_iterator_to(*o);
-	    lane.q.erase(it);
-	    tdo = o;
+          if (unlikely(refcnt == 0)) {
+	    if (o->lru_hook.is_linked()) {
+              Object::Queue::iterator it = Object::Queue::s_iterator_to(*o);
+              if (o->active.test()) {
+                lane.active.erase(it);
+	      } else {
+                lane.q.erase(it);
+	      }
+              tdo = o;
+	    } /* is-linked */
 	  }
 	  lane.lock.unlock();
 	} else if (unlikely(refcnt == SENTINEL_REFCNT)) {
 	  Lane& lane = lane_of(o);
 	  lane.lock.lock();
 	  refcnt = o->lru_refcnt.load();
-	  if (likely(refcnt == SENTINEL_REFCNT)) {
-	    /* move to MRU */
-            Object::Queue::iterator it = Object::Queue::s_iterator_to(*o);
-            auto active = o->active.test();
-            if (active) {
-              lane.active.erase(it);
-            } else {
-              lane.q.erase(it);
-            }
-            lane.q.push_front(*o);
-	    /* hiwat check */
-            if (lane.q.size() > lane_hiwat) {
-              /* discard the actual lane LRU immediately */
-              Object* o2 = &(lane.q.back());
-	      Object::Queue::iterator it = Object::Queue::s_iterator_to(*o2);
-	      lane.q.erase(it);
-	      tdo = o2;
-	    }
-	  }
+          if (likely(refcnt == SENTINEL_REFCNT)) {
+            if (o->lru_hook.is_linked()) {
+              /* move to MRU */
+              Object::Queue::iterator it = Object::Queue::s_iterator_to(*o);
+              auto active = o->active.test();
+              if (active) {
+                lane.active.erase(it);
+              } else {
+                lane.q.erase(it);
+              }
+              lane.q.push_front(*o);
+              /* hiwat check */
+              if (lane.q.size() > lane_hiwat) {
+                /* discard the actual lane LRU immediately */
+                Object *o2 = &(lane.q.back());
+                Object::Queue::iterator it = Object::Queue::s_iterator_to(*o2);
+                lane.q.erase(it);
+                tdo = o2;
+              }
+            } /* is-linked */
+          } /* sentinel-refcnt */
 	  lane.lock.unlock();
 	}
 	/* unref out-of-line && !LOCKED */

--- a/src/common/cohort_lru.h
+++ b/src/common/cohort_lru.h
@@ -250,6 +250,10 @@ namespace cohort {
               auto active = o->active.test();
               if (active) {
                 lane.active.erase(it);
+                /* object is moving to the evictable q; the flag must follow the
+                 * list, otherwise a later ref()/unref() erases it from the wrong
+                 * lane list and corrupts the constant_time_size counters */
+                o->active.clear();
               } else {
                 lane.q.erase(it);
               }

--- a/src/common/cohort_lru.h
+++ b/src/common/cohort_lru.h
@@ -167,9 +167,12 @@ namespace cohort {
 	    if (o->reclaim(newobj_fac)) {
 	      lane_lock.lock();
 	      --(o->lru_refcnt);
-	      /* assertions that o state has not changed across
-	       * relock */
-	      ceph_assert(o->lru_refcnt == SENTINEL_REFCNT);
+	      if (o->lru_refcnt != SENTINEL_REFCNT) {
+		/* concurrent ref while we were unlocked -- put it back */
+		lane.q.push_front(*o);
+		o->evicting.clear();
+		continue;
+	      }
 	      Object::Queue::iterator it =
 		Object::Queue::s_iterator_to(*o);
 	      lane.q.erase(it);
@@ -196,6 +199,9 @@ namespace cohort {
       ~LRU() { delete[] qlane; }
 
       bool ref(Object* o, uint32_t flags) {
+	if (o->evicting.test()) {
+	  return false;
+	}
 	++(o->lru_refcnt);
         if (flags & FLAG_INITIAL) {
           Lane& lane = lane_of(o);
@@ -248,19 +254,22 @@ namespace cohort {
                 lane.q.erase(it);
               }
               lane.q.push_front(*o);
-              /* hiwat check */
+              /* hiwat check -- evict LRU entry if lane is over capacity;
+               * LMDB cleanup is deferred to the next get_bucket() */
               if (lane.q.size() > lane_hiwat) {
-                /* discard the actual lane LRU immediately */
                 Object *o2 = &(lane.q.back());
-                Object::Queue::iterator it = Object::Queue::s_iterator_to(*o2);
-                lane.q.erase(it);
-                tdo = o2;
+                if (can_reclaim(o2)) {
+                  Object::Queue::iterator it2 =
+                    Object::Queue::s_iterator_to(*o2);
+                  lane.q.erase(it2);
+                  tdo = o2;
+                }
               }
             } /* is-linked */
           } /* sentinel-refcnt */
 	  lane.lock.unlock();
 	}
-	/* unref out-of-line && !LOCKED */
+	/* delete out-of-line && !LOCKED */
 	if (tdo)
 	  delete tdo;
       } /* unref */

--- a/src/common/cohort_lru.h
+++ b/src/common/cohort_lru.h
@@ -212,8 +212,9 @@ namespace cohort {
 	return true;
       } /* ref */
 
-      void
-      unref(Object* o, uint32_t flags) {
+      void unref(Object *o, uint32_t flags) {
+        uint32_t check_refcnt = o->lru_refcnt;
+	ceph_assert(check_refcnt > 0);
 	uint32_t refcnt = --(o->lru_refcnt);
 	Object* tdo = nullptr;
 	if (unlikely(refcnt == 0 /* last ref */)) {
@@ -228,8 +229,8 @@ namespace cohort {
 	      } else {
                 lane.q.erase(it);
 	      }
-              tdo = o;
-	    } /* is-linked */
+            } /* is-linked */
+	    tdo = o;
 	  }
 	  lane.lock.unlock();
 	} else if (unlikely(refcnt == SENTINEL_REFCNT)) {

--- a/src/common/cohort_lru.h
+++ b/src/common/cohort_lru.h
@@ -130,6 +130,7 @@ namespace cohort {
       int n_lanes;
       std::atomic<uint32_t> evict_lane;
       const uint32_t lane_hiwat;
+      std::atomic<bool> last_evict_recycled{false};
 
       static constexpr uint32_t SENTINEL_REFCNT = 1;
 
@@ -150,17 +151,21 @@ namespace cohort {
 
       Object* evict_block(const ObjectFactory* newobj_fac) {
 	uint32_t lane_ix = next_evict_lane();
-	for (int ix = 0; ix < n_lanes; ++ix,
-	       lane_ix = next_evict_lane()) {
-	  Lane& lane = qlane[lane_ix];
+	for (int ix = 0; ix < n_lanes; ++ix, ++lane_ix) {
+	  Lane& lane = qlane[lane_ix % n_lanes];
           std::unique_lock lane_lock{lane.lock};
-          /* back() on empty intrusive list is undefined */
           if (lane.q.empty()) {
             continue;
           }
-          Object* o = &(lane.q.back());
-	  /* if object at LRU has refcnt==1, it may be reclaimable */
-	  if (can_reclaim(o)) {
+	  /* walk from LRU (back) toward MRU looking for a reclaimable
+	   * entry — the tail entry may be mid-eviction by another thread */
+	  auto it = lane.q.end();
+	  while (it != lane.q.begin()) {
+	    --it;
+	    Object* o = &(*it);
+	    if (! can_reclaim(o)) {
+	      continue;
+	    }
 	    ++(o->lru_refcnt);
 	    (void) o->evicting.test_and_set();
 	    lane_lock.unlock();
@@ -168,22 +173,23 @@ namespace cohort {
 	      lane_lock.lock();
 	      --(o->lru_refcnt);
 	      if (o->lru_refcnt != SENTINEL_REFCNT) {
-		/* concurrent ref while we were unlocked -- put it back */
 		lane.q.push_front(*o);
 		o->evicting.clear();
-		continue;
+		break; /* try next lane */
 	      }
-	      Object::Queue::iterator it =
+	      Object::Queue::iterator eit =
 		Object::Queue::s_iterator_to(*o);
-	      lane.q.erase(it);
+	      lane.q.erase(eit);
+	      last_evict_recycled.store(true, std::memory_order_relaxed);
 	      return o;
 	    } else {
               --(o->lru_refcnt);
               o->evicting.clear();
-	      /* unlock in next block */
+	      lane_lock.lock();
 	    }
-	  } /* can_reclaim(o) */
+	  } /* each entry in lane */
 	} /* each lane */
+	last_evict_recycled.store(false, std::memory_order_relaxed);
 	return nullptr;
       } /* evict_block */
 
@@ -197,6 +203,36 @@ namespace cohort {
 	  }
 
       ~LRU() { delete[] qlane; }
+
+#ifndef NDEBUG
+      bool get_last_evict_recycled() const {
+	return last_evict_recycled.load(std::memory_order_relaxed);
+      }
+
+      uint64_t get_size() const {
+	uint64_t total = 0;
+	for (int i = 0; i < n_lanes; ++i) {
+	  total += qlane[i].q.size() + qlane[i].active.size();
+	}
+	return total;
+      }
+
+      uint64_t get_q_size() const {
+	uint64_t total = 0;
+	for (int i = 0; i < n_lanes; ++i) {
+	  total += qlane[i].q.size();
+	}
+	return total;
+      }
+
+      uint64_t get_active_size() const {
+	uint64_t total = 0;
+	for (int i = 0; i < n_lanes; ++i) {
+	  total += qlane[i].active.size();
+	}
+	return total;
+      }
+#endif
 
       bool ref(Object* o, uint32_t flags) {
 	if (o->evicting.test()) {
@@ -466,6 +502,12 @@ namespace cohort {
       bool is_same_partition(uint64_t lhs, uint64_t rhs) {
         return ((lhs % n_part) == (rhs % n_part));
       }
+      void lock_for(uint64_t hk) {
+	partition_of_scalar(hk).lock.lock();
+      }
+      void unlock_for(uint64_t hk) {
+	partition_of_scalar(hk).lock.unlock();
+      }
       void insert_latched(T* v, Latch& lat, uint32_t flags) {
 	(void) lat.p->tr.insert_unique_commit(*v, lat.commit_data);
 	if (flags & FLAG_UNLOCK)
@@ -483,9 +525,9 @@ namespace cohort {
 
       void remove(uint64_t hk, T* v, uint32_t flags) {
 	Partition& p = partition_of_scalar(hk);
-	iterator it = TTree::s_iterator_to(*v);
 	if (flags & FLAG_LOCK)
 	  p.lock.lock();
+	iterator it = TTree::s_iterator_to(*v);
 	p.tr.erase(it);
 	if (csz) { /* template specialize? */
 	  uint32_t slot = hk % csz;

--- a/src/common/cohort_lru.h
+++ b/src/common/cohort_lru.h
@@ -154,8 +154,10 @@ namespace cohort {
 	for (int ix = 0; ix < n_lanes; ++ix, ++lane_ix) {
 	  Lane& lane = qlane[lane_ix % n_lanes];
           std::unique_lock lane_lock{lane.lock};
-	  // only evict when this lane exceeds capacity (otherwise may evict an entry that is still in use)
-	  if (lane.q.size() <= lane_hiwat) {
+	  // evict_block() runs before the pending insert adds its entry, so a
+	  // lane already at lane_hiwat needs an eviction to stay in bounds;
+	  // only skip when there's genuinely free room without evicting.
+	  if (lane.q.size() < lane_hiwat) {
 	    continue;
 	  }
           if (lane.q.empty()) {

--- a/src/rgw/driver/posix/bucket_cache.h
+++ b/src/rgw/driver/posix/bucket_cache.h
@@ -167,6 +167,7 @@ public:
 
 	flags |= FLAG_DELETED;
 	bc->recycle_count++;
+	lsubdout(bc->driver->ctx(), rgw, 21) << "BucketCache: reclaim evicting bucket=" << name << dendl;
 	bc->un->remove_watch(name);
 	env.reset();
 
@@ -535,6 +536,8 @@ public:
       unique_lock ulk{b->mtx, std::adopt_lock};
       if (! (b->flags & BucketCacheEntry<D, B>::FLAG_FILLED)) {
 	/* bulk load into lmdb cache */
+	ldpp_dout(dpp, 21) << "BucketCache: filling bucket=" << sal_bucket->get_name()
+	  << (flags & BucketCache<D, B>::FLAG_CREATE ? " (new entry)" : " (refill)") << dendl;
 	rc = fill(dpp, b, sal_bucket, FLAG_NONE, y);
       }
       /* display them */
@@ -662,6 +665,8 @@ public:
 	[[unlikely]] case EventType::INVALIDATE:
 	{
 	  /* yikes, cache blown */
+	  lsubdout(driver->ctx(), rgw, 21) << "BucketCache: notify INVALIDATE (inotify overflow)"
+	    << " bucket=" << b->name << dendl;
 	  ulk.lock();
 	  mdb_drop(*txn, b->dbi, 0);
 	  txn->commit();
@@ -742,6 +747,8 @@ public:
     if (b) {
       auto unref_guard = make_scope_guard([this, b]{ lru.unref(b, cohort::lru::FLAG_NONE); });
       unique_lock ulk{b->mtx, std::adopt_lock};
+
+      ldpp_dout(dpp, 21) << "BucketCache: invalidate bucket=" << bname << dendl;
 
       auto txn = b->env->getRWTransaction();
       mdb_drop(*txn, b->dbi, 0);

--- a/src/rgw/driver/posix/bucket_cache.h
+++ b/src/rgw/driver/posix/bucket_cache.h
@@ -14,6 +14,7 @@
 #include <shared_mutex>
 #include <condition_variable>
 #include <filesystem>
+#include <boost/container/flat_map.hpp>
 #include <boost/intrusive/avl_set.hpp>
 #include "include/function2.hpp"
 #include "common/cohort_lru.h"
@@ -77,13 +78,8 @@ public:
 
   virtual ~BucketCacheEntry()
   {
-    /* XXX depends on safe_link -- but I think on balance, built-in safe_link
-     * is preferable to a custom mechanism with likely the same cost */
     if (name_hook.is_linked()) {
       bc->cache.remove(hk, this, bucket_avl_cache::FLAG_LOCK);
-    }
-    if (env) {
-      mdb_dbi_close(*env, dbi);
     }
   }
 
@@ -180,9 +176,6 @@ public:
 	  bc->cache.remove(hk, this, bucket_avl_cache::FLAG_LOCK);
 	}
 
-	/* close the database handle; stale data (if any) is dropped
-	 * by fill() when the bucket name is next accessed */
-	mdb_dbi_close(*env, dbi);
 	env.reset();
       } /* ! deleted */
     }
@@ -222,20 +215,26 @@ struct BucketCache : public Notifiable
    * environments, selected by a hash of the bucket name; a bucket's database
    * is dropped/cleared whenever its entry is reclaimed from cache; the entire
    * complex is cleared on restart to preserve consistency */
+  static constexpr MDB_dbi lmdb_max_dbs = 4096;
+
   class Lmdbs
   {
     std::string database_root;
     uint8_t lmdb_count;
-    std::vector<std::shared_ptr<LMDBSafe::MDBEnv>> envs;
+
+    struct Partition {
+      std::shared_ptr<LMDBSafe::MDBEnv> env;
+      boost::container::flat_map<std::string, LMDBSafe::MDBDbi> dbi_map;
+      std::mutex mtx;
+    };
+    std::vector<Partition> parts;
     sf::path dbp;
 
   public:
     Lmdbs(std::string& database_root, uint8_t lmdb_count)
       : database_root(database_root), lmdb_count(lmdb_count),
-        dbp(database_root) {
+        parts(lmdb_count), dbp(database_root) {
 
-      /* create a root for lmdb directory partitions (if it doesn't
-       * exist already) */
       sf::path safe_root_path{dbp / fmt::format("rgw_posix_lmdbs")};
       sf::create_directory(safe_root_path);
 
@@ -248,17 +247,72 @@ struct BucketCache : public Notifiable
       for (int ix = 0; ix < lmdb_count; ++ix) {
 	sf::path env_path{safe_root_path / fmt::format("part_{}", ix)};
 	sf::create_directory(env_path);
-	auto env = LMDBSafe::getMDBEnv(env_path.string().c_str(), 0 /* flags? */, 0600);
-	envs.push_back(env);
+	parts[ix].env = LMDBSafe::getMDBEnv(
+	  env_path.string().c_str(), 0, 0600, lmdb_max_dbs);
       }
     }
 
+    uint8_t partition_ix(BucketCacheEntry<D, B>* bucket) {
+      return bucket->hk % lmdb_count;
+    }
+
     inline std::shared_ptr<LMDBSafe::MDBEnv>& get_sp_env(BucketCacheEntry<D, B>* bucket)  {
-      return envs[(bucket->hk % lmdb_count)];
+      return parts[partition_ix(bucket)].env;
     }
 
     inline LMDBSafe::MDBEnv& get_env(BucketCacheEntry<D, B>* bucket) {
       return *(get_sp_env(bucket));
+    }
+
+    /* look up or create a dbi for the given bucket name in its
+     * partition; if all dbi slots are exhausted, evict the LRU
+     * entry from the dbi map via mdb_drop(del=1) */
+    std::optional<LMDBSafe::MDBDbi> get_dbi(
+      BucketCacheEntry<D, B>* bucket,
+      std::function<LMDBSafe::MDBDbi()> open_fn)
+    {
+      auto& part = parts[partition_ix(bucket)];
+      std::lock_guard lk(part.mtx);
+
+      auto it = part.dbi_map.find(bucket->name);
+      if (it != part.dbi_map.end()) {
+        return it->second;
+      }
+
+      try {
+        auto dbi = open_fn();
+        part.dbi_map.emplace(bucket->name, dbi);
+        return dbi;
+      } catch (const LMDBSafe::LMDBError&) {
+        /* MDB_DBS_FULL — evict the oldest entry to free a slot */
+        if (part.dbi_map.empty()) {
+          return std::nullopt;
+        }
+        auto victim = part.dbi_map.begin();
+        try {
+          auto txn = part.env->getRWTransaction();
+          txn->drop(victim->second);
+          txn->commit();
+        } catch (const LMDBSafe::LMDBError&) {
+          return std::nullopt;
+        }
+        part.dbi_map.erase(victim);
+
+        try {
+          auto dbi = open_fn();
+          part.dbi_map.emplace(bucket->name, dbi);
+          return dbi;
+        } catch (const LMDBSafe::LMDBError&) {
+          return std::nullopt;
+        }
+      }
+    }
+
+    /* remove a dbi from the map (called when a bucket is deleted) */
+    void remove_dbi(BucketCacheEntry<D, B>* bucket) {
+      auto& part = parts[partition_ix(bucket)];
+      std::lock_guard lk(part.mtx);
+      part.dbi_map.erase(bucket->name);
     }
 
     const std::string& get_root() const { return database_root; }
@@ -362,16 +416,17 @@ public:
 	  /* attach bucket to an lmdb partition and prepare it for i/o */
 	  auto& env = lmdbs.get_sp_env(b);
 	  auto cmp = B::lmdb_cmp();
-	  try {
-	    auto dbi = cmp
+	  auto dbi_opt = lmdbs.get_dbi(b, [&]() {
+	    return cmp
 	      ? env->openDB(b->name, MDB_CREATE, cmp)
 	      : env->openDB(b->name, MDB_CREATE);
-	    b->set_env(env, dbi);
-	  } catch (const LMDBSafe::LMDBError& e) {
+	  });
+	  if (!dbi_opt) {
 	    b->mtx.unlock();
 	    lat.lock->unlock();
 	    return result;
 	  }
+	  b->set_env(env, *dbi_opt);
 
 	  if (! (iflags & cohort::lru::FLAG_RECYCLE)) [[likely]] {
 	    /* inserts at cached insert iterator, releasing latch */

--- a/src/rgw/driver/posix/bucket_cache.h
+++ b/src/rgw/driver/posix/bucket_cache.h
@@ -215,12 +215,11 @@ struct BucketCache : public Notifiable
    * environments, selected by a hash of the bucket name; a bucket's database
    * is dropped/cleared whenever its entry is reclaimed from cache; the entire
    * complex is cleared on restart to preserve consistency */
-  static constexpr MDB_dbi lmdb_max_dbs = 4096;
-
   class Lmdbs
   {
     std::string database_root;
     uint8_t lmdb_count;
+    MDB_dbi max_dbs_per_partition;
 
     struct Partition {
       std::shared_ptr<LMDBSafe::MDBEnv> env;
@@ -231,8 +230,10 @@ struct BucketCache : public Notifiable
     sf::path dbp;
 
   public:
-    Lmdbs(std::string& database_root, uint8_t lmdb_count)
+    Lmdbs(std::string& database_root, uint8_t lmdb_count,
+	  uint32_t max_buckets)
       : database_root(database_root), lmdb_count(lmdb_count),
+        max_dbs_per_partition((max_buckets / lmdb_count) * 5 / 4 + 16),
         parts(lmdb_count), dbp(database_root) {
 
       sf::path safe_root_path{dbp / fmt::format("rgw_posix_lmdbs")};
@@ -248,7 +249,7 @@ struct BucketCache : public Notifiable
 	sf::path env_path{safe_root_path / fmt::format("part_{}", ix)};
 	sf::create_directory(env_path);
 	parts[ix].env = LMDBSafe::getMDBEnv(
-	  env_path.string().c_str(), 0, 0600, lmdb_max_dbs);
+	  env_path.string().c_str(), 0, 0600, max_dbs_per_partition);
       }
     }
 
@@ -328,7 +329,7 @@ public:
       lru(max_lanes, max_buckets/max_lanes),
       cache(max_lanes, max_buckets/max_partitions),
       rp(bucket_root),
-      lmdbs(database_root, lmdb_count),
+      lmdbs(database_root, lmdb_count, max_buckets),
       un(Notify::factory(this, bucket_root))
     {
       if (! (sf::exists(rp) && sf::is_directory(rp))) {

--- a/src/rgw/driver/posix/bucket_cache.h
+++ b/src/rgw/driver/posix/bucket_cache.h
@@ -151,33 +151,37 @@ public:
     if (factory == nullptr) {
         return false;
     }
-    { /* anon block */
-      /* in this case, we are being called from a context which holds
-       * A partition lock, and this may be still in use */
+
+    /* Two locks are involved: this entry's mtx and the TreeX partition
+     * lock.  get_bucket() acquires them partition→mtx; reclaim must not
+     * do mtx→partition or we deadlock.  So we mark the entry deleted
+     * under mtx (short critical section), release mtx, then do the
+     * cross-partition tree remove outside. */
+    bool need_cross_remove = false;
+    {
       auto lock = lock_guard{mtx};
       if (! deleted()) {
-	flags |= FLAG_DELETED;
-	bc->recycle_count++;
-
-	//std::cout << fmt::format("reclaim {}!", name) << std::endl;
-	bc->un->remove_watch(name);
-
-	// XXX depends on safe_link
 	if (! name_hook.is_linked()) {
-	  // this should not happen!
 	  abort();
 	}
 
-	/* remove from AVL tree; if the evicted entry is in the same
-	 * partition as the incoming insert, the latch is already held */
+	flags |= FLAG_DELETED;
+	bc->recycle_count++;
+	bc->un->remove_watch(name);
+	env.reset();
+
 	if (bc->cache.is_same_partition(hk, factory->hk)) {
 	  bc->cache.remove(hk, this, bucket_avl_cache::FLAG_NONE);
 	} else {
-	  bc->cache.remove(hk, this, bucket_avl_cache::FLAG_LOCK);
+	  need_cross_remove = true;
 	}
+      }
+    } /* mtx released */
 
-	env.reset();
-      } /* ! deleted */
+    if (need_cross_remove) {
+      bc->cache.unlock_for(factory->hk);
+      bc->cache.remove(hk, this, bucket_avl_cache::FLAG_LOCK);
+      bc->cache.lock_for(factory->hk);
     }
     return true;
 } /* reclaim */
@@ -412,6 +416,18 @@ public:
 	b = static_cast<BucketCacheEntry<D, B>*>(
 	  lru.insert(&fac, cohort::lru::Edge::MRU, iflags));
 	if (b) [[likely]] {
+#ifndef NDEBUG
+	  /* total = q + active;
+	   * q holds idle entries eligible for eviction,
+	   * active holds entries with an outstanding ref (in-flight request).
+	   * A stable total with "recycled" entries means the LRU is healthy. */
+	  ldpp_dout(dpp, 21) << "BucketCache: "
+	    << (iflags & cohort::lru::FLAG_RECYCLE ? "recycled" : "allocated new")
+	    << " entry, LRU total=" << lru.get_size()
+	    << " (q=" << lru.get_q_size()
+	    << " active=" << lru.get_active_size() << ")"
+	    << ", bucket=" << name << dendl;
+#endif
 	  b->mtx.lock();
 
 	  /* attach bucket to an lmdb partition and prepare it for i/o */

--- a/src/rgw/driver/posix/bucket_cache.h
+++ b/src/rgw/driver/posix/bucket_cache.h
@@ -355,7 +355,10 @@ public:
 
 	  /* attach bucket to an lmdb partition and prepare it for i/o */
 	  auto& env = lmdbs.get_sp_env(b);
-	  auto dbi = env->openDB(b->name, MDB_CREATE);
+	  auto cmp = B::lmdb_cmp();
+	  auto dbi = cmp
+	    ? env->openDB(b->name, MDB_CREATE, cmp)
+	    : env->openDB(b->name, MDB_CREATE);
 	  b->set_env(env, dbi);
 
 	  if (! (iflags & cohort::lru::FLAG_RECYCLE)) [[likely]] {
@@ -384,8 +387,9 @@ public:
 
   static inline std::string concat_key(const rgw_obj_index_key& k) {
     std::string k_str;
-    k_str.reserve(k.name.size() + k.instance.size());
+    k_str.reserve(k.name.size() + 1 + k.instance.size());
     k_str += k.name;
+    k_str += '\0';
     k_str += k.instance;
     return k_str;
   }

--- a/src/rgw/driver/posix/bucket_cache.h
+++ b/src/rgw/driver/posix/bucket_cache.h
@@ -80,9 +80,11 @@ public:
     /* XXX depends on safe_link -- but I think on balance, built-in safe_link
      * is preferable to a custom mechanism with likely the same cost */
     if (name_hook.is_linked()) {
-      bc->cache.remove(hk, this, bucket_avl_cache::FLAG_NONE);
+      bc->cache.remove(hk, this, bucket_avl_cache::FLAG_LOCK);
     }
-    mdb_dbi_close(*env, dbi); // return db handle
+    if (env) {
+      mdb_dbi_close(*env, dbi);
+    }
   }
 
   inline bool deleted() const {
@@ -170,14 +172,18 @@ public:
 	  abort();
 	}
 
-	/* discard lmdb data associated with this bucket */
-	auto txn = env->getRWTransaction();
-	mdb_drop(*txn, dbi, 0);
-	txn->commit();
-	/* LMDB applications don't "normally" close database handles,
-	 * but doing so (atomically) is supported, and we must as
-	 * we continually recycle them */
-	mdb_dbi_close(*env, dbi); // return db handle
+	/* remove from AVL tree; if the evicted entry is in the same
+	 * partition as the incoming insert, the latch is already held */
+	if (bc->cache.is_same_partition(hk, factory->hk)) {
+	  bc->cache.remove(hk, this, bucket_avl_cache::FLAG_NONE);
+	} else {
+	  bc->cache.remove(hk, this, bucket_avl_cache::FLAG_LOCK);
+	}
+
+	/* close the database handle; stale data (if any) is dropped
+	 * by fill() when the bucket name is next accessed */
+	mdb_dbi_close(*env, dbi);
+	env.reset();
       } /* ! deleted */
     }
     return true;
@@ -356,10 +362,16 @@ public:
 	  /* attach bucket to an lmdb partition and prepare it for i/o */
 	  auto& env = lmdbs.get_sp_env(b);
 	  auto cmp = B::lmdb_cmp();
-	  auto dbi = cmp
-	    ? env->openDB(b->name, MDB_CREATE, cmp)
-	    : env->openDB(b->name, MDB_CREATE);
-	  b->set_env(env, dbi);
+	  try {
+	    auto dbi = cmp
+	      ? env->openDB(b->name, MDB_CREATE, cmp)
+	      : env->openDB(b->name, MDB_CREATE);
+	    b->set_env(env, dbi);
+	  } catch (const LMDBSafe::LMDBError& e) {
+	    b->mtx.unlock();
+	    lat.lock->unlock();
+	    return result;
+	  }
 
 	  if (! (iflags & cohort::lru::FLAG_RECYCLE)) [[likely]] {
 	    /* inserts at cached insert iterator, releasing latch */
@@ -398,6 +410,9 @@ public:
 	    B* sal_bucket, uint32_t flags, optional_yield y) /* assert: LOCKED */
   {
       auto txn = bucket->env->getRWTransaction();
+
+      /* clear stale data from a prior hiwat eviction before repopulating */
+      mdb_drop(*txn, bucket->dbi, 0);
 
       /* instruct the bucket provider to enumerate all entries,
        * in any order */

--- a/src/rgw/driver/posix/bucket_cache.h
+++ b/src/rgw/driver/posix/bucket_cache.h
@@ -433,9 +433,11 @@ public:
 	    /* inserts at cached insert iterator, releasing latch */
 	    cache.insert_latched(b, lat, BucketCacheEntry<D, B>::bucket_avl_cache::FLAG_UNLOCK);
 	  } else {
-	    /* recycle step invalidates Latch */
-	    lat.lock->unlock(); /* !LATCHED */
+	    /* recycle invalidated the cached insert position, but the latch's
+	     * partition lock still guards this partition; hold it across the
+	     * insert so we don't race concurrent tree ops, then release it */
 	    cache.insert(fac.hk, b, BucketCacheEntry<D, B>::bucket_avl_cache::FLAG_NONE);
+	    lat.lock->unlock(); /* !LATCHED */
 	  }
 	  get<1>(result) |= BucketCache<D, B>::FLAG_CREATE;
 	} else {

--- a/src/rgw/driver/posix/lmdb-safe.cc
+++ b/src/rgw/driver/posix/lmdb-safe.cc
@@ -327,6 +327,13 @@ void MDBRWTransactionImpl::clear(MDB_dbi dbi)
     }
 }
 
+void MDBRWTransactionImpl::drop(MDB_dbi dbi)
+{
+    if (const auto rc = mdb_drop(d_txn, dbi, 1)) {
+        throw LMDBError("Error dropping database: ", rc);
+    }
+}
+
 MDBRWCursor MDBRWTransactionImpl::getRWCursor(const MDBDbi &dbi)
 {
     MDB_cursor *cursor;

--- a/src/rgw/driver/posix/lmdb-safe.cc
+++ b/src/rgw/driver/posix/lmdb-safe.cc
@@ -154,6 +154,30 @@ MDBDbi MDBEnv::openDB(const string_view dbname, unsigned int flags)
     return ret;
 }
 
+MDBDbi MDBEnv::openDB(const string_view dbname, unsigned int flags, MDB_cmp_func *cmp)
+{
+    unsigned int envflags;
+    mdb_env_get_flags(d_env, &envflags);
+    std::lock_guard<std::mutex> l(d_openmut);
+
+    if (!(envflags & MDB_RDONLY)) {
+        auto rwt = getRWTransaction();
+        MDBDbi ret = rwt->openDB(dbname, flags);
+        if (cmp) {
+            ret.set_compare(*rwt, cmp);
+        }
+        rwt->commit();
+        return ret;
+    }
+
+    MDBDbi ret;
+    {
+        auto rot = getROTransaction();
+        ret = rot->openDB(dbname, flags);
+    }
+    return ret;
+}
+
 MDBRWTransactionImpl::MDBRWTransactionImpl(MDBEnv *parent, MDB_txn *txn)
     : MDBROTransactionImpl(parent, txn)
 

--- a/src/rgw/driver/posix/lmdb-safe.hh
+++ b/src/rgw/driver/posix/lmdb-safe.hh
@@ -79,6 +79,10 @@ public:
     }
     explicit MDBDbi(MDB_env *env, MDB_txn *txn, string_view dbname, unsigned int flags);
 
+    void set_compare(MDB_txn *txn, MDB_cmp_func *cmp) {
+        mdb_set_compare(txn, d_dbi, cmp);
+    }
+
     operator const MDB_dbi &() const
     {
         return d_dbi;
@@ -110,6 +114,7 @@ public:
     }
 
     MDBDbi openDB(const string_view dbname, unsigned int flags);
+    MDBDbi openDB(const string_view dbname, unsigned int flags, MDB_cmp_func *cmp);
 
     MDBRWTransaction getRWTransaction();
     MDBROTransaction getROTransaction();

--- a/src/rgw/driver/posix/lmdb-safe.hh
+++ b/src/rgw/driver/posix/lmdb-safe.hh
@@ -547,6 +547,7 @@ public:
     void abort() override;
 
     void clear(MDB_dbi dbi);
+    void drop(MDB_dbi dbi);
 
     void put(MDB_dbi dbi, const MDBInVal &key, const MDBInVal &val, unsigned int flags = 0)
     {

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -969,7 +969,9 @@ public:
 
   /* enumerate all entries by callback, in any order */
   int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb);
-  
+
+  static MDB_cmp_func* lmdb_cmp() { return nullptr; }
+
 private:
   int write_attrs(const DoutPrefixProvider *dpp, optional_yield y);
 }; /* POSIXBucket */

--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1506,13 +1506,15 @@ namespace rgw {
     if (factory == nullptr) {
       return false;
     }
-    /* XXXX seems like we should use a flag rather than is_linked(),
-     * as we now depend on safe_link mode */
-    /* in the non-delete case, handle may still be in handle table */
     if (fh_hook.is_linked()) {
-      /* in this case, we are being called from a context which holds
-       * the partition lock */
-      fs->fh_cache.remove(fh.fh_hk.object, this, FHCache::FLAG_NONE);
+      if (fs->fh_cache.is_same_partition(fh.fh_hk.object,
+					 factory->fhk.fh_hk.object)) {
+	fs->fh_cache.remove(fh.fh_hk.object, this, FHCache::FLAG_NONE);
+      } else {
+	fs->fh_cache.unlock_for(factory->fhk.fh_hk.object);
+	fs->fh_cache.remove(fh.fh_hk.object, this, FHCache::FLAG_LOCK);
+	fs->fh_cache.lock_for(factory->fhk.fh_hk.object);
+      }
     }
     return true;
   } /* RGWFileHandle::reclaim */

--- a/src/rgw/rgw_file_int.h
+++ b/src/rgw/rgw_file_int.h
@@ -6,6 +6,7 @@
 #include "include/rados/rgw_file.h"
 
 /* internal header */
+#include <cstdint>
 #include <string.h>
 #include <string_view>
 #include <sys/stat.h>
@@ -1061,8 +1062,13 @@ namespace rgw {
 	if (likely(! fh_locked))
 	    fh->mtx.lock(); // XXX !RAII because may-return-LOCKED
 	/* need initial ref from LRU (fast path) */
-	if (! fh_lru.ref(fh, cohort::lru::FLAG_INITIAL)) {
-	  lat.lock->unlock();
+
+	/* XXX LRU::ref() always returns true */
+        if (unlikely(! fh_lru.ref(fh, cohort::lru::FLAG_INITIAL))) {
+
+          ceph_assert(0); /* XXX not reached */
+
+          lat.lock->unlock();
 	  if (likely(! fh_locked))
 	    fh->mtx.unlock();
 	  goto retry; /* !LATCHED */

--- a/src/rgw/rgw_file_int.h
+++ b/src/rgw/rgw_file_int.h
@@ -1063,11 +1063,11 @@ namespace rgw {
 	    fh->mtx.lock(); // XXX !RAII because may-return-LOCKED
 	/* need initial ref from LRU (fast path) */
 
-	/* XXX LRU::ref() always returns true */
+	/* ref() returns false if fh is mid-eviction (evict_block() set
+	 * evicting and dropped the lane lock before calling reclaim());
+	 * retry, the racing eviction will finish and fh_cache.find_latch()
+	 * will no longer find this handle. */
         if (unlikely(! fh_lru.ref(fh, cohort::lru::FLAG_INITIAL))) {
-
-          ceph_assert(0); /* XXX not reached */
-
           lat.lock->unlock();
 	  if (likely(! fh_locked))
 	    fh->mtx.unlock();

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -315,6 +315,7 @@ add_dependencies(ceph_test_librgw_file
   ceph_test_librgw_file_rename
   ceph_test_librgw_file_nfsns
   ceph_test_librgw_file_aw
+  ceph_test_librgw_file_chunksim
   ceph_test_librgw_file_marker)
 
 # ceph_test_librgw_file_cd (just the rgw_file create-delete bucket ops)
@@ -411,6 +412,26 @@ target_link_libraries(ceph_test_librgw_file_marker
   ${ALLOC_LIBS}
   )
   target_link_libraries(ceph_test_librgw_file_marker Boost::context)
+install(TARGETS ceph_test_librgw_file_marker DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# ceph_test_librgw_file_chunsim ; fsal-rgw dirent lifetime workload
+add_executable(ceph_test_librgw_file_chunksim
+  librgw_file_chunksim.cc
+  )
+target_include_directories(ceph_test_librgw_file_chunksim
+  PUBLIC "${LUA_INCLUDE_DIR}"
+  SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw"
+  SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw/driver/rados")
+target_link_libraries(ceph_test_librgw_file_chunksim
+  rgw
+  librados
+  ceph-common
+  ${UNITTEST_LIBS}
+  ${EXTRALIBS}
+  ${LUA_LIBRARIES}
+  ${ALLOC_LIBS}
+  )
+  target_link_libraries(ceph_test_librgw_file_chunksim Boost::context)
 install(TARGETS ceph_test_librgw_file_marker DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # ceph_test_librgw_file_xattr (attribute ops)

--- a/src/test/librgw_file_chunksim.cc
+++ b/src/test/librgw_file_chunksim.cc
@@ -1,0 +1,505 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2015 Red Hat, Inc.s
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include <cstdint>
+#include <cstdlib>
+#include <stdint.h>
+#include <tuple>
+#include <iostream>
+#include <fstream>
+#include <stack>
+
+#include "include/rados/librgw.h"
+#include "include/rados/rgw_file.h"
+#include "rgw/rgw_file_int.h"
+#include "rgw/rgw_lib_frontend.h" // direct requests
+
+#include "gtest/gtest.h"
+#include "common/ceph_argparse.h"
+#include "common/debug.h"
+#include "global/global_init.h"
+#include "include/ceph_assert.h"
+
+#define dout_subsys ceph_subsys_rgw
+
+using namespace std;
+
+namespace {
+
+  using namespace rgw;
+  using std::get;
+  using std::string;
+
+  librgw_t rgw_h = nullptr;
+  string userid("testuser");
+  string access_key("");
+  string secret_key("");
+  struct rgw_fs *fs = nullptr;
+  CephContext* cct = nullptr;
+
+  uint32_t owner_uid = 867;
+  uint32_t owner_gid = 5309;
+
+  uint16_t num_rele = 1;
+  uint32_t num_scans = 2;
+
+  uint32_t create_mask = RGW_SETATTR_UID | RGW_SETATTR_GID | RGW_SETATTR_MODE;
+
+  string bucket_name("dchunks");
+
+  class obj_rec
+  {
+  public:
+    string name;
+    struct rgw_file_handle* fh;
+    struct rgw_file_handle* parent_fh;
+    RGWFileHandle* rgw_fh; // alias into fh
+
+    obj_rec(string _name, struct rgw_file_handle* _fh,
+	    struct rgw_file_handle* _parent_fh, RGWFileHandle* _rgw_fh)
+      : name(std::move(_name)), fh(_fh), parent_fh(_parent_fh),
+	rgw_fh(_rgw_fh) {}
+
+    void clear() {
+      fh = nullptr;
+      rgw_fh = nullptr;
+    }
+
+    friend ostream& operator<<(ostream& os, const obj_rec& rec);
+  };
+
+#if 0
+  ostream& operator<<(ostream& os, const obj_rec& rec)
+  {
+    RGWFileHandle* rgw_fh = rec.rgw_fh;
+    if (rgw_fh) {
+      const char* type = rgw_fh->is_dir() ? "DIR " : "FILE ";
+      os << rec.rgw_fh->full_object_name()
+	 << " (" << rec.rgw_fh->object_name() << "): "
+	 << type;
+    }
+    return os;
+  }
+#endif
+
+  class DirentChunk {
+  public:
+    static constexpr uint32_t max_entries = 200;
+    std::vector<obj_rec> dirents;
+    uint32_t num_entries{0};
+
+    bool full() {
+      return (num_entries >= max_entries);
+    }
+
+    bool add(obj_rec& obj) {
+      if (full()) {
+	return false;
+      }
+      dirents.emplace_back(std::move(obj));
+      ++num_entries;
+      return true;
+    }
+
+    void clear(bool evict=false) {
+      // release all entries and set num_entries := 0
+      [[maybe_unused]] auto ret{0};
+      for (auto &obj : dirents) {
+        // XXX obj refcnt is sentinel+1 before returning 1 ref */
+        auto refcnt = obj.rgw_fh->get_refcnt();
+        /* XXX the following assertion permits entry refcnt to be
+         * 2 /or/ 3 for the following reason:
+         * if the number of directory entries is >= to the total
+         * capacity of the chunk cache, the uniform fill order is
+         * sufficient to guarantee that no handle instance from a
+         * prior scan remains in the cache when it is re-added by
+         * the next scan.  this would permit a strict assertion that
+         * refcnt==2 at this location.  however, if the test were
+         * changed to allow the number of entries to vary to smaller
+         * counts, then assert(refcnt==2) would fail (because refcnt
+         * could rise to 3), probably causing concern.  It is in fact
+         * provable that given current workflow, refcnt can never
+         * exceed 3 at this location, for all values of num_scans
+	 * irrespective of entry count */
+        if (refcnt != 2) {
+          auto ref_str = to_string(refcnt);
+          std::cout << "trapped on refcnt=" << ref_str << std::endl;
+          ceph_assert((refcnt == 2) || (refcnt == 3));
+	}
+        if (unlikely(evict)) {
+	  static_cast<RGWLibFS*>(fs->fs_private)->release_evict(obj.rgw_fh);
+	} else {
+          ret = rgw_fh_rele(fs, obj.fh, 0);
+          if (unlikely(num_rele > 1)) {
+	    for (uint16_t ix = 1; ix < num_rele; ++num_rele) {
+              ret = rgw_fh_rele(fs, obj.fh, 0);
+	    }
+	  }
+	}
+      }
+      dirents.clear();
+      num_entries = 0;
+    }
+
+  }; /* DirentChunk */
+
+  /* a simplification of the ganesha mdcache chunk cache.  here,
+   * the only supported operation is a single, continued readdir()
+   * on one directory.  to consume the next set of incoming entries,
+   * the readdir callback must get a fill chunk--which is one of
+   * (1) a new chunk (if there is no active/being-filled chunk)
+   * (2) a chunk currently being filled;  if the current chunk has
+   * filled, the cache will either allocate a new chunk (iff
+   * active_chunks.size() < max_chunks), or else recycle the least
+   * recently allocated existing chunk. */
+
+  class ChunkCache {
+  public:
+    using chunk_list_t = std::deque<DirentChunk *>;
+    DirentChunk* curr_chunk{nullptr};
+    static constexpr uint32_t max_chunks = 25; // XXX param
+    chunk_list_t active_chunks;
+    uint32_t recycle_count;
+
+    DirentChunk* reclaim_chunk() {
+      auto chunk = active_chunks.back();
+      active_chunks.pop_back();
+      chunk->clear();
+      recycle_count++;
+      return chunk;
+    }
+
+    DirentChunk* get_fill_chunk() {
+      if (! curr_chunk) {
+        curr_chunk = new DirentChunk();
+	active_chunks.push_front(curr_chunk);
+	goto out;
+      }
+      if (curr_chunk->full()) {
+        if (active_chunks.size() >= max_chunks) {
+          // reclaim chunk
+	  curr_chunk = reclaim_chunk();
+        } else {
+	  // we can allocate a new chunk
+	  curr_chunk = new DirentChunk();
+	}
+	active_chunks.push_front(curr_chunk);
+      }
+    out:
+      return curr_chunk;
+    } /* get_fill_chunk */
+
+    uint32_t drain() {
+      uint32_t drain_cnt{0};
+      for (auto &chunk : active_chunks) {
+        chunk->clear(true /* evict */);
+        delete (chunk);
+	drain_cnt++;
+      }
+      active_chunks.clear();
+      return drain_cnt;
+    }
+  }; /* Chunkcache */
+
+  ChunkCache dirent_cache;
+
+  bool do_create = false;
+  bool verbose = false;
+
+  string marker_dir("nfs_marker");
+  struct rgw_file_handle *bucket_fh = nullptr;
+  struct rgw_file_handle *marker_fh;
+  uint32_t chunkdir_nobjs = 200000;
+
+  using dirent_t = std::tuple<std::string, uint64_t>;
+  struct dirent_vec
+  {
+    std::vector<dirent_t> obj_names;
+    uint32_t count;
+    dirent_vec() : count(0) {}
+  };
+
+  struct {
+    int argc;
+    char **argv;
+  } saved_args;
+}
+
+TEST(LibRGW, INIT) {
+  int ret = librgw_create(&rgw_h, saved_args.argc, saved_args.argv);
+  ASSERT_EQ(ret, 0);
+  ASSERT_NE(rgw_h, nullptr);
+}
+
+TEST(LibRGW, MOUNT) {
+  int ret = rgw_mount2(rgw_h, userid.c_str(), access_key.c_str(),
+                       secret_key.c_str(), "/", &fs, RGW_MOUNT_FLAG_NONE);
+  ASSERT_EQ(ret, 0);
+  ASSERT_NE(fs, nullptr);
+
+  cct = static_cast<RGWLibFS*>(fs->fs_private)->get_context();
+}
+
+TEST(LibRGW, CHUNK_SETUP_BUCKET) {
+  struct stat st;
+  int ret;
+
+  st.st_uid = owner_uid;
+  st.st_gid = owner_gid;
+  st.st_mode = 755;
+
+  (void) rgw_lookup(fs, fs->root_fh, bucket_name.c_str(), &bucket_fh,
+		    nullptr, 0, RGW_LOOKUP_FLAG_NONE);
+  if (! bucket_fh) {
+    if (do_create) {
+      struct stat st;
+
+      st.st_uid = owner_uid;
+      st.st_gid = owner_gid;
+      st.st_mode = 755;
+
+      ret = rgw_mkdir(fs, fs->root_fh, bucket_name.c_str(), &st, create_mask,
+		      &bucket_fh, RGW_MKDIR_FLAG_NONE);
+      ASSERT_EQ(ret, 0);
+    }
+  }
+
+  ASSERT_NE(bucket_fh, nullptr);
+
+  (void) rgw_lookup(fs, bucket_fh, marker_dir.c_str(), &marker_fh,
+		    nullptr, 0, RGW_LOOKUP_FLAG_NONE);
+  if (! marker_fh) {
+    if (do_create) {
+      ret = rgw_mkdir(fs, bucket_fh, marker_dir.c_str(), &st, create_mask,
+		      &marker_fh, RGW_MKDIR_FLAG_NONE);
+      ASSERT_EQ(ret, 0);
+    }
+  }
+
+  ASSERT_NE(marker_fh, nullptr);
+} /* setup bucket */
+
+TEST(LibRGW, CHUNK_SETUP_OBJECTS)
+{
+  /* "large" directory enumeration test.  this one deals only with
+   * file objects */
+
+  if (do_create) {
+    int ret;
+
+    for (uint32_t ix = 0; ix < chunkdir_nobjs; ++ix) {
+      std::string object_name("f_");
+      object_name += to_string(ix);
+      obj_rec obj{object_name, nullptr, marker_fh, nullptr};
+      // lookup object--all operations are by handle
+      ret = rgw_lookup(fs, marker_fh, obj.name.c_str(), &obj.fh,
+		       nullptr, 0, RGW_LOOKUP_FLAG_CREATE);
+      ASSERT_EQ(ret, 0);
+      obj.rgw_fh = get_rgwfh(obj.fh);
+      // open object--open transaction
+      ret = rgw_open(fs, obj.fh, 0 /* posix flags */, RGW_OPEN_FLAG_NONE);
+      ASSERT_EQ(ret, 0);
+      ASSERT_TRUE(obj.rgw_fh->is_open());
+
+      // unstable write data
+      size_t nbytes;
+      string data("data for ");
+      data += object_name;
+      int ret = rgw_write(fs, obj.fh, 0, data.length(), &nbytes,
+			  (void*) data.c_str(), RGW_WRITE_FLAG_NONE);
+      ASSERT_EQ(ret, 0);
+      ASSERT_EQ(nbytes, data.length());
+
+      // commit transaction (write on close)
+      ret = rgw_close(fs, obj.fh, 0 /* flags */);
+      ASSERT_EQ(ret, 0);
+      if (verbose) {
+	/* XXX std:cout fragged...did it get /0 in the stream
+	 * somewhere? */
+	printf("created: %s:%s\n", bucket_name.c_str(), obj.name.c_str());
+      }
+    }
+  }
+} /* setup objects */
+
+TEST(LibRGW, CHUNK_CACHE) {
+  ChunkCache cache;
+  auto chunk = cache.get_fill_chunk();
+  obj_rec obj{"dummy0", nullptr, nullptr, nullptr};
+  chunk->add(obj);
+}
+
+struct ReaddirArg {
+  int32_t total_entries{0};
+  std::string next_marker{""};
+};
+
+extern "C" {
+  static int r2_cb(const char* name, void *arg, uint64_t offset,
+		    struct stat* st, uint32_t st_mask,
+		    uint32_t flags) {
+
+    ReaddirArg& acc = *(static_cast<ReaddirArg*>(arg));
+
+    string name_str{name};
+    if (!((name_str == ".") || (name_str == ".."))) {
+
+      /* lookup (takes ref) on the next dirent */
+      obj_rec obj{name_str, nullptr, marker_fh, nullptr};
+      // lookup object--all operations are by handle
+      int ret = rgw_lookup(fs, marker_fh, obj.name.c_str(), &obj.fh,
+			   nullptr, 0, RGW_LOOKUP_FLAG_RCB);
+      ceph_assert(ret == 0);
+      obj.rgw_fh = get_rgwfh(obj.fh);
+
+      auto chunk = dirent_cache.get_fill_chunk();
+      chunk->add(obj);
+
+      acc.next_marker = name_str;
+      ++(acc.total_entries);
+    }
+
+    printf("%s bucket=%s dir=%s iv count=%d called back name=%s flags=%d\n",
+	   __func__,
+	   bucket_name.c_str(),
+	   marker_dir.c_str(),
+	   acc.total_entries,
+	   name,
+	   flags);
+
+    return true; /* XXX */
+  }
+}
+
+TEST(LibRGW, CHUNKED_READDIR)
+{
+  using std::get;
+
+  uint32_t grand_total_entries{0};
+  uint32_t grand_total_readdir_cnt{0};
+  bool eof = false;
+
+  for (uint32_t scan_ix = 0; scan_ix < num_scans; ++scan_ix) {
+    uint32_t readdir_count{0};
+    std::string marker{""}; // starting offset==0
+    ReaddirArg arg;
+    do {
+      int ret = rgw_readdir2(fs, marker_fh,
+                             (marker.length() > 0) ? marker.c_str() : nullptr,
+                             r2_cb, &arg, &eof, RGW_READDIR_FLAG_NONE);
+      ASSERT_EQ(ret, 0);
+      marker = arg.next_marker;
+      std::cout << "new marker: " << marker << std::endl;
+      ++readdir_count;
+    } while ((!eof));
+
+    grand_total_entries += arg.total_entries;
+    grand_total_readdir_cnt += readdir_count;
+
+    std::cout << " entries returned: "
+              << arg.total_entries
+	      << " readdir invocations: " << readdir_count
+	      << " for scan #" << scan_ix
+	      << std::endl;
+  } /* scan_ix */
+
+  auto drain_count = dirent_cache.drain();
+
+  // print totals
+  std::cout << " total entries returned: " << grand_total_entries
+            << " total readdir invocations: " << grand_total_readdir_cnt
+            << " reclaimed chunks: " << dirent_cache.recycle_count
+            << " drained chunks: " << drain_count << std::endl;
+}
+
+TEST(LibRGW, UMOUNT) {
+  if (! fs)
+    return;
+
+  int ret = rgw_umount(fs, RGW_UMOUNT_FLAG_NONE);
+  ASSERT_EQ(ret, 0);
+}
+
+TEST(LibRGW, SHUTDOWN) {
+  librgw_shutdown(rgw_h);
+}
+
+int main(int argc, char *argv[])
+{
+  auto args = argv_to_vec(argc, argv);
+  env_to_vec(args);
+
+  char* v = getenv("AWS_ACCESS_KEY_ID");
+  if (v) {
+    access_key = v;
+  }
+
+  v = getenv("AWS_SECRET_ACCESS_KEY");
+  if (v) {
+    secret_key = v;
+  }
+
+  string val;
+  for (auto arg_iter = args.begin(); arg_iter != args.end();) {
+    if (ceph_argparse_witharg(args, arg_iter, &val, "--access",
+			      (char*) nullptr)) {
+      access_key = val;
+    } else if (ceph_argparse_witharg(args, arg_iter, &val, "--secret",
+				     (char*) nullptr)) {
+      secret_key = val;
+    } else if (ceph_argparse_witharg(args, arg_iter, &val, "--userid",
+				     (char*) nullptr)) {
+      userid = val;
+    } else if (ceph_argparse_witharg(args, arg_iter, &val, "--bn",
+				     (char*) nullptr)) {
+      bucket_name = val;
+    } else if (ceph_argparse_witharg(args, arg_iter, &val, "--uid",
+				     (char*) nullptr)) {
+      owner_uid = std::stoi(val);
+    } else if (ceph_argparse_witharg(args, arg_iter, &val, "--gid",
+				     (char*) nullptr)) {
+      owner_gid = std::stoi(val);
+    } else if (ceph_argparse_flag(args, arg_iter, "--create",
+					    (char*) nullptr)) {
+      do_create = true;
+    } else if (ceph_argparse_witharg(args, arg_iter, &val, "--num_scans",
+				     (char*) nullptr)) {
+      num_scans = std::stoi(val);
+    } else if (ceph_argparse_witharg(args, arg_iter, &val, "--num_objs",
+				     (char*) nullptr)) {
+      chunkdir_nobjs = std::stoi(val);
+    } else if (ceph_argparse_witharg(args, arg_iter, &val, "--num_rele",
+				     (char*) nullptr)) {
+      num_rele = std::stoi(val);
+    } else if (ceph_argparse_flag(args, arg_iter, "--verbose",
+					    (char*) nullptr)) {
+      verbose = true;
+    } else {
+      ++arg_iter;
+    }
+  }
+
+  /* don't accidentally run as anonymous */
+  if ((access_key == "") ||
+      (secret_key == "")) {
+    std::cout << argv[0] << " no AWS credentials, exiting" << std::endl;
+    return EPERM;
+  }
+
+  saved_args.argc = argc;
+  saved_args.argv = argv;
+
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/test/librgw_file_chunksim.cc
+++ b/src/test/librgw_file_chunksim.cc
@@ -19,6 +19,7 @@
 #include <iostream>
 #include <fstream>
 #include <stack>
+#include <unordered_set>
 
 #include "include/rados/librgw.h"
 #include "include/rados/rgw_file.h"
@@ -202,8 +203,17 @@ namespace {
 
     uint32_t drain() {
       uint32_t drain_cnt{0};
+      std::unordered_set<RGWFileHandle*> evicted;
       for (auto &chunk : active_chunks) {
-        chunk->clear(true /* evict */);
+	for (auto &obj : chunk->dirents) {
+	  if (evicted.insert(obj.rgw_fh).second) {
+	    static_cast<RGWLibFS*>(fs->fs_private)->release_evict(obj.rgw_fh);
+	  } else {
+	    rgw_fh_rele(fs, obj.fh, 0);
+	  }
+	}
+	chunk->dirents.clear();
+	chunk->num_entries = 0;
         delete (chunk);
 	drain_cnt++;
       }

--- a/src/test/rgw/test_posix_bucket_cache.cc
+++ b/src/test/rgw/test_posix_bucket_cache.cc
@@ -95,6 +95,8 @@ protected:
       return 0;
     } /* fill_cache */
 
+    /* default LMDB sort order, mirroring POSIXBucket::lmdb_cmp() */
+    static MDB_cmp_func* lmdb_cmp() { return nullptr; }
   }; /* MockSalBucket */
 
   using BucketCache = file::listing::BucketCache<MockSalDriver, MockSalBucket>;


### PR DESCRIPTION
fixes a racing in `BucketCache::get_bucket()`

Fixes: https://tracker.ceph.com/issues/77499

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
