### PR TITLE
seastore: Record slow transaction histograms

### DIFF
--- a/src/crimson/os/seastore/ordering_handle.h
+++ b/src/crimson/os/seastore/ordering_handle.h
@@ -5,6 +5,7 @@
 
 #include <chrono>
 
+#include <seastar/core/lowres_clock.hh>
 #include <seastar/core/shared_mutex.hh>
 
 #include "crimson/common/operation.h"
@@ -124,8 +125,8 @@ struct OrderingHandle {
   std::unique_ptr<OperationProxy> op;
   seastar::shared_mutex *collection_ordering_lock = nullptr;
 
-  std::chrono::steady_clock::time_point lock_acquire_time{};
-  std::chrono::steady_clock::duration lock_hold_time{0};
+  seastar::lowres_clock::time_point lock_acquire_time{};
+  seastar::lowres_clock::duration lock_hold_time{0};
 
   // in the future we might add further constructors / template to type
   // erasure while extracting the location of tracking events.
@@ -144,18 +145,18 @@ struct OrderingHandle {
     return collection_ordering_lock->lock();
   }
 
-  void set_lock_acquire_time(std::chrono::steady_clock::time_point tp) {
+  void set_lock_acquire_time(seastar::lowres_clock::time_point tp) {
     lock_acquire_time = tp;
   }
 
-  std::chrono::steady_clock::duration get_lock_hold_time() const {
+  seastar::lowres_clock::duration get_lock_hold_time() const {
     return lock_hold_time;
   }
 
   void maybe_release_collection_lock() {
     if (collection_ordering_lock) {
-      if (lock_acquire_time != std::chrono::steady_clock::time_point{}) {
-        lock_hold_time = std::chrono::steady_clock::now() - lock_acquire_time;
+      if (lock_acquire_time != seastar::lowres_clock::time_point{}) {
+        lock_hold_time = seastar::lowres_clock::now() - lock_acquire_time;
       }
       collection_ordering_lock->unlock();
       collection_ordering_lock = nullptr;

--- a/src/crimson/os/seastore/ordering_handle.h
+++ b/src/crimson/os/seastore/ordering_handle.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <chrono>
+
 #include <seastar/core/shared_mutex.hh>
 
 #include "crimson/common/operation.h"
@@ -122,12 +124,17 @@ struct OrderingHandle {
   std::unique_ptr<OperationProxy> op;
   seastar::shared_mutex *collection_ordering_lock = nullptr;
 
+  std::chrono::steady_clock::time_point lock_acquire_time{};
+  std::chrono::steady_clock::duration lock_hold_time{0};
+
   // in the future we might add further constructors / template to type
   // erasure while extracting the location of tracking events.
   OrderingHandle(std::unique_ptr<OperationProxy> op) : op(std::move(op)) {}
   OrderingHandle(OrderingHandle &&other)
     : op(std::move(other.op)),
-      collection_ordering_lock(other.collection_ordering_lock) {
+      collection_ordering_lock(other.collection_ordering_lock),
+      lock_acquire_time(other.lock_acquire_time),
+      lock_hold_time(other.lock_hold_time) {
     other.collection_ordering_lock = nullptr;
   }
 
@@ -137,8 +144,19 @@ struct OrderingHandle {
     return collection_ordering_lock->lock();
   }
 
+  void set_lock_acquire_time(std::chrono::steady_clock::time_point tp) {
+    lock_acquire_time = tp;
+  }
+
+  std::chrono::steady_clock::duration get_lock_hold_time() const {
+    return lock_hold_time;
+  }
+
   void maybe_release_collection_lock() {
     if (collection_ordering_lock) {
+      if (lock_acquire_time != std::chrono::steady_clock::time_point{}) {
+        lock_hold_time = std::chrono::steady_clock::now() - lock_acquire_time;
+      }
       collection_ordering_lock->unlock();
       collection_ordering_lock = nullptr;
     }

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -11,6 +11,7 @@
 
 #include <seastar/core/file.hh>
 #include <seastar/core/fstream.hh>
+#include <seastar/core/lowres_clock.hh>
 #include <seastar/core/metrics.hh>
 #include <seastar/core/shared_mutex.hh>
 
@@ -1751,11 +1752,11 @@ seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
   --(shard_stats.starting_io_num);
   ++(shard_stats.waiting_collock_io_num);
 
-  auto t_pre_collock = std::chrono::steady_clock::now();
+  auto t_pre_collock = seastar::lowres_clock::now();
   co_await ctx.transaction->get_handle().take_collection_lock(
     static_cast<SeastoreCollection&>(*(ctx.ch)).ordering_lock
   );
-  auto t_post_collock = std::chrono::steady_clock::now();
+  auto t_post_collock = seastar::lowres_clock::now();
   auto collock_wait = t_post_collock - t_pre_collock;
   ctx.transaction->get_handle().set_lock_acquire_time(t_post_collock);
 
@@ -1763,9 +1764,9 @@ seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
   --(shard_stats.waiting_collock_io_num);
   ++(shard_stats.waiting_throttler_io_num);
 
-  auto t_pre_throttler = std::chrono::steady_clock::now();
+  auto t_pre_throttler = seastar::lowres_clock::now();
   co_await throttler.get(1);
-  auto throttler_wait = std::chrono::steady_clock::now() - t_pre_throttler;
+  auto throttler_wait = seastar::lowres_clock::now() - t_pre_throttler;
 
   assert(shard_stats.waiting_throttler_io_num);
   --(shard_stats.waiting_throttler_io_num);
@@ -1804,7 +1805,7 @@ seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
       const size_t total_ops = ctx.ext_transaction.get_num_ops();
       size_t current_op = 0;
 
-      auto build_start = std::chrono::steady_clock::now();
+      auto build_start = seastar::lowres_clock::now();
       while (ctx.iter.have_op()) {
         current_op++;
 
@@ -1813,13 +1814,13 @@ seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
 	co_await _do_transaction_step(
 	  ctx, ctx.ch, onodes, ctx.iter);
       }
-      ctx.build_time += std::chrono::steady_clock::now() - build_start;
+      ctx.build_time += seastar::lowres_clock::now() - build_start;
 
       DEBUGT("completed all {} ops for cid={}",
              t, total_ops, ctx.ch->get_cid());
-      auto submit_start = std::chrono::steady_clock::now();
+      auto submit_start = seastar::lowres_clock::now();
       co_await transaction_manager->submit_transaction(*ctx.transaction);
-      ctx.submit_time += std::chrono::steady_clock::now() - submit_start;
+      ctx.submit_time += seastar::lowres_clock::now() - submit_start;
     })
   ).handle_error(
     crimson::ct_error::all_same_way([FNAME, &ctx](auto e) {
@@ -1833,12 +1834,12 @@ seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
   add_conflict_replay_sample(ctx.transaction->get_num_replays());
   {
     auto& pd = ctx.transaction->get_phase_durations();
-    auto total = std::chrono::steady_clock::now() - ctx.begin_timestamp;
+    auto total = seastar::lowres_clock::now() - ctx.begin_timestamp;
     auto total_us = static_cast<uint64_t>(
       std::chrono::duration_cast<std::chrono::microseconds>(total).count());
 
     const std::array<
-      std::pair<txn_stage_t, std::chrono::steady_clock::duration>, STAGE_MAX>
+      std::pair<txn_stage_t, seastar::lowres_clock::duration>, STAGE_MAX>
       stage_samples = {{
         {txn_stage_t::COLLOCK_WAIT,          collock_wait},
         {txn_stage_t::COLLOCK_HOLD,          ctx.transaction->get_handle().get_lock_hold_time()},
@@ -1867,7 +1868,8 @@ seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
   }
   add_latency_sample(
     op_type_t::DO_TRANSACTION,
-    std::chrono::steady_clock::now() - ctx.begin_timestamp);
+    seastar::lowres_clock::now() - ctx.begin_timestamp);
+
   add_onode_tree_sample(ctx.transaction->get_onode_tree_stats());
 
   throttler.put();
@@ -1969,7 +1971,7 @@ SeaStore::Shard::_do_transaction_step(
   }
   if (!onodes[op->oid]) {
     const ghobject_t& oid = i.get_oid(op->oid);
-    auto t0 = std::chrono::steady_clock::now();
+    auto t0 = seastar::lowres_clock::now();
     if (!create) {
       DEBUGT("op {}, get oid={} ...",
              *ctx.transaction, (uint32_t)op->op, oid);
@@ -1980,7 +1982,7 @@ SeaStore::Shard::_do_transaction_step(
       fut = onode_manager->get_or_create_onode(*ctx.transaction, oid);
     }
     fut = std::move(fut).si_then([&ctx, t0](auto onode) {
-      ctx.get_onode_time += std::chrono::steady_clock::now() - t0;
+      ctx.get_onode_time += seastar::lowres_clock::now() - t0;
       return onode_iertr::make_ready_future<OnodeRef>(std::move(onode));
     });
   }

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -215,6 +215,7 @@ void SeaStore::Shard::register_metrics(store_index_t store_index)
 
   std::pair<txn_stage_t, sm::label_instance> labels_by_stage[] = {
     {txn_stage_t::COLLOCK_WAIT,          sm::label_instance("stage", "collock_wait")},
+    {txn_stage_t::COLLOCK_HOLD,          sm::label_instance("stage", "collock_hold")},
     {txn_stage_t::THROTTLER_WAIT,        sm::label_instance("stage", "throttler_wait")},
     {txn_stage_t::BUILD,                 sm::label_instance("stage", "build")},
     {txn_stage_t::BUILD_GET_ONODE,       sm::label_instance("stage", "build_get_onode")},
@@ -1743,7 +1744,9 @@ seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
   co_await ctx.transaction->get_handle().take_collection_lock(
     static_cast<SeastoreCollection&>(*(ctx.ch)).ordering_lock
   );
-  auto collock_wait = std::chrono::steady_clock::now() - t_pre_collock;
+  auto t_post_collock = std::chrono::steady_clock::now();
+  auto collock_wait = t_post_collock - t_pre_collock;
+  ctx.transaction->get_handle().set_lock_acquire_time(t_post_collock);
 
   assert(shard_stats.waiting_collock_io_num);
   --(shard_stats.waiting_collock_io_num);
@@ -1818,6 +1821,8 @@ seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
   DEBUGT("done", *ctx.transaction);
   add_conflict_replay_sample(ctx.transaction->get_num_replays());
   add_stage_latency_sample(txn_stage_t::COLLOCK_WAIT, collock_wait);
+  add_stage_latency_sample(txn_stage_t::COLLOCK_HOLD,
+                           ctx.transaction->get_handle().get_lock_hold_time());
   add_stage_latency_sample(txn_stage_t::THROTTLER_WAIT, throttler_wait);
   add_stage_latency_sample(txn_stage_t::BUILD, ctx.build_time);
   add_stage_latency_sample(txn_stage_t::BUILD_GET_ONODE, ctx.get_onode_time);

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -227,27 +227,38 @@ void SeaStore::Shard::register_metrics(store_index_t store_index)
     {txn_stage_t::SUBMIT_PREPARE_RECORD, sm::label_instance("stage", "submit_prepare_record")},
     {txn_stage_t::SUBMIT_JOURNAL,        sm::label_instance("stage", "submit_journal")},
   };
-  for (auto& [stage, label] : labels_by_stage) {
-    auto idx = static_cast<std::size_t>(stage);
-    auto& hist = stats.stage_lat[idx];
-    hist.buckets.resize(STAGE_LAT_BUCKETS_US.size());
-    for (std::size_t i = 0; i < STAGE_LAT_BUCKETS_US.size(); ++i) {
-      hist.buckets[i].upper_bound = STAGE_LAT_BUCKETS_US[i];
-      hist.buckets[i].count = 0;
-    }
-    metrics.add_group(
-      "seastore",
-      {
-        sm::make_histogram(
-          "do_transaction_stage_lat",
-          [this, idx]() -> seastar::metrics::histogram& {
-            return stats.stage_lat[idx];
-          },
-          sm::description("per-stage latency (microseconds) of do_transaction"),
-          {label, sm::label_instance("shard_store_index", std::to_string(store_index))}
-        )
+  // Three tiers of the same per-stage histograms
+  std::pair<std::array<seastar::metrics::histogram, STAGE_MAX>*, const char*>
+    tail_tiers[] = {
+      {&stats.stage_lat,           "all"},
+      {&stats.stage_lat_slow,      "slow"},
+      {&stats.stage_lat_very_slow, "very_slow"},
+    };
+  for (auto& [arr_ptr, tail] : tail_tiers) {
+    for (auto& [stage, label] : labels_by_stage) {
+      auto idx = static_cast<std::size_t>(stage);
+      auto& hist = (*arr_ptr)[idx];
+      hist.buckets.resize(STAGE_LAT_BUCKETS_US.size());
+      for (std::size_t i = 0; i < STAGE_LAT_BUCKETS_US.size(); ++i) {
+        hist.buckets[i].upper_bound = STAGE_LAT_BUCKETS_US[i];
+        hist.buckets[i].count = 0;
       }
-    );
+      metrics.add_group(
+        "seastore",
+        {
+          sm::make_histogram(
+            "do_transaction_stage_lat",
+            [arr_ptr, idx]() -> seastar::metrics::histogram& {
+              return (*arr_ptr)[idx];
+            },
+            sm::description("per-stage latency (microseconds) of do_transaction"),
+            {label,
+             sm::label_instance("tail", tail),
+             sm::label_instance("shard_store_index", std::to_string(store_index))}
+          )
+        }
+      );
+    }
   }
 
   metrics.add_group(
@@ -1820,21 +1831,39 @@ seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
 
   DEBUGT("done", *ctx.transaction);
   add_conflict_replay_sample(ctx.transaction->get_num_replays());
-  add_stage_latency_sample(txn_stage_t::COLLOCK_WAIT, collock_wait);
-  add_stage_latency_sample(txn_stage_t::COLLOCK_HOLD,
-                           ctx.transaction->get_handle().get_lock_hold_time());
-  add_stage_latency_sample(txn_stage_t::THROTTLER_WAIT, throttler_wait);
-  add_stage_latency_sample(txn_stage_t::BUILD, ctx.build_time);
-  add_stage_latency_sample(txn_stage_t::BUILD_GET_ONODE, ctx.get_onode_time);
-  add_stage_latency_sample(txn_stage_t::SUBMIT_TOTAL, ctx.submit_time);
   {
     auto& pd = ctx.transaction->get_phase_durations();
-    add_stage_latency_sample(txn_stage_t::SUBMIT_RESERVE, pd.reserve);
-    add_stage_latency_sample(txn_stage_t::SUBMIT_OOL_WRITE, pd.ool_write);
-    add_stage_latency_sample(txn_stage_t::SUBMIT_LBA_UPDATE, pd.lba_update);
-    add_stage_latency_sample(txn_stage_t::SUBMIT_PREPARE_ENTER, pd.prepare_enter);
-    add_stage_latency_sample(txn_stage_t::SUBMIT_PREPARE_RECORD, pd.prepare_record);
-    add_stage_latency_sample(txn_stage_t::SUBMIT_JOURNAL, pd.journal);
+    auto total = std::chrono::steady_clock::now() - ctx.begin_timestamp;
+    auto total_us = static_cast<uint64_t>(
+      std::chrono::duration_cast<std::chrono::microseconds>(total).count());
+
+    const std::array<
+      std::pair<txn_stage_t, std::chrono::steady_clock::duration>, STAGE_MAX>
+      stage_samples = {{
+        {txn_stage_t::COLLOCK_WAIT,          collock_wait},
+        {txn_stage_t::COLLOCK_HOLD,          ctx.transaction->get_handle().get_lock_hold_time()},
+        {txn_stage_t::THROTTLER_WAIT,        throttler_wait},
+        {txn_stage_t::BUILD,                 ctx.build_time},
+        {txn_stage_t::BUILD_GET_ONODE,       ctx.get_onode_time},
+        {txn_stage_t::SUBMIT_TOTAL,          ctx.submit_time},
+        {txn_stage_t::SUBMIT_RESERVE,        pd.reserve},
+        {txn_stage_t::SUBMIT_OOL_WRITE,      pd.ool_write},
+        {txn_stage_t::SUBMIT_LBA_UPDATE,     pd.lba_update},
+        {txn_stage_t::SUBMIT_PREPARE_ENTER,  pd.prepare_enter},
+        {txn_stage_t::SUBMIT_PREPARE_RECORD, pd.prepare_record},
+        {txn_stage_t::SUBMIT_JOURNAL,        pd.journal},
+      }};
+
+    for (auto& [stage, dur] : stage_samples) {
+      add_stage_latency_sample(stats.stage_lat, stage, dur);
+      if (total_us > TAIL_SLOW_US) {
+        add_stage_latency_sample(stats.stage_lat_slow, stage, dur);
+      }
+      if (total_us > TAIL_VERY_SLOW_US) {
+        add_stage_latency_sample(stats.stage_lat_very_slow, stage, dur);
+      }
+    }
+    add_latency_sample(op_type_t::DO_TRANSACTION, total);
   }
   add_latency_sample(
     op_type_t::DO_TRANSACTION,

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -168,9 +168,9 @@ void SeaStore::Shard::register_metrics(store_index_t store_index)
   };
 
   for (auto& hist : stats.op_lat) {
-    hist.buckets.resize(lat_hist_bounds_us.size());
-    for (std::size_t i = 0; i < lat_hist_bounds_us.size(); ++i) {
-      hist.buckets[i].upper_bound = lat_hist_bounds_us[i];
+    hist.buckets.resize(lat_hist_bounds_ms.size());
+    for (std::size_t i = 0; i < lat_hist_bounds_ms.size(); ++i) {
+      hist.buckets[i].upper_bound = lat_hist_bounds_ms[i];
       hist.buckets[i].count = 0;
     }
   }
@@ -239,9 +239,9 @@ void SeaStore::Shard::register_metrics(store_index_t store_index)
     for (auto& [stage, label] : labels_by_stage) {
       auto idx = static_cast<std::size_t>(stage);
       auto& hist = (*arr_ptr)[idx];
-      hist.buckets.resize(STAGE_LAT_BUCKETS_US.size());
-      for (std::size_t i = 0; i < STAGE_LAT_BUCKETS_US.size(); ++i) {
-        hist.buckets[i].upper_bound = STAGE_LAT_BUCKETS_US[i];
+      hist.buckets.resize(STAGE_LAT_BUCKETS_MS.size());
+      for (std::size_t i = 0; i < STAGE_LAT_BUCKETS_MS.size(); ++i) {
+        hist.buckets[i].upper_bound = STAGE_LAT_BUCKETS_MS[i];
         hist.buckets[i].count = 0;
       }
       metrics.add_group(
@@ -252,7 +252,7 @@ void SeaStore::Shard::register_metrics(store_index_t store_index)
             [arr_ptr, idx]() -> seastar::metrics::histogram& {
               return (*arr_ptr)[idx];
             },
-            sm::description("per-stage latency (microseconds) of do_transaction"),
+            sm::description("per-stage latency (milliseconds) of do_transaction"),
             {label,
              sm::label_instance("tail", tail),
              sm::label_instance("shard_store_index", std::to_string(store_index))}
@@ -1835,8 +1835,8 @@ seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
   {
     auto& pd = ctx.transaction->get_phase_durations();
     auto total = seastar::lowres_clock::now() - ctx.begin_timestamp;
-    auto total_us = static_cast<uint64_t>(
-      std::chrono::duration_cast<std::chrono::microseconds>(total).count());
+    auto total_ms = std::chrono::duration_cast<
+      std::chrono::duration<double, std::milli>>(total).count();
 
     const std::array<
       std::pair<txn_stage_t, seastar::lowres_clock::duration>, STAGE_MAX>
@@ -1857,10 +1857,10 @@ seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
 
     for (auto& [stage, dur] : stage_samples) {
       add_stage_latency_sample(stats.stage_lat, stage, dur);
-      if (total_us > TAIL_SLOW_US) {
+      if (total_ms > TAIL_SLOW_MS) {
         add_stage_latency_sample(stats.stage_lat_slow, stage, dur);
       }
-      if (total_us > TAIL_VERY_SLOW_US) {
+      if (total_ms > TAIL_VERY_SLOW_MS) {
         add_stage_latency_sample(stats.stage_lat_very_slow, stage, dur);
       }
     }

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -1866,9 +1866,6 @@ seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
     }
     add_latency_sample(op_type_t::DO_TRANSACTION, total);
   }
-  add_latency_sample(
-    op_type_t::DO_TRANSACTION,
-    seastar::lowres_clock::now() - ctx.begin_timestamp);
 
   add_onode_tree_sample(ctx.transaction->get_onode_tree_stats());
 

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -462,6 +462,9 @@ public:
       10000, 15000, 20000, 30000, 50000, 100000
     };
 
+    static constexpr uint64_t TAIL_SLOW_US = 5000;        // 5 ms
+    static constexpr uint64_t TAIL_VERY_SLOW_US = 10000;  // 10 ms
+
     struct {
       std::array<seastar::metrics::histogram, LAT_MAX> op_lat;
       seastar::metrics::histogram conflict_replays;
@@ -473,6 +476,10 @@ public:
       uint64_t onode_updates = 0;
       uint64_t onode_erases = 0;
       int64_t  onode_extents_delta = 0;
+
+      // same metrics collected two more times for high tail txns.
+      std::array<seastar::metrics::histogram, STAGE_MAX> stage_lat_slow;
+      std::array<seastar::metrics::histogram, STAGE_MAX> stage_lat_very_slow;
     } stats;
 
     void add_onode_tree_sample(const Transaction::tree_stats_t& ts) {
@@ -528,9 +535,11 @@ public:
     // Record the latency of one do_transaction stage (microseconds). Buckets are
     // non-cumulative (bucket = first upper_bound >= value); values above the top
     // bound aren't bucketed but still land in sample_count/sample_sum.
-    void add_stage_latency_sample(txn_stage_t stage,
+    void add_stage_latency_sample(
+        std::array<seastar::metrics::histogram, STAGE_MAX>& arr,
+        txn_stage_t stage,
         std::chrono::steady_clock::duration dur) {
-      auto& hist = stats.stage_lat[static_cast<std::size_t>(stage)];
+      auto& hist = arr[static_cast<std::size_t>(stage)];
       if (hist.buckets.empty()) {
         // register_metrics() did not run (store inactive); nothing to record.
         return;

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -49,6 +49,7 @@ enum class op_type_t : uint8_t {
 
 enum class txn_stage_t : uint8_t {
     COLLOCK_WAIT = 0,  // waiting on the collection ordering_lock
+    COLLOCK_HOLD,      // collection ordering_lock held (acquire -> release at prepare_record)
     THROTTLER_WAIT,    // waiting for a throttler slot
     BUILD,             // building the transaction (_do_transaction_step loop)
     BUILD_GET_ONODE,   // onode_manager get/get_or_create calls within BUILD

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -440,10 +440,12 @@ public:
 
     static constexpr auto LAT_MAX = static_cast<std::size_t>(op_type_t::MAX);
 
-    // Histogram bucket upper bounds in microseconds (0.25ms–20ms).
-    // Ops above 20ms land in the last bucket as overflow.
-    static constexpr std::array<double, 14> lat_hist_bounds_us = {
-      250, 500, 1000,
+    // Histogram bucket upper bounds in microseconds (1ms–100ms).
+    // Ops above 100ms land in the last bucket as overflow. The smallest
+    // bucket is 1ms: sub-ms latencies are below lowres_clock resolution
+    // (~task_quota) and cannot be resolved, so no finer buckets are kept.
+    static constexpr std::array<double, 12> lat_hist_bounds_us = {
+      1000,
       1500, 2000, 3000,
       5000,
       7500, 10000,
@@ -456,9 +458,11 @@ public:
     static constexpr std::size_t REPLAY_BUCKETS = 16;
 
     static constexpr auto STAGE_MAX = static_cast<std::size_t>(txn_stage_t::MAX);
-    // Upper bounds (microseconds) for the per-stage do_transaction latency histograms
-    static constexpr std::array<uint64_t, 14> STAGE_LAT_BUCKETS_US = {
-      250, 500, 1000, 1500, 2000, 3000, 5000, 7500,
+    // Upper bounds (microseconds) for the per-stage do_transaction latency
+    // histograms. Smallest bucket is 1ms; sub-ms is below lowres_clock
+    // resolution (~task_quota) and cannot be resolved.
+    static constexpr std::array<uint64_t, 12> STAGE_LAT_BUCKETS_US = {
+      1000, 1500, 2000, 3000, 5000, 7500,
       10000, 15000, 20000, 30000, 50000, 100000
     };
 

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -440,34 +440,34 @@ public:
 
     static constexpr auto LAT_MAX = static_cast<std::size_t>(op_type_t::MAX);
 
-    // Histogram bucket upper bounds in microseconds (1ms–100ms).
+    // Histogram bucket upper bounds in milliseconds (1ms–100ms).
     // Ops above 100ms land in the last bucket as overflow. The smallest
     // bucket is 1ms: sub-ms latencies are below lowres_clock resolution
     // (~task_quota) and cannot be resolved, so no finer buckets are kept.
-    static constexpr std::array<double, 12> lat_hist_bounds_us = {
-      1000,
-      1500, 2000, 3000,
-      5000,
-      7500, 10000,
-      15000, 20000,
-      30000, 50000,
-      100000
+    static constexpr std::array<double, 12> lat_hist_bounds_ms = {
+      1,
+      1.5, 2, 3,
+      5,
+      7.5, 10,
+      15, 20,
+      30, 50,
+      100
     };
 
     // Buckets for the per-transaction conflict/replay distribution.
     static constexpr std::size_t REPLAY_BUCKETS = 16;
 
     static constexpr auto STAGE_MAX = static_cast<std::size_t>(txn_stage_t::MAX);
-    // Upper bounds (microseconds) for the per-stage do_transaction latency
+    // Upper bounds (milliseconds) for the per-stage do_transaction latency
     // histograms. Smallest bucket is 1ms; sub-ms is below lowres_clock
     // resolution (~task_quota) and cannot be resolved.
-    static constexpr std::array<uint64_t, 12> STAGE_LAT_BUCKETS_US = {
-      1000, 1500, 2000, 3000, 5000, 7500,
-      10000, 15000, 20000, 30000, 50000, 100000
+    static constexpr std::array<double, 12> STAGE_LAT_BUCKETS_MS = {
+      1, 1.5, 2, 3, 5, 7.5,
+      10, 15, 20, 30, 50, 100
     };
 
-    static constexpr uint64_t TAIL_SLOW_US = 5000;        // 5 ms
-    static constexpr uint64_t TAIL_VERY_SLOW_US = 10000;  // 10 ms
+    static constexpr double TAIL_SLOW_MS = 5;        // 5 ms
+    static constexpr double TAIL_VERY_SLOW_MS = 10;  // 10 ms
 
     struct {
       std::array<seastar::metrics::histogram, LAT_MAX> op_lat;
@@ -505,12 +505,13 @@ public:
     void add_latency_sample(op_type_t op_type,
         seastar::lowres_clock::duration dur) {
       seastar::metrics::histogram& lat = get_latency(op_type);
-      auto us = std::chrono::duration_cast<std::chrono::microseconds>(dur).count();
+      auto ms = std::chrono::duration_cast<
+        std::chrono::duration<double, std::milli>>(dur).count();
       lat.sample_count++;
-      lat.sample_sum += us;
+      lat.sample_sum += ms;
       bool found = false;
       for (auto& b : lat.buckets) {
-        if (static_cast<double>(us) <= b.upper_bound) {
+        if (ms <= b.upper_bound) {
           ++b.count;
           found = true;
           break;
@@ -536,7 +537,7 @@ public:
       hist.sample_sum += num_replays;
     }
 
-    // Record the latency of one do_transaction stage (microseconds). Buckets are
+    // Record the latency of one do_transaction stage (milliseconds). Buckets are
     // non-cumulative (bucket = first upper_bound >= value); values above the top
     // bound aren't bucketed but still land in sample_count/sample_sum.
     void add_stage_latency_sample(
@@ -548,15 +549,16 @@ public:
         // register_metrics() did not run (store inactive); nothing to record.
         return;
       }
-      auto us = std::chrono::duration_cast<std::chrono::microseconds>(dur).count();
+      auto ms = std::chrono::duration_cast<
+        std::chrono::duration<double, std::milli>>(dur).count();
       for (auto& b : hist.buckets) {
-        if (static_cast<double>(us) <= b.upper_bound) {
+        if (ms <= b.upper_bound) {
           ++b.count;
           break;
         }
       }
       ++hist.sample_count;
-      hist.sample_sum += us;
+      hist.sample_sum += ms;
     }
 
     /*

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -261,11 +261,11 @@ public:
       TransactionRef transaction;
 
       ceph::os::Transaction::iterator iter;
-      std::chrono::steady_clock::time_point begin_timestamp = std::chrono::steady_clock::now();
+      seastar::lowres_clock::time_point begin_timestamp = seastar::lowres_clock::now();
 
-      std::chrono::steady_clock::duration build_time{0};
-      std::chrono::steady_clock::duration get_onode_time{0};
-      std::chrono::steady_clock::duration submit_time{0};
+      seastar::lowres_clock::duration build_time{0};
+      seastar::lowres_clock::duration get_onode_time{0};
+      seastar::lowres_clock::duration submit_time{0};
 
       void reset_preserve_handle(TransactionManager &tm) {
         tm.reset_transaction_preserve_handle(*transaction);
@@ -287,7 +287,7 @@ public:
       op_type_t op_type,
       cache_hint_t cache_hint_flags,
       F &&f) const {
-      auto begin_time = std::chrono::steady_clock::now();
+      auto begin_time = seastar::lowres_clock::now();
       return seastar::do_with(
         oid, Ret{}, std::forward<F>(f),
         [this, ch, src, op_type, begin_time, tname, cache_hint_flags
@@ -317,7 +317,7 @@ public:
           });
         }).safe_then([&ret, op_type, begin_time, this] {
           const_cast<Shard*>(this)->add_latency_sample(op_type,
-                     std::chrono::steady_clock::now() - begin_time);
+                     seastar::lowres_clock::now() - begin_time);
           return seastar::make_ready_future<Ret>(ret);
         });
       });
@@ -499,7 +499,7 @@ public:
     }
 
     void add_latency_sample(op_type_t op_type,
-        std::chrono::steady_clock::duration dur) {
+        seastar::lowres_clock::duration dur) {
       seastar::metrics::histogram& lat = get_latency(op_type);
       auto us = std::chrono::duration_cast<std::chrono::microseconds>(dur).count();
       lat.sample_count++;
@@ -538,7 +538,7 @@ public:
     void add_stage_latency_sample(
         std::array<seastar::metrics::histogram, STAGE_MAX>& arr,
         txn_stage_t stage,
-        std::chrono::steady_clock::duration dur) {
+        seastar::lowres_clock::duration dur) {
       auto& hist = arr[static_cast<std::size_t>(stage)];
       if (hist.buckets.empty()) {
         // register_metrics() did not run (store inactive); nothing to record.


### PR DESCRIPTION
This is a follow up to https://github.com/ceph/ceph/pull/69281 which adds a transaction breakdown metrics.
However, in order to better narrow down the histograms we need to collect stats for the tail txns only.
This will allow us to see which phases draw the most weight in these txns (over 5ms and over 10ms).

Also, adds a collection lock hold vs wait timings to measure queue depth (actual work vs waiting times).

For context: https://gist.github.com/Matan-B/44b17e2599bb409ca9d96a41fff390ae

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
