### PR TITLE
mgr/dashboard: Loki API implementation for Dashboard

### DIFF
--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -920,6 +920,51 @@ class LokiService(CephadmService):
             }
         }, sorted(deps)
 
+    def get_active_daemon(self, daemon_descrs: List[DaemonDescription]) -> DaemonDescription:
+        if daemon_descrs:
+            return daemon_descrs[0]
+        return DaemonDescription()
+
+    def config_dashboard(self, daemon_descrs: List[DaemonDescription]) -> None:
+        dd = self.get_active_daemon(daemon_descrs)
+        assert dd.hostname is not None
+        addr = dd.ip if dd.ip else self.mgr.get_fqdn(dd.hostname)
+        port = dd.ports[0] if dd.ports else self.DEFAULT_SERVICE_PORT
+        service_url = build_url(scheme='http', host=addr, port=port)
+        self._set_value_on_dashboard(
+            'Loki',
+            'dashboard get-loki-api-host',
+            'dashboard set-loki-api-host',
+            service_url
+        )
+
+    def pre_remove(self, daemon: DaemonDescription) -> None:
+        if daemon.hostname is None:
+            return
+        try:
+            current_api_host = self.mgr.check_mon_command(
+                {"prefix": "dashboard get-loki-api-host"}).stdout.strip()
+            daemon_addr = daemon.ip if daemon.ip else self.mgr.get_fqdn(daemon.hostname)
+            daemon_port = daemon.ports[0] if daemon.ports else self.DEFAULT_SERVICE_PORT
+            service_url = build_url(scheme='http', host=daemon_addr, port=daemon_port)
+
+            if current_api_host == service_url:
+                remaining_daemons = [
+                    d for d in self.mgr.cache.get_daemons_by_service(self.TYPE)
+                    if d.name() != daemon.name()
+                ]
+                if remaining_daemons:
+                    self.config_dashboard(remaining_daemons)
+                    logger.info("Updated dashboard API settings to point to a remaining Loki daemon")
+                else:
+                    self.mgr.check_mon_command({"prefix": "dashboard reset-loki-api-host"})
+                    self.mgr.check_mon_command({"prefix": "dashboard reset-loki-api-ssl-verify"})
+                    logger.info("Reset dashboard API settings as no Loki daemons are remaining")
+            else:
+                logger.info(f"Loki {daemon.name()} removed; no changes to dashboard API settings")
+        except Exception as e:
+            logger.error(f"Error in Loki pre_remove: {str(e)}")
+
 
 @register_cephadm_service
 class AlloyService(CephadmService):

--- a/src/pybind/mgr/dashboard/controllers/loki.py
+++ b/src/pybind/mgr/dashboard/controllers/loki.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+import json
+from typing import Optional
+
+import requests
+
+from ..exceptions import DashboardException
+from ..security import Scope
+from ..settings import Settings
+from . import APIDoc, APIRouter, RESTController
+
+
+class LokiRESTController(RESTController):
+
+    def _get_api_url(self, host: str) -> str:
+        return f'{host.rstrip("/")}/loki/api/v1'
+
+    def _resolve_loki_host(self) -> str:
+        host = (Settings.LOKI_API_HOST or '').strip()
+        if host and '://' in host:
+            return host.rstrip('/')
+
+        raise DashboardException(
+            "Loki API host is not configured. Deploy the loki service or set "
+            "'ceph dashboard set-loki-api-host <scheme>://<host>:3100'.",
+            http_status_code=503,
+            component='loki')
+
+    @staticmethod
+    def _prepare_loki_params(params: Optional[dict]) -> Optional[dict]:
+        if params and 'params' in params:
+            params = dict(params)
+            params['query'] = params.pop('params')
+        return params
+
+    def loki_proxy(self, method: str, path: str, params: Optional[dict] = None,
+                   payload: Optional[dict] = None):
+        return self._proxy(self._get_api_url(self._resolve_loki_host()),
+                           method, path, 'Loki', params, payload,
+                           verify=Settings.LOKI_API_SSL_VERIFY)
+
+    def _proxy(self, base_url: str, method: str, path: str, api_name: str,
+               params: Optional[dict] = None, payload: Optional[dict] = None,
+               verify: bool = True):
+        content = None
+        try:
+            response = requests.request(method, base_url + path, params=params,
+                                        json=payload, verify=verify)
+        except requests.RequestException as e:
+            raise DashboardException(
+                "Could not reach {}'s API on {} error {}".format(api_name, base_url, e),
+                http_status_code=502,
+                component='loki')
+        try:
+            if response.content:
+                content = json.loads(response.content, strict=False)
+        except json.JSONDecodeError as e:
+            raise DashboardException(
+                "Error parsing Loki response: {}".format(e.msg),
+                component='loki')
+        if not isinstance(content, dict) or 'status' not in content:
+            raise DashboardException(
+                'Invalid Loki response',
+                http_status_code=502,
+                component='loki')
+        if content.get('status') == 'success':
+            return content.get('data', content)
+        raise DashboardException(content, http_status_code=400, component='loki')
+
+
+@APIRouter('/loki', Scope.LOG)
+@APIDoc("Loki Management API", "Loki")
+class Loki(LokiRESTController):
+    """
+    Proxy controller for the Loki HTTP query API.
+
+    Supports instant and range LogQL queries, plus label discovery endpoints.
+    """
+
+    @RESTController.Collection(method='GET', path='/query')
+    def query(self, **params):
+        """
+        Instant query against Loki.
+
+        Evaluates a LogQL query at a single point in time. Intended for metric
+        queries such as rate() or count_over_time(). Accepts Loki query params:
+        query, limit, time, direction.
+        """
+        return self.loki_proxy('GET', '/query', self._prepare_loki_params(params))
+
+    @RESTController.Collection(method='GET', path='/query_range')
+    def query_range(self, **params):
+        """
+        Range query against Loki.
+
+        Queries logs or metrics over a time range. Accepts Loki query params:
+        query, limit, start, end, since, step, interval, direction.
+        """
+        return self.loki_proxy('GET', '/query_range', self._prepare_loki_params(params))
+
+    @RESTController.Collection(method='GET', path='/labels')
+    def labels(self, **params):
+        """
+        List known label names within a time span.
+
+        Accepts Loki query params: start, end, since, query.
+        """
+        return self.loki_proxy('GET', '/labels', self._prepare_loki_params(params))
+
+    @RESTController.Collection(method='GET', path='/label/{name}/values')
+    def label_values(self, name, **params):
+        """
+        List known values for a label within a time span.
+
+        Accepts Loki query params: start, end, since, query.
+        """
+        return self.loki_proxy('GET', f'/label/{name}/values',
+                               self._prepare_loki_params(params))

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -9973,6 +9973,119 @@ paths:
       - jwt: []
       tags:
       - IscsiTarget
+  /api/loki/label/{name}/values:
+    get:
+      parameters:
+      - in: path
+        name: name
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+            application/vnd.ceph.api.v1.0+json:
+              schema:
+                type: object
+          description: OK
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: Get Loki label values
+      tags:
+      - Logs
+  /api/loki/labels:
+    get:
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+            application/vnd.ceph.api.v1.0+json:
+              schema:
+                type: object
+          description: OK
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: Get Loki labels
+      tags:
+      - Logs
+  /api/loki/query:
+    get:
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+            application/vnd.ceph.api.v1.0+json:
+              schema:
+                type: object
+          description: OK
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: Query Loki logs
+      tags:
+      - Logs
+  /api/loki/query_range:
+    get:
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+            application/vnd.ceph.api.v1.0+json:
+              schema:
+                type: object
+          description: OK
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: Query Loki logs in a range
+      tags:
+      - Logs
   /api/logs/all:
     get:
       parameters: []

--- a/src/pybind/mgr/dashboard/settings.py
+++ b/src/pybind/mgr/dashboard/settings.py
@@ -90,6 +90,10 @@ class Options(object):
     ALERTMANAGER_API_SSL_VERIFY = Setting(True, [bool])
     PROM_ALERT_CREDENTIAL_CACHE_TTL = Setting(60, [int])
 
+    # Loki settings
+    LOKI_API_HOST = Setting('', [str])
+    LOKI_API_SSL_VERIFY = Setting(True, [bool])
+
     # iSCSI management settings
     ISCSI_API_SSL_VERIFICATION = Setting(True, [bool])
 

--- a/src/pybind/mgr/dashboard/tests/test_loki.py
+++ b/src/pybind/mgr/dashboard/tests/test_loki.py
@@ -1,0 +1,131 @@
+# -*- coding: utf-8 -*-
+ # pylint: disable=protected-access
+try:
+    from mock import patch
+except ImportError:
+    from unittest.mock import patch
+
+from urllib.parse import urlencode
+
+from requests import Response
+
+from .. import mgr
+from ..controllers.loki import Loki
+from ..tests import ControllerTestCase
+
+
+class LokiControllerTest(ControllerTestCase):
+    loki_host = 'http://loki:3100'
+    loki_host_api = loki_host + '/loki/api/v1'
+
+    @classmethod
+    def setup_server(cls):
+        settings = {
+            'LOKI_API_HOST': cls.loki_host,
+        }
+        cls._get_module_option = settings.get
+        mgr.get_module_option.side_effect = cls._get_module_option
+        cls.setup_controllers([Loki])
+
+    @staticmethod
+    def _url_with_params(url, params):
+        if not params:
+            return url
+        return '{}?{}'.format(url, urlencode(params))
+
+    @patch('requests.request')
+    def test_query(self, mock_request):
+        r = Response()
+        r.status_code = 200
+        r._content = b'{"status":"success","data":{"resultType":"vector","result":[]}}'
+        mock_request.return_value = r
+
+        self._get(self._url_with_params(
+            '/api/loki/query',
+            {'params': 'sum(rate({job="varlogs"}[10m]))'}))
+        mock_request.assert_called_with(
+            'GET',
+            self.loki_host_api + '/query',
+            json=None,
+            params={'query': 'sum(rate({job="varlogs"}[10m]))'},
+            verify=True)
+        self.assertStatus(200)
+
+    @patch('requests.request')
+    def test_query_range(self, mock_request):
+        r = Response()
+        r.status_code = 200
+        r._content = b'{"status":"success","data":{"resultType":"streams","result":[]}}'
+        mock_request.return_value = r
+
+        self._get(self._url_with_params(
+            '/api/loki/query_range',
+            {'params': '{job="varlogs"}',
+             'start': '1609459200000000000',
+             'end': '1609462800000000000'}))
+        mock_request.assert_called_with(
+            'GET',
+            self.loki_host_api + '/query_range',
+            json=None,
+            params={'query': '{job="varlogs"}',
+                    'start': '1609459200000000000',
+                    'end': '1609462800000000000'},
+            verify=True)
+        self.assertStatus(200)
+
+    @patch('requests.request')
+    def test_labels(self, mock_request):
+        r = Response()
+        r.status_code = 200
+        r._content = b'{"status":"success","data":["filename","job"]}'
+        mock_request.return_value = r
+
+        self._get(self._url_with_params('/api/loki/labels', {'since': '6h'}))
+        mock_request.assert_called_with(
+            'GET',
+            self.loki_host_api + '/labels',
+            json=None,
+            params={'since': '6h'},
+            verify=True)
+        self.assertStatus(200)
+        self.assertJsonBody(['filename', 'job'])
+
+    @patch('requests.request')
+    def test_label_values(self, mock_request):
+        r = Response()
+        r.status_code = 200
+        r._content = b'{"status":"success","data":["Cluster Logs"]}'
+        mock_request.return_value = r
+
+        self._get(self._url_with_params(
+            '/api/loki/label/job/values',
+            {'params': '{job="Cluster Logs"}', 'since': '24h'}))
+        mock_request.assert_called_with(
+            'GET',
+            self.loki_host_api + '/label/job/values',
+            json=None,
+            params={'query': '{job="Cluster Logs"}', 'since': '24h'},
+            verify=True)
+        self.assertStatus(200)
+        self.assertJsonBody(['Cluster Logs'])
+
+    @patch('requests.request')
+    def test_query_error(self, mock_request):
+        r = Response()
+        r.status_code = 200
+        r._content = b'{"status":"error","error":"parse error"}'
+        mock_request.return_value = r
+
+        self._get(self._url_with_params('/api/loki/query', {'params': 'invalid'}))
+        self.assertStatus(400)
+
+    def test_query_unconfigured_host(self):
+        mgr.get_module_option.side_effect = lambda name, default=None: ''
+        try:
+            self._get(self._url_with_params(
+                '/api/loki/query',
+                {'params': '{job="Cluster Logs"}'}))
+            self.assertStatus(503)
+            self.assertIn(b'Loki API host is not configured', self.body)
+        finally:
+            mgr.get_module_option.side_effect = self._get_module_option


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/77638
Signed-off-by: Devika Babrekar <devika.babrekar@ibm.com>


https://github.com/user-attachments/assets/38deb88a-f814-4360-af67-3070ce7117b8

Description:
This PR adds a dedicated Loki API layer to the Ceph Dashboard for querying logs and label metadata. It introduces endpoints for instant queries, range queries, label discovery, and label value lookup, while proxying requests to Loki using the configured API host and handling success/error responses consistently.

Behavior
The controller proxies requests to Loki using the configured API host.
It supports common Loki query parameters such as query, limit, time, start, end, since, step, and direction.
Successful responses return Loki’s data payload, and failures are surfaced as dashboard exceptions with appropriate error handling.

Added endpoints
GET /api/loki/query for instant LogQL queries
GET /api/loki/query_range for range-based LogQL queries
GET /api/loki/labels for listing available label names
GET /api/loki/label/{name}/values for listing values for a specific label

Endpoint details

1. GET /api/loki/query
  Purpose: Executes an instant LogQL query against Loki.
  Accepted parameters:
  -   query (or the dashboard-compatible params alias)
  -   limit
  -   time
  -   direction
  Response: Returns Loki’s successful response payload, typically under the data field, including query results such as resultType and result.
  Example:
  Request:
    params:count_over_time({job=~".+"}[1h])
  Response:
    {
      "status": "success",
      "data": {
        "resultType": "vector" | "streams",
        "result": [<vector value>] | [<stream value>],
        "stats" : [<statistics>]
      }
    }


2. GET /api/loki/query_range
Purpose: Executes a range-based LogQL query over a time window.
  Accepted parameters:
  -   query (or the dashboard-compatible params alias)
  -   limit
  -   start
  -   end
  -   since
  -   step
  -   interval
  -   direction
  Response: Returns Loki’s data payload containing range query results for the requested period.
  Example:
  Request:  
    query:{job="Cluster Logs"}
    limit:10
    since:24h
    direction:backward
  Response: 
    {
      "status": "success",
      "data": {
         "resultType": "matrix" | "streams",
         "result": [<matrix value>] | [<stream value>]
          "stats" : [<statistics>]
        }
    }

  

3. GET /api/loki/labels
  Purpose: Lists known label names available in Loki for the requested time scope.
  Accepted parameters:
  -   start
  -   end
  -   since
  -   query (or the dashboard-compatible params alias)
  Response: Returns the list of labels from Loki’s data response.
  Example:
  Request:
  Response: 
    {
      "status": "success",
      "data": [
          "filename",
          "job",
          "service_name"
      ]
    }

4. GET /api/loki/label/{name}/values

  Purpose: Lists available values for a specific label name.
  Accepted parameters:
  -   start
  -   end
  -   since
  -   query (or the dashboard-compatible params alias)
  Response: Returns the label values from Loki’s data response.
  Example:
  Request: 
    /api/loki/label/filename/values
  Response:
{
    "status": "success",
    "data": [
        "/var/log/ceph/ceph-client.ceph-exporter.ceph-node-00.log",
        "/var/log/ceph/ceph-client.ceph-exporter.ceph-node-01.log",
        "/var/log/ceph/ceph-client.ceph-exporter.ceph-node-02.log",
      ]
}

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
