### PR TITLE
tentacle: mgr/dashboard: fix bind address regression from CherryPy isolation 

### DIFF
--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -210,6 +210,7 @@ class CherryPyConfig(object):
         self._url_prefix = prepare_url_prefix(self.get_module_option(  # type: ignore
             'url_prefix', default=''))
 
+        bind_addr = server_addr
         if server_addr in ['::', '0.0.0.0']:
             server_addr = self.get_mgr_ip()  # type: ignore
         base_url = build_url(
@@ -218,7 +219,7 @@ class CherryPyConfig(object):
             port=server_port,
         )
         uri = f'{base_url}{self.url_prefix}/'
-        return uri, (server_addr, server_port), ssl_info, config
+        return uri, (bind_addr, server_port), ssl_info, config
 
     def await_configuration(self):
         """

--- a/src/pybind/mgr/dashboard/tests/test_settings.py
+++ b/src/pybind/mgr/dashboard/tests/test_settings.py
@@ -2,11 +2,13 @@
 
 import errno
 import unittest
+from unittest.mock import MagicMock
 
 from mgr_module import ERROR_MSG_EMPTY_INPUT_FILE
 
 from .. import settings
 from ..controllers.settings import Settings as SettingsController
+from ..module import CherryPyConfig
 from ..settings import Settings, handle_option_command
 from ..tests import ControllerTestCase, KVStoreMockMixin
 
@@ -124,6 +126,33 @@ class SettingsTest(unittest.TestCase, KVStoreMockMixin):
 
         self.assertEqual(str(ctx.exception),
                          "type object 'Options' has no attribute 'NON_EXISTENT_OPTION'")
+
+    def _setup_cherrypy_config(self, server_addr, server_port):
+        obj = CherryPyConfig()
+        config_map = {
+            'server_addr': server_addr,
+            'ssl': False,
+            'server_port': server_port
+        }
+        obj.get_localized_module_option = MagicMock(
+            side_effect=lambda key, default=None: config_map.get(key, default))
+        obj.get_mgr_ip = MagicMock(return_value='192.168.1.10')
+        obj.get_module_option = MagicMock(return_value='')
+        obj.get_mgr_id = MagicMock(return_value='test')
+        obj.module_name = 'dashboard'
+        obj.log = MagicMock()
+        obj.update_cherrypy_config = MagicMock()
+        return obj
+
+    def test_wildcard_bind_addr_preserved(self):
+        obj = self._setup_cherrypy_config('::', 8080)
+        _, bind_addr, _, _ = obj._configure()  # pylint: disable=protected-access
+        self.assertEqual(bind_addr, ('::', 8080))
+
+    def test_wildcard_bind_addr_preserved_ipv4(self):
+        obj = self._setup_cherrypy_config('0.0.0.0', 8443)
+        _, bind_addr, _, _ = obj._configure()  # pylint: disable=protected-access
+        self.assertEqual(bind_addr, ('0.0.0.0', 8443))
 
 
 class SettingsControllerTest(ControllerTestCase, KVStoreMockMixin):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77663

---

backport of https://github.com/ceph/ceph/pull/69574
parent tracker: https://tracker.ceph.com/issues/77491

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh