### PR TITLE
ceph.in: reject -w/--watch flags when used with subcommands

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -1131,6 +1131,9 @@ def main():
             elif k != "watch_channel":
                 level = k.replace('watch_', '')
     if level:
+        if childargs:
+            print('Invalid command: unused arguments: {0}'.format(childargs), file=sys.stderr)
+            return errno.EINVAL
         # an awfully simple callback
         def watch_cb(arg, line, channel, name, who, stamp_sec, stamp_nsec, seq, level, msg):
             # Filter on channel


### PR DESCRIPTION
parse_known_args() silently consumes -w and all --watch-* flags before subcommand arguments reach the command validator. When a user ran "ceph orch ps -w", the watch handler entered cluster log streaming mode while discarding the subcommand entirely, with no error or indication that the orch ps command was ignored.

Add a guard at the entry of the watch handler: if any watch flag is active and childargs is non-empty, print "Invalid command: unused arguments: [...]" and return EINVAL. This matches the behaviour already seen when -s/--status is combined with a subcommand.

Assisted-by: Claude:claude-4.6-sonnet
Fixes: https://tracker.ceph.com/issues/77121


Tested on a live setup:
```shell
[ceph: root@ceph-node-0 /]# ceph orch ps
NAME                    HOST         PORTS        STATUS        REFRESHED  AGE  MEM USE  MEM LIM  VERSION                IMAGE ID      CONTAINER ID
crash.ceph-node-0       ceph-node-0               running (5m)     3m ago   5m    7824k        -  21.0.0-2078-g561871e2  cb1657099685  8fe5c4b65c71
crash.ceph-node-1       ceph-node-1               running (4m)    87s ago   4m    8055k        -  21.0.0-2078-g561871e2  cb1657099685  827cd2e4974c
crash.ceph-node-2       ceph-node-2               running (2m)    87s ago   2m    7835k        -  21.0.0-2078-g561871e2  cb1657099685  3dcf1905c557
mgr.ceph-node-0.odmxrb  ceph-node-0  *:9283,8765  running (6m)     3m ago   6m     190M        -  21.0.0-2078-g561871e2  cb1657099685  d7da44ab8a6e
mgr.ceph-node-1.bljenc  ceph-node-1  *:8443,8765  running (3m)    87s ago   3m     146M        -  21.0.0-2078-g561871e2  cb1657099685  e942e344ef5a
mon.ceph-node-0         ceph-node-0               running (6m)     3m ago   6m    36.2M    2048M  21.0.0-2078-g561871e2  cb1657099685  468b4d60f9e1
mon.ceph-node-1         ceph-node-1               running (3m)    87s ago   3m    27.4M    2048M  21.0.0-2078-g561871e2  cb1657099685  dfada9aacbae
mon.ceph-node-2         ceph-node-2               running (2m)    87s ago   2m    26.3M    2048M  21.0.0-2078-g561871e2  cb1657099685  d0943e9725af
osd.0                   ceph-node-0               running (4m)     3m ago   4m    48.1M    4096M  21.0.0-2078-g561871e2  cb1657099685  d48e9ce02d6a
osd.1                   ceph-node-1               running (4m)    87s ago   4m    51.2M    4096M  21.0.0-2078-g561871e2  cb1657099685  1d42edf8575e
osd.2                   ceph-node-2               running (2m)    87s ago   2m    49.6M    2987M  21.0.0-2078-g561871e2  cb1657099685  469084b5b83f
[ceph: root@ceph-node-0 /]# ceph orch ps -s
Invalid command: unused arguments: ['orch', 'ps']
status :  show cluster status
Error EINVAL: invalid command
[ceph: root@ceph-node-0 /]# ceph orch ps -w
Invalid command: unused arguments: ['orch', 'ps']
[ceph: root@ceph-node-0 /]# ceph -w orch ps
Invalid command: unused arguments: ['orch', 'ps']

``` 


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
