### PR TITLE
test/encoding: disable LeakSanitizer in readable.sh and check-generated.sh

### DIFF
--- a/src/test/encoding/check-generated.sh
+++ b/src/test/encoding/check-generated.sh
@@ -4,6 +4,12 @@ set -e
 source $(dirname $0)/../detect-build-env-vars.sh
 source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
 
+if ldd $(command -v ceph-dencoder) 2>/dev/null | grep -q libasan; then
+  # Per-object leak checks dominate runtime here (~10s vs ~1s each on riscv64)
+  # and this test only checks encode/decode, so disable them; keep other checks.
+  export ASAN_OPTIONS="${ASAN_OPTIONS:+$ASAN_OPTIONS:}detect_leaks=0"
+fi
+
 dir=$1
 
 test_selected_type() {

--- a/src/test/encoding/readable.sh
+++ b/src/test/encoding/readable.sh
@@ -34,6 +34,10 @@ if ldd $(command -v $CEPH_DENCODER) 2>/dev/null | grep -q libasan; then
   else
     echo "ASAN build detected but 'setarch -R' is unavailable; running ceph-dencoder without ASLR disable"
   fi
+
+  # Per-object leak checks dominate runtime here (~10s vs ~1s each on riscv64)
+  # and this test only checks encode/decode, so disable them; keep other checks.
+  export ASAN_OPTIONS="${ASAN_OPTIONS:+$ASAN_OPTIONS:}detect_leaks=0"
 fi
 
 myversion=$($CEPH_DENCODER version)


### PR DESCRIPTION
readable.sh forks two short-lived ceph-dencoder processes per corpus
object(tens of thousands of processes overall). With ASAN's
LeakSanitizer enabled each process runs a whole-heap leak check at exit
that dominates runtime (~10s vs ~1s per process, measured on riscv64).
This test only validates encode/decode behaviour, not leaks, so disable
leak detection while keeping ASAN's other checks active.

check-generated.sh forks ceph-dencoder the same way, so apply the same
fix there.

Without this change, ceph-dencoder consumes a large amount of mem, forcing us to set MAX_PARALLEL_JOBS to avoid OOM, and readable.sh takes >12h.  With it, MAX_PARALLEL_JOBS can be removed, and readable.sh takes < 1h .

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests