### PR TITLE
tentacle: mgr: replace deprecated PyImport_ImportModuleNoBlock with PyImport_ImportModule

### DIFF
--- a/src/mgr/PyModule.cc
+++ b/src/mgr/PyModule.cc
@@ -369,7 +369,7 @@ int PyModule::load(PyThreadState *pMainThreadState)
 
     int r;
 
-    pPickleModule = PyImport_ImportModuleNoBlock("pickle");
+    pPickleModule = PyImport_ImportModule("pickle");
     if (!pPickleModule) {
       derr << "Unable to load pickle" << dendl;
       return -EINVAL;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77565

---

backport of https://github.com/ceph/ceph/pull/68085
parent tracker: https://tracker.ceph.com/issues/77450

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh