### PR TITLE
rgw/posix: fix bucket cache recycle race failing unittest_posix_bucket_cache

### DIFF
--- a/src/common/cohort_lru.h
+++ b/src/common/cohort_lru.h
@@ -237,6 +237,7 @@ namespace cohort {
             auto active = o->active.test();
             if (active) {
               lane.active.erase(it);
+              o->active.clear(); /* now on lane.q */
             } else {
               lane.q.erase(it);
             }

--- a/src/rgw/driver/posix/bucket_cache.h
+++ b/src/rgw/driver/posix/bucket_cache.h
@@ -362,9 +362,9 @@ public:
 	    /* inserts at cached insert iterator, releasing latch */
 	    cache.insert_latched(b, lat, BucketCacheEntry<D, B>::bucket_avl_cache::FLAG_UNLOCK);
 	  } else {
-	    /* recycle step invalidates Latch */
-	    lat.lock->unlock(); /* !LATCHED */
+	    /* recycle invalidated the Latch; re-insert under the held partition lock */
 	    cache.insert(fac.hk, b, BucketCacheEntry<D, B>::bucket_avl_cache::FLAG_NONE);
+	    lat.lock->unlock(); /* !LATCHED */
 	  }
 	  get<1>(result) |= BucketCache<D, B>::FLAG_CREATE;
 	} else {


### PR DESCRIPTION
- **common/cohort_lru: clear active flag when object returns to lane.q.**
  `unref()` returns an object to `lane.q` when its refcount drops to the
  sentinel value but left the active flag set, so a later `ref()`/`unref()`
  consulted a stale flag and erased the object from the wrong intrusive list.
  Clear it to keep the flag consistent with which queue the object is on.

- **rgw/posix: insert recycled bucket cache entry under the partition lock.**
  `get_bucket()`'s recycle path unlocked the partition lock before calling
  `cache.insert()`, racing `find_latch()` on the AVL tree. The corrupted tree
  and its size counter then hung `TreeX::drain()` at teardown. The lock is
  still held and `fac.hk` maps to the same partition, so insert under it
  (`FLAG_NONE`) and release after; re-locking would invert the lock order.

---

I ran `unittest_posix_bucket_cache` three times and saw three different
outcomes: passing in 30s, hanging and failing after 100s, and looping forever
without ever finishing (still running after 2 hours). 

With these changes, 50 consecutive runs all passed in ~30s.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
</content>
</invoke>
