### PR TITLE
Fix agent daemon version displayed as "unknown"

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1692,26 +1692,25 @@ def command_agent(ctx: CephadmContext) -> None:
 @executes_early
 def command_version(ctx):
     # type: (CephadmContext) -> int
-    import importlib
     import zipimport
     import zipfile
     import types
+    from cephadmlib.agent import _load_version_module
 
     vmod: Optional[types.ModuleType]
     zmod: Optional[types.ModuleType]
+
+    # Use the shared helper to locate _cephadmmeta.version or _version.
+    vmod = _load_version_module()  # type: ignore[assignment]
+
+    # The zmod path is only needed for the verbose zipimport output below.
+    # Try _cephadmmeta.version first (already loaded by vmod if successful),
+    # then fall back to the outer _cephadmmeta package for the loader.
     try:
-        vmod = importlib.import_module('_cephadmmeta.version')
-        zmod = vmod
+        zmod = importlib.import_module('_cephadmmeta.version')
     except ImportError:
-        vmod = zmod = None
-    if vmod is None:
-        # fallback to earlier location
-        try:
-            vmod = importlib.import_module('_version')
-        except ImportError:
-            pass
+        zmod = None
     if zmod is None:
-        # fallback to outer package, for zip import module
         try:
             zmod = importlib.import_module('_cephadmmeta')
         except ImportError:

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2,6 +2,7 @@
 
 import argparse
 import datetime
+import importlib
 import ipaddress
 import io
 import json
@@ -1692,26 +1693,25 @@ def command_agent(ctx: CephadmContext) -> None:
 @executes_early
 def command_version(ctx):
     # type: (CephadmContext) -> int
-    import importlib
     import zipimport
     import zipfile
     import types
+    from cephadmlib.agent import _load_version_module
 
     vmod: Optional[types.ModuleType]
     zmod: Optional[types.ModuleType]
+
+    # Use the shared helper to locate _cephadmmeta.version or _version.
+    vmod = _load_version_module()  # type: ignore[assignment]
+
+    # The zmod path is only needed for the verbose zipimport output below.
+    # Try _cephadmmeta.version first (already loaded by vmod if successful),
+    # then fall back to the outer _cephadmmeta package for the loader.
     try:
-        vmod = importlib.import_module('_cephadmmeta.version')
-        zmod = vmod
+        zmod = importlib.import_module('_cephadmmeta.version')
     except ImportError:
-        vmod = zmod = None
-    if vmod is None:
-        # fallback to earlier location
-        try:
-            vmod = importlib.import_module('_version')
-        except ImportError:
-            pass
+        zmod = None
     if zmod is None:
-        # fallback to outer package, for zip import module
         try:
             zmod = importlib.import_module('_cephadmmeta')
         except ImportError:

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1692,6 +1692,7 @@ def command_agent(ctx: CephadmContext) -> None:
 @executes_early
 def command_version(ctx):
     # type: (CephadmContext) -> int
+    import importlib
     import zipimport
     import zipfile
     import types

--- a/src/cephadm/cephadmlib/agent.py
+++ b/src/cephadm/cephadmlib/agent.py
@@ -1,6 +1,7 @@
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen, Request
 from typing import Optional, Any, Tuple
+import importlib
 import logging
 
 logger = logging.getLogger()
@@ -32,3 +33,36 @@ def http_query(
     except Exception:
         raise
     return (response_status, response_str)
+
+
+def _load_version_module() -> Optional[object]:
+    """Import and return the cephadm version module.
+
+    Tries ``_cephadmmeta.version`` first (the current bundled location),
+    then falls back to the legacy ``_version`` module.  Returns ``None``
+    when neither is importable.
+
+    Note: the ``zmod``/zipimport path used by ``command_version`` for
+    verbose output is intentionally omitted here; we only need the version
+    string.
+    """
+    try:
+        return importlib.import_module('_cephadmmeta.version')
+    except ImportError:
+        pass
+    try:
+        return importlib.import_module('_version')
+    except ImportError:
+        return None
+
+
+def get_agent_version() -> Optional[str]:
+    """Return the ``CEPH_GIT_NICE_VER`` string for the running cephadm.
+
+    Uses :func:`_load_version_module` to locate the version module.
+    Returns ``None`` when the version cannot be determined.
+    """
+    vmod = _load_version_module()
+    if vmod is not None:
+        return getattr(vmod, 'CEPH_GIT_NICE_VER', None)
+    return None

--- a/src/cephadm/cephadmlib/listing_updaters.py
+++ b/src/cephadm/cephadmlib/listing_updaters.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 
+from .agent import get_agent_version
 from .call_wrappers import call, CallVerbosity
 from .container_engines import (
     normalize_container_id,
@@ -189,11 +190,16 @@ class VersionStatusUpdater(DaemonStatusUpdater):
         version = val.get('version', None)
         daemon_type = identity.daemon_type
         container_id = val['container_id']
-        if not image_id and not version:
+        if not image_id and not version and daemon_type != 'agent':
             return  # container info missing or no longer running?
         # identify software version inside the container (if we can)
         if not version or '.' not in version:
             version = self.seen_versions.get(image_id, None)
+        if daemon_type == 'agent':
+            # agent runs as a Python process; use cached value or detect once
+            version = self.seen_versions.get('agent') or get_agent_version()
+            if version:
+                self.seen_versions['agent'] = version
         if daemon_type == NFSGanesha.daemon_type:
             version = NFSGanesha.get_version(ctx, container_id)
         if daemon_type == CephIscsi.daemon_type:

--- a/src/cephadm/tests/test_agent.py
+++ b/src/cephadm/tests/test_agent.py
@@ -808,3 +808,146 @@ def test_command_agent(_agent_run, cephadm_fs):
         cephadm_fs.create_dir(AGENT_DIR)
         _cephadm.command_agent(ctx)
         _agent_run.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests for get_agent_version() and the VersionStatusUpdater agent path
+# ---------------------------------------------------------------------------
+
+class TestGetAgentVersion:
+    """Unit tests for cephadmlib.agent.get_agent_version()."""
+
+    def test_primary_module_used(self):
+        """Returns CEPH_GIT_NICE_VER from _cephadmmeta.version when available."""
+        from cephadmlib.agent import get_agent_version
+
+        fake_vmod = mock.MagicMock()
+        fake_vmod.CEPH_GIT_NICE_VER = 'v19.2.0'
+
+        with mock.patch('cephadmlib.agent.importlib.import_module',
+                        return_value=fake_vmod) as _imp:
+            result = get_agent_version()
+
+        _imp.assert_called_once_with('_cephadmmeta.version')
+        assert result == 'v19.2.0'
+
+    def test_fallback_to_legacy_module(self):
+        """Falls back to _version when _cephadmmeta.version is not importable."""
+        from cephadmlib.agent import get_agent_version
+
+        fake_vmod = mock.MagicMock()
+        fake_vmod.CEPH_GIT_NICE_VER = 'v18.2.4'
+
+        def _side_effect(name):
+            if name == '_cephadmmeta.version':
+                raise ImportError('no _cephadmmeta')
+            return fake_vmod
+
+        with mock.patch('cephadmlib.agent.importlib.import_module',
+                        side_effect=_side_effect):
+            result = get_agent_version()
+
+        assert result == 'v18.2.4'
+
+    def test_returns_none_when_no_module(self):
+        """Returns None when neither version module is importable."""
+        from cephadmlib.agent import get_agent_version
+
+        with mock.patch('cephadmlib.agent.importlib.import_module',
+                        side_effect=ImportError('nothing here')):
+            result = get_agent_version()
+
+        assert result is None
+
+    def test_returns_none_when_attribute_missing(self):
+        """Returns None when the version module lacks CEPH_GIT_NICE_VER."""
+        from cephadmlib.agent import get_agent_version
+
+        fake_vmod = mock.MagicMock(spec=[])  # no attributes
+
+        with mock.patch('cephadmlib.agent.importlib.import_module',
+                        return_value=fake_vmod):
+            result = get_agent_version()
+
+        assert result is None
+
+
+class TestVersionStatusUpdaterAgent:
+    """Unit tests for the agent code-path in VersionStatusUpdater."""
+
+    def _make_updater(self):
+        from cephadmlib.listing_updaters import VersionStatusUpdater
+        return VersionStatusUpdater()
+
+    def _make_val(self, version=None, container_id='', image_id=None):
+        return {
+            'container_id': container_id,
+            'container_image_id': image_id,
+            'version': version,
+        }
+
+    def _make_identity(self, daemon_type='agent'):
+        identity = mock.MagicMock()
+        identity.daemon_type = daemon_type
+        return identity
+
+    def test_agent_version_populated(self):
+        """val['version'] is set for the agent daemon type."""
+        from cephadmlib.listing_updaters import VersionStatusUpdater
+
+        updater = self._make_updater()
+        val = self._make_val()
+        identity = self._make_identity('agent')
+
+        with mock.patch('cephadmlib.listing_updaters.get_agent_version',
+                        return_value='v19.2.0'):
+            with with_cephadm_ctx([]) as ctx:
+                updater.update(val, ctx, identity, '/data')
+
+        assert val['version'] == 'v19.2.0'
+
+    def test_agent_version_cached(self):
+        """get_agent_version() is only called once; subsequent calls use the cache."""
+        from cephadmlib.listing_updaters import VersionStatusUpdater
+
+        updater = self._make_updater()
+        identity = self._make_identity('agent')
+
+        with mock.patch('cephadmlib.listing_updaters.get_agent_version',
+                        return_value='v19.2.0') as _gav:
+            with with_cephadm_ctx([]) as ctx:
+                updater.update(self._make_val(), ctx, identity, '/data')
+                updater.update(self._make_val(), ctx, identity, '/data')
+
+        # second call must use the cache, not re-import
+        _gav.assert_called_once()
+
+    def test_agent_version_none_when_unavailable(self):
+        """val['version'] remains None when get_agent_version() returns None."""
+        from cephadmlib.listing_updaters import VersionStatusUpdater
+
+        updater = self._make_updater()
+        val = self._make_val()
+        identity = self._make_identity('agent')
+
+        with mock.patch('cephadmlib.listing_updaters.get_agent_version',
+                        return_value=None):
+            with with_cephadm_ctx([]) as ctx:
+                updater.update(val, ctx, identity, '/data')
+
+        assert val['version'] is None
+
+    def test_non_agent_without_image_id_returns_early(self):
+        """Non-agent daemon with no image_id and no version still returns early."""
+        from cephadmlib.listing_updaters import VersionStatusUpdater
+
+        updater = self._make_updater()
+        val = self._make_val()  # no image_id, no version
+        identity = self._make_identity('mon')
+
+        with mock.patch('cephadmlib.listing_updaters.get_agent_version') as _gav:
+            with with_cephadm_ctx([]) as ctx:
+                updater.update(val, ctx, identity, '/data')
+
+        _gav.assert_not_called()
+        assert val.get('version') is None


### PR DESCRIPTION
mgr/cephadm: fix agent daemon version displayed as "unknown" The cephadm agent daemon version was being displayed as "unknown" in `ceph orch ps` output.  This occurred because the agent runs as a Python process (not in a container), so the existing version-detection logic - which relies on a container image ID - skips early and never populates the version field.

Fix by special-casing the 'agent' daemon type in VersionStatusUpdater:

* Skip the early-return guard that requires a container image ID when
  the daemon type is 'agent'.
* Before falling through to the container-based version lookup, attempt
  to import the cephadm version module (_cephadmmeta.version or
  _version) and read the CEPH_GIT_NICE_VER attribute.
* Cache the discovered version in seen_versions to avoid repeated
  import attempts on subsequent calls.


Fixes: https://tracker.ceph.com/issues/77111
Signed-off-by: Swati Thombe <swati.thombe@ibm.com>

  

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
