### PR TITLE
umbrella: nvmeofgw:fix forcing unavalable gw exit by sending

### DIFF
--- a/src/mon/NVMeofGwMap.cc
+++ b/src/mon/NVMeofGwMap.cc
@@ -43,10 +43,11 @@ void NVMeofGwMap::to_gmap(
       const auto& gw_id = gw_created_pair.first;
       const auto& gw_created  = gw_created_pair.second;
       gw_availability_t availability = gw_created.availability;
-      if (gw_created.availability == gw_availability_t::GW_DELETING) {
-         dout (4) << gw_id << "Send empty unicast map in Deleting state"
-                  << dendl;
-         continue;
+      if (gw_created.availability == gw_availability_t::GW_DELETING ||
+          gw_created.availability == gw_availability_t::GW_UNAVAILABLE) {
+        dout (4) << "GW " << gw_id << " Send empty unicast map in state "
+                 << gw_created.availability << dendl;
+        continue;
       }
 
       auto gw_state = NvmeGwClientState(

--- a/src/mon/NVMeofGwMon.cc
+++ b/src/mon/NVMeofGwMon.cc
@@ -1119,6 +1119,11 @@ bool NVMeofGwMon::prepare_beacon(MonOpRequestRef op)
 	       << pending_map.created_gws[group_key][gw_id].availability
 	       << dendl;
       if (pending_map.created_gws[group_key][gw_id].availability ==
+          gw_availability_t::GW_UNAVAILABLE) {
+        pending_map.created_gws[group_key][gw_id].availability =
+          gw_availability_t::GW_CREATED; // prevent sending empty map to this GW after restart
+      }
+      if (pending_map.created_gws[group_key][gw_id].availability ==
 	  gw_availability_t::GW_AVAILABLE) {
 	dout(1) << " Warning :GW marked as Available in the NVmeofGwMon "
 		<< "database, performed full startup - Apply it but don't allow failover!"
@@ -1152,11 +1157,9 @@ bool NVMeofGwMon::prepare_beacon(MonOpRequestRef op)
 	   false) &&
 	  (avail == gw_availability_t::GW_AVAILABLE ||
 	   avail == gw_availability_t::GW_UNAVAILABLE )) {
-	ack_map.created_gws[group_key][gw_id] =
-	  pending_map.created_gws[group_key][gw_id];
 	ack_map.epoch = get_ack_map_epoch(true, group_key);
-	dout(1) << " Force gw to exit: first beacon in state " << avail
-		<< " GW " << gw_id << dendl;
+	dout(1) << "Send empty map. Force gw to exit: first beacon in state "
+		<< avail << " GW " << gw_id << dendl;
 	auto msg = make_message<MNVMeofGwMap>(ack_map);
 	mon.send_reply(op, msg.detach());
 	goto false_return;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77690

---

backport of https://github.com/ceph/ceph/pull/68650
parent tracker: https://tracker.ceph.com/issues/77428

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
