### PR TITLE
osd/scheduler: add missing breaks in PGRecoveryMsg::run

### DIFF
--- a/src/osd/scheduler/OpSchedulerItem.cc
+++ b/src/osd/scheduler/OpSchedulerItem.cc
@@ -214,16 +214,22 @@ void PGRecoveryMsg::run(
   switch (op->get_req()->get_type()) {
   case MSG_OSD_PG_PUSH:
     osd->logger->tinc(l_osd_recovery_push_queue_lat, latency);
+    break;
   case MSG_OSD_PG_PUSH_REPLY:
     osd->logger->tinc(l_osd_recovery_push_reply_queue_lat, latency);
+    break;
   case MSG_OSD_PG_PULL:
     osd->logger->tinc(l_osd_recovery_pull_queue_lat, latency);
+    break;
   case MSG_OSD_PG_BACKFILL:
     osd->logger->tinc(l_osd_recovery_backfill_queue_lat, latency);
+    break;
   case MSG_OSD_PG_BACKFILL_REMOVE:
     osd->logger->tinc(l_osd_recovery_backfill_remove_queue_lat, latency);
+    break;
   case MSG_OSD_PG_SCAN:
     osd->logger->tinc(l_osd_recovery_scan_queue_lat, latency);
+    break;
   }
   osd->dequeue_op(pg, op, handle);
   pg->unlock();


### PR DESCRIPTION
Without these breaks the switch fell through, recording a single
message's latency into every following per-type counter.

Fixes: https://tracker.ceph.com/issues/77751

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests