### PR TITLE
Added track metrics flag to store-bench.cc 

### DIFF
--- a/src/crimson/tools/store_bench/store-bench.cc
+++ b/src/crimson/tools/store_bench/store-bench.cc
@@ -22,6 +22,22 @@
    touch store_bench_dir/block
    truncate -s 10G store_bench_dir/block
    ./build/bin/crimson-store-bench --store-path store_bench_dir --smp 4 --duration 10 --work-load-type pg_log --seastore_device_size 10G
+ *
+ * To filter specific metrics from the output, use --track-metrics with a
+ * comma-separated list of metric names.  Only the named metrics will appear
+ * in the metrics_values section instead of the full metric dump:
+ *
+ *   ./build/bin/crimson-store-bench --store-path store_bench_dir --smp 4 \
+ *     --duration 10 --work-load-type pg_log --seastore_device_size 10G \
+ *     --track-metrics cache_cache_access,cache_cache_hit
+ *
+ * Example output:
+ *   "metrics_values": [
+ *       { "cache_cache_access": { "shard": "0", "shard_store_index": "0", "value": 195377 } },
+ *       { "cache_cache_hit":    { "shard": "0", "shard_store_index": "0", "value": 195374 } },
+ *       { "cache_cache_access": { "shard": "1", "shard_store_index": "0", "value": 194982 } },
+ *       { "cache_cache_hit":    { "shard": "1", "shard_store_index": "0", "value": 194979 } }
+ *   ]
  */
 
 #include <random>
@@ -47,6 +63,7 @@
 #include "crimson/common/coroutine.h"
 #include "crimson/common/log.h"
 #include "crimson/common/metrics_helpers.h"
+#include "crimson/common/smp_helpers.h"
 
 #include "crimson/os/futurized_collection.h"
 #include "crimson/os/futurized_store.h"
@@ -108,7 +125,7 @@ public:
       ("dump-metrics", po::bool_switch(&dump_metrics),
        "Dump JSON formatted metrics to stdout")
       ("track-metrics",po:: value<std::string>(&track_metrics),
-        "Metrics we wnat to include in result list,filtered from dump-metrics")
+        "Metrics we want to include in result list,filtered from dump-metrics")
       ;
     return ret;
   }
@@ -964,12 +981,14 @@ int main(int argc, char **argv) {
             }
           }
           f.open_array_section("metrics_values");
-          crimson::metrics::dump_metric_value_map(
-            seastar::scollectd::get_value_map(),
-            &f,
-            [&requested_metrics](const std::string& full_name) { 
-              return requested_metrics.empty() || requested_metrics.count(full_name)>0;
-            });
+          co_await crimson::invoke_on_all_seq([&f, &requested_metrics] {
+            crimson::metrics::dump_metric_value_map(
+              seastar::scollectd::get_value_map(),
+              &f,
+              [&requested_metrics](const std::string& full_name) {
+                return requested_metrics.empty() || requested_metrics.count(full_name) > 0;
+              });
+          });
           f.close_section();
         }
         f.close_section();

--- a/src/crimson/tools/store_bench/store-bench.cc
+++ b/src/crimson/tools/store_bench/store-bench.cc
@@ -92,6 +92,7 @@ private:
 public:
   unsigned num_concurrent_io = 16;
   bool dump_metrics = false;
+  std::string track_metrics="";
   std::chrono::duration<uint64_t> get_duration() const {
     return std::chrono::seconds(duration);
   }
@@ -106,6 +107,8 @@ public:
        "for")
       ("dump-metrics", po::bool_switch(&dump_metrics),
        "Dump JSON formatted metrics to stdout")
+      ("track-metrics",po:: value<std::string>(&track_metrics),
+        "Metrics we wnat to include in result list,filtered from dump-metrics")
       ;
     return ret;
   }
@@ -951,12 +954,22 @@ int main(int argc, char **argv) {
           }
           f.close_section();
         }
-        if (common_options.dump_metrics) {
+        if (common_options.dump_metrics ||!common_options.track_metrics.empty()) {
+          std::set<std::string> requested_metrics;
+          if(!common_options.track_metrics.empty()){
+            std::stringstream ss(common_options.track_metrics);
+            std::string name;
+            while (std::getline(ss,name,',')){
+              requested_metrics.insert(name);
+            }
+          }
           f.open_array_section("metrics_values");
           crimson::metrics::dump_metric_value_map(
             seastar::scollectd::get_value_map(),
             &f,
-            [](const auto &) { return true; });
+            [&requested_metrics](const std::string& full_name) { 
+              return requested_metrics.empty() || requested_metrics.count(full_name)>0;
+            });
           f.close_section();
         }
         f.close_section();


### PR DESCRIPTION
Added track metrics flag to store-bench.cc. It outputs specific metrics we want to see when running crimson store bench benchmarking tool. Waiting for build will test with override file for teuthology job.




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
