### PR TITLE
tentacle: mgr/dashboard: skip the table when an nvmeof cli result has no columns

### DIFF
--- a/src/pybind/mgr/dashboard/services/nvmeof_cli.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_cli.py
@@ -135,6 +135,8 @@ class AnnotatedDataTextOutputFormatter(OutputFormatter):
 
     def _get_list_text_output(self, data):
         columns = list(dict.fromkeys([key for obj in data for key in obj.keys()]))
+        if not columns:
+            return ''
         table = self._create_table(columns)
         for d in data:
             table.add_row(self._get_row(columns, d))
@@ -142,6 +144,8 @@ class AnnotatedDataTextOutputFormatter(OutputFormatter):
 
     def _get_object_text_output(self, data):
         columns = [k for k in data.keys() if k not in ["status", "error_message"]]
+        if not columns:
+            return ''
         table = self._create_table(columns)
         table.add_row(self._get_row(columns, data))
         return table.get_string()

--- a/src/pybind/mgr/dashboard/tests/test_nvmeof_cli.py
+++ b/src/pybind/mgr/dashboard/tests/test_nvmeof_cli.py
@@ -115,13 +115,7 @@ class TestNvmeofCLICommand:
         result = NvmeofCLICommand.COMMANDS[sample_command].call(MagicMock(), {})
         assert isinstance(result, HandleCommandResult)
         assert result.retval == 0
-        assert result.stdout == (
-            "++\n"
-            "||\n"
-            "++\n"
-            "\n"
-            "++"
-        )
+        assert result.stdout == ''
         assert result.stderr == ''
         base_call_return_none_mock.assert_called_once()
 

--- a/src/python-common/ceph/cryptotools/internal.py
+++ b/src/python-common/ceph/cryptotools/internal.py
@@ -45,19 +45,13 @@ class InternalCryptoCaller(CryptoCaller):
     ) -> str:
         _pkey = crypto.load_privatekey(crypto.FILETYPE_PEM, pkey)
 
-        # Create a "subject" object
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            req = crypto.X509Req()
-        subj = req.get_subject()
-
-        # populate the subject with the dname settings
+        # create a self-signed cert and populate its subject with the dname
+        # settings
+        cert = crypto.X509()
+        subj = cert.get_subject()
         for k, v in dname.items():
             setattr(subj, k, v)
-
-        # create a self-signed cert
-        cert = crypto.X509()
-        cert.set_subject(req.get_subject())
+        cert.set_subject(subj)
         cert.set_serial_number(int(uuid4()))
         cert.gmtime_adj_notBefore(0)
         cert.gmtime_adj_notAfter(10 * 365 * 24 * 60 * 60)  # 10 years


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77608
backport tracker: https://tracker.ceph.com/issues/77434

---

backport of https://github.com/ceph/ceph/pull/69659
parent tracker: https://tracker.ceph.com/issues/77589

backport of https://github.com/ceph/ceph/pull/69446
parent tracker: https://tracker.ceph.com/issues/77391

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh