### PR TITLE
test/osd: Add truncate-then-write tests 

### DIFF
--- a/src/common/io_exerciser/EcIoSequence.cc
+++ b/src/common/io_exerciser/EcIoSequence.cc
@@ -45,6 +45,10 @@ std::unique_ptr<IoSequence> EcIoSequence::generate_sequence(
     case Sequence::SEQUENCE_SEQ13:
       [[fallthrough]];
     case Sequence::SEQUENCE_SEQ14:
+      [[fallthrough]];
+    case Sequence::SEQUENCE_SEQ15:
+      [[fallthrough]];
+    case Sequence::SEQUENCE_SEQ16:
       return std::make_unique<ReadInjectSequence>(obj_size_range, seed,
                                                   sequence, km, mappinglayers, check_consistency);
     case Sequence::SEQUENCE_SEQ10:

--- a/src/common/io_exerciser/IoOp.cc
+++ b/src/common/io_exerciser/IoOp.cc
@@ -24,6 +24,9 @@ using DoubleFailedWriteOp = ceph::io_exerciser::DoubleFailedWriteOp;
 using TripleFailedWriteOp = ceph::io_exerciser::TripleFailedWriteOp;
 using SingleAppendOp = ceph::io_exerciser::SingleAppendOp;
 using TruncateOp = ceph::io_exerciser::TruncateOp;
+using SingleTruncateWriteOp = ceph::io_exerciser::SingleTruncateWriteOp;
+using DoubleTruncateWriteOp = ceph::io_exerciser::DoubleTruncateWriteOp;
+using TripleTruncateWriteOp = ceph::io_exerciser::TripleTruncateWriteOp;
 
 namespace {
 std::string value_to_string(uint64_t v) {
@@ -286,6 +289,68 @@ std::unique_ptr<TruncateOp> TruncateOp::generate(uint64_t size) {
 std::string TruncateOp::to_string(uint64_t block_size) const {
   return "Truncate (size=" + value_to_string(size * block_size) + ")";
 }
+
+template <OpType opType, int N>
+ceph::io_exerciser::TruncateWriteOp<opType, N>::TruncateWriteOp(
+    uint64_t size, std::array<uint64_t, N>&& offset,
+    std::array<uint64_t, N>&& length)
+    : TestOp<opType>(), size(size), offset(offset), length(length) {}
+
+template <OpType opType, int N>
+std::string ceph::io_exerciser::TruncateWriteOp<opType, N>::to_string(
+    uint64_t block_size) const {
+  std::string result = "TruncateWrite (size=" + value_to_string(size * block_size);
+  for (int i = 0; i < N; i++) {
+    result += ", offset" + (N > 1 ? std::to_string(i + 1) : "") + "=" +
+              value_to_string(offset[i] * block_size) + ", length" +
+              (N > 1 ? std::to_string(i + 1) : "") + "=" +
+              value_to_string(length[i] * block_size);
+  }
+  result += ")";
+  return result;
+}
+
+SingleTruncateWriteOp::SingleTruncateWriteOp(uint64_t size, uint64_t offset,
+                                             uint64_t length)
+    : TruncateWriteOp<OpType::TruncateWrite, 1>(size, {offset}, {length}) {}
+
+std::unique_ptr<SingleTruncateWriteOp> SingleTruncateWriteOp::generate(
+    uint64_t size, uint64_t offset, uint64_t length) {
+  return std::make_unique<SingleTruncateWriteOp>(size, offset, length);
+}
+
+DoubleTruncateWriteOp::DoubleTruncateWriteOp(uint64_t size, uint64_t offset1,
+                                             uint64_t length1, uint64_t offset2,
+                                             uint64_t length2)
+    : TruncateWriteOp<OpType::TruncateWrite2, 2>(size, {offset1, offset2},
+                                                  {length1, length2}) {}
+
+std::unique_ptr<DoubleTruncateWriteOp> DoubleTruncateWriteOp::generate(
+    uint64_t size, uint64_t offset1, uint64_t length1, uint64_t offset2,
+    uint64_t length2) {
+  return std::make_unique<DoubleTruncateWriteOp>(size, offset1, length1,
+                                                 offset2, length2);
+}
+
+TripleTruncateWriteOp::TripleTruncateWriteOp(uint64_t size, uint64_t offset1,
+                                             uint64_t length1, uint64_t offset2,
+                                             uint64_t length2, uint64_t offset3,
+                                             uint64_t length3)
+    : TruncateWriteOp<OpType::TruncateWrite3, 3>(
+          size, {offset1, offset2, offset3}, {length1, length2, length3}) {}
+
+std::unique_ptr<TripleTruncateWriteOp> TripleTruncateWriteOp::generate(
+    uint64_t size, uint64_t offset1, uint64_t length1, uint64_t offset2,
+    uint64_t length2, uint64_t offset3, uint64_t length3) {
+  return std::make_unique<TripleTruncateWriteOp>(size, offset1, length1,
+                                                 offset2, length2, offset3,
+                                                 length3);
+}
+
+// Explicit template instantiations
+template class ceph::io_exerciser::TruncateWriteOp<OpType::TruncateWrite, 1>;
+template class ceph::io_exerciser::TruncateWriteOp<OpType::TruncateWrite2, 2>;
+template class ceph::io_exerciser::TruncateWriteOp<OpType::TruncateWrite3, 3>;
 
 SingleFailedWriteOp::SingleFailedWriteOp(uint64_t offset, uint64_t length)
     : ReadWriteOp<OpType::FailedWrite, 1>({offset}, {length}) {}

--- a/src/common/io_exerciser/IoOp.h
+++ b/src/common/io_exerciser/IoOp.h
@@ -175,6 +175,49 @@ class TruncateOp : public TestOp<OpType::Truncate> {
   uint64_t size;
 };
 
+template <OpType opType, int numIOs>
+class TruncateWriteOp : public TestOp<opType> {
+ public:
+  uint64_t size;
+  std::array<uint64_t, numIOs> offset;
+  std::array<uint64_t, numIOs> length;
+
+ protected:
+  TruncateWriteOp(uint64_t size,
+                  std::array<uint64_t, numIOs>&& offset,
+                  std::array<uint64_t, numIOs>&& length);
+  std::string to_string(uint64_t block_size) const override;
+};
+
+class SingleTruncateWriteOp : public TruncateWriteOp<OpType::TruncateWrite, 1> {
+ public:
+  SingleTruncateWriteOp(uint64_t size, uint64_t offset, uint64_t length);
+  static std::unique_ptr<SingleTruncateWriteOp> generate(uint64_t size,
+                                                          uint64_t offset,
+                                                          uint64_t length);
+};
+
+class DoubleTruncateWriteOp : public TruncateWriteOp<OpType::TruncateWrite2, 2> {
+ public:
+  DoubleTruncateWriteOp(uint64_t size, uint64_t offset1, uint64_t length1,
+                        uint64_t offset2, uint64_t length2);
+  static std::unique_ptr<DoubleTruncateWriteOp> generate(uint64_t size,
+                                                          uint64_t offset1,
+                                                          uint64_t length1,
+                                                          uint64_t offset2,
+                                                          uint64_t length2);
+};
+
+class TripleTruncateWriteOp : public TruncateWriteOp<OpType::TruncateWrite3, 3> {
+ public:
+  TripleTruncateWriteOp(uint64_t size, uint64_t offset1, uint64_t length1,
+                        uint64_t offset2, uint64_t length2, uint64_t offset3,
+                        uint64_t length3);
+  static std::unique_ptr<TripleTruncateWriteOp> generate(
+      uint64_t size, uint64_t offset1, uint64_t length1, uint64_t offset2,
+      uint64_t length2, uint64_t offset3, uint64_t length3);
+};
+
 class SingleFailedWriteOp : public ReadWriteOp<OpType::FailedWrite, 1> {
  public:
   SingleFailedWriteOp(uint64_t offset, uint64_t length);

--- a/src/common/io_exerciser/IoSequence.cc
+++ b/src/common/io_exerciser/IoSequence.cc
@@ -59,6 +59,9 @@ std::ostream& ceph::io_exerciser::operator<<(std::ostream& os,
     case Sequence::SEQUENCE_SEQ15:
       os << "SEQUENCE_SEQ15";
       break;
+    case Sequence::SEQUENCE_SEQ16:
+      os << "SEQUENCE_SEQ16";
+      break;
     case Sequence::SEQUENCE_END:
       os << "SEQUENCE_END";
       break;
@@ -108,6 +111,8 @@ std::unique_ptr<IoSequence> IoSequence::generate_sequence(
       return std::make_unique<Seq14>(obj_size_range, seed, check_consistency);
     case Sequence::SEQUENCE_SEQ15:
       return std::make_unique<Seq15>(obj_size_range, seed, check_consistency);
+    case Sequence::SEQUENCE_SEQ16:
+      return std::make_unique<Seq16>(obj_size_range, seed, check_consistency);
     default:
       break;
   }
@@ -855,8 +860,82 @@ std::unique_ptr<ceph::io_exerciser::IoOp> ceph::io_exerciser::Seq15::_next() {
       [[fallthrough]];
     default:
       done = true;
+      remove = true;
       break;
   }
 
   return r;
+}
+
+
+// Seq16: Multiple TruncateWrite operations with Consistency checks
+// Each operation performs:
+//   1. Truncate to a random size between 0 and current object size
+//   2. Write a single block (size 1) at a random offset within the object
+//   3. Consistency check
+ceph::io_exerciser::Seq16::Seq16(std::pair<int, int> obj_size_range, int seed, bool check_consistency)
+    : IoSequence(obj_size_range, seed, check_consistency),
+      truncate_size(0),
+      write_offset(0),
+      operation_count(0),
+      total_operations(20),
+      truncate_write_done(false),
+      consistency_done(false) {
+  select_random_object_size();
+  setup_next_operation();
+}
+
+Sequence ceph::io_exerciser::Seq16::get_id() const {
+  return Sequence::SEQUENCE_SEQ16;
+}
+
+std::string ceph::io_exerciser::Seq16::get_name() const {
+  return "Multiple TruncateWrite operations with varying sizes and Consistency checks";
+}
+
+void ceph::io_exerciser::Seq16::setup_next_operation() {
+  // Generate random truncate size between 0 and current object size
+  truncate_size = rng(obj_size + 1);
+  
+  // Generate random write offset within object size
+  // Ensure write stays within bounds (write_offset < obj_size for size 1 write)
+  write_offset = obj_size > 0 ? rng(obj_size) : 0;
+  
+  truncate_write_done = false;
+  consistency_done = false;
+}
+
+std::unique_ptr<ceph::io_exerciser::IoOp> ceph::io_exerciser::Seq16::_next() {
+  // Check if we're done with all operations
+  if (operation_count >= total_operations) {
+    done = true;
+    remove = true;
+    barrier = true;
+    return BarrierOp::generate();
+  }
+  
+  // Perform TruncateWrite operation with a single write of size 1
+  if (!truncate_write_done) {
+    truncate_write_done = true;
+    barrier = true;
+    return SingleTruncateWriteOp::generate(truncate_size, write_offset, 1);
+  }
+  
+  // Perform Consistency check
+  if (!consistency_done) {
+    consistency_done = true;
+    barrier = true;
+    
+    // Move to next operation
+    operation_count++;
+    if (operation_count < total_operations) {
+      setup_next_operation();
+    }
+    
+    return ConsistencyOp::generate();
+  }
+  
+  // Should not reach here
+  barrier = true;
+  return BarrierOp::generate();
 }

--- a/src/common/io_exerciser/IoSequence.h
+++ b/src/common/io_exerciser/IoSequence.h
@@ -48,6 +48,7 @@ enum class Sequence {
   SEQUENCE_SEQ13,
   SEQUENCE_SEQ14,
   SEQUENCE_SEQ15,
+  SEQUENCE_SEQ16,
 
   SEQUENCE_END,
   SEQUENCE_BEGIN = SEQUENCE_SEQ0
@@ -333,6 +334,25 @@ class Seq15 : public IoSequence {
  public:
   Seq15(std::pair<int, int> obj_size_range, int seed, bool check_consistency);
 
+  Sequence get_id() const override;
+  std::string get_name() const override;
+  std::unique_ptr<IoOp> _next() override;
+};
+
+class Seq16 : public IoSequence {
+ private:
+  uint64_t truncate_size;
+  uint64_t write_offset;
+  int operation_count;
+  int total_operations;
+  bool truncate_write_done;
+  bool consistency_done;
+  
+  void setup_next_operation();
+
+ public:
+  Seq16(std::pair<int, int> obj_size_range, int seed, bool check_consistency);
+  
   Sequence get_id() const override;
   std::string get_name() const override;
   std::unique_ptr<IoOp> _next() override;

--- a/src/common/io_exerciser/ObjectModel.cc
+++ b/src/common/io_exerciser/ObjectModel.cc
@@ -212,6 +212,94 @@ void ObjectModel::applyIoOp(IoOp& op) {
       verify_write_and_record_and_generate_seed(appendOp);
     } break;
 
+    case OpType::TruncateWrite: {
+      ceph_assert(primary_created);
+      ceph_assert(reads.empty());
+      ceph_assert(writes.empty());
+      SingleTruncateWriteOp& truncWriteOp = static_cast<SingleTruncateWriteOp&>(op);
+      auto new_size = truncWriteOp.size;
+      auto old_size = primary_contents.size();
+      bool expand = new_size > old_size;
+      primary_contents.resize(new_size);
+      if (expand) {
+        std::generate(std::execution::seq, primary_contents.begin() + old_size,
+                      primary_contents.end(), generate_random);
+      }
+      // Now apply the write operations
+      for (int i = 0; i < 1; i++) {
+        ceph_assert(!reads.intersects(truncWriteOp.offset[i], truncWriteOp.length[i]));
+        ceph_assert(!writes.intersects(truncWriteOp.offset[i], truncWriteOp.length[i]));
+        writes.union_insert(truncWriteOp.offset[i], truncWriteOp.length[i]);
+        if (truncWriteOp.offset[i] + truncWriteOp.length[i] > primary_contents.size()) {
+          primary_contents.resize(truncWriteOp.offset[i] + truncWriteOp.length[i]);
+        }
+        std::generate(std::execution::seq,
+                      std::next(primary_contents.begin(), truncWriteOp.offset[i]),
+                      std::next(primary_contents.begin(),
+                                truncWriteOp.offset[i] + truncWriteOp.length[i]),
+                      generate_random);
+      }
+      num_io++;
+    } break;
+    case OpType::TruncateWrite2: {
+      ceph_assert(primary_created);
+      ceph_assert(reads.empty());
+      ceph_assert(writes.empty());
+      DoubleTruncateWriteOp& truncWriteOp = static_cast<DoubleTruncateWriteOp&>(op);
+      auto new_size = truncWriteOp.size;
+      auto old_size = primary_contents.size();
+      bool expand = new_size > old_size;
+      primary_contents.resize(new_size);
+      if (expand) {
+        std::generate(std::execution::seq, primary_contents.begin() + old_size,
+                      primary_contents.end(), generate_random);
+      }
+      // Now apply the write operations
+      for (int i = 0; i < 2; i++) {
+        ceph_assert(!reads.intersects(truncWriteOp.offset[i], truncWriteOp.length[i]));
+        ceph_assert(!writes.intersects(truncWriteOp.offset[i], truncWriteOp.length[i]));
+        writes.union_insert(truncWriteOp.offset[i], truncWriteOp.length[i]);
+        if (truncWriteOp.offset[i] + truncWriteOp.length[i] > primary_contents.size()) {
+          primary_contents.resize(truncWriteOp.offset[i] + truncWriteOp.length[i]);
+        }
+        std::generate(std::execution::seq,
+                      std::next(primary_contents.begin(), truncWriteOp.offset[i]),
+                      std::next(primary_contents.begin(),
+                                truncWriteOp.offset[i] + truncWriteOp.length[i]),
+                      generate_random);
+      }
+      num_io++;
+    } break;
+    case OpType::TruncateWrite3: {
+      ceph_assert(primary_created);
+      ceph_assert(reads.empty());
+      ceph_assert(writes.empty());
+      TripleTruncateWriteOp& truncWriteOp = static_cast<TripleTruncateWriteOp&>(op);
+      auto new_size = truncWriteOp.size;
+      auto old_size = primary_contents.size();
+      bool expand = new_size > old_size;
+      primary_contents.resize(new_size);
+      if (expand) {
+        std::generate(std::execution::seq, primary_contents.begin() + old_size,
+                      primary_contents.end(), generate_random);
+      }
+      // Now apply the write operations
+      for (int i = 0; i < 3; i++) {
+        ceph_assert(!reads.intersects(truncWriteOp.offset[i], truncWriteOp.length[i]));
+        ceph_assert(!writes.intersects(truncWriteOp.offset[i], truncWriteOp.length[i]));
+        writes.union_insert(truncWriteOp.offset[i], truncWriteOp.length[i]);
+        if (truncWriteOp.offset[i] + truncWriteOp.length[i] > primary_contents.size()) {
+          primary_contents.resize(truncWriteOp.offset[i] + truncWriteOp.length[i]);
+        }
+        std::generate(std::execution::seq,
+                      std::next(primary_contents.begin(), truncWriteOp.offset[i]),
+                      std::next(primary_contents.begin(),
+                                truncWriteOp.offset[i] + truncWriteOp.length[i]),
+                      generate_random);
+      }
+      num_io++;
+    } break;
+
     case OpType::FailedWrite: {
       ceph_assert(primary_created);
       SingleWriteOp& writeOp = static_cast<SingleWriteOp&>(op);

--- a/src/common/io_exerciser/OpType.h
+++ b/src/common/io_exerciser/OpType.h
@@ -27,6 +27,9 @@ enum class OpType {
   Write3,                // Three writes in a single op
   Append,                // Append
   Truncate,              // Truncate
+  TruncateWrite,         // Truncate + single write in a single op
+  TruncateWrite2,        // Truncate + two writes in a single op
+  TruncateWrite3,        // Truncate + three writes in a single op
   FailedWrite,           // A write which should fail
   FailedWrite2,          // Two writes in one op which should fail
   FailedWrite3,          // Three writes in one op which should fail
@@ -84,6 +87,12 @@ struct fmt::formatter<ceph::io_exerciser::OpType> {
         return fmt::format_to(ctx.out(), "Append");
       case ceph::io_exerciser::OpType::Truncate:
         return fmt::format_to(ctx.out(), "Truncate");
+      case ceph::io_exerciser::OpType::TruncateWrite:
+        return fmt::format_to(ctx.out(), "TruncateWrite");
+      case ceph::io_exerciser::OpType::TruncateWrite2:
+        return fmt::format_to(ctx.out(), "TruncateWrite2");
+      case ceph::io_exerciser::OpType::TruncateWrite3:
+        return fmt::format_to(ctx.out(), "TruncateWrite3");
       case ceph::io_exerciser::OpType::FailedWrite:
         return fmt::format_to(ctx.out(), "FailedWrite");
       case ceph::io_exerciser::OpType::FailedWrite2:

--- a/src/common/io_exerciser/RadosIo.cc
+++ b/src/common/io_exerciser/RadosIo.cc
@@ -236,6 +236,13 @@ void RadosIo::applyIoOp(IoOp& op) {
     case OpType::FailedWrite3:
       applyReadWriteOp(op);
       break;
+    case OpType::TruncateWrite:
+      [[fallthrough]];
+    case OpType::TruncateWrite2:
+      [[fallthrough]];
+    case OpType::TruncateWrite3:
+      applyTruncateWriteOp(op);
+      break;
     case OpType::InjectReadError:
       [[fallthrough]];
     case OpType::InjectWriteError:
@@ -404,6 +411,59 @@ void RadosIo::applyReadWriteOp(IoOp& op) {
     default:
       ceph_abort_msg(
           fmt::format("Unsupported Read/Write operation ({})", op.getOpType()));
+      break;
+  }
+}
+
+void RadosIo::applyTruncateWriteOp(IoOp& op) {
+  auto applyTruncateWriteOp = [this]<OpType opType, int N>(
+                                  TruncateWriteOp<opType, N> truncWriteOp) {
+    auto op_info =
+        std::make_shared<AsyncOpInfo<N>>(truncWriteOp.offset, truncWriteOp.length);
+    librados::ObjectWriteOperation wop;
+    
+    // First, add the truncate operation
+    wop.truncate(truncWriteOp.size * block_size);
+    
+    // Then, add the write operations
+    for (int i = 0; i < N; i++) {
+      op_info->bufferlist[i] =
+          db->generate_data(truncWriteOp.offset[i], truncWriteOp.length[i]);
+      wop.write(truncWriteOp.offset[i] * block_size,
+                op_info->bufferlist[i]);
+    }
+    
+    auto write_cb = [this](boost::system::error_code ec, version_t ver) {
+      ceph_assert(ec == boost::system::errc::success);
+      finish_io();
+    };
+    librados::async_operate(asio.get_executor(), io, primary_oid,
+                            std::move(wop), 0, nullptr, write_cb);
+    num_io++;
+  };
+
+  switch (op.getOpType()) {
+    case OpType::TruncateWrite: {
+      start_io();
+      SingleTruncateWriteOp& truncWriteOp = static_cast<SingleTruncateWriteOp&>(op);
+      applyTruncateWriteOp(truncWriteOp);
+      break;
+    }
+    case OpType::TruncateWrite2: {
+      start_io();
+      DoubleTruncateWriteOp& truncWriteOp = static_cast<DoubleTruncateWriteOp&>(op);
+      applyTruncateWriteOp(truncWriteOp);
+      break;
+    }
+    case OpType::TruncateWrite3: {
+      start_io();
+      TripleTruncateWriteOp& truncWriteOp = static_cast<TripleTruncateWriteOp&>(op);
+      applyTruncateWriteOp(truncWriteOp);
+      break;
+    }
+    default:
+      ceph_abort_msg(
+          fmt::format("Unsupported TruncateWrite operation ({})", op.getOpType()));
       break;
   }
 }

--- a/src/common/io_exerciser/RadosIo.h
+++ b/src/common/io_exerciser/RadosIo.h
@@ -81,6 +81,7 @@ class RadosIo : public Model {
 
  private:
   void applyReadWriteOp(IoOp& op);
+  void applyTruncateWriteOp(IoOp& op);
   void applyInjectOp(IoOp& op);
 };
 }  // namespace io_exerciser

--- a/src/test/osd/PGBackendTestFixture.cc
+++ b/src/test/osd/PGBackendTestFixture.cc
@@ -716,6 +716,117 @@ int PGBackendTestFixture::write(
   return result;
 }
 
+int PGBackendTestFixture::do_write_impl(
+  const std::string& obj_name,
+  uint64_t object_size,
+  std::optional<uint64_t> truncate_size,
+  const std::vector<std::pair<uint64_t, std::string>>& writes)
+{
+  hobject_t hoid = make_test_object(obj_name);
+  PGTransactionUPtr pg_t = std::make_unique<PGTransaction>();
+
+  ObjectContextRef obc = get_object_context(hoid, true);
+  if (obc && !obc->obs.exists) {
+    obc->obs.oi.size = object_size;
+  }
+  pg_t->obc_map[hoid] = obc;
+
+  // Track outstanding write
+  outstanding_writes[hoid]++;
+
+  // Apply truncate if specified
+  if (truncate_size.has_value()) {
+    pg_t->truncate(hoid, truncate_size.value());
+  }
+
+  // Apply all writes
+  uint64_t new_size = truncate_size.value_or(object_size);
+  for (const auto& [offset, data] : writes) {
+    bufferlist bl;
+    bl.append(data);
+    pg_t->write(hoid, offset, bl.length(), bl);
+    new_size = std::max(new_size, offset + bl.length());
+  }
+
+  object_stat_sum_t delta_stats;
+  if (new_size > object_size) {
+    delta_stats.num_bytes = new_size - object_size;
+  } else if (new_size < object_size) {
+    delta_stats.num_bytes = -(int64_t)(object_size - new_size);
+  } else {
+    delta_stats.num_bytes = 0;
+  }
+
+  // Prior version comes from the object's current version
+  eversion_t prior_version = obc->obs.oi.version;
+  eversion_t at_version = get_next_version();
+
+  // Build the NEW OI
+  object_info_t new_oi = obc->obs.oi;
+  new_oi.version = at_version;
+  new_oi.prior_version = prior_version;
+  new_oi.size = new_size;
+
+  // Encode new OI into PGTransaction
+  {
+    bufferlist oi_bl;
+    new_oi.encode(oi_bl,
+      osdmap->get_features(CEPH_ENTITY_TYPE_OSD, nullptr));
+    pg_t->setattr(hoid, OI_ATTR, oi_bl);
+  }
+
+  // Update OBC obs to new state BEFORE submitting
+  obc->obs.oi = new_oi;
+
+  std::vector<pg_log_entry_t> log_entries;
+  pg_log_entry_t entry;
+  entry.op = pg_log_entry_t::MODIFY;
+  entry.soid = hoid;
+  entry.version = at_version;
+  entry.prior_version = prior_version;
+  log_entries.push_back(entry);
+
+  // Create completion lambda for write-specific cleanup
+  auto write_complete = [this, hoid, obc, prior_version, object_size](int r) {
+    // Decrement outstanding writes counter
+    if (outstanding_writes[hoid] > 0) {
+      outstanding_writes[hoid]--;
+      if (outstanding_writes[hoid] == 0) {
+        outstanding_writes.erase(hoid);
+      }
+    }
+
+    if (r != 0 && r != -EINPROGRESS) {
+      // Roll back OBC on failure
+      obc->obs.oi.version = prior_version;
+      obc->obs.oi.size = object_size;
+      obc->attr_cache.clear();
+      outstanding_writes.erase(hoid);
+    }
+  };
+
+  return do_transaction_and_complete(
+    hoid, std::move(pg_t), delta_stats, at_version, std::move(log_entries), write_complete);
+}
+
+int PGBackendTestFixture::write(
+  const std::string& obj_name,
+  uint64_t object_size,
+  std::optional<uint64_t> truncate_size,
+  const std::vector<std::pair<uint64_t, std::string>>& writes)
+{
+  int primary_osd = osdmap->get_pg_acting_primary(pgid);
+  ceph_assert(primary_osd >= 0);
+
+  int result = -1;
+  event_loop->schedule_transaction(primary_osd, [this, &result, obj_name, object_size, truncate_size, &writes]() {
+    result = do_write_impl(obj_name, object_size, truncate_size, writes);
+  });
+  event_loop->run_until_idle();
+
+  return result;
+}
+
 int PGBackendTestFixture::read_object(
   const std::string& obj_name,
   uint64_t offset,
@@ -779,6 +890,124 @@ int PGBackendTestFixture::read_object(
   }
 }
 
+void PGBackendTestFixture::visualize_miscompare(
+  const std::string& obj_name,
+  const char* expected_buf,
+  const char* read_buf,
+  size_t size,
+  const std::string& phase)
+{
+  bool mismatch_found = false;
+  size_t first_mismatch = 0;
+  size_t last_mismatch = 0;
+  
+  // Find mismatches
+  for (size_t i = 0; i < size; i++) {
+    if (read_buf[i] != expected_buf[i]) {
+      if (!mismatch_found) {
+        first_mismatch = i;
+        mismatch_found = true;
+      }
+      last_mismatch = i;
+    }
+  }
+  
+  if (!mismatch_found) {
+    return;  // No mismatches to visualize
+  }
+  
+  std::cout << "\n=== MISCOMPARE DETECTED in " << phase << " ===" << std::endl;
+  std::cout << "Object: " << obj_name << std::endl;
+  if (pool_type == EC) {
+    std::cout << "Config: k=" << k << " m=" << m << " stripe_unit=" << stripe_unit << std::endl;
+  } else {
+    std::cout << "Config: Replicated pool, size=" << num_replicas << std::endl;
+  }
+  std::cout << "Miscompare range: [" << first_mismatch << ", " << last_mismatch << "]" << std::endl;
+  std::cout << "Total mismatches: " << (last_mismatch - first_mismatch + 1) << " bytes" << std::endl;
+  
+  // Show detailed hex+ASCII dump around first mismatch
+  size_t dump_start = (first_mismatch > 64) ? (first_mismatch - 64) : 0;
+  size_t dump_end = std::min(last_mismatch + 64, size);
+  
+  std::cout << "\nHex+ASCII dump around first mismatch [" << dump_start << ", " << dump_end << "):" << std::endl;
+  std::cout << "Offset   Hex                                              ASCII" << std::endl;
+  
+  std::string last_line_hex;
+  std::string last_line_ascii;
+  int repeat_count = 0;
+  
+  for (size_t i = dump_start; i < dump_end; i += 16) {
+    // Build hex representation
+    std::ostringstream hex_stream;
+    for (size_t j = 0; j < 16 && (i + j) < dump_end; j++) {
+      unsigned char c = read_buf[i + j];
+      bool mismatch = (c != expected_buf[i + j]);
+      if (mismatch) hex_stream << "\033[1;31m";
+      hex_stream << std::setw(2) << std::setfill('0') << std::hex << (int)c;
+      if (mismatch) hex_stream << "\033[0m";
+      hex_stream << " ";
+    }
+    std::string hex_line = hex_stream.str();
+    
+    // Build ASCII representation
+    std::ostringstream ascii_stream;
+    for (size_t j = 0; j < 16 && (i + j) < dump_end; j++) {
+      char c = read_buf[i + j];
+      bool mismatch = (c != expected_buf[i + j]);
+      if (mismatch) ascii_stream << "\033[1;31m";
+      ascii_stream << (isprint(c) ? c : '.');
+      if (mismatch) ascii_stream << "\033[0m";
+    }
+    std::string ascii_line = ascii_stream.str();
+    
+    // Check if this line is identical to the last line
+    if (hex_line == last_line_hex && ascii_line == last_line_ascii && i > dump_start) {
+      repeat_count++;
+      continue;
+    }
+    
+    // Print any accumulated repeats
+    if (repeat_count > 0) {
+      std::cout << "         * " << repeat_count << " identical line(s) omitted *" << std::endl;
+      repeat_count = 0;
+    }
+    
+    // Print current line
+    std::cout << std::setw(8) << std::setfill('0') << std::hex << i << " "
+              << std::setw(48) << std::left << hex_line << " " << ascii_line
+              << std::dec << std::endl;
+    
+    last_line_hex = hex_line;
+    last_line_ascii = ascii_line;
+  }
+  
+  // Print any remaining repeats
+  if (repeat_count > 0) {
+    std::cout << "         * " << repeat_count << " identical line(s) omitted *" << std::endl;
+  }
+  
+  // Show expected vs read comparison
+  std::cout << "\nExpected vs Read (first 128 bytes of miscompare):" << std::endl;
+  size_t compare_len = std::min(size_t(128), last_mismatch - first_mismatch + 1);
+  
+  std::cout << "Expected: ";
+  for (size_t i = 0; i < compare_len; i++) {
+    char c = expected_buf[first_mismatch + i];
+    std::cout << (isprint(c) ? c : '.');
+  }
+  std::cout << std::endl;
+  
+  std::cout << "Read:     ";
+  for (size_t i = 0; i < compare_len; i++) {
+    char c = read_buf[first_mismatch + i];
+    if (c != expected_buf[first_mismatch + i]) std::cout << "\033[1;31m";
+    std::cout << (isprint(c) ? c : '.');
+    if (c != expected_buf[first_mismatch + i]) std::cout << "\033[0m";
+  }
+  std::cout << std::endl;
+}
+
 void PGBackendTestFixture::verify_object(
   const std::string& obj_name,
   const std::string& expected_data,
@@ -792,8 +1021,22 @@ void PGBackendTestFixture::verify_object(
   EXPECT_EQ(read_data.length(), expected_data.length()) << "Read data length should match";
   
   if (read_data.length() == expected_data.length()) {
-    std::string read_string(read_data.c_str(), read_data.length());
-    EXPECT_EQ(read_string, expected_data) << "Data should match";
+    const char* read_buf = read_data.c_str();
+    const char* expected_buf = expected_data.c_str();
+    
+    // Check for mismatches
+    bool has_mismatch = false;
+    for (size_t i = 0; i < expected_data.length(); i++) {
+      if (read_buf[i] != expected_buf[i]) {
+        has_mismatch = true;
+        break;
+      }
+    }
+    
+    if (has_mismatch) {
+      visualize_miscompare(obj_name, expected_buf, read_buf, expected_data.length(), "verify_object");
+      FAIL() << "Data mismatch detected";
+    }
   }
 }
 

--- a/src/test/osd/PGBackendTestFixture.h
+++ b/src/test/osd/PGBackendTestFixture.h
@@ -355,6 +355,12 @@ public:
     uint64_t offset,
     const std::string& data,
     uint64_t object_size);
+
+  int do_write_impl(
+    const std::string& obj_name,
+    uint64_t object_size,
+    std::optional<uint64_t> truncate_size,
+    const std::vector<std::pair<uint64_t, std::string>>& writes);
   
   int do_write_attribute_impl(
     const std::string& obj_name,
@@ -373,6 +379,21 @@ public:
     uint64_t offset,
     const std::string& data,
     uint64_t object_size);
+
+  /**
+   * Write operation with optional truncate and multiple writes in a single transaction.
+   *
+   * @param obj_name Name of the object
+   * @param object_size Current size of the object
+   * @param truncate_size Optional truncate size (nullopt means no truncate)
+   * @param writes Vector of {offset, data} pairs to write
+   * @return Result code (0 on success, negative on error)
+   */
+  int write(
+    const std::string& obj_name,
+    uint64_t object_size,
+    std::optional<uint64_t> truncate_size,
+    const std::vector<std::pair<uint64_t, std::string>>& writes);
 
   int read_object(
     const std::string& obj_name,
@@ -394,6 +415,22 @@ public:
    * @param offset Offset to read from (default: 0)
    * @param context_msg Optional context message to append to assertion messages
    */
+  /**
+   * Visualize data miscompare with hex+ASCII dump and line compression.
+   *
+   * @param obj_name Name of the object being compared
+   * @param expected_buf Expected data buffer
+   * @param read_buf Actual read data buffer
+   * @param size Size of both buffers
+   * @param phase Description of when the comparison occurred (e.g., "After shard 1 failure")
+   */
+  void visualize_miscompare(
+    const std::string& obj_name,
+    const char* expected_buf,
+    const char* read_buf,
+    size_t size,
+    const std::string& phase);
+
   void verify_object(
     const std::string& obj_name,
     const std::string& expected_data,

--- a/src/test/osd/TestBackendBasics.cc
+++ b/src/test/osd/TestBackendBasics.cc
@@ -385,6 +385,343 @@ TEST_P(TestBackendBasics, DirectRead) {
 }
 
 // ---------------------------------------------------------------------------
+// TestBackendBasics: TruncateAndWrite
+// ---------------------------------------------------------------------------
+
+/**
+ * TruncateAndWrite - test truncate to 0 followed by writes in a single transaction.
+ *
+ * This test verifies the behavior described in the failing test_ec_transaction test
+ * "truncate_then_write_one_shard" at a higher level using the full backend.
+ *
+ * The test:
+ * 1. Creates a 20k object
+ * 2. In one transaction, truncates to 0, then writes at:
+ *    - chunk_size~chunk_size (e.g., 4k~4k for k=4,m=2,su=4k)
+ *    - (chunk_size * (k+1))~chunk_size (e.g., 20k~4k)
+ * 3. Reads back and verifies the resulting 16k object
+ *
+ * This exercises the EC transaction planning logic for truncate+write operations
+ * and ensures data integrity across the operation.
+ */
+TEST_P(TestBackendBasics, TruncateAndWrite) {
+  const auto& param = GetParam().write_read;
+  const auto& backend_config = GetParam().backend;
+
+  // Skip test for non-EC backends - truncate behavior is different
+  if (backend_config.pool_type != EC) {
+    GTEST_SKIP() << "TruncateAndWrite test only applies to EC backends";
+  }
+
+  std::string obj_name = "test_truncate_write_" + backend_config.label + "_" + param.label;
+
+  // Step 1: Create a 20k object
+  const size_t initial_size = (2 * k + 1) * stripe_unit;
+  std::string initial_data(initial_size, 'X');
+  
+  int result = create_and_write(obj_name, initial_data);
+  EXPECT_EQ(result, 0) << param.label << " initial write should complete successfully";
+  verify_object(obj_name, initial_data, 0, initial_size);
+
+  // Step 2: In one transaction, truncate to 0 and write at two offsets
+  uint64_t first_write_offset = stripe_unit;
+  uint64_t second_write_offset = stripe_unit * (k + 1);
+  uint64_t final_size = second_write_offset + stripe_unit;
+  
+  result = write(
+    obj_name,
+    initial_size,
+    0,  // truncate to 0
+    {
+      {first_write_offset, std::string(stripe_unit, 'A')},
+      {second_write_offset, std::string(stripe_unit, 'B')}
+    }
+  );
+  
+  EXPECT_EQ(result, 0) << param.label << " truncate+write transaction should complete successfully";
+  
+  // Step 3: Build expected data and verify
+  std::string expected_data(final_size, '\0');
+  for (size_t i = first_write_offset; i < first_write_offset + stripe_unit; i++) {
+    expected_data[i] = 'A';
+  }
+  for (size_t i = second_write_offset; i < second_write_offset + stripe_unit; i++) {
+    expected_data[i] = 'B';
+  }
+  
+  verify_object(obj_name, expected_data, 0, final_size);
+  
+  // Clean up
+  auto* primary_listener = get_primary_listener();
+  if (primary_listener) {
+    primary_listener->sent_messages.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// TestBackendBasics: TruncateExpandAndWrite
+// ---------------------------------------------------------------------------
+
+/**
+ * TruncateExpandAndWrite - test truncate-expand followed by write in a single transaction.
+ *
+ * This test verifies the behavior when an object is expanded via truncate and then
+ * written to in the same transaction. This is different from TruncateAndWrite which
+ * truncates to 0 (shrinking the object).
+ *
+ * The test:
+ * 1. Creates an 8k object
+ * 2. In one transaction, truncates to 22k (expanding), then writes 2k at offset 2k
+ * 3. Reads back and verifies the resulting object
+ *
+ * Expected result is an object with:
+ * - [0, 2k): original 'X' data (preserved)
+ * - [2k, 4k): 'A' characters (new write)
+ * - [4k, 8k): original 'X' data (preserved)
+ * - [8k, 22k): zeros (expanded region from truncate)
+ *
+ * This exercises the EC transaction planning logic for truncate-expand+write operations
+ * and ensures data integrity across the operation.
+ */
+TEST_P(TestBackendBasics, TruncateExpandAndWrite) {
+  const auto& param = GetParam().write_read;
+  const auto& backend_config = GetParam().backend;
+
+  // Skip test for non-EC backends - truncate behavior is different
+  if (backend_config.pool_type != EC) {
+    GTEST_SKIP() << "TruncateExpandAndWrite test only applies to EC backends";
+  }
+
+  std::string obj_name = "test_truncate_expand_write_" + backend_config.label + "_" + param.label;
+
+  // Step 1: Create an 8k object (2 * stripe_unit for k=4)
+  const size_t initial_size = 2 * stripe_unit;  // 8k
+  std::string initial_data(initial_size, 'X');
+  
+  int result = create_and_write(obj_name, initial_data);
+  EXPECT_EQ(result, 0) << param.label << " initial write should complete successfully";
+  verify_object(obj_name, initial_data, 0, initial_size);
+
+  // Step 2: In one transaction, truncate to 22k and write 2k at offset 2k
+  const uint64_t truncate_size = (k + 1) * stripe_unit + stripe_unit / 2;  // 22k for k=4
+  const uint64_t write_offset = stripe_unit / 2;  // 2k
+  const uint64_t write_size = stripe_unit / 2;    // 2k
+  
+  result = write(
+    obj_name,
+    initial_size,
+    truncate_size,  // truncate to 22k (expand from 8k)
+    {
+      {write_offset, std::string(write_size, 'A')}
+    }
+  );
+  
+  EXPECT_EQ(result, 0) << param.label << " truncate+write transaction should complete successfully";
+  
+  // Step 3: Build expected data and verify
+  std::string expected_data(truncate_size, '\0');
+  
+  // Region [0, 2k): original 'X' data preserved
+  for (size_t i = 0; i < write_offset; i++) {
+    expected_data[i] = 'X';
+  }
+  
+  // Region [2k, 4k): new 'A' data from write
+  for (size_t i = write_offset; i < write_offset + write_size; i++) {
+    expected_data[i] = 'A';
+  }
+  
+  // Region [4k, 8k): original 'X' data preserved
+  for (size_t i = write_offset + write_size; i < initial_size; i++) {
+    expected_data[i] = 'X';
+  }
+  
+  // Region [8k, 22k): zeros (expanded region) - already initialized to '\0'
+  
+  verify_object(obj_name, expected_data, 0, truncate_size);
+  
+  // Clean up
+  auto* primary_listener = get_primary_listener();
+  if (primary_listener) {
+    primary_listener->sent_messages.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// TestBackendBasics: TruncateToChunkSizeAndWrite
+// ---------------------------------------------------------------------------
+
+/**
+ * TruncateToChunkSizeAndWrite - test truncate to chunk_size followed by writes in a single transaction.
+ *
+ * This is a variant of TruncateAndWrite that truncates to chunk_size (4k) instead of 0.
+ * This tests a different code path in the EC transaction planning logic.
+ *
+ * The test:
+ * 1. Creates a (2*k+1)*chunk_size object (e.g., 36k for k=4)
+ * 2. In one transaction, truncates to chunk_size (4k), then writes at:
+ *    - chunk_size~chunk_size (e.g., 4k~4k for k=4,m=2,su=4k)
+ *    - (chunk_size * (k+1))~chunk_size (e.g., 20k~4k)
+ * 3. Reads back and verifies the resulting object
+ *
+ * Expected result is an object with:
+ * - [0, chunk_size): original data (preserved by truncate to 4k)
+ * - [chunk_size, 2*chunk_size): 'A' characters (first write)
+ * - [2*chunk_size, (k+1)*chunk_size): zeros (sparse region)
+ * - [(k+1)*chunk_size, (k+2)*chunk_size): 'B' characters (second write)
+ */
+TEST_P(TestBackendBasics, TruncateToChunkSizeAndWrite) {
+  const auto& param = GetParam().write_read;
+  const auto& backend_config = GetParam().backend;
+
+  // Skip test for non-EC backends - truncate behavior is different
+  if (backend_config.pool_type != EC) {
+    GTEST_SKIP() << "TruncateToChunkSizeAndWrite test only applies to EC backends";
+  }
+
+  std::string obj_name = "test_truncate4k_write_" + backend_config.label + "_" + param.label;
+
+  // Step 1: Create object which will be shrunk
+  const size_t initial_size = (2 * k + 1) * stripe_unit;
+  std::string initial_data(initial_size, 'X');
+  
+  int result = create_and_write(obj_name, initial_data);
+  EXPECT_EQ(result, 0) << param.label << " initial write should complete successfully";
+  verify_object(obj_name, initial_data, 0, initial_size);
+
+  // Step 2: In one transaction, truncate to chunk_size and write at two offsets
+  uint64_t first_write_offset = stripe_unit;
+  uint64_t second_write_offset = stripe_unit * (k + 1);
+  uint64_t final_size = second_write_offset + stripe_unit;
+  
+  result = write(
+    obj_name,
+    initial_size,
+    stripe_unit,  // truncate to chunk_size (4k)
+    {
+      {first_write_offset, std::string(stripe_unit, 'A')},
+      {second_write_offset, std::string(stripe_unit, 'B')}
+    }
+  );
+  
+  EXPECT_EQ(result, 0) << param.label << " truncate+write transaction should complete successfully";
+  
+  // Step 3: Build expected data and verify
+  std::string expected_data(final_size, '\0');
+  // Preserved region [0, chunk_size) with original 'X' data
+  for (size_t i = 0; i < stripe_unit; i++) {
+    expected_data[i] = 'X';
+  }
+  // 'A' region at [chunk_size, 2*chunk_size)
+  for (size_t i = first_write_offset; i < first_write_offset + stripe_unit; i++) {
+    expected_data[i] = 'A';
+  }
+  // 'B' region at [(k+1)*chunk_size, (k+2)*chunk_size)
+  for (size_t i = second_write_offset; i < second_write_offset + stripe_unit; i++) {
+    expected_data[i] = 'B';
+  }
+  
+  verify_object(obj_name, expected_data, 0, final_size);
+  
+  // Clean up
+  auto* primary_listener = get_primary_listener();
+  if (primary_listener) {
+    primary_listener->sent_messages.clear();
+  }
+}
+
+
+// ---------------------------------------------------------------------------
+// TestBackendBasics: TruncateToChunkSizeAndWrite
+// ---------------------------------------------------------------------------
+
+/**
+ * TruncateToChunkSizeAndWrite - test truncate to chunk_size followed by writes in a single transaction.
+ *
+ * This is a variant of TruncateAndWrite that truncates to chunk_size (4k) instead of 0.
+ * This tests a different code path in the EC transaction planning logic.
+ *
+ * The test:
+ * 1. Creates a 20k object
+ * 2. In one transaction, truncates to chunk_size (4k), then writes at:
+ *    - chunk_size~chunk_size (e.g., 4k~4k for k=4,m=2,su=4k)
+ *    - (chunk_size * (k+1))~chunk_size (e.g., 20k~4k)
+ * 3. Reads back and verifies the resulting object
+ *
+ * Expected result is an object with:
+ * - [0, chunk_size): original data (preserved by truncate to 4k)
+ * - [chunk_size, 2*chunk_size): 'A' characters (first write)
+ * - [2*chunk_size, (k+1)*chunk_size): zeros (sparse region)
+ * - [(k+1)*chunk_size, (k+2)*chunk_size): 'B' characters (second write)
+ */
+TEST_P(TestBackendBasics, TruncateToChunkSizeAndWriteToSameSize) {
+  const auto& param = GetParam().write_read;
+  const auto& backend_config = GetParam().backend;
+
+  // Skip test for non-EC backends - truncate behavior is different
+  if (backend_config.pool_type != EC) {
+    GTEST_SKIP() << "TruncateToChunkSizeAndWrite test only applies to EC backends";
+  }
+
+  std::string obj_name = "test_truncate4k_write_" + backend_config.label + "_" + param.label;
+
+  // Step 1: Create object which will be shrunk
+  const size_t initial_size = (k + 2) * stripe_unit;
+  std::string initial_data(initial_size, 'X');
+  
+  int result = create_and_write(obj_name, initial_data);
+  EXPECT_EQ(result, 0) << param.label << " initial write should complete successfully";
+  verify_object(obj_name, initial_data, 0, initial_size);
+
+  // Step 2: In one transaction, truncate to chunk_size and write at two offsets
+  uint64_t first_write_offset = stripe_unit;
+  uint64_t second_write_offset = stripe_unit * (k + 1);
+  uint64_t final_size = second_write_offset + stripe_unit;
+  
+  result = write(
+    obj_name,
+    initial_size,
+    stripe_unit,  // truncate to chunk_size (4k)
+    {
+      {first_write_offset, std::string(stripe_unit, 'A')},
+      {second_write_offset, std::string(stripe_unit, 'B')}
+    }
+  );
+  
+  EXPECT_EQ(result, 0) << param.label << " truncate+write transaction should complete successfully";
+  
+  // Step 3: Build expected data and verify
+  std::string expected_data(final_size, '\0');
+  // Preserved region [0, chunk_size) with original 'X' data
+  for (size_t i = 0; i < stripe_unit; i++) {
+    expected_data[i] = 'X';
+  }
+  // 'A' region at [chunk_size, 2*chunk_size)
+  for (size_t i = first_write_offset; i < first_write_offset + stripe_unit; i++) {
+    expected_data[i] = 'A';
+  }
+  // 'B' region at [(k+1)*chunk_size, (k+2)*chunk_size)
+  for (size_t i = second_write_offset; i < second_write_offset + stripe_unit; i++) {
+    expected_data[i] = 'B';
+  }
+  
+  verify_object(obj_name, expected_data, 0, final_size);
+  
+  // Step 4: Fail shard 1 (which received the write) and verify object can still be read
+  // For optimized EC, shard 1 is a data shard that received part of the write
+  simulate_multiple_osd_failures({1});
+  
+  // Verify the object can still be read correctly via EC reconstruction
+  verify_object(obj_name, expected_data, 0, final_size);
+  
+  // Clean up
+  auto* primary_listener = get_primary_listener();
+  if (primary_listener) {
+    primary_listener->sent_messages.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Backend configurations and size parameters
 // ---------------------------------------------------------------------------
 

--- a/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
+++ b/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
@@ -51,6 +51,9 @@ using DoubleWriteOp = ceph::io_exerciser::DoubleWriteOp;
 using TripleWriteOp = ceph::io_exerciser::TripleWriteOp;
 using SingleAppendOp = ceph::io_exerciser::SingleAppendOp;
 using TruncateOp = ceph::io_exerciser::TruncateOp;
+using SingleTruncateWriteOp = ceph::io_exerciser::SingleTruncateWriteOp;
+using DoubleTruncateWriteOp = ceph::io_exerciser::DoubleTruncateWriteOp;
+using TripleTruncateWriteOp = ceph::io_exerciser::TripleTruncateWriteOp;
 using SingleFailedWriteOp = ceph::io_exerciser::SingleFailedWriteOp;
 using DoubleFailedWriteOp = ceph::io_exerciser::DoubleFailedWriteOp;
 using TripleFailedWriteOp = ceph::io_exerciser::TripleFailedWriteOp;
@@ -1465,6 +1468,28 @@ bool ceph::io_sequence::tester::TestRunner::run_interactive_test() {
       ioop = SingleAppendOp::generate(length);
     } else if (op == "truncate") {
       ioop = TruncateOp::generate(get_numeric_token());
+    } else if (op == "truncatewrite") {
+      uint64_t size = get_numeric_token();
+      uint64_t offset = get_numeric_token();
+      uint64_t length = get_numeric_token();
+      ioop = SingleTruncateWriteOp::generate(size, offset, length);
+    } else if (op == "truncatewrite2") {
+      uint64_t size = get_numeric_token();
+      uint64_t offset1 = get_numeric_token();
+      uint64_t length1 = get_numeric_token();
+      uint64_t offset2 = get_numeric_token();
+      uint64_t length2 = get_numeric_token();
+      ioop = DoubleTruncateWriteOp::generate(size, offset1, length1, offset2, length2);
+    } else if (op == "truncatewrite3") {
+      uint64_t size = get_numeric_token();
+      uint64_t offset1 = get_numeric_token();
+      uint64_t length1 = get_numeric_token();
+      uint64_t offset2 = get_numeric_token();
+      uint64_t length2 = get_numeric_token();
+      uint64_t offset3 = get_numeric_token();
+      uint64_t length3 = get_numeric_token();
+      ioop = TripleTruncateWriteOp::generate(size, offset1, length1, offset2, length2,
+                                             offset3, length3);
     } else if (op == "failedwrite") {
       uint64_t offset = get_numeric_token();
       uint64_t length = get_numeric_token();

--- a/src/test/osd/test_ec_transaction.cc
+++ b/src/test/osd/test_ec_transaction.cc
@@ -505,3 +505,62 @@ TEST(ectransaction, truncate_to_stripe) {
   ECUtil::shard_extent_set_t ref_write(sinfo.get_k_plus_m());
   ASSERT_EQ(ref_write, plan.will_write);
 }
+
+TEST(ectransaction, truncate_then_write_one_shard) {
+  hobject_t h;
+  PGTransaction::ObjectOperation op;
+  bufferlist a, b;
+
+  // Simulate a sparsify operation that overwrites an existing object with data at
+  // specific offsets, creating a sparse pattern.
+  //
+  // Initial object is 20k, with zeros at 0~4k, 8k~4k, 16k~4k
+  //
+  // The sparsify operation writes at offsets 4k~4k and 12k~4k.
+  op.truncate = std::pair(0, 0);
+  
+  // First write at offset 4096, length 4KB (0~4096)
+  a.append_zero(4096);
+  op.buffer_updates.insert(4096, a.length(), PGTransaction::ObjectOperation::BufferUpdate::Write{a, 0});
+  
+  // Second write at offset 12288 (12KB), length 4KB
+  b.append_zero(4096);
+  op.buffer_updates.insert(12288, b.length(), PGTransaction::ObjectOperation::BufferUpdate::Write{b, 0});
+
+  pg_pool_t pool;
+  pool.set_flag(pg_pool_t::FLAG_EC_OPTIMIZATIONS);
+  
+  // EC configuration: k=2, m=1, chunk_size=4096 (matching FastEC profile)
+  ECUtil::stripe_info_t sinfo(2, 1, 8192, &pool, std::vector<shard_id_t>(0));
+  
+  // Set current object size to 16384 (16KB) - the object exists with this size
+  object_info_t oi;
+  oi.size = 16384;
+  
+  shard_id_set shards;
+  shards.insert_range(shard_id_t(0), 3);  // k=2 + m=1 = 3 shards
+
+  ECTransaction::WritePlanObj plan(
+    h,
+    op,
+    sinfo,
+    shards,
+    shards,
+    false,
+    20480,  // current_size
+    oi,
+    std::nullopt,
+    0);
+
+  generic_derr << "plan " << plan << dendl;
+
+  // With truncate 0, we're starting fresh - no reads should be required
+  ASSERT_FALSE(plan.to_read);
+  
+  // Truncates are handled by the transaction generation. 
+  ECUtil::shard_extent_set_t ref_write(sinfo.get_k_plus_m());
+  ref_write[shard_id_t(1)].insert(0, 8192);
+  ref_write[shard_id_t(2)].insert(0, 8192);
+  
+  ASSERT_EQ(ref_write, plan.will_write);
+}


### PR DESCRIPTION
Add an extensive set of tests and unit tests to fully test the combined truncate and write transactions which are supported by the RADOS API. 


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
