### PR TITLE
test/bufferlist: fix BenchDeref overrun and shrink benchmarks under ASan

### DIFF
--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -823,7 +823,7 @@ static void bench_bufferlistiter_deref(const size_t step,
 
   utime_t start = ceph_clock_now();
   bufferlist::iterator iter = bl.begin();
-  while (iter != bl.end()) {
+  while (iter.get_remaining() >= step) {
     iter += step;
   }
   utime_t end = ceph_clock_now();

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -47,6 +47,18 @@
 #define MAX_TEST 1000000
 #define FILENAME "bufferlist"
 
+#ifndef __has_feature
+#define __has_feature(x) 0
+#endif
+#if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
+static constexpr bool bench_under_asan = true;
+#else
+static constexpr bool bench_under_asan = false;
+#endif
+static constexpr size_t asan_bench_rounds(size_t full) {
+  return bench_under_asan ? (full < 2 ? full : 2) : full;
+}
+
 using namespace std;
 
 static char cmd[128];
@@ -140,12 +152,13 @@ void bench_buffer_alloc(int size, int num)
 }
 
 TEST(Buffer, BenchAlloc) {
-  bench_buffer_alloc(16384, 1000000);
-  bench_buffer_alloc(4096, 1000000);
-  bench_buffer_alloc(1024, 1000000);
-  bench_buffer_alloc(256, 1000000);
-  bench_buffer_alloc(32, 1000000);
-  bench_buffer_alloc(4, 1000000);
+  const int n = asan_bench_rounds(1000000);
+  bench_buffer_alloc(16384, n);
+  bench_buffer_alloc(4096, n);
+  bench_buffer_alloc(1024, n);
+  bench_buffer_alloc(256, n);
+  bench_buffer_alloc(32, n);
+  bench_buffer_alloc(4, n);
 }
 
 TEST(BufferRaw, ostream) {
@@ -544,7 +557,7 @@ TEST(BufferPtr, copy_out_bench) {
   for (int s=1; s<=8; s*=2) {
     utime_t start = ceph_clock_now();
     int buflen = 1048576;
-    int count = 1000;
+    int count = asan_bench_rounds(1000);
     uint64_t v;
     for (int i=0; i<count; ++i) {
       bufferptr bp(buflen);
@@ -583,7 +596,7 @@ TEST(BufferPtr, copy_in_bench) {
   for (int s=1; s<=8; s*=2) {
     utime_t start = ceph_clock_now();
     int buflen = 1048576;
-    int count = 1000;
+    int count = asan_bench_rounds(1000);
     for (int i=0; i<count; ++i) {
       bufferptr bp(buflen);
       for (int64_t j=0; j<buflen; j += s) {
@@ -627,7 +640,7 @@ TEST(BufferPtr, append_bench) {
   for (int s=4; s<=16384; s*=4) {
     utime_t start = ceph_clock_now();
     int buflen = 1048576;
-    int count = 4000;
+    int count = asan_bench_rounds(4000);
     for (int i=0; i<count; ++i) {
       bufferptr bp(buflen);
       bp.set_length(0);
@@ -833,15 +846,15 @@ static void bench_bufferlistiter_deref(const size_t step,
 }
 
 TEST(BufferListIterator, BenchDeref) {
-  bench_bufferlistiter_deref(1, 1, 4096000);
-  bench_bufferlistiter_deref(1, 10, 409600);
-  bench_bufferlistiter_deref(1, 100, 40960);
-  bench_bufferlistiter_deref(1, 1000, 4096);
+  bench_bufferlistiter_deref(1, 1, asan_bench_rounds(4096000));
+  bench_bufferlistiter_deref(1, 10, asan_bench_rounds(409600));
+  bench_bufferlistiter_deref(1, 100, asan_bench_rounds(40960));
+  bench_bufferlistiter_deref(1, 1000, asan_bench_rounds(4096));
 
-  bench_bufferlistiter_deref(4, 1, 1024000);
-  bench_bufferlistiter_deref(4, 10, 102400);
-  bench_bufferlistiter_deref(4, 100, 10240);
-  bench_bufferlistiter_deref(4, 1000, 1024);
+  bench_bufferlistiter_deref(4, 1, asan_bench_rounds(1024000));
+  bench_bufferlistiter_deref(4, 10, asan_bench_rounds(102400));
+  bench_bufferlistiter_deref(4, 100, asan_bench_rounds(10240));
+  bench_bufferlistiter_deref(4, 1000, asan_bench_rounds(1024));
 }
 
 TEST(BufferListIterator, advance) {
@@ -1356,17 +1369,18 @@ void bench_bufferlist_alloc(int size, int num, int per)
 }
 
 TEST(BufferList, BenchAlloc) {
-  bench_bufferlist_alloc(32768, 100000, 16);
-  bench_bufferlist_alloc(25000, 100000, 16);
-  bench_bufferlist_alloc(16384, 100000, 16);
-  bench_bufferlist_alloc(10000, 100000, 16);
-  bench_bufferlist_alloc(8192, 100000, 16);
-  bench_bufferlist_alloc(6000, 100000, 16);
-  bench_bufferlist_alloc(4096, 100000, 16);
-  bench_bufferlist_alloc(1024, 100000, 16);
-  bench_bufferlist_alloc(256, 100000, 16);
-  bench_bufferlist_alloc(32, 100000, 16);
-  bench_bufferlist_alloc(4, 100000, 16);
+  const int n = asan_bench_rounds(100000);
+  bench_bufferlist_alloc(32768, n, 16);
+  bench_bufferlist_alloc(25000, n, 16);
+  bench_bufferlist_alloc(16384, n, 16);
+  bench_bufferlist_alloc(10000, n, 16);
+  bench_bufferlist_alloc(8192, n, 16);
+  bench_bufferlist_alloc(6000, n, 16);
+  bench_bufferlist_alloc(4096, n, 16);
+  bench_bufferlist_alloc(1024, n, 16);
+  bench_bufferlist_alloc(256, n, 16);
+  bench_bufferlist_alloc(32, n, 16);
+  bench_bufferlist_alloc(4, n, 16);
 }
 
 /*
@@ -1391,7 +1405,7 @@ TEST(BufferList, append_bench_with_size_hint) {
   for (size_t step = 4; step <= 16384; step *= 4) {
     const utime_t start = ceph_clock_now();
 
-    constexpr size_t rounds = 4000;
+    constexpr size_t rounds = asan_bench_rounds(4000);
     for (size_t r = 0; r < rounds; ++r) {
       ceph::bufferlist bl(std::size(src));
       for (auto iter = std::begin(src);
@@ -1408,7 +1422,7 @@ TEST(BufferList, append_bench_with_size_hint) {
 
 TEST(BufferList, append_bench_with_size_hint2) {
   std::array<char, 1048576> src = { 0, };
-  constexpr size_t rounds = 4000;
+  constexpr size_t rounds = asan_bench_rounds(4000);
   constexpr int conc_bl = 400;
   std::vector<ceph::bufferlist*> bls(conc_bl);
 
@@ -1439,7 +1453,7 @@ TEST(BufferList, append_bench) {
   std::array<char, 1048576> src = { 0, };
   for (size_t step = 4; step <= 16384; step *= 4) {
     const utime_t start = ceph_clock_now();
-    constexpr size_t rounds = 4000;
+    constexpr size_t rounds = asan_bench_rounds(4000);
     for (size_t r = 0; r < rounds; ++r) {
       ceph::bufferlist bl;
       for (auto iter = std::begin(src);
@@ -1456,7 +1470,7 @@ TEST(BufferList, append_bench) {
 
 TEST(BufferList, append_bench2) {
   std::array<char, 1048576> src = { 0, };
-  constexpr size_t rounds = 4000;
+  constexpr size_t rounds = asan_bench_rounds(4000);
   constexpr int conc_bl = 400;
   std::vector<ceph::bufferlist*> bls(conc_bl);
 
@@ -1488,7 +1502,7 @@ TEST(BufferList, append_hole_bench) {
 
   for (size_t step = 512; step <= 65536; step *= 2) {
     const utime_t start = ceph_clock_now();
-    constexpr size_t rounds = 80000;
+    constexpr size_t rounds = asan_bench_rounds(80000);
     for (size_t r = 0; r < rounds; ++r) {
       ceph::bufferlist bl;
       while (bl.length() < targeted_bl_size) {
@@ -1503,7 +1517,7 @@ TEST(BufferList, append_hole_bench) {
 
 TEST(BufferList, append_hole_bench2) {
   constexpr size_t targeted_bl_size = 1048576;
-  constexpr size_t rounds = 80000;
+  constexpr size_t rounds = asan_bench_rounds(80000);
   constexpr int conc_bl = 400;
   std::vector<ceph::bufferlist*> bls(conc_bl);
 


### PR DESCRIPTION
- BenchDeref drove its deref loop by comparing the iterator to end(). When
  the total length was not a multiple of step, `iter += step` could run past
  the end and throw "End of buffer". Drive the loop by
  `get_remaining() >= step` instead.

- The pure-timing `*_bench`/BenchAlloc loops repeat a stateless path millions
  of times. Under ASan that adds no memory-error coverage but inflates the run
  from minutes to hours, so cut the iteration counts when built with ASan.

```
- Test #40: unittest_bufferlist ..............   Passed  7394.76 sec
+ Test #40: unittest_bufferlist ..............   Passed   44.27 sec
```

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests