### PR TITLE
doc/cephfs: clarify deprecated commands and remove obsolete upgrade path

### DIFF
--- a/doc/cephfs/cephfs-mirroring.rst
+++ b/doc/cephfs/cephfs-mirroring.rst
@@ -173,8 +173,9 @@ and the user key. However, bootstrapping a peer is the recommended way to add a
 peer.
 
 .. note:: Only a single peer is currently supported.
-          The ``peer_add`` command is deprecated and will be removed in a future release.
-          Use the ``peer_bootstrap`` command instead.
+          The ``peer_add`` command is deprecated and will be removed in a future
+          release. Use the ``peer_bootstrap create`` command instead. See the
+          :ref:`Bootstrap Peers<cephfs_mirroring_bootstrap_peers>` section.
 
 To remove a peer, run a command of the following form:
 

--- a/doc/cephfs/experimental-features.rst
+++ b/doc/cephfs/experimental-features.rst
@@ -24,8 +24,8 @@ failures within it are unlikely to make non-inlined data inaccessible.
 Inline data has always been off by default and requires setting
 the ``inline_data`` flag.
 
-Inline data has been declared deprecated for the Octopus release, and will
-likely be removed altogether in a future release.
+Inline data has been deprecated since the Octopus release. Enabling it triggers
+a health warning, and the feature will be removed altogether in a future release.
 
 Mantle: Programmable Metadata Load Balancer
 -------------------------------------------

--- a/doc/cephfs/kernel-features.rst
+++ b/doc/cephfs/kernel-features.rst
@@ -8,9 +8,9 @@ in the kernel driver.
 
 Inline data
 -----------
-Inline data was introduced by the Firefly release. This feature is being
-deprecated in mainline CephFS, and may be removed from a future kernel
-release.
+Inline data was introduced by the Firefly release. This feature has been
+deprecated since the Octopus release: enabling it triggers a health warning,
+and it will be removed in a future release.
 
 Linux kernel clients >= 3.19 can read inline data and convert existing
 inline data to RADOS objects when file data is modified. At present,

--- a/doc/cephfs/upgrading.rst
+++ b/doc/cephfs/upgrading.rst
@@ -54,37 +54,3 @@ command. Older versions of Ceph require you to stop these daemons manually.
     ceph fs set <fs_name> max_mds <old_max_mds>
     ceph fs set <fs_name> allow_standby_replay <old_allow_standby_replay>
 
-
-Upgrading pre-Firefly file systems past Jewel
-=============================================
-
-.. tip::
-
-    This advice only applies to users with file systems
-    created using versions of Ceph older than *Firefly* (0.80).
-    Users creating new file systems may disregard this advice.
-
-Pre-firefly versions of Ceph used a now-deprecated format
-for storing CephFS directory objects, called TMAPs.  Support
-for reading these in RADOS will be removed after the Jewel
-release of Ceph, so for upgrading CephFS users it is important
-to ensure that any old directory objects have been converted.
-
-After installing Jewel on all your MDS and OSD servers, and restarting
-the services, run the following command:
-
-::
-    
-    cephfs-data-scan tmap_upgrade <metadata pool name>
-
-This only needs to be run once, and it is not necessary to
-stop any other services while it runs.  The command may take some
-time to execute, as it iterates over all objects in your metadata
-pool.  It is safe to continue using your file system as normal while
-it executes.  If the command aborts for any reason, it is safe
-to simply run it again.
-
-If you are upgrading a pre-Firefly CephFS file system to a newer Ceph version
-than Jewel, you must first upgrade to Jewel and run the ``tmap_upgrade``
-command before completing your upgrade to the latest version.
-


### PR DESCRIPTION
## Summary

Addresses tracker https://tracker.ceph.com/issues/77188.

Several CephFS documentation pages described deprecated commands and features without clear status or replacement guidance, and one page documented an upgrade path that predates every currently supported release.

## Changes

- **cephfs-mirroring.rst**: the `peer_add` deprecation note pointed to a `peer_bootstrap` command that does not exist. Corrected it to `peer_bootstrap create` and linked the Bootstrap Peers section.
- **kernel-features.rst** and **experimental-features.rst**: inline data is now described consistently as deprecated since the Octopus release, and the note mentions that enabling it raises a health warning (`FS_INLINE_DATA_DEPRECATED`).
- **upgrading.rst**: removed the "Upgrading pre-Firefly file systems past Jewel" section. Jewel reached end of life years ago, and the `tmap_upgrade` command it described was removed in Kraken.

## Verified as already correct (no change needed)

- `fs-volumes.rst` subvolume group snapshot note (feature no longer supported; only listing and removal of existing snapshots is documented, which is consistent).
- `mount-using-kernel-driver.rst` `mds_namespace` deprecation note (already shows `fs=` as the replacement).

Fixes: https://tracker.ceph.com/issues/77188
