### PR TITLE
Sc quota enforcement complete changes

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -22,6 +22,8 @@
 
 #include <boost/lexical_cast.hpp>
 
+#include "cls_rgw_types.h"
+
 using std::pair;
 using std::list;
 using std::map;
@@ -754,6 +756,16 @@ int rgw_bucket_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   }
 } // rgw_bucket_list
 
+static void initialize_storage_class(rgw_bucket_dir_header *header) {
+  for (auto kiter = header->stats.begin(); kiter != header->stats.end(); ++kiter) {
+    auto s = kiter->second;
+    if (s.num_entries > 0) {
+      return;
+    }
+  }
+  header->storage_class_stats.emplace();
+}
+
 static int write_bucket_header(cls_method_context_t hctx, rgw_bucket_dir_header *header)
 {
   header->ver++;
@@ -842,6 +854,20 @@ int rgw_bucket_update_stats(cls_method_context_t hctx, bufferlist *in, bufferlis
     }
   }
 
+  if (header.storage_class_stats.has_value()) {
+    for (auto& s : op.storage_class_stats.value()) {
+      auto& dest = header.storage_class_stats.value()[s.first];
+      if (op.absolute) {
+        dest = s.second;
+      } else {
+        dest.total_size += s.second.total_size;
+        dest.total_size_rounded += s.second.total_size_rounded;
+        dest.num_entries += s.second.num_entries;
+        dest.actual_size += s.second.actual_size;
+      }
+    }
+  }
+
   return write_bucket_header(hctx, &header);
 }
 
@@ -866,6 +892,7 @@ int rgw_bucket_init_index(cls_method_context_t hctx, bufferlist *in, bufferlist 
   }
 
   rgw_bucket_dir dir;
+  dir.header.storage_class_stats.emplace();
 
   return write_bucket_header(hctx, &dir.header);
 }
@@ -1029,12 +1056,24 @@ static void unaccount_entry(rgw_bucket_dir_header& header,
 			    rgw_bucket_dir_entry& entry)
 {
   if (entry.exists) {
+    auto& storage_class = rgw_placement_rule::get_canonical_storage_class(entry.meta.storage_class);
     rgw_bucket_category_stats& stats = header.stats[entry.meta.category];
+
     stats.num_entries--;
     stats.total_size -= entry.meta.accounted_size;
     stats.total_size_rounded -=
       cls_rgw_get_rounded_size(entry.meta.accounted_size);
     stats.actual_size -= entry.meta.size;
+    if (header.storage_class_stats.has_value()) {
+      rgw_bucket_category_stats &sc_stats = header.storage_class_stats.value()[storage_class];
+      sc_stats.num_entries--;
+      sc_stats.total_size -= entry.meta.accounted_size;
+      sc_stats.total_size_rounded -=
+              cls_rgw_get_rounded_size(entry.meta.accounted_size);
+      sc_stats.actual_size -= entry.meta.size;
+    } else {
+      initialize_storage_class(&header);
+    }
   }
 }
 
@@ -1317,16 +1356,29 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
     unaccount_entry(header, entry);
 
     rgw_bucket_dir_entry_meta& meta = op.meta;
+    auto& storage_class = rgw_placement_rule::get_canonical_storage_class(meta.storage_class);
     rgw_bucket_category_stats& stats = header.stats[meta.category];
     entry.meta = meta;
     entry.key = op.key;
     entry.exists = true;
     entry.tag = op.tag;
     // account for new entry
+    if (!header.storage_class_stats.has_value()) {
+      // initialize storage class stats if the bucket was the empty
+      initialize_storage_class(&header);
+    }
     stats.num_entries++;
     stats.total_size += meta.accounted_size;
     stats.total_size_rounded += cls_rgw_get_rounded_size(meta.accounted_size);
     stats.actual_size += meta.size;
+    if (header.storage_class_stats.has_value()) {
+      rgw_bucket_category_stats& sc_stats = header.storage_class_stats.value()[storage_class];
+      sc_stats.num_entries++;
+      sc_stats.total_size += meta.accounted_size;
+      sc_stats.total_size_rounded += cls_rgw_get_rounded_size(meta.accounted_size);
+      sc_stats.actual_size += meta.size;
+    }
+
     CLS_LOG_BITX(bitx_inst, 20,
 		 "INFO: %s: setting map entry at key=%s",
 		 __func__, escape_str(idx).c_str());
@@ -2577,15 +2629,27 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx,
     if (cur_disk.pending_map.empty()) {
       CLS_LOG_BITX(bitx_inst, 10, "INFO: %s: cur_disk.pending_map is empty", __func__);
       if (cur_disk.exists) {
-        rgw_bucket_category_stats& old_stats = header.stats[cur_disk.meta.category];
+          auto& storage_class = rgw_placement_rule::get_canonical_storage_class(cur_disk.meta.storage_class);
+          rgw_bucket_category_stats& old_stats = header.stats[cur_disk.meta.category];
 	CLS_LOG_BITX(bitx_inst, 10, "INFO: %s: stats.num_entries: %ld -> %ld",
 		     __func__, old_stats.num_entries, old_stats.num_entries - 1);
         old_stats.num_entries--;
         old_stats.total_size -= cur_disk.meta.accounted_size;
         old_stats.total_size_rounded -= cls_rgw_get_rounded_size(cur_disk.meta.accounted_size);
         old_stats.actual_size -= cur_disk.meta.size;
+        if (header.storage_class_stats.has_value()) {
+          rgw_bucket_category_stats &old_sc_stats = header.storage_class_stats.value()[storage_class];
+          old_sc_stats.num_entries--;
+          old_sc_stats.total_size -= cur_disk.meta.accounted_size;
+          old_sc_stats.total_size_rounded -= cls_rgw_get_rounded_size(cur_disk.meta.accounted_size);
+          old_sc_stats.actual_size -= cur_disk.meta.size;
+        } else {
+          initialize_storage_class(&header);
+        }
         header_changed = true;
       }
+      auto& storage_class = rgw_placement_rule::get_canonical_storage_class(cur_change.meta.storage_class);
+      std::optional<std::unordered_map<std::string, rgw_bucket_category_stats>> storage_class_stats = header.storage_class_stats;
       rgw_bucket_category_stats& stats = header.stats[cur_change.meta.category];
 
       switch(op) {
@@ -2624,6 +2688,13 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx,
         stats.total_size += cur_change.meta.accounted_size;
         stats.total_size_rounded += cls_rgw_get_rounded_size(cur_change.meta.accounted_size);
         stats.actual_size += cur_change.meta.size;
+        if (storage_class_stats.has_value()) {
+          rgw_bucket_category_stats sc_stats = storage_class_stats.value()[storage_class];
+          sc_stats.num_entries++;
+          sc_stats.total_size += cur_change.meta.accounted_size;
+          sc_stats.total_size_rounded += cls_rgw_get_rounded_size(cur_change.meta.accounted_size);
+          sc_stats.actual_size += cur_change.meta.size;
+        }
         header_changed = true;
         cur_change.index_ver = header.ver;
 
@@ -3006,7 +3077,8 @@ static int rgw_bi_put_entries(cls_method_context_t hctx, bufferlist *in, bufferl
       cls_rgw_obj_key key;
       RGWObjCategory category;
       rgw_bucket_category_stats stats;
-      const bool account = entry.get_info(&key, &category, &stats);
+      string storage_class;
+      const bool account = entry.get_info(&key, &category, &stats, &storage_class);
       if (account) {
         auto& dest = header.stats[category];
         dest.total_size -= stats.total_size;
@@ -3032,7 +3104,8 @@ static int rgw_bi_put_entries(cls_method_context_t hctx, bufferlist *in, bufferl
     cls_rgw_obj_key key;
     RGWObjCategory category;
     rgw_bucket_category_stats stats;
-    const bool account = entry.get_info(&key, &category, &stats);
+    string storage_class;
+    const bool account = entry.get_info(&key, &category, &stats, &storage_class);
     if (account) {
       auto& dest = header.stats[category];
       dest.total_size += stats.total_size;
@@ -3510,11 +3583,19 @@ static int check_index(cls_method_context_t hctx,
       }
 
       if (entry.exists && entry.flags == 0) {
+        auto& storage_class = rgw_placement_rule::get_canonical_storage_class(entry.meta.storage_class);
         rgw_bucket_category_stats& stats = calc_header->stats[entry.meta.category];
         stats.num_entries++;
         stats.total_size += entry.meta.accounted_size;
         stats.total_size_rounded += cls_rgw_get_rounded_size(entry.meta.accounted_size);
         stats.actual_size += entry.meta.size;
+        if (calc_header->storage_class_stats.has_value()) {
+          rgw_bucket_category_stats& sc_stats = calc_header->storage_class_stats.value()[storage_class];
+          sc_stats.num_entries++;
+          sc_stats.total_size += entry.meta.accounted_size;
+          sc_stats.total_size_rounded += cls_rgw_get_rounded_size(entry.meta.accounted_size);
+          sc_stats.actual_size += entry.meta.size;
+        }
       }
       start_obj = bientry.idx;
     }
@@ -3539,11 +3620,19 @@ static int check_index(cls_method_context_t hctx,
       }
 
       if (entry.exists) {
+        auto& storage_class = rgw_placement_rule::get_canonical_storage_class(entry.meta.storage_class);
         rgw_bucket_category_stats& stats = calc_header->stats[entry.meta.category];
         stats.num_entries++;
         stats.total_size += entry.meta.accounted_size;
         stats.total_size_rounded += cls_rgw_get_rounded_size(entry.meta.accounted_size);
         stats.actual_size += entry.meta.size;
+        if (calc_header->storage_class_stats.has_value()) {
+          rgw_bucket_category_stats& sc_stats = calc_header->storage_class_stats.value()[storage_class];
+          sc_stats.num_entries++;
+          sc_stats.total_size += entry.meta.accounted_size;
+          sc_stats.total_size_rounded += cls_rgw_get_rounded_size(entry.meta.accounted_size);
+          sc_stats.actual_size += entry.meta.size;
+        }
       }
       start_obj = bientry.idx;
     }
@@ -5433,3 +5522,4 @@ CLS_INIT(rgw)
 
   return;
 }
+

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -73,12 +73,14 @@ void cls_rgw_bucket_set_tag_timeout(librados::ObjectWriteOperation& op,
 
 void cls_rgw_bucket_update_stats(librados::ObjectWriteOperation& o,
 				 bool absolute,
-                                 const map<RGWObjCategory, rgw_bucket_category_stats>& stats,
-                                 const map<RGWObjCategory, rgw_bucket_category_stats>* dec_stats)
+                 const map<RGWObjCategory, rgw_bucket_category_stats>& stats,
+                 const std::unordered_map<std::string, rgw_bucket_category_stats>& storage_class_stats,
+                 const std::map<RGWObjCategory, rgw_bucket_category_stats>* dec_stats)
 {
   rgw_cls_bucket_update_stats_op call;
   call.absolute = absolute;
   call.stats = stats;
+  call.storage_class_stats = storage_class_stats;
   if (dec_stats != NULL)
     call.dec_stats = *dec_stats;
   bufferlist in;

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -135,6 +135,7 @@ void cls_rgw_bucket_set_tag_timeout(librados::ObjectWriteOperation& op,
 void cls_rgw_bucket_update_stats(librados::ObjectWriteOperation& o,
                                  bool absolute,
                                  const std::map<RGWObjCategory, rgw_bucket_category_stats>& stats,
+                                 const std::unordered_map<std::string, rgw_bucket_category_stats>& storage_class_stats,
                                  const std::map<RGWObjCategory, rgw_bucket_category_stats>* dec_stats = nullptr);
 
 void cls_rgw_bucket_prepare_op(librados::ObjectWriteOperation& o, RGWModifyOp op, const std::string& tag,

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -504,22 +504,27 @@ struct rgw_cls_bucket_update_stats_op
   bool absolute{false};
   std::map<RGWObjCategory, rgw_bucket_category_stats> stats;
   std::map<RGWObjCategory, rgw_bucket_category_stats> dec_stats;
+  std::optional<std::unordered_map<std::string, rgw_bucket_category_stats>> storage_class_stats;
 
   rgw_cls_bucket_update_stats_op() {}
 
   void encode(ceph::buffer::list &bl) const {
-    ENCODE_START(2, 1, bl);
+    ENCODE_START(3, 1, bl);
     encode(absolute, bl);
     encode(stats, bl);
     encode(dec_stats, bl);
+    encode(storage_class_stats, bl);
     ENCODE_FINISH(bl);
   }
   void decode(ceph::buffer::list::const_iterator &bl) {
-    DECODE_START(2, bl);
+    DECODE_START(3, bl);
     decode(absolute, bl);
     decode(stats, bl);
     if (struct_v >= 2)
       decode(dec_stats, bl);
+    if (struct_v >= 3) {
+      decode(storage_class_stats, bl);
+    }
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -421,7 +421,8 @@ void rgw_cls_bi_entry::dump(Formatter *f) const
 
 bool rgw_cls_bi_entry::get_info(cls_rgw_obj_key *key,
                                 RGWObjCategory *category,
-                                rgw_bucket_category_stats *accounted_stats) const
+                                rgw_bucket_category_stats *accounted_stats,
+                                string *storage_class) const
 {
   using ceph::decode;
   auto iter = data.cbegin();
@@ -441,6 +442,7 @@ bool rgw_cls_bi_entry::get_info(cls_rgw_obj_key *key,
   rgw_bucket_dir_entry entry;
   decode(entry, iter);
   *key = entry.key;
+  *storage_class = entry.meta.storage_class;
   *category = entry.meta.category;
   accounted_stats->num_entries++;
   accounted_stats->total_size += entry.meta.accounted_size;

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -517,7 +517,7 @@ struct rgw_cls_bi_entry {
   void decode_json(JSONObj *obj, cls_rgw_obj_key *effective_key = NULL);
   static std::list<rgw_cls_bi_entry> generate_test_instances();
   bool get_info(cls_rgw_obj_key *key, RGWObjCategory *category,
-		rgw_bucket_category_stats *accounted_stats) const;
+		rgw_bucket_category_stats *accounted_stats, std::string *storage_class) const;
 };
 WRITE_CLASS_ENCODER(rgw_cls_bi_entry)
 
@@ -856,12 +856,13 @@ struct rgw_bucket_dir_header {
   cls_rgw_bucket_instance_entry new_instance;
   bool syncstopped;
   uint32_t reshardlog_entries;
+  std::optional<std::unordered_map<std::string, rgw_bucket_category_stats>> storage_class_stats;
 
   rgw_bucket_dir_header() : tag_timeout(0), ver(0), master_ver(0), syncstopped(false),
                             reshardlog_entries(0) {}
 
   void encode(ceph::buffer::list &bl) const {
-    ENCODE_START(8, 2, bl);
+    ENCODE_START(9, 2, bl);
     encode(stats, bl);
     encode(tag_timeout, bl);
     encode(ver, bl);
@@ -870,10 +871,11 @@ struct rgw_bucket_dir_header {
     encode(new_instance, bl);
     encode(syncstopped,bl);
     encode(reshardlog_entries, bl);
+    encode(storage_class_stats, bl);
     ENCODE_FINISH(bl);
   }
   void decode(ceph::buffer::list::const_iterator &bl) {
-    DECODE_START_LEGACY_COMPAT_LEN(8, 2, 2, bl);
+    DECODE_START_LEGACY_COMPAT_LEN(9, 2, 2, bl);
     decode(stats, bl);
     if (struct_v > 2) {
       decode(tag_timeout, bl);
@@ -902,6 +904,10 @@ struct rgw_bucket_dir_header {
     } else {
       reshardlog_entries = 0;
     }
+    if (struct_v >= 9) {
+      decode(storage_class_stats, bl);
+    }
+
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;
@@ -980,25 +986,32 @@ struct rgw_usage_data {
   uint64_t bytes_received;
   uint64_t ops;
   uint64_t successful_ops;
+  std::optional<std::string> storage_class;
 
-  rgw_usage_data() : bytes_sent(0), bytes_received(0), ops(0), successful_ops(0) {}
-  rgw_usage_data(uint64_t sent, uint64_t received) : bytes_sent(sent), bytes_received(received), ops(0), successful_ops(0) {}
+  rgw_usage_data() : bytes_sent(0), bytes_received(0), ops(0), successful_ops(0), storage_class({}) {}
+  rgw_usage_data(uint64_t sent, uint64_t received) : bytes_sent(sent), bytes_received(received), ops(0), successful_ops(0), storage_class({}) {}
+  rgw_usage_data(uint64_t sent, uint64_t received, std::string stg_cls) : bytes_sent(sent), bytes_received(received), ops(0), successful_ops(0), storage_class(stg_cls) {}
 
-  void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(1, 1, bl);
+
+    void encode(ceph::buffer::list& bl) const {
+    ENCODE_START(2, 1, bl);
     encode(bytes_sent, bl);
     encode(bytes_received, bl);
     encode(ops, bl);
     encode(successful_ops, bl);
+    encode(storage_class, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START(1, bl);
+    DECODE_START(2, bl);
     decode(bytes_sent, bl);
     decode(bytes_received, bl);
     decode(ops, bl);
     decode(successful_ops, bl);
+    if (struct_v >= 2) {
+      decode(storage_class, bl);
+    }
     DECODE_FINISH(bl);
   }
 
@@ -1007,6 +1020,9 @@ struct rgw_usage_data {
     bytes_received += usage.bytes_received;
     ops += usage.ops;
     successful_ops += usage.successful_ops;
+    if (!storage_class && usage.storage_class){
+      storage_class = { *usage.storage_class };
+    }
   }
   void dump(ceph::Formatter *f) const;
   static std::list<rgw_usage_data> generate_test_instances();
@@ -1022,13 +1038,14 @@ struct rgw_usage_log_entry {
   rgw_usage_data total_usage; /* this one is kept for backwards compatibility */
   std::map<std::string, rgw_usage_data> usage_map;
   rgw_s3select_usage_data s3select_usage;
+  std::unordered_map<std::string, std::map<std::string, rgw_usage_data>> usage_by_storage_class_map;
 
   rgw_usage_log_entry() : epoch(0) {}
   rgw_usage_log_entry(std::string& o, std::string& b) : owner(o), bucket(b), epoch(0) {}
   rgw_usage_log_entry(std::string& o, std::string& p, std::string& b) : owner(o), payer(p), bucket(b), epoch(0) {}
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(4, 1, bl);
+    ENCODE_START(5, 1, bl);
     encode(owner.to_str(), bl);
     encode(bucket, bl);
     encode(epoch, bl);
@@ -1039,12 +1056,14 @@ struct rgw_usage_log_entry {
     encode(usage_map, bl);
     encode(payer.to_str(), bl);
     encode(s3select_usage, bl);
+    encode(total_usage.storage_class, bl);
+    encode(usage_by_storage_class_map, bl);
     ENCODE_FINISH(bl);
   }
 
 
    void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START(4, bl);
+    DECODE_START(5, bl);
     std::string s;
     decode(s, bl);
     owner.from_str(s);
@@ -1067,6 +1086,10 @@ struct rgw_usage_log_entry {
     if (struct_v >= 4) {
       decode(s3select_usage, bl);
     }
+    if (struct_v >= 5) {
+      decode(total_usage.storage_class, bl);
+      decode(usage_by_storage_class_map, bl);
+    }
     DECODE_FINISH(bl);
   }
 
@@ -1079,9 +1102,12 @@ struct rgw_usage_log_entry {
       payer = e.payer;
     }
 
-    for (auto iter = e.usage_map.begin(); iter != e.usage_map.end(); ++iter) {
-      if (!categories || !categories->size() || categories->count(iter->first)) {
-        add_usage(iter->first, iter->second);
+    for (auto iter = e.usage_by_storage_class_map.begin(); iter != e.usage_by_storage_class_map.end(); ++iter) {
+      for (auto iter2 = iter->second.begin(); iter2 != iter->second.end(); ++iter2) {
+        if (!categories || !categories->size() || categories->count(iter2->first)) {
+          add_usage(iter->first, iter2->first, iter2->second);
+          add_usage(iter2->first, iter2->second);
+        }
       }
     }
 
@@ -1102,6 +1128,11 @@ struct rgw_usage_log_entry {
 
   void add_usage(const std::string& category, const rgw_usage_data& data) {
     usage_map[category].aggregate(data);
+    total_usage.aggregate(data);
+  }
+
+  void add_usage(const std::string &storage_class, const std::string &category, const rgw_usage_data &data) {
+    usage_by_storage_class_map[storage_class][category].aggregate(data);
     total_usage.aggregate(data);
   }
 

--- a/src/cls/user/cls_user.cc
+++ b/src/cls/user/cls_user.cc
@@ -138,18 +138,58 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
     return ret;
   }
 
+  if (op.reset) {
+    for (auto &new_entry: op.entries) {
+      std::optional<std::string> storage_class = new_entry.storage_class;
+      string key;
+      get_key_by_bucket_name(new_entry.bucket.name, &key);
+      cls_user_bucket_entry old_entry;
+      if (storage_class.has_value() && !storage_class.value().empty()) {
+        key += "-" + storage_class.value();
+      }
+      ret = get_existing_bucket_entry(hctx, key, old_entry);
+      if (ret == -ENOENT) {
+        continue;
+      }
+      old_entry.size = 0;
+      old_entry.size_rounded = 0;
+      old_entry.count = 0;
+      ret = write_entry(hctx, key, old_entry);
+      if (ret < 0)
+        return ret;
+
+    }
+    header.stats.total_entries = 0;
+    header.stats.total_bytes = 0;
+    header.stats.total_bytes_rounded = 0;
+    header.storage_class_stats.emplace();
+    bufferlist bl;
+    encode(header, bl);
+    ret = cls_cxx_map_write_header(hctx, &bl);
+    if (ret < 0)
+      return ret;
+    return 0;
+  }
+
   for (auto iter = op.entries.begin(); iter != op.entries.end(); ++iter) {
     cls_user_bucket_entry& update_entry = *iter;
-
+    std::optional<std::string> storage_class = update_entry.storage_class;
+    if (!storage_class.has_value()) {
+      header.storage_class_stats.reset();
+      continue;
+    }
     string key;
 
     get_key_by_bucket_name(update_entry.bucket.name, &key);
-
+    string old_key = key;
     cls_user_bucket_entry entry;
+    if (!storage_class.value().empty()) {
+      key += "-" + storage_class.value();
+    }
     ret = get_existing_bucket_entry(hctx, key, entry);
 
     if (ret == -ENOENT) {
-     if (!op.add)
+     if (!op.add && !storage_class)
       continue; /* racing bucket removal */
 
      entry = update_entry;
@@ -160,13 +200,41 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
       entry.bucket.bucket_id = update_entry.bucket.bucket_id;
       // creation date may have changed (ie delete/recreate bucket)
       entry.creation_time = update_entry.creation_time;
+      // updating bucket id for storage classes entries
+      if (header.storage_class_stats.has_value()) {
+        for (auto& idx: header.storage_class_stats.value()) {
+          cls_user_bucket_entry storage_class_entry;
+          string storage_class_key = old_key + "-" + idx.first;
+          int s_ret = get_existing_bucket_entry(hctx, storage_class_key, storage_class_entry);
+          if (s_ret < 0) {
+            CLS_LOG(0, "WARNING: cannot update bucket id for bucket %s and storage class %s. ret: %d.",
+                    old_key.c_str(), idx.first.c_str(), s_ret);
+            continue;
+          }
+          storage_class_entry.bucket.bucket_id = update_entry.bucket.bucket_id;
+          storage_class_entry.creation_time = update_entry.creation_time;
+          s_ret = write_entry(hctx, storage_class_key, storage_class_entry);
+          if (s_ret < 0) {
+            CLS_LOG(0, "WARNING: cannot update bucket id for bucket %s and storage class %s. ret: %d.",
+                    old_key.c_str(), idx.first.c_str(), s_ret);
+          }
+        }
+      }
     }
 
     if (ret < 0) {
       CLS_LOG(0, "ERROR: get_existing_bucket_entry() key=%s returned %d", key.c_str(), ret);
       return ret;
     } else if (ret >= 0 && entry.user_stats_sync) {
-      dec_header_stats(&header.stats, entry);
+      if (!storage_class.value().empty()){
+        if (header.storage_class_stats.has_value()) {
+          header.storage_class_stats.value()[storage_class.value()].total_entries -= entry.count;
+          header.storage_class_stats.value()[storage_class.value()].total_bytes -= entry.size;
+          header.storage_class_stats.value()[storage_class.value()].total_bytes_rounded -= entry.size_rounded;
+        }
+      } else {
+        dec_header_stats(&header.stats, entry);
+      }
     }
 
     CLS_LOG(20, "storing entry for key=%s size=%lld count=%lld",
@@ -184,7 +252,15 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
     if (ret < 0)
       return ret;
 
-    add_header_stats(&header.stats, entry);
+    if (!storage_class.value().empty()){
+      if (header.storage_class_stats.has_value()) {
+        header.storage_class_stats.value()[storage_class.value()].total_entries += entry.count;
+        header.storage_class_stats.value()[storage_class.value()].total_bytes += entry.size;
+        header.storage_class_stats.value()[storage_class.value()].total_bytes_rounded += entry.size_rounded;
+      }
+    } else {
+      add_header_stats(&header.stats, entry);
+    }
   }
 
   bufferlist bl;
@@ -193,6 +269,10 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
 
   if (header.last_stats_update < op.time)
     header.last_stats_update = op.time;
+
+  if (header.stats.total_entries == 0) {
+    header.storage_class_stats.emplace();
+  }
 
   encode(header, bl);
   
@@ -268,7 +348,13 @@ static int cls_user_remove_bucket(cls_method_context_t hctx, bufferlist *in, buf
     CLS_LOG(0, "ERROR: get existing bucket entry, key=%s ret=%d", key.c_str(), ret);
     return ret;
   }
-
+  if (header.storage_class_stats.has_value()) {
+    for(auto it = header.storage_class_stats.value().begin(); it != header.storage_class_stats.value().end(); ++it){
+      auto new_key = key + "-" + it->first;
+      CLS_LOG(20, "removing entry at %s", new_key.c_str());
+      remove_entry(hctx, new_key);
+    }
+  }
   CLS_LOG(20, "removing entry at %s", key.c_str());
 
   ret = remove_entry(hctx, key);

--- a/src/cls/user/cls_user.cc
+++ b/src/cls/user/cls_user.cc
@@ -117,6 +117,7 @@ static void apply_entry_stats(const cls_user_bucket_entry& src_entry, cls_user_b
   target_entry->size = src_entry.size;
   target_entry->size_rounded = src_entry.size_rounded;
   target_entry->count = src_entry.count;
+  target_entry->storage_class_stats = src_entry.storage_class_stats;
 }
 
 static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
@@ -140,13 +141,9 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
 
   if (op.reset) {
     for (auto &new_entry: op.entries) {
-      std::optional<std::string> storage_class = new_entry.storage_class;
       string key;
       get_key_by_bucket_name(new_entry.bucket.name, &key);
       cls_user_bucket_entry old_entry;
-      if (storage_class.has_value() && !storage_class.value().empty()) {
-        key += "-" + storage_class.value();
-      }
       ret = get_existing_bucket_entry(hctx, key, old_entry);
       if (ret == -ENOENT) {
         continue;
@@ -154,6 +151,7 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
       old_entry.size = 0;
       old_entry.size_rounded = 0;
       old_entry.count = 0;
+      old_entry.storage_class_stats.emplace();
       ret = write_entry(hctx, key, old_entry);
       if (ret < 0)
         return ret;
@@ -173,25 +171,20 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
 
   for (auto iter = op.entries.begin(); iter != op.entries.end(); ++iter) {
     cls_user_bucket_entry& update_entry = *iter;
-    std::optional<std::string> storage_class = update_entry.storage_class;
-    if (!storage_class.has_value()) {
-      header.storage_class_stats.reset();
-      continue;
+    std::optional<std::unordered_map<std::string, cls_user_bucket_entry>> storage_class_stats = update_entry.storage_class_stats;
+    if (!storage_class_stats.has_value()) {
+      storage_class_stats.emplace();
     }
     string key;
 
     get_key_by_bucket_name(update_entry.bucket.name, &key);
-    string old_key = key;
     cls_user_bucket_entry entry;
-    if (!storage_class.value().empty()) {
-      key += "-" + storage_class.value();
-    }
     ret = get_existing_bucket_entry(hctx, key, entry);
 
     if (ret == -ENOENT) {
-     if (!op.add && !storage_class)
-      continue; /* racing bucket removal */
-
+     if (!op.add) {
+       continue; /* racing bucket removal */
+     }
      entry = update_entry;
 
      ret = 0;
@@ -200,43 +193,23 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
       entry.bucket.bucket_id = update_entry.bucket.bucket_id;
       // creation date may have changed (ie delete/recreate bucket)
       entry.creation_time = update_entry.creation_time;
-      // updating bucket id for storage classes entries
-      if (header.storage_class_stats.has_value()) {
-        for (auto& idx: header.storage_class_stats.value()) {
-          cls_user_bucket_entry storage_class_entry;
-          string storage_class_key = old_key + "-" + idx.first;
-          int s_ret = get_existing_bucket_entry(hctx, storage_class_key, storage_class_entry);
-          if (s_ret < 0) {
-            CLS_LOG(0, "WARNING: cannot update bucket id for bucket %s and storage class %s. ret: %d.",
-                    old_key.c_str(), idx.first.c_str(), s_ret);
-            continue;
-          }
-          storage_class_entry.bucket.bucket_id = update_entry.bucket.bucket_id;
-          storage_class_entry.creation_time = update_entry.creation_time;
-          s_ret = write_entry(hctx, storage_class_key, storage_class_entry);
-          if (s_ret < 0) {
-            CLS_LOG(0, "WARNING: cannot update bucket id for bucket %s and storage class %s. ret: %d.",
-                    old_key.c_str(), idx.first.c_str(), s_ret);
-          }
-        }
-      }
     }
 
     if (ret < 0) {
       CLS_LOG(0, "ERROR: get_existing_bucket_entry() key=%s returned %d", key.c_str(), ret);
       return ret;
     } else if (ret >= 0 && entry.user_stats_sync) {
-      if (!storage_class.value().empty()){
-        if (header.storage_class_stats.has_value()) {
-          header.storage_class_stats.value()[storage_class.value()].total_entries -= entry.count;
-          header.storage_class_stats.value()[storage_class.value()].total_bytes -= entry.size;
-          header.storage_class_stats.value()[storage_class.value()].total_bytes_rounded -= entry.size_rounded;
+      if (header.storage_class_stats.has_value() && entry.storage_class_stats.has_value()) {
+        for (auto it = entry.storage_class_stats.value().begin(); it != entry.storage_class_stats.value().end(); ++it) {
+          std::string storage_class = it->first;
+          cls_user_bucket_entry stats = it->second;
+          header.storage_class_stats.value()[storage_class].total_entries -= stats.count;
+          header.storage_class_stats.value()[storage_class].total_bytes -= stats.size;
+          header.storage_class_stats.value()[storage_class].total_bytes_rounded -= stats.size_rounded;
         }
-      } else {
-        dec_header_stats(&header.stats, entry);
       }
+      dec_header_stats(&header.stats, entry);
     }
-
     CLS_LOG(20, "storing entry for key=%s size=%lld count=%lld",
             key.c_str(), (long long)update_entry.size, (long long)update_entry.count);
 
@@ -249,26 +222,30 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
     entry.user_stats_sync = true;
 
     ret = write_entry(hctx, key, entry);
-    if (ret < 0)
+    if (ret < 0) {
       return ret;
-
-    if (!storage_class.value().empty()){
-      if (header.storage_class_stats.has_value()) {
-        header.storage_class_stats.value()[storage_class.value()].total_entries += entry.count;
-        header.storage_class_stats.value()[storage_class.value()].total_bytes += entry.size;
-        header.storage_class_stats.value()[storage_class.value()].total_bytes_rounded += entry.size_rounded;
-      }
-    } else {
-      add_header_stats(&header.stats, entry);
     }
-  }
 
+    if (!storage_class_stats.value().empty()){
+      if (header.storage_class_stats.has_value()) {
+        for (auto it = storage_class_stats.value().begin(); it != storage_class_stats.value().end(); ++it) {
+          std::string storage_class = it->first;
+          cls_user_bucket_entry stats = it->second;
+          header.storage_class_stats.value()[storage_class].total_entries += stats.count;
+          header.storage_class_stats.value()[storage_class].total_bytes += stats.size;
+          header.storage_class_stats.value()[storage_class].total_bytes_rounded += stats.size_rounded;
+        }
+      }
+    }
+    add_header_stats(&header.stats, entry);
+  }
   bufferlist bl;
 
   CLS_LOG(20, "header: total bytes=%lld entries=%lld", (long long)header.stats.total_bytes, (long long)header.stats.total_entries);
 
-  if (header.last_stats_update < op.time)
+  if (header.last_stats_update < op.time) {
     header.last_stats_update = op.time;
+  }
 
   if (header.stats.total_entries == 0) {
     header.storage_class_stats.emplace();

--- a/src/cls/user/cls_user_client.cc
+++ b/src/cls/user/cls_user_client.cc
@@ -17,12 +17,13 @@ using librados::ObjectOperationCompletion;
 using librados::ObjectReadOperation;
 using namespace cls::user;
 
-void cls_user_set_buckets(librados::ObjectWriteOperation& op, list<cls_user_bucket_entry>& entries, bool add)
+void cls_user_set_buckets(librados::ObjectWriteOperation& op, list<cls_user_bucket_entry>& entries, bool add, bool reset)
 {
   bufferlist in;
   cls_user_set_buckets_op call;
   call.entries = entries;
   call.add = add;
+  call.reset = reset;
   call.time = real_clock::now();
   encode(call, in);
   op.exec(method::set_buckets_info, in);

--- a/src/cls/user/cls_user_client.h
+++ b/src/cls/user/cls_user_client.h
@@ -18,7 +18,7 @@ public:
  * user objclass
  */
 
-void cls_user_set_buckets(librados::ObjectWriteOperation& op, std::list<cls_user_bucket_entry>& entries, bool add);
+void cls_user_set_buckets(librados::ObjectWriteOperation& op, std::list<cls_user_bucket_entry>& entries, bool add, bool reset);
 void cls_user_complete_stats_sync(librados::ObjectWriteOperation& op);
 void cls_user_remove_bucket(librados::ObjectWriteOperation& op,  const cls_user_bucket& bucket);
 void cls_user_bucket_list(librados::ObjectReadOperation& op,

--- a/src/cls/user/cls_user_ops.h
+++ b/src/cls/user/cls_user_ops.h
@@ -10,23 +10,28 @@
 struct cls_user_set_buckets_op {
   std::list<cls_user_bucket_entry> entries;
   bool add;
+  bool reset;
   ceph::real_time time; /* op time */
 
-  cls_user_set_buckets_op() : add(false) {}
+  cls_user_set_buckets_op() : add(false), reset(false) {}
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 1, bl);
     encode(entries, bl);
     encode(add, bl);
     encode(time, bl);
+    encode(reset, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START(1, bl);
+    DECODE_START(2, bl);
     decode(entries, bl);
     decode(add, bl);
     decode(time, bl);
+    if (struct_v >= 2) {
+        decode(reset, bl);
+    }
     DECODE_FINISH(bl);
   }
 

--- a/src/cls/user/cls_user_types.h
+++ b/src/cls/user/cls_user_types.h
@@ -104,11 +104,12 @@ struct cls_user_bucket_entry {
   ceph::real_time creation_time;
   uint64_t count;
   bool user_stats_sync;
+  std::optional<std::string> storage_class;
 
-  cls_user_bucket_entry() : size(0), size_rounded(0), count(0), user_stats_sync(false) {}
+  cls_user_bucket_entry() : size(0), size_rounded(0), count(0), user_stats_sync(false), storage_class({}) {}
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(9, 5, bl);
+    ENCODE_START(10, 5, bl);
     uint64_t s = size;
     __u32 mt = ceph::real_clock::to_time_t(creation_time);
     std::string empty_str;  // originally had the bucket name here, but we encode bucket later
@@ -122,10 +123,11 @@ struct cls_user_bucket_entry {
     encode(user_stats_sync, bl);
     encode(creation_time, bl);
     //::encode(placement_rule, bl); removed in v9
+    encode(storage_class, bl);
     ENCODE_FINISH(bl);
   }
   void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START_LEGACY_COMPAT_LEN(9, 5, 5, bl);
+    DECODE_START_LEGACY_COMPAT_LEN(10, 5, 5, bl);
     __u32 mt;
     uint64_t s;
     std::string empty_str;  // backward compatibility
@@ -150,6 +152,9 @@ struct cls_user_bucket_entry {
     if (struct_v == 8) { // added in v8, removed in v9
       std::string placement_rule;
       decode(placement_rule, bl);
+    }
+    if (struct_v >= 10) {
+      decode(storage_class, bl);
     }
     DECODE_FINISH(bl);
   }
@@ -193,21 +198,26 @@ WRITE_CLASS_ENCODER(cls_user_stats)
  */
 struct cls_user_header {
   cls_user_stats stats;
+  std::optional<std::unordered_map<std::string, cls_user_stats>> storage_class_stats;
   ceph::real_time last_stats_sync;     /* last time a full stats sync completed */
   ceph::real_time last_stats_update;   /* last time a stats update was done */
 
   void encode(ceph::buffer::list& bl) const {
-     ENCODE_START(1, 1, bl);
+     ENCODE_START(2, 1, bl);
     encode(stats, bl);
     encode(last_stats_sync, bl);
     encode(last_stats_update, bl);
+    encode(storage_class_stats, bl);
     ENCODE_FINISH(bl);
   }
   void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START(1, bl);
+    DECODE_START(2, bl);
     decode(stats, bl);
     decode(last_stats_sync, bl);
     decode(last_stats_update, bl);
+    if (struct_v >= 2) {
+      decode(storage_class_stats, bl);
+    }
     DECODE_FINISH(bl);
   }
 

--- a/src/cls/user/cls_user_types.h
+++ b/src/cls/user/cls_user_types.h
@@ -104,9 +104,9 @@ struct cls_user_bucket_entry {
   ceph::real_time creation_time;
   uint64_t count;
   bool user_stats_sync;
-  std::optional<std::string> storage_class;
+  std::optional<std::unordered_map<std::string, cls_user_bucket_entry>> storage_class_stats;
 
-  cls_user_bucket_entry() : size(0), size_rounded(0), count(0), user_stats_sync(false), storage_class({}) {}
+  cls_user_bucket_entry() : size(0), size_rounded(0), count(0), user_stats_sync(false), storage_class_stats({}) {}
 
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(10, 5, bl);
@@ -123,7 +123,7 @@ struct cls_user_bucket_entry {
     encode(user_stats_sync, bl);
     encode(creation_time, bl);
     //::encode(placement_rule, bl); removed in v9
-    encode(storage_class, bl);
+    encode(storage_class_stats, bl);
     ENCODE_FINISH(bl);
   }
   void decode(ceph::buffer::list::const_iterator& bl) {
@@ -154,7 +154,7 @@ struct cls_user_bucket_entry {
       decode(placement_rule, bl);
     }
     if (struct_v >= 10) {
-      decode(storage_class, bl);
+      decode(storage_class_stats, bl);
     }
     DECODE_FINISH(bl);
   }

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -147,7 +147,8 @@ set(librgw_common_srcs
   rgw_bucket_logging.cc
   rgw_rest_bucket_logging.cc
   rgw_bucket_sync.cc
-  rgw_rest_restore.cc)
+  rgw_rest_restore.cc
+  rgw_sc_quota_checker.cc)
 
 list(APPEND librgw_common_srcs
   driver/immutable_config/store.cc

--- a/src/rgw/driver/daos/rgw_sal_daos.h
+++ b/src/rgw/driver/daos/rgw_sal_daos.h
@@ -322,7 +322,8 @@ class DaosBucket : public StoreBucket {
                           optional_yield y) override;
   virtual int check_quota(const DoutPrefixProvider* dpp, RGWQuota& quota,
                           uint64_t obj_size, optional_yield y,
-                          bool check_size_only = false) override;
+                          bool check_size_only = false,
+                          const rgw_placement_rule* dest_placement = nullptr) override;
   virtual int merge_and_store_attrs(const DoutPrefixProvider* dpp, Attrs& attrs,
                                     optional_yield y) override;
   virtual int try_refresh_info(const DoutPrefixProvider* dpp,

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -2962,7 +2962,7 @@ int POSIXBucket::check_empty(const DoutPrefixProvider* dpp, optional_yield y)
 }
 
 int POSIXBucket::check_quota(const DoutPrefixProvider *dpp, RGWQuota& quota, uint64_t obj_size,
-				optional_yield y, bool check_size_only)
+				optional_yield y, bool check_size_only, const rgw_placement_rule* dest_placement)
 {
   return driver->get_quota_handler()->check_quota(dpp, info.owner, get_key(),
                                                   quota, (check_size_only ? 0 : 1),

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -2844,6 +2844,7 @@ int POSIXBucket::read_stats(const DoutPrefixProvider *dpp, optional_yield y,
 			    const bucket_index_layout_generation& idx_layout,
 			    int shard_id, std::string* bucket_ver, std::string* master_ver,
 			    std::map<RGWObjCategory, RGWStorageStats>& stats,
+			    std::optional<std::map<std::string, RGWStorageStats>>& sc_stats,
 			    std::string* max_marker, bool* syncstopped)
 {
   auto& main = stats[RGWObjCategory::Main];

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -2894,6 +2894,7 @@ int POSIXBucket::read_stats_async(const DoutPrefixProvider *dpp,
 }
 
 int POSIXBucket::sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y,
+                                  bool reset,
                                   RGWBucketEnt* ent)
 {
   return 0;

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -909,6 +909,7 @@ public:
 			 const bucket_index_layout_generation& idx_layout,
 			 int shard_id, std::string* bucket_ver, std::string* master_ver,
 			 std::map<RGWObjCategory, RGWStorageStats>& stats,
+			 std::optional<std::map<std::string, RGWStorageStats>>& sc_stats,
 			 std::string* max_marker = nullptr,
 			 bool* syncstopped = nullptr) override;
   virtual int read_stats_async(const DoutPrefixProvider *dpp,

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -914,7 +914,7 @@ public:
   virtual int read_stats_async(const DoutPrefixProvider *dpp,
 			       const bucket_index_layout_generation& idx_layout,
 			       int shard_id, boost::intrusive_ptr<ReadStatsCB> ctx) override;
-  virtual int sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y,
+  virtual int sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y, bool reset,
                                RGWBucketEnt* ent) override;
   virtual int check_bucket_shards(const DoutPrefixProvider* dpp,
                                   uint64_t num_objs, optional_yield y) override;

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -926,7 +926,7 @@ public:
   virtual int put_info(const DoutPrefixProvider* dpp, bool exclusive,
                        ceph::real_time mtime, optional_yield y) override;
   virtual int check_empty(const DoutPrefixProvider* dpp, optional_yield y) override;
-  virtual int check_quota(const DoutPrefixProvider *dpp, RGWQuota& quota, uint64_t obj_size, optional_yield y, bool check_size_only = false) override;
+  virtual int check_quota(const DoutPrefixProvider *dpp, RGWQuota& quota, uint64_t obj_size, optional_yield y, bool check_size_only = false, const rgw_placement_rule* dest_placement = nullptr) override;
   virtual int try_refresh_info(const DoutPrefixProvider* dpp, ceph::real_time* pmtime, optional_yield y) override;
   virtual int read_usage(const DoutPrefixProvider *dpp, uint64_t start_epoch,
 			 uint64_t end_epoch, uint32_t max_entries, bool* is_truncated,

--- a/src/rgw/driver/rados/buckets.cc
+++ b/src/rgw/driver/rados/buckets.cc
@@ -26,11 +26,30 @@ namespace rgwrados::buckets {
 
 static int set(const DoutPrefixProvider* dpp, optional_yield y,
                librados::Rados& rados, const rgw_raw_obj& obj,
-               cls_user_bucket_entry&& entry, bool add)
+               cls_user_bucket_entry&& entry, bool add, bool reset,
+               const RGWBucketEnt* ent)
 {
   std::list<cls_user_bucket_entry> entries;
-  entries.push_back(std::move(entry));
-
+  cls_user_bucket_entry main_entry = std::move(entry);
+  main_entry.storage_class = "";
+  entries.push_back(main_entry);
+  if (ent != nullptr) {
+    std::string placement_target = ent->placement_rule.name;
+    if (main_entry.count > 0 && ent->storage_class_ents.empty()) {
+      cls_user_bucket_entry do_not_initialize_storage_classes;
+      ent->convert(&do_not_initialize_storage_classes);
+      do_not_initialize_storage_classes.storage_class.reset();
+      entries.push_back(do_not_initialize_storage_classes);
+    }
+    for (auto it = ent->storage_class_ents.begin(); it != ent->storage_class_ents.end(); ++it) {
+      std::string storage_class = it->first;
+      RGWBucketEnt bent = it->second;
+      cls_user_bucket_entry en;
+      bent.convert(&en);
+      en.storage_class = placement_target + "::" + storage_class;
+      entries.push_back(en);
+    }
+  }
   rgw_rados_ref ref;
   int r = rgw_get_rados_ref(dpp, &rados, obj, &ref);
   if (r < 0) {
@@ -38,7 +57,7 @@ static int set(const DoutPrefixProvider* dpp, optional_yield y,
   }
 
   librados::ObjectWriteOperation op;
-  ::cls_user_set_buckets(op, entries, add);
+  ::cls_user_set_buckets(op, entries, add, reset);
   return ref.operate(dpp, std::move(op), y);
 }
 
@@ -56,7 +75,7 @@ int add(const DoutPrefixProvider* dpp, optional_yield y,
   }
 
   constexpr bool add = true; // create/update entry
-  return set(dpp, y, rados, obj, std::move(entry), add);
+  return set(dpp, y, rados, obj, std::move(entry), add, false, nullptr);
 }
 
 int remove(const DoutPrefixProvider* dpp, optional_yield y,
@@ -141,13 +160,13 @@ int list(const DoutPrefixProvider* dpp, optional_yield y,
 
 int write_stats(const DoutPrefixProvider* dpp, optional_yield y,
                 librados::Rados& rados, const rgw_raw_obj& obj,
-                const RGWBucketEnt& ent)
+                const RGWBucketEnt& ent, bool reset)
 {
   cls_user_bucket_entry entry;
   ent.convert(&entry);
 
   constexpr bool add = false; // bucket entry must exist
-  return set(dpp, y, rados, obj, std::move(entry), add);
+  return set(dpp, y, rados, obj, std::move(entry), add, reset, &ent);
 }
 
 int read_stats(const DoutPrefixProvider* dpp, optional_yield y,
@@ -174,6 +193,18 @@ int read_stats(const DoutPrefixProvider* dpp, optional_yield y,
   stats.size = header.stats.total_bytes;
   stats.size_rounded = header.stats.total_bytes_rounded;
   stats.num_objects = header.stats.total_entries;
+  if (header.storage_class_stats.has_value()) {
+    if (!stats.storage_class_stats.has_value()) {
+      stats.storage_class_stats.emplace();
+    }
+    for (auto it = header.storage_class_stats.value().begin(); it != header.storage_class_stats.value().end(); ++it) {
+      std::string storage_class = it->first;
+      stats.storage_class_stats.value()[storage_class].size = it->second.total_bytes;
+      stats.storage_class_stats.value()[storage_class].size_rounded = it->second.total_bytes_rounded;
+      stats.storage_class_stats.value()[storage_class].num_objects = it->second.total_entries;
+    }
+  }
+
   if (last_synced) {
     *last_synced = header.last_stats_sync;
   }

--- a/src/rgw/driver/rados/buckets.cc
+++ b/src/rgw/driver/rados/buckets.cc
@@ -30,26 +30,8 @@ static int set(const DoutPrefixProvider* dpp, optional_yield y,
                const RGWBucketEnt* ent)
 {
   std::list<cls_user_bucket_entry> entries;
-  cls_user_bucket_entry main_entry = std::move(entry);
-  main_entry.storage_class = "";
-  entries.push_back(main_entry);
-  if (ent != nullptr) {
-    std::string placement_target = ent->placement_rule.name;
-    if (main_entry.count > 0 && ent->storage_class_ents.empty()) {
-      cls_user_bucket_entry do_not_initialize_storage_classes;
-      ent->convert(&do_not_initialize_storage_classes);
-      do_not_initialize_storage_classes.storage_class.reset();
-      entries.push_back(do_not_initialize_storage_classes);
-    }
-    for (auto it = ent->storage_class_ents.begin(); it != ent->storage_class_ents.end(); ++it) {
-      std::string storage_class = it->first;
-      RGWBucketEnt bent = it->second;
-      cls_user_bucket_entry en;
-      bent.convert(&en);
-      en.storage_class = placement_target + "::" + storage_class;
-      entries.push_back(en);
-    }
-  }
+  entries.push_back(std::move(entry));
+
   rgw_rados_ref ref;
   int r = rgw_get_rados_ref(dpp, &rados, obj, &ref);
   if (r < 0) {

--- a/src/rgw/driver/rados/buckets.h
+++ b/src/rgw/driver/rados/buckets.h
@@ -64,7 +64,8 @@ int write_stats(const DoutPrefixProvider* dpp,
                 optional_yield y,
                 librados::Rados& rados,
                 const rgw_raw_obj& obj,
-                const RGWBucketEnt& bucket);
+                const RGWBucketEnt& bucket,
+                bool reset);
 
 /// Read the total usage stats of all buckets.
 int read_stats(const DoutPrefixProvider* dpp,

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -316,6 +316,30 @@ static void dump_bucket_usage(map<RGWObjCategory, RGWStorageStats>& stats, Forma
   formatter->close_section();
 }
 
+static void dump_bucket_storage_classes_usage(map<RGWObjCategory, RGWStorageStats>& stats, std::optional<map<std::string, RGWStorageStats>> sc_stats, Formatter *formatter)
+{
+  formatter->open_object_section("usage");
+  for (auto it = stats.begin(); it != stats.end(); ++it) {
+    RGWStorageStats& s = it->second;
+    formatter->open_object_section(to_string(it->first));
+    s.dump(formatter);
+    formatter->close_section();
+  }
+  if (sc_stats.has_value()) {
+    formatter->open_array_section("rgw.storage-classes");
+    for (auto it = sc_stats.value().begin(); it != sc_stats.value().end(); ++it){
+      RGWStorageStats& s = it->second;
+      std::string storage_class = it->first;
+      formatter->open_object_section(storage_class);
+      formatter->dump_string("name", storage_class);
+      s.dump(formatter);
+      formatter->close_section();
+    }
+    formatter->close_section();
+  }
+  formatter->close_section();
+}
+
 #ifdef WITH_RADOSGW_RADOS
 static void dump_index_check(map<RGWObjCategory, RGWStorageStats> existing_stats,
         map<RGWObjCategory, RGWStorageStats> calculated_stats,
@@ -1598,6 +1622,8 @@ static int bucket_stats(rgw::sal::Driver* driver, const rgw::SiteConfig& site,
                         const DoutPrefixProvider* dpp, optional_yield y) {
   std::unique_ptr<rgw::sal::Bucket> bucket;
   map<RGWObjCategory, RGWStorageStats> stats;
+  std::optional<map<string, RGWStorageStats>> sc_stats;
+  sc_stats.emplace();
 
   int ret = driver->load_bucket(dpp, rgw_bucket(tenant_name, bucket_name),
                                 &bucket, y);
@@ -1624,6 +1650,20 @@ static int bucket_stats(rgw::sal::Driver* driver, const rgw::SiteConfig& site,
       cerr << "error getting bucket stats bucket=" << bucket->get_name() << " ret=" << ret << std::endl;
       return ret;
     }
+  }
+
+  auto radosdriver = static_cast<rgw::sal::RadosStore*>(driver);
+  if (!radosdriver) {
+    cerr << "rados store only" << std::endl;
+    return -ENOTSUP;
+  }
+
+  ret = radosdriver->getRados()->get_bucket_storage_classes_stats(dpp, y, bucket_info, RGW_NO_SHARD,
+                                                            &bucket_ver, &master_ver, sc_stats,
+                                                            &max_marker, index);
+  if (ret < 0) {
+    cerr << "error getting bucket storage class stats bucket=" << bucket->get_name() << " ret=" << ret << std::endl;
+    return ret;
   }
 
   utime_t ut(bucket->get_modification_time());
@@ -1659,6 +1699,7 @@ static int bucket_stats(rgw::sal::Driver* driver, const rgw::SiteConfig& site,
   }
   ut.gmtime(formatter->dump_stream("mtime"));
   ctime_ut.gmtime(formatter->dump_stream("creation_time"));
+  dump_bucket_storage_classes_usage(stats, sc_stats, formatter);
   encode_json("bucket_quota", bucket_info.quota, formatter);
 
   // bucket tags
@@ -3659,6 +3700,7 @@ int RGWBucketCtl::sync_owner_stats(const DoutPrefixProvider *dpp,
                                    const rgw_owner& owner,
                                    const RGWBucketInfo& bucket_info,
                                    optional_yield y,
+                                   bool reset,
                                    RGWBucketEnt* pent)
 {
   RGWBucketEnt ent;
@@ -3680,7 +3722,7 @@ int RGWBucketCtl::sync_owner_stats(const DoutPrefixProvider *dpp,
         const RGWZoneParams& zone = svc.zone->get_zone_params();
         return rgwrados::account::get_buckets_obj(zone, id);
       }), owner);
-  return rgwrados::buckets::write_stats(dpp, y, rados, obj, *pent);
+  return rgwrados::buckets::write_stats(dpp, y, rados, obj, *pent, reset);
 }
 #endif
 

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -302,7 +302,7 @@ static void dump_bucket_index(const vector<rgw_bucket_dir_entry>& objs,  Formatt
   }
 }
 
-static void dump_bucket_usage(map<RGWObjCategory, RGWStorageStats>& stats, Formatter *formatter)
+static void dump_bucket_usage(map<RGWObjCategory, RGWStorageStats>& stats, std::optional<std::map<std::string, RGWStorageStats>> sc_stats, Formatter *formatter)
 {
   map<RGWObjCategory, RGWStorageStats>::iterator iter;
 
@@ -310,18 +310,6 @@ static void dump_bucket_usage(map<RGWObjCategory, RGWStorageStats>& stats, Forma
   for (iter = stats.begin(); iter != stats.end(); ++iter) {
     RGWStorageStats& s = iter->second;
     formatter->open_object_section(to_string(iter->first));
-    s.dump(formatter);
-    formatter->close_section();
-  }
-  formatter->close_section();
-}
-
-static void dump_bucket_storage_classes_usage(map<RGWObjCategory, RGWStorageStats>& stats, std::optional<map<std::string, RGWStorageStats>> sc_stats, Formatter *formatter)
-{
-  formatter->open_object_section("usage");
-  for (auto it = stats.begin(); it != stats.end(); ++it) {
-    RGWStorageStats& s = it->second;
-    formatter->open_object_section(to_string(it->first));
     s.dump(formatter);
     formatter->close_section();
   }
@@ -345,12 +333,13 @@ static void dump_index_check(map<RGWObjCategory, RGWStorageStats> existing_stats
         map<RGWObjCategory, RGWStorageStats> calculated_stats,
         Formatter *formatter)
 {
+  std::optional<std::map<std::string, RGWStorageStats>> sc_stats;
   formatter->open_object_section("check_result");
   formatter->open_object_section("existing_header");
-  dump_bucket_usage(existing_stats, formatter);
+  dump_bucket_usage(existing_stats, sc_stats, formatter);
   formatter->close_section();
   formatter->open_object_section("calculated_header");
-  dump_bucket_usage(calculated_stats, formatter);
+  dump_bucket_usage(calculated_stats, sc_stats, formatter);
   formatter->close_section();
   formatter->close_section();
 }
@@ -1622,8 +1611,9 @@ static int bucket_stats(rgw::sal::Driver* driver, const rgw::SiteConfig& site,
                         const DoutPrefixProvider* dpp, optional_yield y) {
   std::unique_ptr<rgw::sal::Bucket> bucket;
   map<RGWObjCategory, RGWStorageStats> stats;
-  std::optional<map<string, RGWStorageStats>> sc_stats;
-  sc_stats.emplace();
+  std::optional<std::map<std::string, RGWStorageStats>> sc_stats{
+    std::map<std::string, RGWStorageStats>{}
+  };
 
   int ret = driver->load_bucket(dpp, rgw_bucket(tenant_name, bucket_name),
                                 &bucket, y);
@@ -1645,7 +1635,7 @@ static int bucket_stats(rgw::sal::Driver* driver, const rgw::SiteConfig& site,
   std::string max_marker;
 
   if (has_index) {
-    ret = bucket->read_stats(dpp, y, index, RGW_NO_SHARD, &bucket_ver, &master_ver, stats, &max_marker);
+    ret = bucket->read_stats(dpp, y, index, RGW_NO_SHARD, &bucket_ver, &master_ver, stats, sc_stats, &max_marker);
     if (ret < 0) {
       cerr << "error getting bucket stats bucket=" << bucket->get_name() << " ret=" << ret << std::endl;
       return ret;
@@ -1656,14 +1646,6 @@ static int bucket_stats(rgw::sal::Driver* driver, const rgw::SiteConfig& site,
   if (!radosdriver) {
     cerr << "rados store only" << std::endl;
     return -ENOTSUP;
-  }
-
-  ret = radosdriver->getRados()->get_bucket_storage_classes_stats(dpp, y, bucket_info, RGW_NO_SHARD,
-                                                            &bucket_ver, &master_ver, sc_stats,
-                                                            &max_marker, index);
-  if (ret < 0) {
-    cerr << "error getting bucket storage class stats bucket=" << bucket->get_name() << " ret=" << ret << std::endl;
-    return ret;
   }
 
   utime_t ut(bucket->get_modification_time());
@@ -1695,11 +1677,10 @@ static int bucket_stats(rgw::sal::Driver* driver, const rgw::SiteConfig& site,
     formatter->dump_string("ver", bucket_ver);
     formatter->dump_string("master_ver", master_ver);
     formatter->dump_string("max_marker", max_marker);
-    dump_bucket_usage(stats, formatter);
+    dump_bucket_usage(stats, sc_stats, formatter);
   }
   ut.gmtime(formatter->dump_stream("mtime"));
   ctime_ut.gmtime(formatter->dump_stream("creation_time"));
-  dump_bucket_storage_classes_usage(stats, sc_stats, formatter);
   encode_json("bucket_quota", bucket_info.quota, formatter);
 
   // bucket tags
@@ -1783,7 +1764,10 @@ int RGWBucketAdminOp::limit_check(rgw::sal::Driver* driver,
 	/* need stats for num_entries */
 	string bucket_ver, master_ver;
 	std::map<RGWObjCategory, RGWStorageStats> stats;
-	ret = bucket->read_stats(dpp, y, index, RGW_NO_SHARD, &bucket_ver, &master_ver, stats, nullptr);
+  std::optional<std::map<std::string, RGWStorageStats>> sc_stats{
+    std::map<std::string, RGWStorageStats>{}
+  };
+	ret = bucket->read_stats(dpp, y, index, RGW_NO_SHARD, &bucket_ver, &master_ver, stats, sc_stats, nullptr);
 
 	if (ret < 0)
 	  continue;

--- a/src/rgw/driver/rados/rgw_bucket.h
+++ b/src/rgw/driver/rados/rgw_bucket.h
@@ -704,6 +704,7 @@ public:
                        const rgw_owner& owner,
                        const RGWBucketInfo& bucket_info,
                        optional_yield y,
+                       bool reset,
                        RGWBucketEnt* pent);
 
   /* bucket sync */

--- a/src/rgw/driver/rados/rgw_dedup.cc
+++ b/src/rgw/driver/rados/rgw_dedup.cc
@@ -2626,10 +2626,13 @@ namespace rgw::dedup {
     }
 
     std::map<RGWObjCategory, RGWStorageStats> stats;
+    std::optional<std::map<std::string, RGWStorageStats>> sc_stats{
+      std::map<std::string, RGWStorageStats>{}
+    };
     std::string bucket_ver, master_ver;
     std::string max_marker;
     ret = bucket->read_stats(dpp, null_yield, index, RGW_NO_SHARD, &bucket_ver,
-                             &master_ver, stats, &max_marker);
+                             &master_ver, stats, sc_stats, &max_marker);
     if (ret < 0) {
       ldpp_dout(dpp, 1) << __func__ << "::ERR getting bucket stats bucket="
                         << bucket->get_name() << " ret=" << ret << dendl;

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -10167,8 +10167,8 @@ int RGWRados::get_bucket_storage_classes_stats(const DoutPrefixProvider *dpp, op
     if (!has_storage_class) {
       sc_stats.reset();
     }
-    ver_mgr.add(viter->first, fmt::format("%lu", (unsigned long)iter->ver));
-    master_ver_mgr.add(viter->first, fmt::format("%lu", (unsigned long)iter->master_ver));
+    ver_mgr.add(viter->first, std::to_string(iter->ver));
+    master_ver_mgr.add(viter->first, std::to_string(iter->master_ver));
     if (shard_id >= 0) {
       *max_marker = iter->max_marker;
     } else {

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -6373,6 +6373,18 @@ void RGWRados::delete_objs_inline(const DoutPrefixProvider *dpp, cls_rgw_obj_cha
   std::ignore = rgw::check_for_errors(completed);
 }
 
+
+static bool is_empty_stats(const rgw_bucket_dir_header& header) {
+  for (const auto& pair : header.stats) {
+    const rgw_bucket_category_stats& header_stats = pair.second;
+    if (header_stats.num_entries > 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+
 static void accumulate_raw_stats(const rgw_bucket_dir_header& header,
                                  map<RGWObjCategory, RGWStorageStats>& stats)
 {
@@ -10112,6 +10124,64 @@ int RGWRados::raw_obj_stat(const DoutPrefixProvider *dpp,
     rgw_filter_attrset(unfiltered_attrset, RGW_ATTR_PREFIX, attrs);
   }
 
+  return 0;
+}
+
+int RGWRados::get_bucket_storage_classes_stats(const DoutPrefixProvider *dpp, optional_yield y, const RGWBucketInfo& bucket_info, int shard_id, string *bucket_ver, string *master_ver,
+                                               std::optional<map<std::string, RGWStorageStats>>& sc_stats, string *max_marker,
+                                               const rgw::bucket_index_layout_generation& idx_layout, bool *syncstopped)
+{
+  vector<rgw_bucket_dir_header> headers;
+  map<int, string> bucket_instance_ids;
+  int r = svc.bi_rados->cls_bucket_head(dpp, bucket_info, idx_layout, shard_id, &headers, &bucket_instance_ids, y);
+  if (r < 0) {
+    return r;
+  }
+
+  ceph_assert(headers.size() == bucket_instance_ids.size());
+
+  auto iter = headers.begin();
+  map<int, string>::iterator viter = bucket_instance_ids.begin();
+  bool has_storage_class = true;
+  BucketIndexShardsManager ver_mgr;
+  BucketIndexShardsManager master_ver_mgr;
+  BucketIndexShardsManager marker_mgr;
+  for(; iter != headers.end(); ++iter, ++viter) {
+    if (is_empty_stats(*iter)) {
+      iter->storage_class_stats.emplace();
+    }
+    if (has_storage_class && iter->storage_class_stats.has_value()) {
+      for (auto it = iter->storage_class_stats.value().begin(); it != iter->storage_class_stats.value().end(); ++it) {
+        std::string storage_class = it->first;
+        rgw_bucket_category_stats stats = it->second;
+        RGWStorageStats& s = sc_stats.value()[storage_class];
+
+        s.size += stats.total_size;
+        s.size_rounded += stats.total_size_rounded;
+        s.size_utilized += stats.actual_size;
+        s.num_objects += stats.num_entries;
+      }
+    } else {
+      has_storage_class = false;
+    }
+    if (!has_storage_class) {
+      sc_stats.reset();
+    }
+    ver_mgr.add(viter->first, fmt::format("%lu", (unsigned long)iter->ver));
+    master_ver_mgr.add(viter->first, fmt::format("%lu", (unsigned long)iter->master_ver));
+    if (shard_id >= 0) {
+      *max_marker = iter->max_marker;
+    } else {
+      marker_mgr.add(viter->first, iter->max_marker);
+    }
+    if (syncstopped != NULL)
+      *syncstopped = iter->syncstopped;
+  }
+  ver_mgr.to_string(bucket_ver);
+  master_ver_mgr.to_string(master_ver);
+  if (shard_id < 0) {
+    marker_mgr.to_string(max_marker);
+  }
   return 0;
 }
 

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -6386,7 +6386,8 @@ static bool is_empty_stats(const rgw_bucket_dir_header& header) {
 
 
 static void accumulate_raw_stats(const rgw_bucket_dir_header& header,
-                                 map<RGWObjCategory, RGWStorageStats>& stats)
+                                 map<RGWObjCategory, RGWStorageStats>& stats,
+                                 std::optional<map<std::string, RGWStorageStats>>& sc_stats)
 {
   for (const auto& pair : header.stats) {
     const RGWObjCategory category = static_cast<RGWObjCategory>(pair.first);
@@ -6400,6 +6401,22 @@ static void accumulate_raw_stats(const rgw_bucket_dir_header& header,
     s.size_utilized += header_stats.actual_size;
     s.num_objects += header_stats.num_entries;
   }
+  if (sc_stats.has_value()) {
+    if (header.storage_class_stats.has_value()) {
+      for (auto it = header.storage_class_stats.value().begin(); it != header.storage_class_stats.value().end(); ++it) {
+        std::string storage_class = it->first;
+        rgw_bucket_category_stats stats = it->second;
+        RGWStorageStats& s = sc_stats.value()[storage_class];
+
+        s.size += stats.total_size;
+        s.size_rounded += stats.total_size_rounded;
+        s.size_utilized += stats.actual_size;
+        s.num_objects += stats.num_entries;
+      }
+    } else {
+      sc_stats.reset();
+    }
+  }
 }
 
 int RGWRados::bucket_check_index(const DoutPrefixProvider *dpp, optional_yield y,
@@ -6412,15 +6429,17 @@ int RGWRados::bucket_check_index(const DoutPrefixProvider *dpp, optional_yield y
   if (ret < 0) {
     return ret;
   }
-
+  std::optional<std::map<std::string, RGWStorageStats>> sc_stats{
+    std::map<std::string, RGWStorageStats>{}
+  };
   try {
     // decode and accumulate the results
     for (const auto& kv : buffers) {
       rgw_cls_check_index_ret result;
       cls_rgw_bucket_check_index_decode(kv.second, result);
 
-      accumulate_raw_stats(result.existing_header, *existing_stats);
-      accumulate_raw_stats(result.calculated_header, *calculated_stats);
+      accumulate_raw_stats(result.existing_header, *existing_stats, sc_stats);
+      accumulate_raw_stats(result.calculated_header, *calculated_stats, sc_stats);
     }
   } catch (const ceph::buffer::error&) {
     return -EIO;
@@ -10127,69 +10146,12 @@ int RGWRados::raw_obj_stat(const DoutPrefixProvider *dpp,
   return 0;
 }
 
-int RGWRados::get_bucket_storage_classes_stats(const DoutPrefixProvider *dpp, optional_yield y, const RGWBucketInfo& bucket_info, int shard_id, string *bucket_ver, string *master_ver,
-                                               std::optional<map<std::string, RGWStorageStats>>& sc_stats, string *max_marker,
-                                               const rgw::bucket_index_layout_generation& idx_layout, bool *syncstopped)
-{
-  vector<rgw_bucket_dir_header> headers;
-  map<int, string> bucket_instance_ids;
-  int r = svc.bi_rados->cls_bucket_head(dpp, bucket_info, idx_layout, shard_id, &headers, &bucket_instance_ids, y);
-  if (r < 0) {
-    return r;
-  }
-
-  ceph_assert(headers.size() == bucket_instance_ids.size());
-
-  auto iter = headers.begin();
-  map<int, string>::iterator viter = bucket_instance_ids.begin();
-  bool has_storage_class = true;
-  BucketIndexShardsManager ver_mgr;
-  BucketIndexShardsManager master_ver_mgr;
-  BucketIndexShardsManager marker_mgr;
-  for(; iter != headers.end(); ++iter, ++viter) {
-    if (is_empty_stats(*iter)) {
-      iter->storage_class_stats.emplace();
-    }
-    if (has_storage_class && iter->storage_class_stats.has_value()) {
-      for (auto it = iter->storage_class_stats.value().begin(); it != iter->storage_class_stats.value().end(); ++it) {
-        std::string storage_class = it->first;
-        rgw_bucket_category_stats stats = it->second;
-        RGWStorageStats& s = sc_stats.value()[storage_class];
-
-        s.size += stats.total_size;
-        s.size_rounded += stats.total_size_rounded;
-        s.size_utilized += stats.actual_size;
-        s.num_objects += stats.num_entries;
-      }
-    } else {
-      has_storage_class = false;
-    }
-    if (!has_storage_class) {
-      sc_stats.reset();
-    }
-    ver_mgr.add(viter->first, std::to_string(iter->ver));
-    master_ver_mgr.add(viter->first, std::to_string(iter->master_ver));
-    if (shard_id >= 0) {
-      *max_marker = iter->max_marker;
-    } else {
-      marker_mgr.add(viter->first, iter->max_marker);
-    }
-    if (syncstopped != NULL)
-      *syncstopped = iter->syncstopped;
-  }
-  ver_mgr.to_string(bucket_ver);
-  master_ver_mgr.to_string(master_ver);
-  if (shard_id < 0) {
-    marker_mgr.to_string(max_marker);
-  }
-  return 0;
-}
-
 int RGWRados::get_bucket_stats(const DoutPrefixProvider *dpp, optional_yield y,
 			       RGWBucketInfo& bucket_info,
 			       const rgw::bucket_index_layout_generation& idx_layout,
 			       int shard_id, string *bucket_ver, string *master_ver,
 			       map<RGWObjCategory, RGWStorageStats>& stats,
+			       std::optional<std::map<std::string, RGWStorageStats>>& sc_stats,
 			       string *max_marker, bool *syncstopped)
 {
   vector<rgw_bucket_dir_header> headers;
@@ -10209,7 +10171,10 @@ int RGWRados::get_bucket_stats(const DoutPrefixProvider *dpp, optional_yield y,
   BucketIndexShardsManager marker_mgr;
   char buf[64];
   for(; iter != headers.end(); ++iter, ++viter) {
-    accumulate_raw_stats(*iter, stats);
+    if (is_empty_stats(*iter)) {
+      iter->storage_class_stats.emplace();
+    }
+    accumulate_raw_stats(*iter, stats, sc_stats);
     snprintf(buf, sizeof(buf), "%lu", (unsigned long)iter->ver);
     ver_mgr.add(viter->first, string(buf));
     snprintf(buf, sizeof(buf), "%lu", (unsigned long)iter->master_ver);

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -11916,8 +11916,8 @@ int RGWRados::add_bucket_to_reshard(const DoutPrefixProvider *dpp,
 
 int RGWRados::check_quota(const DoutPrefixProvider *dpp, const rgw_owner& bucket_owner, rgw_bucket& bucket,
                           RGWQuota& quota,
-			  uint64_t obj_size, optional_yield y,
-			  bool check_size_only)
+			                    uint64_t obj_size, optional_yield y,
+			                    bool check_size_only, const rgw_placement_rule* dest_placement)
 {
   // if we only check size, then num_objs will set to 0
   if(check_size_only)

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1502,13 +1502,9 @@ public:
     rctx->set_compressed(obj);
   }
   int decode_policy(const DoutPrefixProvider *dpp, bufferlist& bl, ACLOwner *owner);
-  int get_bucket_storage_classes_stats(const DoutPrefixProvider *dpp, optional_yield y, const RGWBucketInfo& bucket_info,
-                                       int shard_id, std::string *bucket_ver, std::string *master_ver,
-                                       std::optional<std::map<std::string, RGWStorageStats>>& sc_stats, std::string *max_marker,
-                                       const rgw::bucket_index_layout_generation& idx_layout, bool* syncstopped = NULL);
   int get_bucket_stats(const DoutPrefixProvider *dpp, optional_yield y,
                        RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout, int shard_id, std::string *bucket_ver, std::string *master_ver,
-      std::map<RGWObjCategory, RGWStorageStats>& stats, std::string *max_marker, bool* syncstopped = NULL);
+      std::map<RGWObjCategory, RGWStorageStats>& stats, std::optional<std::map<std::string, RGWStorageStats>>& sc_stats, std::string *max_marker, bool* syncstopped = NULL);
   int get_bucket_stats_async(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout, int shard_id, boost::intrusive_ptr<rgw::sal::ReadStatsCB> cb);
 
   int put_bucket_instance_info(RGWBucketInfo& info, bool exclusive, ceph::real_time mtime, const std::map<std::string, bufferlist> *pattrs, const DoutPrefixProvider *dpp, optional_yield y);

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1665,7 +1665,7 @@ public:
 
   int check_quota(const DoutPrefixProvider *dpp, const rgw_owner& bucket_owner, rgw_bucket& bucket,
                   RGWQuota& quota, uint64_t obj_size,
-		  optional_yield y, bool check_size_only = false);
+		  optional_yield y, bool check_size_only = false, const rgw_placement_rule* dest_placement = nullptr);
 
   void calculate_preferred_shards(const DoutPrefixProvider* dpp,
 				  bool is_versioned,

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1502,6 +1502,10 @@ public:
     rctx->set_compressed(obj);
   }
   int decode_policy(const DoutPrefixProvider *dpp, bufferlist& bl, ACLOwner *owner);
+  int get_bucket_storage_classes_stats(const DoutPrefixProvider *dpp, optional_yield y, const RGWBucketInfo& bucket_info,
+                                       int shard_id, std::string *bucket_ver, std::string *master_ver,
+                                       std::optional<std::map<std::string, RGWStorageStats>>& sc_stats, std::string *max_marker,
+                                       const rgw::bucket_index_layout_generation& idx_layout, bool* syncstopped = NULL);
   int get_bucket_stats(const DoutPrefixProvider *dpp, optional_yield y,
                        RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout, int shard_id, std::string *bucket_ver, std::string *master_ver,
       std::map<RGWObjCategory, RGWStorageStats>& stats, std::string *max_marker, bool* syncstopped = NULL);

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -156,6 +156,7 @@ class BucketReshardShard {
   RGWRados::BucketShard bs;
   vector<rgw_cls_bi_entry> entries;
   map<RGWObjCategory, rgw_bucket_category_stats> stats;
+  unordered_map<string, rgw_bucket_category_stats> storage_class_stats;
   deque<librados::AioCompletion *>& aio_completions;
   uint64_t max_aio_completions;
   uint64_t reshard_shard_batch_size;
@@ -212,11 +213,17 @@ public:
   }
 
   int add_entry(rgw_cls_bi_entry& entry, bool account, RGWObjCategory category,
-                const rgw_bucket_category_stats& entry_stats,
+                const rgw_bucket_category_stats& entry_stats, string& storage_class,
                 bool process_log = false) {
     entries.push_back(entry);
     if (account) {
       rgw_bucket_category_stats& target = stats[category];
+      storage_class = rgw_placement_rule::get_canonical_storage_class(storage_class);
+      rgw_bucket_category_stats& sc_target = storage_class_stats[storage_class];
+      sc_target.num_entries += entry_stats.num_entries;
+      sc_target.total_size += entry_stats.total_size;
+      sc_target.total_size_rounded += entry_stats.total_size_rounded;
+      sc_target.actual_size += entry_stats.actual_size;
       target.num_entries += entry_stats.num_entries;
       target.total_size += entry_stats.total_size;
       target.total_size_rounded += entry_stats.total_size_rounded;
@@ -248,7 +255,7 @@ public:
       for (auto& entry : entries) {
         store->getRados()->bi_put(op, bs, entry, null_yield);
       }
-      cls_rgw_bucket_update_stats(op, false, stats);
+      cls_rgw_bucket_update_stats(op, false, stats, storage_class_stats);
     }
 
     librados::AioCompletion *c;
@@ -263,7 +270,7 @@ public:
     }
     entries.clear();
     stats.clear();
-
+    storage_class_stats.clear();
     return 0;
   }
 
@@ -313,9 +320,10 @@ public:
   int add_entry(int shard_index,
                 rgw_cls_bi_entry& entry, bool account, RGWObjCategory category,
                 const rgw_bucket_category_stats& entry_stats,
+                string& storage_class,
                 bool process_log = false) {
     int ret = target_shards[shard_index].add_entry(entry, account, category,
-						   entry_stats, process_log);
+						   entry_stats, storage_class, process_log);
     if (ret < 0) {
       derr << "ERROR: target_shards.add_entry(" << entry.idx <<
 	") returned error: " << cpp_strerror(-ret) << dendl;
@@ -1136,7 +1144,8 @@ int RGWBucketReshard::reshard_process(const rgw::bucket_index_layout_generation&
         cls_rgw_obj_key cls_key;
         RGWObjCategory category;
         rgw_bucket_category_stats stats;
-        bool account = entry.get_info(&cls_key, &category, &stats);
+        string storage_class;
+        bool account = entry.get_info(&cls_key, &category, &stats, &storage_class);
         rgw_obj_key key(cls_key);
         if (entry.type == BIIndexType::OLH && key.empty()) {
           // bogus entry created by https://tracker.ceph.com/issues/46456
@@ -1153,7 +1162,7 @@ int RGWBucketReshard::reshard_process(const rgw::bucket_index_layout_generation&
         }
 
         ret = target_shards_mgr.add_entry(shard_index, entry, account,
-                  category, stats, process_log);
+                  category, stats, storage_class, process_log);
         if (ret < 0) {
           return ret;
         }

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -1610,9 +1610,12 @@ int RGWReshard::process_entry(const cls_rgw_reshard_entry& entry,
 
     // determine how many entries there are in the bucket index
     std::map<RGWObjCategory, RGWStorageStats> stats;
+    std::optional<std::map<std::string, RGWStorageStats>> sc_stats{
+      std::map<std::string, RGWStorageStats>{}
+    };
     ret = store->getRados()->get_bucket_stats(dpp, y, bucket_info,
 					      bucket_info.layout.current_index,
-					      -1, nullptr, nullptr, stats, nullptr, nullptr);
+					      -1, nullptr, nullptr, stats, sc_stats, nullptr, nullptr);
     if (ret < 0) {
       return clean_up("unable to access buckets current stats");
     }

--- a/src/rgw/driver/rados/rgw_rest_log.cc
+++ b/src/rgw/driver/rados/rgw_rest_log.cc
@@ -556,9 +556,12 @@ void RGWOp_BILog_Info::execute(optional_yield y) {
   }
 
   map<RGWObjCategory, RGWStorageStats> stats;
+  std::optional<std::map<std::string, RGWStorageStats>> sc_stats{
+    std::map<std::string, RGWStorageStats>{}
+  };
   const auto& index = log_to_index_layout(logs.back());
 
-  int ret =  bucket->read_stats(s, y, index, shard_id, &bucket_ver, &master_ver, stats, &max_marker, &syncstopped);
+  int ret =  bucket->read_stats(s, y, index, shard_id, &bucket_ver, &master_ver, stats, sc_stats, &max_marker, &syncstopped);
   if (ret < 0 && ret != -ENOENT) {
     op_ret = ret;
     return;

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -498,6 +498,9 @@ int RadosBucket::remove_bypass_gc(int concurrent_max, bool
 {
   int ret;
   map<RGWObjCategory, RGWStorageStats> stats;
+  std::optional<std::map<std::string, RGWStorageStats>> sc_stats{
+    std::map<std::string, RGWStorageStats>{}
+  };
   map<string, bool> common_prefixes;
   RGWObjectCtx obj_ctx(store);
   CephContext *cct = store->ctx();
@@ -509,7 +512,7 @@ int RadosBucket::remove_bypass_gc(int concurrent_max, bool
     return ret;
 
   const auto& index = info.get_current_index();
-  ret = read_stats(dpp, y, index, RGW_NO_SHARD, &bucket_ver, &master_ver, stats, NULL);
+  ret = read_stats(dpp, y, index, RGW_NO_SHARD, &bucket_ver, &master_ver, stats, sc_stats, NULL);
   if (ret < 0)
     return ret;
 
@@ -661,9 +664,10 @@ int RadosBucket::read_stats(const DoutPrefixProvider *dpp, optional_yield y,
 			    const bucket_index_layout_generation& idx_layout,
 			    int shard_id, std::string* bucket_ver, std::string* master_ver,
 			    std::map<RGWObjCategory, RGWStorageStats>& stats,
+			    std::optional<std::map<std::string, RGWStorageStats>>& sc_stats,
 			    std::string* max_marker, bool* syncstopped)
 {
-  return store->getRados()->get_bucket_stats(dpp, y, info, idx_layout, shard_id, bucket_ver, master_ver, stats, max_marker, syncstopped);
+  return store->getRados()->get_bucket_stats(dpp, y, info, idx_layout, shard_id, bucket_ver, master_ver, stats,sc_stats, max_marker, syncstopped);
 }
 
 int RadosBucket::read_stats_async(const DoutPrefixProvider *dpp,

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -452,7 +452,7 @@ int RadosBucket::remove(const DoutPrefixProvider* dpp,
 
   librados::Rados& rados = *store->getRados()->get_rados_handle();
   if (own_bucket) {
-    ret = store->ctl()->bucket->sync_owner_stats(dpp, rados, info.owner, info, y, nullptr);
+    ret = store->ctl()->bucket->sync_owner_stats(dpp, rados, info.owner, info, y, false, nullptr);
     if (ret < 0) {
       ldout(store->ctx(), 1) << "WARNING: failed sync user stats before bucket delete. ret=" <<  ret << dendl;
     }
@@ -612,7 +612,7 @@ int RadosBucket::remove_bypass_gc(int concurrent_max, bool
     return ret;
   }
 
-  sync_owner_stats(dpp, y, nullptr);
+  sync_owner_stats(dpp, y, false, nullptr);
   if (ret < 0) {
      ldpp_dout(dpp, 1) << "WARNING: failed sync user stats before bucket delete. ret=" <<  ret << dendl;
   }
@@ -674,10 +674,11 @@ int RadosBucket::read_stats_async(const DoutPrefixProvider *dpp,
 }
 
 int RadosBucket::sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y,
+                                  bool reset,
                                   RGWBucketEnt* ent)
 {
   librados::Rados& rados = *store->getRados()->get_rados_handle();
-  return store->ctl()->bucket->sync_owner_stats(dpp, rados, info.owner, info, y, ent);
+  return store->ctl()->bucket->sync_owner_stats(dpp, rados, info.owner, info, y, reset, ent);
 }
 
 int RadosBucket::check_bucket_shards(const DoutPrefixProvider* dpp,

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -788,10 +788,10 @@ int RadosBucket::check_empty(const DoutPrefixProvider* dpp, optional_yield y)
 }
 
 int RadosBucket::check_quota(const DoutPrefixProvider *dpp, RGWQuota& quota, uint64_t obj_size,
-				optional_yield y, bool check_size_only)
+				optional_yield y, bool check_size_only, const rgw_placement_rule* dest_placement)
 {
     return store->getRados()->check_quota(dpp, info.owner, get_key(),
-					  quota, obj_size, y, check_size_only);
+					  quota, obj_size, y, check_size_only, dest_placement);
 }
 
 int RadosBucket::merge_and_store_attrs(const DoutPrefixProvider* dpp, Attrs& new_attrs, optional_yield y)

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -756,7 +756,7 @@ class RadosBucket : public StoreBucket {
                       optional_yield y) override;
     virtual int put_info(const DoutPrefixProvider* dpp, bool exclusive, ceph::real_time mtime, optional_yield y) override;
     virtual int check_empty(const DoutPrefixProvider* dpp, optional_yield y) override;
-    virtual int check_quota(const DoutPrefixProvider *dpp, RGWQuota& quota, uint64_t obj_size, optional_yield y, bool check_size_only = false) override;
+    virtual int check_quota(const DoutPrefixProvider *dpp, RGWQuota& quota, uint64_t obj_size, optional_yield y, bool check_size_only = false, const rgw_placement_rule* dest_placement = nullptr) override;
     virtual int merge_and_store_attrs(const DoutPrefixProvider* dpp, Attrs& attrs, optional_yield y) override;
     virtual int try_refresh_info(const DoutPrefixProvider* dpp, ceph::real_time* pmtime, optional_yield y) override;
     virtual int read_usage(const DoutPrefixProvider *dpp, uint64_t start_epoch, uint64_t end_epoch, uint32_t max_entries,

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -746,7 +746,7 @@ class RadosBucket : public StoreBucket {
                                  const bucket_index_layout_generation& idx_layout,
                                  int shard_id, boost::intrusive_ptr<ReadStatsCB> ctx) override;
     int sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y,
-                         RGWBucketEnt* ent) override;
+						 bool reset, RGWBucketEnt* ent) override;
     int check_bucket_shards(const DoutPrefixProvider* dpp, uint64_t num_objs,
                             optional_yield y) override;
     virtual int chown(const DoutPrefixProvider* dpp,

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -740,6 +740,7 @@ class RadosBucket : public StoreBucket {
                            const bucket_index_layout_generation& idx_layout,
                            int shard_id, std::string* bucket_ver, std::string* master_ver,
                            std::map<RGWObjCategory, RGWStorageStats>& stats,
+                           std::optional<std::map<std::string, RGWStorageStats>>& sc_stats,
                            std::string* max_marker = nullptr,
                            bool* syncstopped = nullptr) override;
     virtual int read_stats_async(const DoutPrefixProvider *dpp,

--- a/src/rgw/driver/rados/rgw_user.cc
+++ b/src/rgw/driver/rados/rgw_user.cc
@@ -171,6 +171,13 @@ static void dump_user_info(Formatter *f, RGWUserInfo &info,
   encode_json("group_ids", info.group_ids, f);
   if (stats) {
     encode_json("stats", *stats, f);
+    if (stats->storage_class_stats.has_value()) {
+      f->open_object_section("stats.storage-classes");
+      for(auto it = stats->storage_class_stats.value().begin(); it != stats->storage_class_stats.value().end(); ++it){
+        encode_json(it->first.c_str(), it->second, f);
+      }
+      f->close_section();
+    }
   }
   f->close_section();
 }
@@ -2323,7 +2330,7 @@ int RGWUserAdminOp_User::info(const DoutPrefixProvider *dpp,
   }
 
   if (op_state.sync_stats) {
-    ret = rgw_sync_all_stats(dpp, y, driver, owner, ruser->get_tenant());
+    ret = rgw_sync_all_stats(dpp, y, driver, owner, false, ruser->get_tenant());
     if (ret < 0) {
       return ret;
     }

--- a/src/rgw/driver/rados/rgw_user.h
+++ b/src/rgw/driver/rados/rgw_user.h
@@ -80,7 +80,7 @@ struct bucket_meta_entry {
 
 int rgw_sync_all_stats(const DoutPrefixProvider *dpp,
                        optional_yield y, rgw::sal::Driver* driver,
-                       const rgw_owner& owner, const std::string& tenant);
+                       const rgw_owner& owner, bool reset, const std::string& tenant);
 extern int rgw_user_get_all_buckets_stats(const DoutPrefixProvider *dpp,
   rgw::sal::Driver* driver, rgw::sal::User* user,
   std::map<std::string, bucket_meta_entry>& buckets_usage_map, optional_yield y);

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -10003,7 +10003,7 @@ next:
           cerr << "ERROR: could not init bucket: " << cpp_strerror(-ret) << std::endl;
           return -ret;
         }
-        ret = bucket->sync_owner_stats(dpp(), null_yield, nullptr);
+        ret = bucket->sync_owner_stats(dpp(), null_yield, false, nullptr);
         if (ret < 0) {
           cerr << "ERROR: could not sync bucket stats: " <<
 	    cpp_strerror(-ret) << std::endl;
@@ -10011,7 +10011,16 @@ next:
         }
       } else {
         int ret = rgw_sync_all_stats(dpp(), null_yield, driver,
-                                     user->get_id(), user->get_tenant());
+                                   user->get_id(), fix, user->get_tenant());
+        if (ret < 0) {
+          cerr << "ERROR: could not sync user stats: " <<
+               cpp_strerror(-ret) << std::endl;
+          return -ret;
+        }
+        if (fix) {
+          ret = rgw_sync_all_stats(dpp(), null_yield, driver,
+                                       user->get_id(), false, user->get_tenant());
+        }
         if (ret < 0) {
           cerr << "ERROR: could not sync user stats: " <<
 	    cpp_strerror(-ret) << std::endl;
@@ -10052,6 +10061,13 @@ next:
     {
       Formatter::ObjectSection os(*formatter, "result");
       encode_json("stats", stats, formatter.get());
+      if (stats.storage_class_stats.has_value()) {
+        formatter->open_object_section("stats.storage-classes");
+        for(auto it = stats.storage_class_stats.value().begin(); it != stats.storage_class_stats.value().end(); ++it){
+          encode_json(it->first.c_str(), it->second, formatter.get());
+        }
+        formatter->close_section();
+      }
       utime_t last_sync_ut(last_stats_sync);
       encode_json("last_stats_sync", last_sync_ut, formatter.get());
       utime_t last_update_ut(last_stats_update);

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -1714,6 +1714,30 @@ int set_bucket_sc_quota(rgw::sal::Driver* driver, OPT opt_cmd,
          << ": " << cpp_strerror(-r) << std::endl;
     return -r;
   }
+
+  if (opt_cmd == OPT::QUOTA_SET || opt_cmd == OPT::QUOTA_ENABLE) {
+    std::map<RGWObjCategory, RGWStorageStats> cat_stats;
+    std::optional<std::map<std::string, RGWStorageStats>> sc_stats;
+    sc_stats.emplace();  // BUG 2 fix applies here too
+    std::string bver, mver;
+    const auto& idx = bucket->get_info().layout.current_index;
+    r = bucket->read_stats(dpp(), null_yield, idx, -1,
+                           &bver, &mver, cat_stats, sc_stats);
+    if (r < 0) {
+      cerr << "ERROR: failed reading bucket stats: "
+           << cpp_strerror(-r) << std::endl;
+      return -r;
+    }
+    if (!sc_stats.has_value()) {
+      cerr << "ERROR: bucket '" << bucket_name << "' has not been "
+           << "converted to per-storage-class stats tracking. "
+           << "Per-storage-class quota cannot be enforced until the "
+           << "bucket is converted. See the radosgw documentation on "
+           << "storage-class stats conversion." << std::endl;
+      return EINVAL;
+    }
+  }
+  
   if (!set_sc_quota_info(bucket->get_info().quota, opt_cmd,
                          placement_id, storage_class,
                          max_size, max_objects,

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -95,6 +95,7 @@ extern "C" {
 #include "services/svc_mdlog.h"
 #include "services/svc_user.h"
 #include "services/svc_zone.h"
+#include "rgw_sc_quota_types.h"
 
 #include "driver/rados/rgw_bucket.h"
 #ifdef WITH_RADOSGW_RADOS
@@ -450,7 +451,8 @@ void usage()
   cout << "   --read-only                       set zone as read-only (when adding to zonegroup)\n";
   cout << "   --redirect-zone                   specify zone id to redirect when response is 404 (not found)\n";
   cout << "   --placement-id                    placement id for zonegroup placement commands\n";
-  cout << "   --storage-class                   storage class for zonegroup placement commands\n";
+  cout << "   --placement-target                alias for --placement-id; for 'quota set' this scopes the quota to a per-storage-class slot\n";
+  cout << "   --storage-class                   storage class for zonegroup placement commands; for 'quota set' this scopes the quota to a per-SC slot\n";
   cout << "   --tags=<list>                     list of tags for zonegroup placement add and modify commands\n";
   cout << "   --tags-add=<list>                 list of tags to add for zonegroup placement modify command\n";
   cout << "   --tags-rm=<list>                  list of tags to remove for zonegroup placement modify command\n";
@@ -1626,6 +1628,141 @@ void set_quota_info(RGWQuotaInfo& quota, OPT opt_cmd, int64_t max_size, int64_t 
     default:
       break;
   }
+}
+
+/*
+ * Per-storage-class quota setter.
+ *
+ * Writes into RGWQuotaInfo.storage_class_quotas at key
+ *   rgw_sc_quota_key(placement_id, storage_class)
+ * and bumps enforcement_mode to HYBRID if it is currently LEGACY -- so
+ * that the existing global quota fields keep being enforced AND the new
+ * per-SC field is enforced too.  Admins that want SC-only enforcement
+ * can explicitly downgrade to STORAGE_CLASS via the JSON admin API
+ * after setting up the per-SC entries.
+ *
+ * Returns true if any change was applied (so callers know whether to
+ * actually persist the RGWQuotaInfo back to the store).
+ */
+static bool set_sc_quota_info(RGWQuotaInfo& quota, OPT opt_cmd,
+                              const std::string& placement_id,
+                              const std::string& storage_class,
+                              int64_t max_size, int64_t max_objects,
+                              bool have_max_size, bool have_max_objects)
+{
+  const std::string key = rgw_sc_quota_key(placement_id, storage_class);
+
+  switch (opt_cmd) {
+    case OPT::QUOTA_SET:
+    case OPT::QUOTA_ENABLE: {
+      auto& sc = quota.storage_class_quotas[key];
+      if (have_max_objects) {
+        sc.max_objects = (max_objects < 0) ? -1 : max_objects;
+      }
+      if (have_max_size) {
+        /* Match the kB-rounding semantics of the global quota path so
+         * that radosgw-admin's --max-size value behaves identically
+         * whether or not a storage class is supplied. */
+        sc.max_size = (max_size < 0) ? -1 : rgw_rounded_kb(max_size) * 1024;
+      }
+      if (opt_cmd == OPT::QUOTA_ENABLE) {
+        sc.enabled = true;
+      } else if (sc.max_size >= 0 || sc.max_objects >= 0) {
+        /* `quota set` with at least one limit specified -- mark this
+         * entry "enabled" automatically so the admin doesn't need a
+         * separate `quota enable` step.  This matches the practical
+         * UX expectation that "set a limit" implies "enforce it". */
+        sc.enabled = true;
+      }
+      /* If the bucket/user was running in LEGACY mode, upgrade to
+       * HYBRID so the new SC entry actually takes effect.  We never
+       * silently downgrade enforcement_mode -- if the admin chose
+       * STORAGE_CLASS explicitly we honour that. */
+      if (quota.enforcement_mode == RGWQuotaEnforcementMode::LEGACY ||
+          quota.enforcement_mode == RGWQuotaEnforcementMode::GLOBAL_ONLY) {
+        quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+      }
+      return true;
+    }
+    case OPT::QUOTA_DISABLE: {
+      auto it = quota.storage_class_quotas.find(key);
+      if (it == quota.storage_class_quotas.end()) {
+        cerr << "WARNING: no per-storage-class quota configured for key="
+             << key << "; nothing to disable" << std::endl;
+        return false;
+      }
+      it->second.enabled = false;
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+
+int set_bucket_sc_quota(rgw::sal::Driver* driver, OPT opt_cmd,
+                        const string& tenant_name, const string& bucket_name,
+                        const string& placement_id,
+                        const string& storage_class,
+                        int64_t max_size, int64_t max_objects,
+                        bool have_max_size, bool have_max_objects)
+{
+  std::unique_ptr<rgw::sal::Bucket> bucket;
+  int r = driver->load_bucket(dpp(), rgw_bucket(tenant_name, bucket_name),
+                              &bucket, null_yield);
+  if (r < 0) {
+    cerr << "could not get bucket info for bucket=" << bucket_name
+         << ": " << cpp_strerror(-r) << std::endl;
+    return -r;
+  }
+  if (!set_sc_quota_info(bucket->get_info().quota, opt_cmd,
+                         placement_id, storage_class,
+                         max_size, max_objects,
+                         have_max_size, have_max_objects)) {
+    return 0;  // nothing to write
+  }
+  r = bucket->put_info(dpp(), false, real_time(), null_yield);
+  if (r < 0) {
+    cerr << "ERROR: failed writing bucket instance info: "
+         << cpp_strerror(-r) << std::endl;
+    return -r;
+  }
+  return 0;
+}
+
+int set_user_sc_quota(OPT opt_cmd, RGWUser& user, RGWUserAdminOpState& op_state,
+                      const string& quota_scope,
+                      const string& placement_id,
+                      const string& storage_class,
+                      int64_t max_size, int64_t max_objects,
+                      bool have_max_size, bool have_max_objects)
+{
+  RGWUserInfo& user_info = op_state.get_user_info();
+  /* For users the per-SC limits live under user.quota.user_quota or
+   * user.quota.bucket_quota depending on --quota-scope, matching the
+   * existing semantics of the global quotas. */
+  RGWQuotaInfo& target = (quota_scope == "bucket")
+                         ? user_info.quota.bucket_quota
+                         : user_info.quota.user_quota;
+  if (!set_sc_quota_info(target, opt_cmd, placement_id, storage_class,
+                         max_size, max_objects,
+                         have_max_size, have_max_objects)) {
+    return 0;
+  }
+  /* Mirror the global path: push the updated RGWQuotaInfo through
+   * RGWUserAdminOpState so user metadata replication picks it up. */
+  if (quota_scope == "bucket") {
+    op_state.set_bucket_quota(user_info.quota.bucket_quota);
+  } else {
+    op_state.set_user_quota(user_info.quota.user_quota);
+  }
+  string err;
+  int r = user.modify(dpp(), op_state, null_yield, &err);
+  if (r < 0) {
+    cerr << "ERROR: failed updating user info: "
+         << cpp_strerror(-r) << ": " << err << std::endl;
+    return -r;
+  }
+  return 0;
 }
 
 int set_bucket_quota(rgw::sal::Driver* driver, OPT opt_cmd,
@@ -4467,6 +4604,8 @@ int main(int argc, const char **argv)
     } else if (ceph_argparse_witharg(args, i, &val, "--zonegroup-new-name", (char*)NULL)) {
       zonegroup_new_name = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--placement-id", (char*)NULL)) {
+      placement_id = val;
+    } else if (ceph_argparse_witharg(args, i, &val, "--placement-target", (char*)NULL)) {
       placement_id = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--storage-class", (char*)NULL)) {
       opt_storage_class = val;
@@ -11713,6 +11852,42 @@ next:
   bool quota_op = (opt_cmd == OPT::QUOTA_SET || opt_cmd == OPT::QUOTA_ENABLE || opt_cmd == OPT::QUOTA_DISABLE);
 
   if (quota_op) {
+    const bool sc_quota_op =
+        !placement_id.empty() && opt_storage_class && !opt_storage_class->empty();
+    if (sc_quota_op) {
+      if (!bucket_name.empty()) {
+        if (!quota_scope.empty() && quota_scope != "bucket") {
+          cerr << "ERROR: invalid quota scope specification." << std::endl;
+          return EINVAL;
+        }
+        return set_bucket_sc_quota(driver, opt_cmd, tenant, bucket_name,
+                                   placement_id, *opt_storage_class,
+                                   max_size, max_objects,
+                                   have_max_size, have_max_objects);
+      } else if (!rgw::sal::User::empty(user)) {
+        if (quota_scope != "bucket" && quota_scope != "user") {
+          cerr << "ERROR: invalid quota scope specification. Please specify "
+                  "either --quota-scope=bucket or --quota-scope=user"
+               << std::endl;
+          return EINVAL;
+        }
+        return set_user_sc_quota(opt_cmd, ruser, user_op, quota_scope,
+                                 placement_id, *opt_storage_class,
+                                 max_size, max_objects,
+                                 have_max_size, have_max_objects);
+      } else {
+        cerr << "ERROR: --placement-target and --storage-class require "
+                "a --bucket or --uid scope" << std::endl;
+        return EINVAL;
+      }
+    }
+    if (!placement_id.empty() ||
+        (opt_storage_class && !opt_storage_class->empty())) {
+      cerr << "ERROR: per-storage-class quota requires BOTH "
+              "--placement-target and --storage-class" << std::endl;
+      return EINVAL;
+    }
+
     if (!bucket_name.empty()) {
       if (!quota_scope.empty() && quota_scope != "bucket") {
         cerr << "ERROR: invalid quota scope specification." << std::endl;

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -7277,11 +7277,20 @@ int main(int argc, const char **argv)
     rgw_placement_rule target_rule;
     target_rule.name = placement_id;
     target_rule.storage_class = opt_storage_class.value_or("");
-    if (!driver->valid_placement(target_rule)) {
-      cerr << "NOTICE: invalid dest placement: " << target_rule.to_str() << std::endl;
+
+    // Skip placement validation for quota commands , as the SC quota is just a string identifier and not a live placement target
+    const bool is_quota_cmd = (opt_cmd == OPT::QUOTA_SET   ||
+                               opt_cmd == OPT::QUOTA_ENABLE ||
+                               opt_cmd == OPT::QUOTA_DISABLE);
+    if (!is_quota_cmd && !driver->valid_placement(target_rule)) {
+      cerr << "NOTICE: invalid dest placement: "
+           << target_rule.to_str() << std::endl;
       return EINVAL;
     }
-    user_op.set_default_placement(target_rule);
+    if (!is_quota_cmd) {
+      user_op.set_default_placement(target_rule);
+    }
+
   }
 
   if (!tags.empty()) {

--- a/src/rgw/rgw_account.cc
+++ b/src/rgw/rgw_account.cc
@@ -530,7 +530,7 @@ int stats(const DoutPrefixProvider* dpp,
   const rgw_owner owner = rgw_account_id{info.id};
 
   if (sync_stats) {
-    ret = rgw_sync_all_stats(dpp, y, driver, owner, info.tenant);
+    ret = rgw_sync_all_stats(dpp, y, driver, owner, false, info.tenant);
     if (ret < 0) {
       err_msg = "failed to sync account stats";
       return ret;

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1245,6 +1245,7 @@ struct RGWStorageStats
   uint64_t num_objects;
   uint64_t size_utilized{0}; //< size after compression, encryption
   bool dump_utilized;        // whether dump should include utilized values
+  std::optional<std::map<std::string, RGWStorageStats>> storage_class_stats;
 
   RGWStorageStats(bool _dump_utilized=true)
     : category(RGWObjCategory::None),
@@ -1496,6 +1497,7 @@ struct RGWBucketEnt {
    * of the Swift API. Although the info available in RGWBucketInfo, we need
    * to duplicate it here to not affect the performance of buckets listing. */
   rgw_placement_rule placement_rule;
+  std::map<std::string, RGWBucketEnt> storage_class_ents;
 
   RGWBucketEnt()
     : size(0),
@@ -1523,7 +1525,7 @@ struct RGWBucketEnt {
   }
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(7, 5, bl);
+    ENCODE_START(8, 5, bl);
     uint64_t s = size;
     // issue tracked here: https://tracker.ceph.com/issues/61160
     // coverity[store_truncates_time_t:SUPPRESS]
@@ -1538,10 +1540,11 @@ struct RGWBucketEnt {
     encode(s, bl);
     encode(creation_time, bl);
     encode(placement_rule, bl);
+    encode(storage_class_ents, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START_LEGACY_COMPAT_LEN(7, 5, 5, bl);
+    DECODE_START_LEGACY_COMPAT_LEN(8, 5, 5, bl);
     __u32 mt;
     uint64_t s;
     std::string empty_str;  // backward compatibility
@@ -1563,6 +1566,8 @@ struct RGWBucketEnt {
       decode(creation_time, bl);
     if (struct_v >= 7)
       decode(placement_rule, bl);
+    if (struct_v >= 8)
+      decode(storage_class_ents, bl);
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1522,6 +1522,17 @@ struct RGWBucketEnt {
     b->size_rounded = size_rounded;
     b->creation_time = creation_time;
     b->count = count;
+    for (auto it = storage_class_ents.begin(); it != storage_class_ents.end(); ++it) {
+      std::string storage_class = it->first;
+      RGWBucketEnt bent = it->second;
+      std::string placement_target = placement_rule.name;
+      b->storage_class_stats.emplace();
+      cls_user_bucket_entry stats;
+      stats.count = bent.count;
+      stats.size = bent.size;
+      stats.size_rounded = bent.size_rounded;
+      b->storage_class_stats.value()[placement_target + "::" + storage_class] = stats;
+    }
   }
 
   void encode(bufferlist& bl) const {

--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -229,7 +229,7 @@ static void log_usage(req_state *s, const string& op_name)
   uint64_t bytes_sent = ACCOUNTING_IO(s)->get_bytes_sent();
   uint64_t bytes_received = ACCOUNTING_IO(s)->get_bytes_received();
 
-  rgw_usage_data data(bytes_sent, bytes_received);
+  rgw_usage_data data(bytes_sent, bytes_received, s->dest_placement.get_storage_class());
 
   data.ops = 1;
   if (!s->is_err())
@@ -242,7 +242,7 @@ static void log_usage(req_state *s, const string& op_name)
 	<< ", bytes_processed=" << s->s3select_usage.bytes_processed
 	<< ", bytes_returned=" << s->s3select_usage.bytes_returned << dendl;
 
-  entry.add_usage(op_name, data);
+  entry.add_usage(s->dest_placement.name + "::" + s->dest_placement.get_storage_class(), op_name, data);
   entry.s3select_usage = s->s3select_usage;
 
   utime_t ts = ceph_clock_now();

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -7876,7 +7876,7 @@ void RGWCompleteMultipart::execute(optional_yield y)
   if (dest_placement) {
     uint64_t mp_total_size = 0;
     int lp_ret = upload->list_parts(this, s->cct,
-                                    /*max_parts=*/1000,
+                                    /*max_parts=*/10000,
                                     /*marker=*/0,
                                     /*next_marker=*/nullptr,
                                     /*truncated=*/nullptr,

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1843,16 +1843,19 @@ int RGWOp::init_quota()
 
   driver->get_quota(quota);
 
-  if (s->bucket->get_info().quota.enabled) {
-    quota.bucket_quota = s->bucket->get_info().quota;
-  } else if (user_quotas.bucket_quota.enabled) {
-    quota.bucket_quota = user_quotas.bucket_quota;
+  const auto& bucket_info_quota = s->bucket->get_info().quota;
+  if (bucket_info_quota.enabled || bucket_info_quota.has_any_sc_quota()) {
+      quota.bucket_quota = bucket_info_quota;
+  } else if (user_quotas.bucket_quota.enabled ||
+            user_quotas.bucket_quota.has_any_sc_quota()) {
+      quota.bucket_quota = user_quotas.bucket_quota;
   }
 
-  if (user_quotas.user_quota.enabled) {
-    quota.user_quota = user_quotas.user_quota;
+  if (user_quotas.user_quota.enabled ||
+      user_quotas.user_quota.has_any_sc_quota()) {
+      quota.user_quota = user_quotas.user_quota;
   }
-
+  
   return 0;
 }
 
@@ -4809,7 +4812,7 @@ void RGWPutObj::execute(optional_yield y)
       return;
     }
     op_ret = rgw::quota::rgw_check_storage_class_quota(
-        this, quota, s->bucket->get_key(), s->dest_placement,
+        this, driver, quota, s->bucket->get_key(), s->dest_placement,
         s->content_length, /*new_objects=*/1, y);
     if (op_ret < 0) {
       ldpp_dout(this, 20) << "sc-quota pre-check returned ret=" << op_ret << dendl;
@@ -5100,7 +5103,7 @@ void RGWPutObj::execute(optional_yield y)
   }
   
   op_ret = rgw::quota::rgw_check_storage_class_quota(
-      this, quota, s->bucket->get_key(), s->dest_placement,
+      this, driver, quota, s->bucket->get_key(), s->dest_placement,
       s->obj_size, /*new_objects=*/1, y);
   if (op_ret < 0) {
     ldpp_dout(this, 20) << "sc-quota final check returned ret=" << op_ret << dendl;
@@ -5360,7 +5363,7 @@ void RGWPostObj::execute(optional_yield y)
       return;
     }
     op_ret = rgw::quota::rgw_check_storage_class_quota(
-        this, quota, s->bucket->get_key(), s->dest_placement,
+        this, driver, quota, s->bucket->get_key(), s->dest_placement,
         s->content_length, /*new_objects=*/1, y);
     if (op_ret < 0) {
       return;
@@ -5499,7 +5502,7 @@ void RGWPostObj::execute(optional_yield y)
       return;
     }
     op_ret = rgw::quota::rgw_check_storage_class_quota(
-        this, quota, s->bucket->get_key(), s->dest_placement,
+        this, driver, quota, s->bucket->get_key(), s->dest_placement,
         s->obj_size, /*new_objects=*/1, y);
     if (op_ret < 0) {
       return;
@@ -6652,7 +6655,7 @@ void RGWCopyObj::execute(optional_yield y)
         return;
       }
       op_ret = rgw::quota::rgw_check_storage_class_quota(
-          this, quota, s->bucket->get_key(), s->dest_placement,
+          this, driver, quota, s->bucket->get_key(), s->dest_placement,
           s->src_object->get_accounted_size(), /*new_objects=*/1, y);
       if (op_ret < 0) {
         return;
@@ -7886,7 +7889,7 @@ void RGWCompleteMultipart::execute(optional_yield y)
         mp_total_size += mp_part->get_size();
       }
       int q_ret = rgw::quota::rgw_check_storage_class_quota(
-          this, quota, s->bucket->get_key(), *dest_placement,
+          this, driver, quota, s->bucket->get_key(), *dest_placement,
           mp_total_size, /*new_objects=*/1, y);
       if (q_ret < 0) {
         op_ret = q_ret;
@@ -8935,7 +8938,7 @@ int RGWBulkUploadOp::handle_file(const std::string_view path,
   dest_placement.inherit_from(bucket->get_placement_rule());
 
   op_ret = rgw::quota::rgw_check_storage_class_quota(
-      this, quota, bucket->get_key(), dest_placement,
+      this, driver, quota, bucket->get_key(), dest_placement,
       size, /*new_objects=*/1, y);
   if (op_ret < 0) {
     return op_ret;
@@ -9013,7 +9016,7 @@ int RGWBulkUploadOp::handle_file(const std::string_view path,
   }
   
   op_ret = rgw::quota::rgw_check_storage_class_quota(
-      this, quota, bucket->get_key(), dest_placement,
+      this, driver, quota, bucket->get_key(), dest_placement,
       size, /*new_objects=*/1, y);
   if (op_ret < 0) {
     ldpp_dout(this, 20) << "sc-quota exceeded for path=" << path << dendl;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3173,7 +3173,7 @@ void RGWGetUsage::execute(optional_yield y)
   }
 
   op_ret = rgw_sync_all_stats(this, y, driver, s->user->get_id(),
-                              s->user->get_tenant());
+                              false, s->user->get_tenant());
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "ERROR: failed to sync user stats" << dendl;
     return;
@@ -4341,7 +4341,7 @@ void RGWDeleteBucket::execute(optional_yield y)
 
   if (own_bucket) {
     // only if we own the bucket
-    op_ret = s->bucket->sync_owner_stats(this, y, nullptr);
+    op_ret = s->bucket->sync_owner_stats(this, y, false, nullptr);
     if (op_ret < 0) {
       ldpp_dout(this, 1) << "WARNING: failed to sync user stats before bucket delete: op_ret= " << op_ret << dendl;
     }

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -71,7 +71,7 @@
 #include "rgw_bucket_logging.h"
 #include "rgw_restore.h"
 #include "rgw_restore_waiter.h"
-
+#include "rgw_sc_quota_checker.h"
 #include "services/svc_zone.h"
 #include "services/svc_quota.h"
 #include "services/svc_sys_obj.h"
@@ -4808,6 +4808,13 @@ void RGWPutObj::execute(optional_yield y)
       ldpp_dout(this, 20) << "check_quota() returned ret=" << op_ret << dendl;
       return;
     }
+    op_ret = rgw::quota::rgw_check_storage_class_quota(
+        this, quota, s->bucket->get_key(), s->dest_placement,
+        s->content_length, /*new_objects=*/1, y);
+    if (op_ret < 0) {
+      ldpp_dout(this, 20) << "sc-quota pre-check returned ret=" << op_ret << dendl;
+      return;
+    }
   }
 
   if (supplied_etag) {
@@ -5091,6 +5098,14 @@ void RGWPutObj::execute(optional_yield y)
     ldpp_dout(this, 20) << "second check_quota() returned op_ret=" << op_ret << dendl;
     return;
   }
+  
+  op_ret = rgw::quota::rgw_check_storage_class_quota(
+      this, quota, s->bucket->get_key(), s->dest_placement,
+      s->obj_size, /*new_objects=*/1, y);
+  if (op_ret < 0) {
+    ldpp_dout(this, 20) << "sc-quota final check returned ret=" << op_ret << dendl;
+    return;
+  }
 
   hash.Final(m);
 
@@ -5344,7 +5359,12 @@ void RGWPostObj::execute(optional_yield y)
     if (op_ret < 0) {
       return;
     }
-
+    op_ret = rgw::quota::rgw_check_storage_class_quota(
+        this, quota, s->bucket->get_key(), s->dest_placement,
+        s->content_length, /*new_objects=*/1, y);
+    if (op_ret < 0) {
+      return;
+    }
     if (supplied_md5_b64) {
       char supplied_md5_bin[CEPH_CRYPTO_MD5_DIGESTSIZE + 1];
       ldpp_dout(this, 15) << "supplied_md5_b64=" << supplied_md5_b64 << dendl;
@@ -5478,7 +5498,12 @@ void RGWPostObj::execute(optional_yield y)
     if (op_ret < 0) {
       return;
     }
-
+    op_ret = rgw::quota::rgw_check_storage_class_quota(
+        this, quota, s->bucket->get_key(), s->dest_placement,
+        s->obj_size, /*new_objects=*/1, y);
+    if (op_ret < 0) {
+      return;
+    }
     hash.Final(m);
     etag.clear();
     etag.reserve(CEPH_CRYPTO_MD5_DIGESTSIZE * 2);
@@ -6623,6 +6648,12 @@ void RGWCopyObj::execute(optional_yield y)
       }
       // enforce quota against the destination bucket owner
       op_ret = s->bucket->check_quota(this, quota, s->src_object->get_accounted_size(), y);
+      if (op_ret < 0) {
+        return;
+      }
+      op_ret = rgw::quota::rgw_check_storage_class_quota(
+          this, quota, s->bucket->get_key(), s->dest_placement,
+          s->src_object->get_accounted_size(), /*new_objects=*/1, y);
       if (op_ret < 0) {
         return;
       }
@@ -7842,6 +7873,33 @@ void RGWCompleteMultipart::execute(optional_yield y)
     return;
   }
 
+  if (dest_placement) {
+    uint64_t mp_total_size = 0;
+    int lp_ret = upload->list_parts(this, s->cct,
+                                    /*max_parts=*/1000,
+                                    /*marker=*/0,
+                                    /*next_marker=*/nullptr,
+                                    /*truncated=*/nullptr,
+                                    y);
+    if (lp_ret >= 0) {
+      for (auto& [_, mp_part] : upload->get_parts()) {
+        mp_total_size += mp_part->get_size();
+      }
+      int q_ret = rgw::quota::rgw_check_storage_class_quota(
+          this, quota, s->bucket->get_key(), *dest_placement,
+          mp_total_size, /*new_objects=*/1, y);
+      if (q_ret < 0) {
+        op_ret = q_ret;
+        ldpp_dout(this, 20) << "sc-quota multipart complete check returned ret="
+                            << op_ret << " total_size=" << mp_total_size << dendl;
+        return;
+      }
+    } else {
+      ldpp_dout(this, 10) << "WARNING: list_parts for sc-quota sum failed ret="
+                          << lp_ret << "; skipping multipart sc-quota check" << dendl;
+    }
+  }
+
   op_ret =
     upload->complete(this, y, s->cct, parts->parts, remove_objs, accounted_size,
                      compressed, cs_info, ofs, s->req_id, s->owner, olh_epoch,
@@ -8876,6 +8934,13 @@ int RGWBulkUploadOp::handle_file(const std::string_view path,
   rgw_placement_rule dest_placement = s->dest_placement;
   dest_placement.inherit_from(bucket->get_placement_rule());
 
+  op_ret = rgw::quota::rgw_check_storage_class_quota(
+      this, quota, bucket->get_key(), dest_placement,
+      size, /*new_objects=*/1, y);
+  if (op_ret < 0) {
+    return op_ret;
+  }
+
   std::unique_ptr<rgw::sal::Writer> processor;
   processor = driver->get_atomic_writer(this, s->yield, obj.get(), bowner,
 				       &s->dest_placement, 0, s->req_id);
@@ -8944,6 +9009,14 @@ int RGWBulkUploadOp::handle_file(const std::string_view path,
   op_ret = bucket->check_quota(this, quota, size, y);
   if (op_ret < 0) {
     ldpp_dout(this, 20) << "quota exceeded for path=" << path << dendl;
+    return op_ret;
+  }
+  
+  op_ret = rgw::quota::rgw_check_storage_class_quota(
+      this, quota, bucket->get_key(), dest_placement,
+      size, /*new_objects=*/1, y);
+  if (op_ret < 0) {
+    ldpp_dout(this, 20) << "sc-quota exceeded for path=" << path << dendl;
     return op_ret;
   }
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1847,7 +1847,7 @@ int RGWOp::init_quota()
   if (bucket_info_quota.enabled || bucket_info_quota.has_any_sc_quota()) {
       quota.bucket_quota = bucket_info_quota;
   } else if (user_quotas.bucket_quota.enabled ||
-            user_quotas.bucket_quota.has_any_sc_quota()) {
+      user_quotas.bucket_quota.has_any_sc_quota()) {
       quota.bucket_quota = user_quotas.bucket_quota;
   }
 
@@ -4806,16 +4806,9 @@ void RGWPutObj::execute(optional_yield y)
 
   if (!chunked_upload) { /* with chunked upload we don't know how big is the upload.
                             we also check sizes at the end anyway */
-    op_ret = s->bucket->check_quota(this, quota, s->content_length, y);
+    op_ret = s->bucket->check_quota(this, quota, s->content_length, y, &s->dest_placement);
     if (op_ret < 0) {
       ldpp_dout(this, 20) << "check_quota() returned ret=" << op_ret << dendl;
-      return;
-    }
-    op_ret = rgw::quota::rgw_check_storage_class_quota(
-        this, driver, quota, s->bucket->get_key(), s->dest_placement,
-        s->content_length, /*new_objects=*/1, y);
-    if (op_ret < 0) {
-      ldpp_dout(this, 20) << "sc-quota pre-check returned ret=" << op_ret << dendl;
       return;
     }
   }
@@ -5096,17 +5089,9 @@ void RGWPutObj::execute(optional_yield y)
     return;
   }
 
-  op_ret = s->bucket->check_quota(this, quota, s->obj_size, y);
+  op_ret = s->bucket->check_quota(this, quota, s->obj_size, y,  &s->dest_placement);
   if (op_ret < 0) {
     ldpp_dout(this, 20) << "second check_quota() returned op_ret=" << op_ret << dendl;
-    return;
-  }
-  
-  op_ret = rgw::quota::rgw_check_storage_class_quota(
-      this, driver, quota, s->bucket->get_key(), s->dest_placement,
-      s->obj_size, /*new_objects=*/1, y);
-  if (op_ret < 0) {
-    ldpp_dout(this, 20) << "sc-quota final check returned ret=" << op_ret << dendl;
     return;
   }
 
@@ -5358,16 +5343,11 @@ void RGWPostObj::execute(optional_yield y)
     hash.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
     ceph::buffer::list bl, aclbl;
 
-    op_ret = s->bucket->check_quota(this, quota, s->content_length, y);
+    op_ret = s->bucket->check_quota(this, quota, s->content_length, y, &s->dest_placement);
     if (op_ret < 0) {
       return;
     }
-    op_ret = rgw::quota::rgw_check_storage_class_quota(
-        this, driver, quota, s->bucket->get_key(), s->dest_placement,
-        s->content_length, /*new_objects=*/1, y);
-    if (op_ret < 0) {
-      return;
-    }
+
     if (supplied_md5_b64) {
       char supplied_md5_bin[CEPH_CRYPTO_MD5_DIGESTSIZE + 1];
       ldpp_dout(this, 15) << "supplied_md5_b64=" << supplied_md5_b64 << dendl;
@@ -5497,16 +5477,11 @@ void RGWPostObj::execute(optional_yield y)
       }
     }
 
-    op_ret = s->bucket->check_quota(this, quota, s->obj_size, y);
+    op_ret = s->bucket->check_quota(this, quota, s->obj_size, y, &s->dest_placement);
     if (op_ret < 0) {
       return;
     }
-    op_ret = rgw::quota::rgw_check_storage_class_quota(
-        this, driver, quota, s->bucket->get_key(), s->dest_placement,
-        s->obj_size, /*new_objects=*/1, y);
-    if (op_ret < 0) {
-      return;
-    }
+    
     hash.Final(m);
     etag.clear();
     etag.reserve(CEPH_CRYPTO_MD5_DIGESTSIZE * 2);
@@ -6650,13 +6625,7 @@ void RGWCopyObj::execute(optional_yield y)
         return;
       }
       // enforce quota against the destination bucket owner
-      op_ret = s->bucket->check_quota(this, quota, s->src_object->get_accounted_size(), y);
-      if (op_ret < 0) {
-        return;
-      }
-      op_ret = rgw::quota::rgw_check_storage_class_quota(
-          this, driver, quota, s->bucket->get_key(), s->dest_placement,
-          s->src_object->get_accounted_size(), /*new_objects=*/1, y);
+      op_ret = s->bucket->check_quota(this, quota, s->src_object->get_accounted_size(), y, &s->dest_placement);
       if (op_ret < 0) {
         return;
       }
@@ -7888,18 +7857,16 @@ void RGWCompleteMultipart::execute(optional_yield y)
       for (auto& [_, mp_part] : upload->get_parts()) {
         mp_total_size += mp_part->get_size();
       }
-      int q_ret = rgw::quota::rgw_check_storage_class_quota(
-          this, driver, quota, s->bucket->get_key(), *dest_placement,
-          mp_total_size, /*new_objects=*/1, y);
-      if (q_ret < 0) {
-        op_ret = q_ret;
-        ldpp_dout(this, 20) << "sc-quota multipart complete check returned ret="
+      op_ret = s->bucket->check_quota(this, quota, mp_total_size, y,
+                                       false, dest_placement);
+      if (op_ret < 0) {
+        ldpp_dout(this, 20) << "multipart quota check returned ret="
                             << op_ret << " total_size=" << mp_total_size << dendl;
         return;
       }
     } else {
-      ldpp_dout(this, 10) << "WARNING: list_parts for sc-quota sum failed ret="
-                          << lp_ret << "; skipping multipart sc-quota check" << dendl;
+      ldpp_dout(this, 10) << "WARNING: list_parts for quota sum failed ret="
+                          << lp_ret << "; skipping multipart quota check" << dendl;
     }
   }
 
@@ -8925,7 +8892,8 @@ int RGWBulkUploadOp::handle_file(const std::string_view path,
     return op_ret;
   }
 
-  op_ret = bucket->check_quota(this, quota, size, y);
+  rgw_placement_rule dest_placement = s->dest_placement;
+  op_ret = bucket->check_quota(this, quota, size, y, &dest_placement);
   if (op_ret < 0) {
     return op_ret;
   }
@@ -8934,15 +8902,7 @@ int RGWBulkUploadOp::handle_file(const std::string_view path,
     obj->gen_rand_obj_instance_name();
   }
 
-  rgw_placement_rule dest_placement = s->dest_placement;
   dest_placement.inherit_from(bucket->get_placement_rule());
-
-  op_ret = rgw::quota::rgw_check_storage_class_quota(
-      this, driver, quota, bucket->get_key(), dest_placement,
-      size, /*new_objects=*/1, y);
-  if (op_ret < 0) {
-    return op_ret;
-  }
 
   std::unique_ptr<rgw::sal::Writer> processor;
   processor = driver->get_atomic_writer(this, s->yield, obj.get(), bowner,
@@ -9009,17 +8969,9 @@ int RGWBulkUploadOp::handle_file(const std::string_view path,
     return op_ret;
   }
 
-  op_ret = bucket->check_quota(this, quota, size, y);
+  op_ret = bucket->check_quota(this, quota, size, y, &dest_placement);
   if (op_ret < 0) {
     ldpp_dout(this, 20) << "quota exceeded for path=" << path << dendl;
-    return op_ret;
-  }
-  
-  op_ret = rgw::quota::rgw_check_storage_class_quota(
-      this, driver, quota, bucket->get_key(), dest_placement,
-      size, /*new_objects=*/1, y);
-  if (op_ret < 0) {
-    ldpp_dout(this, 20) << "sc-quota exceeded for path=" << path << dendl;
     return op_ret;
   }
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3529,8 +3529,11 @@ static int load_bucket_stats(const DoutPrefixProvider* dpp, optional_yield y,
   const auto& index = bucket.get_info().layout.current_index;
   std::string bver, mver; // ignored
   std::map<RGWObjCategory, RGWStorageStats> categories;
+  std::optional<std::map<std::string, RGWStorageStats>> sc_stats{
+    std::map<std::string, RGWStorageStats>{}
+  };
 
-  int r = bucket.read_stats(dpp, y, index, -1, &bver, &mver, categories);
+  int r = bucket.read_stats(dpp, y, index, -1, &bver, &mver, categories, sc_stats);
   if (r < 0) {
     return r;
   }

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -610,7 +610,7 @@ int RGWOwnerStatsCache::sync_bucket(const rgw_owner& owner, const rgw_bucket& b,
   }
 
   RGWBucketEnt ent;
-  r = bucket->sync_owner_stats(dpp, y, &ent);
+  r = bucket->sync_owner_stats(dpp, y, false, &ent);
   if (r < 0) {
     ldpp_dout(dpp, 0) << "ERROR: sync_owner_stats() for bucket=" << bucket << " returned " << r << dendl;
     return r;
@@ -676,7 +676,7 @@ int RGWOwnerStatsCache::sync_owner(const DoutPrefixProvider *dpp,
     return ret;
   }
 
-  ret = rgw_sync_all_stats(dpp, y, driver, owner, tenant);
+  ret = rgw_sync_all_stats(dpp, y, driver, owner, false, tenant);
   if (ret < 0) {
     ldpp_dout(dpp, 0) << "ERROR: failed user stats sync, ret=" << ret << dendl;
     return ret;

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -1062,15 +1062,18 @@ void RGWQuotaInfo::dump(Formatter *f) const
   f->dump_int("max_size_kb", rgw_rounded_kb(max_size));
   f->dump_int("max_objects", max_objects);
   
-  f->dump_string("enforcement_mode", to_string(enforcement_mode));
-  f->open_array_section("storage_class_quotas");
-  for (const auto& [key, q] : storage_class_quotas) {
-    f->open_object_section("entry");
-    f->dump_string("key", key);
-    q.dump(f);
+  if (!storage_class_quotas.empty() ||
+      enforcement_mode != RGWQuotaEnforcementMode::LEGACY) {
+    f->dump_string("enforcement_mode", to_string(enforcement_mode));
+    f->open_array_section("storage_class_quotas");
+    for (const auto& [key, q] : storage_class_quotas) {
+      f->open_object_section("entry");
+      f->dump_string("key", key);
+      q.dump(f);
+      f->close_section();
+    }
     f->close_section();
   }
-  f->close_section();
 }
 
 std::list<RGWQuotaInfo> RGWQuotaInfo::generate_test_instances()

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -30,6 +30,8 @@
 #include "rgw_quota.h"
 #include "rgw_bucket.h"
 #include "driver/rados/rgw_user.h"
+#include "rgw_sc_quota_checker.h"
+#include "rgw_sc_quota_types.h"
 
 #include "services/svc_sys_obj.h"
 
@@ -930,7 +932,75 @@ class RGWQuotaHandlerImpl : public RGWQuotaHandler {
                             << " stats.size=" << stats.size << dendl;
     return 0;
   }
-public:
+
+  int check_sc_quota(const DoutPrefixProvider* dpp,
+                    const RGWQuota& quota,
+                    const rgw_placement_rule& placement,
+                    const RGWStorageStats& bucket_stats,
+                    uint64_t new_size,
+                    uint64_t new_objects)
+  {
+    using namespace rgw::quota;
+
+    const bool bucket_active = sc_enforcement_active(quota.bucket_quota);
+    const bool user_active   = sc_enforcement_active(quota.user_quota);
+    if (!bucket_active && !user_active) return 0;
+
+    const std::string sc_key = rgw_sc_quota_key(placement);
+
+    const RGWStorageClassQuota* bq =
+        bucket_active ? quota.bucket_quota.get_sc_quota(sc_key) : nullptr;
+    const RGWStorageClassQuota* uq =
+        user_active   ? quota.user_quota.get_sc_quota(sc_key)   : nullptr;
+
+    if ((!bq || !bq->enabled) && (!uq || !uq->enabled)) return 0;
+
+    const EffectiveScQuota lim = combine_sc_quota(bq, uq);
+    if (!lim.have_size_limit && !lim.have_object_limit) return 0;
+
+    std::string sc_name = sc_key;
+    const auto sep = sc_key.rfind("::");
+    if (sep != std::string::npos) {
+      sc_name = sc_key.substr(sep + 2);
+    }
+
+    ScUsageStats usage{0, 0};
+    if (!bucket_stats.storage_class_stats.has_value()) {
+      ldpp_dout(dpp, 10) << "sc-quota: bucket has no per-SC stats "
+                        << "(predates #66501); failing open" << dendl;
+      return 0;
+    }
+    auto it = bucket_stats.storage_class_stats->find(sc_name);
+    if (it != bucket_stats.storage_class_stats->end()) {
+      usage.size        = it->second.size;
+      usage.num_objects = it->second.num_objects;
+    }
+
+    if (lim.have_size_limit &&
+        sc_quota_would_exceed(lim.max_size, usage.size, new_size)) {
+        ldpp_dout(dpp, 5) << "sc-quota: size exceeded sc=" << sc_name
+                        << " current=" << usage.size
+                        << " +" << new_size
+                        << " limit=" << lim.max_size << dendl;
+      return -EDQUOT;
+    }
+    if (lim.have_object_limit &&
+        sc_quota_would_exceed(lim.max_objects, usage.num_objects, new_objects)) {
+        ldpp_dout(dpp, 5) << "sc-quota: objects exceeded sc=" << sc_name
+                        << " current=" << usage.num_objects
+                        << " +" << new_objects
+                        << " limit=" << lim.max_objects << dendl;
+      return -EDQUOT;
+    }
+
+    ldpp_dout(dpp, 25) << "sc-quota: ok sc=" << sc_name
+                      << " size=" << usage.size << "+" << new_size
+                      << " objs=" << usage.num_objects << "+" << new_objects
+                      << dendl;
+    return 0;
+  }
+
+  public:
   RGWQuotaHandlerImpl(const DoutPrefixProvider *dpp, rgw::sal::Driver* _driver, bool quota_threads) : driver(_driver),
                                     bucket_stats_cache(_driver),
                                     owner_stats_cache(dpp, _driver, quota_threads) {}
@@ -940,11 +1010,14 @@ public:
                   const rgw_bucket& bucket,
                   const RGWQuota& quota,
                   uint64_t num_objs,
-                  uint64_t size, optional_yield y) override {
+                  uint64_t size, optional_yield y,
+                  const rgw_placement_rule* dest_placement = nullptr) override {
 
-    if (!quota.bucket_quota.enabled && !quota.user_quota.enabled) {
-      return 0;
-    }
+    if (!quota.bucket_quota.enabled && !quota.user_quota.enabled &&
+        !quota.bucket_quota.has_any_sc_quota() &&
+        !quota.user_quota.has_any_sc_quota()) {
+            return 0;
+        }
 
     /*
      * we need to fetch bucket stats if the user quota is enabled, because
@@ -954,15 +1027,25 @@ public:
      */
 
     const DoutPrefix dp(driver->ctx(), dout_subsys, "rgw quota handler: ");
-    if (quota.bucket_quota.enabled) {
-      RGWStorageStats bucket_stats;
+    RGWStorageStats bucket_stats;
+    if (quota.bucket_quota.enabled || quota.bucket_quota.has_any_sc_quota()) {
       int ret = bucket_stats_cache.get_stats(owner, bucket, bucket_stats, y, &dp);
       if (ret < 0) {
         return ret;
       }
-      ret = check_quota(dpp, "bucket", quota.bucket_quota, bucket_stats, num_objs, size);
-      if (ret < 0) {
-        return ret;
+      if (quota.bucket_quota.enabled) {
+        ret = check_quota(&dp, "bucket", quota.bucket_quota, bucket_stats,
+                          num_objs, size);
+        if (ret < 0) {
+          return ret;
+        }
+      }
+      if (dest_placement && quota.bucket_quota.has_any_sc_quota()) {
+        ret = check_sc_quota(dpp, quota, *dest_placement, bucket_stats,
+                            size, num_objs);
+        if (ret < 0) {
+          return ret;
+        }
       }
     }
 
@@ -972,11 +1055,13 @@ public:
       if (ret < 0) {
         return ret;
       }
-      ret = check_quota(dpp, "user", quota.user_quota, owner_stats, num_objs, size);
+      ret = check_quota(&dp, "user", quota.user_quota, owner_stats,
+                        num_objs, size);
       if (ret < 0) {
         return ret;
       }
     }
+
     return 0;
   }
 

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -1034,6 +1034,25 @@ void rgw_apply_default_account_quota(RGWQuotaInfo& quota, const ConfigProxy& con
   }
 }
 
+void RGWStorageClassQuota::dump(Formatter *f) const
+{
+  f->dump_bool("enabled", enabled);
+  f->dump_int("max_size", max_size);
+  f->dump_int("max_size_kb", rgw_rounded_kb(max_size));
+  f->dump_int("max_objects", max_objects);
+}
+
+void RGWStorageClassQuota::decode_json(JSONObj *obj)
+{
+  if (!JSONDecoder::decode_json("max_size", max_size, obj)) {
+    int64_t max_size_kb = 0;
+    JSONDecoder::decode_json("max_size_kb", max_size_kb, obj);
+    max_size = max_size_kb * 1024;
+  }
+  JSONDecoder::decode_json("max_objects", max_objects, obj);
+  JSONDecoder::decode_json("enabled", enabled, obj);
+}
+
 void RGWQuotaInfo::dump(Formatter *f) const
 {
   f->dump_bool("enabled", enabled);
@@ -1042,6 +1061,16 @@ void RGWQuotaInfo::dump(Formatter *f) const
   f->dump_int("max_size", max_size);
   f->dump_int("max_size_kb", rgw_rounded_kb(max_size));
   f->dump_int("max_objects", max_objects);
+  
+  f->dump_string("enforcement_mode", to_string(enforcement_mode));
+  f->open_array_section("storage_class_quotas");
+  for (const auto& [key, q] : storage_class_quotas) {
+    f->open_object_section("entry");
+    f->dump_string("key", key);
+    q.dump(f);
+    f->close_section();
+  }
+  f->close_section();
 }
 
 std::list<RGWQuotaInfo> RGWQuotaInfo::generate_test_instances()
@@ -1053,6 +1082,15 @@ std::list<RGWQuotaInfo> RGWQuotaInfo::generate_test_instances()
   o.back().check_on_raw = true;
   o.back().max_size = 1024;
   o.back().max_objects = 1;
+  o.emplace_back();
+  o.back().enabled = true;
+  o.back().max_size = 10ULL << 30;          // 10 GiB global
+  o.back().max_objects = 1'000'000;
+  o.back().enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  o.back().storage_class_quotas[rgw_sc_quota_key("default-placement", "SSD")] =
+    RGWStorageClassQuota{ 1LL << 30, 100'000, true };
+  o.back().storage_class_quotas[rgw_sc_quota_key("default-placement", "GLACIER")] =
+    RGWStorageClassQuota{ 100LL << 30, -1, true };
   return o;
 }
 
@@ -1069,5 +1107,28 @@ void RGWQuotaInfo::decode_json(JSONObj *obj)
 
   JSONDecoder::decode_json("check_on_raw", check_on_raw, obj);
   JSONDecoder::decode_json("enabled", enabled, obj);
+  
+  std::string mode_str;
+  if (JSONDecoder::decode_json("enforcement_mode", mode_str, obj)) {
+    RGWQuotaEnforcementMode parsed;
+    if (parse_quota_enforcement_mode(mode_str, parsed)) {
+      enforcement_mode = parsed;
+    }
+  }
+
+  JSONObj *sc_arr = obj->find_obj("storage_class_quotas");
+  if (sc_arr) {
+    storage_class_quotas.clear();
+    auto iter = sc_arr->find_first();
+    for (; !iter.end(); ++iter) {
+      JSONObj *entry = *iter;
+      std::string key;
+      JSONDecoder::decode_json("key", key, entry);
+      if (key.empty()) continue;
+      RGWStorageClassQuota q;
+      q.decode_json(entry);
+      storage_class_quotas.emplace(std::move(key), std::move(q));
+    }
+  }
 }
 

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -269,8 +269,11 @@ int RGWBucketStatsCache::fetch_stats_from_storage(const rgw_owner& owner, const 
   string master_ver;
 
   map<RGWObjCategory, RGWStorageStats> bucket_stats;
+  std::optional<std::map<std::string, RGWStorageStats>> sc_stats{
+    std::map<std::string, RGWStorageStats>{}
+  };
   r = bucket->read_stats(dpp, y, index, RGW_NO_SHARD, &bucket_ver,
-			 &master_ver, bucket_stats, nullptr);
+			 &master_ver, bucket_stats, sc_stats, nullptr);
   if (r < 0) {
     ldpp_dout(dpp, 0) << "could not get bucket stats for bucket="
                            << _b.name << dendl;

--- a/src/rgw/rgw_quota.h
+++ b/src/rgw/rgw_quota.h
@@ -33,7 +33,7 @@ public:
   }
   virtual int check_quota(const DoutPrefixProvider *dpp, const rgw_owner& bucket_owner,
                           const rgw_bucket& bucket, const RGWQuota& quota,
-			  uint64_t num_objs, uint64_t size, optional_yield y) = 0;
+			  uint64_t num_objs, uint64_t size, optional_yield y, const rgw_placement_rule* dest_placement = nullptr) = 0;
 
   virtual void update_stats(const rgw_owner& bucket_owner, rgw_bucket& bucket, int obj_delta, uint64_t added_bytes, uint64_t removed_bytes) = 0;
 

--- a/src/rgw/rgw_quota_types.h
+++ b/src/rgw/rgw_quota_types.h
@@ -19,6 +19,7 @@
  */
 
 #pragma once
+#include "rgw_sc_quota_types.h"
 
 static inline int64_t rgw_rounded_kb(int64_t bytes)
 {
@@ -35,6 +36,9 @@ struct RGWQuotaInfo {
    * or maybe rounded-to-4KiB RGWStorageStats::size_rounded (false)? */
   bool check_on_raw;
 
+  RGWStorageClassQuotaMap storage_class_quotas;
+  RGWQuotaEnforcementMode enforcement_mode = RGWQuotaEnforcementMode::LEGACY;
+
   RGWQuotaInfo()
     : max_size(-1),
       max_objects(-1),
@@ -43,7 +47,7 @@ struct RGWQuotaInfo {
   }
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(3, 1, bl);
+    ENCODE_START(4, 1, bl);
     if (max_size < 0) {
       encode(-rgw_rounded_kb(abs(max_size)), bl);
     } else {
@@ -53,10 +57,12 @@ struct RGWQuotaInfo {
     encode(enabled, bl);
     encode(max_size, bl);
     encode(check_on_raw, bl);
+    encode(storage_class_quotas, bl);
+    encode(static_cast<uint8_t>(enforcement_mode), bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START_LEGACY_COMPAT_LEN(3, 1, 1, bl);
+    DECODE_START_LEGACY_COMPAT_LEN(4, 1, 1, bl);
     int64_t max_size_kb;
     decode(max_size_kb, bl);
     decode(max_objects, bl);
@@ -70,6 +76,27 @@ struct RGWQuotaInfo {
       decode(check_on_raw, bl);
     }
     DECODE_FINISH(bl);
+    if (struct_v >= 4) {
+      decode(storage_class_quotas, bl);
+      uint8_t mode_byte = 0;
+      decode(mode_byte, bl);
+      enforcement_mode = static_cast<RGWQuotaEnforcementMode>(mode_byte);
+    } else {
+      storage_class_quotas.clear();
+      enforcement_mode = RGWQuotaEnforcementMode::LEGACY;
+    }
+  }
+
+  const RGWStorageClassQuota* get_sc_quota(const std::string& sc_key) const {
+    auto it = storage_class_quotas.find(sc_key);
+    return it == storage_class_quotas.end() ? nullptr : &it->second;
+  }
+
+  bool has_any_sc_quota() const {
+    for (const auto& [_, q] : storage_class_quotas) {
+      if (q.enabled) return true;
+    }
+    return false;
   }
 
   void dump(Formatter *f) const;

--- a/src/rgw/rgw_quota_types.h
+++ b/src/rgw/rgw_quota_types.h
@@ -75,7 +75,6 @@ struct RGWQuotaInfo {
     if (struct_v >= 3) {
       decode(check_on_raw, bl);
     }
-    DECODE_FINISH(bl);
     if (struct_v >= 4) {
       decode(storage_class_quotas, bl);
       uint8_t mode_byte = 0;
@@ -85,6 +84,8 @@ struct RGWQuotaInfo {
       storage_class_quotas.clear();
       enforcement_mode = RGWQuotaEnforcementMode::LEGACY;
     }
+
+    DECODE_FINISH(bl);
   }
 
   const RGWStorageClassQuota* get_sc_quota(const std::string& sc_key) const {

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -957,6 +957,7 @@ class Bucket {
 				 int shard_id, boost::intrusive_ptr<ReadStatsCB> cb) = 0;
     /** Sync this bucket's stats to the owning user's stats in the backing store */
     virtual int sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y,
+                                 bool reset,
                                  RGWBucketEnt* optional_ent) = 0;
     /** Check if this bucket needs resharding, and schedule it if it does */
     virtual int check_bucket_shards(const DoutPrefixProvider* dpp,

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -976,7 +976,7 @@ class Bucket {
     /** Check in the backing store if this bucket is empty */
     virtual int check_empty(const DoutPrefixProvider* dpp, optional_yield y) = 0;
     /** Check if the given size fits within the quota */
-    virtual int check_quota(const DoutPrefixProvider *dpp, RGWQuota& quota, uint64_t obj_size, optional_yield y, bool check_size_only = false) = 0;
+    virtual int check_quota(const DoutPrefixProvider *dpp, RGWQuota& quota, uint64_t obj_size, optional_yield y, bool check_size_only = false, const rgw_placement_rule* dest_placement = nullptr) = 0;
     /** Set the attributes in attrs, leaving any other existing attrs set, and
      * write them to the backing store; a merge operation */
     virtual int merge_and_store_attrs(const DoutPrefixProvider* dpp, Attrs& new_attrs, optional_yield y) = 0;

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -949,6 +949,7 @@ class Bucket {
 			   const bucket_index_layout_generation& idx_layout,
 			   int shard_id, std::string* bucket_ver, std::string* master_ver,
 			   std::map<RGWObjCategory, RGWStorageStats>& stats,
+			   std::optional<std::map<std::string, RGWStorageStats>>& sc_stats,
 			   std::string* max_marker = nullptr,
 			   bool* syncstopped = nullptr) = 0;
     /** Read the bucket stats from the backing Store, asynchronous */

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -219,6 +219,7 @@ namespace rgw::sal {
   }
 
   int DBBucket::sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y,
+                                 bool reset,
                                  RGWBucketEnt* ent)
   {
     return 0;

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -259,7 +259,7 @@ namespace rgw::sal {
   }
 
   int DBBucket::check_quota(const DoutPrefixProvider *dpp, RGWQuota& quota, uint64_t obj_size,
-      optional_yield y, bool check_size_only)
+      optional_yield y, bool check_size_only, const rgw_placement_rule* dest_placement)
   {
     /* Not Handled in the first pass as stats are also needed */
     return 0;

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -208,6 +208,7 @@ namespace rgw::sal {
       int shard_id,
       std::string *bucket_ver, std::string *master_ver,
       std::map<RGWObjCategory, RGWStorageStats>& stats,
+      std::optional<std::map<std::string, RGWStorageStats>>& sc_stats,
       std::string *max_marker, bool *syncstopped)
   {
     return 0;

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -160,7 +160,7 @@ protected:
           std::string *max_marker = nullptr,
           bool *syncstopped = nullptr) override;
       virtual int read_stats_async(const DoutPrefixProvider *dpp, const bucket_index_layout_generation& idx_layout, int shard_id, boost::intrusive_ptr<ReadStatsCB> ctx) override;
-      int sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y,
+      int sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y, bool reset,
                            RGWBucketEnt* ent) override;
       int check_bucket_shards(const DoutPrefixProvider *dpp,
                               uint64_t num_objs, optional_yield y) override;

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -171,7 +171,7 @@ protected:
                         optional_yield y) override;
       virtual int put_info(const DoutPrefixProvider *dpp, bool exclusive, ceph::real_time mtime, optional_yield y) override;
       virtual int check_empty(const DoutPrefixProvider *dpp, optional_yield y) override;
-      virtual int check_quota(const DoutPrefixProvider *dpp, RGWQuota& quota, uint64_t obj_size, optional_yield y, bool check_size_only = false) override;
+      virtual int check_quota(const DoutPrefixProvider *dpp, RGWQuota& quota, uint64_t obj_size, optional_yield y, bool check_size_only = false, const rgw_placement_rule* dest_placement = nullptr) override;
       virtual int merge_and_store_attrs(const DoutPrefixProvider *dpp, Attrs& attrs, optional_yield y) override;
       virtual int try_refresh_info(const DoutPrefixProvider *dpp, ceph::real_time *pmtime, optional_yield y) override;
       virtual int read_usage(const DoutPrefixProvider *dpp, uint64_t start_epoch, uint64_t end_epoch, uint32_t max_entries,

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -157,6 +157,7 @@ protected:
 			     int shard_id,
           std::string *bucket_ver, std::string *master_ver,
           std::map<RGWObjCategory, RGWStorageStats>& stats,
+          std::optional<std::map<std::string, RGWStorageStats>>& sc_stats,
           std::string *max_marker = nullptr,
           bool *syncstopped = nullptr) override;
       virtual int read_stats_async(const DoutPrefixProvider *dpp, const bucket_index_layout_generation& idx_layout, int shard_id, boost::intrusive_ptr<ReadStatsCB> ctx) override;

--- a/src/rgw/rgw_sal_filter.cc
+++ b/src/rgw/rgw_sal_filter.cc
@@ -862,10 +862,11 @@ int FilterBucket::read_stats(const DoutPrefixProvider *dpp, optional_yield y,
 			     int shard_id, std::string* bucket_ver,
 			     std::string* master_ver,
 			     std::map<RGWObjCategory, RGWStorageStats>& stats,
+			     std::optional<std::map<std::string, RGWStorageStats>>& sc_stats,
 			     std::string* max_marker, bool* syncstopped)
 {
   return next->read_stats(dpp, y, idx_layout, shard_id, bucket_ver, master_ver,
-			  stats, max_marker, syncstopped);
+			  stats, sc_stats, max_marker, syncstopped);
 }
 
 int FilterBucket::read_stats_async(const DoutPrefixProvider *dpp,

--- a/src/rgw/rgw_sal_filter.cc
+++ b/src/rgw/rgw_sal_filter.cc
@@ -914,7 +914,7 @@ int FilterBucket::check_empty(const DoutPrefixProvider* dpp, optional_yield y)
 
 int FilterBucket::check_quota(const DoutPrefixProvider *dpp, RGWQuota& quota,
 			      uint64_t obj_size, optional_yield y,
-			      bool check_size_only)
+			      bool check_size_only, const rgw_placement_rule* dest_placement)
 {
   return next->check_quota(dpp, quota, obj_size, y, check_size_only);
 }

--- a/src/rgw/rgw_sal_filter.cc
+++ b/src/rgw/rgw_sal_filter.cc
@@ -876,9 +876,10 @@ int FilterBucket::read_stats_async(const DoutPrefixProvider *dpp,
 }
 
 int FilterBucket::sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y,
+                                   bool reset,
                                    RGWBucketEnt* ent)
 {
-  return next->sync_owner_stats(dpp, y, ent);
+  return next->sync_owner_stats(dpp, y, reset, ent);
 }
 
 int FilterBucket::check_bucket_shards(const DoutPrefixProvider* dpp,

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -612,7 +612,7 @@ public:
   virtual int check_empty(const DoutPrefixProvider* dpp, optional_yield y) override;
   virtual int check_quota(const DoutPrefixProvider *dpp, RGWQuota& quota,
 			  uint64_t obj_size, optional_yield y,
-			  bool check_size_only = false) override;
+			  bool check_size_only = false, const rgw_placement_rule* dest_placement = nullptr) override;
   virtual int merge_and_store_attrs(const DoutPrefixProvider* dpp,
 				    Attrs& new_attrs, optional_yield y) override;
   virtual int try_refresh_info(const DoutPrefixProvider* dpp,

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -592,6 +592,7 @@ public:
 			 const bucket_index_layout_generation& idx_layout,
 			 int shard_id, std::string* bucket_ver, std::string* master_ver,
 			 std::map<RGWObjCategory, RGWStorageStats>& stats,
+			 std::optional<std::map<std::string, RGWStorageStats>>& sc_stats,
 			 std::string* max_marker = nullptr,
 			 bool* syncstopped = nullptr) override;
   virtual int read_stats_async(const DoutPrefixProvider *dpp,

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -597,7 +597,7 @@ public:
   virtual int read_stats_async(const DoutPrefixProvider *dpp,
 			       const bucket_index_layout_generation& idx_layout,
 			       int shard_id, boost::intrusive_ptr<ReadStatsCB> ctx) override;
-  int sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y,
+  int sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y, bool reset,
                        RGWBucketEnt* ent) override;
   int check_bucket_shards(const DoutPrefixProvider* dpp,
                           uint64_t num_objs, optional_yield y) override;

--- a/src/rgw/rgw_sc_quota_checker.cc
+++ b/src/rgw/rgw_sc_quota_checker.cc
@@ -1,0 +1,186 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Per-storage-class quota enforcement engine.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#include "rgw_sc_quota_checker.h"
+
+#include <atomic>
+#include <cerrno>
+#include <limits>
+
+#include "common/dout.h"
+#include "rgw_common.h"     // rgw_bucket, ldpp_dout
+
+#define dout_subsys ceph_subsys_rgw
+
+namespace rgw::quota {
+
+static std::atomic<ScUsageStatsProvider*> g_sc_stats_provider{nullptr};
+
+void set_sc_stats_provider(ScUsageStatsProvider* p) {
+  g_sc_stats_provider.store(p, std::memory_order_release);
+}
+
+ScUsageStatsProvider* get_sc_stats_provider() {
+  return g_sc_stats_provider.load(std::memory_order_acquire);
+}
+
+namespace {
+
+inline bool would_exceed(int64_t limit, uint64_t current, uint64_t delta) {
+  
+  if (delta > 0 && current > std::numeric_limits<uint64_t>::max() - delta) {
+    return true;  // overflow -> definitely over quota
+  }
+  return (current + delta) > static_cast<uint64_t>(limit);
+}
+
+/*
+ * Combine the bucket and user SC quotas for a given key into "the
+ * effective limit this op must satisfy".
+ *
+ * The semantics intentionally mirror the existing global-quota path
+ * (bucket->check_quota): if both a bucket-level and user-level limit
+ * apply, the tighter one wins.  When only one side has a quota, that
+ * one is used directly.
+ */
+struct EffectiveScQuota {
+  bool      have_size_limit   = false;
+  bool      have_object_limit = false;
+  int64_t   max_size          = -1;
+  int64_t   max_objects       = -1;
+};
+
+EffectiveScQuota combine(const RGWStorageClassQuota* bq,
+                         const RGWStorageClassQuota* uq) {
+  EffectiveScQuota out;
+  auto fold = [&](const RGWStorageClassQuota* q) {
+    if (!q || !q->enabled) return;
+    if (q->max_size >= 0) {
+      if (!out.have_size_limit || q->max_size < out.max_size) {
+        out.max_size = q->max_size;
+      }
+      out.have_size_limit = true;
+    }
+    if (q->max_objects >= 0) {
+      if (!out.have_object_limit || q->max_objects < out.max_objects) {
+        out.max_objects = q->max_objects;
+      }
+      out.have_object_limit = true;
+    }
+  };
+  fold(bq);
+  fold(uq);
+  return out;
+}
+
+inline bool sc_enforcement_active(const RGWQuotaInfo& q) {
+  switch (q.enforcement_mode) {
+    case RGWQuotaEnforcementMode::STORAGE_CLASS:
+    case RGWQuotaEnforcementMode::HYBRID:
+      return q.has_any_sc_quota();
+    case RGWQuotaEnforcementMode::LEGACY:
+    case RGWQuotaEnforcementMode::GLOBAL_ONLY:
+      return false;
+  }
+  return false;
+}
+
+} // anonymous namespace
+
+int rgw_check_storage_class_quota(const DoutPrefixProvider* dpp,
+                                  const RGWQuota& quota,
+                                  const rgw_bucket& bucket,
+                                  const rgw_placement_rule& placement,
+                                  uint64_t new_size,
+                                  uint64_t new_objects,
+                                  optional_yield y) {
+
+  const bool bucket_active = sc_enforcement_active(quota.bucket_quota);
+  const bool user_active   = sc_enforcement_active(quota.user_quota);
+  if (!bucket_active && !user_active) {
+    return 0;
+  }
+
+  /* Compose the lookup key.  See rgw_sc_quota_key() for the format
+   * rationale ("placement::storage_class"). */
+  const std::string sc_key = rgw_sc_quota_key(placement);
+
+  /* Find the per-SC limit on each side. */
+  const RGWStorageClassQuota* bq =
+    bucket_active ? quota.bucket_quota.get_sc_quota(sc_key) : nullptr;
+  const RGWStorageClassQuota* uq =
+    user_active   ? quota.user_quota.get_sc_quota(sc_key)   : nullptr;
+
+  if ((!bq || !bq->enabled) && (!uq || !uq->enabled)) {
+    return 0;
+  }
+
+  const EffectiveScQuota lim = combine(bq, uq);
+  if (!lim.have_size_limit && !lim.have_object_limit) {
+    /* Both sides set enabled=true but neither set an actual limit
+     * (max_size=-1 and max_objects=-1).  Treat as "no constraint". */
+    return 0;
+  }
+
+  ScUsageStatsProvider* provider = get_sc_stats_provider();
+  if (!provider) {
+    ldpp_dout(dpp, 20)
+      << "sc-quota: no stats provider installed; failing open for sc_key="
+      << sc_key << dendl;
+    return 0;
+  }
+
+  const std::optional<ScUsageStats> usage = provider->lookup(bucket, sc_key);
+  if (!usage) {
+    ldpp_dout(dpp, 20)
+      << "sc-quota: no cached stats for sc_key=" << sc_key
+      << " bucket=" << bucket << "; failing open" << dendl;
+    return 0;
+  }
+
+  if (lim.have_size_limit &&
+      would_exceed(lim.max_size, usage->size, new_size)) {
+    ldpp_dout(dpp, 5)
+      << "sc-quota: size limit exceeded for sc_key=" << sc_key
+      << " bucket=" << bucket
+      << " current=" << usage->size
+      << " delta=" << new_size
+      << " limit=" << lim.max_size
+      << dendl;
+    return -EDQUOT;
+  }
+
+  if (lim.have_object_limit &&
+      would_exceed(lim.max_objects, usage->num_objects, new_objects)) {
+    ldpp_dout(dpp, 5)
+      << "sc-quota: object-count limit exceeded for sc_key=" << sc_key
+      << " bucket=" << bucket
+      << " current=" << usage->num_objects
+      << " delta=" << new_objects
+      << " limit=" << lim.max_objects
+      << dendl;
+    return -EDQUOT;
+  }
+
+  ldpp_dout(dpp, 25)
+    << "sc-quota: ok sc_key=" << sc_key
+    << " size " << usage->size << "+" << new_size
+    << "<=" << (lim.have_size_limit ? lim.max_size : -1)
+    << " objs " << usage->num_objects << "+" << new_objects
+    << "<=" << (lim.have_object_limit ? lim.max_objects : -1)
+    << dendl;
+  return 0;
+}
+
+} // namespace rgw::quota

--- a/src/rgw/rgw_sc_quota_checker.cc
+++ b/src/rgw/rgw_sc_quota_checker.cc
@@ -13,57 +13,32 @@
  */
 
 #include "rgw_sc_quota_checker.h"
-
-#include <atomic>
-#include <cerrno>
 #include <limits>
-
-#include "common/dout.h"
-#include "rgw_common.h"     // rgw_bucket, ldpp_dout
-#include "rgw_bucket_layout.h"
-
-#define dout_subsys ceph_subsys_rgw
 
 namespace rgw::quota {
 
-static std::atomic<ScUsageStatsProvider*> g_sc_stats_provider{nullptr};
-
-void set_sc_stats_provider(ScUsageStatsProvider* p) {
-  g_sc_stats_provider.store(p, std::memory_order_release);
-}
-
-ScUsageStatsProvider* get_sc_stats_provider() {
-  return g_sc_stats_provider.load(std::memory_order_acquire);
-}
-
-namespace {
-
-inline bool would_exceed(int64_t limit, uint64_t current, uint64_t delta) {
-  
+bool sc_quota_would_exceed(int64_t limit, uint64_t current, uint64_t delta) {
+  if (limit < 0) return false;  // unlimited
   if (delta > 0 && current > std::numeric_limits<uint64_t>::max() - delta) {
-    return true;  // overflow -> definitely over quota
+    return true;  // overflow
   }
   return (current + delta) > static_cast<uint64_t>(limit);
 }
 
-/*
- * Combine the bucket and user SC quotas for a given key into "the
- * effective limit this op must satisfy".
- *
- * The semantics intentionally mirror the existing global-quota path
- * (bucket->check_quota): if both a bucket-level and user-level limit
- * apply, the tighter one wins.  When only one side has a quota, that
- * one is used directly.
- */
-struct EffectiveScQuota {
-  bool      have_size_limit   = false;
-  bool      have_object_limit = false;
-  int64_t   max_size          = -1;
-  int64_t   max_objects       = -1;
-};
+bool sc_enforcement_active(const RGWQuotaInfo& q) {
+  switch (q.enforcement_mode) {
+    case RGWQuotaEnforcementMode::STORAGE_CLASS:
+    case RGWQuotaEnforcementMode::HYBRID:
+      return q.has_any_sc_quota();
+    case RGWQuotaEnforcementMode::LEGACY:
+    case RGWQuotaEnforcementMode::GLOBAL_ONLY:
+      return false;
+  }
+  return false;
+}
 
-EffectiveScQuota combine(const RGWStorageClassQuota* bq,
-                         const RGWStorageClassQuota* uq) {
+EffectiveScQuota combine_sc_quota(const RGWStorageClassQuota* bq,
+                                   const RGWStorageClassQuota* uq) {
   EffectiveScQuota out;
   auto fold = [&](const RGWStorageClassQuota* q) {
     if (!q || !q->enabled) return;
@@ -83,137 +58,6 @@ EffectiveScQuota combine(const RGWStorageClassQuota* bq,
   fold(bq);
   fold(uq);
   return out;
-}
-
-inline bool sc_enforcement_active(const RGWQuotaInfo& q) {
-  switch (q.enforcement_mode) {
-    case RGWQuotaEnforcementMode::STORAGE_CLASS:
-    case RGWQuotaEnforcementMode::HYBRID:
-      return q.has_any_sc_quota();
-    case RGWQuotaEnforcementMode::LEGACY:
-    case RGWQuotaEnforcementMode::GLOBAL_ONLY:
-      return false;
-  }
-  return false;
-}
-
-} // anonymous namespace
-
-int rgw_check_storage_class_quota(const DoutPrefixProvider* dpp,
-                                  rgw::sal::Driver* driver, 
-                                  const RGWQuota& quota,
-                                  const rgw_bucket& bucket,
-                                  const rgw_placement_rule& placement,
-                                  uint64_t new_size,
-                                  uint64_t new_objects,
-                                  optional_yield y) {
-  
-  const bool bucket_active = sc_enforcement_active(quota.bucket_quota);
-  const bool user_active   = sc_enforcement_active(quota.user_quota);
-  if (!bucket_active && !user_active) {
-    return 0;
-  }
-
-  /* Compose the lookup key.  See rgw_sc_quota_key() for the format
-   * rationale ("placement::storage_class"). */
-  const std::string sc_key = rgw_sc_quota_key(placement);
-
-  /* Find the per-SC limit on each side. */
-  const RGWStorageClassQuota* bq =
-    bucket_active ? quota.bucket_quota.get_sc_quota(sc_key) : nullptr;
-  const RGWStorageClassQuota* uq =
-    user_active   ? quota.user_quota.get_sc_quota(sc_key)   : nullptr;
-
-  if ((!bq || !bq->enabled) && (!uq || !uq->enabled)) {
-    return 0;
-  }
-
-  const EffectiveScQuota lim = combine(bq, uq);
-  if (!lim.have_size_limit && !lim.have_object_limit) {
-    /* Both sides set enabled=true but neither set an actual limit
-     * (max_size=-1 and max_objects=-1).  Treat as "no constraint". */
-    return 0;
-  }
-
-  // Get current usage 
-  ScUsageStats usage{0, 0};
-
-  ScUsageStatsProvider* provider = get_sc_stats_provider();
-  if (provider) {
-    // Fast path: obs cache registered
-    auto cached = provider->lookup(bucket, sc_key);
-    if (!cached) {
-      ldpp_dout(dpp, 20) << "sc-quota: no cached stats for sc_key="
-                         << sc_key << " failing open" << dendl;
-      return 0;
-    }
-    usage = *cached;
-  } else {
-    // Fallback: read directly from Pedro's bucket index (PR #66501)
-    std::unique_ptr<rgw::sal::Bucket> bkt;
-    int r = driver->load_bucket(dpp, bucket, &bkt, y);
-    if (r < 0) {
-      return 0;
-    }
-
-    std::map<RGWObjCategory, RGWStorageStats> cat_stats;
-    std::optional<std::map<std::string, RGWStorageStats>> sc_stats;
-    sc_stats.emplace(); // must pre-initialize for accumulate_raw_stats to populate it
-    std::string bver, mver;
-    const auto& idx_layout = bkt->get_info().layout.current_index;
-
-    r = bkt->read_stats(dpp, y, idx_layout, -1, &bver, &mver, cat_stats, sc_stats);
-    if (r < 0) {
-      return 0;
-    }
-    if (!sc_stats.has_value()) {
-      return 0;
-    }
-
-    // Log all keys Pedro's stats actually contain
-    for (const auto& [k, v] : *sc_stats) {
-    }
-
-    // read_stats keys stats by SC name only ("STANDARD"),
-    // not the composite quota key ("default-placement::STANDARD").
-    // Extract just the SC name for the lookup.
-    std::string sc_name_for_lookup = sc_key;
-    auto sep_pos = sc_key.rfind("::");
-    if (sep_pos != std::string::npos) {
-      sc_name_for_lookup = sc_key.substr(sep_pos + 2);
-    }
-    auto it = sc_stats->find(sc_name_for_lookup);
-    if (it != sc_stats->end()) {
-      usage.size        = it->second.size;
-      usage.num_objects = it->second.num_objects;
-    }
-  }
-
-  // Enforce 
-  if (lim.have_size_limit &&
-    would_exceed(lim.max_size, usage.size, new_size)) {
-    ldpp_dout(dpp, 5) << "sc-quota: size exceeded sc_key=" << sc_key
-                      << " current=" << usage.size
-                      << " delta=" << new_size
-                      << " limit=" << lim.max_size << dendl;
-    return -EDQUOT;
-  }
-
-  if (lim.have_object_limit &&
-    would_exceed(lim.max_objects, usage.num_objects, new_objects)) {
-    ldpp_dout(dpp, 5) << "sc-quota: object count exceeded sc_key=" << sc_key
-                      << " current=" << usage.num_objects
-                      << " delta=" << new_objects
-                      << " limit=" << lim.max_objects << dendl;
-    return -EDQUOT;
-  }
-
-  ldpp_dout(dpp, 25) << "sc-quota: ok sc_key=" << sc_key
-                     << " size=" << usage.size << "+" << new_size
-                     << "<=" << lim.max_size
-                     << " objs=" << usage.num_objects << "+" << new_objects
-                     << dendl;
-  return 0;
 }
 
 } // namespace rgw::quota

--- a/src/rgw/rgw_sc_quota_checker.cc
+++ b/src/rgw/rgw_sc_quota_checker.cc
@@ -20,6 +20,7 @@
 
 #include "common/dout.h"
 #include "rgw_common.h"     // rgw_bucket, ldpp_dout
+#include "rgw_bucket_layout.h"
 
 #define dout_subsys ceph_subsys_rgw
 
@@ -99,13 +100,14 @@ inline bool sc_enforcement_active(const RGWQuotaInfo& q) {
 } // anonymous namespace
 
 int rgw_check_storage_class_quota(const DoutPrefixProvider* dpp,
+                                  rgw::sal::Driver* driver, 
                                   const RGWQuota& quota,
                                   const rgw_bucket& bucket,
                                   const rgw_placement_rule& placement,
                                   uint64_t new_size,
                                   uint64_t new_objects,
                                   optional_yield y) {
-
+  
   const bool bucket_active = sc_enforcement_active(quota.bucket_quota);
   const bool user_active   = sc_enforcement_active(quota.user_quota);
   if (!bucket_active && !user_active) {
@@ -133,53 +135,84 @@ int rgw_check_storage_class_quota(const DoutPrefixProvider* dpp,
     return 0;
   }
 
+  // Get current usage 
+  ScUsageStats usage{0, 0};
+
   ScUsageStatsProvider* provider = get_sc_stats_provider();
-  if (!provider) {
-    ldpp_dout(dpp, 20)
-      << "sc-quota: no stats provider installed; failing open for sc_key="
-      << sc_key << dendl;
-    return 0;
+  if (provider) {
+    // Fast path: obs cache registered
+    auto cached = provider->lookup(bucket, sc_key);
+    if (!cached) {
+      ldpp_dout(dpp, 20) << "sc-quota: no cached stats for sc_key="
+                         << sc_key << " failing open" << dendl;
+      return 0;
+    }
+    usage = *cached;
+  } else {
+    // Fallback: read directly from Pedro's bucket index (PR #66501)
+    std::unique_ptr<rgw::sal::Bucket> bkt;
+    int r = driver->load_bucket(dpp, bucket, &bkt, y);
+    if (r < 0) {
+      return 0;
+    }
+
+    std::map<RGWObjCategory, RGWStorageStats> cat_stats;
+    std::optional<std::map<std::string, RGWStorageStats>> sc_stats;
+    sc_stats.emplace(); // must pre-initialize for accumulate_raw_stats to populate it
+    std::string bver, mver;
+    const auto& idx_layout = bkt->get_info().layout.current_index;
+
+    r = bkt->read_stats(dpp, y, idx_layout, -1, &bver, &mver, cat_stats, sc_stats);
+    if (r < 0) {
+      return 0;
+    }
+    if (!sc_stats.has_value()) {
+      return 0;
+    }
+
+    // Log all keys Pedro's stats actually contain
+    for (const auto& [k, v] : *sc_stats) {
+    }
+
+    // read_stats keys stats by SC name only ("STANDARD"),
+    // not the composite quota key ("default-placement::STANDARD").
+    // Extract just the SC name for the lookup.
+    std::string sc_name_for_lookup = sc_key;
+    auto sep_pos = sc_key.rfind("::");
+    if (sep_pos != std::string::npos) {
+      sc_name_for_lookup = sc_key.substr(sep_pos + 2);
+    }
+    auto it = sc_stats->find(sc_name_for_lookup);
+    if (it != sc_stats->end()) {
+      usage.size        = it->second.size;
+      usage.num_objects = it->second.num_objects;
+    }
   }
 
-  const std::optional<ScUsageStats> usage = provider->lookup(bucket, sc_key);
-  if (!usage) {
-    ldpp_dout(dpp, 20)
-      << "sc-quota: no cached stats for sc_key=" << sc_key
-      << " bucket=" << bucket << "; failing open" << dendl;
-    return 0;
-  }
-
+  // Enforce 
   if (lim.have_size_limit &&
-      would_exceed(lim.max_size, usage->size, new_size)) {
-    ldpp_dout(dpp, 5)
-      << "sc-quota: size limit exceeded for sc_key=" << sc_key
-      << " bucket=" << bucket
-      << " current=" << usage->size
-      << " delta=" << new_size
-      << " limit=" << lim.max_size
-      << dendl;
+    would_exceed(lim.max_size, usage.size, new_size)) {
+    ldpp_dout(dpp, 5) << "sc-quota: size exceeded sc_key=" << sc_key
+                      << " current=" << usage.size
+                      << " delta=" << new_size
+                      << " limit=" << lim.max_size << dendl;
     return -EDQUOT;
   }
 
   if (lim.have_object_limit &&
-      would_exceed(lim.max_objects, usage->num_objects, new_objects)) {
-    ldpp_dout(dpp, 5)
-      << "sc-quota: object-count limit exceeded for sc_key=" << sc_key
-      << " bucket=" << bucket
-      << " current=" << usage->num_objects
-      << " delta=" << new_objects
-      << " limit=" << lim.max_objects
-      << dendl;
+    would_exceed(lim.max_objects, usage.num_objects, new_objects)) {
+    ldpp_dout(dpp, 5) << "sc-quota: object count exceeded sc_key=" << sc_key
+                      << " current=" << usage.num_objects
+                      << " delta=" << new_objects
+                      << " limit=" << lim.max_objects << dendl;
     return -EDQUOT;
   }
 
-  ldpp_dout(dpp, 25)
-    << "sc-quota: ok sc_key=" << sc_key
-    << " size " << usage->size << "+" << new_size
-    << "<=" << (lim.have_size_limit ? lim.max_size : -1)
-    << " objs " << usage->num_objects << "+" << new_objects
-    << "<=" << (lim.have_object_limit ? lim.max_objects : -1)
-    << dendl;
+  ldpp_dout(dpp, 25) << "sc-quota: ok sc_key=" << sc_key
+                     << " size=" << usage.size << "+" << new_size
+                     << "<=" << lim.max_size
+                     << " objs=" << usage.num_objects << "+" << new_objects
+                     << dendl;
   return 0;
 }
 

--- a/src/rgw/rgw_sc_quota_checker.h
+++ b/src/rgw/rgw_sc_quota_checker.h
@@ -1,0 +1,100 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Per-storage-class quota enforcement engine.
+ *
+ * This is the layer that turns the configured RGWStorageClassQuota values
+ * (in RGWQuotaInfo) into accept/reject decisions on the write path.  It is
+ * deliberately separated from rgw_quota.{h,cc} because:
+ *
+ *   1. The legacy quota path (RGWQuotaHandler) is tightly coupled to RADOS;
+ *      our checker must be usable from any SAL backend.
+ *   2. The legacy path owns its own cache.  We do NOT want a second cache
+ *      for SC stats -- we read from the observability cache (PR #66109).
+ *   3. Mixing the two would force PR #66109 and Pedro's per-SC stats PR
+ *      (#66501) into one giant patch series.  Splitting them keeps each
+ *      reviewable on its own merits.
+ *
+ * The checker exposes a single hot-path function -- rgw_check_storage_class_quota
+ * -- plus a tiny stats-provider interface that lets the obs-cache PR plug
+ * itself in without us taking a build-time dependency on it.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include "common/async/yield_context.h"
+#include "common/dout.h"
+
+#include "rgw_quota_types.h"      // RGWQuotaInfo, RGWQuota
+#include "rgw_sc_quota_types.h"   // RGWStorageClassQuota, rgw_sc_quota_key
+#include "rgw_placement_types.h"  // rgw_placement_rule
+
+struct rgw_bucket;
+
+namespace rgw::quota {
+
+
+struct ScUsageStats {
+  uint64_t size        = 0;  // total bytes currently stored in this SC
+  uint64_t num_objects = 0;  // total object count in this SC
+};
+
+class ScUsageStatsProvider {
+ public:
+  virtual ~ScUsageStatsProvider() = default;
+
+ 
+  virtual std::optional<ScUsageStats> lookup(
+      const rgw_bucket& bucket,
+      const std::string& sc_key) const = 0;
+};
+
+void set_sc_stats_provider(ScUsageStatsProvider* p);
+ScUsageStatsProvider* get_sc_stats_provider();
+
+/*
+ * The hot-path entry point.
+ *
+ * Called from rgw_op.cc on every write that could touch a quota-managed
+ * storage class.  Returns:
+ *
+ *   0           : write is allowed (either no SC quota applies, or
+ *                 it applies and there is sufficient headroom).
+ *   -EDQUOT     : write would exceed a configured SC quota.  rgw_op.cc
+ *                 already translates -EDQUOT into S3 QuotaExceeded.
+ *   other < 0   : unrecoverable internal error.  In practice we never
+ *                 return such a code: any internal error path falls
+ *                 through to "fail open" and returns 0.
+ *
+ * Arguments:
+ *   quota       : the aggregated (bucket + user) RGWQuota for this op,
+ *                 as already built by get_quota_info() in rgw_op.cc.
+ *   bucket      : the destination bucket.  
+ *   placement   : the destination placement rule (name + storage_class).
+ *                 Already filled in by rgw_build_object_placement() for
+ *                 every write-path op before we get here.
+ *   new_size    : bytes about to be added by this op.  For multipart it
+ *                 is the sum of part sizes.
+ *   new_objects : object count about to be added (almost always 1).           
+ */
+int rgw_check_storage_class_quota(const DoutPrefixProvider* dpp,
+                                  const RGWQuota& quota,
+                                  const rgw_bucket& bucket,
+                                  const rgw_placement_rule& placement,
+                                  uint64_t new_size,
+                                  uint64_t new_objects,
+                                  optional_yield y);
+
+} // namespace rgw::quota

--- a/src/rgw/rgw_sc_quota_checker.h
+++ b/src/rgw/rgw_sc_quota_checker.h
@@ -40,6 +40,7 @@
 #include "rgw_quota_types.h"      // RGWQuotaInfo, RGWQuota
 #include "rgw_sc_quota_types.h"   // RGWStorageClassQuota, rgw_sc_quota_key
 #include "rgw_placement_types.h"  // rgw_placement_rule
+#include "rgw_sal.h"
 
 struct rgw_bucket;
 
@@ -90,6 +91,7 @@ ScUsageStatsProvider* get_sc_stats_provider();
  *   new_objects : object count about to be added (almost always 1).           
  */
 int rgw_check_storage_class_quota(const DoutPrefixProvider* dpp,
+                                  rgw::sal::Driver* driver, 
                                   const RGWQuota& quota,
                                   const rgw_bucket& bucket,
                                   const rgw_placement_rule& placement,

--- a/src/rgw/rgw_sc_quota_checker.h
+++ b/src/rgw/rgw_sc_quota_checker.h
@@ -10,22 +10,6 @@
  * (in RGWQuotaInfo) into accept/reject decisions on the write path.  It is
  * deliberately separated from rgw_quota.{h,cc} because:
  *
- *   1. The legacy quota path (RGWQuotaHandler) is tightly coupled to RADOS;
- *      our checker must be usable from any SAL backend.
- *   2. The legacy path owns its own cache.  We do NOT want a second cache
- *      for SC stats -- we read from the observability cache (PR #66109).
- *   3. Mixing the two would force PR #66109 and Pedro's per-SC stats PR
- *      (#66501) into one giant patch series.  Splitting them keeps each
- *      reviewable on its own merits.
- *
- * The checker exposes a single hot-path function -- rgw_check_storage_class_quota
- * -- plus a tiny stats-provider interface that lets the obs-cache PR plug
- * itself in without us taking a build-time dependency on it.
- *
- * This is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software
- * Foundation.  See file COPYING.
  */
 
 #pragma once
@@ -34,69 +18,33 @@
 #include <optional>
 #include <string>
 
-#include "common/async/yield_context.h"
 #include "common/dout.h"
 
 #include "rgw_quota_types.h"      // RGWQuotaInfo, RGWQuota
 #include "rgw_sc_quota_types.h"   // RGWStorageClassQuota, rgw_sc_quota_key
 #include "rgw_placement_types.h"  // rgw_placement_rule
-#include "rgw_sal.h"
-
-struct rgw_bucket;
 
 namespace rgw::quota {
 
-
+// Current usage for one storage class, as read from RGWStorageStats.
 struct ScUsageStats {
-  uint64_t size        = 0;  // total bytes currently stored in this SC
-  uint64_t num_objects = 0;  // total object count in this SC
+  uint64_t size = 0;
+  uint64_t num_objects = 0;
 };
 
-class ScUsageStatsProvider {
- public:
-  virtual ~ScUsageStatsProvider() = default;
-
- 
-  virtual std::optional<ScUsageStats> lookup(
-      const rgw_bucket& bucket,
-      const std::string& sc_key) const = 0;
+// The effective (tighter) limit when both bucket and user quotas apply.
+struct EffectiveScQuota {
+  bool have_size_limit = false;
+  bool have_object_limit = false;
+  int64_t max_size = -1;
+  int64_t max_objects = -1;
 };
 
-void set_sc_stats_provider(ScUsageStatsProvider* p);
-ScUsageStatsProvider* get_sc_stats_provider();
+bool sc_enforcement_active(const RGWQuotaInfo& q);
 
-/*
- * The hot-path entry point.
- *
- * Called from rgw_op.cc on every write that could touch a quota-managed
- * storage class.  Returns:
- *
- *   0           : write is allowed (either no SC quota applies, or
- *                 it applies and there is sufficient headroom).
- *   -EDQUOT     : write would exceed a configured SC quota.  rgw_op.cc
- *                 already translates -EDQUOT into S3 QuotaExceeded.
- *   other < 0   : unrecoverable internal error.  In practice we never
- *                 return such a code: any internal error path falls
- *                 through to "fail open" and returns 0.
- *
- * Arguments:
- *   quota       : the aggregated (bucket + user) RGWQuota for this op,
- *                 as already built by get_quota_info() in rgw_op.cc.
- *   bucket      : the destination bucket.  
- *   placement   : the destination placement rule (name + storage_class).
- *                 Already filled in by rgw_build_object_placement() for
- *                 every write-path op before we get here.
- *   new_size    : bytes about to be added by this op.  For multipart it
- *                 is the sum of part sizes.
- *   new_objects : object count about to be added (almost always 1).           
- */
-int rgw_check_storage_class_quota(const DoutPrefixProvider* dpp,
-                                  rgw::sal::Driver* driver, 
-                                  const RGWQuota& quota,
-                                  const rgw_bucket& bucket,
-                                  const rgw_placement_rule& placement,
-                                  uint64_t new_size,
-                                  uint64_t new_objects,
-                                  optional_yield y);
+EffectiveScQuota combine_sc_quota(const RGWStorageClassQuota* bq,
+                                   const RGWStorageClassQuota* uq);
+
+bool sc_quota_would_exceed(int64_t limit, uint64_t current, uint64_t delta);
 
 } // namespace rgw::quota

--- a/src/rgw/rgw_sc_quota_types.h
+++ b/src/rgw/rgw_sc_quota_types.h
@@ -1,0 +1,156 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Per-storage-class quota types.
+ *
+ * This header defines the fundamental serialized types that extend
+ * RGWQuotaInfo with a per-storage-class breakdown.  It is intentionally
+ * minimal and free of radosgw / OSD-context includes so that it can be
+ * pulled in from headers shared with the OSD-side bucket index code.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <string>
+
+#include "include/encoding.h"
+#include "rgw_placement_types.h"
+
+class JSONObj;
+namespace ceph { class Formatter; }
+
+/*
+ * RGWStorageClassQuota
+ *
+ * Holds a single per-storage-class quota limit.  An instance lives inside
+ * RGWQuotaInfo's storage_class_quotas map, keyed by
+ *   rgw_sc_quota_key(placement, storage_class).
+ *
+ * Field semantics intentionally mirror RGWQuotaInfo so that callers can
+ * reason about them identically:
+ *   max_size    : maximum total bytes allowed in this storage class.
+ *                 A value < 0 means "unlimited".
+ *   max_objects : maximum total object count.  < 0 means "unlimited".
+ *   enabled     : if false, the quota is configured but not enforced.
+ *                
+ */
+struct RGWStorageClassQuota {
+  int64_t max_size    = -1;
+  int64_t max_objects = -1;
+  bool    enabled     = false;
+
+  RGWStorageClassQuota() = default;
+  RGWStorageClassQuota(int64_t sz, int64_t objs, bool en)
+    : max_size(sz), max_objects(objs), enabled(en) {}
+
+  bool has_size_limit()    const { return enabled && max_size    >= 0; }
+  bool has_object_limit()  const { return enabled && max_objects >= 0; }
+  bool is_active()         const { return enabled && (max_size >= 0 || max_objects >= 0); }
+
+  void encode(ceph::buffer::list& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(max_size,    bl);
+    encode(max_objects, bl);
+    encode(enabled,     bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(ceph::buffer::list::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(max_size,    bl);
+    decode(max_objects, bl);
+    decode(enabled,     bl);
+    DECODE_FINISH(bl);
+  }
+
+  void dump(ceph::Formatter *f) const;
+  void decode_json(JSONObj *obj);
+};
+WRITE_CLASS_ENCODER(RGWStorageClassQuota)
+
+/*
+ * RGWQuotaEnforcementMode
+ *
+ * Controls which quota dimensions are evaluated on the write path.
+ *
+ *   LEGACY        : Behaves exactly like pre-feature RGW: only the global
+ *                   bucket/user quotas are checked.  This is the value
+ *                   produced when an old (v3) RGWQuotaInfo blob is decoded,
+ *                   so existing buckets get the legacy semantics by default.
+ *   GLOBAL_ONLY   : Same as LEGACY semantically, but set explicitly by the
+ *                   admin (so the value survives re-encoding without being
+ *                   reinterpreted).
+ *   STORAGE_CLASS : Only per-storage-class quotas are enforced; the global
+ *                   bucket/user quota fields are ignored.  Useful for tier
+ *                   workloads where the global limit would just be the sum
+ *                   of the per-class limits anyway.
+ *   HYBRID        : Both global AND per-storage-class quotas are enforced.
+ *                   A write must satisfy every applicable limit.  This is
+ *                   the mode automatically set by `radosgw-admin quota set`
+ *                   when --placement-target/--storage-class are provided.
+ *
+ * The enum is encoded as uint8_t so its on-wire footprint is one byte.
+ */
+enum class RGWQuotaEnforcementMode : uint8_t {
+  LEGACY        = 0,
+  GLOBAL_ONLY   = 1,
+  STORAGE_CLASS = 2,
+  HYBRID        = 3,
+};
+
+inline const char* to_string(RGWQuotaEnforcementMode m) {
+  switch (m) {
+    case RGWQuotaEnforcementMode::LEGACY:        return "legacy";
+    case RGWQuotaEnforcementMode::GLOBAL_ONLY:   return "global_only";
+    case RGWQuotaEnforcementMode::STORAGE_CLASS: return "storage_class";
+    case RGWQuotaEnforcementMode::HYBRID:        return "hybrid";
+  }
+  return "unknown";
+}
+
+inline bool parse_quota_enforcement_mode(const std::string& s,
+                                         RGWQuotaEnforcementMode& out) {
+  if      (s == "legacy")        { out = RGWQuotaEnforcementMode::LEGACY;        return true; }
+  else if (s == "global_only" ||
+           s == "global")        { out = RGWQuotaEnforcementMode::GLOBAL_ONLY;   return true; }
+  else if (s == "storage_class" ||
+           s == "sc")            { out = RGWQuotaEnforcementMode::STORAGE_CLASS; return true; }
+  else if (s == "hybrid" ||
+           s == "both")          { out = RGWQuotaEnforcementMode::HYBRID;        return true; }
+  return false;
+}
+
+/*
+ * rgw_sc_quota_key
+ *
+ * Composite key used to index both the configured per-storage-class
+ *
+ * Format: "<placement-id>::<storage-class>"
+ *
+ * The "::" delimiter is chosen deliberately:
+ *   - Neither placement IDs nor S3 storage-class names use "::"
+ */
+inline std::string rgw_sc_quota_key(const std::string& placement_id,
+                                    const std::string& storage_class) {
+  const std::string& sc =
+    rgw_placement_rule::get_canonical_storage_class(storage_class);
+  return placement_id + "::" + sc;
+}
+
+inline std::string rgw_sc_quota_key(const rgw_placement_rule& rule) {
+  return rgw_sc_quota_key(rule.name, rule.storage_class);
+}
+
+/*
+ * RGWStorageClassQuotaMap
+ */
+using RGWStorageClassQuotaMap = std::map<std::string, RGWStorageClassQuota>;

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -15,7 +15,7 @@ using namespace std;
 
 int rgw_sync_all_stats(const DoutPrefixProvider *dpp,
                        optional_yield y, rgw::sal::Driver* driver,
-                       const rgw_owner& owner, const std::string& tenant)
+                       const rgw_owner& owner, bool reset, const std::string& tenant)
 {
   size_t max_entries = dpp->get_cct()->_conf->rgw_list_buckets_max_chunk;
 
@@ -36,7 +36,7 @@ int rgw_sync_all_stats(const DoutPrefixProvider *dpp,
         ldpp_dout(dpp, 0) << "ERROR: could not read bucket info: bucket=" << bucket << " ret=" << ret << dendl;
         continue;
       }
-      ret = bucket->sync_owner_stats(dpp, y, &ent);
+      ret = bucket->sync_owner_stats(dpp, y, reset, &ent);
       if (ret < 0) {
         ldpp_dout(dpp, 0) << "ERROR: could not sync bucket stats: ret=" << ret << dendl;
         return ret;

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -587,6 +587,17 @@ int RGWSI_BucketIndex_RADOS::read_stats(const DoutPrefixProvider *dpp,
       result->size += stats.total_size;
       result->size_rounded += stats.total_size_rounded;
     }
+    if (hiter->storage_class_stats.has_value()) {
+      for(auto it = hiter->storage_class_stats.value().begin(); it != hiter->storage_class_stats.value().end(); ++it){
+        std::string storage_class = it->first;
+        struct rgw_bucket_category_stats& stats = it->second;
+        result->storage_class_ents[storage_class].count += stats.num_entries;
+        result->storage_class_ents[storage_class].size += stats.total_size;
+        result->storage_class_ents[storage_class].size_rounded += stats.total_size_rounded;
+        result->storage_class_ents[storage_class].bucket = result->bucket;
+      }
+    }
+
   }
 
   result->placement_rule = std::move(bucket_info.placement_rule);

--- a/src/test/cls_rgw/test_cls_rgw.cc
+++ b/src/test/cls_rgw/test_cls_rgw.cc
@@ -1633,3 +1633,109 @@ TEST_F(cls_rgw, bi_put_entries)
     test_stats(ioctx, dst_bucket, RGWObjCategory::Main, 3, 24576);
   }
 }
+
+// ============================================================================
+// STORAGE CLASS STATS std::optional TESTS
+// ============================================================================
+
+// Helper function to write bucket header
+static int write_header(librados::IoCtx& ioctx, const string& oid,
+                        const rgw_bucket_dir_header& header)
+{
+  librados::ObjectWriteOperation op;
+  bufferlist bl;
+  encode(header, bl);
+  op.omap_set_header(bl);
+  return ioctx.operate(oid, &op);
+}
+
+TEST_F(cls_rgw, StorageClassStats_BasicInit) {
+  string oid = "bucket.index.basic";
+  
+  // Create header with storage_class_stats initialized
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  ASSERT_EQ(0, write_header(ioctx, oid, header));
+  
+  // Read it back
+  rgw_bucket_dir_header read_hdr;
+  ASSERT_EQ(0, read_header(ioctx, oid, read_hdr));
+  
+  ASSERT_TRUE(read_hdr.storage_class_stats.has_value());
+  ASSERT_TRUE(read_hdr.storage_class_stats->empty());
+}
+
+TEST_F(cls_rgw, StorageClassStats_LegacyToConverted) {
+  string oid = "bucket.index.legacy";
+  
+  // Start with nullopt (legacy bucket)
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::nullopt;
+  
+  ASSERT_EQ(0, write_header(ioctx, oid, header));
+  
+  // Verify it's nullopt
+  rgw_bucket_dir_header read_hdr;
+  ASSERT_EQ(0, read_header(ioctx, oid, read_hdr));
+  ASSERT_FALSE(read_hdr.storage_class_stats.has_value());
+  
+  // Now convert it to has_value
+  read_hdr.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  (*read_hdr.storage_class_stats)["STANDARD"].num_entries = 5;
+  (*read_hdr.storage_class_stats)["STANDARD"].total_size = 5120;
+  
+  ASSERT_EQ(0, write_header(ioctx, oid, read_hdr));
+  
+  // Verify converted
+  rgw_bucket_dir_header final_hdr;
+  ASSERT_EQ(0, read_header(ioctx, oid, final_hdr));
+  ASSERT_TRUE(final_hdr.storage_class_stats.has_value());
+  EXPECT_EQ((*final_hdr.storage_class_stats)["STANDARD"].num_entries, 5);
+}
+
+TEST_F(cls_rgw, StorageClassStats_MultipleClasses) {
+  string oid = "bucket.index.multi";
+  
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Add multiple storage classes
+  (*header.storage_class_stats)["STANDARD"].num_entries = 10;
+  (*header.storage_class_stats)["HDD"].num_entries = 20;
+  (*header.storage_class_stats)["GLACIER"].num_entries = 30;
+  
+  ASSERT_EQ(0, write_header(ioctx, oid, header));
+  
+  // Read back and verify
+  rgw_bucket_dir_header read_hdr;
+  ASSERT_EQ(0, read_header(ioctx, oid, read_hdr));
+  
+  ASSERT_TRUE(read_hdr.storage_class_stats.has_value());
+  EXPECT_EQ(read_hdr.storage_class_stats->size(), 3);
+  EXPECT_EQ((*read_hdr.storage_class_stats)["STANDARD"].num_entries, 10);
+  EXPECT_EQ((*read_hdr.storage_class_stats)["HDD"].num_entries, 20);
+  EXPECT_EQ((*read_hdr.storage_class_stats)["GLACIER"].num_entries, 30);
+}
+
+TEST_F(cls_rgw, StorageClassStats_ZeroAfterDelete) {
+  string oid = "bucket.index.zero";
+  
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Simulate deletion - entry exists but with zero values
+  (*header.storage_class_stats)["STANDARD"].num_entries = 0;
+  (*header.storage_class_stats)["STANDARD"].total_size = 0;
+  
+  ASSERT_EQ(0, write_header(ioctx, oid, header));
+  
+  // Verify entry persists with zero values
+  rgw_bucket_dir_header read_hdr;
+  ASSERT_EQ(0, read_header(ioctx, oid, read_hdr));
+  
+  ASSERT_TRUE(read_hdr.storage_class_stats.has_value());
+  EXPECT_TRUE(read_hdr.storage_class_stats->count("STANDARD") > 0);
+  EXPECT_EQ((*read_hdr.storage_class_stats)["STANDARD"].num_entries, 0);
+}
+

--- a/src/test/cls_rgw/test_cls_rgw.cc
+++ b/src/test/cls_rgw/test_cls_rgw.cc
@@ -1649,93 +1649,91 @@ static int write_header(librados::IoCtx& ioctx, const string& oid,
   return ioctx.operate(oid, &op);
 }
 
-TEST_F(cls_rgw, StorageClassStats_BasicInit) {
-  string oid = "bucket.index.basic";
-  
-  // Create header with storage_class_stats initialized
-  rgw_bucket_dir_header header;
-  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
-  
-  ASSERT_EQ(0, write_header(ioctx, oid, header));
-  
-  // Read it back
-  rgw_bucket_dir_header read_hdr;
-  ASSERT_EQ(0, read_header(ioctx, oid, read_hdr));
-  
-  ASSERT_TRUE(read_hdr.storage_class_stats.has_value());
-  ASSERT_TRUE(read_hdr.storage_class_stats->empty());
-}
-
 TEST_F(cls_rgw, StorageClassStats_LegacyToConverted) {
-  string oid = "bucket.index.legacy";
-  
-  // Start with nullopt (legacy bucket)
+  string oid = str_int("bucket-sc", 100);
+
+  ObjectWriteOperation init_op;
+  cls_rgw_bucket_init_index(init_op);
+  ASSERT_EQ(0, ioctx.operate(oid, &init_op));
+
+  // Simulate legacy bucket: clear storage_class_stats to nullopt
   rgw_bucket_dir_header header;
+  ASSERT_EQ(0, read_header(ioctx, oid, header));
   header.storage_class_stats = std::nullopt;
-  
   ASSERT_EQ(0, write_header(ioctx, oid, header));
-  
-  // Verify it's nullopt
-  rgw_bucket_dir_header read_hdr;
-  ASSERT_EQ(0, read_header(ioctx, oid, read_hdr));
-  ASSERT_FALSE(read_hdr.storage_class_stats.has_value());
-  
-  // Now convert it to has_value
-  read_hdr.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
-  (*read_hdr.storage_class_stats)["STANDARD"].num_entries = 5;
-  (*read_hdr.storage_class_stats)["STANDARD"].total_size = 5120;
-  
-  ASSERT_EQ(0, write_header(ioctx, oid, read_hdr));
-  
-  // Verify converted
-  rgw_bucket_dir_header final_hdr;
-  ASSERT_EQ(0, read_header(ioctx, oid, final_hdr));
-  ASSERT_TRUE(final_hdr.storage_class_stats.has_value());
-  EXPECT_EQ((*final_hdr.storage_class_stats)["STANDARD"].num_entries, 5);
+
+  // Confirm nullopt
+  ASSERT_EQ(0, read_header(ioctx, oid, header));
+  ASSERT_FALSE(header.storage_class_stats.has_value());
+
+  rgw_bucket_dir_entry_meta meta;
+  meta.size = 5120;
+  meta.storage_class = "STANDARD";
+  meta.category = RGWObjCategory::Main;
+  index_complete(ioctx, oid, CLS_RGW_OP_ADD, "tag1", 1,
+                 cls_rgw_obj_key("obj1"), meta);
+
+  // storage_class_stats must now be initialized by the write
+  ASSERT_EQ(0, read_header(ioctx, oid, header));
+  ASSERT_TRUE(header.storage_class_stats.has_value());
+  EXPECT_EQ((*header.storage_class_stats)["STANDARD"].num_entries, 1u);
+  EXPECT_EQ((*header.storage_class_stats)["STANDARD"].total_size, 5120u);
 }
 
-TEST_F(cls_rgw, StorageClassStats_MultipleClasses) {
-  string oid = "bucket.index.multi";
-  
+// nonzero stats + uninitialized storage_class_stats,
+// delete to zero, write with SC, verify storage_class_stats initialized
+TEST_F(cls_rgw, StorageClassStats_LegacyBucketConversion) {
+  string oid = str_int("bucket-sc", 101);
+
+  ObjectWriteOperation init_op;
+  cls_rgw_bucket_init_index(init_op);
+  ASSERT_EQ(0, ioctx.operate(oid, &init_op));
+
+  // Write 3 objects to get nonzero stats
+  for (int i = 0; i < 3; i++) {
+    rgw_bucket_dir_entry_meta meta;
+    meta.size = 1024;
+    meta.storage_class = "STANDARD";
+    meta.category = RGWObjCategory::Main;
+    index_complete(ioctx, oid, CLS_RGW_OP_ADD,
+                   str_int("tag", i), i + 1,
+                   cls_rgw_obj_key(str_int("obj", i)), meta);
+  }
+
+  // Verify nonzero stats, then clear storage_class_stats (legacy simulation)
   rgw_bucket_dir_header header;
-  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
-  
-  // Add multiple storage classes
-  (*header.storage_class_stats)["STANDARD"].num_entries = 10;
-  (*header.storage_class_stats)["HDD"].num_entries = 20;
-  (*header.storage_class_stats)["GLACIER"].num_entries = 30;
-  
+  ASSERT_EQ(0, read_header(ioctx, oid, header));
+  ASSERT_GT(header.stats[RGWObjCategory::Main].num_entries, 0u);
+  header.storage_class_stats = std::nullopt;
   ASSERT_EQ(0, write_header(ioctx, oid, header));
-  
-  // Read back and verify
-  rgw_bucket_dir_header read_hdr;
-  ASSERT_EQ(0, read_header(ioctx, oid, read_hdr));
-  
-  ASSERT_TRUE(read_hdr.storage_class_stats.has_value());
-  EXPECT_EQ(read_hdr.storage_class_stats->size(), 3);
-  EXPECT_EQ((*read_hdr.storage_class_stats)["STANDARD"].num_entries, 10);
-  EXPECT_EQ((*read_hdr.storage_class_stats)["HDD"].num_entries, 20);
-  EXPECT_EQ((*read_hdr.storage_class_stats)["GLACIER"].num_entries, 30);
-}
 
-TEST_F(cls_rgw, StorageClassStats_ZeroAfterDelete) {
-  string oid = "bucket.index.zero";
-  
-  rgw_bucket_dir_header header;
-  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
-  
-  // Simulate deletion - entry exists but with zero values
-  (*header.storage_class_stats)["STANDARD"].num_entries = 0;
-  (*header.storage_class_stats)["STANDARD"].total_size = 0;
-  
-  ASSERT_EQ(0, write_header(ioctx, oid, header));
-  
-  // Verify entry persists with zero values
-  rgw_bucket_dir_header read_hdr;
-  ASSERT_EQ(0, read_header(ioctx, oid, read_hdr));
-  
-  ASSERT_TRUE(read_hdr.storage_class_stats.has_value());
-  EXPECT_TRUE(read_hdr.storage_class_stats->count("STANDARD") > 0);
-  EXPECT_EQ((*read_hdr.storage_class_stats)["STANDARD"].num_entries, 0);
-}
+  // Confirm: nonzero stats, nullopt storage_class_stats
+  ASSERT_EQ(0, read_header(ioctx, oid, header));
+  ASSERT_FALSE(header.storage_class_stats.has_value());
+  ASSERT_EQ(header.stats[RGWObjCategory::Main].num_entries, 3u);
 
+  // Simulate deletes (decrement stats toward zero)
+  for (int i = 0; i < 3; i++) {
+    rgw_bucket_dir_entry_meta meta;
+    meta.size = 1024;
+    meta.storage_class = "STANDARD";
+    meta.category = RGWObjCategory::Main;
+    index_complete(ioctx, oid, CLS_RGW_OP_DEL,
+                   str_int("tag-del", i), i + 4,
+                   cls_rgw_obj_key(str_int("obj", i)), meta);
+  }
+
+  // Now write a new object with a storage class
+  rgw_bucket_dir_entry_meta new_meta;
+  new_meta.size = 2048;
+  new_meta.storage_class = "HDD";
+  new_meta.category = RGWObjCategory::Main;
+  index_complete(ioctx, oid, CLS_RGW_OP_ADD,
+                 "tag-new", 10, cls_rgw_obj_key("new-obj"), new_meta);
+
+  // storage_class_stats must be initialized by that write
+  ASSERT_EQ(0, read_header(ioctx, oid, header));
+  ASSERT_TRUE(header.storage_class_stats.has_value());
+  EXPECT_EQ((*header.storage_class_stats)["HDD"].num_entries, 1u);
+  EXPECT_EQ((*header.storage_class_stats)["HDD"].total_size, 2048u);
+}

--- a/src/test/cls_user/test_cls_user.cc
+++ b/src/test/cls_user/test_cls_user.cc
@@ -209,3 +209,139 @@ TEST_F(ClsAccount, list)
   ASSERT_EQ(0, add(oid, u5, false, max_users)); // overwrite u1
   EXPECT_EQ(make_list(u5, u3, u4), list_all(oid, ""));
 }
+
+// ============================================================================
+// USER STORAGE CLASS STATS std::optional TESTS
+// ============================================================================
+
+// Helper functions for user header operations
+static int write_user_header_test(librados::IoCtx& ioctx, const std::string& oid,
+                                   const cls_user_header& header)
+{
+  librados::ObjectWriteOperation op;
+  bufferlist bl;
+  encode(header, bl);
+  op.omap_set_header(bl);
+  return ioctx.operate(oid, &op);
+}
+
+static int read_user_header_test(librados::IoCtx& ioctx, const std::string& oid,
+                                  cls_user_header& header)
+{
+  librados::ObjectReadOperation op;
+  bufferlist bl;
+  int rc;
+  
+  op.omap_get_header(&bl, &rc);
+  
+  int ret = ioctx.operate(oid, &op, nullptr);
+  if (ret < 0) return ret;
+  if (rc < 0) return rc;
+  
+  if (bl.length() > 0) {
+    auto iter = bl.cbegin();
+    decode(header, iter);
+  }
+  
+  return 0;
+}
+
+// Create a test fixture for user storage class stats
+class ClsUserStorageClass : public ::testing::Test {
+  static librados::Rados rados;
+  static std::string pool_name;
+protected:
+  static librados::IoCtx ioctx;
+
+  static void SetUpTestCase() {
+    pool_name = get_temp_pool_name();
+    ASSERT_EQ("", create_one_pool_pp(pool_name, rados));
+    ASSERT_EQ(0, rados.ioctx_create(pool_name.c_str(), ioctx));
+  }
+  
+  static void TearDownTestCase() {
+    ioctx.close();
+    ASSERT_EQ(0, destroy_one_pool_pp(pool_name, rados));
+  }
+};
+
+librados::Rados ClsUserStorageClass::rados;
+std::string ClsUserStorageClass::pool_name;
+librados::IoCtx ClsUserStorageClass::ioctx;
+
+TEST_F(ClsUserStorageClass, BasicInit) {
+  std::string oid = "user.basic";
+  
+  cls_user_header header;
+  header.storage_class_stats = std::unordered_map<std::string, cls_user_stats>();
+  
+  ASSERT_EQ(0, write_user_header_test(ioctx, oid, header));
+  
+  cls_user_header read_hdr;
+  ASSERT_EQ(0, read_user_header_test(ioctx, oid, read_hdr));
+  
+  ASSERT_TRUE(read_hdr.storage_class_stats.has_value());
+  ASSERT_TRUE(read_hdr.storage_class_stats->empty());
+}
+
+TEST_F(ClsUserStorageClass, LegacyToConverted) {
+  std::string oid = "user.legacy";
+  
+  // Start with nullopt (legacy user)
+  cls_user_header header;
+  header.storage_class_stats = std::nullopt;
+  
+  ASSERT_EQ(0, write_user_header_test(ioctx, oid, header));
+  
+  // Verify nullopt
+  cls_user_header read_hdr;
+  ASSERT_EQ(0, read_user_header_test(ioctx, oid, read_hdr));
+  ASSERT_FALSE(read_hdr.storage_class_stats.has_value());
+  
+  // Convert to has_value
+  read_hdr.storage_class_stats = std::unordered_map<std::string, cls_user_stats>();
+  cls_user_stats stats;
+  stats.total_entries = 10;
+  stats.total_bytes = 10240;
+  stats.total_bytes_rounded = 10240;
+  (*read_hdr.storage_class_stats)["default::STANDARD"] = stats;
+  
+  ASSERT_EQ(0, write_user_header_test(ioctx, oid, read_hdr));
+  
+  // Verify converted
+  cls_user_header final_hdr;
+  ASSERT_EQ(0, read_user_header_test(ioctx, oid, final_hdr));
+  ASSERT_TRUE(final_hdr.storage_class_stats.has_value());
+  EXPECT_EQ((*final_hdr.storage_class_stats)["default::STANDARD"].total_entries, 10);
+}
+
+TEST_F(ClsUserStorageClass, MultipleClasses) {
+  std::string oid = "user.multi";
+  
+  cls_user_header header;
+  header.storage_class_stats = std::unordered_map<std::string, cls_user_stats>();
+  
+  cls_user_stats std_stats;
+  std_stats.total_entries = 100;
+  std_stats.total_bytes = 102400;
+  std_stats.total_bytes_rounded = 102400;
+  
+  cls_user_stats hdd_stats;
+  hdd_stats.total_entries = 200;
+  hdd_stats.total_bytes = 204800;
+  hdd_stats.total_bytes_rounded = 204800;
+  
+  (*header.storage_class_stats)["default::STANDARD"] = std_stats;
+  (*header.storage_class_stats)["default::HDD"] = hdd_stats;
+  
+  ASSERT_EQ(0, write_user_header_test(ioctx, oid, header));
+  
+  cls_user_header read_hdr;
+  ASSERT_EQ(0, read_user_header_test(ioctx, oid, read_hdr));
+  
+  ASSERT_TRUE(read_hdr.storage_class_stats.has_value());
+  EXPECT_EQ(read_hdr.storage_class_stats->size(), 2);
+  EXPECT_EQ((*read_hdr.storage_class_stats)["default::STANDARD"].total_entries, 100);
+  EXPECT_EQ((*read_hdr.storage_class_stats)["default::HDD"].total_entries, 200);
+}
+

--- a/src/test/cls_user/test_cls_user.cc
+++ b/src/test/cls_user/test_cls_user.cc
@@ -214,7 +214,6 @@ TEST_F(ClsAccount, list)
 // USER STORAGE CLASS STATS std::optional TESTS
 // ============================================================================
 
-// Helper functions for user header operations
 static int write_user_header_test(librados::IoCtx& ioctx, const std::string& oid,
                                    const cls_user_header& header)
 {
@@ -229,24 +228,10 @@ static int read_user_header_test(librados::IoCtx& ioctx, const std::string& oid,
                                   cls_user_header& header)
 {
   librados::ObjectReadOperation op;
-  bufferlist bl;
-  int rc;
-  
-  op.omap_get_header(&bl, &rc);
-  
-  int ret = ioctx.operate(oid, &op, nullptr);
-  if (ret < 0) return ret;
-  if (rc < 0) return rc;
-  
-  if (bl.length() > 0) {
-    auto iter = bl.cbegin();
-    decode(header, iter);
-  }
-  
-  return 0;
+  cls_user_get_header(op, &header, nullptr);
+  return ioctx.operate(oid, &op, nullptr);
 }
 
-// Create a test fixture for user storage class stats
 class ClsUserStorageClass : public ::testing::Test {
   static librados::Rados rados;
   static std::string pool_name;
@@ -258,7 +243,6 @@ protected:
     ASSERT_EQ("", create_one_pool_pp(pool_name, rados));
     ASSERT_EQ(0, rados.ioctx_create(pool_name.c_str(), ioctx));
   }
-  
   static void TearDownTestCase() {
     ioctx.close();
     ASSERT_EQ(0, destroy_one_pool_pp(pool_name, rados));
@@ -269,79 +253,148 @@ librados::Rados ClsUserStorageClass::rados;
 std::string ClsUserStorageClass::pool_name;
 librados::IoCtx ClsUserStorageClass::ioctx;
 
-TEST_F(ClsUserStorageClass, BasicInit) {
-  std::string oid = "user.basic";
-  
-  cls_user_header header;
-  header.storage_class_stats = std::unordered_map<std::string, cls_user_stats>();
-  
-  ASSERT_EQ(0, write_user_header_test(ioctx, oid, header));
-  
-  cls_user_header read_hdr;
-  ASSERT_EQ(0, read_user_header_test(ioctx, oid, read_hdr));
-  
-  ASSERT_TRUE(read_hdr.storage_class_stats.has_value());
-  ASSERT_TRUE(read_hdr.storage_class_stats->empty());
+// Helper: call cls_user_set_buckets() with a single bucket entry
+// This exercises cls_user.cc:cls_user_set_buckets_info()
+static void set_bucket(librados::IoCtx& ioctx, const std::string& oid,
+                       cls_user_bucket_entry& entry, bool add)
+{
+  std::list<cls_user_bucket_entry> entries = {entry};
+  librados::ObjectWriteOperation op;
+  cls_user_set_buckets(op, entries, add, false);
+  ASSERT_EQ(0, ioctx.operate(oid, &op));
 }
 
 TEST_F(ClsUserStorageClass, LegacyToConverted) {
-  std::string oid = "user.legacy";
-  
-  // Start with nullopt (legacy user)
+  std::string oid = "user.legacy-sc";
+
+  // Start with nullopt (legacy user header)
   cls_user_header header;
   header.storage_class_stats = std::nullopt;
-  
   ASSERT_EQ(0, write_user_header_test(ioctx, oid, header));
-  
-  // Verify nullopt
+
+  // Confirm nullopt
   cls_user_header read_hdr;
   ASSERT_EQ(0, read_user_header_test(ioctx, oid, read_hdr));
   ASSERT_FALSE(read_hdr.storage_class_stats.has_value());
-  
-  // Convert to has_value
-  read_hdr.storage_class_stats = std::unordered_map<std::string, cls_user_stats>();
-  cls_user_stats stats;
-  stats.total_entries = 10;
-  stats.total_bytes = 10240;
-  stats.total_bytes_rounded = 10240;
-  (*read_hdr.storage_class_stats)["default::STANDARD"] = stats;
-  
-  ASSERT_EQ(0, write_user_header_test(ioctx, oid, read_hdr));
-  
-  // Verify converted
-  cls_user_header final_hdr;
-  ASSERT_EQ(0, read_user_header_test(ioctx, oid, final_hdr));
-  ASSERT_TRUE(final_hdr.storage_class_stats.has_value());
-  EXPECT_EQ((*final_hdr.storage_class_stats)["default::STANDARD"].total_entries, 10);
+
+  cls_user_bucket_entry entry;
+  entry.bucket.name = "test-bucket";
+  entry.size = 5120;
+  entry.size_rounded = 5120;
+  entry.count = 1;
+  entry.storage_class_stats = std::unordered_map<std::string, cls_user_bucket_entry>();
+  cls_user_bucket_entry sc_entry;
+  sc_entry.size = 5120;
+  sc_entry.size_rounded = 5120;
+  sc_entry.count = 1;
+  (*entry.storage_class_stats)["STANDARD"] = sc_entry;
+
+  set_bucket(ioctx, oid, entry, true);
+
+  // storage_class_stats must now be initialized by cls_user_set_buckets_info()
+  ASSERT_EQ(0, read_user_header_test(ioctx, oid, read_hdr));
+  ASSERT_TRUE(read_hdr.storage_class_stats.has_value());
+  EXPECT_TRUE(read_hdr.storage_class_stats->count("STANDARD") > 0);
+  EXPECT_EQ((*read_hdr.storage_class_stats)["STANDARD"].total_entries, 1u);
+  EXPECT_EQ((*read_hdr.storage_class_stats)["STANDARD"].total_bytes, 5120u);
+}
+
+TEST_F(ClsUserStorageClass, LegacyBucketConversion) {
+  // nonzero stats + uninitialized storage_class_stats,
+  // remove bucket (decrement to zero), add bucket with SC,
+  // verify storage_class_stats initialized by that add
+  std::string oid = "user.legacy-convert";
+
+  // Add 3 bucket entries to get nonzero stats
+  for (int i = 0; i < 3; i++) {
+    cls_user_bucket_entry entry;
+    entry.bucket.name = str_int("bucket", i);
+    entry.size = 1024;
+    entry.size_rounded = 1024;
+    entry.count = 1;
+    entry.storage_class_stats = std::unordered_map<std::string, cls_user_bucket_entry>();
+    cls_user_bucket_entry sc_entry;
+    sc_entry.size = 1024;
+    sc_entry.size_rounded = 1024;
+    sc_entry.count = 1;
+    (*entry.storage_class_stats)["STANDARD"] = sc_entry;
+    set_bucket(ioctx, oid, entry, true);
+  }
+
+  // Verify nonzero stats, then clear storage_class_stats (legacy simulation)
+  cls_user_header header;
+  ASSERT_EQ(0, read_user_header_test(ioctx, oid, header));
+  ASSERT_GT(header.stats.total_entries, 0u);
+  header.storage_class_stats = std::nullopt;
+  ASSERT_EQ(0, write_user_header_test(ioctx, oid, header));
+
+  // Confirm: nonzero stats, nullopt storage_class_stats
+  ASSERT_EQ(0, read_user_header_test(ioctx, oid, header));
+  ASSERT_FALSE(header.storage_class_stats.has_value());
+  ASSERT_EQ(header.stats.total_entries, 3u);
+
+  // Remove all buckets (decrement stats toward zero)
+  for (int i = 0; i < 3; i++) {
+    cls_user_bucket_entry entry;
+    entry.bucket.name = str_int("bucket", i);
+    entry.size = 1024;
+    entry.size_rounded = 1024;
+    entry.count = 1;
+    set_bucket(ioctx, oid, entry, false); // add=false means remove
+  }
+
+  // Now add a new bucket with a different storage class
+  cls_user_bucket_entry new_entry;
+  new_entry.bucket.name = "new-bucket";
+  new_entry.size = 2048;
+  new_entry.size_rounded = 2048;
+  new_entry.count = 1;
+  new_entry.storage_class_stats = std::unordered_map<std::string, cls_user_bucket_entry>();
+  cls_user_bucket_entry hdd_entry;
+  hdd_entry.size = 2048;
+  hdd_entry.size_rounded = 2048;
+  hdd_entry.count = 1;
+  (*new_entry.storage_class_stats)["HDD"] = hdd_entry;
+  set_bucket(ioctx, oid, new_entry, true);
+
+  // storage_class_stats must be initialized by that add
+  ASSERT_EQ(0, read_user_header_test(ioctx, oid, header));
+  ASSERT_TRUE(header.storage_class_stats.has_value());
+  EXPECT_TRUE(header.storage_class_stats->count("HDD") > 0);
+  EXPECT_EQ((*header.storage_class_stats)["HDD"].total_entries, 1u);
+  EXPECT_EQ((*header.storage_class_stats)["HDD"].total_bytes, 2048u);
 }
 
 TEST_F(ClsUserStorageClass, MultipleClasses) {
-  std::string oid = "user.multi";
-  
-  cls_user_header header;
-  header.storage_class_stats = std::unordered_map<std::string, cls_user_stats>();
-  
-  cls_user_stats std_stats;
-  std_stats.total_entries = 100;
-  std_stats.total_bytes = 102400;
-  std_stats.total_bytes_rounded = 102400;
-  
-  cls_user_stats hdd_stats;
-  hdd_stats.total_entries = 200;
-  hdd_stats.total_bytes = 204800;
-  hdd_stats.total_bytes_rounded = 204800;
-  
-  (*header.storage_class_stats)["default::STANDARD"] = std_stats;
-  (*header.storage_class_stats)["default::HDD"] = hdd_stats;
-  
-  ASSERT_EQ(0, write_user_header_test(ioctx, oid, header));
-  
-  cls_user_header read_hdr;
-  ASSERT_EQ(0, read_user_header_test(ioctx, oid, read_hdr));
-  
-  ASSERT_TRUE(read_hdr.storage_class_stats.has_value());
-  EXPECT_EQ(read_hdr.storage_class_stats->size(), 2);
-  EXPECT_EQ((*read_hdr.storage_class_stats)["default::STANDARD"].total_entries, 100);
-  EXPECT_EQ((*read_hdr.storage_class_stats)["default::HDD"].total_entries, 200);
-}
+  std::string oid = "user.multi-sc";
 
+  // Add buckets with different storage classes via cls_user_set_buckets()
+  struct { const char* sc; const char* bucket; uint64_t size; } data[] = {
+    {"STANDARD", "bucket-std", 1024},
+    {"HDD",      "bucket-hdd", 2048},
+  };
+
+  for (auto& d : data) {
+    cls_user_bucket_entry entry;
+    entry.bucket.name = d.bucket;
+    entry.size = d.size;
+    entry.size_rounded = d.size;
+    entry.count = 1;
+    entry.storage_class_stats = std::unordered_map<std::string, cls_user_bucket_entry>();
+    cls_user_bucket_entry sc_entry;
+    sc_entry.size = d.size;
+    sc_entry.size_rounded = d.size;
+    sc_entry.count = 1;
+    (*entry.storage_class_stats)[d.sc] = sc_entry;
+    set_bucket(ioctx, oid, entry, true);
+  }
+
+  cls_user_header header;
+  ASSERT_EQ(0, read_user_header_test(ioctx, oid, header));
+  ASSERT_TRUE(header.storage_class_stats.has_value());
+  EXPECT_EQ(header.storage_class_stats->size(), 2u);
+  EXPECT_EQ((*header.storage_class_stats)["STANDARD"].total_entries, 1u);
+  EXPECT_EQ((*header.storage_class_stats)["STANDARD"].total_bytes, 1024u);
+  EXPECT_EQ((*header.storage_class_stats)["HDD"].total_entries, 1u);
+  EXPECT_EQ((*header.storage_class_stats)["HDD"].total_bytes, 2048u);
+}

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -446,6 +446,18 @@ target_link_libraries(ceph_test_datalog
 install(TARGETS ceph_test_datalog DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
+# Test for storage class stats with std::optional
+add_executable(unittest_rgw_storage_class_stats
+               test_rgw_storage_class_stats.cc
+              )
+target_link_libraries(unittest_rgw_storage_class_stats
+                      cls_rgw_client
+                      cls_user_client
+                      global
+                      ${UNITTEST_LIBS}
+                      )
+add_ceph_unittest(unittest_rgw_storage_class_stats)
+
 #
 # Helper for adding RGW tests built with Catch2:
 # Note: to define a test that does not use Catch2::main(), use:

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -328,6 +328,13 @@ target_include_directories(unittest_rgw_arn
   SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
 target_link_libraries(unittest_rgw_arn ${rgw_libs})
 
+# unittest_rgw_sc_quota per-storage-class quota encode/decode and checker
+add_executable(unittest_rgw_sc_quota test_rgw_sc_quota.cc)
+add_ceph_unittest(unittest_rgw_sc_quota)
+target_include_directories(unittest_rgw_sc_quota
+  SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
+target_link_libraries(unittest_rgw_sc_quota ${rgw_libs})
+
 # unittest_rgw_kms
 add_executable(unittest_rgw_kms test_rgw_kms.cc)
 add_ceph_unittest(unittest_rgw_kms)

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -328,12 +328,16 @@ target_include_directories(unittest_rgw_arn
   SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
 target_link_libraries(unittest_rgw_arn ${rgw_libs})
 
-# unittest_rgw_sc_quota per-storage-class quota encode/decode and checker
 add_executable(unittest_rgw_sc_quota test_rgw_sc_quota.cc)
-add_ceph_unittest(unittest_rgw_sc_quota)
 target_include_directories(unittest_rgw_sc_quota
   SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
-target_link_libraries(unittest_rgw_sc_quota ${rgw_libs})
+target_link_libraries(unittest_rgw_sc_quota
+  ${rgw_libs}
+  GTest::GTest      # not GTest::Main — we supply main()
+  global)
+add_test(NAME unittest_rgw_sc_quota
+         COMMAND unittest_rgw_sc_quota
+         WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 
 # unittest_rgw_kms
 add_executable(unittest_rgw_kms test_rgw_kms.cc)

--- a/src/test/rgw/test_rgw_sc_quota.cc
+++ b/src/test/rgw/test_rgw_sc_quota.cc
@@ -1,0 +1,326 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+/*
+ * Unit tests for the per-storage-class quota feature.
+ *
+ * We exercise three layers in isolation:
+ *
+ *   1. The on-the-wire encoding of RGWQuotaInfo at v3 <-> v4 boundaries.
+ *
+ *   2. The composite-key construction (rgw_sc_quota_key).
+ *
+ *   3. rgw_check_storage_class_quota() against a deterministic in-test
+ *      stats provider, covering:
+ *        - no enforcement_mode set => check returns 0 (legacy preservation)
+ *        - HYBRID + under limit    => returns 0
+ *        - HYBRID + over size      => returns -EDQUOT
+ *        - HYBRID + over count     => returns -EDQUOT
+ *        - HYBRID + missing stats  => returns 0 (fail-open)
+ *        - STORAGE_CLASS mode      => global quota fields ignored
+ *        - Different sc_key        => no false positive
+ *
+ * All cases are pure unit tests: no RADOS, no driver, no asio.
+ */
+
+#include <gtest/gtest.h>
+#include <cerrno>
+
+#include "common/ceph_context.h"
+#include "common/dout.h"
+#include "common/async/yield_context.h"
+#include "global/global_context.h"
+
+#include "rgw_quota_types.h"
+#include "rgw_sc_quota_types.h"
+#include "rgw_sc_quota_checker.h"
+#include "rgw_placement_types.h"
+#include "rgw_basic_types.h"        // for rgw_bucket
+#include "include/buffer.h"
+
+using namespace rgw::quota;
+
+namespace {
+struct TestDpp : NoDoutPrefix {
+  TestDpp() : NoDoutPrefix(g_ceph_context, /*subsys=*/0) {}
+};
+} // namespace
+
+
+static rgw_bucket make_bucket(const std::string& name = "test-bucket",
+                              const std::string& tenant = "") {
+  rgw_bucket b;
+  b.name = name;
+  b.tenant = tenant;
+  return b;
+}
+
+static rgw_placement_rule make_placement(const std::string& name,
+                                         const std::string& sc) {
+  return rgw_placement_rule(name, sc);
+}
+
+namespace {
+class FakeStatsProvider : public ScUsageStatsProvider {
+ public:
+  std::map<std::string, ScUsageStats> stats;
+  std::optional<ScUsageStats> lookup(const rgw_bucket& /*b*/,
+                                     const std::string& sc_key) const override {
+    auto it = stats.find(sc_key);
+    if (it == stats.end()) return std::nullopt;
+    return it->second;
+  }
+};
+
+// RAII installer for the global provider slot so tests don't leak state.
+struct ScopedProvider {
+  explicit ScopedProvider(ScUsageStatsProvider* p) {
+    set_sc_stats_provider(p);
+  }
+  ~ScopedProvider() { set_sc_stats_provider(nullptr); }
+};
+} // namespace
+
+TEST(RGWQuotaInfoV4, RoundtripEmptyScMap) {
+  RGWQuotaInfo in;
+  in.enabled = true;
+  in.max_size = 1024;
+  in.max_objects = 10;
+
+  ceph::buffer::list bl;
+  encode(in, bl);
+
+  RGWQuotaInfo out;
+  auto p = bl.cbegin();
+  decode(out, p);
+
+  EXPECT_TRUE(out.enabled);
+  EXPECT_EQ(out.max_size, 1024);
+  EXPECT_EQ(out.max_objects, 10);
+  EXPECT_TRUE(out.storage_class_quotas.empty());
+  EXPECT_EQ(out.enforcement_mode, RGWQuotaEnforcementMode::LEGACY);
+}
+
+TEST(RGWQuotaInfoV4, RoundtripPopulatedScMap) {
+  RGWQuotaInfo in;
+  in.enabled = true;
+  in.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  in.storage_class_quotas[rgw_sc_quota_key("default", "SSD")] =
+    RGWStorageClassQuota{ 1024 * 1024, 100, true };
+  in.storage_class_quotas[rgw_sc_quota_key("default", "GLACIER")] =
+    RGWStorageClassQuota{ -1, 50, true };
+
+  ceph::buffer::list bl;
+  encode(in, bl);
+
+  RGWQuotaInfo out;
+  auto p = bl.cbegin();
+  decode(out, p);
+
+  EXPECT_EQ(out.enforcement_mode, RGWQuotaEnforcementMode::HYBRID);
+  ASSERT_EQ(out.storage_class_quotas.size(), 2u);
+
+  const auto* ssd = out.get_sc_quota(rgw_sc_quota_key("default", "SSD"));
+  ASSERT_NE(ssd, nullptr);
+  EXPECT_EQ(ssd->max_size, 1024 * 1024);
+  EXPECT_EQ(ssd->max_objects, 100);
+  EXPECT_TRUE(ssd->enabled);
+
+  const auto* gla = out.get_sc_quota(rgw_sc_quota_key("default", "GLACIER"));
+  ASSERT_NE(gla, nullptr);
+  EXPECT_EQ(gla->max_size, -1);
+  EXPECT_EQ(gla->max_objects, 50);
+}
+
+/*
+ * Critical backward-compat test: encode a v4 blob with NO sc quotas and
+ * an explicit LEGACY mode, decode it, then re-encode it.  The behaviour
+ * must be indistinguishable from how a pre-feature RGW would treat the
+ * same RGWQuotaInfo -- empty map, legacy mode preserved.
+ */
+TEST(RGWQuotaInfoV4, RoundtripLegacyDefaultsStable) {
+  for (auto& in : RGWQuotaInfo::generate_test_instances()) {
+    ceph::buffer::list bl;
+    encode(in, bl);
+    RGWQuotaInfo out;
+    auto p = bl.cbegin();
+    decode(out, p);
+    EXPECT_EQ(in.enabled, out.enabled);
+    EXPECT_EQ(in.max_size, out.max_size);
+    EXPECT_EQ(in.max_objects, out.max_objects);
+    EXPECT_EQ(in.check_on_raw, out.check_on_raw);
+    EXPECT_EQ(in.enforcement_mode, out.enforcement_mode);
+    EXPECT_EQ(in.storage_class_quotas.size(), out.storage_class_quotas.size());
+  }
+}
+
+TEST(RGWScQuotaKey, BasicComposition) {
+  EXPECT_EQ(rgw_sc_quota_key("default-placement", "SSD"),
+            "default-placement::SSD");
+}
+
+TEST(RGWScQuotaKey, EmptyStorageClassMapsToSTANDARD) {
+  // get_canonical_storage_class("") -> "STANDARD"
+  EXPECT_EQ(rgw_sc_quota_key("default-placement", ""),
+            "default-placement::STANDARD");
+}
+
+TEST(RGWScQuotaKey, FromRule) {
+  EXPECT_EQ(rgw_sc_quota_key(make_placement("p1", "GLACIER")),
+            "p1::GLACIER");
+}
+
+
+TEST(RGWScQuotaChecker, LegacyModeReturnsZero) {
+  TestDpp dpp;
+  FakeStatsProvider prov;
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enabled = true;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::LEGACY;
+  // Even with an entry present, LEGACY mode must NOT consult it.
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+    RGWStorageClassQuota{ 1, 1, true };
+
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      1ULL << 30, 100, null_yield);
+  EXPECT_EQ(r, 0);
+}
+
+TEST(RGWScQuotaChecker, NoSCConfiguredFallsThrough) {
+  TestDpp dpp;
+  FakeStatsProvider prov;
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enabled = true;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  // storage_class_quotas is empty -> sc_enforcement_active() returns false.
+
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      1ULL << 40, 1'000'000, null_yield);
+  EXPECT_EQ(r, 0);
+}
+
+TEST(RGWScQuotaChecker, UnderLimitAllows) {
+  TestDpp dpp;
+  FakeStatsProvider prov;
+  prov.stats[rgw_sc_quota_key("p", "SSD")] = ScUsageStats{ 50, 5 };
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+    RGWStorageClassQuota{ /*max_size=*/100, /*max_objects=*/10, /*enabled=*/true };
+
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      /*new_size=*/40, /*new_objects=*/3, null_yield);
+  EXPECT_EQ(r, 0);
+}
+
+TEST(RGWScQuotaChecker, OverSizeReturnsEDQUOT) {
+  TestDpp dpp;
+  FakeStatsProvider prov;
+  prov.stats[rgw_sc_quota_key("p", "SSD")] = ScUsageStats{ 90, 5 };
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+    RGWStorageClassQuota{ 100, -1, true };
+
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      /*new_size=*/15, /*new_objects=*/1, null_yield);
+  EXPECT_EQ(r, -EDQUOT);
+}
+
+TEST(RGWScQuotaChecker, OverObjectCountReturnsEDQUOT) {
+  TestDpp dpp;
+  FakeStatsProvider prov;
+  prov.stats[rgw_sc_quota_key("p", "SSD")] = ScUsageStats{ 10, 9 };
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+    RGWStorageClassQuota{ -1, /*max_objects=*/10, true };
+
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      /*new_size=*/1, /*new_objects=*/2, null_yield);
+  EXPECT_EQ(r, -EDQUOT);
+}
+
+TEST(RGWScQuotaChecker, MissingStatsFailsOpen) {
+  TestDpp dpp;
+  FakeStatsProvider prov;  // empty
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+    RGWStorageClassQuota{ 1, 1, true };
+
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      1'000'000, 1, null_yield);
+  EXPECT_EQ(r, 0);  // fail-open even though we are way over limit
+}
+
+TEST(RGWScQuotaChecker, NoProviderFailsOpen) {
+  TestDpp dpp;
+  // No ScopedProvider -> get_sc_stats_provider() returns nullptr.
+
+  RGWQuota q;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+    RGWStorageClassQuota{ 1, 1, true };
+
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      1'000'000, 1, null_yield);
+  EXPECT_EQ(r, 0);
+}
+
+TEST(RGWScQuotaChecker, DifferentScKeyNoFalsePositive) {
+  TestDpp dpp;
+  FakeStatsProvider prov;
+  prov.stats[rgw_sc_quota_key("p", "GLACIER")] = ScUsageStats{ 9999999, 9999 };
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+    RGWStorageClassQuota{ 1, 1, true };
+  // Writing to GLACIER but only SSD has a quota -> no SC quota applies.
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "GLACIER"),
+      1, 1, null_yield);
+  EXPECT_EQ(r, 0);
+}
+
+TEST(RGWScQuotaChecker, BucketAndUserCombineTighter) {
+  TestDpp dpp;
+  FakeStatsProvider prov;
+  prov.stats[rgw_sc_quota_key("p", "SSD")] = ScUsageStats{ 80, 5 };
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+    RGWStorageClassQuota{ /*max_size=*/200, /*max_objects=*/-1, true };
+  q.user_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  q.user_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+    RGWStorageClassQuota{ /*max_size=*/100, /*max_objects=*/-1, true };
+
+  // 80 + 25 = 105 > 100 (user limit) but < 200 (bucket limit) -> reject.
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      25, 1, null_yield);
+  EXPECT_EQ(r, -EDQUOT);
+}

--- a/src/test/rgw/test_rgw_sc_quota.cc
+++ b/src/test/rgw/test_rgw_sc_quota.cc
@@ -29,8 +29,9 @@
 #include "common/ceph_context.h"
 #include "common/dout.h"
 #include "common/async/yield_context.h"
-#include "global/global_context.h"
 
+#include "global/global_init.h"
+#include "common/ceph_argparse.h"
 #include "rgw_quota_types.h"
 #include "rgw_sc_quota_types.h"
 #include "rgw_sc_quota_checker.h"
@@ -41,8 +42,10 @@
 using namespace rgw::quota;
 
 namespace {
-struct TestDpp : NoDoutPrefix {
-  TestDpp() : NoDoutPrefix(g_ceph_context, /*subsys=*/0) {}
+struct TestDpp : public DoutPrefixProvider {
+  CephContext* get_cct() const override { return g_ceph_context; }
+  unsigned get_subsys() const override { return ceph_subsys_rgw; }
+  std::ostream& gen_prefix(std::ostream& out) const override { return out; }
 };
 } // namespace
 
@@ -323,4 +326,17 @@ TEST(RGWScQuotaChecker, BucketAndUserCombineTighter) {
       &dpp, q, make_bucket(), make_placement("p", "SSD"),
       25, 1, null_yield);
   EXPECT_EQ(r, -EDQUOT);
+}
+
+int main(int argc, char** argv)
+{
+  auto args = argv_to_vec(argc, argv);
+  auto cct = global_init(nullptr, args,
+                         CEPH_ENTITY_TYPE_CLIENT,
+                         CODE_ENVIRONMENT_UTILITY,
+                         CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+  common_init_finish(g_ceph_context);
+
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }

--- a/src/test/rgw/test_rgw_sc_quota.cc
+++ b/src/test/rgw/test_rgw_sc_quota.cc
@@ -340,3 +340,109 @@ int main(int argc, char** argv)
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
+
+TEST(RGWScQuotaChecker, StorageClassOnlyModeIgnoresGlobalQuota) {
+  TestDpp dpp;
+  FakeStatsProvider prov;
+  prov.stats[rgw_sc_quota_key("p", "SSD")] = ScUsageStats{50, 5};
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  // Global quota would fail (max_size=10, current=50+10=60 > 10)
+  q.bucket_quota.max_size    = 10;
+  q.bucket_quota.max_objects = 10;
+  q.bucket_quota.enabled     = true;
+  // But mode is STORAGE_CLASS — global quota is ignored
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::STORAGE_CLASS;
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+      RGWStorageClassQuota{200, 100, true};  // generous SC limit
+
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      10, 1, null_yield);
+  // SC check passes (50+10 < 200), global check not run
+  EXPECT_EQ(r, 0);
+}
+
+TEST(RGWScQuotaChecker, DisabledEntryNotEnforced) {
+  TestDpp dpp;
+  FakeStatsProvider prov;
+  prov.stats[rgw_sc_quota_key("p", "SSD")] = ScUsageStats{999, 999};
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+      RGWStorageClassQuota{1, 1, /*enabled=*/false};  // tiny limit but disabled
+
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      1000, 100, null_yield);
+  EXPECT_EQ(r, 0);  // disabled entry = no enforcement
+}
+
+TEST(RGWScQuotaChecker, ExactLimitBoundaryAllows) {
+  TestDpp dpp;
+  FakeStatsProvider prov;
+  prov.stats[rgw_sc_quota_key("p", "SSD")] = ScUsageStats{90, 9};
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+      RGWStorageClassQuota{100, 10, true};
+
+  // 90 + 10 == 100 exactly — should PASS (not exceed)
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      10, 1, null_yield);
+  EXPECT_EQ(r, 0);
+}
+
+TEST(RGWQuotaInfoV4, JSONRoundtrip) {
+  RGWQuotaInfo in;
+  in.enabled          = true;
+  in.max_size         = 1024 * 1024;
+  in.enforcement_mode = RGWQuotaEnforcementMode::HYBRID;
+  in.storage_class_quotas[rgw_sc_quota_key("default", "SSD")] =
+      RGWStorageClassQuota{512 * 1024, 50, true};
+
+  // Dump to JSON
+  JSONFormatter f;
+  f.open_object_section("quota");
+  in.dump(&f);
+  f.close_section();
+  std::stringstream ss;
+  f.flush(ss);
+
+  // Parse back
+  JSONParser p;
+  ASSERT_TRUE(p.parse(ss.str().c_str(), ss.str().size()));
+  RGWQuotaInfo out;
+  out.decode_json(&p);
+
+  EXPECT_EQ(out.enforcement_mode, RGWQuotaEnforcementMode::HYBRID);
+  ASSERT_EQ(out.storage_class_quotas.size(), 1u);
+  const auto* ssd = out.get_sc_quota(rgw_sc_quota_key("default", "SSD"));
+  ASSERT_NE(ssd, nullptr);
+  EXPECT_EQ(ssd->max_size, 512 * 1024);
+  EXPECT_EQ(ssd->max_objects, 50);
+  EXPECT_TRUE(ssd->enabled);
+}
+
+TEST(RGWScQuotaChecker, GlobalOnlyModeReturnsZero) {
+  TestDpp dpp;
+  FakeStatsProvider prov;
+  prov.stats[rgw_sc_quota_key("p", "SSD")] = ScUsageStats{1, 1};
+  ScopedProvider sp(&prov);
+
+  RGWQuota q;
+  q.bucket_quota.enforcement_mode = RGWQuotaEnforcementMode::GLOBAL_ONLY;
+  q.bucket_quota.storage_class_quotas[rgw_sc_quota_key("p", "SSD")] =
+      RGWStorageClassQuota{1, 1, true};  // tiny limit
+
+  int r = rgw_check_storage_class_quota(
+      &dpp, q, make_bucket(), make_placement("p", "SSD"),
+      1000, 100, null_yield);
+  EXPECT_EQ(r, 0);  // GLOBAL_ONLY = no SC enforcement
+}

--- a/src/test/rgw/test_rgw_storage_class_stats.cc
+++ b/src/test/rgw/test_rgw_storage_class_stats.cc
@@ -1,0 +1,753 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <gtest/gtest.h>
+#include "cls/rgw/cls_rgw_types.h"
+#include "cls/user/cls_user_types.h"
+#include <chrono>
+
+using namespace std;
+
+TEST(StorageClassStats, OptionalInitialization) {
+  rgw_bucket_dir_header header;
+  
+  // New buckets should initialize storage_class_stats as nullopt initially
+  EXPECT_FALSE(header.storage_class_stats.has_value());
+  
+  // After initialization, should have value
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  EXPECT_TRUE(header.storage_class_stats.has_value());
+  EXPECT_TRUE(header.storage_class_stats->empty());
+}
+
+TEST(StorageClassStats, OptionalEmptyVsNull) {
+  rgw_bucket_dir_header legacy_header;
+  rgw_bucket_dir_header new_empty_header;
+  rgw_bucket_dir_header converted_header;
+  
+  // Legacy bucket - nullopt (not converted)
+  EXPECT_FALSE(legacy_header.storage_class_stats.has_value());
+  
+  // New empty bucket - empty map (converted)
+  new_empty_header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  EXPECT_TRUE(new_empty_header.storage_class_stats.has_value());
+  EXPECT_TRUE(new_empty_header.storage_class_stats->empty());
+  
+  // Converted bucket with data
+  converted_header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  rgw_bucket_category_stats stats;
+  stats.num_entries = 10;
+  stats.total_size = 1024;
+  (*converted_header.storage_class_stats)["STANDARD"] = stats;
+  
+  EXPECT_TRUE(converted_header.storage_class_stats.has_value());
+  EXPECT_FALSE(converted_header.storage_class_stats->empty());
+  EXPECT_EQ((*converted_header.storage_class_stats)["STANDARD"].num_entries, 10);
+}
+
+TEST(StorageClassStats, OptionalAfterDeletion) {
+  rgw_bucket_dir_header header;
+  
+  // Initialize with data
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  rgw_bucket_category_stats stats;
+  stats.num_entries = 5;
+  stats.total_size = 2048;
+  (*header.storage_class_stats)["HDD"] = stats;
+  
+  EXPECT_TRUE(header.storage_class_stats.has_value());
+  EXPECT_EQ((*header.storage_class_stats)["HDD"].num_entries, 5);
+  
+  // Simulate deletion - set to 0 but keep entry
+  (*header.storage_class_stats)["HDD"].num_entries = 0;
+  (*header.storage_class_stats)["HDD"].total_size = 0;
+  
+  // Field should still have value (not nullopt)
+  EXPECT_TRUE(header.storage_class_stats.has_value());
+  EXPECT_EQ((*header.storage_class_stats)["HDD"].num_entries, 0);
+  EXPECT_EQ((*header.storage_class_stats)["HDD"].total_size, 0);
+}
+
+TEST(StorageClassStats, UserHeaderOptional) {
+  cls_user_header header;
+  
+  // Should start as nullopt
+  EXPECT_FALSE(header.storage_class_stats.has_value());
+  
+  // Initialize
+  header.storage_class_stats = std::unordered_map<std::string, cls_user_stats>();
+  EXPECT_TRUE(header.storage_class_stats.has_value());
+  
+  // Add stats
+  cls_user_stats user_stats;
+  user_stats.total_entries = 100;
+  user_stats.total_bytes = 10240;
+  (*header.storage_class_stats)["default-placement::STANDARD"] = user_stats;
+  
+  EXPECT_EQ((*header.storage_class_stats)["default-placement::STANDARD"].total_entries, 100);
+}
+
+TEST(StorageClassStats, MultipleStorageClasses) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Add multiple storage classes
+  rgw_bucket_category_stats standard_stats;
+  standard_stats.num_entries = 10;
+  standard_stats.total_size = 5120;
+  
+  rgw_bucket_category_stats hdd_stats;
+  hdd_stats.num_entries = 20;
+  hdd_stats.total_size = 10240;
+  
+  (*header.storage_class_stats)["STANDARD"] = standard_stats;
+  (*header.storage_class_stats)["HDD"] = hdd_stats;
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 2);
+  EXPECT_EQ((*header.storage_class_stats)["STANDARD"].num_entries, 10);
+  EXPECT_EQ((*header.storage_class_stats)["HDD"].num_entries, 20);
+}
+
+TEST(StorageClassStats, SafeAccess) {
+  rgw_bucket_dir_header header;
+  
+  // Accessing without initialization should be safe with has_value check
+  if (header.storage_class_stats.has_value()) {
+    // This should not execute
+    FAIL() << "Should not have value before initialization";
+  }
+  
+  // Initialize
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Now access is safe
+  if (header.storage_class_stats.has_value()) {
+    EXPECT_TRUE(header.storage_class_stats->empty());
+  } else {
+    FAIL() << "Should have value after initialization";
+  }
+}
+
+TEST(StorageClassStats, ResetToNullopt) {
+  rgw_bucket_dir_header header;
+  
+  // Initialize with value
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  (*header.storage_class_stats)["STANDARD"].num_entries = 10;
+  EXPECT_TRUE(header.storage_class_stats.has_value());
+  
+  // Reset to nullopt (simulate legacy bucket state)
+  header.storage_class_stats = std::nullopt;
+  EXPECT_FALSE(header.storage_class_stats.has_value());
+  
+  // Re-initialize
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  EXPECT_TRUE(header.storage_class_stats.has_value());
+  EXPECT_TRUE(header.storage_class_stats->empty()); // Should be empty after reset
+}
+
+TEST(StorageClassStats, EmptyStringStorageClassName) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Test with empty string as storage class name (edge case)
+  rgw_bucket_category_stats stats;
+  stats.num_entries = 5;
+  stats.total_size = 1024;
+  (*header.storage_class_stats)[""] = stats;
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 1);
+  EXPECT_EQ((*header.storage_class_stats)[""].num_entries, 5);
+}
+
+TEST(StorageClassStats, VeryLongStorageClassName) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Test with very long storage class name (1000 characters)
+  std::string long_name(1000, 'A');
+  rgw_bucket_category_stats stats;
+  stats.num_entries = 10;
+  (*header.storage_class_stats)[long_name] = stats;
+  
+  EXPECT_EQ((*header.storage_class_stats)[long_name].num_entries, 10);
+}
+
+TEST(StorageClassStats, SpecialCharactersInName) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Test with special characters
+  std::vector<std::string> special_names = {
+    "STANDARD-IA",
+    "storage_class_1",
+    "storage.class.dots",
+    "storage:class:colons",
+    "UTF8-名称",
+    "with spaces",
+    "with\ttabs",
+    "with\nnewlines"
+  };
+  
+  for (const auto& name : special_names) {
+    rgw_bucket_category_stats stats;
+    stats.num_entries = 1;
+    (*header.storage_class_stats)[name] = stats;
+  }
+  
+  EXPECT_EQ(header.storage_class_stats->size(), special_names.size());
+}
+
+TEST(StorageClassStats, MaximumValues) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Test with maximum uint64_t values
+  rgw_bucket_category_stats stats;
+  stats.num_entries = UINT64_MAX;
+  stats.total_size = UINT64_MAX;
+  stats.total_size_rounded = UINT64_MAX;
+  stats.actual_size = UINT64_MAX;
+  
+  (*header.storage_class_stats)["STANDARD"] = stats;
+  
+  EXPECT_EQ((*header.storage_class_stats)["STANDARD"].num_entries, UINT64_MAX);
+  EXPECT_EQ((*header.storage_class_stats)["STANDARD"].total_size, UINT64_MAX);
+}
+
+TEST(StorageClassStats, ManyStorageClasses) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Test with 100 different storage classes
+  for (int i = 0; i < 100; i++) {
+    std::string name = "SC_" + std::to_string(i);
+    rgw_bucket_category_stats stats;
+    stats.num_entries = i;
+    stats.total_size = i * 1024;
+    (*header.storage_class_stats)[name] = stats;
+  }
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 100);
+  EXPECT_EQ((*header.storage_class_stats)["SC_50"].num_entries, 50);
+  EXPECT_EQ((*header.storage_class_stats)["SC_50"].total_size, 50 * 1024);
+}
+
+TEST(StorageClassStats, OverwriteExistingEntry) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Add entry
+  rgw_bucket_category_stats stats1;
+  stats1.num_entries = 10;
+  stats1.total_size = 1024;
+  (*header.storage_class_stats)["STANDARD"] = stats1;
+  
+  // Overwrite with new values
+  rgw_bucket_category_stats stats2;
+  stats2.num_entries = 20;
+  stats2.total_size = 2048;
+  (*header.storage_class_stats)["STANDARD"] = stats2;
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 1);
+  EXPECT_EQ((*header.storage_class_stats)["STANDARD"].num_entries, 20);
+  EXPECT_EQ((*header.storage_class_stats)["STANDARD"].total_size, 2048);
+}
+
+TEST(StorageClassStats, EraseEntry) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Add multiple entries
+  (*header.storage_class_stats)["STANDARD"].num_entries = 10;
+  (*header.storage_class_stats)["HDD"].num_entries = 20;
+  (*header.storage_class_stats)["GLACIER"].num_entries = 30;
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 3);
+  
+  // Erase one entry
+  header.storage_class_stats->erase("HDD");
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 2);
+  EXPECT_EQ(header.storage_class_stats->count("STANDARD"), 1);
+  EXPECT_EQ(header.storage_class_stats->count("HDD"), 0);
+  EXPECT_EQ(header.storage_class_stats->count("GLACIER"), 1);
+}
+
+TEST(StorageClassStats, ClearAll) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Add entries
+  (*header.storage_class_stats)["STANDARD"].num_entries = 10;
+  (*header.storage_class_stats)["HDD"].num_entries = 20;
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 2);
+  
+  // Clear all entries
+  header.storage_class_stats->clear();
+  
+  EXPECT_TRUE(header.storage_class_stats.has_value()); // Still has_value
+  EXPECT_TRUE(header.storage_class_stats->empty());    // But is empty
+  EXPECT_EQ(header.storage_class_stats->size(), 0);
+}
+
+// ============================================================================
+// COPY/MOVE SEMANTICS TESTS
+// ============================================================================
+
+TEST(StorageClassStats, CopyConstruction) {
+  rgw_bucket_dir_header header1;
+  header1.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  (*header1.storage_class_stats)["STANDARD"].num_entries = 10;
+  
+  // Copy construct
+  rgw_bucket_dir_header header2 = header1;
+  
+  EXPECT_TRUE(header2.storage_class_stats.has_value());
+  EXPECT_EQ((*header2.storage_class_stats)["STANDARD"].num_entries, 10);
+  
+  // Modify copy - original should not change
+  (*header2.storage_class_stats)["STANDARD"].num_entries = 20;
+  EXPECT_EQ((*header1.storage_class_stats)["STANDARD"].num_entries, 10);
+  EXPECT_EQ((*header2.storage_class_stats)["STANDARD"].num_entries, 20);
+}
+
+TEST(StorageClassStats, MoveConstruction) {
+  rgw_bucket_dir_header header1;
+  header1.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  (*header1.storage_class_stats)["STANDARD"].num_entries = 10;
+  
+  // Move construct
+  rgw_bucket_dir_header header2 = std::move(header1);
+  
+  EXPECT_TRUE(header2.storage_class_stats.has_value());
+  EXPECT_EQ((*header2.storage_class_stats)["STANDARD"].num_entries, 10);
+}
+
+TEST(StorageClassStats, CopyAssignment) {
+  rgw_bucket_dir_header header1, header2;
+  header1.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  (*header1.storage_class_stats)["STANDARD"].num_entries = 10;
+  
+  // Copy assign
+  header2 = header1;
+  
+  EXPECT_TRUE(header2.storage_class_stats.has_value());
+  EXPECT_EQ((*header2.storage_class_stats)["STANDARD"].num_entries, 10);
+}
+
+TEST(StorageClassStats, AssignNulloptToValue) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  (*header.storage_class_stats)["STANDARD"].num_entries = 10;
+  
+  EXPECT_TRUE(header.storage_class_stats.has_value());
+  
+  // Assign nullopt (e.g., during legacy bucket handling)
+  header.storage_class_stats = std::nullopt;
+  
+  EXPECT_FALSE(header.storage_class_stats.has_value());
+}
+
+// ============================================================================
+// SERIALIZATION TESTS (Ceph encoding/decoding)
+// ============================================================================
+
+TEST(StorageClassStats, EncodeDecodeWithValue) {
+  rgw_bucket_dir_header original;
+  original.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  (*original.storage_class_stats)["STANDARD"].num_entries = 10;
+  (*original.storage_class_stats)["HDD"].num_entries = 20;
+  
+  // Encode
+  bufferlist bl;
+  encode(original, bl);
+  
+  // Decode
+  rgw_bucket_dir_header decoded;
+  auto iter = bl.cbegin();
+  decode(decoded, iter);
+  
+  // Verify
+  EXPECT_TRUE(decoded.storage_class_stats.has_value());
+  EXPECT_EQ(decoded.storage_class_stats->size(), 2);
+  EXPECT_EQ((*decoded.storage_class_stats)["STANDARD"].num_entries, 10);
+  EXPECT_EQ((*decoded.storage_class_stats)["HDD"].num_entries, 20);
+}
+
+TEST(StorageClassStats, EncodeDecodeNullopt) {
+  rgw_bucket_dir_header original;
+  // Leave storage_class_stats as nullopt
+  
+  // Encode
+  bufferlist bl;
+  encode(original, bl);
+  
+  // Decode
+  rgw_bucket_dir_header decoded;
+  auto iter = bl.cbegin();
+  decode(decoded, iter);
+  
+  // Verify nullopt is preserved
+  EXPECT_FALSE(decoded.storage_class_stats.has_value());
+}
+
+TEST(StorageClassStats, EncodeDecodeEmpty) {
+  rgw_bucket_dir_header original;
+  original.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  // Leave map empty
+  
+  // Encode
+  bufferlist bl;
+  encode(original, bl);
+  
+  // Decode
+  rgw_bucket_dir_header decoded;
+  auto iter = bl.cbegin();
+  decode(decoded, iter);
+  
+  // Verify empty map is preserved (not nullopt)
+  EXPECT_TRUE(decoded.storage_class_stats.has_value());
+  EXPECT_TRUE(decoded.storage_class_stats->empty());
+}
+
+// ============================================================================
+// USER STATS TESTS
+// ============================================================================
+
+TEST(StorageClassStats, UserStatsMultiplePlacements) {
+  cls_user_header header;
+  header.storage_class_stats = std::unordered_map<std::string, cls_user_stats>();
+  
+  // Add stats for multiple placements and storage classes
+  std::vector<std::string> keys = {
+    "default-placement::STANDARD",
+    "default-placement::HDD",
+    "archive-placement::GLACIER",
+    "fast-placement::SSD"
+  };
+  
+  for (size_t i = 0; i < keys.size(); i++) {
+    cls_user_stats stats;
+    stats.total_entries = (i + 1) * 10;
+    stats.total_bytes = (i + 1) * 1024;
+    (*header.storage_class_stats)[keys[i]] = stats;
+  }
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 4);
+  EXPECT_EQ((*header.storage_class_stats)["archive-placement::GLACIER"].total_entries, 30);
+}
+
+// ============================================================================
+// ITERATOR SAFETY TESTS
+// ============================================================================
+
+TEST(StorageClassStats, IterationWhileModifying) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Add initial entries
+  for (int i = 0; i < 10; i++) {
+    (*header.storage_class_stats)["SC_" + std::to_string(i)].num_entries = i;
+  }
+  
+  // Iterate and collect keys
+  std::vector<std::string> keys;
+  for (const auto& [key, value] : *header.storage_class_stats) {
+    keys.push_back(key);
+  }
+  
+  EXPECT_EQ(keys.size(), 10);
+}
+
+TEST(StorageClassStats, SafeIterationWithHasValue) {
+  rgw_bucket_dir_header header;
+
+  // Should be nullopt initially
+  EXPECT_FALSE(header.storage_class_stats.has_value());
+
+  // Initialize and iterate
+  header.storage_class_stats =
+      std::unordered_map<std::string, rgw_bucket_category_stats>();
+  (*header.storage_class_stats)["STANDARD"].num_entries = 10;
+
+  ASSERT_TRUE(header.storage_class_stats.has_value());
+
+  int count = 0;
+  for (const auto& [key, value] : *header.storage_class_stats) {
+    count++;
+    EXPECT_EQ(key, "STANDARD");
+    EXPECT_EQ(value.num_entries, 10);
+  }
+
+  EXPECT_EQ(count, 1);
+}
+
+// ============================================================================
+// THREAD SAFETY TESTS (Basic)
+// ============================================================================
+
+TEST(StorageClassStats, ConcurrentReads) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  (*header.storage_class_stats)["STANDARD"].num_entries = 100;
+  (*header.storage_class_stats)["HDD"].num_entries = 200;
+  
+  // Multiple threads reading simultaneously
+  std::vector<std::thread> threads;
+  std::atomic<int> success_count{0};
+  
+  for (int i = 0; i < 10; i++) {
+    threads.emplace_back([&header, &success_count]() {
+      if (header.storage_class_stats.has_value()) {
+        if (header.storage_class_stats->count("STANDARD") > 0) {
+          auto val = (*header.storage_class_stats)["STANDARD"].num_entries;
+          if (val == 100) {
+            success_count++;
+          }
+        }
+      }
+    });
+  }
+  
+  for (auto& t : threads) {
+    t.join();
+  }
+  
+  EXPECT_EQ(success_count, 10);
+}
+
+// ============================================================================
+// BOUNDARY CONDITION TESTS
+// ============================================================================
+
+TEST(StorageClassStats, ZeroValues) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // All zero values
+  rgw_bucket_category_stats stats;
+  stats.num_entries = 0;
+  stats.total_size = 0;
+  stats.total_size_rounded = 0;
+  stats.actual_size = 0;
+  
+  (*header.storage_class_stats)["STANDARD"] = stats;
+  
+  EXPECT_EQ((*header.storage_class_stats)["STANDARD"].num_entries, 0);
+  EXPECT_TRUE(header.storage_class_stats.has_value()); // Still has_value even with 0
+}
+
+TEST(StorageClassStats, ValueOrAlternative) {
+  rgw_bucket_dir_header header1, header2;
+  
+  // header1 is nullopt
+  auto map1 = header1.storage_class_stats.value_or(
+    std::unordered_map<std::string, rgw_bucket_category_stats>()
+  );
+  EXPECT_TRUE(map1.empty());
+  
+  // header2 has value
+  header2.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  (*header2.storage_class_stats)["STANDARD"].num_entries = 10;
+  
+  auto map2 = header2.storage_class_stats.value_or(
+    std::unordered_map<std::string, rgw_bucket_category_stats>()
+  );
+  EXPECT_EQ(map2.size(), 1);
+  EXPECT_EQ(map2["STANDARD"].num_entries, 10);
+}
+
+// ============================================================================
+// REGRESSION TESTS
+// ============================================================================
+
+TEST(StorageClassStats, DereferenceSafety) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Test all dereference operators work correctly
+  EXPECT_NO_THROW({
+    (*header.storage_class_stats)["STANDARD"].num_entries = 10;  // operator*
+    header.storage_class_stats->size();                          // operator->
+  });
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 1);
+  EXPECT_EQ((*header.storage_class_stats)["STANDARD"].num_entries, 10);
+}
+
+// ============================================================================
+// PERFORMANCE BENCHMARK TESTS
+// ============================================================================
+
+TEST(StorageClassStats, BenchmarkLargeScale) {
+  using namespace std::chrono;
+  
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  auto start = high_resolution_clock::now();
+  
+  // Add 10,000 storage classes
+  for (int i = 0; i < 10000; i++) {
+    std::string name = "STORAGE_CLASS_" + std::to_string(i);
+    rgw_bucket_category_stats stats;
+    stats.num_entries = i;
+    stats.total_size = i * 1024;
+    (*header.storage_class_stats)[name] = stats;
+  }
+  
+  auto end = high_resolution_clock::now();
+  auto duration = duration_cast<microseconds>(end - start).count();
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 10000);
+  std::cout << "Added 10,000 storage classes in " << duration << " µs" << std::endl;
+  
+  // Should complete in under 100ms
+  EXPECT_LT(duration, 100000); // 100ms in microseconds
+}
+
+TEST(StorageClassStats, BenchmarkIteration) {
+  using namespace std::chrono;
+  
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Setup: 1000 storage classes
+  for (int i = 0; i < 1000; i++) {
+    (*header.storage_class_stats)["SC_" + std::to_string(i)].num_entries = i;
+  }
+  
+  auto start = high_resolution_clock::now();
+  
+  // Iterate 1000 times
+  uint64_t sum = 0;
+  for (int iteration = 0; iteration < 1000; iteration++) {
+    if (header.storage_class_stats.has_value()) {
+      for (const auto& [key, value] : *header.storage_class_stats) {
+        sum += value.num_entries;
+      }
+    }
+  }
+  
+  auto end = high_resolution_clock::now();
+  auto duration = duration_cast<microseconds>(end - start).count();
+  
+  std::cout << "1000 iterations over 1000 entries in " << duration << " µs" << std::endl;
+  EXPECT_LT(duration, 50000); // Should be under 50ms
+  EXPECT_GT(sum, 0); // Make sure loop ran
+}
+
+TEST(StorageClassStats, BenchmarkSerialization) {
+  using namespace std::chrono;
+  
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Add 100 storage classes
+  for (int i = 0; i < 100; i++) {
+    (*header.storage_class_stats)["SC_" + std::to_string(i)].num_entries = i * 100;
+    (*header.storage_class_stats)["SC_" + std::to_string(i)].total_size = i * 1024 * 1024;
+  }
+  
+  auto start = high_resolution_clock::now();
+  
+  // Encode/decode 100 times
+  for (int i = 0; i < 100; i++) {
+    bufferlist bl;
+    encode(header, bl);
+    
+    rgw_bucket_dir_header decoded;
+    auto iter = bl.cbegin();
+    decode(decoded, iter);
+  }
+  
+  auto end = high_resolution_clock::now();
+  auto duration = duration_cast<microseconds>(end - start).count();
+  
+  std::cout << "100 encode/decode cycles in " << duration << " µs" << std::endl;
+  EXPECT_LT(duration, 10000); // Should be under 10ms
+}
+
+TEST(StorageClassStats, BenchmarkMemoryUsage) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  size_t initial_size = sizeof(header);
+  std::cout << "Header base size: " << initial_size << " bytes" << std::endl;
+  
+  // Add varying numbers of storage classes and measure
+  std::vector<int> sizes = {1, 10, 100, 1000};
+  
+  for (int size : sizes) {
+    rgw_bucket_dir_header test_header;
+    test_header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+    
+    for (int i = 0; i < size; i++) {
+      (*test_header.storage_class_stats)["SC_" + std::to_string(i)].num_entries = i;
+    }
+    
+    bufferlist bl;
+    encode(test_header, bl);
+    
+    std::cout << "  " << size << " storage classes: " << bl.length() << " bytes encoded" << std::endl;
+  }
+  
+  SUCCEED(); // Informational test
+}
+
+// ============================================================================
+// STRESS TESTS
+// ============================================================================
+
+TEST(StorageClassStats, StressTestRapidChanges) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Rapidly add and remove storage classes
+  for (int cycle = 0; cycle < 100; cycle++) {
+    // Add 50
+    for (int i = 0; i < 50; i++) {
+      std::string name = "SC_" + std::to_string(cycle) + "_" + std::to_string(i);
+      (*header.storage_class_stats)[name].num_entries = i;
+    }
+    
+    // Remove half
+    int removed = 0;
+    for (auto it = header.storage_class_stats->begin(); 
+         it != header.storage_class_stats->end() && removed < 25; ) {
+      it = header.storage_class_stats->erase(it);
+      removed++;
+    }
+  }
+  
+  // Should still be valid
+  EXPECT_TRUE(header.storage_class_stats.has_value());
+  std::cout << "Final size after stress test: " 
+            << header.storage_class_stats->size() << " entries" << std::endl;
+}
+
+TEST(StorageClassStats, StressTestDeepCopy) {
+  rgw_bucket_dir_header original;
+  original.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Add 100 entries
+  for (int i = 0; i < 100; i++) {
+    (*original.storage_class_stats)["SC_" + std::to_string(i)].num_entries = i;
+  }
+  
+  // Make 1000 copies
+  std::vector<rgw_bucket_dir_header> copies;
+  for (int i = 0; i < 1000; i++) {
+    copies.push_back(original);
+  }
+  
+  // Verify all copies are valid
+  for (const auto& copy : copies) {
+    EXPECT_TRUE(copy.storage_class_stats.has_value());
+    EXPECT_EQ(copy.storage_class_stats->size(), 100);
+  }
+  
+  std::cout << "Successfully created 1000 deep copies" << std::endl;
+}


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
