### PR TITLE
cmake,ceph,qa: update and populate ASan options to ceph cli

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -724,6 +724,13 @@ endif(LINUX)
 option(WITH_ASAN "build with ASAN" OFF)
 if(WITH_ASAN)
   list(APPEND sanitizers "address")
+  # Shared ASan/LSan runtime options: the in-tree suppression files plus the
+  # flags our tests need.  Consumed by add_ceph_test() and baked into bin/ceph
+  # so both ignore the same still-reachable third-party leaks.
+  set(CEPH_ASAN_OPTIONS "suppressions=${CMAKE_SOURCE_DIR}/qa/asan.supp,detect_odr_violation=0"
+      CACHE INTERNAL "ASAN_OPTIONS for ceph tests and the ceph CLI")
+  set(CEPH_LSAN_OPTIONS "suppressions=${CMAKE_SOURCE_DIR}/qa/lsan.supp,print_suppressions=0"
+      CACHE INTERNAL "LSAN_OPTIONS for ceph tests and the ceph CLI")
 endif()
 
 option(WITH_ASAN_LEAK "explicitly enable ASAN leak detection" OFF)

--- a/cmake/modules/AddCephTest.cmake
+++ b/cmake/modules/AddCephTest.cmake
@@ -33,8 +33,8 @@ function(add_ceph_test test_name test_path)
     set_property(TEST ${test_name}
       APPEND
       PROPERTY ENVIRONMENT
-      ASAN_OPTIONS=suppressions=${CMAKE_SOURCE_DIR}/qa/asan.supp,detect_odr_violation=0
-      LSAN_OPTIONS=suppressions=${CMAKE_SOURCE_DIR}/qa/lsan.supp,print_suppressions=0)
+      ASAN_OPTIONS=${CEPH_ASAN_OPTIONS}
+      LSAN_OPTIONS=${CEPH_LSAN_OPTIONS})
   endif()
   set_property(TEST ${test_name}
     PROPERTY TIMEOUT ${CEPH_TEST_TIMEOUT})

--- a/qa/lsan.supp
+++ b/qa/lsan.supp
@@ -29,15 +29,14 @@ leak:^PyUnicode_New
 leak:^PyMem_Malloc
 leak:^PyDict_Copy
 leak:^_PyObject_GC_NewVar
-# Catch unsymbolised interpreter frames in both the standalone
-# /usr/bin/python3.10 binary (used by the bin/ceph wrapper) and the
-# /lib/.../libpython3.10.so.1.0 embedded by C++ unittests such as
-# unittest_mgr_pyformatter / unittest_mgr_pyutil.  Not all CPython
-# 3.10 internal helpers are exported in .dynsym, so function-name
-# matches above don't cover everything; this substring-matches the
-# module path in the stack frame.  Remove when CI moves to >= 3.12.
+# Catch unsymbolised interpreter frames in the standalone python binary used by
+# the bin/ceph wrapper and in the libpython embedded by C++ unittests such as
+# unittest_mgr_pyformatter / unittest_mgr_pyutil.  Not all CPython internal
+# helpers are exported in .dynsym, so the function-name matches above don't
+# cover everything; this substring-matches the module path in the stack frame.
 leak:python3.10
-# python3.12 doesn't leak anything
+leak:python3.12
+leak:python3.13
 # python3.13
 leak:^PyModule_ExecDef
 

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -140,6 +140,13 @@ if os.path.exists(os.path.join(MYPDIR, "CMakeCache.txt")) \
         pythonlib_path = os.path.join(lib_path,
                                       "cython_modules",
                                       get_pythonlib_dir())
+        if with_asan:
+            # respawn_in_path() below re-execs with the ASan runtime preloaded.
+            # Load the same suppression options add_ceph_test() uses (configured
+            # by CMake) first, so the re-exec'd interpreter does not report
+            # CPython/Cython module-init allocations as leaks at exit.
+            os.environ.setdefault("ASAN_OPTIONS", "@CEPH_ASAN_OPTIONS@")
+            os.environ.setdefault("LSAN_OPTIONS", "@CEPH_LSAN_OPTIONS@")
         respawn_in_path(lib_path, pybind_path, pythonlib_path,
                         asan_lib_path if with_asan else None)
 


### PR DESCRIPTION
after enabling ASan, when it comes to tests not launched with ctest, we cannot populate the ASan options with environmental variables, as API tests are driven by `vstart_runner.py`, which runs `bin/ceph` directly, so we have to set these ASan options at configure time.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
