### PR TITLE
mon: nvmof mon client: be more graceful when dealing with future keepalive timestamps

### DIFF
--- a/doc/governance.rst
+++ b/doc/governance.rst
@@ -112,7 +112,7 @@ Current Members
  * Vikhyat Umrao <vikhyat@ibm.com>
  * Xie Xingguo <xie.xingguo@zte.com.cn>
  * Yaarit Hatuka <yhatuka@ibm.com>
- * Yehuda Sadeh <yehuda@redhat.com>
+ * Yehuda Sadeh <yehuda@ui.com>
  * Yingxin Cheng <yingxin.cheng@intel.com>
  * Yuri Weinstein <yweinste@redhat.com>
  * Zac Dover <zac.dover@proton.me>

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -1013,11 +1013,19 @@ void MonClient::tick()
       if (cct->_conf->mon_client_ping_timeout > 0 &&
 	  cur_con->has_feature(CEPH_FEATURE_MSGR_KEEPALIVE2)) {
 	utime_t lk = cur_con->get_last_keepalive_ack();
-	utime_t interval = now - lk;
-	if (interval > cct->_conf->mon_client_ping_timeout) {
-	  ldout(cct, 1) << "no keepalive since " << lk << " (" << interval
-			<< " seconds), reconnecting" << dendl;
-	  return _reopen_session();
+	// Only treat this as a missed keepalive when the last ack is genuinely
+	// in the past. utime_t stores seconds as an unsigned 32-bit value and
+	// operator- does not clamp, so if 'lk' is even slightly ahead of 'now'
+	// (clock skew / a forward step between the reads), "now - lk" wraps to
+	// ~2^32 seconds and spuriously exceeds mon_client_ping_timeout, forcing
+	// a needless _reopen_session(). Guard the subtraction against that.
+	if (now > lk) {
+	  utime_t interval = now - lk;
+	  if (interval > cct->_conf->mon_client_ping_timeout) {
+	    ldout(cct, 1) << "no keepalive since " << lk << " (" << interval
+			  << " seconds), reconnecting" << dendl;
+	    return _reopen_session();
+	  }
 	}
       }
 

--- a/src/nvmeof/NVMeofGwMonitorClient.cc
+++ b/src/nvmeof/NVMeofGwMonitorClient.cc
@@ -42,7 +42,6 @@ NVMeofGwMonitorClient::NVMeofGwMonitorClient(int argc, const char **argv) :
   osdmap_epoch(0),
   gwmap_epoch(0),
   last_map_time(std::chrono::steady_clock::now()),
-  reset_timestamp(std::chrono::steady_clock::now()),
   start_time(last_map_time),
   cluster_beacon_diff_included(0),
   poolctx(),
@@ -391,23 +390,17 @@ void NVMeofGwMonitorClient::handle_nvmeof_gw_map(ceph::ref_t<MNVMeofGwMap> nmap)
   gwmap_epoch = nmap->get_gwmap_epoch();
   auto group_key = std::make_pair(pool, group);
   dout(10) << "handle nvmeof gw map: " << new_map << dendl;
-  uint64_t reset_elapsed_seconds =
-      std::chrono::duration_cast<std::chrono::seconds>(now - reset_timestamp).count();
   NvmeGwClientState old_gw_state;
-  uint64_t ignore_wrong_map_interval_sec =
-       g_conf().get_val<uint64_t>("mon_nvmeofgw_wrong_map_ignore_sec");
-  auto got_old_gw_state = get_gw_state("old map", map, group_key, name, old_gw_state); 
+  auto got_old_gw_state = get_gw_state("old map", map, group_key, name, old_gw_state);
   NvmeGwClientState new_gw_state;
   auto got_new_gw_state = get_gw_state("new map", new_map, group_key, name, new_gw_state); 
 
-  /*It is possible that wrong second map would be sent by monitor in rear cases when several GWs doing reboot
-  * and entity_address of the monitor client changes. So Monitor may send the unicast map to the wrong destination
-  * since this "old" address still appears in its map. It is asynchronous process in the monitor, better to protect
-  * from this scenario by silently ignoring the wrong map. This can happen just in the first several seconds after restart
+  /* A map in which this gateway was present before but is now absent
+  * ("got_old_gw_state && !got_new_gw_state") is a transient, recoverable
+  * glitch, we shouldn't crash the gateway
   */
-  if ( (reset_elapsed_seconds < ignore_wrong_map_interval_sec) &&
-        !got_new_gw_state && got_old_gw_state) {
-    dout(4) << "Wrong map received, Ignore it" << dendl;
+  if (!got_new_gw_state && got_old_gw_state) {
+    dout(4) << "Wrong map received (gw vanished from map), Ignore it" << dendl;
     return;
   }
   // ensure that the gateway state has not vanished

--- a/src/nvmeof/NVMeofGwMonitorClient.h
+++ b/src/nvmeof/NVMeofGwMonitorClient.h
@@ -48,8 +48,6 @@ private:
   std::chrono::time_point<std::chrono::steady_clock>
               last_map_time; // used to panic on disconnect
   std::chrono::time_point<std::chrono::steady_clock>
-                reset_timestamp; // used to bypass some validations
-  std::chrono::time_point<std::chrono::steady_clock>
                 start_time; // used to panic on connect
 
   bool first_beacon = true;


### PR DESCRIPTION
A couple of issues fixed here:
 - don't try to compute keepalive time length if it's in the future
 - don't assert due to possible transient state

Fixes: https://tracker.ceph.com/issues/77673

Signed-off-by: Yehuda Sadeh Weinraub <yehuda@ui.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
