### PR TITLE
tentacle: qa: fix nvmeof upgrade from v20.2.0

### DIFF
--- a/qa/suites/nvmeof/upgrade/1-start-distro/1-start-centos_9.stream-v20.2.0.yaml
+++ b/qa/suites/nvmeof/upgrade/1-start-distro/1-start-centos_9.stream-v20.2.0.yaml
@@ -14,6 +14,7 @@ tasks:
 
 - cephadm:
     image: quay.io/ceph/ceph:v20.2.0
+    compiled_cephadm_branch: tentacle 
 
 - nvmeof:
     installer: host.a


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75932

---

backport of https://github.com/ceph/ceph/pull/68266
parent tracker: https://tracker.ceph.com/issues/75912

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh