### PR TITLE
client: Check if dname is too long after wrap_name 

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1331,6 +1331,10 @@ bool Client::_wrap_name(Inode& diri, std::string& dname, std::string& alternate_
   ceph_assert(dname.size() > 0);
   alternate_name = "";
 
+  if (dname.size() > NAME_MAX) {
+    return -ENAMETOOLONG;
+  }
+
   if (dname == cct->_conf->client_snapdir) {
     ldout(cct, 25) << __func__ << ": is special name" << dendl;
     return true;
@@ -1434,6 +1438,10 @@ bool Client::_wrap_name(Inode& diri, std::string& dname, std::string& alternate_
     }
   }
 #endif
+
+  if (dname.size() > NAME_MAX) {
+    return -ENAMETOOLONG;
+  }
 
   return true;
 }
@@ -7975,11 +7983,6 @@ int Client::path_walk(InodeRef dirinode, const filepath& origpath,
         goto out;
       }
       caps = CEPH_CAP_AUTH_SHARED;
-    }
-
-    if (dname.size() > NAME_MAX) {
-      rc = -ENAMETOOLONG;
-      goto out;
     }
 
     // N.B.: we don't validate alternate_name we generate during wrapping

--- a/src/client/FSCrypt.cc
+++ b/src/client/FSCrypt.cc
@@ -740,8 +740,11 @@ int FSCryptFNameDenc::get_encrypted_symlink_length(const int& plain_size) const
 {
    int padding_size = ctx->get_filename_padding_bytes();
    int padded_size = (plain_size + padding_size - 1) & ~ (padding_size - 1);
-   if (padded_size > PATH_MAX) {
-    padded_size = PATH_MAX;
+   // The usable symlink target length is maxed at PATH_MAX - 3. This is due
+   // to two bytes being used for defining length and then one byte used for
+   // nul character.
+   if (padded_size > PATH_MAX - 2) {
+    padded_size = PATH_MAX - 2;
   }
   return padded_size;
 }
@@ -830,13 +833,19 @@ struct fscrypt_slink_data {
 int FSCryptFNameDenc::get_encrypted_symlink(const std::string& plain, std::string *encrypted)
 {
   auto plain_size = plain.size();
+
+  fscrypt_slink_data slink_data;
+
+  if (plain_size > sizeof(slink_data.enc)) {
+    return -ENAMETOOLONG;
+  }
+
   auto symlink_padded_size = get_encrypted_symlink_length(plain_size);
 
   char orig[symlink_padded_size];
   memcpy(orig, plain.c_str(), plain_size);
   memset(orig + plain_size, 0, symlink_padded_size - plain_size);
 
-  fscrypt_slink_data slink_data;
   int r = encrypt(orig, symlink_padded_size,
                   slink_data.enc, sizeof(slink_data.enc));
 

--- a/src/client/FSCrypt.cc
+++ b/src/client/FSCrypt.cc
@@ -664,11 +664,6 @@ int FSCryptDenc::decrypt(const char *in_data, int in_len,
     return -EINVAL;
   }
 
-  if ((uint64_t)out_len < (fscrypt_align_ofs(in_len))) {
-    ldout(cct, 0) << __FILE__ << ":" << __LINE__ << dendl;
-    return -ERANGE;
-  }
-
   if (!EVP_CipherInit_ex2(cipher_ctx, cipher, (const uint8_t *)key.data(), iv.raw,
                           0, cipher_params.data())) {
     ldout(cct, 0) << __FILE__ << ":" << __LINE__ << dendl;
@@ -702,10 +697,6 @@ int FSCryptDenc::encrypt(const char *in_data, int in_len,
     if ((int)key.size() != key_size) {
       ldout(cct, 0) << "ERROR: unexpected encryption key size: " << key.size() << " (expected: " << key_size << ")" << dendl;
       return -EINVAL;
-    }
-
-    if ((uint64_t)out_len < (fscrypt_align_ofs(in_len))) {
-      return -ERANGE;
     }
 
     if (!EVP_CipherInit_ex2(cipher_ctx, cipher, (const uint8_t *)key.data(), iv.raw,
@@ -768,7 +759,7 @@ int FSCryptFNameDenc::get_encrypted_fname(const std::string& plain, std::string 
   memcpy(orig, plain.c_str(), plain_size);
   memset(orig + plain_size, 0, filename_padded_size - plain_size);
 
-  char enc_name[NAME_MAX + 64]; /* some extra just in case */
+  char enc_name[NAME_MAX];
   int r = encrypt(orig, filename_padded_size,
                   enc_name, sizeof(enc_name));
 
@@ -818,7 +809,7 @@ int FSCryptFNameDenc::get_decrypted_fname(const std::string& b64enc, const std::
                                 enc, sizeof(enc));
   }
 
-  char dec_fname[NAME_MAX + 64]; /* some extra just in case */
+  char dec_fname[NAME_MAX];
   int r = decrypt(penc, len, dec_fname, sizeof(dec_fname));
 
   if (r >= 0) {
@@ -872,7 +863,7 @@ int FSCryptFNameDenc::get_decrypted_symlink(const std::string& b64enc, std::stri
   int len = fscrypt_fname_unarmor(b64enc.c_str(), b64enc.size(),
                                   (char *)&slink_data, sizeof(slink_data));
 
-  char dec_fname[PATH_MAX + 64]; /* some extra just in case */
+  char dec_fname[sizeof(slink_data.enc)];
 
   if (slink_data.len > len) { /* should never happen */
     ldout(cct, 0) << __FILE__ << ":" << __LINE__ << ":" << __func__ << "(): ERROR: slink_data.len greater than decrypted buffer (slink_data.len=" << slink_data.len << ", len=" << len << ")" << dendl;
@@ -967,6 +958,11 @@ int FSCryptFDataDenc::decrypt_bl(uint64_t off, uint64_t len, uint64_t pos, const
 
       chunk.append_hole(chunk_len);
 
+      if ((uint64_t)chunk_len < (fscrypt_align_ofs(chunk_len))) {
+        ldout(cct, 0) << __FILE__ << ":" << __LINE__ << dendl;
+        return -ERANGE;
+      }
+
       uint64_t bl_off = pos - start_block_off;
       r = decrypt(bl->c_str() + bl_off, chunk_len,
                   chunk.c_str(), chunk_len);
@@ -1028,6 +1024,10 @@ int FSCryptFDataDenc::encrypt_bl(uint64_t off, uint64_t len, bufferlist& bl, buf
 
     bufferlist chunk;
     chunk.append_hole(chunk_len);
+
+    if ((uint64_t)chunk_len < (fscrypt_align_ofs(chunk_len))) {
+      return -ERANGE;
+    }
 
     r = encrypt(bl.c_str() + pos - off, chunk_len,
                 chunk.c_str(), chunk_len);

--- a/src/test/libcephfs/fscrypt.cc
+++ b/src/test/libcephfs/fscrypt.cc
@@ -239,6 +239,7 @@ static int init_fscrypt()
 
   libcephfs_test_set_mount_call(do_fscrypt_mount);
   libcephfs_test_set_dir_prefix(fscrypt_dir);
+  libcephfs_test_set_is_encrypted(true);
   std::clog << __func__ << "(): init fscrypt done" << std::endl;
 
   return 0;

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -68,6 +68,7 @@ static std::string generate_random_string(int length = 20) {
 
 static int (*do_ceph_mount)(struct ceph_mount_info *cmount, const char *root) = ceph_mount;
 static std::string dir_prefix = std::string("/");
+static bool is_encrypted = false;
 
 void libcephfs_test_set_mount_call(int (*mount_call)(struct ceph_mount_info *cmount, const char *root))
 {
@@ -77,6 +78,11 @@ void libcephfs_test_set_mount_call(int (*mount_call)(struct ceph_mount_info *cmo
 void libcephfs_test_set_dir_prefix(std::string (prefix))
 {
   dir_prefix = prefix;
+}
+
+void libcephfs_test_set_is_encrypted(bool encrypted)
+{
+  is_encrypted = encrypted;
 }
 
 TEST(LibCephFS, OpenEmptyComponent) {
@@ -5163,4 +5169,42 @@ TEST(LibCephFS, ZeroSizeBufferAsyncReadFsync) {
   ASSERT_EQ(0, ceph_unmount(cmount));
   ceph_release(cmount);
   ceph_userperm_destroy(perms);
+}
+
+TEST(LibCephFS, SymlinkLongTarget) {
+  pid_t mypid = getpid();
+
+  struct ceph_mount_info *cmount;
+  ASSERT_EQ(ceph_create(&cmount, NULL), 0);
+  ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
+  ASSERT_EQ(do_ceph_mount(cmount, "/"), 0);
+
+  char dir_name[128];
+  char dir_path[256];
+  sprintf(dir_name, "dir_%d", mypid);
+  sprintf(dir_path, "/%s", dir_name);
+  ASSERT_EQ(ceph_mkdir(cmount, dir_path, 0777), 0);
+
+
+  int max_path = PATH_MAX - 1;
+
+  if(is_encrypted) {
+    max_path = PATH_MAX - 3;
+  }
+
+  char rel_file_path[PATH_MAX];
+  memset(rel_file_path, 'b', max_path);
+  rel_file_path[max_path] = '\0';
+
+  char link_path[PATH_MAX];
+  char rel_link_path[1024];
+  sprintf(rel_link_path, "./linkfile_%d", mypid);
+  sprintf(link_path, "%s/%s", dir_path, rel_link_path);
+  ASSERT_EQ(0, ceph_symlink(cmount, rel_file_path, link_path));
+
+  ASSERT_EQ(0, ceph_chdir(cmount, dir_path));
+  ASSERT_EQ(0, ceph_unlink(cmount, link_path));
+  ASSERT_EQ(0, ceph_rmdir(cmount, dir_path));
+  ceph_shutdown(cmount);
 }

--- a/src/test/libcephfs/test.h
+++ b/src/test/libcephfs/test.h
@@ -5,3 +5,4 @@ struct ceph_mount_info;
 
 void libcephfs_test_set_mount_call(int (*mount_call)(struct ceph_mount_info *cmount, const char *root));
 void libcephfs_test_set_dir_prefix(std::string (prefix));
+void libcephfs_test_set_is_encrypted(bool encrypted);


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/77122

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
