### PR TITLE
squid: mon: fix ConnectionTracker::notify_rank_removed

### DIFF
--- a/src/mon/ConnectionTracker.cc
+++ b/src/mon/ConnectionTracker.cc
@@ -259,17 +259,14 @@ void ConnectionTracker::notify_rank_removed(int rank_removed, int new_rank)
   ceph_assert((peer_reports.size() == starting_size) ||
 	  (peer_reports.size() + 1 == starting_size));
 
-  if (rank_removed < rank) { // if the rank removed is lower than us, we need to adjust.
-    --rank;
-    my_reports.rank = rank; // also adjust my_reports.rank.
-  }
+  // Trust the caller's new_rank from the monmap rather than trying to compute it.
+  // This handles cases where multiple ranks are removed simultaneously.
+  rank = new_rank;
+  my_reports.rank = new_rank;
 
   ldout(cct, 20) << "my rank after: " << rank << dendl;
   ldout(cct, 20) << "peer_reports after: " << peer_reports << dendl;
   ldout(cct, 20) << "my_reports after: " << my_reports << dendl;
-
-  //check if the new_rank from monmap is equal to our adjusted rank.
-  ceph_assert(rank == new_rank);
 
   increase_version();
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77655

---

backport of https://github.com/ceph/ceph/pull/69497
parent tracker: https://tracker.ceph.com/issues/77423

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh