### PR TITLE
doc/ceph-volume: update stale ceph-disk references

### DIFF
--- a/doc/ceph-volume/index.rst
+++ b/doc/ceph-volume/index.rst
@@ -29,18 +29,18 @@ about a node's physical disk inventory.
 
 Migrating
 ---------
-Starting on Ceph version 13.0.0, ``ceph-disk`` is deprecated. Deprecation
-warnings will show up that will link to this page. It is strongly suggested
-that users start consuming ``ceph-volume``. There are two paths for migrating:
+``ceph-disk`` was deprecated in Ceph 13.0.0 and has since been removed.
+``ceph-volume`` is the supported tool for provisioning and managing OSDs. If
+your cluster still has OSDs that were originally deployed with ``ceph-disk``,
+there are two migration paths:
 
-#. Keep OSDs deployed with ``ceph-disk``: The :ref:`ceph-volume-simple` command
-   provides a way to take over the management while disabling ``ceph-disk``
-   triggers.
-#. Redeploy existing OSDs with ``ceph-volume``: This is covered in depth on
-   :ref:`rados-replacing-an-osd`
+#. Keep OSDs deployed with ``ceph-disk``: the :ref:`ceph-volume-simple` command
+   takes over their management and disables the old ``ceph-disk`` triggers.
+#. Redeploy existing OSDs with ``ceph-volume``: this is covered in depth in
+   :ref:`rados-replacing-an-osd`.
 
-For details on why ``ceph-disk`` was removed please see the :ref:`Why was
-ceph-disk replaced? <ceph-disk-replaced>` section.
+For background on why ``ceph-disk`` was replaced, see the :ref:`Replacing
+ceph-disk <ceph-disk-replaced>` section.
 
 
 New deployments

--- a/doc/ceph-volume/index.rst
+++ b/doc/ceph-volume/index.rst
@@ -29,15 +29,22 @@ about a node's physical disk inventory.
 
 Migrating
 ---------
-``ceph-disk`` was deprecated in Ceph 13.0.0 and has since been removed.
+``ceph-disk`` was deprecated in the Mimic release and has since been removed.
 ``ceph-volume`` is the supported tool for provisioning and managing OSDs. If
-your cluster still has OSDs that were originally deployed with ``ceph-disk``,
+your cluster still has OSDs that rely on ``ceph-disk``,
 there are two migration paths:
 
 #. Keep OSDs deployed with ``ceph-disk``: the :ref:`ceph-volume-simple` command
    takes over their management and disables the old ``ceph-disk`` triggers.
 #. Redeploy existing OSDs with ``ceph-volume``: this is covered in depth in
    :ref:`rados-replacing-an-osd`.
+
+.. note::
+
+   Adopted ``ceph-disk`` OSDs continue to run, but the cephadm
+   orchestrator cannot manage them as it does ``ceph-volume`` OSDs.
+   Incremental redeployment with ``ceph-volume`` is therefore
+   preferred.
 
 For background on why ``ceph-disk`` was replaced, see the :ref:`Replacing
 ceph-disk <ceph-disk-replaced>` section.

--- a/doc/ceph-volume/intro.rst
+++ b/doc/ceph-volume/intro.rst
@@ -2,14 +2,13 @@
 
 Overview
 --------
-The ``ceph-volume`` tool aims to be a single purpose command line tool to deploy
-logical volumes as OSDs, trying to maintain a similar API to ``ceph-disk`` when
-preparing, activating, and creating OSDs.
+The ``ceph-volume`` tool is a single purpose command line tool to deploy
+logical volumes as OSDs. It maintains an API similar to that of the older
+``ceph-disk`` tool when preparing, activating, and creating OSDs.
 
-It deviates from ``ceph-disk`` by not interacting or relying on the udev rules
-that come installed for Ceph. These rules allow automatic detection of
-previously set up devices that are in turn fed into ``ceph-disk`` to activate
-them.
+Unlike ``ceph-disk``, it does not interact with or rely on udev rules. Those
+rules allowed automatic detection of previously set up devices, which were in
+turn fed into ``ceph-disk`` to activate them.
 
 Cephadm shell
 -------------
@@ -50,70 +49,19 @@ testing, or development.
 
 Replacing ``ceph-disk``
 -----------------------
-The ``ceph-disk`` tool was created at a time when the project was required to
-support many different types of init systems (upstart, sysvinit, etc.) while
-being able to discover devices. This caused the tool to concentrate initially
-(and exclusively afterwards) on GPT partitions. Specifically on GPT GUIDs,
-which were used to label devices in a unique way to answer questions like:
+``ceph-disk`` was the original OSD provisioning tool. It relied on GPT
+partitions and ``UDEV`` rules to label, discover, and activate devices. That
+approach was slow and hard to debug, and because it was tied to GPT partitions
+it could not work with technologies such as LVM. For these reasons
+``ceph-disk`` was deprecated in Ceph 13.0.0 and has since been removed.
 
-* is this device a Journal?
-* an encrypted data partition?
-* was the device left partially prepared?
-
-To solve these, it used ``UDEV`` rules to match the GUIDs, that would call
-``ceph-disk``, and end up in a back and forth between the ``ceph-disk`` systemd
-unit and the ``ceph-disk`` executable. The process was very unreliable and time
-consuming (a timeout of close to three hours **per OSD** had to be put in
-place), and would cause OSDs to not come up at all during the boot process of
-a node.
-
-It was hard to debug, or even replicate these problems given the asynchronous
-behavior of ``UDEV``.
-
-Since the worldview of ``ceph-disk`` had to be GPT partitions exclusively, it meant
-that it couldn't work with other technologies like LVM, or similar device
-mapper devices. It was ultimately decided to create something modular, starting
-with LVM support, and the ability to expand on other technologies as needed.
-
-
-GPT partitions are simple?
---------------------------
-Although partitions in general are simple to reason about, ``ceph-disk``
-partitions were not simple by any means. It required a tremendous amount of
-special flags in order to get them to work correctly with the device discovery
-workflow. Here is an example call to create a data partition::
-
-    /sbin/sgdisk --largest-new=1 --change-name=1:ceph data --partition-guid=1:f0fc39fd-eeb2-49f1-b922-a11939cf8a0f --typecode=1:89c57f98-2fe5-4dc0-89c1-f3ad0ceff2be --mbrtogpt -- /dev/sdb
-
-Not only creating these was hard, but these partitions required devices to be
-exclusively owned by Ceph. For example, in some cases a special partition would
-be created when devices were encrypted, which would contain unencrypted keys.
-This was ``ceph-disk`` domain knowledge, which would not translate to a "GPT
-partitions are simple" understanding. Here is an example of that special
-partition being created::
-
-    /sbin/sgdisk --new=5:0:+10M --change-name=5:ceph lockbox --partition-guid=5:None --typecode=5:fb3aabf9-d25f-47cc-bf5e-721d181642be --mbrtogpt -- /dev/sdad
-
-
-Modularity
-----------
-``ceph-volume`` was designed to be a modular tool because we anticipate that
-there are going to be lots of ways that people provision the hardware devices
-that we need to consider. There are already two: legacy ceph-disk devices that
-are still in use and have GPT partitions (handled by :ref:`ceph-volume-simple`),
-and LVM. SPDK devices where we manage NVMe devices directly from userspace are
-on the immediate horizon, where LVM won't work there since the kernel isn't
-involved at all.
+``ceph-volume`` replaces it with a modular design: OSDs that were originally
+deployed with ``ceph-disk`` (plain disks with GPT partitions) are managed by
+:ref:`ceph-volume-simple`, while new OSDs are provisioned with
+:ref:`ceph-volume-lvm`.
 
 ``ceph-volume lvm``
 -------------------
 By making use of :term:`LVM tags`, the :ref:`ceph-volume-lvm` subcommand is
 able to store and later re-discover and query devices associated with OSDs so
 that they can later be activated.
-
-LVM performance penalty
------------------------
-In short: we haven't been able to notice any significant performance penalties
-associated with the change to LVM. By being able to work closely with LVM, the
-ability to work with other device mapper technologies was a given: there is no
-technical difficulty in working with anything that can sit below a Logical Volume.

--- a/doc/ceph-volume/intro.rst
+++ b/doc/ceph-volume/intro.rst
@@ -2,9 +2,9 @@
 
 Overview
 --------
-The ``ceph-volume`` tool is a single purpose command line tool to deploy
-logical volumes as OSDs. It maintains an API similar to that of the older
-``ceph-disk`` tool when preparing, activating, and creating OSDs.
+The ``ceph-volume`` tool deploys and manages OSDs on logical volumes. It
+maintains an API similar to that of the older ``ceph-disk`` tool when
+preparing, activating, and creating OSDs.
 
 Unlike ``ceph-disk``, it does not interact with or rely on udev rules. Those
 rules allowed automatic detection of previously set up devices, which were in
@@ -53,7 +53,8 @@ Replacing ``ceph-disk``
 partitions and ``UDEV`` rules to label, discover, and activate devices. That
 approach was slow and hard to debug, and because it was tied to GPT partitions
 it could not work with technologies such as LVM. For these reasons
-``ceph-disk`` was deprecated in Ceph 13.0.0 and has since been removed.
+``ceph-disk`` was deprecated in the Mimic release and has since been
+removed.
 
 ``ceph-volume`` replaces it with a modular design: OSDs that were originally
 deployed with ``ceph-disk`` (plain disks with GPT partitions) are managed by

--- a/doc/man/8/ceph-volume.rst
+++ b/doc/man/8/ceph-volume.rst
@@ -24,13 +24,12 @@ Description
 ===========
 
 :program:`ceph-volume` is a single-purpose command line tool to deploy logical
-volumes as OSDs, trying to maintain a similar API to ``ceph-disk`` when
-preparing, activating, and creating OSDs.
+volumes as OSDs. It maintains an API similar to that of the older ``ceph-disk``
+tool when preparing, activating, and creating OSDs.
 
-It deviates from ``ceph-disk`` by not interacting or relying on the udev rules
-that come installed for Ceph. These rules allow automatic detection of
-previously setup devices that are in turn fed into ``ceph-disk`` to activate
-them.
+Unlike ``ceph-disk``, it does not interact with or rely on udev rules. Those
+rules allowed automatic detection of previously set up devices, which were in
+turn fed into ``ceph-disk`` to activate them.
 
 
 Commands


### PR DESCRIPTION
## Summary

Addresses tracker https://tracker.ceph.com/issues/77186.

`ceph-disk` was deprecated in Ceph 13.0.0 and has since been removed, but the `ceph-volume` documentation still described it as a current, deprecated tool and carried a long historical migration narrative that is now confusing to new operators.

## Changes

- **ceph-volume/index.rst**: the "Migrating" section said `ceph-disk` "is deprecated" since 13.0.0 and that "deprecation warnings will show up." `ceph-disk` is now fully removed and no such warnings appear, so this is reworded. The two migration paths are kept because they are still valid for clusters that have OSDs originally deployed with `ceph-disk`.
- **ceph-volume/intro.rst**: collapsed the historical "Replacing ceph-disk", "GPT partitions are simple?", "Modularity", and "LVM performance penalty" subsections into a single brief historical note. The `ceph-disk-replaced` anchor (referenced from `index.rst`) and the `ceph-volume lvm` subsection are preserved.
- **man/8/ceph-volume.rst**: describe `ceph-disk` in the past tense in the overview.

## Intentionally left unchanged

- `ceph-volume/simple/*` and the `ceph-disk` mentions in `lvm/activate.rst`, `lvm/encryption.rst`, and `lvm/list.rst`. The `ceph-volume simple` subcommand still exists and its job is to take over and disable legacy `ceph-disk` OSDs, so those references correctly describe current behavior.
- `cephadm/adoption.rst`, which already labels `ceph-deploy` as "a legacy deployment tool" and legitimately needs to name the tools that existing clusters were deployed with.

Fixes: https://tracker.ceph.com/issues/77186


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
