### PR TITLE
umbrella: osdc: deliver neorados completions to associated executor

### DIFF
--- a/src/common/async/async_cond.h
+++ b/src/common/async/async_cond.h
@@ -28,6 +28,7 @@
 #include <boost/asio/any_io_executor.hpp>
 #include <boost/asio/append.hpp>
 #include <boost/asio/async_result.hpp>
+#include <boost/asio/bind_executor.hpp>
 #include <boost/asio/consign.hpp>
 #include <boost/asio/error.hpp>
 #include <boost/asio/execution_context.hpp>
@@ -58,8 +59,8 @@ class async_cond : public service_list_base_hook {
 
   std::mutex m;
   std::vector<std::pair<
-    boost::asio::any_completion_handler<
-    void(boost::system::error_code)>, std::unique_lock<BasicLockable>*>> handlers;
+    boost::asio::any_completion_handler<void(boost::system::error_code)>,
+    std::unique_lock<BasicLockable>*>> handlers;
 
   void service_shutdown() {
     std::unique_lock l(m);
@@ -135,12 +136,13 @@ public:
       handlers.resize(0);
       l.unlock();
       for (auto&& [handler, lock] : workhandlers) {
+	auto ex = asio::get_associated_executor(handler, executor);
 	asio::post(executor,
-		   [handler = std::move(handler), lock = lock]() mutable {
-		     lock->lock();
-		     std::move(handler)(sys::error_code{});
-		   });
-
+		   asio::bind_executor(ex,
+		     [handler = std::move(handler), lock = lock]() mutable {
+		       lock->lock();
+		       std::move(handler)(sys::error_code{});
+		     }));
       }
     }
   }
@@ -157,12 +159,13 @@ public:
       handlers.resize(0);
       l.unlock();
       for (auto&& [handler, lock] : workhandlers) {
+	auto ex = asio::get_associated_executor(handler, executor);
 	asio::post(executor,
-		   [handler = std::move(handler), lock = lock]() mutable {
-		     lock->lock();
-		     std::move(handler)(asio::error::operation_aborted);
-		   });
-
+		   asio::bind_executor(ex,
+		     [handler = std::move(handler), lock = lock]() mutable {
+		       lock->lock();
+		       std::move(handler)(asio::error::operation_aborted);
+		     }));
       }
     }
   }

--- a/src/test/neorados/CMakeLists.txt
+++ b/src/test/neorados/CMakeLists.txt
@@ -21,6 +21,9 @@ target_link_libraries(neoradostest-support
 add_executable(ceph_test_neorados_completions completions.cc)
 target_link_libraries(ceph_test_neorados_completions
   libneorados neoradostest-support GTest::Main)
+install(TARGETS
+  ceph_test_neorados_completions
+  DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 add_executable(ceph_test_neorados_list_pool list_pool.cc)
 target_link_libraries(ceph_test_neorados_list_pool


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77275

---

backport of ~~https://github.com/ceph/ceph/pull/69253~~ https://github.com/ceph/ceph/pull/69314
parent tracker: https://tracker.ceph.com/issues/76725

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh