### PR TITLE
tentacle: osdc: deliver neorados completions to associated executor

### DIFF
--- a/qa/workunits/rados/test.sh
+++ b/qa/workunits/rados/test.sh
@@ -52,7 +52,7 @@ do
 done
 
 for f in \
-    cls cmd handler_error io ec_io list ec_list misc pool read_operations snapshots \
+    cls cmd completions handler_error io ec_io list ec_list misc pool read_operations snapshots \
     watch_notify write_operations
 do
     if [ $parallel -eq 1 ]; then

--- a/src/common/async/async_cond.h
+++ b/src/common/async/async_cond.h
@@ -26,6 +26,7 @@
 #include <boost/asio/any_completion_handler.hpp>
 #include <boost/asio/append.hpp>
 #include <boost/asio/async_result.hpp>
+#include <boost/asio/bind_executor.hpp>
 #include <boost/asio/consign.hpp>
 #include <boost/asio/error.hpp>
 #include <boost/asio/execution_context.hpp>
@@ -55,8 +56,8 @@ class async_cond : public service_list_base_hook {
 
   std::mutex m;
   std::vector<std::pair<
-    boost::asio::any_completion_handler<
-    void(boost::system::error_code)>, std::unique_lock<BasicLockable>*>> handlers;
+    boost::asio::any_completion_handler<void(boost::system::error_code)>,
+    std::unique_lock<BasicLockable>*>> handlers;
 
   void service_shutdown() {
     std::unique_lock l(m);
@@ -132,12 +133,13 @@ public:
       handlers.resize(0);
       l.unlock();
       for (auto&& [handler, lock] : workhandlers) {
+	auto ex = asio::get_associated_executor(handler, executor);
 	asio::post(executor,
-		   [handler = std::move(handler), lock = lock]() mutable {
-		     lock->lock();
-		     std::move(handler)(sys::error_code{});
-		   });
-
+		   asio::bind_executor(ex,
+		     [handler = std::move(handler), lock = lock]() mutable {
+		       lock->lock();
+		       std::move(handler)(sys::error_code{});
+		     }));
       }
     }
   }
@@ -154,12 +156,13 @@ public:
       handlers.resize(0);
       l.unlock();
       for (auto&& [handler, lock] : workhandlers) {
+	auto ex = asio::get_associated_executor(handler, executor);
 	asio::post(executor,
-		   [handler = std::move(handler), lock = lock]() mutable {
-		     lock->lock();
-		     std::move(handler)(asio::error::operation_aborted);
-		   });
-
+		   asio::bind_executor(ex,
+		     [handler = std::move(handler), lock = lock]() mutable {
+		       lock->lock();
+		       std::move(handler)(asio::error::operation_aborted);
+		     }));
       }
     }
   }

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -2061,8 +2061,9 @@ public:
 			      fu2::unique_function<OpSig>>) {
 		     std::move(arg)(ec);
                    } else {
-		     boost::asio::defer(e,
-					boost::asio::append(std::move(arg), ec));
+		     auto ex = boost::asio::get_associated_executor(arg, e);
+		     boost::asio::dispatch(ex,
+					   boost::asio::append(std::move(arg), ec));
 		   }
 		 }, std::move(f));
     }

--- a/src/test/neorados/CMakeLists.txt
+++ b/src/test/neorados/CMakeLists.txt
@@ -21,6 +21,9 @@ target_link_libraries(neoradostest-support
 add_executable(ceph_test_neorados_completions completions.cc)
 target_link_libraries(ceph_test_neorados_completions
   libneorados neoradostest-support GTest::Main)
+install(TARGETS
+  ceph_test_neorados_completions
+  DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 add_executable(ceph_test_neorados_list_pool list_pool.cc)
 target_link_libraries(ceph_test_neorados_list_pool

--- a/src/test/neorados/CMakeLists.txt
+++ b/src/test/neorados/CMakeLists.txt
@@ -10,10 +10,6 @@ add_executable(ceph_test_neorados_start_stop start_stop.cc)
 target_link_libraries(ceph_test_neorados_start_stop global libneorados
   ${unittest_libs})
 
-add_executable(ceph_test_neorados_completions completions.cc)
-target_link_libraries(ceph_test_neorados_completions Boost::system pthread
-  ${unittest_libs})
-
 add_executable(ceph_test_neorados_op_speed op_speed.cc)
 target_link_libraries(ceph_test_neorados_op_speed
   libneorados ${FMT_LIB} ${unittest_libs})
@@ -21,6 +17,10 @@ target_link_libraries(ceph_test_neorados_op_speed
 add_library(neoradostest-support STATIC common_tests.cc)
 target_link_libraries(neoradostest-support
   libneorados ${FMT_LIB} GTest::GTest)
+
+add_executable(ceph_test_neorados_completions completions.cc)
+target_link_libraries(ceph_test_neorados_completions
+  libneorados neoradostest-support GTest::Main)
 
 add_executable(ceph_test_neorados_list_pool list_pool.cc)
 target_link_libraries(ceph_test_neorados_list_pool

--- a/src/test/neorados/completions.cc
+++ b/src/test/neorados/completions.cc
@@ -1,19 +1,62 @@
-#include <boost/asio/io_context.hpp>
-#include <boost/asio/post.hpp>
+#include <optional>
+#include <boost/asio/bind_executor.hpp>
+#include "include/neorados/RADOS.hpp"
+#include "test/neorados/common_tests.h"
 
-constexpr int max_completions = 10'000'000;
-int completed = 0;
+TEST(NeoRadosCompletion, CrossExecutor)
+{
+  boost::asio::io_context rados_context;
+  std::optional<neorados::RADOS> rados;
+  std::optional<neorados::IOContext> pool;
 
-boost::asio::io_context c;
+  neorados::RADOS::Builder{}.build(rados_context,
+      [&rados, &pool] (boost::system::error_code ec, neorados::RADOS r) {
+        if (ec) {
+          throw boost::system::system_error(ec);
+        }
+        rados = std::move(r);
 
-void nested_cb() {
-  if (++completed < max_completions)
-    boost::asio::post(c, &nested_cb);
-}
+        const char* pool_name = "ceph_test_neorados_completions";
+        rados->lookup_pool(pool_name,
+            [&rados, &pool, pool_name] (boost::system::error_code ec, int64_t id) {
+              if (ec == boost::system::errc::no_such_file_or_directory) {
+                create_pool(*rados, pool_name,
+                    [&pool] (boost::system::error_code ec, int64_t id) {
+                      if (ec) {
+                        throw boost::system::system_error(ec);
+                      }
+                      pool.emplace(id);
+                    });
+              } else if (ec) {
+                throw boost::system::system_error(ec);
+              } else {
+                pool.emplace(id);
+              }
+            });
+      });
+  rados_context.run();
 
-int main(void) {
-  boost::asio::post(c, &nested_cb);
-  c.run();
-  assert(completed == max_completions);
-  return 0;
+  // expect ReadOp completion on a separate execution context
+  boost::asio::io_context completion_context;
+  std::optional<boost::system::error_code> ec;
+  uint64_t size;
+  ceph::real_time mtime;
+
+  rados->execute("nonexistent", *pool, neorados::ReadOp{}.stat(&size, &mtime), nullptr,
+      boost::asio::bind_executor(completion_context,
+          [&ec] (boost::system::error_code e) { ec = e; }));
+
+  rados_context.restart();
+  rados_context.run();
+
+  EXPECT_FALSE(ec); // completion does not run on rados_context
+
+  completion_context.run();
+
+  EXPECT_TRUE(ec);
+
+  rados->delete_pool(pool->get_pool(), boost::asio::detached);
+
+  rados_context.restart();
+  rados_context.run();
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77274

---

backport of https://github.com/ceph/ceph/pull/69253 and https://github.com/ceph/ceph/pull/69741
parent tracker: https://tracker.ceph.com/issues/76725

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh