### PR TITLE
mgr/dashboard: Align RGW Account Role forms with updated UX design

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/accounts.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/accounts.po.ts
@@ -32,6 +32,8 @@ export class AccountsPageHelper extends PageHelper {
     // Enter email
     cy.get('#email').type(account.email);
 
+    cy.contains('button', 'Show advanced settings').click();
+
     // Enter max buckets
     cy.get('input#max_buckets').should('exist').should('have.value', '1000');
 
@@ -49,7 +51,7 @@ export class AccountsPageHelper extends PageHelper {
     cy.get('input#account_checkbox_input').check({ force: true });
 
     // Click the create button and wait for account to be made
-    cy.contains('button', 'Create Account').click();
+    cy.contains('button', 'Create account').click();
 
     this.getFirstTableCell(account.name).should('have.text', account.name);
     this.getTableRow(account.name).within(() => {
@@ -106,6 +108,8 @@ export class AccountsPageHelper extends PageHelper {
     // Enter email
     cy.get('#email').clear().type(account.email);
 
+    cy.contains('button', 'Show advanced settings').click();
+
     // Enter max buckets
     this.selectOption('max_buckets_mode', 'Custom');
     cy.get('input#max_buckets').click().clear().type(account.max_buckets);
@@ -129,7 +133,7 @@ export class AccountsPageHelper extends PageHelper {
     cy.get('input#account_quota_max_objects').clear().type('200');
 
     // Click the create button and wait for account to be made
-    cy.contains('button', 'Edit Account').click();
+    cy.contains('button', 'Edit account').click();
 
     this.getTableRow(account.name).within(() => {
       cy.get('td').eq(this.columnIndex.tenant).should('have.text', account.tenant);
@@ -215,6 +219,8 @@ export class AccountsPageHelper extends PageHelper {
       .find('.cds--form-requirement')
       .should('have.text', ' Please enter a valid email ');
 
+    cy.contains('button', 'Show advanced settings').click();
+
     cy.get('input#max_buckets').click().clear().type('0').blur();
 
     cy.get('label[for=max_buckets]')
@@ -251,6 +257,8 @@ export class AccountsPageHelper extends PageHelper {
     cy.get('cds-text-label[for=email]')
       .find('.cds--form-requirement')
       .should('have.text', ' Please enter a valid email ');
+
+    cy.contains('button', 'Show advanced settings').click();
 
     cy.get('input#max_buckets').click().clear().type('0').blur();
 

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/roles.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/roles.po.ts
@@ -38,7 +38,7 @@ export class RolesPageHelper extends PageHelper {
     cy.get('cds-number[formControlName="max_session_duration"] input')
       .clear()
       .type(maxSessionDuration.toString());
-    cy.get('cds-modal').contains('button', 'Edit').click();
+    cy.get('cds-modal').contains('button', 'Save').click();
     cy.get('cds-modal').should('not.exist');
 
     this.getRolesTableCell(this.columnIndex.roleName, name)

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-role-form/rgw-account-role-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-role-form/rgw-account-role-form.component.html
@@ -1,19 +1,38 @@
 <cds-modal size="md" [open]="open" [hasScrollingContent]="false" (overlaySelected)="closeModal()">
   <cds-modal-header (closeSelect)="closeModal()">
-    <h4 cdsModalHeaderLabel class="cds--type-label-01">{{ accountName }}</h4>
-    <h3 cdsModalHeaderHeading i18n>{{ mode }} role</h3>
+    @if (isEdit) {
+      <h4 cdsModalHeaderLabel class="cds--type-label-01" i18n>Role</h4>
+      <h3 cdsModalHeaderHeading i18n>Edit session duration</h3>
+      <p class="cds--modal-header__description cds--type-body-01 cds-mt-3" i18n>
+        Update the maximum session duration for this role.
+      </p>
+    } @else {
+      <h4 cdsModalHeaderLabel class="cds--type-label-01" i18n>User account</h4>
+      <h3 cdsModalHeaderHeading i18n>Create role</h3>
+      <p class="cds--modal-header__description cds--type-body-01 cds-mt-3" i18n>
+        Role grants temporary permissions to trusted users, applications, or services.
+      </p>
+    }
   </cds-modal-header>
 
   <form class="form" #formDir="ngForm" [formGroup]="form">
     <div cdsModalContent>
+      @if (!isEdit) {
+      <!-- Account -->
+      <div class="form-item">
+        <label class="cds--label cds--type-label-01" i18n>Account</label>
+        <p class="cds--type-body-01">{{ accountName }}</p>
+      </div>
+
       <!-- Role Name -->
       <div class="form-item">
         <cds-text-label
           label="Role name"
           for="role_name"
-          cdRequiredField="Role name"
           [invalid]="roleName.isInvalid"
           [invalidText]="roleNameError"
+          helperText="Unique name used to identify this role within the account."
+          i18n-helperText
           >Role name
           <input
             cdsText
@@ -23,7 +42,7 @@
             id="role_name"
             name="role_name"
             formControlName="role_name"
-            placeholder="Placeholder text"
+            placeholder="Enter a role name (e.g. BackupServiceRole)"
             [invalid]="roleName.isInvalid"
             [autofocus]="true"
             modal-primary-focus
@@ -36,17 +55,44 @@
         </ng-template>
       </div>
 
+      <!-- Role (Edit only) -->
+      } @else {
+      <div class="form-item">
+        <label class="cds--label cds--type-label-01" i18n>Role</label>
+        <p class="cds--type-body-01">
+          <cds-tooltip-definition
+            align="right"
+            [description]="accountTooltip"
+            [openOnHover]="true"
+            [caret]="true"
+            [highContrast]="true"
+            [dropShadow]="true"
+            [autoAlign]="true"
+          >
+            {{ form.getValue('role_name') }}
+          </cds-tooltip-definition>
+        </p>
+        <ng-template #accountTooltip>
+          <div>
+            User account:<br />
+            <strong>{{ accountName }}</strong>
+          </div>
+        </ng-template>
+      </div>
+      }
+
       <!-- Path & Assume Role Policy Document (Create only) -->
       @if (!isEdit) {
       <!-- Path -->
       <div class="form-item">
         <cds-text-label
-          label="Path"
+          label="Role path"
           for="role_path"
-          cdRequiredField="Path"
           [invalid]="rolePath.isInvalid"
           [invalidText]="pathError"
-          >Path
+          helperText='Specifies the hierarchy or namespace for the role. Use "/" for the root path.'
+          i18n-helperText
+          >Role path
           <input
             cdsText
             cdValidate
@@ -55,7 +101,7 @@
             id="role_path"
             name="role_path"
             formControlName="role_path"
-            placeholder="Placeholder text"
+            placeholder="Enter path (/applications/)"
             [invalid]="rolePath.isInvalid"
           />
         </cds-text-label>
@@ -72,7 +118,8 @@
           labelInputID="role_assume_policy_doc"
           [invalid]="policyDoc.isInvalid"
           [invalidText]="policyError"
-          cdRequiredField="Trust Policy"
+          helperText="Defines which principals can assume this role. Enter a valid JSON policy document."
+          i18n-helperText
           >Trust policy
           <textarea
             cdsTextArea
@@ -81,7 +128,7 @@
             id="role_assume_policy_doc"
             name="role_assume_policy_doc"
             formControlName="role_assume_policy_doc"
-            placeholder="Placeholder text"
+            placeholder="Enter a JSON trust policy document"
             rows="8"
             cols="200"
             [invalid]="policyDoc.isInvalid"
@@ -98,11 +145,11 @@
       </div>
       }
 
-      <!-- Max Session Duration (Edit only) -->
+      <!-- Maximum Session Duration (Edit only) -->
       @if (isEdit) {
       <div class="form-item">
         <cds-number
-          label="Max Session Duration (Hours)"
+          label="Maximum session duration (hours)"
           cdValidate
           #maxSessionDuration="cdValidate"
           [invalid]="maxSessionDuration.isInvalid"
@@ -129,7 +176,7 @@
     <cd-form-button-panel
       (submitActionEvent)="onSubmit()"
       [form]="form"
-      [submitText]="mode"
+      [submitText]="isEdit ? 'Save' : 'Create'"
       [modalForm]="true"
     ></cd-form-button-panel>
   </form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-role-form/rgw-account-role-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-role-form/rgw-account-role-form.component.ts
@@ -88,7 +88,8 @@ export class RgwAccountRoleFormComponent extends BaseModal implements OnInit {
           next: () => {
             this.notificationService.show(
               NotificationType.success,
-              $localize`Role updated successfully`
+              $localize`Session duration updated`,
+              $localize`The maximum session duration for role "${this.roleName}" has been updated to ${payload.max_session_duration} hours.`
             );
             this.closeModal();
           },

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts-form/rgw-user-accounts-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts-form/rgw-user-accounts-form.component.html
@@ -7,20 +7,23 @@
           novalidate>
 
       <div i18n="form title"
-           class="form-header">{{ action | titlecase }} {{ resource | upperFirst }}
+           class="form-header cds--type-heading-04 cds-mb-5">{{ action | titlecase }} {{ resource | lowercase }}
       </div>
+
+      <h4 class="cds--type-heading-03 cds-mb-4" i18n>Account details</h4>
 
       <!-- Account Name -->
       <div class="form-item">
-        <cds-text-label label="Account Name"
+        <cds-text-label label="Account name"
                         for="acc_name"
-                        cdRequiredField="Account Name"
                         [invalid]="!accountForm.controls.name.valid && accountForm.controls.name.dirty"
                         [invalidText]="accountIdError"
-                        i18n>Account Name
+                        helperText="Name must start and end in alphanumeric characters (3 to 63). Characters allowed: lowercase, numbers and nonconsecutive dots and hyphens."
+                        i18n-helperText
+                        i18n>Account name
           <input cdsText
                  type="text"
-                 placeholder="Enter account name"
+                 placeholder="for example, team-storage-01"
                  id="acc_name"
                  name="acc_name"
                  formControlName="name"/>
@@ -34,12 +37,14 @@
       </div>
       <!-- Tenant -->
       <div class="form-item">
-        <cds-text-label label="tenant"
+        <cds-text-label label="Tenant (optional)"
                         for="tenant"
-                        i18n>Tenant
+                        helperText="Associates this account with an existing tenant namespace."
+                        i18n-helperText
+                        i18n>Tenant (optional)
           <input cdsText
                  type="text"
-                 placeholder="Enter tenant"
+                 placeholder="for example, finance-team"
                  id="tenant"
                  name="tenant"
                  formControlName="tenant"/>
@@ -48,14 +53,16 @@
 
       <!-- Email -->
       <div class="form-item">
-        <cds-text-label label="email"
+        <cds-text-label label="Email address (optional)"
                         for="email"
                         [invalid]="!accountForm.controls.email.valid && accountForm.controls.email.dirty"
                         [invalidText]="emailError"
-                        i18n>Email
+                        helperText="Contact for quota alerts and notifications."
+                        i18n-helperText
+                        i18n>Email address (optional)
           <input cdsText
                  type="text"
-                 placeholder="Enter email"
+                 placeholder="for example, admin@example.com"
                  id="email"
                  name="email"
                  formControlName="email"/>
@@ -67,108 +74,113 @@
         </ng-template>
       </div>
 
-      <div class="form-item form-item-append"
-           cdsRow>
-        <div cdsCol>
-          <!-- Max. bucket mode -->
-          <ng-container *ngTemplateOutlet="selectModeTemplate;context: { formControl: 'max_buckets_mode' }"></ng-container>
-        </div>
-        <div cdsCol>
-        <!-- Max buckets -->
-        <span *ngIf="1 == accountForm.get('max_buckets_mode').value">
-          <ng-container *ngTemplateOutlet="accountMaxValueTemplate;context: { formControl: 'max_buckets' }"></ng-container>
-          </span>
+      <div class="form-item cds-mt-5 cds-mb-3">
+        <h4 class="cds--type-heading-03" i18n>Advanced settings</h4>
+        <p class="cds--type-body-01" i18n>Configure resource limits and quota for this account</p>
+        <div class="cds-mt-3">
+          <button type="button" class="cds--btn cds--btn--ghost advanced-settings-btn" (click)="showAdvanced = !showAdvanced">
+            {{ showAdvanced ? 'Hide advanced settings' : 'Show advanced settings' }}
+            <svg cdsIcon="chevron--down" *ngIf="!showAdvanced" size="16" class="cds--btn__icon"></svg>
+            <svg cdsIcon="chevron--up" *ngIf="showAdvanced" size="16" class="cds--btn__icon"></svg>
+          </button>
         </div>
       </div>
 
-      <div class="form-item form-item-append"
-           cdsRow>
-        <div cdsCol>
-          <!-- Max. users mode -->
-          <ng-container *ngTemplateOutlet="selectModeTemplate;context: { formControl: 'max_users_mode' }"></ng-container>
-        </div>
-        <div cdsCol>
-        <!-- Max users -->
-        <span *ngIf="1 == accountForm.get('max_users_mode').value">
-          <ng-container *ngTemplateOutlet="accountMaxValueTemplate;context: { formControl: 'max_users' }"></ng-container>
-          </span>
-        </div>
-      </div>
+      <div *ngIf="showAdvanced">
+        <h5 class="cds--type-heading-02 cds-mb-2" i18n>Resource limits</h5>
+        <p class="cds--type-body-01 cds-mb-4" i18n>Set the mode and maximum allowed values for each resource type. Select Custom to specify a limit.</p>
 
-      <div class="form-item form-item-append"
-           cdsRow>
-        <div cdsCol>
-          <!-- Max. roles mode -->
-          <ng-container *ngTemplateOutlet="selectModeTemplate;context: { formControl: 'max_roles_mode' }"></ng-container>
+        <div class="form-item form-item-append" cdsRow>
+          <div cdsCol>
+            <!-- Max. bucket mode -->
+            <ng-container *ngTemplateOutlet="selectModeTemplate;context: { formControl: 'max_buckets_mode' }"></ng-container>
+          </div>
+          <div cdsCol>
+            <!-- Max buckets -->
+            <ng-container *ngTemplateOutlet="accountMaxValueTemplate;context: { formControl: 'max_buckets' }"></ng-container>
+          </div>
         </div>
-        <div cdsCol>
-        <!-- Max roles -->
-        <span *ngIf="1 == accountForm.get('max_roles_mode').value">
-          <ng-container *ngTemplateOutlet="accountMaxValueTemplate;context: { formControl: 'max_roles' }"></ng-container>
-        </span>
-        </div>
-      </div>
 
-      <div class="form-item form-item-append"
-           cdsRow>
-        <div cdsCol>
-          <!-- Max. group mode -->
-          <ng-container *ngTemplateOutlet="selectModeTemplate;context: { formControl: 'max_groups_mode' }"></ng-container>
+        <div class="form-item form-item-append" cdsRow>
+          <div cdsCol>
+            <!-- Max. users mode -->
+            <ng-container *ngTemplateOutlet="selectModeTemplate;context: { formControl: 'max_users_mode' }"></ng-container>
+          </div>
+          <div cdsCol>
+            <!-- Max users -->
+            <ng-container *ngTemplateOutlet="accountMaxValueTemplate;context: { formControl: 'max_users' }"></ng-container>
+          </div>
         </div>
-        <div cdsCol>
-        <!-- Max group -->
-        <span *ngIf="1 == accountForm.get('max_groups_mode').value">
-          <ng-container *ngTemplateOutlet="accountMaxValueTemplate;context: { formControl: 'max_groups' }"></ng-container>
-          </span>
-        </div>
-      </div>
 
-      <div class="form-item form-item-append"
-           cdsRow>
-        <div cdsCol>
-          <!-- Max. acess keys mode -->
-          <ng-container *ngTemplateOutlet="selectModeTemplate;context: { formControl: 'max_access_keys_mode' }"></ng-container>
+        <div class="form-item form-item-append" cdsRow>
+          <div cdsCol>
+            <!-- Max. roles mode -->
+            <ng-container *ngTemplateOutlet="selectModeTemplate;context: { formControl: 'max_roles_mode' }"></ng-container>
+          </div>
+          <div cdsCol>
+            <!-- Max roles -->
+            <ng-container *ngTemplateOutlet="accountMaxValueTemplate;context: { formControl: 'max_roles' }"></ng-container>
+          </div>
         </div>
-        <div cdsCol>
-        <!-- Max acess keys -->
-        <span *ngIf="1 == accountForm.get('max_access_keys_mode').value">
-          <ng-container *ngTemplateOutlet="accountMaxValueTemplate;context: { formControl: 'max_access_keys' }"></ng-container>
-        </span>
+
+        <div class="form-item form-item-append" cdsRow>
+          <div cdsCol>
+            <!-- Max. group mode -->
+            <ng-container *ngTemplateOutlet="selectModeTemplate;context: { formControl: 'max_groups_mode' }"></ng-container>
+          </div>
+          <div cdsCol>
+            <!-- Max group -->
+            <ng-container *ngTemplateOutlet="accountMaxValueTemplate;context: { formControl: 'max_groups' }"></ng-container>
+          </div>
         </div>
-      </div>
 
-      <!-- Account Quota -->
-      <div class="form-item">
-        <ng-container *ngTemplateOutlet="quotaTemplate;context: { formControl: {
-                      enabled: 'account_quota_enabled',
-                      unlimitedSize: 'account_quota_max_size_unlimited',
-                      maxSize: 'account_quota_max_size',
-                      unlimitedObjects: 'account_quota_max_objects_unlimited',
-                      maxObjects: 'account_quota_max_objects'
-                      },
-                      quotaType: 'account'
-                      }">
-        </ng-container>
-      </div>
+        <div class="form-item form-item-append" cdsRow>
+          <div cdsCol>
+            <!-- Max. access keys mode -->
+            <ng-container *ngTemplateOutlet="selectModeTemplate;context: { formControl: 'max_access_keys_mode' }"></ng-container>
+          </div>
+          <div cdsCol>
+            <!-- Max access keys -->
+            <ng-container *ngTemplateOutlet="accountMaxValueTemplate;context: { formControl: 'max_access_keys' }"></ng-container>
+          </div>
+        </div>
 
-      <!-- Bucket Quota -->
-      <div class="form-item">
-        <ng-container *ngTemplateOutlet="quotaTemplate;
-                      context: {
-                      formControl: {
-                      enabled: 'bucket_quota_enabled',
-                      unlimitedSize: 'bucket_quota_max_size_unlimited',
-                      maxSize: 'bucket_quota_max_size',
-                      unlimitedObjects: 'bucket_quota_max_objects_unlimited',
-                      maxObjects: 'bucket_quota_max_objects'
-                      },
-                      quotaType: 'bucket'
-                      }">
-        </ng-container>
+        <h5 class="cds--type-heading-02 cds-mb-2 cds-mt-5" i18n>Quotas</h5>
+        <p class="cds--type-body-01 cds-mb-4" i18n>Define storage usage limits for the account and the buckets it owns. Quotas help control capacity consumption and enforce resource allocation policies.</p>
+
+        <!-- Account Quota -->
+        <div class="form-item">
+          <ng-container *ngTemplateOutlet="quotaTemplate;context: { formControl: {
+                        enabled: 'account_quota_enabled',
+                        unlimitedSize: 'account_quota_max_size_unlimited',
+                        maxSize: 'account_quota_max_size',
+                        unlimitedObjects: 'account_quota_max_objects_unlimited',
+                        maxObjects: 'account_quota_max_objects'
+                        },
+                        quotaType: 'account'
+                        }">
+          </ng-container>
+        </div>
+
+        <!-- Bucket Quota -->
+        <div class="form-item">
+          <ng-container *ngTemplateOutlet="quotaTemplate;
+                        context: {
+                        formControl: {
+                        enabled: 'bucket_quota_enabled',
+                        unlimitedSize: 'bucket_quota_max_size_unlimited',
+                        maxSize: 'bucket_quota_max_size',
+                        unlimitedObjects: 'bucket_quota_max_objects_unlimited',
+                        maxObjects: 'bucket_quota_max_objects'
+                        },
+                        quotaType: 'bucket'
+                        }">
+          </ng-container>
+        </div>
       </div>
       <cd-form-button-panel (submitActionEvent)="submit()"
                             [form]="formDir"
-                            [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
+                            [submitText]="(action | titlecase) + ' ' + (resource | lowercase)"
                             wrappingClass="text-right"></cd-form-button-panel>
 
     </form>
@@ -181,7 +193,7 @@
   <cds-select [formControlName]="formControl"
               [name]="formControl"
               [id]="formControl"
-              label="{{formControl.split('_')[1] | upperFirst}} Mode"
+              label="{{formControl.split('_')[1] | upperFirst}} mode"
               (change)="onModeChange($event.target.value, formControl)"
               [helperText]="getHelperTextForMode(formControl)">
     <option value="0">Unlimited</option>
@@ -193,14 +205,28 @@
 <ng-template #accountMaxValueTemplate
              let-formControl="formControl"
              [formGroup]="accountForm">
-<cds-number [id]="formControl"
-            [name]="formControl"
-            formControlName="{{formControl}}"
-            label="{{formControl.split('_')[0] | upperFirst}}. {{formControl.split('_').length > 2 ? formControl.split('_')[1]+' '+formControl.split('_')[2]: formControl.split('_')[1]}}"
-            [min]="1"
-            cdRequiredField="{{formControl.split('_')[0] | upperFirst}}. {{formControl.split('_').length > 2 ? formControl.split('_')[1]+' '+formControl.split('_')[2]: formControl.split('_')[1]}}"
-            [invalid]="!accountForm.controls[formControl].valid && accountForm.controls[formControl].dirty"
-            [invalidText]="maxValError"></cds-number>
+  <cds-number *ngIf="accountForm.get(formControl + '_mode').value == '1'"
+              [id]="formControl"
+              [name]="formControl"
+              formControlName="{{formControl}}"
+              label="Maximum {{formControl.replace('max_', '').replace('_', ' ')}}"
+              [min]="1"
+              [invalid]="!accountForm.controls[formControl].valid && accountForm.controls[formControl].dirty"
+              [invalidText]="maxValError"></cds-number>
+  
+  <cds-text-label *ngIf="accountForm.get(formControl + '_mode').value != '1'"
+                  label="Maximum {{formControl.replace('max_', '').replace('_', ' ')}}"
+                  for="{{formControl}}_disabled">
+    Maximum {{formControl.replace('max_', '').replace('_', ' ')}}
+    <input cdsText
+           type="text"
+           [id]="formControl + '_disabled'"
+           name="{{formControl}}_disabled"
+           [ngModel]="'-'"
+           [ngModelOptions]="{standalone: true}"
+           [disabled]="true" />
+  </cds-text-label>
+
 <ng-template #maxValError>
   <span *ngIf="accountForm.showError(formControl, formDir, 'required')"
         i18n>This field is required.</span>
@@ -215,20 +241,19 @@
              let-quotaType="quotaType"
              let-formControl="formControl"
              [formGroup]="accountForm">
-  <fieldset class="cds--fieldset">
-    <legend class="cds--label">{{quotaType | upperFirst}} Quota</legend>
-    <div *ngIf="quotaType == 'account';else bucket"
-         class="quota-heading">Set quota on account owned by users.</div>
-    <ng-template #bucket>
-      <div class="quota-heading">
-        Set quota on buckets owned by an account.
-      </div>
-    </ng-template>
+  <fieldset class="cds--fieldset cds-mb-4">
+    <legend class="cds--label">{{quotaType | upperFirst}} quota</legend>
     <!-- Enabled -->
-    <cds-checkbox [formControlName]="formControl.enabled"
-                  [id]="quotaType+'_checkbox'">
-      Enabled
+    <cds-checkbox *ngIf="quotaType == 'account'" [formControlName]="formControl.enabled"
+                  [id]="quotaType+'_checkbox'" class="cds-mb-3">
+      Enable account quota
     </cds-checkbox >
+    <cds-checkbox *ngIf="quotaType == 'bucket'" [formControlName]="formControl.enabled"
+                  [id]="quotaType+'_checkbox'" class="cds-mb-3">
+      Enable bucket quota
+    </cds-checkbox >
+    <p class="cds--type-body-01 cds-mb-4" *ngIf="quotaType == 'account'">Applies a storage quota to each user account.</p>
+    <p class="cds--type-body-01 cds-mb-4" *ngIf="quotaType == 'bucket'">Limits the total storage available across all buckets in an account.</p>
     <div class="quota-sub-block"
          *ngIf="accountForm.controls[formControl.enabled].value">
       <!-- Unlimited size -->
@@ -242,10 +267,9 @@
            *ngIf="accountForm.controls[formControl.enabled].value && !accountForm.getValue(formControl.unlimitedSize)">
         <cds-text-label [label]="formControl.maxSize"
                         [for]="formControl.maxSize"
-                        cdRequiredField="Max. size"
                         [invalid]="!accountForm.controls[formControl.maxSize].valid && accountForm.controls[formControl.maxSize].dirty"
                         [invalidText]="quotaSizeError"
-                        i18n>Max. size
+                        i18n>Maximum size
           <input cdsText
                  type="text"
                  placeholder="Enter size"
@@ -274,10 +298,9 @@
            *ngIf="accountForm.controls[formControl.enabled].value && !accountForm.getValue(formControl.unlimitedObjects)">
         <cds-text-label [label]="formControl.maxObjects"
                         [for]="formControl.maxObjects"
-                        cdRequiredField="Max. objects"
                         [invalid]="!accountForm.controls[formControl.maxObjects].valid && accountForm.controls[formControl.maxObjects].dirty"
                         [invalidText]="quotaObjectError"
-                        i18n>Max. objects
+                        i18n>Maximum objects
           <input cdsText
                  type="number"
                  placeholder="Enter number of objects"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts-form/rgw-user-accounts-form.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts-form/rgw-user-accounts-form.component.scss
@@ -19,3 +19,7 @@
     }
   }
 }
+
+.advanced-settings-btn {
+  margin-left: calc(-1 * layout.$spacing-05);
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts-form/rgw-user-accounts-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts-form/rgw-user-accounts-form.component.ts
@@ -25,6 +25,7 @@ export class RgwUserAccountsFormComponent extends CdForm implements OnInit {
   action: string;
   resource: string;
   editing: boolean = false;
+  showAdvanced: boolean = false;
   submitObservables: Observable<Object>[] = [];
 
   constructor(

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts/rgw-user-accounts.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts/rgw-user-accounts.component.html
@@ -2,7 +2,7 @@
 <legend i18n>
   User Accounts
   <cd-help-text>
-    Administrators can assign unique credentials to users or applications, enabling granular access control and enhancing security across the cluster.
+    Create and manage accounts and their permissions.
   </cd-help-text>
 </legend>
 <cd-table #table

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
@@ -96,6 +96,8 @@ import ShareIcon from '@carbon/icons/es/share/16';
 import ViewIcon from '@carbon/icons/es/view/16';
 import PasswordIcon from '@carbon/icons/es/password/16';
 import ArrowDownIcon from '@carbon/icons/es/arrow--down/16';
+import ChevronDownIcon from '@carbon/icons/es/chevron--down/16';
+import ChevronUpIcon from '@carbon/icons/es/chevron--up/16';
 import ProgressBarRoundIcon from '@carbon/icons/es/progress-bar--round/32';
 import ToolsIcon from '@carbon/icons/es/tools/32';
 import UserAccessLocked from '@carbon/icons/es/user--access-locked/16';
@@ -248,6 +250,8 @@ export class RgwModule {
       ViewIcon,
       PasswordIcon,
       ArrowDownIcon,
+      ChevronDownIcon,
+      ChevronUpIcon,
       ProgressBarRoundIcon,
       ToolsIcon,
       UserAccessLocked
@@ -287,12 +291,12 @@ const routes: Routes = [
       {
         path: URLVerbs.CREATE,
         component: RgwUserAccountsFormComponent,
-        data: { breadcrumbs: ActionLabels.CREATE }
+        data: { breadcrumbs: $localize`Create account` }
       },
       {
         path: `${URLVerbs.EDIT}/:id`,
         component: RgwUserAccountsFormComponent,
-        data: { breadcrumbs: ActionLabels.EDIT }
+        data: { breadcrumbs: $localize`Edit account` }
       }
     ]
   },

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/context/context.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/context/context.component.html
@@ -2,22 +2,24 @@
   <ng-container *ngIf="data.ftMap && data.ftMap.rgw && permissions.rgw.read && isRgwRoute && data.daemons.length > 1">
     <div class="cd-context-bar pt-3 pb-3">
       <span class="me-1"
-            i18n>Selected Object Gateway:</span>
+            i18n>Object gateway:</span>
       <div ngbDropdown
            placement="bottom-left"
            class="d-inline-block ms-2">
         <button ngbDropdownToggle
                 class="btn btn-outline-info ctx-bar-selected-rgw-daemon"
                 i18n-title
-                title="Select Object Gateway">
-          {{ data.selectedDaemon.id }} ( {{ data.selectedDaemon.zonegroup_name }} )
+                title="Object gateway">
+          {{ data.selectedDaemon.id }}
+          <cds-tag type="blue" size="sm">{{ data.selectedDaemon.zonegroup_name }}</cds-tag>
         </button>
         <div ngbDropdownMenu>
           <ng-container *ngFor="let daemon of data.daemons">
             <button ngbDropdownItem
                     class="ctx-bar-available-rgw-daemon"
                     (click)="onDaemonSelection(daemon)">
-              {{ daemon.id }} ( {{ daemon.zonegroup_name }} )
+              {{ daemon.id }}
+              <cds-tag type="blue" size="sm">{{ daemon.zonegroup_name }}</cds-tag>
             </button>
           </ng-container>
         </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/context/context.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/context/context.component.spec.ts
@@ -12,6 +12,8 @@ import {
   FeatureTogglesService
 } from '~/app/shared/services/feature-toggles.service';
 import { configureTestBed, RgwHelper } from '~/testing/unit-test-helper';
+import { TagModule } from 'carbon-components-angular';
+import { RgwDaemonService } from '~/app/shared/api/rgw-daemon.service';
 import { ContextComponent } from './context.component';
 
 describe('ContextComponent', () => {
@@ -29,7 +31,7 @@ describe('ContextComponent', () => {
 
   configureTestBed({
     declarations: [ContextComponent],
-    imports: [HttpClientTestingModule, RouterTestingModule]
+    imports: [HttpClientTestingModule, RouterTestingModule, TagModule]
   });
 
   beforeEach(() => {
@@ -46,6 +48,7 @@ describe('ContextComponent', () => {
     ftMap = new FeatureTogglesMap();
     ftMap.rgw = true;
     getFeatureTogglesSpy.and.returnValue(of(ftMap));
+    TestBed.inject(RgwDaemonService).selectDaemon(null);
     fixture = TestBed.createComponent(ContextComponent);
     component = fixture.componentInstance;
   });
@@ -69,13 +72,13 @@ describe('ContextComponent', () => {
     const selectedDaemon = fixture.debugElement.nativeElement.querySelector(
       '.ctx-bar-selected-rgw-daemon'
     );
-    expect(selectedDaemon.textContent).toEqual(' daemon2 ( zonegroup2 ) ');
+    expect(selectedDaemon.textContent).toEqual(' daemon2 zonegroup2');
 
     const availableDaemons = fixture.debugElement.nativeElement.querySelectorAll(
       '.ctx-bar-available-rgw-daemon'
     );
     expect(availableDaemons.length).toEqual(daemonList.length);
-    expect(availableDaemons[0].textContent).toEqual(' daemon1 ( zonegroup1 ) ');
+    expect(availableDaemons[0].textContent).toEqual(' daemon1 zonegroup1');
     component.ngOnDestroy();
   }));
 
@@ -94,7 +97,7 @@ describe('ContextComponent', () => {
     const selectedDaemon = fixture.debugElement.nativeElement.querySelector(
       '.ctx-bar-selected-rgw-daemon'
     );
-    expect(selectedDaemon.textContent).toEqual(' daemon3 ( zonegroup3 ) ');
+    expect(selectedDaemon.textContent).toEqual(' daemon3 zonegroup3');
     component.ngOnDestroy();
   }));
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/core.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/core.module.ts
@@ -8,7 +8,8 @@ import {
   PlaceholderModule,
   IconModule,
   ThemeModule,
-  ButtonModule
+  ButtonModule,
+  TagModule
 } from 'carbon-components-angular';
 
 import { ContextComponent } from '~/app/core/context/context.component';
@@ -30,7 +31,8 @@ import { NavigationModule } from './navigation/navigation.module';
     PlaceholderModule,
     IconModule,
     ThemeModule,
-    ButtonModule
+    ButtonModule,
+    TagModule
   ],
   exports: [NavigationModule],
   declarations: [


### PR DESCRIPTION
mgr/dashboard: Align RGW Account Role forms with updated UX design

Signed-off-by: Sagar Gopale <sagar.gopale@ibm.com>

Screencast : 
<img width="3838" height="2118" alt="image" src="https://github.com/user-attachments/assets/47fda3ed-db74-4495-9286-32f64f2603e5" />
<img width="3838" height="2092" alt="image" src="https://github.com/user-attachments/assets/781fe9af-4f4b-46b2-bcc2-4bc91f492b02" />

<img width="3838" height="2100" alt="image" src="https://github.com/user-attachments/assets/b28c5880-2ff7-48f9-a73f-439f932cc13f" />

<img width="3840" height="1912" alt="image" src="https://github.com/user-attachments/assets/74a420ef-8cdc-4c65-a5d8-73842df56178" />
<img width="3840" height="2400" alt="image" src="https://github.com/user-attachments/assets/2786380c-b024-4040-aee5-f43f89da15f5" />


### RGW UX Content Design Alignment Changes

* **Object Gateway Context Selector:**
  * Dropped the redundant `"Selected"` word from the dropdown context label, changing it to `"Object gateway"`.
  * Used Carbon's inline `<cds-tag>` component to display the `( default )` tag, removing the extra whitespace padding around parentheses.
* **User Accounts Page Description:**
  * Updated the page description help text to a clearer, more concise version: `"Create and manage accounts and their permissions."`
* **RGW User Accounts Form:**
  * Updated the page title and breadcrumbs to sentence case (`"Create account"`).
  * Removed the `(required)` suffix from all required fields, and marked optional fields (`Tenant` and `Email`) with `(optional)`.
  * Replaced instructional placeholder text with realistic data examples (e.g. `"team-storage-01"`, `"finance-team"`, `"admin@example.com"`).
  * Grouped limits under a single `"Resource limits"` section heading and description.
  * Standardized limit labels to sentence case, spelled out `"Max."` as `"Maximum"`, and disabled maximum inputs when their mode is set to a non-custom option.
  * Standardized Quota headers/checkboxes to sentence case and updated helper texts to be descriptive.
* **RGW Account Role Form:**
  * Restructured modal headers, descriptions, and buttons for both Create Role and Edit Session Duration modals.
  * Added a read-only parent `"Account"` field in Create mode.
  * Spelled out abbreviations and standardized labels to sentence case (`"Role path"`, `"Trust policy"`, `"Maximum session duration (hours)"`).
  * Provided descriptive helper texts and realistic placeholder examples for all fields.
  * Replaced the plain-text role name display in Edit mode with a dotted-underline `<cds-tooltip-definition>` trigger. Configured it to show the parent account name on hover, aligned to the right with a left-facing caret.



PR Description :

### What this PR does / why we need it
This PR updates the Ceph Dashboard RGW Role and Account forms to align precisely with the latest UX design specifications and Carbon Design System standards.

**Key UI/UX improvements included:**
- **Form Design Alignment:** Refactored the Create/Edit Role forms and Account forms to match the latest UX feedback.
- **Form Field Clean-up:** Removed the explicit `(Required)` label indicators from form inputs to match the cleaner visual design, and updated placeholders and helper texts to match approved UX copy.
- **Advanced Settings Toggle:** Modernized the "Show/Hide advanced settings" section using a Carbon Ghost Button with dynamic chevron icons (`chevron--down` / `chevron--up`), setting a cleaner standard for collapsible form sections.

### Figma References
Designed forms as per the UX feedback and Figma links, which are as follows:

* **Create Role Form:** https://www.figma.com/design/tRv5Xgxk8mgFzekw4X94AV/General-design-updates?node-id=2009-26203
* **Account Form:** https://www.figma.com/design/tRv5Xgxk8mgFzekw4X94AV/Design-updates?node-id=2-1343


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
