### PR TITLE
cmake/boost: build libboost_context with BOOST_USE_ASAN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -825,12 +825,7 @@ else()
     # Boost.Context is built ucontext-only here (context-impl=ucontext); define
     # the matching backend tree-wide so every Boost.Context/Coroutine2 consumer
     # agrees on it, instead of relying on per-target propagation that is easy to miss.
-    # Except riscv64: its ASan mis-handles ucontext, so it keeps fcontext.
-    if(CMAKE_SYSTEM_PROCESSOR MATCHES "riscv")
-      add_compile_definitions(BOOST_USE_ASAN)
-    else()
-      add_compile_definitions(BOOST_USE_ASAN BOOST_USE_UCONTEXT)
-    endif()
+    add_compile_definitions(BOOST_USE_ASAN BOOST_USE_UCONTEXT)
   endif()
 endif()
 include_directories(BEFORE SYSTEM ${Boost_INCLUDE_DIRS})

--- a/cmake/modules/BuildBoost.cmake
+++ b/cmake/modules/BuildBoost.cmake
@@ -146,9 +146,11 @@ function(do_build_boost root_dir version)
   endif()
   set(b2_targets headers stage)
   set(b2_install_targets install)
-  # Except riscv64: its ASan mis-handles ucontext, so it keeps fcontext.
-  if(WITH_ASAN AND NOT (CMAKE_SYSTEM_PROCESSOR MATCHES "riscv"))
+  if(WITH_ASAN)
     list(APPEND b2 context-impl=ucontext)
+    # build the library with the BOOST_USE_ASAN consumers get from Boost::context,
+    # so fiber_activation_record has one layout (else heap-buffer-overflow)
+    list(APPEND b2 define=BOOST_USE_ASAN)
     # `context-impl` is declared in libs/context/build/Jamfile.v2; the headers/stage
     # and install targets never load it, so b2 aborts with `unknown feature
     # "<context-impl>"`. Name the context project as a target so its Jamfile loads


### PR DESCRIPTION
The ceph-api job failed under ASan: radosgw-admin aborted at startup with a heap-buffer-overflow in boost.context's fiber `resume()`.
```
  ==1155842==ERROR: AddressSanitizer: heap-buffer-overflow ... READ of size 8
    #0 boost::context::detail::fiber_activation_record::resume() fiber_ucontext.hpp:153
    #10 RGWSI_Notify::do_start(optional_yield, DoutPrefixProvider const*) svc_notify.cc:261
  0x... is located 8 bytes after 1048-byte region allocated by
    boost::context::detail::fiber_activation_record_initializer()
```
fiber_activation_record carries three extra members (fake_stack, stack_bottom, stack_size) only when BOOST_USE_ASAN is defined.  Under `WITH_ASAN` we build boost.context with `context-impl=ucontext` and give consumers `BOOST_USE_ASAN` and `BOOST_USE_UCONTEXT` through `Boost::context`'s `INTERFACE_COMPILE_DEFINITIONS`, but we never pass `BOOST_USE_ASAN` to b2.  So `libboost_context`, which compiles `fiber_activation_record_initializer()` and allocates the record, uses the smaller no-ASan layout, while consumers that include the header (here rgw's `RGWSI_Notify::do_start` via `boost::asio::spawn`) compile resume() with the larger layout and read stack_bottom/stack_size past the allocation.

Pass `define=BOOST_USE_ASAN` to b2 so the library and its consumers agree on the struct layout.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
