### PR TITLE
tentacle: ceph-volume: skip internal raid mirror LVs in inventory

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -314,11 +314,13 @@ class TestDevice(object):
         assert not disk.available
 
     @patch("ceph_volume.util.disk.has_bluestore_label", lambda x: False)
+    @patch('ceph_volume.util.device.disk.path_is_block_device', return_value=True)
     @patch('ceph_volume.util.device.os.path.realpath')
     @patch('ceph_volume.util.device.os.path.islink')
     def test_reject_lv_symlink_to_device(self,
                                          m_os_path_islink,
                                          m_os_path_realpath,
+                                         m_path_is_block_device,
                                          device_info,
                                          fake_call):
         m_os_path_islink.return_value = True
@@ -328,6 +330,26 @@ class TestDevice(object):
         device_info(lv=lv,lsblk=lsblk)
         disk = device.Device("/dev/vg/lv")
         assert disk.path == '/dev/vg/lv'
+        m_path_is_block_device.assert_called_with('/dev/vg/lv')
+
+    @patch("ceph_volume.util.disk.has_bluestore_label", lambda x: False)
+    @patch('ceph_volume.util.device.disk.path_is_block_device', return_value=False)
+    @patch('ceph_volume.util.device.os.path.realpath')
+    @patch('ceph_volume.util.device.os.path.islink')
+    def test_lv_keeps_mapper_path_when_lv_path_missing(self,
+                                                       m_os_path_islink,
+                                                       m_os_path_realpath,
+                                                       m_path_is_block_device,
+                                                       device_info,
+                                                       fake_call):
+        m_os_path_islink.return_value = False
+        m_os_path_realpath.return_value = '/dev/mapper/vg-var_rmeta_0'
+        lv = {"lv_path": "/dev/vg/var_rmeta_0", "vg_name": "vg", "name": "var_rmeta_0", "tags": {}}
+        lsblk = {"TYPE": "lvm", "NAME": "vg-var_rmeta_0"}
+        device_info(lv=lv, lsblk=lsblk)
+        disk = device.Device("/dev/mapper/vg-var_rmeta_0")
+        assert disk.path == '/dev/mapper/vg-var_rmeta_0'
+        m_path_is_block_device.assert_called_with('/dev/vg/var_rmeta_0')
 
     @patch("ceph_volume.util.disk.has_bluestore_label", lambda x: False)
     def test_reject_smaller_than_5gb(self, fake_call, device_info):

--- a/src/ceph-volume/ceph_volume/tests/util/test_disk.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_disk.py
@@ -1,5 +1,7 @@
 import pytest
 import stat
+from typing import Any, Callable, ClassVar, Optional
+
 from ceph_volume.util import disk
 from unittest.mock import patch, Mock, MagicMock, mock_open
 from pyfakefs.fake_filesystem_unittest import TestCase
@@ -358,7 +360,7 @@ class TestGetDevices(object):
         fake_filesystem.create_file('/sys/block/dm-0/queue/hw_sector_size', contents='512')
         with patch("ceph_volume.util.disk.UdevData") as MockUdevData:
             mock_instance = MagicMock()
-            mock_instance.slashed_path = lv_path
+            mock_instance.preferred_block_path = lv_path
             mock_instance.environment = {}
             MockUdevData.return_value = mock_instance
             result = disk.get_devices()
@@ -731,7 +733,29 @@ class TestBlockSysFs(TestCase):
         assert b.active_mappers()['dm-1']['uuid'] == 'abcdef'
 
 
+class _StatWithStRdev:
+    __slots__ = ('_st', 'st_rdev')
+
+    def __init__(self, st: Any, rdev: int = 0) -> None:
+        object.__setattr__(self, '_st', st)
+        object.__setattr__(self, 'st_rdev', rdev)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._st, name)
+
+
+def _udev_data_patched_os_stat(path: str, *args: Any, **kwargs: Any) -> Any:
+    if TestUdevData._pyfakefs_os_stat is None:
+        raise RuntimeError('TestUdevData.setUp must assign _pyfakefs_os_stat')
+    st = TestUdevData._pyfakefs_os_stat(path, *args, **kwargs)
+    if not hasattr(st, 'st_rdev'):
+        return _StatWithStRdev(st, 0)
+    return st
+
+
 class TestUdevData(TestCase):
+    _pyfakefs_os_stat: ClassVar[Optional[Callable[..., Any]]] = None
+
     def setUp(self) -> None:
         udev_data_lv_device: str = """
 S:disk/by-id/dm-uuid-LVM-1f1RaxWlzQ61Sbc7oCIHRMdh0M8zRTSnU03ekuStqWuiA6eEDmwoGg3cWfFtE2li
@@ -774,13 +798,20 @@ V:1"""
         self.fs.create_file('/run/udev/data/b999:0', create_missing_dirs=True, contents=udev_data_bare_device)
         self.fs.create_file('/run/udev/data/b998:1', create_missing_dirs=True, contents=udev_data_lv_device)
         self.fs.create_file('/run/udev/data/b997:2', create_missing_dirs=True, contents="")
+        TestUdevData._pyfakefs_os_stat = disk.os.stat
+
+    def tearDown(self) -> None:
+        try:
+            super().tearDown()
+        finally:
+            TestUdevData._pyfakefs_os_stat = None
 
     def test_device_not_found(self) -> None:
         self.fs.remove(self.fake_device)
         with pytest.raises(RuntimeError):
             disk.UdevData(self.fake_device)
 
-    @patch('ceph_volume.util.disk.os.stat', MagicMock())
+    @patch('ceph_volume.util.disk.os.stat', _udev_data_patched_os_stat)
     @patch('ceph_volume.util.disk.os.minor', Mock(return_value=0))
     @patch('ceph_volume.util.disk.os.major', Mock(return_value=999))
     def test_no_data(self) -> None:
@@ -788,56 +819,110 @@ V:1"""
         with pytest.raises(RuntimeError):
             disk.UdevData(self.fake_device)
 
-    @patch('ceph_volume.util.disk.os.stat', MagicMock())
+    @patch('ceph_volume.util.disk.os.stat', _udev_data_patched_os_stat)
     @patch('ceph_volume.util.disk.os.minor', Mock(return_value=2))
     @patch('ceph_volume.util.disk.os.major', Mock(return_value=997))
     def test_empty_data(self) -> None:
         # no exception should be raised when a /run/udev/data/* file is empty
         _ = disk.UdevData(self.fake_device)
 
-    @patch('ceph_volume.util.disk.os.stat', MagicMock())
+    @patch('ceph_volume.util.disk.os.stat', _udev_data_patched_os_stat)
     @patch('ceph_volume.util.disk.os.minor', Mock(return_value=0))
     @patch('ceph_volume.util.disk.os.major', Mock(return_value=999))
     def test_is_dm_false(self) -> None:
         assert not disk.UdevData(self.fake_device).is_dm
 
-    @patch('ceph_volume.util.disk.os.stat', MagicMock())
+    @patch('ceph_volume.util.disk.os.stat', _udev_data_patched_os_stat)
     @patch('ceph_volume.util.disk.os.minor', Mock(return_value=1))
     @patch('ceph_volume.util.disk.os.major', Mock(return_value=998))
     def test_is_dm_true(self) -> None:
         assert disk.UdevData(self.fake_device).is_dm
 
-    @patch('ceph_volume.util.disk.os.stat', MagicMock())
+    @patch('ceph_volume.util.disk.os.stat', _udev_data_patched_os_stat)
     @patch('ceph_volume.util.disk.os.minor', Mock(return_value=1))
     @patch('ceph_volume.util.disk.os.major', Mock(return_value=998))
     def test_is_lvm_true(self) -> None:
-        assert disk.UdevData(self.fake_device).is_dm
+        assert disk.UdevData(self.fake_device).is_lvm
 
-    @patch('ceph_volume.util.disk.os.stat', MagicMock())
+    @patch('ceph_volume.util.disk.os.stat', _udev_data_patched_os_stat)
     @patch('ceph_volume.util.disk.os.minor', Mock(return_value=0))
     @patch('ceph_volume.util.disk.os.major', Mock(return_value=999))
     def test_is_lvm_false(self) -> None:
-        assert not disk.UdevData(self.fake_device).is_dm
+        assert not disk.UdevData(self.fake_device).is_lvm
 
-    @patch('ceph_volume.util.disk.os.stat', MagicMock())
+    @patch('ceph_volume.util.disk.os.stat', _udev_data_patched_os_stat)
     @patch('ceph_volume.util.disk.os.minor', Mock(return_value=1))
     @patch('ceph_volume.util.disk.os.major', Mock(return_value=998))
     def test_slashed_path_with_lvm(self) -> None:
         assert disk.UdevData(self.fake_device).slashed_path == '/dev/fake_vg1/fake-lv1'
 
-    @patch('ceph_volume.util.disk.os.stat', MagicMock())
+    @patch('ceph_volume.util.disk.os.stat', _udev_data_patched_os_stat)
     @patch('ceph_volume.util.disk.os.minor', Mock(return_value=1))
     @patch('ceph_volume.util.disk.os.major', Mock(return_value=998))
     def test_dashed_path_with_lvm(self) -> None:
         assert disk.UdevData(self.fake_device).dashed_path == '/dev/mapper/fake_vg1-fake-lv1'
 
-    @patch('ceph_volume.util.disk.os.stat', MagicMock())
+    @patch('ceph_volume.util.disk.os.stat', _udev_data_patched_os_stat)
+    @patch('ceph_volume.util.disk.os.minor', Mock(return_value=1))
+    @patch('ceph_volume.util.disk.os.major', Mock(return_value=998))
+    def test_preferred_block_path_lvm_falls_back_to_mapper(self) -> None:
+        """When /dev/vg/lv is missing, use /dev/mapper/vg-lv (container-style LVM)."""
+        mapper: str = '/dev/mapper/fake_vg1-fake-lv1'
+        self.fs.create_file(mapper, st_mode=(stat.S_IFBLK | 0o600))
+        assert disk.UdevData(self.fake_device).preferred_block_path == mapper
+
+    @patch('ceph_volume.util.disk.os.stat', _udev_data_patched_os_stat)
+    @patch('ceph_volume.util.disk.os.minor', Mock(return_value=1))
+    @patch('ceph_volume.util.disk.os.major', Mock(return_value=998))
+    def test_preferred_block_path_lvm_skips_slashed_when_not_block_device(self) -> None:
+        """If /dev/vg/lv exists but is not a block device (for example, a directory), try mapper."""
+        slashed: str = '/dev/fake_vg1/fake-lv1'
+        mapper: str = '/dev/mapper/fake_vg1-fake-lv1'
+        self.fs.create_dir(slashed)
+        self.fs.create_file(mapper, st_mode=(stat.S_IFBLK | 0o600))
+        assert disk.UdevData(self.fake_device).preferred_block_path == mapper
+
+    @patch('ceph_volume.util.disk.os.stat', _udev_data_patched_os_stat)
+    @patch('ceph_volume.util.disk.os.minor', Mock(return_value=1))
+    @patch('ceph_volume.util.disk.os.major', Mock(return_value=998))
+    def test_preferred_block_path_lvm_falls_back_when_candidates_are_not_block_devices(
+        self,
+    ) -> None:
+        """Neither candidate may be used if they are only directories (for example, empty udev fields)."""
+        slashed: str = '/dev/fake_vg1/fake-lv1'
+        mapper: str = '/dev/mapper/fake_vg1-fake-lv1'
+        self.fs.create_dir(slashed)
+        self.fs.create_dir(mapper)
+        assert disk.UdevData(self.fake_device).preferred_block_path == self.fake_device
+
+    @patch('ceph_volume.util.disk.os.stat', _udev_data_patched_os_stat)
+    @patch('ceph_volume.util.disk.os.minor', Mock(return_value=1))
+    @patch('ceph_volume.util.disk.os.major', Mock(return_value=998))
+    def test_preferred_block_path_lvm_prefers_slashed_when_present(self) -> None:
+        slashed: str = '/dev/fake_vg1/fake-lv1'
+        self.fs.create_file(slashed, st_mode=(stat.S_IFBLK | 0o600))
+        assert disk.UdevData(self.fake_device).preferred_block_path == slashed
+
+    @patch('ceph_volume.util.disk.os.stat', _udev_data_patched_os_stat)
+    @patch('ceph_volume.util.disk.os.minor', Mock(return_value=1))
+    @patch('ceph_volume.util.disk.os.major', Mock(return_value=998))
+    def test_preferred_block_path_lvm_falls_back_to_opening_path_when_no_symlinks(self) -> None:
+        """Neither /dev/vg/lv nor /dev/mapper/name exist; keep the original device node."""
+        assert disk.UdevData(self.fake_device).preferred_block_path == self.fake_device
+
+    @patch('ceph_volume.util.disk.os.stat', _udev_data_patched_os_stat)
+    @patch('ceph_volume.util.disk.os.minor', Mock(return_value=0))
+    @patch('ceph_volume.util.disk.os.major', Mock(return_value=999))
+    def test_preferred_block_path_bare_device(self) -> None:
+        assert disk.UdevData(self.fake_device).preferred_block_path == '/dev/cephtest'
+
+    @patch('ceph_volume.util.disk.os.stat', _udev_data_patched_os_stat)
     @patch('ceph_volume.util.disk.os.minor', Mock(return_value=0))
     @patch('ceph_volume.util.disk.os.major', Mock(return_value=999))
     def test_slashed_path_with_bare_device(self) -> None:
         assert disk.UdevData(self.fake_device).slashed_path == '/dev/cephtest'
 
-    @patch('ceph_volume.util.disk.os.stat', MagicMock())
+    @patch('ceph_volume.util.disk.os.stat', _udev_data_patched_os_stat)
     @patch('ceph_volume.util.disk.os.minor', Mock(return_value=0))
     @patch('ceph_volume.util.disk.os.major', Mock(return_value=999))
     def test_dashed_path_with_bare_device(self) -> None:

--- a/src/ceph-volume/ceph_volume/tests/util/test_disk.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_disk.py
@@ -358,8 +358,10 @@ class TestGetDevices(object):
         fake_filesystem.create_file('/sys/block/dm-0/size', contents='204800')
         fake_filesystem.create_file('/sys/block/dm-0/queue/rotational', contents='1')
         fake_filesystem.create_file('/sys/block/dm-0/queue/hw_sector_size', contents='512')
+        fake_filesystem.create_file(lv_path, st_mode=(stat.S_IFBLK | 0o600))
         with patch("ceph_volume.util.disk.UdevData") as MockUdevData:
             mock_instance = MagicMock()
+            mock_instance.is_internal_lv = False
             mock_instance.preferred_block_path = lv_path
             mock_instance.environment = {}
             MockUdevData.return_value = mock_instance
@@ -367,6 +369,46 @@ class TestGetDevices(object):
         assert lv_path in result
         assert result[lv_path]['type'] == 'lvm'
         assert result[lv_path]['human_readable_size'] == '100.00 MB'
+
+    def test_internal_raid_lv_is_excluded(self, patched_get_block_devs_sysfs, fake_filesystem):
+        mapper_path = '/dev/mapper/debian-var_rmeta_0'
+        dm_path = '/dev/dm-5'
+        patched_get_block_devs_sysfs.return_value = [
+            [dm_path, mapper_path, 'lvm', dm_path]
+        ]
+        fake_filesystem.create_dir('/sys/block/dm-5/slaves')
+        fake_filesystem.create_dir('/sys/block/dm-5/queue')
+        fake_filesystem.create_file('/sys/block/dm-5/size', contents='8192')
+        fake_filesystem.create_file('/sys/block/dm-5/queue/rotational', contents='1')
+        fake_filesystem.create_file('/sys/block/dm-5/queue/hw_sector_size', contents='512')
+        with patch("ceph_volume.util.disk.UdevData") as MockUdevData:
+            mock_instance = MagicMock()
+            mock_instance.is_internal_lv = True
+            MockUdevData.return_value = mock_instance
+            result = disk.get_devices()
+        assert mapper_path not in result
+        assert not result
+
+    def test_lvm_device_without_accessible_node_is_excluded(
+        self, patched_get_block_devs_sysfs, fake_filesystem
+    ):
+        mapper_path = '/dev/mapper/debian-var_rmeta_0'
+        dm_path = '/dev/dm-5'
+        patched_get_block_devs_sysfs.return_value = [
+            [dm_path, mapper_path, 'lvm', dm_path]
+        ]
+        fake_filesystem.create_dir('/sys/block/dm-5/slaves')
+        fake_filesystem.create_dir('/sys/block/dm-5/queue')
+        fake_filesystem.create_file('/sys/block/dm-5/size', contents='8192')
+        fake_filesystem.create_file('/sys/block/dm-5/queue/rotational', contents='1')
+        fake_filesystem.create_file('/sys/block/dm-5/queue/hw_sector_size', contents='512')
+        with patch("ceph_volume.util.disk.UdevData") as MockUdevData:
+            mock_instance = MagicMock()
+            mock_instance.is_internal_lv = False
+            mock_instance.preferred_block_path = '/dev/debian/var_rmeta_0'
+            MockUdevData.return_value = mock_instance
+            result = disk.get_devices()
+        assert not result
 
 
 class TestGetBlockDevsSysfs(object):
@@ -861,6 +903,36 @@ V:1"""
     @patch('ceph_volume.util.disk.os.major', Mock(return_value=998))
     def test_dashed_path_with_lvm(self) -> None:
         assert disk.UdevData(self.fake_device).dashed_path == '/dev/mapper/fake_vg1-fake-lv1'
+
+    @patch('ceph_volume.util.disk.os.stat', _udev_data_patched_os_stat)
+    @patch('ceph_volume.util.disk.os.minor', Mock(return_value=1))
+    @patch('ceph_volume.util.disk.os.major', Mock(return_value=998))
+    def test_is_internal_lv_true_for_raid_metadata(self) -> None:
+        udev = disk.UdevData(self.fake_device)
+        udev.environment['DM_LV_NAME'] = 'var_rmeta_0'
+        assert udev.is_internal_lv
+
+    @patch('ceph_volume.util.disk.os.stat', _udev_data_patched_os_stat)
+    @patch('ceph_volume.util.disk.os.minor', Mock(return_value=1))
+    @patch('ceph_volume.util.disk.os.major', Mock(return_value=998))
+    def test_is_internal_lv_true_for_raid_image(self) -> None:
+        udev = disk.UdevData(self.fake_device)
+        udev.environment['DM_LV_NAME'] = 'var_rimage_1'
+        assert udev.is_internal_lv
+
+    @patch('ceph_volume.util.disk.os.stat', _udev_data_patched_os_stat)
+    @patch('ceph_volume.util.disk.os.minor', Mock(return_value=1))
+    @patch('ceph_volume.util.disk.os.major', Mock(return_value=998))
+    def test_is_internal_lv_true_for_layered_lv(self) -> None:
+        udev = disk.UdevData(self.fake_device)
+        udev.environment['DM_LV_LAYER'] = 'var'
+        assert udev.is_internal_lv
+
+    @patch('ceph_volume.util.disk.os.stat', _udev_data_patched_os_stat)
+    @patch('ceph_volume.util.disk.os.minor', Mock(return_value=1))
+    @patch('ceph_volume.util.disk.os.major', Mock(return_value=998))
+    def test_is_internal_lv_false_for_public_lv(self) -> None:
+        assert not disk.UdevData(self.fake_device).is_internal_lv
 
     @patch('ceph_volume.util.disk.os.stat', _udev_data_patched_os_stat)
     @patch('ceph_volume.util.disk.os.minor', Mock(return_value=1))

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -236,7 +236,8 @@ class Device(object):
         if lv:
             self.lv_api = lv
             self.lvs = [lv]
-            self.path = lv.lv_path
+            if disk.path_is_block_device(lv.lv_path):
+                self.path = lv.lv_path
             self.vg_name = lv.vg_name
             self.lv_name = lv.name
             self.ceph_device_lvm = lvm.is_ceph_device(lv)
@@ -319,7 +320,10 @@ class Device(object):
         src/common/blkdev.cc
         """
 
-        udev_data = disk.UdevData(self.path)
+        try:
+            udev_data = disk.UdevData(self.path)
+        except RuntimeError:
+            return ''
         env = udev_data.environment
         parts: list[str] = []
         model = env.get('ID_MODEL', '')

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -801,7 +801,7 @@ def get_devices(_sys_block_path='/sys/block', device=''):
     for block in block_devs:
         metadata: Dict[str, Any] = {}
         if block[2] == 'lvm':
-            block[1] = UdevData(block[1]).slashed_path
+            block[1] = UdevData(block[1]).preferred_block_path
         devname = os.path.basename(block[0])
         diskname = block[1]
         if block[2] not in block_types:
@@ -1444,3 +1444,33 @@ class UdevData:
             name: str = self.environment.get('DM_NAME', '')
             result = f'/dev/mapper/{name}'
         return result
+
+    @staticmethod
+    def _path_is_block_device(path: str) -> bool:
+        """True if ``path`` exists and is a block device (follows symlinks)."""
+        try:
+            return _stat_is_device(os.stat(path).st_mode)
+        except OSError:
+            return False
+
+    @property
+    def preferred_block_path(self) -> str:
+        """Return a device path that exists for typical open(2) / blkid usage.
+
+        `slashed_path` (/dev/vg/lv) is only present when udev/LVM created those
+        nodes; many environments (e.g. containers) only provide
+        `dashed_path` (/dev/mapper/name).
+
+        Returns:
+            str: For non-LVM, `path`. For LVM, `slashed_path` if it is a block
+                 device, else `dashed_path` if it is a block device, else `path`.
+        """
+        if not self.is_lvm:
+            return self.path
+        slashed: str = self.slashed_path
+        if self._path_is_block_device(slashed):
+            return slashed
+        dashed: str = self.dashed_path
+        if self._path_is_block_device(dashed):
+            return dashed
+        return self.path

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -163,6 +163,14 @@ def _stat_is_device(stat_obj):
     return stat.S_ISBLK(stat_obj)
 
 
+def path_is_block_device(path: str) -> bool:
+    """True if ``path`` exists and is a block device (follows symlinks)."""
+    try:
+        return _stat_is_device(os.stat(path).st_mode)
+    except OSError:
+        return False
+
+
 def _lsblk_parser(line):
     """
     Parses lines in lsblk output. Requires output to be in pair mode (``-P`` flag). Lines
@@ -801,7 +809,22 @@ def get_devices(_sys_block_path='/sys/block', device=''):
     for block in block_devs:
         metadata: Dict[str, Any] = {}
         if block[2] == 'lvm':
-            block[1] = UdevData(block[1]).preferred_block_path
+            try:
+                udev_data = UdevData(block[1])
+            except RuntimeError as exc:
+                logger.debug(
+                    'get_devices(): skipping LVM device %s: %s', block[1], exc)
+                continue
+            if udev_data.is_internal_lv:
+                logger.debug(
+                    'get_devices(): skipping internal LVM LV %s', block[1])
+                continue
+            block[1] = udev_data.preferred_block_path
+            if not path_is_block_device(block[1]):
+                logger.debug(
+                    'get_devices(): skipping LVM device without accessible node %s',
+                    block[1])
+                continue
         devname = os.path.basename(block[0])
         diskname = block[1]
         if block[2] not in block_types:
@@ -1417,6 +1440,16 @@ class UdevData:
         return self.environment.get('DM_UUID', '').startswith('LVM')
 
     @property
+    def is_internal_lv(self) -> bool:
+        lv_name = self.environment.get('DM_LV_NAME', '')
+        if not lv_name:
+            return False
+        for marker in ('_rmeta_', '_rimage_', '_rtmeta_', '_rtimage_'):
+            if marker in lv_name:
+                return True
+        return bool(self.environment.get('DM_LV_LAYER', ''))
+
+    @property
     def slashed_path(self) -> str:
         """Get the LVM path structured with slashes.
 
@@ -1445,14 +1478,6 @@ class UdevData:
             result = f'/dev/mapper/{name}'
         return result
 
-    @staticmethod
-    def _path_is_block_device(path: str) -> bool:
-        """True if ``path`` exists and is a block device (follows symlinks)."""
-        try:
-            return _stat_is_device(os.stat(path).st_mode)
-        except OSError:
-            return False
-
     @property
     def preferred_block_path(self) -> str:
         """Return a device path that exists for typical open(2) / blkid usage.
@@ -1468,9 +1493,9 @@ class UdevData:
         if not self.is_lvm:
             return self.path
         slashed: str = self.slashed_path
-        if self._path_is_block_device(slashed):
+        if path_is_block_device(slashed):
             return slashed
         dashed: str = self.dashed_path
-        if self._path_is_block_device(dashed):
+        if path_is_block_device(dashed):
             return dashed
         return self.path


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77636

---

backport of https://github.com/ceph/ceph/pull/69569
parent tracker: https://tracker.ceph.com/issues/77486

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh