### PR TITLE
compressor: zstd error checking and more tests

### DIFF
--- a/src/compressor/zstd/ZstdCompressor.h
+++ b/src/compressor/zstd/ZstdCompressor.h
@@ -19,6 +19,7 @@
 #define ZSTD_STATIC_LINKING_ONLY
 #include <zstd.h>
 
+#include <memory>
 #include "include/buffer.h"
 #include "include/encoding.h"
 #include "compressor/Compressor.h"
@@ -28,35 +29,45 @@ class ZstdCompressor : public Compressor {
   ZstdCompressor(CephContext *cct) : Compressor(COMP_ALG_ZSTD, "zstd"), cct(cct) {}
 
   int compress(const ceph::buffer::list &src, ceph::buffer::list &dst, std::optional<int32_t> &compressor_message) override {
-    ZSTD_CCtx *s = ZSTD_createCCtx();
-    if (!s) {
+    // RAII wrapper so every error path frees the stream (no manual frees).
+    // ZSTD_freeCCtx is documented to accept NULL in case creation fails.
+    std::unique_ptr<ZSTD_CCtx, decltype(&ZSTD_freeCCtx)> s(
+      ZSTD_createCCtx(), &ZSTD_freeCCtx);
+    if (s.get() == nullptr) {
+      // It's not documented when ZSTD_createCCtx() returns NULL but it can happen in the case of a malloc failure.
       return -ENOMEM;
     }
-    size_t res = ZSTD_CCtx_reset(s, ZSTD_reset_session_and_parameters);
-    if (ZSTD_isError(res)) {
-      ZSTD_freeCCtx(s);
+
+    // ZSTD_CCtx_reset is not needed because we create a fresh context every time (see zstd streaming_compressio.c example)
+
+    if (ZSTD_isError(ZSTD_CCtx_setParameter(s.get(), ZSTD_c_compressionLevel, cct->_conf->compressor_zstd_level))) {
       return -EINVAL;
     }
-    res = ZSTD_CCtx_setParameter(s, ZSTD_c_compressionLevel, cct->_conf->compressor_zstd_level);
-    if (ZSTD_isError(res)) {
-      ZSTD_freeCCtx(s);
-      return -EINVAL;
-    }
-    res = ZSTD_CCtx_setPledgedSrcSize(s, src.length());
-    if (ZSTD_isError(res)) {
-      ZSTD_freeCCtx(s);
+    if (ZSTD_isError(ZSTD_CCtx_setPledgedSrcSize(s.get(), src.length()))) {
       return -EINVAL;
     }
     auto p = src.begin();
     size_t left = src.length();
 
+    // The on-disk format prefixes the compressed payload with the decompressed
+    // length as a uint32_t (ceph::encode below); ensure it does not overflow.
+    if (left > std::numeric_limits<uint32_t>::max()) {
+      return -EFBIG;
+    }
+
     size_t const out_max = ZSTD_compressBound(left);
+    if (ZSTD_isError(out_max)) {
+      return -EINVAL;
+    }
     ceph::buffer::ptr outptr = ceph::buffer::create_small_page_aligned(out_max);
     ZSTD_outBuffer_s outbuf;
     outbuf.dst = outptr.c_str();
     outbuf.size = outptr.length();
     outbuf.pos = 0;
 
+    // Tracks the most recent ZSTD_compressStream2 return value. After the final
+    // ZSTD_e_end flush, 0 means the frame was fully completed and flushed.
+    size_t r = 0;
     while (left) {
       ceph_assert(!p.end());
       struct ZSTD_inBuffer_s inbuf;
@@ -64,15 +75,27 @@ class ZstdCompressor : public Compressor {
       inbuf.size = p.get_ptr_and_advance(left, (const char**)&inbuf.src);
       left -= inbuf.size;
       ZSTD_EndDirective const zed = (left==0) ? ZSTD_e_end : ZSTD_e_continue;
-      size_t r = ZSTD_compressStream2(s, &outbuf, &inbuf, zed);
-      if (ZSTD_isError(r)) {
-        ZSTD_freeCCtx(s);
-        return -EINVAL;
-      }
+      // ZSTD_compressStream is not guaranteed to finish immediately, so loop until it does.
+      // From the docs:
+      //   Note that the function may not consume the entire input, for example, because
+      //   the output buffer is already full, in which case `input.pos < input.size`.
+      //   The caller must check if input has been entirely consumed.
+      //   note: ZSTD_e_continue is guaranteed to make some forward progress when called,
+      //   but doesn't guarantee maximal forward progress. This is especially relevant
+      do {
+        r = ZSTD_compressStream2(s.get(), &outbuf, &inbuf, zed);
+        if (ZSTD_isError(r)) {
+          return -EINVAL;
+        }
+      } while (inbuf.pos < inbuf.size || (zed == ZSTD_e_end && r != 0));
     }
     ceph_assert(p.get_remaining() == 0);
 
-    ZSTD_freeCCtx(s);
+    // The final ZSTD_e_end call must have returned 0, i.e. the frame epilogue
+    // was fully flushed. Otherwise we'd emit a truncated, undecodable frame.
+    if (r != 0) {
+      return -EINVAL;
+    }
 
     // prefix with decompressed length
     ceph::encode((uint32_t)src.length(), dst);
@@ -90,7 +113,7 @@ class ZstdCompressor : public Compressor {
 		 ceph::buffer::list &dst,
 		 std::optional<int32_t> compressor_message) override {
     if (compressed_len < 4) {
-      return -1;
+      return -EINVAL;
     }
     compressed_len -= 4;
     uint32_t dst_len;
@@ -101,20 +124,70 @@ class ZstdCompressor : public Compressor {
     outbuf.dst = dstptr.c_str();
     outbuf.size = dstptr.length();
     outbuf.pos = 0;
-    ZSTD_DStream *s = ZSTD_createDStream();
-    ZSTD_initDStream(s);
+
+    // RAII wrapper so every error path frees the stream (no manual frees).
+    // ZSTD_freeDStream is documented to accept NULL in case creation fails.
+    std::unique_ptr<ZSTD_DStream, decltype(&ZSTD_freeDStream)> s(
+      ZSTD_createDStream(), &ZSTD_freeDStream);
+    if (s.get() == nullptr) {
+      // It's not documented when ZSTD_createDStream() returns NULL but it can happen in the case of a malloc failure.
+      return -ENOMEM;
+    }
+
+    // Tracks the most recent ZSTD_decompressStream return value; 0 means the
+    // frame completed cleanly.
+    size_t r = 0;
     while (compressed_len > 0) {
       if (p.end()) {
-	return -1;
+        // Truncated input: compressed_len claims more data than the buffer
+        // actually contains.
+        return -EINVAL;
       }
       ZSTD_inBuffer_s inbuf;
       inbuf.pos = 0;
       inbuf.size = p.get_ptr_and_advance(compressed_len,
 					 (const char**)&inbuf.src);
-      ZSTD_decompressStream(s, &outbuf, &inbuf);
       compressed_len -= inbuf.size;
+
+      // Drive zstd until it has consumed this whole input chunk. zstd may stop
+      // consuming input before the chunk is exhausted (e.g. if the output
+      // buffer fills because the encoded dst_len prefix understated the real
+      // size); looping on inbuf.pos ensures we don't silently drop the
+      // remaining bytes of the chunk.
+      while (inbuf.pos < inbuf.size) {
+        size_t const prev_in_pos = inbuf.pos;
+        size_t const prev_out_pos = outbuf.pos;
+        r = ZSTD_decompressStream(s.get(), &outbuf, &inbuf);
+        if (ZSTD_isError(r)) {
+          // Corrupt input, etc.
+          return -EINVAL;
+        }
+        if (r == 0) {
+          // Frame ended.
+          break;
+        }
+        if (inbuf.pos == prev_in_pos && outbuf.pos == prev_out_pos) {
+          // No forward progress on either input or output, yet input remains
+          // and the frame has not ended. This happens when the output buffer
+          // is full but zstd still has more to emit, i.e. dst_len understated
+          // the real decompressed size. Treat as corrupt rather than silently
+          // truncating (and avoid spinning forever). Note: zstd legitimately
+          // consumes input without producing output (and vice versa), so we
+          // only bail when *neither* advances.
+          return -EINVAL;
+        }
+      }
     }
-    ZSTD_freeDStream(s);
+
+    // Verify the frame actually completed and produced exactly the advertised
+    // number of bytes. r != 0 means zstd is still expecting more input (a
+    // truncated frame); a short output means dst_len overstated the size.
+    if (r != 0) {
+      return -EINVAL;
+    }
+    if (outbuf.pos != dst_len) {
+      return -EINVAL;
+    }
 
     dst.append(dstptr, 0, outbuf.pos);
     return 0;

--- a/src/test/compressor/test_compression.cc
+++ b/src/test/compressor/test_compression.cc
@@ -144,6 +144,147 @@ TEST_P(CompressorTest, big_round_trip_randomish)
        << " with " << GetParam() << std::endl;
 }
 
+TEST(ZstdCompressor, truncated_decompress)
+{
+  // Compress some data, then lop off the tail of the compressed buffer and
+  // make sure the decompressor reports a failure instead of silently
+  // returning success with truncated/garbage output.
+  auto compressor = Compressor::create(g_ceph_context, "zstd");
+  ASSERT_TRUE(compressor);
+
+  bufferlist orig;
+  while (orig.length() < 128 * 1024) {
+    orig.append("This is a short string.  There are many strings like it but this one is mine.");
+  }
+  bufferlist compressed;
+  std::optional<int32_t> compressor_message;
+  int r = compressor->compress(orig, compressed, compressor_message);
+  ASSERT_EQ(0, r);
+  ASSERT_GT(compressed.length(), 8u);
+
+  // Drop the last quarter of the compressed payload.
+  bufferlist truncated;
+  truncated.substr_of(compressed, 0, compressed.length() * 3 / 4);
+
+  bufferlist decompressed;
+  r = compressor->decompress(truncated, decompressed, compressor_message);
+  // ZstdCompressor must detect the truncated frame and report an error rather than
+  // silently returning success with truncated output.
+  ASSERT_LT(r, 0);
+}
+
+TEST(ZstdCompressor, corrupted_decompress)
+{
+  // Flip bytes in the middle of a compressed frame and confirm the
+  // decompressor never returns success with the wrong bytes.
+  auto compressor = Compressor::create(g_ceph_context, "zstd");
+  ASSERT_TRUE(compressor);
+
+  bufferlist orig;
+  while (orig.length() < 128 * 1024) {
+    orig.append("This is a short string.  There are many strings like it but this one is mine.");
+  }
+  bufferlist compressed;
+  std::optional<int32_t> compressor_message;
+  int r = compressor->compress(orig, compressed, compressor_message);
+  ASSERT_EQ(0, r);
+  ASSERT_GT(compressed.length(), 16u);
+
+  // Rebuild into a contiguous, mutable buffer and corrupt the middle, well
+  // past the length prefix and frame header.
+  bufferlist corrupted;
+  corrupted.append(compressed);
+  corrupted.rebuild();
+  char *p = corrupted.c_str();
+  size_t mid = corrupted.length() / 2;
+  for (size_t i = 0; i < 8 && mid + i < corrupted.length(); ++i) {
+    p[mid + i] ^= 0xff;
+  }
+
+  bufferlist decompressed;
+  r = compressor->decompress(corrupted, decompressed, compressor_message);
+  // zstd's block checks must catch the corruption; never return success with
+  // the wrong bytes.
+  if (r == 0) {
+    ASSERT_FALSE(decompressed.contents_equal(orig));
+  } else {
+    ASSERT_LT(r, 0);
+  }
+}
+
+TEST(ZstdCompressor, oversized_length_prefix)
+{
+  // ZstdCompressor prefixes the compressed payload with a 4-byte decompressed length.
+  // A prefix larger than the real decompressed size must be rejected (the
+  // frame won't fill the buffer, so the final output length won't match)
+  // rather than returning success with the wrong length. We use a modestly
+  // oversized value (not 0xffffffff) so the test doesn't attempt a multi-GiB
+  // allocation.
+  auto compressor = Compressor::create(g_ceph_context, "zstd");
+  ASSERT_TRUE(compressor);
+
+  bufferlist orig;
+  orig.append("compress me");
+  bufferlist compressed;
+  std::optional<int32_t> compressor_message;
+  int r = compressor->compress(orig, compressed, compressor_message);
+  ASSERT_EQ(0, r);
+  ASSERT_GE(compressed.length(), 4u);
+
+  // Replace the 4-byte length prefix with a value well above the real size.
+  bufferlist payload;
+  payload.substr_of(compressed, 4, compressed.length() - 4);
+  bufferlist bad;
+  ceph::encode((uint32_t)(orig.length() + 4096), bad);
+  bad.append(payload);
+
+  bufferlist decompressed;
+  r = compressor->decompress(bad, decompressed, compressor_message);
+  ASSERT_LT(r, 0);
+}
+
+TEST(ZstdCompressor, undersized_length_prefix)
+{
+  // A length prefix smaller than the real decompressed size must be rejected
+  // rather than silently returning truncated output.
+  auto compressor = Compressor::create(g_ceph_context, "zstd");
+  ASSERT_TRUE(compressor);
+
+  bufferlist orig;
+  while (orig.length() < 64 * 1024) {
+    orig.append("the quick brown fox jumps over the lazy dog, repeatedly. ");
+  }
+  bufferlist compressed;
+  std::optional<int32_t> compressor_message;
+  int r = compressor->compress(orig, compressed, compressor_message);
+  ASSERT_EQ(0, r);
+  ASSERT_GE(compressed.length(), 4u);
+
+  bufferlist payload;
+  payload.substr_of(compressed, 4, compressed.length() - 4);
+  bufferlist bad;
+  ceph::encode((uint32_t)1, bad);  // claim the output is just 1 byte
+  bad.append(payload);
+
+  bufferlist decompressed;
+  r = compressor->decompress(bad, decompressed, compressor_message);
+  ASSERT_LT(r, 0);
+}
+
+TEST(ZstdCompressor, short_input)
+{
+  // Fewer than 4 bytes cannot even hold the length prefix.
+  auto compressor = Compressor::create(g_ceph_context, "zstd");
+  ASSERT_TRUE(compressor);
+
+  bufferlist bad;
+  bad.append("ab");
+  bufferlist decompressed;
+  std::optional<int32_t> compressor_message;
+  int r = compressor->decompress(bad, decompressed, compressor_message);
+  ASSERT_LT(r, 0);
+}
+
 #if 0
 TEST_P(CompressorTest, big_round_trip_file)
 {


### PR DESCRIPTION
This addresses some current issues in ZstdCompressor (https://tracker.ceph.com/issues/77334)

* `decompressStream` was unchecked, which could silently return corrupt data.
* `compressStream2` and `decompressStream` are now called repeatedly until they say they're finished. According to the zstd manual this is not guaranteed by a single call.
* Check overflow of `uint32` compressed length field.

Enhancements: 
* Removed unnecessary `CCtx_reset` on a fresh `CCtx`.
* `unique_ptr` for the contexts so we can't forget to free.
* Some more tests for `ZstdCompressor`.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
