### PR TITLE
add option to pause RGW accepting requests

### DIFF
--- a/src/rgw/rgw_appmain.cc
+++ b/src/rgw/rgw_appmain.cc
@@ -614,6 +614,26 @@ void rgw::AppMain::init_dedup()
 }
 #endif
 
+void rgw::AppMain::pause_frontends()
+{
+  ldpp_dout(dpp, 1)
+      << "Pausing all frontends to stop accepting new TCP connections" << dendl;
+  for (auto& fe : fes) {
+    fe->pause_for_new_config();
+  }
+  ldpp_dout(dpp, 1) << "All frontends paused" << dendl;
+}
+
+void rgw::AppMain::unpause_frontends()
+{
+  ldpp_dout(dpp, 1)
+      << "Unpausing all frontends to resume accepting TCP connections" << dendl;
+  for (auto& fe : fes) {
+    fe->unpause_with_new_config();
+  }
+  ldpp_dout(dpp, 1) << "All frontends unpaused" << dendl;
+}
+
 void rgw::AppMain::shutdown(std::function<void(void)> finalize_async_signals)
 {
   // stop the realm reloader

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -503,6 +503,10 @@ class AsioFrontend {
 
   std::atomic<bool> going_down{false};
 
+  // Socket options saved for reopening listeners after pause
+  bool reuse_port{false};
+  int max_connection_backlog{boost::asio::socket_base::max_listen_connections};
+
   RGWAsioBackoff backoff;
   CephContext* ctx() const { return cct.get(); }
   std::optional<dmc::ClientCounters> client_counters;
@@ -549,6 +553,11 @@ class AsioFrontend {
   void join();
   void pause();
   void unpause();
+
+private:
+  // Helper to open, bind, listen and start accept loop for a listener
+  // Returns 0 on success, negative error code on failure
+  int start_listener(Listener& l);
 };
 
 unsigned short parse_port(const char *input, boost::system::error_code& ec)
@@ -632,6 +641,72 @@ static int drop_privileges(CephContext *ctx)
     ldout(ctx, 0) << "set uid:gid to " << uid << ":" << gid
                   << " (" << uid_string << ":" << gid_string << ")" << dendl;
   }
+  return 0;
+}
+
+int AsioFrontend::start_listener(Listener& l)
+{
+  boost::system::error_code ec;
+
+  l.acceptor.open(l.endpoint.protocol(), ec);
+  if (ec) {
+    if (ec == boost::asio::error::address_family_not_supported) {
+      ldout(ctx(), 0) << "WARNING: cannot open socket for endpoint="
+                      << l.endpoint << ", " << ec.message() << dendl;
+      return -ec.value();
+    }
+    lderr(ctx()) << "failed to open socket: " << ec.message() << dendl;
+    return -ec.value();
+  }
+
+  if (l.endpoint.protocol() == tcp::v6()) {
+    l.acceptor.set_option(boost::asio::ip::v6_only(true), ec);
+    if (ec) {
+      lderr(ctx()) << "failed to set v6_only socket option: " << ec.message()
+                   << dendl;
+      return -ec.value();
+    }
+  }
+
+  if (reuse_port) {
+    int one = 1;
+    if (setsockopt(
+            l.acceptor.native_handle(), SOL_SOCKET, SO_REUSEADDR | SO_REUSEPORT,
+            &one, sizeof(one)) == -1) {
+      lderr(ctx()) << "setsockopt SO_REUSEADDR | SO_REUSEPORT failed" << dendl;
+      return -errno;
+    }
+  } else {
+    l.acceptor.set_option(tcp::acceptor::reuse_address(true), ec);
+    if (ec) {
+      lderr(ctx()) << "failed to set reuse_address socket option: "
+                   << ec.message() << dendl;
+      return -ec.value();
+    }
+  }
+
+  l.acceptor.bind(l.endpoint, ec);
+  if (ec) {
+    lderr(ctx()) << "failed to bind address " << l.endpoint << ": "
+                 << ec.message() << dendl;
+    return -ec.value();
+  }
+
+  l.acceptor.listen(max_connection_backlog, ec);
+  if (ec) {
+    lderr(ctx()) << "failed to listen on " << l.endpoint << ": " << ec.message()
+                 << dendl;
+    return -ec.value();
+  }
+
+  // spawn a cancellable coroutine to run the accept loop
+  boost::asio::spawn(
+      context,
+      [this, &l](boost::asio::yield_context yield) mutable { accept(l, yield); },
+      bind_cancellation_slot(
+          l.signal.slot(), bind_executor(context, boost::asio::detached)));
+
+  ldout(ctx(), 4) << "frontend listening on " << l.endpoint << dendl;
   return 0;
 }
 
@@ -724,78 +799,32 @@ int AsioFrontend::init()
     }
   }
 
-  bool reuse_port = false;
   auto reuse_port_it = config.find("so_reuseport");
   if (reuse_port_it != config.end()) {
     reuse_port = (reuse_port_it->second == "1");
   }
+
+  auto backlog_it = config.find("max_connection_backlog");
+  if (backlog_it != config.end()) {
+    string err;
+    max_connection_backlog = strict_strtol(backlog_it->second.c_str(), 10, &err);
+    if (!err.empty()) {
+      ldout(ctx(), 0) << "WARNING: invalid value for max_connection_backlog="
+                      << backlog_it->second << dendl;
+      max_connection_backlog = boost::asio::socket_base::max_listen_connections;
+    }
+  }
+
   bool socket_bound = false;
   // start listeners
   for (auto& l : listeners) {
-    l.acceptor.open(l.endpoint.protocol(), ec);
-    if (ec) {
-      if (ec == boost::asio::error::address_family_not_supported) {
-	ldout(ctx(), 0) << "WARNING: cannot open socket for endpoint=" << l.endpoint
-			<< ", " << ec.message() << dendl;
-	continue;
-      }
-
-      lderr(ctx()) << "failed to open socket: " << ec.message() << dendl;
-      return -ec.value();
+    int r = start_listener(l);
+    if (r == 0) {
+      socket_bound = true;
+    } else if (r != -EAFNOSUPPORT) {
+      // address_family_not_supported is not fatal, but other errors are
+      return r;
     }
-
-    if (l.endpoint.protocol() == tcp::v6()) {
-      l.acceptor.set_option(boost::asio::ip::v6_only(true), ec);
-      if (ec) {
-        lderr(ctx()) << "failed to set v6_only socket option: "
-		     << ec.message() << dendl;
-	return -ec.value();
-      }
-    }
-
-    if (reuse_port) {
-      // setting option |SO_REUSEPORT| allows running of multiple rgw processes on
-      // the same port. Can read more about the implementation here.
-      // https://web.git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git/commit/?id=c617f398edd4db2b8567a28e899a88f8f574798d
-      int one = 1;
-      if (setsockopt(l.acceptor.native_handle(), SOL_SOCKET,
-                     SO_REUSEADDR | SO_REUSEPORT, &one, sizeof(one)) == -1) {
-        lderr(ctx()) << "setsockopt SO_REUSEADDR | SO_REUSEPORT failed:" <<
- dendl;
-        return -1;
-      }
-    } else {
-      l.acceptor.set_option(tcp::acceptor::reuse_address(true));
-    }
-
-    l.acceptor.bind(l.endpoint, ec);
-    if (ec) {
-      lderr(ctx()) << "failed to bind address " << l.endpoint
-          << ": " << ec.message() << dendl;
-      return -ec.value();
-    }
-
-    auto it = config.find("max_connection_backlog");
-    auto max_connection_backlog = boost::asio::socket_base::max_listen_connections;
-    if (it != config.end()) {
-      string err;
-      max_connection_backlog = strict_strtol(it->second.c_str(), 10, &err);
-      if (!err.empty()) {
-        ldout(ctx(), 0) << "WARNING: invalid value for max_connection_backlog=" << it->second << dendl;
-        max_connection_backlog = boost::asio::socket_base::max_listen_connections;
-      }
-    }
-    l.acceptor.listen(max_connection_backlog);
-
-    // spawn a cancellable coroutine to the run the accept loop
-    boost::asio::spawn(context,
-      [this, &l] (boost::asio::yield_context yield) mutable {
-        accept(l, yield);
-      }, bind_cancellation_slot(l.signal.slot(),
-             bind_executor(context, boost::asio::detached)));
-
-    ldout(ctx(), 4) << "frontend listening on " << l.endpoint << dendl;
-    socket_bound = true;
   }
   if (!socket_bound) {
     lderr(ctx()) << "Unable to listen at any endpoints" << dendl;
@@ -1287,12 +1316,12 @@ void AsioFrontend::join()
 
 void AsioFrontend::pause()
 {
-  ldout(ctx(), 4) << "frontend pausing, closing connections..." << dendl;
+  ldout(ctx(), 4) << "frontend pausing, closing listener sockets..." << dendl;
 
-  // cancel pending calls to accept(), but don't close the sockets
   boost::system::error_code ec;
+  // close all listener sockets so new connections are refused immediately
   for (auto& l : listeners) {
-    l.acceptor.cancel(ec);
+    l.acceptor.close(ec);
     // signal cancellation of accept()
     l.signal.emit(boost::asio::cancellation_type::terminal);
   }
@@ -1309,23 +1338,25 @@ void AsioFrontend::pause()
   if (ec) {
     ldout(ctx(), 1) << "frontend failed to pause: " << ec.message() << dendl;
   } else {
-    ldout(ctx(), 4) << "frontend paused" << dendl;
+    ldout(ctx(), 4) << "frontend paused, listener sockets closed" << dendl;
   }
 }
 
-void AsioFrontend::unpause()
+void
+AsioFrontend::unpause()
 {
+  ldout(ctx(), 4) << "frontend unpausing, reopening listener sockets..."
+                  << dendl;
+
   // unpause to unblock connections
   pause_mutex.unlock();
 
-  // start accepting connections again
+  // reopen, rebind and start listening on all sockets
   for (auto& l : listeners) {
-    boost::asio::spawn(context,
-      [this, &l] (boost::asio::yield_context yield) mutable {
-        accept(l, yield);
-      }, bind_cancellation_slot(l.signal.slot(),
-             bind_executor(context, boost::asio::detached)));
-
+    int r = start_listener(l);
+    if (r < 0 && r != -EAFNOSUPPORT) {
+      lderr(ctx()) << "failed to start listener during unpause: " << r << dendl;
+    }
   }
 
   ldout(ctx(), 4) << "frontend unpaused" << dendl;

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -135,7 +135,16 @@ int main(int argc, char *argv[])
   register_async_signal_handler(SIGINT, rgw::signal::handle_sigterm);
   register_async_signal_handler(SIGUSR1, rgw::signal::handle_sigterm);
   register_async_signal_handler(SIGXFSZ, rgw::signal::sig_handler_noop);
+  // SIGUSR2 to pause frontend (stop accepting new TCP connections)
+  register_async_signal_handler(SIGUSR2, rgw::signal::handle_sigpause);
+#ifdef SIGCONT
+  // SIGCONT to resume frontend (start accepting TCP connections again)
+  register_async_signal_handler(SIGCONT, rgw::signal::handle_sigresume);
+#endif
   sighandler_alrm = signal(SIGALRM, godown_alarm);
+
+  // Set the app_main pointer for signal handlers to use
+  rgw::signal::set_app_main(&main);
 
   main.init_perfcounters();
   main.init_http_clients();
@@ -188,6 +197,10 @@ int main(int argc, char *argv[])
     unregister_async_signal_handler(SIGINT, rgw::signal::handle_sigterm);
     unregister_async_signal_handler(SIGUSR1, rgw::signal::handle_sigterm);
     unregister_async_signal_handler(SIGXFSZ, rgw::signal::sig_handler_noop);
+    unregister_async_signal_handler(SIGUSR2, rgw::signal::handle_sigpause);
+#ifdef SIGCONT
+    unregister_async_signal_handler(SIGCONT, rgw::signal::handle_sigresume);
+#endif
     shutdown_async_signal_handler();
   };
 

--- a/src/rgw/rgw_main.h
+++ b/src/rgw/rgw_main.h
@@ -129,6 +129,11 @@ public:
   void init_dedup();
 #endif
 
+  // Pause frontends to stop accepting new TCP connections
+  void pause_frontends();
+  // Unpause frontends to resume accepting TCP connections
+  void unpause_frontends();
+
   bool have_http() {
     return have_http_frontend;
   }

--- a/src/rgw/rgw_signal.cc
+++ b/src/rgw/rgw_signal.cc
@@ -14,11 +14,15 @@
  */
 
 #include "rgw_signal.h"
-#include "global/signal_handler.h"
-#include "common/safe_io.h"
+
+#include <atomic>
+
 #include "common/errno.h"
-#include "rgw_main.h"
+#include "common/safe_io.h"
+#include "global/signal_handler.h"
+
 #include "rgw_log.h"
+#include "rgw_main.h"
 
 #ifdef HAVE_SYS_PRCTL_H
 #include <sys/prctl.h>
@@ -92,4 +96,53 @@ void handle_sigterm(int signum)
   }
 } /* handle_sigterm */
 
-}} /* namespace rgw::signal */
+static std::atomic<bool> frontend_paused{false};
+static rgw::AppMain* g_app_main{nullptr};
+
+void set_app_main(rgw::AppMain* app_main) { g_app_main = app_main; }
+
+void handle_sigpause(int signum)
+{
+  dout(1) << __func__ << " received signal " << signum << dendl;
+
+  if (!g_app_main) {
+    derr << "ERROR: " << __func__ << " app_main not set, cannot pause frontends"
+         << dendl;
+    return;
+  }
+
+  // Only pause if not already paused
+  bool expected = false;
+  if (frontend_paused.compare_exchange_strong(expected, true)) {
+    dout(1) << __func__ << " pausing TCP frontend listeners..." << dendl;
+    g_app_main->pause_frontends();
+    dout(1) << __func__ << " TCP frontend listeners paused" << dendl;
+  } else {
+    dout(1) << __func__ << " frontends already paused, ignoring" << dendl;
+  }
+} /* handle_sigpause */
+
+void handle_sigresume(int signum)
+{
+  dout(1) << __func__ << " received signal " << signum << dendl;
+
+  if (!g_app_main) {
+    derr << "ERROR: " << __func__
+         << " app_main not set, cannot resume frontends" << dendl;
+    return;
+  }
+
+  // Only unpause if currently paused
+  bool expected = true;
+  if (frontend_paused.compare_exchange_strong(expected, false)) {
+    dout(1) << __func__ << " resuming TCP frontend listeners..." << dendl;
+    g_app_main->unpause_frontends();
+    dout(1) << __func__ << " TCP frontend listeners resumed" << dendl;
+  } else {
+    dout(1) << __func__ << " frontends not paused, ignoring" << dendl;
+  }
+} /* handle_sigresume */
+
+
+} // namespace signal
+} // namespace rgw

--- a/src/rgw/rgw_signal.h
+++ b/src/rgw/rgw_signal.h
@@ -17,6 +17,8 @@
 
 
 namespace rgw {
+class AppMain; // forward declaration
+
 namespace signal {
 
 void sig_handler_noop(int signum);
@@ -27,6 +29,9 @@ void signal_fd_finalize();
 void handle_sigterm(int signum);
 void handle_sigterm(int signum);
 void sighup_handler(int signum);
+void handle_sigpause(int signum);
+void handle_sigresume(int signum);
+void set_app_main(rgw::AppMain* app_main);
 
 } // namespace signal
 } // namespace rgw


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
