### PR TITLE
squid: rgw: match CORS rules like Amazon S3

### DIFF
--- a/src/rgw/rgw_cors.cc
+++ b/src/rgw/rgw_cors.cc
@@ -190,6 +190,10 @@ bool RGWCORSRule::matches_method(const char *req_meth)
     dout(5) << "matches_method: req_meth is null or empty" << dendl;
     return false;
   }
+  if (allowed_methods == RGW_CORS_ALL) {
+    dout(10) << "matches_method: AllowedMethod * allows " << req_meth << dendl;
+    return true;
+  }
   const uint8_t flags = get_multi_cors_method_flags(req_meth);
   return flags != 0 && (allowed_methods & flags);
 }
@@ -197,6 +201,8 @@ bool RGWCORSRule::matches_method(const char *req_meth)
 bool RGWCORSRule::matches_preflight_headers(const char *req_hdrs)
 {
   if (!req_hdrs || !*req_hdrs) {
+    dout(20) << "matches_preflight_headers: no Access-Control-Request-Headers, "
+             << "passing per CORS spec 6.2.4" << dendl;
     return true;
   }
   vector<string> hdrs;

--- a/src/rgw/rgw_cors.cc
+++ b/src/rgw/rgw_cors.cc
@@ -209,6 +209,7 @@ bool RGWCORSRule::matches_preflight_headers(const char *req_hdrs)
   get_str_vec(req_hdrs, hdrs);
   for (const auto& hdr : hdrs) {
     if (!is_header_allowed(hdr.c_str(), hdr.length())) {
+      dout(5) << "Header " << hdr << " is not registered in this rule" << dendl;
       return false;
     }
   }

--- a/src/rgw/rgw_cors.cc
+++ b/src/rgw/rgw_cors.cc
@@ -187,7 +187,8 @@ void RGWCORSRule::format_exp_headers(string& s) {
 bool RGWCORSRule::matches_method(const char *req_meth)
 {
   if (!req_meth || !*req_meth) {
-    return true;
+    dout(5) << "matches_method: req_meth is null or empty" << dendl;
+    return false;
   }
   const uint8_t flags = get_multi_cors_method_flags(req_meth);
   return flags != 0 && (allowed_methods & flags);

--- a/src/rgw/rgw_cors.cc
+++ b/src/rgw/rgw_cors.cc
@@ -17,6 +17,7 @@
 
 #include <iostream>
 #include <map>
+#include <vector>
 
 #include <boost/algorithm/string.hpp>
 
@@ -181,6 +182,56 @@ void RGWCORSRule::format_exp_headers(string& s) {
     // response header, so we escape '\n' to avoid header injection
     boost::replace_all_copy(std::back_inserter(s), header, "\n", "\\n");
   }
+}
+
+bool RGWCORSRule::matches_method(const char *req_meth)
+{
+  if (!req_meth || !*req_meth) {
+    return true;
+  }
+  const uint8_t flags = get_multi_cors_method_flags(req_meth);
+  return flags != 0 && (allowed_methods & flags);
+}
+
+bool RGWCORSRule::matches_preflight_headers(const char *req_hdrs)
+{
+  if (!req_hdrs || !*req_hdrs) {
+    return true;
+  }
+  vector<string> hdrs;
+  get_str_vec(req_hdrs, hdrs);
+  for (const auto& hdr : hdrs) {
+    if (!is_header_allowed(hdr.c_str(), hdr.length())) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool RGWCORSRule::matches(const char *origin,
+                          const char *req_meth,
+                          const char *req_hdrs)
+{
+  if (!origin || !*origin) {
+    return false;
+  }
+  return is_origin_present(origin)
+      && matches_method(req_meth)
+      && matches_preflight_headers(req_hdrs);
+}
+
+RGWCORSRule * RGWCORSConfiguration::match_rule(const char *origin,
+                                               const char *req_meth,
+                                               const char *req_hdrs)
+{
+  for (list<RGWCORSRule>::iterator it_r = rules.begin();
+       it_r != rules.end(); ++it_r) {
+    RGWCORSRule& r = (*it_r);
+    if (r.matches(origin, req_meth, req_hdrs)) {
+      return &r;
+    }
+  }
+  return NULL;
 }
 
 RGWCORSRule * RGWCORSConfiguration::host_name_rule(const char *origin) {

--- a/src/rgw/rgw_cors.h
+++ b/src/rgw/rgw_cors.h
@@ -18,6 +18,7 @@
 #include <map>
 #include <string>
 #include <include/types.h>
+#include "include/str_list.h"
 
 #define RGW_CORS_GET    0x1
 #define RGW_CORS_PUT    0x2
@@ -150,6 +151,23 @@ static inline uint8_t get_cors_method_flags(const char *req_meth) {
   else if (strcmp(req_meth, "PUT") == 0) flags = RGW_CORS_PUT;
   else if (strcmp(req_meth, "DELETE") == 0) flags = RGW_CORS_DELETE;
   else if (strcmp(req_meth, "HEAD") == 0) flags = RGW_CORS_HEAD;
+  else if (strcmp(req_meth, "COPY") == 0) flags = RGW_CORS_COPY;
+
+  return flags;
+}
+
+static inline uint8_t get_multi_cors_method_flags(const char *req_meth) {
+  uint8_t flags = 0;
+  const std::string allowed_methods(req_meth);
+  auto apply_flag = [&flags] (std::string_view method) {
+    if (method == "GET") flags |= RGW_CORS_GET;
+    else if (method == "POST") flags |= RGW_CORS_POST;
+    else if (method == "PUT") flags |= RGW_CORS_PUT;
+    else if (method == "DELETE") flags |= RGW_CORS_DELETE;
+    else if (method == "HEAD") flags |= RGW_CORS_HEAD;
+    else if (method == "COPY") flags |= RGW_CORS_COPY;
+  };
+  ceph::for_each_substr(allowed_methods, ";,= \t", apply_flag);
 
   return flags;
 }

--- a/src/rgw/rgw_cors.h
+++ b/src/rgw/rgw_cors.h
@@ -88,6 +88,11 @@ public:
   void dump_origins(); 
   void dump(Formatter *f) const;
   bool is_header_allowed(const char *hdr, size_t len);
+  bool matches_method(const char *req_meth);
+  bool matches_preflight_headers(const char *req_hdrs);
+  bool matches(const char *origin,
+               const char *req_meth,
+               const char *req_hdrs);
 };
 WRITE_CLASS_ENCODER(RGWCORSRule)
 
@@ -118,6 +123,9 @@ class RGWCORSConfiguration
   }
   void get_origins_list(const char *origin, std::list<std::string>& origins);
   RGWCORSRule * host_name_rule(const char *origin);
+  RGWCORSRule * match_rule(const char *origin,
+                           const char *req_meth,
+                           const char *req_hdrs);
   void erase_host_name_rule(std::string& origin);
   void dump();
   void stack_rule(RGWCORSRule& r) {

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1448,38 +1448,6 @@ int RGWOp::init_quota()
   return 0;
 }
 
-static bool validate_cors_rule_method(const DoutPrefixProvider *dpp, RGWCORSRule *rule, const char *req_meth) {
-  if (!req_meth) {
-    ldpp_dout(dpp, 5) << "req_meth is null" << dendl;
-    return false;
-  }
-
-  uint8_t flags = get_cors_method_flags(req_meth);
-
-  if (rule->get_allowed_methods() & flags) {
-    ldpp_dout(dpp, 10) << "Method " << req_meth << " is supported" << dendl;
-  } else {
-    ldpp_dout(dpp, 5) << "Method " << req_meth << " is not supported" << dendl;
-    return false;
-  }
-
-  return true;
-}
-
-static bool validate_cors_rule_header(const DoutPrefixProvider *dpp, RGWCORSRule *rule, const char *req_hdrs) {
-  if (req_hdrs) {
-    vector<string> hdrs;
-    get_str_vec(req_hdrs, hdrs);
-    for (const auto& hdr : hdrs) {
-      if (!rule->is_header_allowed(hdr.c_str(), hdr.length())) {
-        ldpp_dout(dpp, 5) << "Header " << hdr << " is not registered in this rule" << dendl;
-        return false;
-      }
-    }
-  }
-  return true;
-}
-
 int RGWOp::read_bucket_cors()
 {
   bufferlist bl;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1559,44 +1559,46 @@ bool RGWOp::generate_cors_headers(string& origin, string& method, string& header
     return false;
   }
 
-  /* CORS 6.2.2. */
-  RGWCORSRule *rule = bucket_cors.host_name_rule(orig);
-  if (!rule)
-    return false;
-
-  /*
-   * Set the Allowed-Origin header to a asterisk if this is allowed in the rule
-   * and no Authorization was send by the client
-   *
-   * The origin parameter specifies a URI that may access the resource.  The browser must enforce this.
-   * For requests without credentials, the server may specify "*" as a wildcard,
-   * thereby allowing any origin to access the resource.
-   */
-  const char *authorization = s->info.env->get("HTTP_AUTHORIZATION");
-  if (!authorization && rule->has_wildcard_origin())
-    origin = "*";
-
-  /* CORS 6.2.3. */
+  /* CORS 6.2.2–6.2.5: first rule matching origin, method, and preflight headers. */
   const char *req_meth = s->info.env->get("HTTP_ACCESS_CONTROL_REQUEST_METHOD");
   if (!req_meth) {
     req_meth = s->info.method;
   }
-
-  if (req_meth) {
-    method = req_meth;
-    /* CORS 6.2.5. */
-    if (!validate_cors_rule_method(this, rule, req_meth)) {
-     return false;
-    }
-  }
-
-  /* CORS 6.2.4. */
   const char *req_hdrs = s->info.env->get("HTTP_ACCESS_CONTROL_REQUEST_HEADERS");
 
-  /* CORS 6.2.6. */
-  get_cors_response_headers(this, rule, req_hdrs, headers, exp_headers, max_age);
+  RGWCORSRule *rule = bucket_cors.match_rule(orig, req_meth, req_hdrs);
+  auto is_allowed_to_generate_rule_cors_header = [this, &origin, &method, &headers, &exp_headers, &max_age, req_meth, req_hdrs] (RGWCORSRule *rule) {
+    if (!rule)
+      return false;
 
-  return true;
+    /*
+     * Set the Allowed-Origin header to a asterisk if this is allowed in the rule
+     * and no Authorization was send by the client
+     *
+     * The origin parameter specifies a URI that may access the resource.  The browser must enforce this.
+     * For requests without credentials, the server may specify "*" as a wildcard,
+     * thereby allowing any origin to access the resource.
+     */
+    const char *authorization = s->info.env->get("HTTP_AUTHORIZATION");
+    if (!authorization && rule->has_wildcard_origin())
+      origin = "*";
+
+    /* CORS 6.2.3. */
+    if (req_meth) {
+      method = req_meth;
+    }
+
+    /* CORS 6.2.6. */
+    get_cors_response_headers(this, rule, req_hdrs, headers, exp_headers, max_age);
+
+    return true;
+  };
+
+  if (is_allowed_to_generate_rule_cors_header(rule)) {
+    return true;
+  }
+
+  return false;
 }
 
 int rgw_policy_from_attrset(const DoutPrefixProvider *dpp, CephContext *cct, map<string, bufferlist>& attrset, RGWAccessControlPolicy *policy)
@@ -6154,17 +6156,10 @@ void RGWOptionsCORS::get_response_params(string& hdrs, string& exp_hdrs, unsigne
 }
 
 int RGWOptionsCORS::validate_cors_request(RGWCORSConfiguration *cc) {
-  rule = cc->host_name_rule(origin);
+  rule = cc->match_rule(origin, req_meth, req_hdrs);
   if (!rule) {
-    ldpp_dout(this, 10) << "There is no cors rule present for " << origin << dendl;
-    return -ENOENT;
-  }
-
-  if (!validate_cors_rule_method(this, rule, req_meth)) {
-    return -ENOENT;
-  }
-
-  if (!validate_cors_rule_header(this, rule, req_hdrs)) {
+    ldpp_dout(this, 10) << "no CORS rule matching origin=" << origin
+                        << " method=" << req_meth << dendl;
     return -ENOENT;
   }
 

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -63,7 +63,9 @@ add_ceph_unittest(unittest_rgw_bencode)
 target_link_libraries(unittest_rgw_bencode ${rgw_libs})
 
 # unittest_rgw_cors
-add_executable(unittest_rgw_cors test_rgw_cors.cc)
+add_executable(unittest_rgw_cors
+  test_rgw_cors.cc
+  $<TARGET_OBJECTS:unit-main>)
 add_ceph_unittest(unittest_rgw_cors)
 target_link_libraries(unittest_rgw_cors ${rgw_libs})
 

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -62,6 +62,12 @@ add_executable(unittest_rgw_bencode test_rgw_bencode.cc)
 add_ceph_unittest(unittest_rgw_bencode)
 target_link_libraries(unittest_rgw_bencode ${rgw_libs})
 
+# unittest_rgw_cors
+add_executable(unittest_rgw_cors test_rgw_cors.cc)
+add_ceph_unittest(unittest_rgw_cors)
+target_link_libraries(unittest_rgw_cors ${rgw_libs})
+
+
 # unittest_rgw_bucket_sync_cache
 add_executable(unittest_rgw_bucket_sync_cache test_rgw_bucket_sync_cache.cc)
 add_ceph_unittest(unittest_rgw_bucket_sync_cache)

--- a/src/test/rgw/test_rgw_cors.cc
+++ b/src/test/rgw/test_rgw_cors.cc
@@ -1,0 +1,73 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#include "gtest/gtest.h"
+
+#include "rgw_cors.h"
+
+using namespace std;
+
+static RGWCORSRule make_rule(const char *origin, uint8_t methods,
+                             const char *allowed_hdr = nullptr)
+{
+  set<string> origins;
+  origins.insert(origin);
+  set<string> hdrs;
+  if (allowed_hdr) {
+    hdrs.insert(allowed_hdr);
+  }
+  list<string> expose;
+  return RGWCORSRule(origins, hdrs, expose, methods, 3000);
+}
+
+TEST(RGWCORS, MatchRuleSameOriginDifferentMethods)
+{
+  RGWCORSConfiguration cfg;
+  cfg.get_rules().push_back(make_rule("https://app.example", RGW_CORS_GET));
+  cfg.get_rules().push_back(make_rule("https://app.example", RGW_CORS_PUT));
+
+  auto it_get = cfg.get_rules().begin();
+  auto it_put = std::next(it_get);
+
+  EXPECT_EQ(cfg.match_rule("https://app.example", "GET", nullptr), &(*it_get));
+  EXPECT_EQ(cfg.match_rule("https://app.example", "PUT", nullptr), &(*it_put));
+  EXPECT_EQ(cfg.match_rule("https://app.example", "DELETE", nullptr), nullptr);
+}
+
+TEST(RGWCORS, MatchRuleSkipsOriginOnlyMatch)
+{
+  RGWCORSConfiguration cfg;
+  cfg.get_rules().push_back(make_rule("https://app.example", RGW_CORS_GET));
+  cfg.get_rules().push_back(make_rule("https://app.example", RGW_CORS_PUT));
+
+  EXPECT_NE(nullptr, cfg.match_rule("https://app.example", "PUT", nullptr));
+}
+
+TEST(RGWCORS, MatchRulePreflightHeaders)
+{
+  RGWCORSConfiguration cfg;
+  cfg.get_rules().push_back(
+      make_rule("https://app.example", RGW_CORS_GET, "content-type"));
+  cfg.get_rules().push_back(
+      make_rule("https://app.example", RGW_CORS_GET, "*"));
+
+  auto it_strict = cfg.get_rules().begin();
+  auto it_wild = std::next(it_strict);
+
+  EXPECT_EQ(cfg.match_rule("https://app.example", "GET",
+                           "content-type"),
+            &(*it_strict));
+  EXPECT_EQ(cfg.match_rule("https://app.example", "GET",
+                           "authorization"),
+            &(*it_wild));
+}
+
+TEST(RGWCORS, HostNameRuleStillOriginOnly)
+{
+  RGWCORSConfiguration cfg;
+  cfg.get_rules().push_back(make_rule("https://app.example", RGW_CORS_GET));
+  cfg.get_rules().push_back(make_rule("https://other.example", RGW_CORS_PUT));
+
+  auto it_first = cfg.get_rules().begin();
+  EXPECT_EQ(cfg.host_name_rule("https://app.example"), &(*it_first));
+}


### PR DESCRIPTION
## Summary

Backport of https://github.com/ceph/ceph/pull/69190 to **squid**.

RGW previously selected a CORS rule with `host_name_rule()` (origin only), then
validated method and headers on that single rule. Bucket configs with multiple
`CORSRule` elements sharing the same `AllowedOrigin` but different
`AllowedMethod` values could fail preflight when a later rule should match.
This aligns rule selection with Amazon S3 (first rule matching origin, method,
and preflight headers).

**Why squid:** the buggy origin-only matching exists on squid; users running
multi-rule bucket CORS on squid RGW hit the same preflight failures fixed on
main.

**Minimal change:** cherry-pick of all six commits from PR #69190 with `git
cherry-pick -x`.
Conflict in `rgw_op.cc` resolved by dropping global CORS
(`optional_global_cors`) because squid does not have global CORS; bucket
CORS uses `match_rule()` only.

Parent tracker: https://tracker.ceph.com/issues/77575
Official backport tracker: https://tracker.ceph.com/issues/77586

## Testing

- Includes `unittest_rgw_cors` (from main PR)
- Not run locally on squid yet

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).
- If you are submitting a fix for a stable branch, please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

Fixes: https://tracker.ceph.com/issues/77586
