### PR TITLE
squid: qa: suppress reachable dlopen leak in libceph-common

### DIFF
--- a/qa/valgrind.supp
+++ b/qa/valgrind.supp
@@ -1023,6 +1023,18 @@
 }
 
 {
+   glibc_2.34+_dlopen reachable leak
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   obj:*/lib*/ld-linux-x86-64.so.2
+   ...
+   fun:_dl_open
+   ...
+   fun:dlopen@@GLIBC_2.34
+}
+
+{
   ethdev_init_log thing
   Memcheck:Leak
   match-leak-kinds: reachable


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75895

---

backport of https://github.com/ceph/ceph/pull/68218
parent tracker: https://tracker.ceph.com/issues/74566

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh