### PR TITLE
mgr/dashboard:  Add hardware monitoring dashboard using node proxy metrics

### DIFF
--- a/monitoring/ceph-mixin/dashboards.libsonnet
+++ b/monitoring/ceph-mixin/dashboards.libsonnet
@@ -12,5 +12,6 @@
     (import 'dashboards/smb-overview.libsonnet') +
     (import 'dashboards/ceph-nvmeof.libsonnet') +
     (import 'dashboards/ceph-nvmeof-performance.libsonnet') +
+    (import 'dashboards/hardware.libsonnet') +
     { _config:: $._config },
 }

--- a/monitoring/ceph-mixin/dashboards/hardware.libsonnet
+++ b/monitoring/ceph-mixin/dashboards/hardware.libsonnet
@@ -1,0 +1,603 @@
+local g = import 'grafonnet/grafana.libsonnet';
+
+(import 'utils.libsonnet') {
+  'hardware.json':
+    $.dashboardSchema(
+      'Ceph Hardware - Platform Monitoring',
+      'Comprehensive hardware monitoring with temperatures, fans, storage, and firmware from node-proxy',
+      'hardware001',
+      'now-1h',
+      '10s',
+      22,
+      $._config.dashboardTags,
+      ''
+    )
+    .addAnnotation(
+      $.addAnnotationSchema(
+        1,
+        '-- Grafana --',
+        true,
+        true,
+        'rgba(0, 211, 255, 1)',
+        'Annotations & Alerts',
+        'dashboard'
+      )
+    )
+    .addLinks([
+      $.addLinkSchema(
+        asDropdown=true,
+        icon='external link',
+        includeVars=true,
+        keepTime=true,
+        tags=[],
+        targetBlank=false,
+        title='Browse Dashboards',
+        tooltip='',
+        type='dashboards',
+        url=''
+      ),
+    ])
+    .addTemplate(
+      g.template.datasource('datasource', 'prometheus', 'default', label='Data Source')
+    )
+    .addTemplate(
+      $.addClusterTemplate()
+    )
+    .addTemplate(
+      $.addTemplateSchema(
+        'hostname',
+        '$datasource',
+        'label_values(ceph_node_proxy_health, hostname)',
+        1,
+        false,
+        1,
+        'Host',
+        ''
+      )
+    )
+    .addTemplate(
+      g.template.new(
+        'fan_speeds',
+        '$datasource',
+        'label_values(ceph_node_proxy_fan_rpm{hostname="$hostname"},fan_name)',
+        label='',
+        refresh='load',
+        includeAll=true,
+        multi=false,
+        allValues='',
+        sort=0,
+        regex='/.*TACH.*/',
+        hide=2
+      )
+    )
+    .addPanels([
+      // Row 1: Overview (collapsed)
+      $.addRowSchema(collapse=true, showTitle=true, title='Overview') + { gridPos: { x: 0, y: 0, w: 24, h: 1 }, panels: [
+        // Health
+        $.addStatPanel(
+          title='Health',
+          unit='short',
+          datasource='$datasource',
+          gridPosition={ h: 4, w: 4, x: 0, y: 1 }
+        )
+        .addTarget($.addTargetSchema(
+          'max(ceph_node_proxy_health)',
+          legendFormat='__auto'
+        ))
+        + {
+          fieldConfig: {
+            defaults: {
+              mappings: [
+                { type: 'value', options: { '0': { color: 'green', index: 0, text: 'OK' } } },
+                { type: 'range', options: { from: 1, to: 999, result: { color: 'semi-dark-red', index: 1, text: 'NOT OK' } } },
+              ],
+              thresholds: {
+                mode: 'absolute',
+                steps: [{ color: 'green' }, { color: 'red', value: 1 }],
+              },
+            },
+          },
+          options+: { colorMode: 'background_solid' },
+        },
+
+        // CPU Temp
+        $.addStatPanel(
+          title='CPU Temp',
+          unit='celsius',
+          datasource='$datasource',
+          gridPosition={ h: 4, w: 3, x: 4, y: 1 }
+        ).addTarget($.addTargetSchema(
+          'max(ceph_node_proxy_temperature_celsius{sensor_name=~".*CPU_TEMP"})',
+          legendFormat='__auto'
+        ))
+        + {
+          fieldConfig: {
+            defaults: {
+              min: 0,
+              max: 100,
+              thresholds: {
+                mode: 'absolute',
+                steps: [{ color: 'green' }, { color: '#EAB839', value: 75 }, { color: 'red', value: 85 }],
+              },
+            },
+          },
+        },
+
+        // BMC Versions
+        $.pieChartPanel(
+          title='BMC Versions',
+          datasource='$datasource',
+          gridPos={ x: 7, y: 1, w: 3, h: 8 }
+        )
+        .addTarget($.addTargetSchema(
+          'count by(version) (ceph_node_proxy_firmware_info{component=~".*BMC.*"})',
+          legendFormat='{{version}}'
+        ))
+        + {
+          fieldConfig+: {
+            defaults+: {
+              color+: {
+                mode: 'palette-classic',
+              },
+            },
+          },
+          options+: {
+            legend+: { showLegend: false },
+            displayLabels: ['name'],
+          },
+        },
+
+        // BIOS Versions
+        $.pieChartPanel(
+          title='BIOS Versions',
+          datasource='$datasource',
+          gridPos={ x: 10, y: 1, w: 3, h: 8 }
+        )
+        .addTarget($.addTargetSchema(
+          'count by(version) (ceph_node_proxy_firmware_info{component=~".*BIOS.*"})',
+          legendFormat='{{version}}'
+        ))
+        + {
+          fieldConfig+: {
+            defaults+: {
+              color+: {
+                mode: 'palette-classic',
+              },
+            },
+          },
+          options+: {
+            legend+: { showLegend: false },
+            displayLabels: ['name'],
+          },
+        },
+
+        // Drive Types
+        $.pieChartPanel(
+          title='Drive Types',
+          datasource='$datasource',
+          gridPos={ x: 13, y: 1, w: 6, h: 8 }
+        )
+        .addTarget($.addTargetSchema(
+          'count by(model) (ceph_node_proxy_storage_capacity_bytes)',
+          legendFormat='{{model}}'
+        ))
+        + {
+          fieldConfig+: {
+            defaults+: {
+              color+: {
+                mode: 'palette-classic',
+              },
+            },
+          },
+          options+: {
+            legend+: { showLegend: true, placement: 'right' },
+            displayLabels: ['value'],
+          },
+        },
+
+        // Drive Firmware
+        $.pieChartPanel(
+          title='Drive Firmware',
+          datasource='$datasource',
+          gridPos={ x: 19, y: 1, w: 5, h: 8 }
+        )
+        .addTarget($.addTargetSchema(
+          'count by(version) (ceph_node_proxy_firmware_info{component=~".*Drive.*"})',
+          legendFormat='{{version}}',
+          instant=true
+        ))
+        + {
+          fieldConfig+: {
+            defaults+: {
+              color+: {
+                mode: 'palette-classic',
+              },
+            },
+          },
+          options+: {
+            legend+: { showLegend: true, placement: 'right' },
+            displayLabels: ['value'],
+          },
+        },
+
+        // Hosts
+        $.addStatPanel(
+          title='Hosts',
+          unit='short',
+          datasource='$datasource',
+          gridPosition={ h: 4, w: 2, x: 0, y: 5 }
+        ).addTarget($.addTargetSchema(
+          'count(count by(hostname) (ceph_node_proxy_health))',
+          legendFormat='__auto'
+        )),
+
+        // Drives
+        $.addStatPanel(
+          title='Drives',
+          unit='short',
+          datasource='$datasource',
+          gridPosition={ h: 4, w: 2, x: 2, y: 5 }
+        ).addTarget($.addTargetSchema(
+          'count(ceph_node_proxy_storage_capacity_bytes)',
+          legendFormat='__auto'
+        )),
+
+        // NVMe Temp
+        $.addStatPanel(
+          title='NVMe Temp',
+          unit='celsius',
+          datasource='$datasource',
+          gridPosition={ h: 4, w: 3, x: 4, y: 5 }
+        ).addTarget($.addTargetSchema(
+          'max(ceph_node_proxy_temperature_celsius{sensor_name=~"NVME.*_TEMP"})',
+          legendFormat='__auto'
+        ))
+        + {
+          fieldConfig: {
+            defaults: {
+              min: 0,
+              max: 85,
+              thresholds: {
+                mode: 'absolute',
+                steps: [{ color: 'green' }, { color: 'yellow', value: 75 }, { color: 'red', value: 80 }],
+              },
+            },
+          },
+        },
+      ] },
+
+      // Row 2: Host Overview
+      $.addRowSchema(true, true, 'Host Overview: $hostname') + { gridPos: { x: 0, y: 1, w: 24, h: 1 }, panels: [
+        // Power
+        $.addStatPanel(
+          title='Power',
+          unit='short',
+          datasource='$datasource',
+          gridPosition={ h: 3, w: 2, x: 0, y: 2 }
+        ).addTarget($.addTargetSchema(
+          'ceph_node_proxy_health{hostname="$hostname",category="power"}',
+          legendFormat='__auto'
+        ))
+        + {
+          fieldConfig: {
+            defaults: {
+              mappings: [
+                { type: 'value', options: { '0': { color: 'green', index: 0, text: 'OK' } } },
+                { type: 'range', options: { from: 1, to: 9999, result: { color: 'red', index: 1, text: 'NOT OK' } } },
+              ],
+              thresholds: { mode: 'absolute', steps: [{ color: 'green' }, { color: 'red', value: 1 }] },
+            },
+          },
+          options+: { colorMode: 'background_solid' },
+        },
+
+        // MB Temperature
+        $.addStatPanel(
+          title='MB Temperature (max)',
+          unit='celsius',
+          datasource='$datasource',
+          gridPosition={ h: 4, w: 3, x: 2, y: 2 }
+        ).addTarget($.addTargetSchema(
+          'max(ceph_node_proxy_temperature_celsius{hostname=~"$hostname", sensor_name=~".*MB_TEMP.*"})',
+          legendFormat='__auto'
+        )),
+
+        // CPU Temperature
+        $.addStatPanel(
+          title='CPU Temperature',
+          unit='celsius',
+          datasource='$datasource',
+          gridPosition={ h: 4, w: 3, x: 5, y: 2 }
+        ).addTarget($.addTargetSchema(
+          'avg(ceph_node_proxy_temperature_celsius{hostname=~"$hostname", sensor_name=~".*CPU_TEMP"})',
+          legendFormat='__auto'
+        )),
+
+        // DIMM Temperature
+        $.addStatPanel(
+          title='DIMM Temperature (max)',
+          unit='celsius',
+          datasource='$datasource',
+          gridPosition={ h: 4, w: 3, x: 8, y: 2 }
+        ).addTarget($.addTargetSchema(
+          'max(ceph_node_proxy_temperature_celsius{hostname=~"$hostname", sensor_name=~".*DIMM.*_TEMP"})',
+          legendFormat='__auto'
+        )),
+
+        // PSU Fans
+        $.addStatPanel(
+          title='PSU Fans',
+          unit='short',
+          datasource='$datasource',
+          gridPosition={ h: 4, w: 3, x: 11, y: 2 }
+        ).addTarget($.addTargetSchema(
+          'count(ceph_node_proxy_fan_rpm{hostname=~"$hostname", fan_name=~"PSU.*"})',
+          legendFormat='__auto'
+        )),
+
+        // AVG PSU Temperature
+        $.addStatPanel(
+          title='AVG PSU Temperature',
+          unit='celsius',
+          datasource='$datasource',
+          gridPosition={ h: 4, w: 3, x: 14, y: 2 }
+        ).addTarget($.addTargetSchema(
+          'avg(ceph_node_proxy_temperature_celsius{hostname=~"$hostname", sensor_name=~"PSU.*_TEMP.*"})',
+          legendFormat='__auto'
+        )),
+
+        // NVMe Drives
+        $.addStatPanel(
+          title='NVMe Drives',
+          unit='short',
+          datasource='$datasource',
+          gridPosition={ h: 4, w: 3, x: 17, y: 2 }
+        ).addTarget($.addTargetSchema(
+          'count(ceph_node_proxy_temperature_celsius{hostname=~"$hostname", sensor_name=~"NVME.*"})',
+          legendFormat='__auto'
+        )),
+
+        // NVMe Temperature
+        $.addStatPanel(
+          title='NVMe Temperature (max)',
+          unit='celsius',
+          datasource='$datasource',
+          gridPosition={ h: 4, w: 3, x: 20, y: 2 }
+        ).addTarget($.addTargetSchema(
+          'max(ceph_node_proxy_temperature_celsius{hostname=~"$hostname", sensor_name=~"NVME.*"})',
+          legendFormat='__auto'
+        )),
+
+        // Power Control
+        $.addStatPanel(
+          title='Power Control',
+          unit='short',
+          datasource='$datasource',
+          gridPosition={ h: 3, w: 2, x: 0, y: 5 }
+        ).addTarget($.addTargetSchema(
+          'ceph_node_proxy_health{hostname="$hostname",category="power"}',
+          legendFormat='__auto'
+        ))
+        + {
+          fieldConfig: {
+            defaults: {
+              mappings: [
+                { type: 'value', options: { '0': { color: 'green', index: 0, text: 'OK' } } },
+                { type: 'range', options: { from: 1, to: 9999, result: { color: 'red', index: 1, text: 'NOT OK' } } },
+              ],
+              thresholds: { mode: 'absolute', steps: [{ color: 'green' }, { color: 'red', value: 1 }] },
+            },
+          },
+          options+: { colorMode: 'background_solid' },
+        },
+
+        // Cooling
+        $.addStatPanel(
+          title='Cooling',
+          unit='short',
+          datasource='$datasource',
+          gridPosition={ h: 3, w: 2, x: 0, y: 8 }
+        ).addTarget($.addTargetSchema(
+          'ceph_node_proxy_health{hostname="$hostname",category="fans"}',
+          legendFormat='__auto'
+        ))
+        + {
+          fieldConfig: {
+            defaults: {
+              mappings: [
+                { type: 'value', options: { '0': { color: 'green', index: 0, text: 'OK' } } },
+                { type: 'range', options: { from: 1, to: 9999, result: { color: 'red', index: 1, text: 'NOT OK' } } },
+              ],
+              thresholds: { mode: 'absolute', steps: [{ color: 'green' }, { color: 'red', value: 1 }] },
+            },
+          },
+          options+: { colorMode: 'background_solid' },
+        },
+
+        // Drives
+        $.addStatPanel(
+          title='Drives',
+          unit='short',
+          datasource='$datasource',
+          gridPosition={ h: 3, w: 2, x: 0, y: 11 }
+        ).addTarget($.addTargetSchema(
+          'ceph_node_proxy_health{hostname="$hostname",category="storage"}',
+          legendFormat='__auto'
+        ))
+        + {
+          fieldConfig: {
+            defaults: {
+              mappings: [
+                { type: 'value', options: { '0': { color: 'green', index: 0, text: 'OK' } } },
+                { type: 'range', options: { from: 1, to: 9999, result: { color: 'red', index: 1, text: 'NOT OK' } } },
+              ],
+              thresholds: { mode: 'absolute', steps: [{ color: 'green' }, { color: 'red', value: 1 }] },
+            },
+          },
+          options+: { colorMode: 'background_solid' },
+        },
+      ] },
+
+      // Row 3: FAN Speeds
+      $.addRowSchema(true, true, 'FAN Speeds: $hostname') + { gridPos: { x: 0, y: 2, w: 24, h: 1 }, panels: [
+        // Repeating panel
+        $.addStatPanel(
+          title='FAN: $fan_speeds (RPM)',
+          unit='short',
+          datasource='$datasource',
+          gridPosition={ h: 5, w: 4, x: 0, y: 3 }
+        ).addTarget($.addTargetSchema(
+          'ceph_node_proxy_fan_rpm{hostname=~"$hostname",fan_name=~"$fan_speeds"}',
+          legendFormat='{{fan_name}}'
+        ))
+        + {
+          repeat: 'fan_speeds',
+          repeatDirection: 'h',
+          maxPerRow: 6,
+        },
+
+        // PSU1
+        $.addStatPanel(
+          title='PSU1 Fan Speed (RPM)',
+          unit='short',
+          datasource='$datasource',
+          gridPosition={ h: 5, w: 4, x: 0, y: 8 }
+        ).addTarget($.addTargetSchema(
+          'ceph_node_proxy_fan_rpm{hostname=~"$hostname",fan_name=~"PSU1.*"}',
+          legendFormat='{{fan_name}}'
+        )),
+
+        // PSU2
+        $.addStatPanel(
+          title='PSU2 Fan Speed (RPM)',
+          unit='short',
+          datasource='$datasource',
+          gridPosition={ h: 5, w: 4, x: 4, y: 8 }
+        ).addTarget($.addTargetSchema(
+          'ceph_node_proxy_fan_rpm{hostname=~"$hostname",fan_name=~"PSU2.*"}',
+          legendFormat='{{fan_name}}'
+        )),
+      ] },
+
+      // Row 4: Temperature History
+      $.addRowSchema(true, true, 'Temperature History: $hostname') + { gridPos: { x: 0, y: 3, w: 24, h: 1 }, panels: [
+        // CPU Temperature
+        g.graphPanel.new(
+          title='CPU Temperature',
+          datasource='$datasource',
+          format='celsius',
+        ).addTarget(
+          g.prometheus.target(
+            'ceph_node_proxy_temperature_celsius{hostname=~"$hostname", sensor_name=~".*CPU_TEMP"}',
+            legendFormat='{{sensor_name}}'
+          )
+        ).addTarget(
+          g.prometheus.target('vector(100)', legendFormat='Critical')
+        )
+        + {
+          gridPos: { x: 0, y: 4, w: 12, h: 8 },
+          yaxes: [{ min: 0 }, {}],
+          seriesOverrides: [
+            { alias: 'Critical', color: 'dark-red', dashes: true, fill: 0 },
+          ],
+        },
+
+        // DIMM Temperatures
+        g.graphPanel.new(
+          title='DIMM Temperatures',
+          datasource='$datasource',
+          format='celsius',
+        ).addTarget(
+          g.prometheus.target(
+            'ceph_node_proxy_temperature_celsius{hostname=~"$hostname", sensor_name=~".*DIMM.*_TEMP"}',
+            legendFormat='{{sensor_name}}'
+          )
+        ).addTarget(
+          g.prometheus.target('vector(88)', legendFormat='Critical')
+        )
+        + {
+          gridPos: { x: 12, y: 4, w: 12, h: 8 },
+          yaxes: [{ min: 0 }, {}],
+          seriesOverrides: [
+            { alias: 'Critical', color: 'dark-red', dashes: true, fill: 0 },
+          ],
+        },
+
+        // Motherboard Temperatures
+        g.graphPanel.new(
+          title='Motherboard Temperatures',
+          datasource='$datasource',
+          format='celsius',
+        ).addTarget(
+          g.prometheus.target(
+            'ceph_node_proxy_temperature_celsius{hostname=~"$hostname", sensor_name=~".*MB_TEMP.*"}',
+            legendFormat='{{sensor_name}}'
+          )
+        ).addTarget(
+          g.prometheus.target('vector(85)', legendFormat='Critical')
+        )
+        + {
+          gridPos: { x: 0, y: 12, w: 12, h: 8 },
+          yaxes: [{ min: 0 }, {}],
+          seriesOverrides: [
+            { alias: 'Critical', color: 'dark-red', dashes: true, fill: 0 },
+          ],
+        },
+
+        // NVMe Temperatures
+        g.graphPanel.new(
+          title='NVMe Temperatures',
+          datasource='$datasource',
+          format='celsius',
+        ).addTarget(
+          g.prometheus.target(
+            'ceph_node_proxy_temperature_celsius{hostname=~"$hostname", sensor_name=~"NVME.*_TEMP"}',
+            legendFormat='{{sensor_name}}'
+          )
+        ).addTarget(
+          g.prometheus.target('vector(85)', legendFormat='Critical')
+        )
+        + {
+          gridPos: { x: 12, y: 12, w: 12, h: 8 },
+          yaxes: [{ min: 0 }, {}],
+          seriesOverrides: [
+            { alias: 'Critical', color: 'dark-red', dashes: true, fill: 0 },
+          ],
+        },
+      ] },
+
+      // Row 5: FAN Speed History
+      $.addRowSchema(true, true, 'FAN Speed History: $hostname') + { gridPos: { x: 0, y: 4, w: 24, h: 1 }, panels: [
+        // AVG PSU Fan Speed
+        g.graphPanel.new(
+          title='AVG PSU Fan Speed',
+          datasource='$datasource',
+          format='short',
+        ).addTarget(
+          g.prometheus.target(
+            'avg(ceph_node_proxy_fan_rpm{hostname=~"$hostname", fan_name=~"PSU.*"})',
+            legendFormat='PSU Fans'
+          )
+        )
+        + {
+          gridPos: { x: 0, y: 5, w: 12, h: 8 },
+          description: 'AVG across both PSUs',
+        },
+
+        // AVG Cooling Fan Speed
+        g.graphPanel.new(
+          title='AVG Cooling Fan Speed',
+          datasource='$datasource',
+          format='short',
+        ).addTarget(
+          g.prometheus.target(
+            'avg(ceph_node_proxy_fan_rpm{hostname=~"$hostname", fan_name=~".*TACH.*"})',
+            legendFormat='System Fans'
+          )
+        )
+        + {
+          gridPos: { x: 12, y: 5, w: 12, h: 8 },
+        },
+      ] },
+    ]),
+}

--- a/monitoring/ceph-mixin/dashboards/hardware.libsonnet
+++ b/monitoring/ceph-mixin/dashboards/hardware.libsonnet
@@ -47,7 +47,7 @@ local g = import 'grafonnet/grafana.libsonnet';
       $.addTemplateSchema(
         'hostname',
         '$datasource',
-        'label_values(ceph_node_proxy_health, hostname)',
+        'label_values(ceph_hardware_health, hostname)',
         1,
         false,
         1,
@@ -59,14 +59,14 @@ local g = import 'grafonnet/grafana.libsonnet';
       g.template.new(
         'fan_speeds',
         '$datasource',
-        'label_values(ceph_node_proxy_fan_rpm{hostname=~"$hostname"},fan_name)',
+        'label_values(ceph_hardware_fan_rpm{hostname=~"$hostname"},fan_name)',
         label='',
         refresh='load',
         includeAll=true,
         multi=true,
         allValues='',
         sort=0,
-        regex='',
+        regex='/.*TACH_OUT/',
         hide=2
       )
     )
@@ -81,7 +81,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           gridPosition={ h: 4, w: 4, x: 0, y: 1 }
         )
         .addTarget($.addTargetSchema(
-          'max(ceph_node_proxy_health)',
+          'max(ceph_hardware_health)',
           legendFormat='__auto'
         ))
         + {
@@ -115,7 +115,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           { color: 'red', value: 85 },
         ])
         .addTarget($.addTargetSchema(
-          'max(ceph_node_proxy_temperature_celsius{sensor_name=~".*CPU_TEMP"})',
+          'max(ceph_hardware_temperature_celsius{sensor_name=~".*CPU_TEMP"})',
           legendFormat='__auto'
         )),
 
@@ -126,7 +126,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           gridPos={ x: 7, y: 1, w: 3, h: 8 }
         )
         .addTarget($.addTargetSchema(
-          'count by(version) (ceph_node_proxy_firmware_info{component=~".*BMC.*"})',
+          'count by(version) (ceph_hardware_firmware_info{component=~".*BMC.*"})',
           legendFormat='{{version}}'
         ))
         + {
@@ -149,7 +149,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           gridPos={ x: 10, y: 1, w: 3, h: 8 }
         )
         .addTarget($.addTargetSchema(
-          'count by(version) (ceph_node_proxy_firmware_info{component=~".*BIOS.*"})',
+          'count by(version) (ceph_hardware_firmware_info{component=~".*BIOS.*"})',
           legendFormat='{{version}}'
         ))
         + {
@@ -172,7 +172,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           gridPos={ x: 13, y: 1, w: 6, h: 8 }
         )
         .addTarget($.addTargetSchema(
-          'count by(model) (ceph_node_proxy_storage_capacity_bytes)',
+          'count by(model) (ceph_hardware_storage_capacity_bytes)',
           legendFormat='{{model}}'
         ))
         + {
@@ -195,8 +195,8 @@ local g = import 'grafonnet/grafana.libsonnet';
           gridPos={ x: 19, y: 1, w: 5, h: 8 }
         )
         .addTarget($.addTargetSchema(
-          'count by(version) (ceph_node_proxy_firmware_info{component=~".*Drive.*"})',
-          legendFormat='{{version}}',
+          'count by(firmware_version) (ceph_hardware_storage_capacity_bytes{firmware_version!="unknown"})',
+          legendFormat='{{firmware_version}}',
           instant=true
         ))
         + {
@@ -219,7 +219,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           datasource='$datasource',
           gridPosition={ h: 4, w: 2, x: 0, y: 5 }
         ).addTarget($.addTargetSchema(
-          'count(count by(hostname) (ceph_node_proxy_health))',
+          'count(count by(hostname) (ceph_hardware_health))',
           legendFormat='__auto'
         )),
 
@@ -230,7 +230,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           datasource='$datasource',
           gridPosition={ h: 4, w: 2, x: 2, y: 5 }
         ).addTarget($.addTargetSchema(
-          'count(ceph_node_proxy_storage_capacity_bytes)',
+          'count(ceph_hardware_storage_capacity_bytes)',
           legendFormat='__auto'
         )),
 
@@ -249,7 +249,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           { color: 'red', value: 80 },
         ])
         .addTarget($.addTargetSchema(
-          'max(ceph_node_proxy_temperature_celsius{sensor_name=~"NVME.*_TEMP"})',
+          'max(ceph_hardware_temperature_celsius{sensor_name=~"NVME.*_TEMP"})',
           legendFormat='__auto'
         )),
       ] },
@@ -263,7 +263,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           datasource='$datasource',
           gridPosition={ h: 3, w: 2, x: 0, y: 2 }
         ).addTarget($.addTargetSchema(
-          'max(ceph_node_proxy_health{hostname=~"$hostname",category="power"})',
+          'max(ceph_hardware_health{hostname=~"$hostname",category="power"})',
           legendFormat='__auto'
         ))
         + {
@@ -286,9 +286,13 @@ local g = import 'grafonnet/grafana.libsonnet';
           datasource='$datasource',
           gridPosition={ h: 4, w: 3, x: 2, y: 2 }
         ).addTarget($.addTargetSchema(
-          'max(ceph_node_proxy_temperature_celsius{hostname=~"$hostname", sensor_name=~".*MB_TEMP.*"})',
+          'max(ceph_hardware_temperature_celsius{hostname=~"$hostname", sensor_name=~".*MB_TEMP.*"})',
           legendFormat='__auto'
-        )),
+        ))
+        + {
+          fieldConfig+: { defaults+: { thresholds: { mode: 'absolute', steps: [{ color: 'green' }, { color: '#EAB839', value: 70 }, { color: 'red', value: 80 }] } } },
+          options+: { colorMode: 'none', graphMode: 'area' },
+        },
 
         // CPU Temperature
         $.addStatPanel(
@@ -297,9 +301,13 @@ local g = import 'grafonnet/grafana.libsonnet';
           datasource='$datasource',
           gridPosition={ h: 4, w: 3, x: 5, y: 2 }
         ).addTarget($.addTargetSchema(
-          'avg(ceph_node_proxy_temperature_celsius{hostname=~"$hostname", sensor_name=~".*CPU_TEMP"})',
+          'avg(ceph_hardware_temperature_celsius{hostname=~"$hostname", sensor_name=~".*CPU_TEMP"})',
           legendFormat='__auto'
-        )),
+        ))
+        + {
+          fieldConfig+: { defaults+: { max: 85, min: 0, thresholds: { mode: 'absolute', steps: [{ color: 'green' }, { color: '#EAB839', value: 80 }, { color: 'semi-dark-red', value: 90 }] } } },
+          options+: { colorMode: 'none', graphMode: 'area' },
+        },
 
         // DIMM Temperature
         $.addStatPanel(
@@ -308,9 +316,13 @@ local g = import 'grafonnet/grafana.libsonnet';
           datasource='$datasource',
           gridPosition={ h: 4, w: 3, x: 8, y: 2 }
         ).addTarget($.addTargetSchema(
-          'max(ceph_node_proxy_temperature_celsius{hostname=~"$hostname", sensor_name=~".*DIMM.*_TEMP"})',
+          'max(ceph_hardware_temperature_celsius{hostname=~"$hostname", sensor_name=~".*DIMM.*_TEMP"})',
           legendFormat='__auto'
-        )),
+        ))
+        + {
+          fieldConfig+: { defaults+: { max: 88, min: 0, thresholds: { mode: 'absolute', steps: [{ color: 'green' }, { color: 'yellow', value: 70 }, { color: 'semi-dark-red', value: 80 }] } } },
+          options+: { colorMode: 'none', graphMode: 'area' },
+        },
 
         // PSU Fans
         $.addStatPanel(
@@ -319,9 +331,10 @@ local g = import 'grafonnet/grafana.libsonnet';
           datasource='$datasource',
           gridPosition={ h: 4, w: 3, x: 11, y: 2 }
         ).addTarget($.addTargetSchema(
-          'count(ceph_node_proxy_fan_rpm{hostname=~"$hostname", fan_name=~"PSU.*"})',
+          'count(ceph_hardware_fan_rpm{hostname=~"$hostname", fan_name=~"PSU.*"})',
           legendFormat='__auto'
-        )),
+        ))
+        + { options+: { colorMode: 'none', graphMode: 'none' } },
 
         // AVG PSU Temperature
         $.addStatPanel(
@@ -330,9 +343,13 @@ local g = import 'grafonnet/grafana.libsonnet';
           datasource='$datasource',
           gridPosition={ h: 4, w: 3, x: 14, y: 2 }
         ).addTarget($.addTargetSchema(
-          'avg(ceph_node_proxy_temperature_celsius{hostname=~"$hostname", sensor_name=~"PSU.*_TEMP.*"})',
+          'avg(ceph_hardware_temperature_celsius{hostname=~"$hostname", sensor_name=~"PSU.*_TEMP.*"})',
           legendFormat='__auto'
-        )),
+        ))
+        + {
+          fieldConfig+: { defaults+: { color: { fixedColor: 'blue', mode: 'fixed' }, max: 100, min: 0, thresholds: { mode: 'absolute', steps: [{ color: 'green' }, { color: 'yellow', value: 80 }, { color: 'semi-dark-red', value: 90 }] } } },
+          options+: { colorMode: 'none', graphMode: 'area' },
+        },
 
         // NVMe Drives
         $.addStatPanel(
@@ -341,9 +358,13 @@ local g = import 'grafonnet/grafana.libsonnet';
           datasource='$datasource',
           gridPosition={ h: 4, w: 3, x: 17, y: 2 }
         ).addTarget($.addTargetSchema(
-          'count(ceph_node_proxy_storage_capacity_bytes{hostname=~"$hostname", protocol="NVMe"})',
+          'count(ceph_hardware_storage_capacity_bytes{hostname=~"$hostname", protocol="NVMe"})',
           legendFormat='__auto'
-        )),
+        ))
+        + {
+          fieldConfig+: { defaults+: { color: { fixedColor: 'blue', mode: 'thresholds' }, thresholds: { mode: 'absolute', steps: [{ color: 'green' }, { color: '#EAB839', value: 70 }, { color: 'semi-dark-red', value: 78 }] } } },
+          options+: { colorMode: 'none', graphMode: 'none' },
+        },
 
         // NVMe Temperature
         $.addStatPanel(
@@ -352,9 +373,13 @@ local g = import 'grafonnet/grafana.libsonnet';
           datasource='$datasource',
           gridPosition={ h: 4, w: 3, x: 20, y: 2 }
         ).addTarget($.addTargetSchema(
-          'max(ceph_node_proxy_temperature_celsius{hostname=~"$hostname", sensor_name=~"NVME.*"})',
+          'max(ceph_hardware_temperature_celsius{hostname=~"$hostname", sensor_name=~"NVME.*"})',
           legendFormat='__auto'
-        )),
+        ))
+        + {
+          fieldConfig+: { defaults+: { color: { fixedColor: 'blue', mode: 'thresholds' }, max: 85, min: 0, thresholds: { mode: 'absolute', steps: [{ color: 'green' }, { color: '#EAB839', value: 70 }, { color: 'semi-dark-red', value: 78 }] } } },
+          options+: { colorMode: 'none', graphMode: 'area' },
+        },
 
         // Network
         $.addStatPanel(
@@ -363,7 +388,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           datasource='$datasource',
           gridPosition={ h: 3, w: 2, x: 0, y: 5 }
         ).addTarget($.addTargetSchema(
-          'max(ceph_node_proxy_health{hostname=~"$hostname",category="network"})',
+          'max(ceph_hardware_health{hostname=~"$hostname",category="network"})',
           legendFormat='__auto'
         ))
         + {
@@ -386,7 +411,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           datasource='$datasource',
           gridPosition={ h: 3, w: 2, x: 0, y: 8 }
         ).addTarget($.addTargetSchema(
-          'max(ceph_node_proxy_health{hostname=~"$hostname",category="fans"})',
+          'max(ceph_hardware_health{hostname=~"$hostname",category="fans"})',
           legendFormat='__auto'
         ))
         + {
@@ -409,7 +434,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           datasource='$datasource',
           gridPosition={ h: 3, w: 2, x: 0, y: 11 }
         ).addTarget($.addTargetSchema(
-          'max(ceph_node_proxy_health{hostname=~"$hostname",category="storage"})',
+          'max(ceph_hardware_health{hostname=~"$hostname",category="storage"})',
           legendFormat='__auto'
         ))
         + {
@@ -441,7 +466,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           },
         )
         .addTarget($.addTargetSchema(
-          'ceph_node_proxy_storage_capacity_bytes{hostname=~"$hostname"}',
+          'ceph_hardware_storage_capacity_bytes{hostname=~"$hostname"}',
           legendFormat='__auto',
           instant=true
         ) + { format: 'table' })
@@ -483,7 +508,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           },
         )
         .addTarget($.addTargetSchema(
-          'ceph_node_proxy_firmware_info{hostname=~"$hostname"}',
+          'ceph_hardware_firmware_info{hostname=~"$hostname"}',
           legendFormat='__auto',
           instant=true
         ) + { format: 'table' })
@@ -518,10 +543,12 @@ local g = import 'grafonnet/grafana.libsonnet';
           datasource='$datasource',
           gridPosition={ h: 5, w: 4, x: 0, y: 3 }
         ).addTarget($.addTargetSchema(
-          'ceph_node_proxy_fan_rpm{hostname=~"$hostname",fan_name=~"$fan_speeds"}',
+          'ceph_hardware_fan_rpm{hostname=~"$hostname",fan_name=~"$fan_speeds"}',
           legendFormat='{{fan_name}}'
         ))
         + {
+          fieldConfig+: { defaults+: { color: { fixedColor: 'blue', mode: 'fixed' } } },
+          options+: { colorMode: 'none', graphMode: 'area' },
           repeat: 'fan_speeds',
           repeatDirection: 'h',
           maxPerRow: 6,
@@ -534,9 +561,13 @@ local g = import 'grafonnet/grafana.libsonnet';
           datasource='$datasource',
           gridPosition={ h: 5, w: 4, x: 0, y: 8 }
         ).addTarget($.addTargetSchema(
-          'ceph_node_proxy_fan_rpm{hostname=~"$hostname",fan_name=~"PSU1.*"}',
+          'ceph_hardware_fan_rpm{hostname=~"$hostname",fan_name=~"PSU1.*"}',
           legendFormat='{{fan_name}}'
-        )),
+        ))
+        + {
+          fieldConfig+: { defaults+: { color: { fixedColor: 'blue', mode: 'fixed' } } },
+          options+: { colorMode: 'none', graphMode: 'area' },
+        },
 
         // PSU2
         $.addStatPanel(
@@ -545,9 +576,13 @@ local g = import 'grafonnet/grafana.libsonnet';
           datasource='$datasource',
           gridPosition={ h: 5, w: 4, x: 4, y: 8 }
         ).addTarget($.addTargetSchema(
-          'ceph_node_proxy_fan_rpm{hostname=~"$hostname",fan_name=~"PSU2.*"}',
+          'ceph_hardware_fan_rpm{hostname=~"$hostname",fan_name=~"PSU2.*"}',
           legendFormat='{{fan_name}}'
-        )),
+        ))
+        + {
+          fieldConfig+: { defaults+: { color: { fixedColor: 'blue', mode: 'fixed' } } },
+          options+: { colorMode: 'none', graphMode: 'area' },
+        },
       ] },
 
       // Row 4: Temperature History
@@ -559,7 +594,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           format='celsius',
         ).addTarget(
           g.prometheus.target(
-            'ceph_node_proxy_temperature_celsius{hostname=~"$hostname", sensor_name=~".*CPU_TEMP"}',
+            'ceph_hardware_temperature_celsius{hostname=~"$hostname", sensor_name=~".*CPU_TEMP"}',
             legendFormat='{{sensor_name}}'
           )
         ).addTarget(
@@ -580,7 +615,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           format='celsius',
         ).addTarget(
           g.prometheus.target(
-            'ceph_node_proxy_temperature_celsius{hostname=~"$hostname", sensor_name=~".*DIMM.*_TEMP"}',
+            'ceph_hardware_temperature_celsius{hostname=~"$hostname", sensor_name=~".*DIMM.*_TEMP"}',
             legendFormat='{{sensor_name}}'
           )
         ).addTarget(
@@ -601,7 +636,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           format='celsius',
         ).addTarget(
           g.prometheus.target(
-            'ceph_node_proxy_temperature_celsius{hostname=~"$hostname", sensor_name=~".*MB_TEMP.*"}',
+            'ceph_hardware_temperature_celsius{hostname=~"$hostname", sensor_name=~".*MB_TEMP.*"}',
             legendFormat='{{sensor_name}}'
           )
         ).addTarget(
@@ -622,7 +657,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           format='celsius',
         ).addTarget(
           g.prometheus.target(
-            'ceph_node_proxy_temperature_celsius{hostname=~"$hostname", sensor_name=~"NVME.*_TEMP"}',
+            'ceph_hardware_temperature_celsius{hostname=~"$hostname", sensor_name=~"NVME.*_TEMP"}',
             legendFormat='{{sensor_name}}'
           )
         ).addTarget(
@@ -643,10 +678,11 @@ local g = import 'grafonnet/grafana.libsonnet';
         g.graphPanel.new(
           title='AVG PSU Fan Speed',
           datasource='$datasource',
-          format='none',
+          format='locale',
+          fill=1,
         ).addTarget(
           g.prometheus.target(
-            'avg(ceph_node_proxy_fan_rpm{hostname=~"$hostname", fan_name=~"PSU.*"})',
+            'avg(ceph_hardware_fan_rpm{hostname=~"$hostname", fan_name=~"PSU.*"})',
             legendFormat='PSU Fans'
           )
         )
@@ -655,14 +691,15 @@ local g = import 'grafonnet/grafana.libsonnet';
           description: 'AVG across both PSUs',
         },
 
-        // AVG Cooling Fan Speed
+        // AVG Cooling Fan RPMs
         g.graphPanel.new(
-          title='AVG Cooling Fan Speed',
+          title='AVG Cooling Fan RPMs',
           datasource='$datasource',
-          format='none',
+          format='locale',
+          fill=1,
         ).addTarget(
           g.prometheus.target(
-            'avg(ceph_node_proxy_fan_rpm{hostname=~"$hostname", fan_name!~"PSU.*"})',
+            'avg(ceph_hardware_fan_rpm{hostname=~"$hostname", fan_name!~"PSU.*"})',
             legendFormat='System Fans'
           )
         )

--- a/monitoring/ceph-mixin/dashboards/hardware.libsonnet
+++ b/monitoring/ceph-mixin/dashboards/hardware.libsonnet
@@ -3,7 +3,7 @@ local g = import 'grafonnet/grafana.libsonnet';
 (import 'utils.libsonnet') {
   'hardware.json':
     $.dashboardSchema(
-      'Ceph Hardware - Platform Monitoring',
+      'Ceph Hardware - Overview',
       'Comprehensive hardware monitoring with temperatures, fans, storage, and firmware from node-proxy',
       'hardware001',
       'now-1h',
@@ -31,7 +31,7 @@ local g = import 'grafonnet/grafana.libsonnet';
         keepTime=true,
         tags=[],
         targetBlank=false,
-        title='Browse Dashboards',
+        title='Ceph Hardware - Overview',
         tooltip='',
         type='dashboards',
         url=''
@@ -101,27 +101,23 @@ local g = import 'grafonnet/grafana.libsonnet';
         },
 
         // CPU Temp
-        $.addStatPanel(
+        $.addGaugePanel(
           title='CPU Temp',
           unit='celsius',
           datasource='$datasource',
-          gridPosition={ h: 4, w: 3, x: 4, y: 1 }
-        ).addTarget($.addTargetSchema(
+          gridPosition={ h: 4, w: 3, x: 4, y: 1 },
+          min=0,
+          max=100,
+        )
+        .addThresholds([
+          { color: 'green' },
+          { color: '#EAB839', value: 75 },
+          { color: 'red', value: 85 },
+        ])
+        .addTarget($.addTargetSchema(
           'max(ceph_node_proxy_temperature_celsius{sensor_name=~".*CPU_TEMP"})',
           legendFormat='__auto'
-        ))
-        + {
-          fieldConfig: {
-            defaults: {
-              min: 0,
-              max: 100,
-              thresholds: {
-                mode: 'absolute',
-                steps: [{ color: 'green' }, { color: '#EAB839', value: 75 }, { color: 'red', value: 85 }],
-              },
-            },
-          },
-        },
+        )),
 
         // BMC Versions
         $.pieChartPanel(
@@ -136,14 +132,13 @@ local g = import 'grafonnet/grafana.libsonnet';
         + {
           fieldConfig+: {
             defaults+: {
-              color+: {
-                mode: 'palette-classic',
-              },
+              color+: { mode: 'palette-classic' },
             },
           },
           options+: {
-            legend+: { showLegend: false },
-            displayLabels: ['name'],
+            pieType: 'donut',
+            legend+: { showLegend: true, placement: 'bottom' },
+            displayLabels: ['name', 'value'],
           },
         },
 
@@ -160,14 +155,13 @@ local g = import 'grafonnet/grafana.libsonnet';
         + {
           fieldConfig+: {
             defaults+: {
-              color+: {
-                mode: 'palette-classic',
-              },
+              color+: { mode: 'palette-classic' },
             },
           },
           options+: {
-            legend+: { showLegend: false },
-            displayLabels: ['name'],
+            pieType: 'donut',
+            legend+: { showLegend: true, placement: 'bottom' },
+            displayLabels: ['name', 'value'],
           },
         },
 
@@ -184,12 +178,11 @@ local g = import 'grafonnet/grafana.libsonnet';
         + {
           fieldConfig+: {
             defaults+: {
-              color+: {
-                mode: 'palette-classic',
-              },
+              color+: { mode: 'palette-classic' },
             },
           },
           options+: {
+            pieType: 'donut',
             legend+: { showLegend: true, placement: 'right' },
             displayLabels: ['value'],
           },
@@ -209,12 +202,11 @@ local g = import 'grafonnet/grafana.libsonnet';
         + {
           fieldConfig+: {
             defaults+: {
-              color+: {
-                mode: 'palette-classic',
-              },
+              color+: { mode: 'palette-classic' },
             },
           },
           options+: {
+            pieType: 'donut',
             legend+: { showLegend: true, placement: 'right' },
             displayLabels: ['value'],
           },
@@ -243,27 +235,23 @@ local g = import 'grafonnet/grafana.libsonnet';
         )),
 
         // NVMe Temp
-        $.addStatPanel(
+        $.addGaugePanel(
           title='NVMe Temp',
           unit='celsius',
           datasource='$datasource',
-          gridPosition={ h: 4, w: 3, x: 4, y: 5 }
-        ).addTarget($.addTargetSchema(
+          gridPosition={ h: 4, w: 3, x: 4, y: 5 },
+          min=0,
+          max=85,
+        )
+        .addThresholds([
+          { color: 'green' },
+          { color: 'yellow', value: 75 },
+          { color: 'red', value: 80 },
+        ])
+        .addTarget($.addTargetSchema(
           'max(ceph_node_proxy_temperature_celsius{sensor_name=~"NVME.*_TEMP"})',
           legendFormat='__auto'
-        ))
-        + {
-          fieldConfig: {
-            defaults: {
-              min: 0,
-              max: 85,
-              thresholds: {
-                mode: 'absolute',
-                steps: [{ color: 'green' }, { color: 'yellow', value: 75 }, { color: 'red', value: 80 }],
-              },
-            },
-          },
-        },
+        )),
       ] },
 
       // Row 2: Host Overview
@@ -275,7 +263,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           datasource='$datasource',
           gridPosition={ h: 3, w: 2, x: 0, y: 2 }
         ).addTarget($.addTargetSchema(
-          'ceph_node_proxy_health{hostname=~"$hostname",category="power"}',
+          'max(ceph_node_proxy_health{hostname=~"$hostname",category="power"})',
           legendFormat='__auto'
         ))
         + {
@@ -375,7 +363,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           datasource='$datasource',
           gridPosition={ h: 3, w: 2, x: 0, y: 5 }
         ).addTarget($.addTargetSchema(
-          'ceph_node_proxy_health{hostname=~"$hostname",category="network"}',
+          'max(ceph_node_proxy_health{hostname=~"$hostname",category="network"})',
           legendFormat='__auto'
         ))
         + {
@@ -398,7 +386,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           datasource='$datasource',
           gridPosition={ h: 3, w: 2, x: 0, y: 8 }
         ).addTarget($.addTargetSchema(
-          'ceph_node_proxy_health{hostname=~"$hostname",category="fans"}',
+          'max(ceph_node_proxy_health{hostname=~"$hostname",category="fans"})',
           legendFormat='__auto'
         ))
         + {
@@ -421,7 +409,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           datasource='$datasource',
           gridPosition={ h: 3, w: 2, x: 0, y: 11 }
         ).addTarget($.addTargetSchema(
-          'ceph_node_proxy_health{hostname=~"$hostname",category="storage"}',
+          'max(ceph_node_proxy_health{hostname=~"$hostname",category="storage"})',
           legendFormat='__auto'
         ))
         + {
@@ -436,6 +424,89 @@ local g = import 'grafonnet/grafana.libsonnet';
           },
           options+: { colorMode: 'background_solid' },
         },
+
+        // Device List
+        $.addTableExtended(
+          title='Device List',
+          datasource='$datasource',
+          gridPosition={ h: 8, w: 11, x: 2, y: 6 },
+          options={
+            footer: { show: false },
+            showHeader: true,
+          },
+          custom={ align: 'auto', cellOptions: { type: 'auto' }, filterable: false, inspect: false },
+          thresholds={
+            mode: 'absolute',
+            steps: [{ color: 'green', value: null }],
+          },
+        )
+        .addTarget($.addTargetSchema(
+          'ceph_node_proxy_storage_capacity_bytes{hostname=~"$hostname"}',
+          legendFormat='__auto',
+          instant=true
+        ) + { format: 'table' })
+        .addTransformations([
+          {
+            id: 'organize',
+            options: {
+              excludeByName: {
+                Time: true,
+                Value: true,
+                __name__: true,
+                cluster: true,
+                hostname: true,
+                job: true,
+                instance: true,
+              },
+              renameByName: {
+                device: 'Device Name',
+                model: 'Drive Model',
+                protocol: 'Protocol',
+              },
+            },
+          },
+        ]),
+
+        // Platform Firmware
+        $.addTableExtended(
+          title='Platform Firmware',
+          datasource='$datasource',
+          gridPosition={ h: 8, w: 11, x: 13, y: 6 },
+          options={
+            footer: { show: false },
+            showHeader: true,
+          },
+          custom={ align: 'auto', cellOptions: { type: 'auto' }, filterable: false, inspect: false },
+          thresholds={
+            mode: 'absolute',
+            steps: [{ color: 'green', value: null }],
+          },
+        )
+        .addTarget($.addTargetSchema(
+          'ceph_node_proxy_firmware_info{hostname=~"$hostname"}',
+          legendFormat='__auto',
+          instant=true
+        ) + { format: 'table' })
+        .addTransformations([
+          {
+            id: 'organize',
+            options: {
+              excludeByName: {
+                Time: true,
+                Value: true,
+                __name__: true,
+                cluster: true,
+                hostname: true,
+                job: true,
+                instance: true,
+              },
+              renameByName: {
+                component: 'Component',
+                version: 'Version',
+              },
+            },
+          },
+        ]),
       ] },
 
       // Row 3: FAN Speeds
@@ -443,7 +514,7 @@ local g = import 'grafonnet/grafana.libsonnet';
         // Repeating panel
         $.addStatPanel(
           title='FAN: $fan_speeds (RPM)',
-          unit='short',
+          unit='locale',
           datasource='$datasource',
           gridPosition={ h: 5, w: 4, x: 0, y: 3 }
         ).addTarget($.addTargetSchema(
@@ -459,7 +530,7 @@ local g = import 'grafonnet/grafana.libsonnet';
         // PSU1
         $.addStatPanel(
           title='PSU1 Fan Speed (RPM)',
-          unit='short',
+          unit='locale',
           datasource='$datasource',
           gridPosition={ h: 5, w: 4, x: 0, y: 8 }
         ).addTarget($.addTargetSchema(
@@ -470,7 +541,7 @@ local g = import 'grafonnet/grafana.libsonnet';
         // PSU2
         $.addStatPanel(
           title='PSU2 Fan Speed (RPM)',
-          unit='short',
+          unit='locale',
           datasource='$datasource',
           gridPosition={ h: 5, w: 4, x: 4, y: 8 }
         ).addTarget($.addTargetSchema(
@@ -572,7 +643,7 @@ local g = import 'grafonnet/grafana.libsonnet';
         g.graphPanel.new(
           title='AVG PSU Fan Speed',
           datasource='$datasource',
-          format='short',
+          format='none',
         ).addTarget(
           g.prometheus.target(
             'avg(ceph_node_proxy_fan_rpm{hostname=~"$hostname", fan_name=~"PSU.*"})',
@@ -588,7 +659,7 @@ local g = import 'grafonnet/grafana.libsonnet';
         g.graphPanel.new(
           title='AVG Cooling Fan Speed',
           datasource='$datasource',
-          format='short',
+          format='none',
         ).addTarget(
           g.prometheus.target(
             'avg(ceph_node_proxy_fan_rpm{hostname=~"$hostname", fan_name!~"PSU.*"})',

--- a/monitoring/ceph-mixin/dashboards/hardware.libsonnet
+++ b/monitoring/ceph-mixin/dashboards/hardware.libsonnet
@@ -59,14 +59,14 @@ local g = import 'grafonnet/grafana.libsonnet';
       g.template.new(
         'fan_speeds',
         '$datasource',
-        'label_values(ceph_node_proxy_fan_rpm{hostname="$hostname"},fan_name)',
+        'label_values(ceph_node_proxy_fan_rpm{hostname=~"$hostname"},fan_name)',
         label='',
         refresh='load',
         includeAll=true,
-        multi=false,
+        multi=true,
         allValues='',
         sort=0,
-        regex='/.*TACH.*/',
+        regex='',
         hide=2
       )
     )
@@ -275,7 +275,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           datasource='$datasource',
           gridPosition={ h: 3, w: 2, x: 0, y: 2 }
         ).addTarget($.addTargetSchema(
-          'ceph_node_proxy_health{hostname="$hostname",category="power"}',
+          'ceph_node_proxy_health{hostname=~"$hostname",category="power"}',
           legendFormat='__auto'
         ))
         + {
@@ -353,7 +353,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           datasource='$datasource',
           gridPosition={ h: 4, w: 3, x: 17, y: 2 }
         ).addTarget($.addTargetSchema(
-          'count(ceph_node_proxy_temperature_celsius{hostname=~"$hostname", sensor_name=~"NVME.*"})',
+          'count(ceph_node_proxy_storage_capacity_bytes{hostname=~"$hostname", protocol="NVMe"})',
           legendFormat='__auto'
         )),
 
@@ -368,14 +368,14 @@ local g = import 'grafonnet/grafana.libsonnet';
           legendFormat='__auto'
         )),
 
-        // Power Control
+        // Network
         $.addStatPanel(
-          title='Power Control',
+          title='Network',
           unit='short',
           datasource='$datasource',
           gridPosition={ h: 3, w: 2, x: 0, y: 5 }
         ).addTarget($.addTargetSchema(
-          'ceph_node_proxy_health{hostname="$hostname",category="power"}',
+          'ceph_node_proxy_health{hostname=~"$hostname",category="network"}',
           legendFormat='__auto'
         ))
         + {
@@ -398,7 +398,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           datasource='$datasource',
           gridPosition={ h: 3, w: 2, x: 0, y: 8 }
         ).addTarget($.addTargetSchema(
-          'ceph_node_proxy_health{hostname="$hostname",category="fans"}',
+          'ceph_node_proxy_health{hostname=~"$hostname",category="fans"}',
           legendFormat='__auto'
         ))
         + {
@@ -421,7 +421,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           datasource='$datasource',
           gridPosition={ h: 3, w: 2, x: 0, y: 11 }
         ).addTarget($.addTargetSchema(
-          'ceph_node_proxy_health{hostname="$hostname",category="storage"}',
+          'ceph_node_proxy_health{hostname=~"$hostname",category="storage"}',
           legendFormat='__auto'
         ))
         + {
@@ -591,7 +591,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           format='short',
         ).addTarget(
           g.prometheus.target(
-            'avg(ceph_node_proxy_fan_rpm{hostname=~"$hostname", fan_name=~".*TACH.*"})',
+            'avg(ceph_node_proxy_fan_rpm{hostname=~"$hostname", fan_name!~"PSU.*"})',
             legendFormat='System Fans'
           )
         )

--- a/monitoring/ceph-mixin/dashboards_out/hardware.json
+++ b/monitoring/ceph-mixin/dashboards_out/hardware.json
@@ -117,7 +117,7 @@
                "pluginVersion": "9.1.3",
                "targets": [
                   {
-                     "expr": "max(ceph_node_proxy_health)",
+                     "expr": "max(ceph_hardware_health)",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "__auto",
@@ -180,7 +180,7 @@
                "pluginVersion": "9.1.3",
                "targets": [
                   {
-                     "expr": "max(ceph_node_proxy_temperature_celsius{sensor_name=~\".*CPU_TEMP\"})",
+                     "expr": "max(ceph_hardware_temperature_celsius{sensor_name=~\".*CPU_TEMP\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "__auto",
@@ -235,7 +235,7 @@
                },
                "targets": [
                   {
-                     "expr": "count by(version) (ceph_node_proxy_firmware_info{component=~\".*BMC.*\"})",
+                     "expr": "count by(version) (ceph_hardware_firmware_info{component=~\".*BMC.*\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "{{version}}",
@@ -289,7 +289,7 @@
                },
                "targets": [
                   {
-                     "expr": "count by(version) (ceph_node_proxy_firmware_info{component=~\".*BIOS.*\"})",
+                     "expr": "count by(version) (ceph_hardware_firmware_info{component=~\".*BIOS.*\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "{{version}}",
@@ -342,7 +342,7 @@
                },
                "targets": [
                   {
-                     "expr": "count by(model) (ceph_node_proxy_storage_capacity_bytes)",
+                     "expr": "count by(model) (ceph_hardware_storage_capacity_bytes)",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "{{model}}",
@@ -395,11 +395,11 @@
                },
                "targets": [
                   {
-                     "expr": "count by(version) (ceph_node_proxy_firmware_info{component=~\".*Drive.*\"})",
+                     "expr": "count by(firmware_version) (ceph_hardware_storage_capacity_bytes{firmware_version!=\"unknown\"})",
                      "format": "time_series",
                      "instant": true,
                      "intervalFactor": 1,
-                     "legendFormat": "{{version}}",
+                     "legendFormat": "{{firmware_version}}",
                      "refId": "A"
                   }
                ],
@@ -447,7 +447,7 @@
                "pluginVersion": "9.1.3",
                "targets": [
                   {
-                     "expr": "count(count by(hostname) (ceph_node_proxy_health))",
+                     "expr": "count(count by(hostname) (ceph_hardware_health))",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "__auto",
@@ -499,7 +499,7 @@
                "pluginVersion": "9.1.3",
                "targets": [
                   {
-                     "expr": "count(ceph_node_proxy_storage_capacity_bytes)",
+                     "expr": "count(ceph_hardware_storage_capacity_bytes)",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "__auto",
@@ -562,7 +562,7 @@
                "pluginVersion": "9.1.3",
                "targets": [
                   {
-                     "expr": "max(ceph_node_proxy_temperature_celsius{sensor_name=~\"NVME.*_TEMP\"})",
+                     "expr": "max(ceph_hardware_temperature_celsius{sensor_name=~\"NVME.*_TEMP\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "__auto",
@@ -662,7 +662,7 @@
                "pluginVersion": "9.1.3",
                "targets": [
                   {
-                     "expr": "max(ceph_node_proxy_health{hostname=~\"$hostname\",category=\"power\"})",
+                     "expr": "max(ceph_hardware_health{hostname=~\"$hostname\",category=\"power\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "__auto",
@@ -684,7 +684,19 @@
                      "mappings": [ ],
                      "thresholds": {
                         "mode": "absolute",
-                        "steps": [ ]
+                        "steps": [
+                           {
+                              "color": "green"
+                           },
+                           {
+                              "color": "#EAB839",
+                              "value": 70
+                           },
+                           {
+                              "color": "red",
+                              "value": 80
+                           }
+                        ]
                      },
                      "unit": "celsius"
                   }
@@ -699,7 +711,7 @@
                "links": [ ],
                "options": {
                   "colorMode": "none",
-                  "graphMode": "none",
+                  "graphMode": "area",
                   "justifyMode": "auto",
                   "orientation": "horizontal",
                   "reduceOptions": {
@@ -714,7 +726,7 @@
                "pluginVersion": "9.1.3",
                "targets": [
                   {
-                     "expr": "max(ceph_node_proxy_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\".*MB_TEMP.*\"})",
+                     "expr": "max(ceph_hardware_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\".*MB_TEMP.*\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "__auto",
@@ -734,9 +746,23 @@
                      "decimals": 0,
                      "links": [ ],
                      "mappings": [ ],
+                     "max": 85,
+                     "min": 0,
                      "thresholds": {
                         "mode": "absolute",
-                        "steps": [ ]
+                        "steps": [
+                           {
+                              "color": "green"
+                           },
+                           {
+                              "color": "#EAB839",
+                              "value": 80
+                           },
+                           {
+                              "color": "semi-dark-red",
+                              "value": 90
+                           }
+                        ]
                      },
                      "unit": "celsius"
                   }
@@ -751,7 +777,7 @@
                "links": [ ],
                "options": {
                   "colorMode": "none",
-                  "graphMode": "none",
+                  "graphMode": "area",
                   "justifyMode": "auto",
                   "orientation": "horizontal",
                   "reduceOptions": {
@@ -766,7 +792,7 @@
                "pluginVersion": "9.1.3",
                "targets": [
                   {
-                     "expr": "avg(ceph_node_proxy_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\".*CPU_TEMP\"})",
+                     "expr": "avg(ceph_hardware_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\".*CPU_TEMP\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "__auto",
@@ -786,9 +812,23 @@
                      "decimals": 0,
                      "links": [ ],
                      "mappings": [ ],
+                     "max": 88,
+                     "min": 0,
                      "thresholds": {
                         "mode": "absolute",
-                        "steps": [ ]
+                        "steps": [
+                           {
+                              "color": "green"
+                           },
+                           {
+                              "color": "yellow",
+                              "value": 70
+                           },
+                           {
+                              "color": "semi-dark-red",
+                              "value": 80
+                           }
+                        ]
                      },
                      "unit": "celsius"
                   }
@@ -803,7 +843,7 @@
                "links": [ ],
                "options": {
                   "colorMode": "none",
-                  "graphMode": "none",
+                  "graphMode": "area",
                   "justifyMode": "auto",
                   "orientation": "horizontal",
                   "reduceOptions": {
@@ -818,7 +858,7 @@
                "pluginVersion": "9.1.3",
                "targets": [
                   {
-                     "expr": "max(ceph_node_proxy_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\".*DIMM.*_TEMP\"})",
+                     "expr": "max(ceph_hardware_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\".*DIMM.*_TEMP\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "__auto",
@@ -870,7 +910,7 @@
                "pluginVersion": "9.1.3",
                "targets": [
                   {
-                     "expr": "count(ceph_node_proxy_fan_rpm{hostname=~\"$hostname\", fan_name=~\"PSU.*\"})",
+                     "expr": "count(ceph_hardware_fan_rpm{hostname=~\"$hostname\", fan_name=~\"PSU.*\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "__auto",
@@ -887,12 +927,30 @@
                "description": "",
                "fieldConfig": {
                   "defaults": {
+                     "color": {
+                        "fixedColor": "blue",
+                        "mode": "fixed"
+                     },
                      "decimals": 0,
                      "links": [ ],
                      "mappings": [ ],
+                     "max": 100,
+                     "min": 0,
                      "thresholds": {
                         "mode": "absolute",
-                        "steps": [ ]
+                        "steps": [
+                           {
+                              "color": "green"
+                           },
+                           {
+                              "color": "yellow",
+                              "value": 80
+                           },
+                           {
+                              "color": "semi-dark-red",
+                              "value": 90
+                           }
+                        ]
                      },
                      "unit": "celsius"
                   }
@@ -907,7 +965,7 @@
                "links": [ ],
                "options": {
                   "colorMode": "none",
-                  "graphMode": "none",
+                  "graphMode": "area",
                   "justifyMode": "auto",
                   "orientation": "horizontal",
                   "reduceOptions": {
@@ -922,7 +980,7 @@
                "pluginVersion": "9.1.3",
                "targets": [
                   {
-                     "expr": "avg(ceph_node_proxy_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\"PSU.*_TEMP.*\"})",
+                     "expr": "avg(ceph_hardware_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\"PSU.*_TEMP.*\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "__auto",
@@ -939,12 +997,28 @@
                "description": "",
                "fieldConfig": {
                   "defaults": {
+                     "color": {
+                        "fixedColor": "blue",
+                        "mode": "thresholds"
+                     },
                      "decimals": 0,
                      "links": [ ],
                      "mappings": [ ],
                      "thresholds": {
                         "mode": "absolute",
-                        "steps": [ ]
+                        "steps": [
+                           {
+                              "color": "green"
+                           },
+                           {
+                              "color": "#EAB839",
+                              "value": 70
+                           },
+                           {
+                              "color": "semi-dark-red",
+                              "value": 78
+                           }
+                        ]
                      },
                      "unit": "short"
                   }
@@ -974,7 +1048,7 @@
                "pluginVersion": "9.1.3",
                "targets": [
                   {
-                     "expr": "count(ceph_node_proxy_storage_capacity_bytes{hostname=~\"$hostname\", protocol=\"NVMe\"})",
+                     "expr": "count(ceph_hardware_storage_capacity_bytes{hostname=~\"$hostname\", protocol=\"NVMe\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "__auto",
@@ -991,12 +1065,30 @@
                "description": "",
                "fieldConfig": {
                   "defaults": {
+                     "color": {
+                        "fixedColor": "blue",
+                        "mode": "thresholds"
+                     },
                      "decimals": 0,
                      "links": [ ],
                      "mappings": [ ],
+                     "max": 85,
+                     "min": 0,
                      "thresholds": {
                         "mode": "absolute",
-                        "steps": [ ]
+                        "steps": [
+                           {
+                              "color": "green"
+                           },
+                           {
+                              "color": "#EAB839",
+                              "value": 70
+                           },
+                           {
+                              "color": "semi-dark-red",
+                              "value": 78
+                           }
+                        ]
                      },
                      "unit": "celsius"
                   }
@@ -1011,7 +1103,7 @@
                "links": [ ],
                "options": {
                   "colorMode": "none",
-                  "graphMode": "none",
+                  "graphMode": "area",
                   "justifyMode": "auto",
                   "orientation": "horizontal",
                   "reduceOptions": {
@@ -1026,7 +1118,7 @@
                "pluginVersion": "9.1.3",
                "targets": [
                   {
-                     "expr": "max(ceph_node_proxy_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\"NVME.*\"})",
+                     "expr": "max(ceph_hardware_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\"NVME.*\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "__auto",
@@ -1106,7 +1198,7 @@
                "pluginVersion": "9.1.3",
                "targets": [
                   {
-                     "expr": "max(ceph_node_proxy_health{hostname=~\"$hostname\",category=\"network\"})",
+                     "expr": "max(ceph_hardware_health{hostname=~\"$hostname\",category=\"network\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "__auto",
@@ -1186,7 +1278,7 @@
                "pluginVersion": "9.1.3",
                "targets": [
                   {
-                     "expr": "max(ceph_node_proxy_health{hostname=~\"$hostname\",category=\"fans\"})",
+                     "expr": "max(ceph_hardware_health{hostname=~\"$hostname\",category=\"fans\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "__auto",
@@ -1266,7 +1358,7 @@
                "pluginVersion": "9.1.3",
                "targets": [
                   {
-                     "expr": "max(ceph_node_proxy_health{hostname=~\"$hostname\",category=\"storage\"})",
+                     "expr": "max(ceph_hardware_health{hostname=~\"$hostname\",category=\"storage\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "__auto",
@@ -1320,7 +1412,7 @@
                "styles": [ ],
                "targets": [
                   {
-                     "expr": "ceph_node_proxy_storage_capacity_bytes{hostname=~\"$hostname\"}",
+                     "expr": "ceph_hardware_storage_capacity_bytes{hostname=~\"$hostname\"}",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 1,
@@ -1397,7 +1489,7 @@
                "styles": [ ],
                "targets": [
                   {
-                     "expr": "ceph_node_proxy_firmware_info{hostname=~\"$hostname\"}",
+                     "expr": "ceph_hardware_firmware_info{hostname=~\"$hostname\"}",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 1,
@@ -1456,6 +1548,10 @@
                "description": "",
                "fieldConfig": {
                   "defaults": {
+                     "color": {
+                        "fixedColor": "blue",
+                        "mode": "fixed"
+                     },
                      "decimals": 0,
                      "links": [ ],
                      "mappings": [ ],
@@ -1477,7 +1573,7 @@
                "maxPerRow": 6,
                "options": {
                   "colorMode": "none",
-                  "graphMode": "none",
+                  "graphMode": "area",
                   "justifyMode": "auto",
                   "orientation": "horizontal",
                   "reduceOptions": {
@@ -1494,7 +1590,7 @@
                "repeatDirection": "h",
                "targets": [
                   {
-                     "expr": "ceph_node_proxy_fan_rpm{hostname=~\"$hostname\",fan_name=~\"$fan_speeds\"}",
+                     "expr": "ceph_hardware_fan_rpm{hostname=~\"$hostname\",fan_name=~\"$fan_speeds\"}",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "{{fan_name}}",
@@ -1511,6 +1607,10 @@
                "description": "",
                "fieldConfig": {
                   "defaults": {
+                     "color": {
+                        "fixedColor": "blue",
+                        "mode": "fixed"
+                     },
                      "decimals": 0,
                      "links": [ ],
                      "mappings": [ ],
@@ -1531,7 +1631,7 @@
                "links": [ ],
                "options": {
                   "colorMode": "none",
-                  "graphMode": "none",
+                  "graphMode": "area",
                   "justifyMode": "auto",
                   "orientation": "horizontal",
                   "reduceOptions": {
@@ -1546,7 +1646,7 @@
                "pluginVersion": "9.1.3",
                "targets": [
                   {
-                     "expr": "ceph_node_proxy_fan_rpm{hostname=~\"$hostname\",fan_name=~\"PSU1.*\"}",
+                     "expr": "ceph_hardware_fan_rpm{hostname=~\"$hostname\",fan_name=~\"PSU1.*\"}",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "{{fan_name}}",
@@ -1563,6 +1663,10 @@
                "description": "",
                "fieldConfig": {
                   "defaults": {
+                     "color": {
+                        "fixedColor": "blue",
+                        "mode": "fixed"
+                     },
                      "decimals": 0,
                      "links": [ ],
                      "mappings": [ ],
@@ -1583,7 +1687,7 @@
                "links": [ ],
                "options": {
                   "colorMode": "none",
-                  "graphMode": "none",
+                  "graphMode": "area",
                   "justifyMode": "auto",
                   "orientation": "horizontal",
                   "reduceOptions": {
@@ -1598,7 +1702,7 @@
                "pluginVersion": "9.1.3",
                "targets": [
                   {
-                     "expr": "ceph_node_proxy_fan_rpm{hostname=~\"$hostname\",fan_name=~\"PSU2.*\"}",
+                     "expr": "ceph_hardware_fan_rpm{hostname=~\"$hostname\",fan_name=~\"PSU2.*\"}",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "{{fan_name}}",
@@ -1678,7 +1782,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "ceph_node_proxy_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\".*CPU_TEMP\"}",
+                     "expr": "ceph_hardware_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\".*CPU_TEMP\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{sensor_name}}",
@@ -1765,7 +1869,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "ceph_node_proxy_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\".*DIMM.*_TEMP\"}",
+                     "expr": "ceph_hardware_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\".*DIMM.*_TEMP\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{sensor_name}}",
@@ -1852,7 +1956,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "ceph_node_proxy_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\".*MB_TEMP.*\"}",
+                     "expr": "ceph_hardware_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\".*MB_TEMP.*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{sensor_name}}",
@@ -1939,7 +2043,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "ceph_node_proxy_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\"NVME.*_TEMP\"}",
+                     "expr": "ceph_hardware_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\"NVME.*_TEMP\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{sensor_name}}",
@@ -2040,7 +2144,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "avg(ceph_node_proxy_fan_rpm{hostname=~\"$hostname\", fan_name=~\"PSU.*\"})",
+                     "expr": "avg(ceph_hardware_fan_rpm{hostname=~\"$hostname\", fan_name=~\"PSU.*\"})",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "PSU Fans",
@@ -2066,7 +2170,7 @@
                },
                "yaxes": [
                   {
-                     "format": "none",
+                     "format": "locale",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -2074,7 +2178,7 @@
                      "show": true
                   },
                   {
-                     "format": "none",
+                     "format": "locale",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -2125,7 +2229,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "avg(ceph_node_proxy_fan_rpm{hostname=~\"$hostname\", fan_name!~\"PSU.*\"})",
+                     "expr": "avg(ceph_hardware_fan_rpm{hostname=~\"$hostname\", fan_name!~\"PSU.*\"})",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "System Fans",
@@ -2135,7 +2239,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "AVG Cooling Fan Speed",
+               "title": "AVG Cooling Fan RPMs",
                "tooltip": {
                   "shared": true,
                   "sort": 0,
@@ -2151,7 +2255,7 @@
                },
                "yaxes": [
                   {
-                     "format": "none",
+                     "format": "locale",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -2159,7 +2263,7 @@
                      "show": true
                   },
                   {
-                     "format": "none",
+                     "format": "locale",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -2231,7 +2335,7 @@
             "multi": false,
             "name": "hostname",
             "options": [ ],
-            "query": "label_values(ceph_node_proxy_health, hostname)",
+            "query": "label_values(ceph_hardware_health, hostname)",
             "refresh": 1,
             "regex": "",
             "sort": 1,
@@ -2251,9 +2355,9 @@
             "multi": true,
             "name": "fan_speeds",
             "options": [ ],
-            "query": "label_values(ceph_node_proxy_fan_rpm{hostname=~\"$hostname\"},fan_name)",
+            "query": "label_values(ceph_hardware_fan_rpm{hostname=~\"$hostname\"},fan_name)",
             "refresh": 1,
-            "regex": "",
+            "regex": "/.*TACH_OUT/",
             "sort": 0,
             "tagValuesQuery": "",
             "tags": [ ],

--- a/monitoring/ceph-mixin/dashboards_out/hardware.json
+++ b/monitoring/ceph-mixin/dashboards_out/hardware.json
@@ -1,0 +1,2142 @@
+{
+   "__inputs": [ ],
+   "__requires": [ ],
+   "annotations": {
+      "list": [
+         {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "showIn": 0,
+            "tags": [ ],
+            "type": "dashboard"
+         }
+      ]
+   },
+   "description": "Comprehensive hardware monitoring with temperatures, fans, storage, and firmware from node-proxy",
+   "editable": false,
+   "gnetId": null,
+   "graphTooltip": 0,
+   "hideControls": false,
+   "id": null,
+   "links": [
+      {
+         "asDropdown": true,
+         "icon": "external link",
+         "includeVars": true,
+         "keepTime": true,
+         "tags": [ ],
+         "targetBlank": false,
+         "title": "Browse Dashboards",
+         "tooltip": "",
+         "type": "dashboards",
+         "url": ""
+      }
+   ],
+   "panels": [
+      {
+         "collapse": true,
+         "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+         },
+         "id": 2,
+         "panels": [
+            {
+               "colors": null,
+               "datasource": "$datasource",
+               "description": "",
+               "fieldConfig": {
+                  "defaults": {
+                     "mappings": [
+                        {
+                           "options": {
+                              "0": {
+                                 "color": "green",
+                                 "index": 0,
+                                 "text": "OK"
+                              }
+                           },
+                           "type": "value"
+                        },
+                        {
+                           "options": {
+                              "from": 1,
+                              "result": {
+                                 "color": "semi-dark-red",
+                                 "index": 1,
+                                 "text": "NOT OK"
+                              },
+                              "to": 999
+                           },
+                           "type": "range"
+                        }
+                     ],
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                           {
+                              "color": "green"
+                           },
+                           {
+                              "color": "red",
+                              "value": 1
+                           }
+                        ]
+                     }
+                  }
+               },
+               "gridPos": {
+                  "h": 4,
+                  "w": 4,
+                  "x": 0,
+                  "y": 1
+               },
+               "id": 3,
+               "links": [ ],
+               "options": {
+                  "colorMode": "background_solid",
+                  "graphMode": "none",
+                  "justifyMode": "auto",
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                     "calcs": [
+                        "lastNotNull"
+                     ],
+                     "fields": "",
+                     "values": false
+                  },
+                  "textMode": "auto"
+               },
+               "pluginVersion": "9.1.3",
+               "targets": [
+                  {
+                     "expr": "max(ceph_node_proxy_health)",
+                     "format": "time_series",
+                     "intervalFactor": 1,
+                     "legendFormat": "__auto",
+                     "refId": "A"
+                  }
+               ],
+               "title": "Health",
+               "transparent": false,
+               "type": "stat"
+            },
+            {
+               "colors": null,
+               "datasource": "$datasource",
+               "description": "",
+               "fieldConfig": {
+                  "defaults": {
+                     "max": 100,
+                     "min": 0,
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                           {
+                              "color": "green"
+                           },
+                           {
+                              "color": "#EAB839",
+                              "value": 75
+                           },
+                           {
+                              "color": "red",
+                              "value": 85
+                           }
+                        ]
+                     }
+                  }
+               },
+               "gridPos": {
+                  "h": 4,
+                  "w": 3,
+                  "x": 4,
+                  "y": 1
+               },
+               "id": 4,
+               "links": [ ],
+               "options": {
+                  "colorMode": "none",
+                  "graphMode": "none",
+                  "justifyMode": "auto",
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                     "calcs": [
+                        "lastNotNull"
+                     ],
+                     "fields": "",
+                     "values": false
+                  },
+                  "textMode": "auto"
+               },
+               "pluginVersion": "9.1.3",
+               "targets": [
+                  {
+                     "expr": "max(ceph_node_proxy_temperature_celsius{sensor_name=~\".*CPU_TEMP\"})",
+                     "format": "time_series",
+                     "intervalFactor": 1,
+                     "legendFormat": "__auto",
+                     "refId": "A"
+                  }
+               ],
+               "title": "CPU Temp",
+               "transparent": false,
+               "type": "stat"
+            },
+            {
+               "datasource": "$datasource",
+               "description": "",
+               "fieldConfig": {
+                  "defaults": {
+                     "color": {
+                        "mode": "palette-classic"
+                     },
+                     "custom": {
+                        "hideFrom": {
+                           "legend": false,
+                           "tooltip": false,
+                           "viz": false
+                        }
+                     },
+                     "mappings": [ ]
+                  },
+                  "overrides": [ ]
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 3,
+                  "x": 7,
+                  "y": 1
+               },
+               "id": 5,
+               "options": {
+                  "displayLabels": [
+                     "name"
+                  ],
+                  "legend": {
+                     "calcs": [ ],
+                     "displayMode": "table",
+                     "placement": "bottom",
+                     "showLegend": false,
+                     "values": [ ]
+                  },
+                  "pieType": "pie",
+                  "reduceOptions": { },
+                  "tooltip": { }
+               },
+               "targets": [
+                  {
+                     "expr": "count by(version) (ceph_node_proxy_firmware_info{component=~\".*BMC.*\"})",
+                     "format": "time_series",
+                     "intervalFactor": 1,
+                     "legendFormat": "{{version}}",
+                     "refId": "A"
+                  }
+               ],
+               "title": "BMC Versions",
+               "type": "piechart"
+            },
+            {
+               "datasource": "$datasource",
+               "description": "",
+               "fieldConfig": {
+                  "defaults": {
+                     "color": {
+                        "mode": "palette-classic"
+                     },
+                     "custom": {
+                        "hideFrom": {
+                           "legend": false,
+                           "tooltip": false,
+                           "viz": false
+                        }
+                     },
+                     "mappings": [ ]
+                  },
+                  "overrides": [ ]
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 3,
+                  "x": 10,
+                  "y": 1
+               },
+               "id": 6,
+               "options": {
+                  "displayLabels": [
+                     "name"
+                  ],
+                  "legend": {
+                     "calcs": [ ],
+                     "displayMode": "table",
+                     "placement": "bottom",
+                     "showLegend": false,
+                     "values": [ ]
+                  },
+                  "pieType": "pie",
+                  "reduceOptions": { },
+                  "tooltip": { }
+               },
+               "targets": [
+                  {
+                     "expr": "count by(version) (ceph_node_proxy_firmware_info{component=~\".*BIOS.*\"})",
+                     "format": "time_series",
+                     "intervalFactor": 1,
+                     "legendFormat": "{{version}}",
+                     "refId": "A"
+                  }
+               ],
+               "title": "BIOS Versions",
+               "type": "piechart"
+            },
+            {
+               "datasource": "$datasource",
+               "description": "",
+               "fieldConfig": {
+                  "defaults": {
+                     "color": {
+                        "mode": "palette-classic"
+                     },
+                     "custom": {
+                        "hideFrom": {
+                           "legend": false,
+                           "tooltip": false,
+                           "viz": false
+                        }
+                     },
+                     "mappings": [ ]
+                  },
+                  "overrides": [ ]
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 13,
+                  "y": 1
+               },
+               "id": 7,
+               "options": {
+                  "displayLabels": [
+                     "value"
+                  ],
+                  "legend": {
+                     "calcs": [ ],
+                     "displayMode": "table",
+                     "placement": "right",
+                     "showLegend": true,
+                     "values": [ ]
+                  },
+                  "pieType": "pie",
+                  "reduceOptions": { },
+                  "tooltip": { }
+               },
+               "targets": [
+                  {
+                     "expr": "count by(model) (ceph_node_proxy_storage_capacity_bytes)",
+                     "format": "time_series",
+                     "intervalFactor": 1,
+                     "legendFormat": "{{model}}",
+                     "refId": "A"
+                  }
+               ],
+               "title": "Drive Types",
+               "type": "piechart"
+            },
+            {
+               "datasource": "$datasource",
+               "description": "",
+               "fieldConfig": {
+                  "defaults": {
+                     "color": {
+                        "mode": "palette-classic"
+                     },
+                     "custom": {
+                        "hideFrom": {
+                           "legend": false,
+                           "tooltip": false,
+                           "viz": false
+                        }
+                     },
+                     "mappings": [ ]
+                  },
+                  "overrides": [ ]
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 5,
+                  "x": 19,
+                  "y": 1
+               },
+               "id": 8,
+               "options": {
+                  "displayLabels": [
+                     "value"
+                  ],
+                  "legend": {
+                     "calcs": [ ],
+                     "displayMode": "table",
+                     "placement": "right",
+                     "showLegend": true,
+                     "values": [ ]
+                  },
+                  "pieType": "pie",
+                  "reduceOptions": { },
+                  "tooltip": { }
+               },
+               "targets": [
+                  {
+                     "expr": "count by(version) (ceph_node_proxy_firmware_info{component=~\".*Drive.*\"})",
+                     "format": "time_series",
+                     "instant": true,
+                     "intervalFactor": 1,
+                     "legendFormat": "{{version}}",
+                     "refId": "A"
+                  }
+               ],
+               "title": "Drive Firmware",
+               "type": "piechart"
+            },
+            {
+               "colors": null,
+               "datasource": "$datasource",
+               "description": "",
+               "fieldConfig": {
+                  "defaults": {
+                     "decimals": 0,
+                     "links": [ ],
+                     "mappings": [ ],
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ ]
+                     },
+                     "unit": "short"
+                  }
+               },
+               "gridPos": {
+                  "h": 4,
+                  "w": 2,
+                  "x": 0,
+                  "y": 5
+               },
+               "id": 9,
+               "links": [ ],
+               "options": {
+                  "colorMode": "none",
+                  "graphMode": "none",
+                  "justifyMode": "auto",
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                     "calcs": [
+                        "lastNotNull"
+                     ],
+                     "fields": "",
+                     "values": false
+                  },
+                  "textMode": "auto"
+               },
+               "pluginVersion": "9.1.3",
+               "targets": [
+                  {
+                     "expr": "count(count by(hostname) (ceph_node_proxy_health))",
+                     "format": "time_series",
+                     "intervalFactor": 1,
+                     "legendFormat": "__auto",
+                     "refId": "A"
+                  }
+               ],
+               "title": "Hosts",
+               "transparent": false,
+               "type": "stat"
+            },
+            {
+               "colors": null,
+               "datasource": "$datasource",
+               "description": "",
+               "fieldConfig": {
+                  "defaults": {
+                     "decimals": 0,
+                     "links": [ ],
+                     "mappings": [ ],
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ ]
+                     },
+                     "unit": "short"
+                  }
+               },
+               "gridPos": {
+                  "h": 4,
+                  "w": 2,
+                  "x": 2,
+                  "y": 5
+               },
+               "id": 10,
+               "links": [ ],
+               "options": {
+                  "colorMode": "none",
+                  "graphMode": "none",
+                  "justifyMode": "auto",
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                     "calcs": [
+                        "lastNotNull"
+                     ],
+                     "fields": "",
+                     "values": false
+                  },
+                  "textMode": "auto"
+               },
+               "pluginVersion": "9.1.3",
+               "targets": [
+                  {
+                     "expr": "count(ceph_node_proxy_storage_capacity_bytes)",
+                     "format": "time_series",
+                     "intervalFactor": 1,
+                     "legendFormat": "__auto",
+                     "refId": "A"
+                  }
+               ],
+               "title": "Drives",
+               "transparent": false,
+               "type": "stat"
+            },
+            {
+               "colors": null,
+               "datasource": "$datasource",
+               "description": "",
+               "fieldConfig": {
+                  "defaults": {
+                     "max": 85,
+                     "min": 0,
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                           {
+                              "color": "green"
+                           },
+                           {
+                              "color": "yellow",
+                              "value": 75
+                           },
+                           {
+                              "color": "red",
+                              "value": 80
+                           }
+                        ]
+                     }
+                  }
+               },
+               "gridPos": {
+                  "h": 4,
+                  "w": 3,
+                  "x": 4,
+                  "y": 5
+               },
+               "id": 11,
+               "links": [ ],
+               "options": {
+                  "colorMode": "none",
+                  "graphMode": "none",
+                  "justifyMode": "auto",
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                     "calcs": [
+                        "lastNotNull"
+                     ],
+                     "fields": "",
+                     "values": false
+                  },
+                  "textMode": "auto"
+               },
+               "pluginVersion": "9.1.3",
+               "targets": [
+                  {
+                     "expr": "max(ceph_node_proxy_temperature_celsius{sensor_name=~\"NVME.*_TEMP\"})",
+                     "format": "time_series",
+                     "intervalFactor": 1,
+                     "legendFormat": "__auto",
+                     "refId": "A"
+                  }
+               ],
+               "title": "NVMe Temp",
+               "transparent": false,
+               "type": "stat"
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Overview",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": true,
+         "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 1
+         },
+         "id": 12,
+         "panels": [
+            {
+               "colors": null,
+               "datasource": "$datasource",
+               "description": "",
+               "fieldConfig": {
+                  "defaults": {
+                     "mappings": [
+                        {
+                           "options": {
+                              "0": {
+                                 "color": "green",
+                                 "index": 0,
+                                 "text": "OK"
+                              }
+                           },
+                           "type": "value"
+                        },
+                        {
+                           "options": {
+                              "from": 1,
+                              "result": {
+                                 "color": "red",
+                                 "index": 1,
+                                 "text": "NOT OK"
+                              },
+                              "to": 9999
+                           },
+                           "type": "range"
+                        }
+                     ],
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                           {
+                              "color": "green"
+                           },
+                           {
+                              "color": "red",
+                              "value": 1
+                           }
+                        ]
+                     }
+                  }
+               },
+               "gridPos": {
+                  "h": 3,
+                  "w": 2,
+                  "x": 0,
+                  "y": 2
+               },
+               "id": 13,
+               "links": [ ],
+               "options": {
+                  "colorMode": "background_solid",
+                  "graphMode": "none",
+                  "justifyMode": "auto",
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                     "calcs": [
+                        "lastNotNull"
+                     ],
+                     "fields": "",
+                     "values": false
+                  },
+                  "textMode": "auto"
+               },
+               "pluginVersion": "9.1.3",
+               "targets": [
+                  {
+                     "expr": "ceph_node_proxy_health{hostname=\"$hostname\",category=\"power\"}",
+                     "format": "time_series",
+                     "intervalFactor": 1,
+                     "legendFormat": "__auto",
+                     "refId": "A"
+                  }
+               ],
+               "title": "Power",
+               "transparent": false,
+               "type": "stat"
+            },
+            {
+               "colors": null,
+               "datasource": "$datasource",
+               "description": "",
+               "fieldConfig": {
+                  "defaults": {
+                     "decimals": 0,
+                     "links": [ ],
+                     "mappings": [ ],
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ ]
+                     },
+                     "unit": "celsius"
+                  }
+               },
+               "gridPos": {
+                  "h": 4,
+                  "w": 3,
+                  "x": 2,
+                  "y": 2
+               },
+               "id": 14,
+               "links": [ ],
+               "options": {
+                  "colorMode": "none",
+                  "graphMode": "none",
+                  "justifyMode": "auto",
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                     "calcs": [
+                        "lastNotNull"
+                     ],
+                     "fields": "",
+                     "values": false
+                  },
+                  "textMode": "auto"
+               },
+               "pluginVersion": "9.1.3",
+               "targets": [
+                  {
+                     "expr": "max(ceph_node_proxy_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\".*MB_TEMP.*\"})",
+                     "format": "time_series",
+                     "intervalFactor": 1,
+                     "legendFormat": "__auto",
+                     "refId": "A"
+                  }
+               ],
+               "title": "MB Temperature (max)",
+               "transparent": false,
+               "type": "stat"
+            },
+            {
+               "colors": null,
+               "datasource": "$datasource",
+               "description": "",
+               "fieldConfig": {
+                  "defaults": {
+                     "decimals": 0,
+                     "links": [ ],
+                     "mappings": [ ],
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ ]
+                     },
+                     "unit": "celsius"
+                  }
+               },
+               "gridPos": {
+                  "h": 4,
+                  "w": 3,
+                  "x": 5,
+                  "y": 2
+               },
+               "id": 15,
+               "links": [ ],
+               "options": {
+                  "colorMode": "none",
+                  "graphMode": "none",
+                  "justifyMode": "auto",
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                     "calcs": [
+                        "lastNotNull"
+                     ],
+                     "fields": "",
+                     "values": false
+                  },
+                  "textMode": "auto"
+               },
+               "pluginVersion": "9.1.3",
+               "targets": [
+                  {
+                     "expr": "avg(ceph_node_proxy_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\".*CPU_TEMP\"})",
+                     "format": "time_series",
+                     "intervalFactor": 1,
+                     "legendFormat": "__auto",
+                     "refId": "A"
+                  }
+               ],
+               "title": "CPU Temperature",
+               "transparent": false,
+               "type": "stat"
+            },
+            {
+               "colors": null,
+               "datasource": "$datasource",
+               "description": "",
+               "fieldConfig": {
+                  "defaults": {
+                     "decimals": 0,
+                     "links": [ ],
+                     "mappings": [ ],
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ ]
+                     },
+                     "unit": "celsius"
+                  }
+               },
+               "gridPos": {
+                  "h": 4,
+                  "w": 3,
+                  "x": 8,
+                  "y": 2
+               },
+               "id": 16,
+               "links": [ ],
+               "options": {
+                  "colorMode": "none",
+                  "graphMode": "none",
+                  "justifyMode": "auto",
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                     "calcs": [
+                        "lastNotNull"
+                     ],
+                     "fields": "",
+                     "values": false
+                  },
+                  "textMode": "auto"
+               },
+               "pluginVersion": "9.1.3",
+               "targets": [
+                  {
+                     "expr": "max(ceph_node_proxy_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\".*DIMM.*_TEMP\"})",
+                     "format": "time_series",
+                     "intervalFactor": 1,
+                     "legendFormat": "__auto",
+                     "refId": "A"
+                  }
+               ],
+               "title": "DIMM Temperature (max)",
+               "transparent": false,
+               "type": "stat"
+            },
+            {
+               "colors": null,
+               "datasource": "$datasource",
+               "description": "",
+               "fieldConfig": {
+                  "defaults": {
+                     "decimals": 0,
+                     "links": [ ],
+                     "mappings": [ ],
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ ]
+                     },
+                     "unit": "short"
+                  }
+               },
+               "gridPos": {
+                  "h": 4,
+                  "w": 3,
+                  "x": 11,
+                  "y": 2
+               },
+               "id": 17,
+               "links": [ ],
+               "options": {
+                  "colorMode": "none",
+                  "graphMode": "none",
+                  "justifyMode": "auto",
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                     "calcs": [
+                        "lastNotNull"
+                     ],
+                     "fields": "",
+                     "values": false
+                  },
+                  "textMode": "auto"
+               },
+               "pluginVersion": "9.1.3",
+               "targets": [
+                  {
+                     "expr": "count(ceph_node_proxy_fan_rpm{hostname=~\"$hostname\", fan_name=~\"PSU.*\"})",
+                     "format": "time_series",
+                     "intervalFactor": 1,
+                     "legendFormat": "__auto",
+                     "refId": "A"
+                  }
+               ],
+               "title": "PSU Fans",
+               "transparent": false,
+               "type": "stat"
+            },
+            {
+               "colors": null,
+               "datasource": "$datasource",
+               "description": "",
+               "fieldConfig": {
+                  "defaults": {
+                     "decimals": 0,
+                     "links": [ ],
+                     "mappings": [ ],
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ ]
+                     },
+                     "unit": "celsius"
+                  }
+               },
+               "gridPos": {
+                  "h": 4,
+                  "w": 3,
+                  "x": 14,
+                  "y": 2
+               },
+               "id": 18,
+               "links": [ ],
+               "options": {
+                  "colorMode": "none",
+                  "graphMode": "none",
+                  "justifyMode": "auto",
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                     "calcs": [
+                        "lastNotNull"
+                     ],
+                     "fields": "",
+                     "values": false
+                  },
+                  "textMode": "auto"
+               },
+               "pluginVersion": "9.1.3",
+               "targets": [
+                  {
+                     "expr": "avg(ceph_node_proxy_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\"PSU.*_TEMP.*\"})",
+                     "format": "time_series",
+                     "intervalFactor": 1,
+                     "legendFormat": "__auto",
+                     "refId": "A"
+                  }
+               ],
+               "title": "AVG PSU Temperature",
+               "transparent": false,
+               "type": "stat"
+            },
+            {
+               "colors": null,
+               "datasource": "$datasource",
+               "description": "",
+               "fieldConfig": {
+                  "defaults": {
+                     "decimals": 0,
+                     "links": [ ],
+                     "mappings": [ ],
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ ]
+                     },
+                     "unit": "short"
+                  }
+               },
+               "gridPos": {
+                  "h": 4,
+                  "w": 3,
+                  "x": 17,
+                  "y": 2
+               },
+               "id": 19,
+               "links": [ ],
+               "options": {
+                  "colorMode": "none",
+                  "graphMode": "none",
+                  "justifyMode": "auto",
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                     "calcs": [
+                        "lastNotNull"
+                     ],
+                     "fields": "",
+                     "values": false
+                  },
+                  "textMode": "auto"
+               },
+               "pluginVersion": "9.1.3",
+               "targets": [
+                  {
+                     "expr": "count(ceph_node_proxy_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\"NVME.*\"})",
+                     "format": "time_series",
+                     "intervalFactor": 1,
+                     "legendFormat": "__auto",
+                     "refId": "A"
+                  }
+               ],
+               "title": "NVMe Drives",
+               "transparent": false,
+               "type": "stat"
+            },
+            {
+               "colors": null,
+               "datasource": "$datasource",
+               "description": "",
+               "fieldConfig": {
+                  "defaults": {
+                     "decimals": 0,
+                     "links": [ ],
+                     "mappings": [ ],
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ ]
+                     },
+                     "unit": "celsius"
+                  }
+               },
+               "gridPos": {
+                  "h": 4,
+                  "w": 3,
+                  "x": 20,
+                  "y": 2
+               },
+               "id": 20,
+               "links": [ ],
+               "options": {
+                  "colorMode": "none",
+                  "graphMode": "none",
+                  "justifyMode": "auto",
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                     "calcs": [
+                        "lastNotNull"
+                     ],
+                     "fields": "",
+                     "values": false
+                  },
+                  "textMode": "auto"
+               },
+               "pluginVersion": "9.1.3",
+               "targets": [
+                  {
+                     "expr": "max(ceph_node_proxy_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\"NVME.*\"})",
+                     "format": "time_series",
+                     "intervalFactor": 1,
+                     "legendFormat": "__auto",
+                     "refId": "A"
+                  }
+               ],
+               "title": "NVMe Temperature (max)",
+               "transparent": false,
+               "type": "stat"
+            },
+            {
+               "colors": null,
+               "datasource": "$datasource",
+               "description": "",
+               "fieldConfig": {
+                  "defaults": {
+                     "mappings": [
+                        {
+                           "options": {
+                              "0": {
+                                 "color": "green",
+                                 "index": 0,
+                                 "text": "OK"
+                              }
+                           },
+                           "type": "value"
+                        },
+                        {
+                           "options": {
+                              "from": 1,
+                              "result": {
+                                 "color": "red",
+                                 "index": 1,
+                                 "text": "NOT OK"
+                              },
+                              "to": 9999
+                           },
+                           "type": "range"
+                        }
+                     ],
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                           {
+                              "color": "green"
+                           },
+                           {
+                              "color": "red",
+                              "value": 1
+                           }
+                        ]
+                     }
+                  }
+               },
+               "gridPos": {
+                  "h": 3,
+                  "w": 2,
+                  "x": 0,
+                  "y": 5
+               },
+               "id": 21,
+               "links": [ ],
+               "options": {
+                  "colorMode": "background_solid",
+                  "graphMode": "none",
+                  "justifyMode": "auto",
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                     "calcs": [
+                        "lastNotNull"
+                     ],
+                     "fields": "",
+                     "values": false
+                  },
+                  "textMode": "auto"
+               },
+               "pluginVersion": "9.1.3",
+               "targets": [
+                  {
+                     "expr": "ceph_node_proxy_health{hostname=\"$hostname\",category=\"power\"}",
+                     "format": "time_series",
+                     "intervalFactor": 1,
+                     "legendFormat": "__auto",
+                     "refId": "A"
+                  }
+               ],
+               "title": "Power Control",
+               "transparent": false,
+               "type": "stat"
+            },
+            {
+               "colors": null,
+               "datasource": "$datasource",
+               "description": "",
+               "fieldConfig": {
+                  "defaults": {
+                     "mappings": [
+                        {
+                           "options": {
+                              "0": {
+                                 "color": "green",
+                                 "index": 0,
+                                 "text": "OK"
+                              }
+                           },
+                           "type": "value"
+                        },
+                        {
+                           "options": {
+                              "from": 1,
+                              "result": {
+                                 "color": "red",
+                                 "index": 1,
+                                 "text": "NOT OK"
+                              },
+                              "to": 9999
+                           },
+                           "type": "range"
+                        }
+                     ],
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                           {
+                              "color": "green"
+                           },
+                           {
+                              "color": "red",
+                              "value": 1
+                           }
+                        ]
+                     }
+                  }
+               },
+               "gridPos": {
+                  "h": 3,
+                  "w": 2,
+                  "x": 0,
+                  "y": 8
+               },
+               "id": 22,
+               "links": [ ],
+               "options": {
+                  "colorMode": "background_solid",
+                  "graphMode": "none",
+                  "justifyMode": "auto",
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                     "calcs": [
+                        "lastNotNull"
+                     ],
+                     "fields": "",
+                     "values": false
+                  },
+                  "textMode": "auto"
+               },
+               "pluginVersion": "9.1.3",
+               "targets": [
+                  {
+                     "expr": "ceph_node_proxy_health{hostname=\"$hostname\",category=\"fans\"}",
+                     "format": "time_series",
+                     "intervalFactor": 1,
+                     "legendFormat": "__auto",
+                     "refId": "A"
+                  }
+               ],
+               "title": "Cooling",
+               "transparent": false,
+               "type": "stat"
+            },
+            {
+               "colors": null,
+               "datasource": "$datasource",
+               "description": "",
+               "fieldConfig": {
+                  "defaults": {
+                     "mappings": [
+                        {
+                           "options": {
+                              "0": {
+                                 "color": "green",
+                                 "index": 0,
+                                 "text": "OK"
+                              }
+                           },
+                           "type": "value"
+                        },
+                        {
+                           "options": {
+                              "from": 1,
+                              "result": {
+                                 "color": "red",
+                                 "index": 1,
+                                 "text": "NOT OK"
+                              },
+                              "to": 9999
+                           },
+                           "type": "range"
+                        }
+                     ],
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                           {
+                              "color": "green"
+                           },
+                           {
+                              "color": "red",
+                              "value": 1
+                           }
+                        ]
+                     }
+                  }
+               },
+               "gridPos": {
+                  "h": 3,
+                  "w": 2,
+                  "x": 0,
+                  "y": 11
+               },
+               "id": 23,
+               "links": [ ],
+               "options": {
+                  "colorMode": "background_solid",
+                  "graphMode": "none",
+                  "justifyMode": "auto",
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                     "calcs": [
+                        "lastNotNull"
+                     ],
+                     "fields": "",
+                     "values": false
+                  },
+                  "textMode": "auto"
+               },
+               "pluginVersion": "9.1.3",
+               "targets": [
+                  {
+                     "expr": "ceph_node_proxy_health{hostname=\"$hostname\",category=\"storage\"}",
+                     "format": "time_series",
+                     "intervalFactor": 1,
+                     "legendFormat": "__auto",
+                     "refId": "A"
+                  }
+               ],
+               "title": "Drives",
+               "transparent": false,
+               "type": "stat"
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Host Overview: $hostname",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": true,
+         "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 2
+         },
+         "id": 24,
+         "panels": [
+            {
+               "colors": null,
+               "datasource": "$datasource",
+               "description": "",
+               "fieldConfig": {
+                  "defaults": {
+                     "decimals": 0,
+                     "links": [ ],
+                     "mappings": [ ],
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ ]
+                     },
+                     "unit": "short"
+                  }
+               },
+               "gridPos": {
+                  "h": 5,
+                  "w": 4,
+                  "x": 0,
+                  "y": 3
+               },
+               "id": 25,
+               "links": [ ],
+               "maxPerRow": 6,
+               "options": {
+                  "colorMode": "none",
+                  "graphMode": "none",
+                  "justifyMode": "auto",
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                     "calcs": [
+                        "lastNotNull"
+                     ],
+                     "fields": "",
+                     "values": false
+                  },
+                  "textMode": "auto"
+               },
+               "pluginVersion": "9.1.3",
+               "repeat": "fan_speeds",
+               "repeatDirection": "h",
+               "targets": [
+                  {
+                     "expr": "ceph_node_proxy_fan_rpm{hostname=~\"$hostname\",fan_name=~\"$fan_speeds\"}",
+                     "format": "time_series",
+                     "intervalFactor": 1,
+                     "legendFormat": "{{fan_name}}",
+                     "refId": "A"
+                  }
+               ],
+               "title": "FAN: $fan_speeds (RPM)",
+               "transparent": false,
+               "type": "stat"
+            },
+            {
+               "colors": null,
+               "datasource": "$datasource",
+               "description": "",
+               "fieldConfig": {
+                  "defaults": {
+                     "decimals": 0,
+                     "links": [ ],
+                     "mappings": [ ],
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ ]
+                     },
+                     "unit": "short"
+                  }
+               },
+               "gridPos": {
+                  "h": 5,
+                  "w": 4,
+                  "x": 0,
+                  "y": 8
+               },
+               "id": 26,
+               "links": [ ],
+               "options": {
+                  "colorMode": "none",
+                  "graphMode": "none",
+                  "justifyMode": "auto",
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                     "calcs": [
+                        "lastNotNull"
+                     ],
+                     "fields": "",
+                     "values": false
+                  },
+                  "textMode": "auto"
+               },
+               "pluginVersion": "9.1.3",
+               "targets": [
+                  {
+                     "expr": "ceph_node_proxy_fan_rpm{hostname=~\"$hostname\",fan_name=~\"PSU1.*\"}",
+                     "format": "time_series",
+                     "intervalFactor": 1,
+                     "legendFormat": "{{fan_name}}",
+                     "refId": "A"
+                  }
+               ],
+               "title": "PSU1 Fan Speed (RPM)",
+               "transparent": false,
+               "type": "stat"
+            },
+            {
+               "colors": null,
+               "datasource": "$datasource",
+               "description": "",
+               "fieldConfig": {
+                  "defaults": {
+                     "decimals": 0,
+                     "links": [ ],
+                     "mappings": [ ],
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ ]
+                     },
+                     "unit": "short"
+                  }
+               },
+               "gridPos": {
+                  "h": 5,
+                  "w": 4,
+                  "x": 4,
+                  "y": 8
+               },
+               "id": 27,
+               "links": [ ],
+               "options": {
+                  "colorMode": "none",
+                  "graphMode": "none",
+                  "justifyMode": "auto",
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                     "calcs": [
+                        "lastNotNull"
+                     ],
+                     "fields": "",
+                     "values": false
+                  },
+                  "textMode": "auto"
+               },
+               "pluginVersion": "9.1.3",
+               "targets": [
+                  {
+                     "expr": "ceph_node_proxy_fan_rpm{hostname=~\"$hostname\",fan_name=~\"PSU2.*\"}",
+                     "format": "time_series",
+                     "intervalFactor": 1,
+                     "legendFormat": "{{fan_name}}",
+                     "refId": "A"
+                  }
+               ],
+               "title": "PSU2 Fan Speed (RPM)",
+               "transparent": false,
+               "type": "stat"
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "FAN Speeds: $hostname",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": true,
+         "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 3
+         },
+         "id": 28,
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 4
+               },
+               "id": 29,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [
+                  {
+                     "alias": "Critical",
+                     "color": "dark-red",
+                     "dashes": true,
+                     "fill": 0
+                  }
+               ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "ceph_node_proxy_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\".*CPU_TEMP\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{sensor_name}}",
+                     "refId": "A"
+                  },
+                  {
+                     "expr": "vector(100)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "Critical",
+                     "refId": "B"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU Temperature",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "min": 0
+                  },
+                  { }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 4
+               },
+               "id": 30,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [
+                  {
+                     "alias": "Critical",
+                     "color": "dark-red",
+                     "dashes": true,
+                     "fill": 0
+                  }
+               ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "ceph_node_proxy_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\".*DIMM.*_TEMP\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{sensor_name}}",
+                     "refId": "A"
+                  },
+                  {
+                     "expr": "vector(88)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "Critical",
+                     "refId": "B"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "DIMM Temperatures",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "min": 0
+                  },
+                  { }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 12
+               },
+               "id": 31,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [
+                  {
+                     "alias": "Critical",
+                     "color": "dark-red",
+                     "dashes": true,
+                     "fill": 0
+                  }
+               ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "ceph_node_proxy_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\".*MB_TEMP.*\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{sensor_name}}",
+                     "refId": "A"
+                  },
+                  {
+                     "expr": "vector(85)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "Critical",
+                     "refId": "B"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Motherboard Temperatures",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "min": 0
+                  },
+                  { }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 12
+               },
+               "id": 32,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [
+                  {
+                     "alias": "Critical",
+                     "color": "dark-red",
+                     "dashes": true,
+                     "fill": 0
+                  }
+               ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "ceph_node_proxy_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\"NVME.*_TEMP\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{sensor_name}}",
+                     "refId": "A"
+                  },
+                  {
+                     "expr": "vector(85)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "Critical",
+                     "refId": "B"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "NVMe Temperatures",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "min": 0
+                  },
+                  { }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Temperature History: $hostname",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": true,
+         "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 4
+         },
+         "id": 33,
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "description": "AVG across both PSUs",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 5
+               },
+               "id": 34,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "avg(ceph_node_proxy_fan_rpm{hostname=~\"$hostname\", fan_name=~\"PSU.*\"})",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "PSU Fans",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "AVG PSU Fan Speed",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 5
+               },
+               "id": 35,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "avg(ceph_node_proxy_fan_rpm{hostname=~\"$hostname\", fan_name=~\".*TACH.*\"})",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "System Fans",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "AVG Cooling Fan Speed",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "FAN Speed History: $hostname",
+         "titleSize": "h6",
+         "type": "row"
+      }
+   ],
+   "refresh": "10s",
+   "rows": [ ],
+   "schemaVersion": 22,
+   "style": "dark",
+   "tags": [
+      "ceph-mixin"
+   ],
+   "templating": {
+      "list": [
+         {
+            "current": {
+               "text": "default",
+               "value": "default"
+            },
+            "hide": 0,
+            "label": "Data Source",
+            "name": "datasource",
+            "options": [ ],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "",
+            "type": "datasource"
+         },
+         {
+            "allValue": null,
+            "current": { },
+            "datasource": "$datasource",
+            "hide": 0,
+            "includeAll": false,
+            "label": "cluster",
+            "multi": false,
+            "name": "cluster",
+            "options": [ ],
+            "query": "label_values(ceph_health_status, cluster)",
+            "refresh": 1,
+            "regex": "(.*)",
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [ ],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         },
+         {
+            "allValue": null,
+            "current": { },
+            "datasource": "$datasource",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Host",
+            "multi": false,
+            "name": "hostname",
+            "options": [ ],
+            "query": "label_values(ceph_node_proxy_health, hostname)",
+            "refresh": 1,
+            "regex": "",
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [ ],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         },
+         {
+            "allValue": "",
+            "current": { },
+            "datasource": "$datasource",
+            "hide": 2,
+            "includeAll": true,
+            "label": "",
+            "multi": false,
+            "name": "fan_speeds",
+            "options": [ ],
+            "query": "label_values(ceph_node_proxy_fan_rpm{hostname=\"$hostname\"},fan_name)",
+            "refresh": 1,
+            "regex": "/.*TACH.*/",
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [ ],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         }
+      ]
+   },
+   "time": {
+      "from": "now-1h",
+      "to": "now"
+   },
+   "timepicker": {
+      "refresh_intervals": [
+         "5s",
+         "10s",
+         "30s",
+         "1m",
+         "5m",
+         "15m",
+         "30m",
+         "1h",
+         "2h",
+         "1d"
+      ],
+      "time_options": [
+         "5m",
+         "15m",
+         "1h",
+         "6h",
+         "12h",
+         "24h",
+         "2d",
+         "7d",
+         "30d"
+      ]
+   },
+   "timezone": "",
+   "title": "Ceph Hardware - Platform Monitoring",
+   "uid": "hardware001",
+   "version": 0
+}

--- a/monitoring/ceph-mixin/dashboards_out/hardware.json
+++ b/monitoring/ceph-mixin/dashboards_out/hardware.json
@@ -658,7 +658,7 @@
                "pluginVersion": "9.1.3",
                "targets": [
                   {
-                     "expr": "ceph_node_proxy_health{hostname=\"$hostname\",category=\"power\"}",
+                     "expr": "ceph_node_proxy_health{hostname=~\"$hostname\",category=\"power\"}",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "__auto",
@@ -970,7 +970,7 @@
                "pluginVersion": "9.1.3",
                "targets": [
                   {
-                     "expr": "count(ceph_node_proxy_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\"NVME.*\"})",
+                     "expr": "count(ceph_node_proxy_storage_capacity_bytes{hostname=~\"$hostname\", protocol=\"NVMe\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "__auto",
@@ -1102,14 +1102,14 @@
                "pluginVersion": "9.1.3",
                "targets": [
                   {
-                     "expr": "ceph_node_proxy_health{hostname=\"$hostname\",category=\"power\"}",
+                     "expr": "ceph_node_proxy_health{hostname=~\"$hostname\",category=\"network\"}",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "__auto",
                      "refId": "A"
                   }
                ],
-               "title": "Power Control",
+               "title": "Network",
                "transparent": false,
                "type": "stat"
             },
@@ -1182,7 +1182,7 @@
                "pluginVersion": "9.1.3",
                "targets": [
                   {
-                     "expr": "ceph_node_proxy_health{hostname=\"$hostname\",category=\"fans\"}",
+                     "expr": "ceph_node_proxy_health{hostname=~\"$hostname\",category=\"fans\"}",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "__auto",
@@ -1262,7 +1262,7 @@
                "pluginVersion": "9.1.3",
                "targets": [
                   {
-                     "expr": "ceph_node_proxy_health{hostname=\"$hostname\",category=\"storage\"}",
+                     "expr": "ceph_node_proxy_health{hostname=~\"$hostname\",category=\"storage\"}",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "__auto",
@@ -1968,7 +1968,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "avg(ceph_node_proxy_fan_rpm{hostname=~\"$hostname\", fan_name=~\".*TACH.*\"})",
+                     "expr": "avg(ceph_node_proxy_fan_rpm{hostname=~\"$hostname\", fan_name!~\"PSU.*\"})",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "System Fans",
@@ -2091,12 +2091,12 @@
             "hide": 2,
             "includeAll": true,
             "label": "",
-            "multi": false,
+            "multi": true,
             "name": "fan_speeds",
             "options": [ ],
-            "query": "label_values(ceph_node_proxy_fan_rpm{hostname=\"$hostname\"},fan_name)",
+            "query": "label_values(ceph_node_proxy_fan_rpm{hostname=~\"$hostname\"},fan_name)",
             "refresh": 1,
-            "regex": "/.*TACH.*/",
+            "regex": "",
             "sort": 0,
             "tagValuesQuery": "",
             "tags": [ ],

--- a/monitoring/ceph-mixin/dashboards_out/hardware.json
+++ b/monitoring/ceph-mixin/dashboards_out/hardware.json
@@ -30,7 +30,7 @@
          "keepTime": true,
          "tags": [ ],
          "targetBlank": false,
-         "title": "Browse Dashboards",
+         "title": "Ceph Hardware - Overview",
          "tooltip": "",
          "type": "dashboards",
          "url": ""
@@ -129,11 +129,12 @@
                "type": "stat"
             },
             {
-               "colors": null,
                "datasource": "$datasource",
                "description": "",
                "fieldConfig": {
                   "defaults": {
+                     "links": [ ],
+                     "mappings": [ ],
                      "max": 100,
                      "min": 0,
                      "thresholds": {
@@ -151,7 +152,8 @@
                               "value": 85
                            }
                         ]
-                     }
+                     },
+                     "unit": "celsius"
                   }
                },
                "gridPos": {
@@ -161,12 +163,10 @@
                   "y": 1
                },
                "id": 4,
+               "interval": "1m",
                "links": [ ],
+               "maxDataPoints": 100,
                "options": {
-                  "colorMode": "none",
-                  "graphMode": "none",
-                  "justifyMode": "auto",
-                  "orientation": "horizontal",
                   "reduceOptions": {
                      "calcs": [
                         "lastNotNull"
@@ -174,7 +174,8 @@
                      "fields": "",
                      "values": false
                   },
-                  "textMode": "auto"
+                  "showThresholdLabels": false,
+                  "showThresholdMarkers": true
                },
                "pluginVersion": "9.1.3",
                "targets": [
@@ -188,7 +189,7 @@
                ],
                "title": "CPU Temp",
                "transparent": false,
-               "type": "stat"
+               "type": "gauge"
             },
             {
                "datasource": "$datasource",
@@ -218,16 +219,17 @@
                "id": 5,
                "options": {
                   "displayLabels": [
-                     "name"
+                     "name",
+                     "value"
                   ],
                   "legend": {
                      "calcs": [ ],
                      "displayMode": "table",
                      "placement": "bottom",
-                     "showLegend": false,
+                     "showLegend": true,
                      "values": [ ]
                   },
-                  "pieType": "pie",
+                  "pieType": "donut",
                   "reduceOptions": { },
                   "tooltip": { }
                },
@@ -271,16 +273,17 @@
                "id": 6,
                "options": {
                   "displayLabels": [
-                     "name"
+                     "name",
+                     "value"
                   ],
                   "legend": {
                      "calcs": [ ],
                      "displayMode": "table",
                      "placement": "bottom",
-                     "showLegend": false,
+                     "showLegend": true,
                      "values": [ ]
                   },
-                  "pieType": "pie",
+                  "pieType": "donut",
                   "reduceOptions": { },
                   "tooltip": { }
                },
@@ -333,7 +336,7 @@
                      "showLegend": true,
                      "values": [ ]
                   },
-                  "pieType": "pie",
+                  "pieType": "donut",
                   "reduceOptions": { },
                   "tooltip": { }
                },
@@ -386,7 +389,7 @@
                      "showLegend": true,
                      "values": [ ]
                   },
-                  "pieType": "pie",
+                  "pieType": "donut",
                   "reduceOptions": { },
                   "tooltip": { }
                },
@@ -508,11 +511,12 @@
                "type": "stat"
             },
             {
-               "colors": null,
                "datasource": "$datasource",
                "description": "",
                "fieldConfig": {
                   "defaults": {
+                     "links": [ ],
+                     "mappings": [ ],
                      "max": 85,
                      "min": 0,
                      "thresholds": {
@@ -530,7 +534,8 @@
                               "value": 80
                            }
                         ]
-                     }
+                     },
+                     "unit": "celsius"
                   }
                },
                "gridPos": {
@@ -540,12 +545,10 @@
                   "y": 5
                },
                "id": 11,
+               "interval": "1m",
                "links": [ ],
+               "maxDataPoints": 100,
                "options": {
-                  "colorMode": "none",
-                  "graphMode": "none",
-                  "justifyMode": "auto",
-                  "orientation": "horizontal",
                   "reduceOptions": {
                      "calcs": [
                         "lastNotNull"
@@ -553,7 +556,8 @@
                      "fields": "",
                      "values": false
                   },
-                  "textMode": "auto"
+                  "showThresholdLabels": false,
+                  "showThresholdMarkers": true
                },
                "pluginVersion": "9.1.3",
                "targets": [
@@ -567,7 +571,7 @@
                ],
                "title": "NVMe Temp",
                "transparent": false,
-               "type": "stat"
+               "type": "gauge"
             }
          ],
          "repeat": null,
@@ -658,7 +662,7 @@
                "pluginVersion": "9.1.3",
                "targets": [
                   {
-                     "expr": "ceph_node_proxy_health{hostname=~\"$hostname\",category=\"power\"}",
+                     "expr": "max(ceph_node_proxy_health{hostname=~\"$hostname\",category=\"power\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "__auto",
@@ -1102,7 +1106,7 @@
                "pluginVersion": "9.1.3",
                "targets": [
                   {
-                     "expr": "ceph_node_proxy_health{hostname=~\"$hostname\",category=\"network\"}",
+                     "expr": "max(ceph_node_proxy_health{hostname=~\"$hostname\",category=\"network\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "__auto",
@@ -1182,7 +1186,7 @@
                "pluginVersion": "9.1.3",
                "targets": [
                   {
-                     "expr": "ceph_node_proxy_health{hostname=~\"$hostname\",category=\"fans\"}",
+                     "expr": "max(ceph_node_proxy_health{hostname=~\"$hostname\",category=\"fans\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "__auto",
@@ -1262,7 +1266,7 @@
                "pluginVersion": "9.1.3",
                "targets": [
                   {
-                     "expr": "ceph_node_proxy_health{hostname=~\"$hostname\",category=\"storage\"}",
+                     "expr": "max(ceph_node_proxy_health{hostname=~\"$hostname\",category=\"storage\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "__auto",
@@ -1272,6 +1276,159 @@
                "title": "Drives",
                "transparent": false,
                "type": "stat"
+            },
+            {
+               "columns": [ ],
+               "datasource": "$datasource",
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "align": "auto",
+                        "cellOptions": {
+                           "type": "auto"
+                        },
+                        "filterable": false,
+                        "inspect": false
+                     },
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                           {
+                              "color": "green",
+                              "value": null
+                           }
+                        ]
+                     }
+                  },
+                  "overrides": [ ]
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 11,
+                  "x": 2,
+                  "y": 6
+               },
+               "id": 24,
+               "links": [ ],
+               "options": {
+                  "footer": {
+                     "show": false
+                  },
+                  "showHeader": true
+               },
+               "pluginVersion": "9.1.3",
+               "styles": [ ],
+               "targets": [
+                  {
+                     "expr": "ceph_node_proxy_storage_capacity_bytes{hostname=~\"$hostname\"}",
+                     "format": "table",
+                     "instant": true,
+                     "intervalFactor": 1,
+                     "legendFormat": "__auto",
+                     "refId": "A"
+                  }
+               ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Device List",
+               "transformations": [
+                  {
+                     "id": "organize",
+                     "options": {
+                        "excludeByName": {
+                           "Time": true,
+                           "Value": true,
+                           "__name__": true,
+                           "cluster": true,
+                           "hostname": true,
+                           "instance": true,
+                           "job": true
+                        },
+                        "renameByName": {
+                           "device": "Device Name",
+                           "model": "Drive Model",
+                           "protocol": "Protocol"
+                        }
+                     }
+                  }
+               ],
+               "type": "table"
+            },
+            {
+               "columns": [ ],
+               "datasource": "$datasource",
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "align": "auto",
+                        "cellOptions": {
+                           "type": "auto"
+                        },
+                        "filterable": false,
+                        "inspect": false
+                     },
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                           {
+                              "color": "green",
+                              "value": null
+                           }
+                        ]
+                     }
+                  },
+                  "overrides": [ ]
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 11,
+                  "x": 13,
+                  "y": 6
+               },
+               "id": 25,
+               "links": [ ],
+               "options": {
+                  "footer": {
+                     "show": false
+                  },
+                  "showHeader": true
+               },
+               "pluginVersion": "9.1.3",
+               "styles": [ ],
+               "targets": [
+                  {
+                     "expr": "ceph_node_proxy_firmware_info{hostname=~\"$hostname\"}",
+                     "format": "table",
+                     "instant": true,
+                     "intervalFactor": 1,
+                     "legendFormat": "__auto",
+                     "refId": "A"
+                  }
+               ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Platform Firmware",
+               "transformations": [
+                  {
+                     "id": "organize",
+                     "options": {
+                        "excludeByName": {
+                           "Time": true,
+                           "Value": true,
+                           "__name__": true,
+                           "cluster": true,
+                           "hostname": true,
+                           "instance": true,
+                           "job": true
+                        },
+                        "renameByName": {
+                           "component": "Component",
+                           "version": "Version"
+                        }
+                     }
+                  }
+               ],
+               "type": "table"
             }
          ],
          "repeat": null,
@@ -1291,7 +1448,7 @@
             "x": 0,
             "y": 2
          },
-         "id": 24,
+         "id": 26,
          "panels": [
             {
                "colors": null,
@@ -1306,7 +1463,7 @@
                         "mode": "absolute",
                         "steps": [ ]
                      },
-                     "unit": "short"
+                     "unit": "locale"
                   }
                },
                "gridPos": {
@@ -1315,7 +1472,7 @@
                   "x": 0,
                   "y": 3
                },
-               "id": 25,
+               "id": 27,
                "links": [ ],
                "maxPerRow": 6,
                "options": {
@@ -1361,7 +1518,7 @@
                         "mode": "absolute",
                         "steps": [ ]
                      },
-                     "unit": "short"
+                     "unit": "locale"
                   }
                },
                "gridPos": {
@@ -1370,7 +1527,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 26,
+               "id": 28,
                "links": [ ],
                "options": {
                   "colorMode": "none",
@@ -1413,7 +1570,7 @@
                         "mode": "absolute",
                         "steps": [ ]
                      },
-                     "unit": "short"
+                     "unit": "locale"
                   }
                },
                "gridPos": {
@@ -1422,7 +1579,7 @@
                   "x": 4,
                   "y": 8
                },
-               "id": 27,
+               "id": 29,
                "links": [ ],
                "options": {
                   "colorMode": "none",
@@ -1470,7 +1627,7 @@
             "x": 0,
             "y": 3
          },
-         "id": 28,
+         "id": 30,
          "panels": [
             {
                "aliasColors": { },
@@ -1486,7 +1643,7 @@
                   "x": 0,
                   "y": 4
                },
-               "id": 29,
+               "id": 31,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1573,7 +1730,7 @@
                   "x": 12,
                   "y": 4
                },
-               "id": 30,
+               "id": 32,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1660,7 +1817,7 @@
                   "x": 0,
                   "y": 12
                },
-               "id": 31,
+               "id": 33,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1747,7 +1904,7 @@
                   "x": 12,
                   "y": 12
                },
-               "id": 32,
+               "id": 34,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1838,7 +1995,7 @@
             "x": 0,
             "y": 4
          },
-         "id": 33,
+         "id": 35,
          "panels": [
             {
                "aliasColors": { },
@@ -1855,7 +2012,7 @@
                   "x": 0,
                   "y": 5
                },
-               "id": 34,
+               "id": 36,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1909,7 +2066,7 @@
                },
                "yaxes": [
                   {
-                     "format": "short",
+                     "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -1917,7 +2074,7 @@
                      "show": true
                   },
                   {
-                     "format": "short",
+                     "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -1940,7 +2097,7 @@
                   "x": 12,
                   "y": 5
                },
-               "id": 35,
+               "id": 37,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1994,7 +2151,7 @@
                },
                "yaxes": [
                   {
-                     "format": "short",
+                     "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -2002,7 +2159,7 @@
                      "show": true
                   },
                   {
-                     "format": "short",
+                     "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -2136,7 +2293,7 @@
       ]
    },
    "timezone": "",
-   "title": "Ceph Hardware - Platform Monitoring",
+   "title": "Ceph Hardware - Overview",
    "uid": "hardware001",
    "version": 0
 }

--- a/monitoring/ceph-mixin/tests_dashboards/util.py
+++ b/monitoring/ceph-mixin/tests_dashboards/util.py
@@ -44,7 +44,9 @@ def add_dashboard_queries(data: Dict[str, Any], dashboard_data: Dict[str, Any], 
         return
     error = 0
     panel_ids_in_file = set()
-    for panel in dashboard_data['panels']:
+
+    def process_panel(panel, in_row=False):
+        nonlocal error
         if (
                 'title' in panel
                 and 'targets' in panel
@@ -55,13 +57,33 @@ def add_dashboard_queries(data: Dict[str, Any], dashboard_data: Dict[str, Any], 
                 title = panel['title']
                 legend_format = target['legendFormat'] if 'legendFormat' in target else ""
                 query_id = f'{title}-{legend_format}'
-                if query_id in panel_ids_in_file and legend_format != '__auto':
-                    cprint((f'ERROR: Query in panel "{title}" with legend "{legend_format}"'
-                            f' already exists in the same file: "{path}"'), 'red')
-                    error = 1
+                # Skip duplicates within collapsed rows
+                # but error on duplicates at top-level or across different contexts
+                if query_id in panel_ids_in_file:
+                    if legend_format != '__auto' and not in_row:
+                        cprint((f'ERROR: Query in panel "{title}" with legend "{legend_format}"'
+                                f' already exists in the same file: "{path}"'), 'red')
+                        error = 1
+                    # Skip adding duplicate
+                    continue
+                # Also check for duplicates across different files
+                # NOTE: This silently skips duplicate panel+legend combinations across dashboards,
+                # which means some queries never get tested. A better approach would be to include
+                # dashboard name in query_id (e.g., "dashboard:panel-legend"), but that requires
+                # updating all test .feature files to specify which dashboard they're testing.
+                if query_id in data['queries']:
+                    # Skip silently for duplicates across files (first one wins)
+                    continue
                 data['queries'][query_id] = {'query': target['expr'], 'path': path}
                 data['stats'][path]['total'] += 1
                 panel_ids_in_file.add(query_id)
+        # Recurse into row panels
+        if panel.get('type') == 'row' and 'panels' in panel:
+            for nested_panel in panel['panels']:
+                process_panel(nested_panel, in_row=True)
+
+    for panel in dashboard_data['panels']:
+        process_panel(panel)
     if error:
         raise ValueError('Missing legend_format in queries, please add a proper value.')
 

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -140,6 +140,20 @@ NUM_OBJECTS = ['degraded', 'misplaced', 'unfound']
 SMB_METADATA = ('smb_version', 'volume',
                 'subvolume_group', 'subvolume', 'netbiosname', 'share')
 
+NODE_PROXY_STORAGE_LABELS = ('hostname', 'device', 'model', 'protocol')
+
+NODE_PROXY_CPU_LABELS = ('hostname', 'cpu', 'manufacturer', 'model')
+
+NODE_PROXY_MEMORY_LABELS = ('hostname', 'dimm', 'type', 'manufacturer')
+
+NODE_PROXY_HEALTH_LABELS = ('hostname', 'component', 'category')
+
+NODE_PROXY_TEMP_LABELS = ('hostname', 'sensor_name')
+
+NODE_PROXY_FAN_LABELS = ('hostname', 'fan_name')
+
+NODE_PROXY_FIRMWARE_LABELS = ('hostname', 'component', 'version')
+
 CEPHADM_DAEMON_STATUS = ('service_type', 'daemon_name', 'hostname', 'service_name')
 
 alert_metric = namedtuple('alert_metric', 'name description')
@@ -997,6 +1011,55 @@ class Module(MgrModule, OrchestratorClientMixin):
                 path,
                 check.description,
             )
+
+        metrics['node_proxy_storage_capacity_bytes'] = Metric(
+            'gauge',
+            'node_proxy_storage_capacity_bytes',
+            'Storage device capacity in bytes',
+            NODE_PROXY_STORAGE_LABELS
+        )
+
+        metrics['node_proxy_cpu_cores'] = Metric(
+            'gauge',
+            'node_proxy_cpu_cores',
+            'Total CPU cores',
+            NODE_PROXY_CPU_LABELS
+        )
+
+        metrics['node_proxy_memory_capacity_mib'] = Metric(
+            'gauge',
+            'node_proxy_memory_capacity_mib',
+            'Memory capacity in MiB',
+            NODE_PROXY_MEMORY_LABELS
+        )
+
+        metrics['node_proxy_health'] = Metric(
+            'gauge',
+            'node_proxy_health',
+            'Hardware component health status (0=OK, 1=Warning, 2=Error)',
+            NODE_PROXY_HEALTH_LABELS
+        )
+
+        metrics['node_proxy_temperature_celsius'] = Metric(
+            'gauge',
+            'node_proxy_temperature_celsius',
+            'Hardware temperature sensor reading in Celsius',
+            NODE_PROXY_TEMP_LABELS
+        )
+
+        metrics['node_proxy_fan_rpm'] = Metric(
+            'gauge',
+            'node_proxy_fan_rpm',
+            'Hardware fan speed in RPM',
+            NODE_PROXY_FAN_LABELS
+        )
+
+        metrics['node_proxy_firmware_info'] = Metric(
+            'gauge',
+            'node_proxy_firmware_info',
+            'Firmware version information (value is always 1, version in label)',
+            NODE_PROXY_FIRMWARE_LABELS
+        )
 
         return metrics
 
@@ -2001,6 +2064,115 @@ class Module(MgrModule, OrchestratorClientMixin):
             self.log.error(f"Failed to get SMB metadata: {str(e)}")
 
     @profile_method(True)
+    def get_hardware_metrics(self) -> None:
+        """Collect hardware metrics from node-proxy KV store"""
+        NODE_PROXY_CACHE_PREFIX = 'node_proxy'
+
+        try:
+            for key, value in self.get_store_prefix(f'{NODE_PROXY_CACHE_PREFIX}/data').items():
+                host = key.split('/')[-1]
+                try:
+                    data = json.loads(value)
+                except json.JSONDecodeError:
+                    self.log.error(f"Failed to decode node-proxy data for host {host}")
+                    continue
+
+                status = data.get('status', {})
+
+                # Storage metrics
+                for sys_id, devices in status.get('storage', {}).items():
+                    for device_id, device in devices.items():
+                        capacity = device.get('capacity_bytes', 0)
+                        labels = (
+                            host,
+                            device_id,
+                            device.get('model', 'unknown'),
+                            device.get('protocol', 'unknown')
+                        )
+                        self.metrics['node_proxy_storage_capacity_bytes'].set(capacity, labels)
+
+                # CPU metrics
+                for sys_id, cpus in status.get('processors', {}).items():
+                    for cpu_id, cpu in cpus.items():
+                        cores = cpu.get('total_cores', 0)
+                        labels = (
+                            host,
+                            cpu_id,
+                            cpu.get('manufacturer', 'unknown'),
+                            cpu.get('model', 'unknown')
+                        )
+                        self.metrics['node_proxy_cpu_cores'].set(cores, labels)
+
+                # Memory metrics
+                for sys_id, dimms in status.get('memory', {}).items():
+                    for dimm_id, dimm in dimms.items():
+                        capacity = dimm.get('capacity_mi_b', 0)
+                        labels = (
+                            host,
+                            dimm_id,
+                            dimm.get('memory_device_type', 'unknown'),
+                            dimm.get('manufacturer', 'unknown')
+                        )
+                        self.metrics['node_proxy_memory_capacity_mib'].set(capacity, labels)
+
+                # Health metrics for all component types
+                for category in ['storage', 'processors', 'memory', 'power', 'fans', 'network']:
+                    for sys_id, components in status.get(category, {}).items():
+                        for comp_id, comp in components.items():
+                            health_str = comp.get('status', {}).get('health', 'Unknown')
+                            if health_str == 'OK':
+                                health_value = 0
+                            elif health_str in ['Warning', 'Degraded']:
+                                health_value = 1
+                            else:
+                                health_value = 2
+
+                            labels = (host, comp_id, category)
+                            self.metrics['node_proxy_health'].set(health_value, labels)
+
+                # Temperature metrics
+                for sys_id, sensors in status.get('temperatures', {}).items():
+                    for sensor_id, sensor in sensors.items():
+                        reading = sensor.get('reading')
+                        sensor_name = sensor.get('name', sensor_id)
+                        # Skip absent/unknown sensors
+                        if reading is None or reading == 'unknown':
+                            continue
+                        try:
+                            temp_value = float(reading)
+                            labels = (host, sensor_name)
+                            self.metrics['node_proxy_temperature_celsius'].set(temp_value, labels)
+                        except (ValueError, TypeError):
+                            continue
+
+                # Fan RPM metrics
+                for sys_id, fans_data in status.get('fans', {}).items():
+                    for fan_id, fan in fans_data.items():
+                        # Redfish uses 'Reading' field per Thermal schema
+                        # node-proxy normalizes it to lowercase 'reading'
+                        rpm = fan.get('reading')
+                        fan_name = fan.get('name', fan_id)
+                        if rpm is None or rpm == 'unknown':
+                            continue
+                        try:
+                            rpm_value = float(rpm)
+                            labels = (host, fan_name)
+                            self.metrics['node_proxy_fan_rpm'].set(rpm_value, labels)
+                        except (ValueError, TypeError):
+                            continue
+
+                # Firmware version metrics
+                firmwares = data.get('firmwares', {})
+                for fw_id, fw_info in firmwares.items():
+                    component = fw_info.get('name', fw_id)
+                    version = fw_info.get('version', 'unknown')
+                    if version and version != 'unknown':
+                        labels = (host, component, str(version))
+                        self.metrics['node_proxy_firmware_info'].set(1, labels)
+        except Exception as e:
+            self.log.error(f"Failed to collect hardware metrics: {str(e)}")
+
+    @profile_method(True)
     def collect(self) -> str:
         # Clear the metrics before scraping
         for k in self.metrics.keys():
@@ -2020,6 +2192,7 @@ class Module(MgrModule, OrchestratorClientMixin):
         self.get_num_objects()
         self.get_all_daemon_health_metrics()
         self.get_smb_metadata()
+        self.get_hardware_metrics()
         self.set_cephadm_daemon_status_metrics()
 
         if not self.get_module_option('exclude_perf_counters'):

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -145,6 +145,7 @@ NODE_PROXY_STORAGE_LABELS = ('hostname', 'device', 'model', 'protocol')
 NODE_PROXY_CPU_LABELS = ('hostname', 'cpu', 'manufacturer', 'model')
 
 NODE_PROXY_MEMORY_LABELS = ('hostname', 'dimm', 'type', 'manufacturer')
+MIB_TO_BYTES = 1048576
 
 NODE_PROXY_HEALTH_LABELS = ('hostname', 'component', 'category')
 
@@ -1026,10 +1027,10 @@ class Module(MgrModule, OrchestratorClientMixin):
             NODE_PROXY_CPU_LABELS
         )
 
-        metrics['node_proxy_memory_capacity_mib'] = Metric(
+        metrics['node_proxy_memory_capacity_bytes'] = Metric(
             'gauge',
-            'node_proxy_memory_capacity_mib',
-            'Memory capacity in MiB',
+            'node_proxy_memory_capacity_bytes',
+            'Memory capacity in bytes',
             NODE_PROXY_MEMORY_LABELS
         )
 
@@ -2102,19 +2103,29 @@ class Module(MgrModule, OrchestratorClientMixin):
 
             for sys_id, dimms in status.get('memory', {}).items():
                 for dimm_id, dimm in dimms.items():
-                    capacity = dimm.get('capacity_mi_b', 0)
+                    capacity_mib = dimm.get('capacity_mi_b', 0)
+                    capacity_bytes = capacity_mib * MIB_TO_BYTES
                     labels = (
                         host,
                         dimm_id,
                         dimm.get('memory_device_type', 'unknown'),
                         dimm.get('manufacturer', 'unknown')
                     )
-                    self.metrics['node_proxy_memory_capacity_mib'].set(capacity, labels)
+                    self.metrics['node_proxy_memory_capacity_bytes'].set(capacity_bytes, labels)
 
             for category in ['storage', 'processors', 'memory', 'power', 'fans', 'network', 'temperatures']:
                 for sys_id, components in status.get(category, {}).items():
                     for comp_id, comp in components.items():
-                        health_str = comp.get('status', {}).get('health', 'Unknown')
+                        if not isinstance(comp, dict):
+                            continue
+                        status_val = comp.get('status', {})
+                        if isinstance(status_val, dict):
+                            health_str = status_val.get('health', 'Unknown')
+                        elif isinstance(status_val, str):
+                            health_str = status_val
+                        else:
+                            health_str = 'Unknown'
+
                         if health_str == 'OK':
                             health_value = 0
                         elif health_str in ['Warning', 'Degraded']:

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -140,20 +140,41 @@ NUM_OBJECTS = ['degraded', 'misplaced', 'unfound']
 SMB_METADATA = ('smb_version', 'volume',
                 'subvolume_group', 'subvolume', 'netbiosname', 'share')
 
-NODE_PROXY_STORAGE_LABELS = ('hostname', 'device', 'model', 'protocol')
+HW_STORAGE_LABELS = ('hostname', 'device', 'model', 'protocol', 'firmware_version', 'slot', 'serial_number')
 
-NODE_PROXY_CPU_LABELS = ('hostname', 'cpu', 'manufacturer', 'model')
+HW_CPU_LABELS = ('hostname', 'cpu', 'manufacturer', 'model', 'total_threads')
 
-NODE_PROXY_MEMORY_LABELS = ('hostname', 'dimm', 'type', 'manufacturer')
+HW_MEMORY_LABELS = ('hostname', 'dimm', 'type')
 MIB_TO_BYTES = 1048576
 
-NODE_PROXY_HEALTH_LABELS = ('hostname', 'component', 'category')
+HW_HEALTH_LABELS = ('hostname', 'component', 'category')
 
-NODE_PROXY_TEMP_LABELS = ('hostname', 'sensor_name')
+HW_TEMP_LABELS = ('hostname', 'sensor_name')
 
-NODE_PROXY_FAN_LABELS = ('hostname', 'fan_name')
+HW_FAN_LABELS = ('hostname', 'fan_name')
 
-NODE_PROXY_FIRMWARE_LABELS = ('hostname', 'component', 'version')
+HW_FIRMWARE_LABELS = ('hostname', 'component', 'version')
+
+HEALTH_STATUS_MAP = {
+    'OK': 0,
+    'Warning': 1,
+    'Degraded': 1,
+    'Error': 2,
+    'Critical': 2,
+}
+
+SENSOR_METRICS = {
+    'fans': {
+        'metric': 'hardware_fan_rpm',
+        'description': 'Hardware fan speed in RPM',
+        'labels': HW_FAN_LABELS,
+    },
+    'temperatures': {
+        'metric': 'hardware_temperature_celsius',
+        'description': 'Hardware temperature sensor reading in Celsius',
+        'labels': HW_TEMP_LABELS,
+    },
+}
 
 CEPHADM_DAEMON_STATUS = ('service_type', 'daemon_name', 'hostname', 'service_name')
 
@@ -1013,53 +1034,47 @@ class Module(MgrModule, OrchestratorClientMixin):
                 check.description,
             )
 
-        metrics['node_proxy_storage_capacity_bytes'] = Metric(
+        metrics['hardware_storage_capacity_bytes'] = Metric(
             'gauge',
-            'node_proxy_storage_capacity_bytes',
+            'hardware_storage_capacity_bytes',
             'Storage device capacity in bytes',
-            NODE_PROXY_STORAGE_LABELS
+            HW_STORAGE_LABELS
         )
 
-        metrics['node_proxy_cpu_cores'] = Metric(
+        metrics['hardware_cpu_cores'] = Metric(
             'gauge',
-            'node_proxy_cpu_cores',
+            'hardware_cpu_cores',
             'Total CPU cores',
-            NODE_PROXY_CPU_LABELS
+            HW_CPU_LABELS
         )
 
-        metrics['node_proxy_memory_capacity_bytes'] = Metric(
+        metrics['hardware_memory_capacity_bytes'] = Metric(
             'gauge',
-            'node_proxy_memory_capacity_bytes',
+            'hardware_memory_capacity_bytes',
             'Memory capacity in bytes',
-            NODE_PROXY_MEMORY_LABELS
+            HW_MEMORY_LABELS
         )
 
-        metrics['node_proxy_health'] = Metric(
+        metrics['hardware_health'] = Metric(
             'gauge',
-            'node_proxy_health',
+            'hardware_health',
             'Hardware component health status (0=OK, 1=Warning, 2=Error)',
-            NODE_PROXY_HEALTH_LABELS
+            HW_HEALTH_LABELS
         )
 
-        metrics['node_proxy_temperature_celsius'] = Metric(
-            'gauge',
-            'node_proxy_temperature_celsius',
-            'Hardware temperature sensor reading in Celsius',
-            NODE_PROXY_TEMP_LABELS
-        )
+        for sensor in SENSOR_METRICS.values():
+            metrics[sensor['metric']] = Metric(
+                'gauge',
+                sensor['metric'],
+                sensor['description'],
+                sensor['labels']
+            )
 
-        metrics['node_proxy_fan_rpm'] = Metric(
+        metrics['hardware_firmware_info'] = Metric(
             'gauge',
-            'node_proxy_fan_rpm',
-            'Hardware fan speed in RPM',
-            NODE_PROXY_FAN_LABELS
-        )
-
-        metrics['node_proxy_firmware_info'] = Metric(
-            'gauge',
-            'node_proxy_firmware_info',
+            'hardware_firmware_info',
             'Firmware version information (value is always 1, version in label)',
-            NODE_PROXY_FIRMWARE_LABELS
+            HW_FIRMWARE_LABELS
         )
 
         return metrics
@@ -2064,111 +2079,139 @@ class Module(MgrModule, OrchestratorClientMixin):
         except Exception as e:
             self.log.error(f"Failed to get SMB metadata: {str(e)}")
 
+    def _hw_get_health_value(self, status_val, hostname='', comp_id='', category=''):
+        """Map a Redfish health status to a numeric value (0=OK, 1=Warning, 2=Error)."""
+        if isinstance(status_val, dict):
+            health_str = status_val.get('health', 'Unknown')
+        elif isinstance(status_val, str):
+            health_str = status_val
+        else:
+            health_str = 'Unknown'
+
+        value = HEALTH_STATUS_MAP.get(health_str)
+        if value is None:
+            self.log.warning(
+                f"node-proxy: unexpected health status "
+                f"'{health_str}' for {category}/{comp_id} "
+                f"on {hostname}, skipping"
+            )
+        return value
+
+    def _hw_set_health_metric(self, status_val, hostname, comp_id, category):
+        """Set ceph_hardware_health gauge for a single component."""
+        health_value = self._hw_get_health_value(
+            status_val, hostname, comp_id, category
+        )
+        if health_value is not None:
+            self.metrics['hardware_health'].set(
+                health_value, (hostname, comp_id, category)
+            )
+
+    def _hw_iter_components(self, status, category):
+        """Yield (comp_id, comp_dict) pairs from nested status[category] dicts."""
+        for components in status.get(category, {}).values():
+            for comp_id, comp in components.items():
+                if isinstance(comp, dict):
+                    yield comp_id, comp
+
+    def _hw_set_sensor_metric(self, comp, comp_id, hostname, category, metric_key):
+        """Set sensor value (temperature/fan) and health gauges using the sensor name."""
+        name = comp.get('name', comp_id)
+        reading = comp.get('reading')
+        if reading is not None and reading != 'unknown':
+            try:
+                self.metrics[metric_key].set(float(reading), (hostname, name))
+            except (ValueError, TypeError):
+                pass
+        self._hw_set_health_metric(comp.get('status', {}), hostname, name, category)
+
+    def _process_storage(self, status, hostname):
+        """Set storage capacity and health metrics per drive."""
+        for device_id, device in self._hw_iter_components(status, 'storage'):
+            capacity = device.get('capacity_bytes', 0)
+            labels = (
+                hostname,
+                device_id,
+                device.get('model', 'unknown'),
+                device.get('protocol', 'unknown'),
+                device.get('firmware_version', 'unknown'),
+                device.get('slot', 'unknown'),
+                device.get('serial_number', 'unknown')
+            )
+            self.metrics['hardware_storage_capacity_bytes'].set(capacity, labels)
+            self._hw_set_health_metric(device.get('status', {}), hostname, device_id, 'storage')
+
+    def _process_processors(self, status, hostname):
+        """Set CPU cores count and health metrics per processor."""
+        for cpu_id, cpu in self._hw_iter_components(status, 'processors'):
+            cores = cpu.get('total_cores', 0)
+            labels = (
+                hostname,
+                cpu_id,
+                cpu.get('manufacturer', 'unknown'),
+                cpu.get('model', 'unknown'),
+                cpu.get('total_threads', 'unknown')
+            )
+            self.metrics['hardware_cpu_cores'].set(cores, labels)
+            self._hw_set_health_metric(cpu.get('status', {}), hostname, cpu_id, 'processors')
+
+    def _process_memory(self, status, hostname):
+        """Set memory capacity (in bytes) and health metrics per DIMM."""
+        for dimm_id, dimm in self._hw_iter_components(status, 'memory'):
+            capacity_mib = dimm.get('capacity_mi_b', 0)
+            capacity_bytes = capacity_mib * MIB_TO_BYTES
+            labels = (
+                hostname,
+                dimm_id,
+                dimm.get('memory_device_type', 'unknown'),
+            )
+            self.metrics['hardware_memory_capacity_bytes'].set(capacity_bytes, labels)
+            self._hw_set_health_metric(dimm.get('status', {}), hostname, dimm_id, 'memory')
+
+    def _process_power_network(self, status, hostname):
+        """Set health metrics for power and network"""
+        for comp_id, comp in self._hw_iter_components(status, 'power'):
+            name = comp.get('name', comp_id)
+            self._hw_set_health_metric(comp.get('status', {}), hostname, name, 'power')
+        for comp_id, comp in self._hw_iter_components(status, 'network'):
+            self._hw_set_health_metric(comp.get('status', {}), hostname, comp_id, 'network')
+
+    def _process_sensors(self, status, hostname):
+        """Set fan and temperature readings and health metrics"""
+        for category, sensor in SENSOR_METRICS.items():
+            for comp_id, comp in self._hw_iter_components(status, category):
+                self._hw_set_sensor_metric(comp, comp_id, hostname, category, sensor['metric'])
+
+    def _process_firmware(self, hostname, data):
+        """Set firmware info metrics (value=1) with version as label, skip unknown."""
+        fw_data = data.get('firmware', data.get('firmwares', {}))
+        for fw_id, fw_info in fw_data.items():
+            component = fw_info.get('name', fw_id)
+            version = fw_info.get('version', 'unknown')
+            if version and version != 'unknown':
+                labels = (hostname, component, str(version))
+                self.metrics['hardware_firmware_info'].set(1, labels)
+
     @profile_method(True)
     def get_hardware_metrics(self) -> None:
+        """Fetch node-proxy fullreport and export all hardware metrics."""
         if not self.orch_is_available():
             return
 
         try:
             report = raise_if_exception(self.node_proxy_fullreport())
-            firmware_report = raise_if_exception(self.node_proxy_firmware())
         except Exception as e:
             self.log.debug(f"node-proxy data not available: {e}")
             return
 
-        for host, data in report.items():
+        for hostname, data in report.items():
             status = data.get('status', {})
-
-            for sys_id, devices in status.get('storage', {}).items():
-                for device_id, device in devices.items():
-                    capacity = device.get('capacity_bytes', 0)
-                    labels = (
-                        host,
-                        device_id,
-                        device.get('model', 'unknown'),
-                        device.get('protocol', 'unknown')
-                    )
-                    self.metrics['node_proxy_storage_capacity_bytes'].set(capacity, labels)
-
-            for sys_id, cpus in status.get('processors', {}).items():
-                for cpu_id, cpu in cpus.items():
-                    cores = cpu.get('total_cores', 0)
-                    labels = (
-                        host,
-                        cpu_id,
-                        cpu.get('manufacturer', 'unknown'),
-                        cpu.get('model', 'unknown')
-                    )
-                    self.metrics['node_proxy_cpu_cores'].set(cores, labels)
-
-            for sys_id, dimms in status.get('memory', {}).items():
-                for dimm_id, dimm in dimms.items():
-                    capacity_mib = dimm.get('capacity_mi_b', 0)
-                    capacity_bytes = capacity_mib * MIB_TO_BYTES
-                    labels = (
-                        host,
-                        dimm_id,
-                        dimm.get('memory_device_type', 'unknown'),
-                        dimm.get('manufacturer', 'unknown')
-                    )
-                    self.metrics['node_proxy_memory_capacity_bytes'].set(capacity_bytes, labels)
-
-            for category in ['storage', 'processors', 'memory', 'power', 'fans', 'network', 'temperatures']:
-                for sys_id, components in status.get(category, {}).items():
-                    for comp_id, comp in components.items():
-                        if not isinstance(comp, dict):
-                            continue
-                        status_val = comp.get('status', {})
-                        if isinstance(status_val, dict):
-                            health_str = status_val.get('health', 'Unknown')
-                        elif isinstance(status_val, str):
-                            health_str = status_val
-                        else:
-                            health_str = 'Unknown'
-
-                        if health_str == 'OK':
-                            health_value = 0
-                        elif health_str in ['Warning', 'Degraded']:
-                            health_value = 1
-                        else:
-                            health_value = 2
-
-                        labels = (host, comp_id, category)
-                        self.metrics['node_proxy_health'].set(health_value, labels)
-
-            for sys_id, sensors in status.get('temperatures', {}).items():
-                for sensor_id, sensor in sensors.items():
-                    reading = sensor.get('reading')
-                    sensor_name = sensor.get('name', sensor_id)
-                    if reading is None or reading == 'unknown':
-                        continue
-                    try:
-                        temp_value = float(reading)
-                        labels = (host, sensor_name)
-                        self.metrics['node_proxy_temperature_celsius'].set(temp_value, labels)
-                    except (ValueError, TypeError):
-                        continue
-
-            for sys_id, fans_data in status.get('fans', {}).items():
-                for fan_id, fan in fans_data.items():
-                    rpm = fan.get('reading')
-                    fan_name = fan.get('name', fan_id)
-                    if rpm is None or rpm == 'unknown':
-                        continue
-                    try:
-                        rpm_value = float(rpm)
-                        labels = (host, fan_name)
-                        self.metrics['node_proxy_fan_rpm'].set(rpm_value, labels)
-                    except (ValueError, TypeError):
-                        continue
-
-        for host, fw_data in firmware_report.items():
-            for fw_id, fw_info in fw_data.items():
-                component = fw_info.get('name', fw_id)
-                version = fw_info.get('version', 'unknown')
-                if version and version != 'unknown':
-                    labels = (host, component, str(version))
-                    self.metrics['node_proxy_firmware_info'].set(1, labels)
+            self._process_firmware(hostname, data)
+            self._process_storage(status, hostname)
+            self._process_processors(status, hostname)
+            self._process_memory(status, hostname)
+            self._process_power_network(status, hostname)
+            self._process_sensors(status, hostname)
 
     @profile_method(True)
     def collect(self) -> str:

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -2111,7 +2111,7 @@ class Module(MgrModule, OrchestratorClientMixin):
                     )
                     self.metrics['node_proxy_memory_capacity_mib'].set(capacity, labels)
 
-            for category in ['storage', 'processors', 'memory', 'power', 'fans', 'network']:
+            for category in ['storage', 'processors', 'memory', 'power', 'fans', 'network', 'temperatures']:
                 for sys_id, components in status.get(category, {}).items():
                     for comp_id, comp in components.items():
                         health_str = comp.get('status', {}).get('health', 'Unknown')

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -163,17 +163,19 @@ HEALTH_STATUS_MAP = {
     'Critical': 2,
 }
 
-SENSOR_METRICS = {
-    'fans': {
-        'metric': 'hardware_fan_rpm',
-        'description': 'Hardware fan speed in RPM',
-        'labels': HW_FAN_LABELS,
-    },
-    'temperatures': {
-        'metric': 'hardware_temperature_celsius',
-        'description': 'Hardware temperature sensor reading in Celsius',
-        'labels': HW_TEMP_LABELS,
-    },
+sensor_metric = namedtuple('sensor_metric', 'metric description labels')
+
+SENSOR_METRICS: Dict[str, sensor_metric] = {
+    'fans': sensor_metric(
+        'hardware_fan_rpm',
+        'Hardware fan speed in RPM',
+        HW_FAN_LABELS,
+    ),
+    'temperatures': sensor_metric(
+        'hardware_temperature_celsius',
+        'Hardware temperature sensor reading in Celsius',
+        HW_TEMP_LABELS,
+    )
 }
 
 CEPHADM_DAEMON_STATUS = ('service_type', 'daemon_name', 'hostname', 'service_name')
@@ -1063,11 +1065,11 @@ class Module(MgrModule, OrchestratorClientMixin):
         )
 
         for sensor in SENSOR_METRICS.values():
-            metrics[sensor['metric']] = Metric(
+            metrics[sensor.metric] = Metric(
                 'gauge',
-                sensor['metric'],
-                sensor['description'],
-                sensor['labels']
+                sensor.metric,
+                sensor.description,
+                sensor.labels
             )
 
         metrics['hardware_firmware_info'] = Metric(
@@ -2079,7 +2081,10 @@ class Module(MgrModule, OrchestratorClientMixin):
         except Exception as e:
             self.log.error(f"Failed to get SMB metadata: {str(e)}")
 
-    def _hw_get_health_value(self, status_val, hostname='', comp_id='', category=''):
+    def _hw_get_health_value(
+            self, status_val: Any, hostname: str = '',
+            comp_id: str = '', category: str = ''
+    ) -> Optional[int]:
         """Map a Redfish health status to a numeric value (0=OK, 1=Warning, 2=Error)."""
         if isinstance(status_val, dict):
             health_str = status_val.get('health', 'Unknown')
@@ -2097,8 +2102,11 @@ class Module(MgrModule, OrchestratorClientMixin):
             )
         return value
 
-    def _hw_set_health_metric(self, status_val, hostname, comp_id, category):
-        """Set ceph_hardware_health gauge for a single component."""
+    def _hw_set_health_metric(
+            self, status_val: Any, hostname: str,
+            comp_id: str, category: str
+    ) -> None:
+        """Set hardware_health gauge for a single component."""
         health_value = self._hw_get_health_value(
             status_val, hostname, comp_id, category
         )
@@ -2107,14 +2115,19 @@ class Module(MgrModule, OrchestratorClientMixin):
                 health_value, (hostname, comp_id, category)
             )
 
-    def _hw_iter_components(self, status, category):
+    def _hw_iter_components(
+            self, status: Dict[str, Any], category: str
+    ) -> Iterator[Tuple[str, Dict[str, Any]]]:
         """Yield (comp_id, comp_dict) pairs from nested status[category] dicts."""
         for components in status.get(category, {}).values():
             for comp_id, comp in components.items():
                 if isinstance(comp, dict):
                     yield comp_id, comp
 
-    def _hw_set_sensor_metric(self, comp, comp_id, hostname, category, metric_key):
+    def _hw_set_sensor_metric(
+            self, comp: Dict[str, Any], comp_id: str,
+            hostname: str, category: str, metric_key: str
+    ) -> None:
         """Set sensor value (temperature/fan) and health gauges using the sensor name."""
         name = comp.get('name', comp_id)
         reading = comp.get('reading')
@@ -2125,7 +2138,7 @@ class Module(MgrModule, OrchestratorClientMixin):
                 pass
         self._hw_set_health_metric(comp.get('status', {}), hostname, name, category)
 
-    def _process_storage(self, status, hostname):
+    def _process_storage(self, status: Dict[str, Any], hostname: str) -> None:
         """Set storage capacity and health metrics per drive."""
         for device_id, device in self._hw_iter_components(status, 'storage'):
             capacity = device.get('capacity_bytes', 0)
@@ -2141,7 +2154,7 @@ class Module(MgrModule, OrchestratorClientMixin):
             self.metrics['hardware_storage_capacity_bytes'].set(capacity, labels)
             self._hw_set_health_metric(device.get('status', {}), hostname, device_id, 'storage')
 
-    def _process_processors(self, status, hostname):
+    def _process_processors(self, status: Dict[str, Any], hostname: str) -> None:
         """Set CPU cores count and health metrics per processor."""
         for cpu_id, cpu in self._hw_iter_components(status, 'processors'):
             cores = cpu.get('total_cores', 0)
@@ -2155,7 +2168,7 @@ class Module(MgrModule, OrchestratorClientMixin):
             self.metrics['hardware_cpu_cores'].set(cores, labels)
             self._hw_set_health_metric(cpu.get('status', {}), hostname, cpu_id, 'processors')
 
-    def _process_memory(self, status, hostname):
+    def _process_memory(self, status: Dict[str, Any], hostname: str) -> None:
         """Set memory capacity (in bytes) and health metrics per DIMM."""
         for dimm_id, dimm in self._hw_iter_components(status, 'memory'):
             capacity_mib = dimm.get('capacity_mi_b', 0)
@@ -2168,7 +2181,7 @@ class Module(MgrModule, OrchestratorClientMixin):
             self.metrics['hardware_memory_capacity_bytes'].set(capacity_bytes, labels)
             self._hw_set_health_metric(dimm.get('status', {}), hostname, dimm_id, 'memory')
 
-    def _process_power_network(self, status, hostname):
+    def _process_power_network(self, status: Dict[str, Any], hostname: str) -> None:
         """Set health metrics for power and network"""
         for comp_id, comp in self._hw_iter_components(status, 'power'):
             name = comp.get('name', comp_id)
@@ -2176,13 +2189,13 @@ class Module(MgrModule, OrchestratorClientMixin):
         for comp_id, comp in self._hw_iter_components(status, 'network'):
             self._hw_set_health_metric(comp.get('status', {}), hostname, comp_id, 'network')
 
-    def _process_sensors(self, status, hostname):
+    def _process_sensors(self, status: Dict[str, Any], hostname: str) -> None:
         """Set fan and temperature readings and health metrics"""
         for category, sensor in SENSOR_METRICS.items():
             for comp_id, comp in self._hw_iter_components(status, category):
-                self._hw_set_sensor_metric(comp, comp_id, hostname, category, sensor['metric'])
+                self._hw_set_sensor_metric(comp, comp_id, hostname, category, sensor.metric)
 
-    def _process_firmware(self, hostname, data):
+    def _process_firmware(self, hostname: str, data: Dict[str, Any]) -> None:
         """Set firmware info metrics (value=1) with version as label, skip unknown."""
         fw_data = data.get('firmware', data.get('firmwares', {}))
         for fw_id, fw_info in fw_data.items():

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -2065,112 +2065,99 @@ class Module(MgrModule, OrchestratorClientMixin):
 
     @profile_method(True)
     def get_hardware_metrics(self) -> None:
-        """Collect hardware metrics from node-proxy KV store"""
-        NODE_PROXY_CACHE_PREFIX = 'mgr/cephadm/node_proxy'
+        if not self.orch_is_available():
+            return
 
         try:
-            for key, value in self.get_store_prefix(f'{NODE_PROXY_CACHE_PREFIX}/data').items():
-                host = key.split('/')[-1]
-                try:
-                    data = json.loads(value)
-                except json.JSONDecodeError:
-                    self.log.error(f"Failed to decode node-proxy data for host {host}")
-                    continue
-
-                status = data.get('status', {})
-
-                # Storage metrics
-                for sys_id, devices in status.get('storage', {}).items():
-                    for device_id, device in devices.items():
-                        capacity = device.get('capacity_bytes', 0)
-                        labels = (
-                            host,
-                            device_id,
-                            device.get('model', 'unknown'),
-                            device.get('protocol', 'unknown')
-                        )
-                        self.metrics['node_proxy_storage_capacity_bytes'].set(capacity, labels)
-
-                # CPU metrics
-                for sys_id, cpus in status.get('processors', {}).items():
-                    for cpu_id, cpu in cpus.items():
-                        cores = cpu.get('total_cores', 0)
-                        labels = (
-                            host,
-                            cpu_id,
-                            cpu.get('manufacturer', 'unknown'),
-                            cpu.get('model', 'unknown')
-                        )
-                        self.metrics['node_proxy_cpu_cores'].set(cores, labels)
-
-                # Memory metrics
-                for sys_id, dimms in status.get('memory', {}).items():
-                    for dimm_id, dimm in dimms.items():
-                        capacity = dimm.get('capacity_mi_b', 0)
-                        labels = (
-                            host,
-                            dimm_id,
-                            dimm.get('memory_device_type', 'unknown'),
-                            dimm.get('manufacturer', 'unknown')
-                        )
-                        self.metrics['node_proxy_memory_capacity_mib'].set(capacity, labels)
-
-                # Health metrics for all component types
-                for category in ['storage', 'processors', 'memory', 'power', 'fans', 'network']:
-                    for sys_id, components in status.get(category, {}).items():
-                        for comp_id, comp in components.items():
-                            health_str = comp.get('status', {}).get('health', 'Unknown')
-                            if health_str == 'OK':
-                                health_value = 0
-                            elif health_str in ['Warning', 'Degraded']:
-                                health_value = 1
-                            else:
-                                health_value = 2
-
-                            labels = (host, comp_id, category)
-                            self.metrics['node_proxy_health'].set(health_value, labels)
-
-                # Temperature metrics
-                for sys_id, sensors in status.get('temperatures', {}).items():
-                    for sensor_id, sensor in sensors.items():
-                        reading = sensor.get('reading')
-                        sensor_name = sensor.get('name', sensor_id)
-                        # Skip absent/unknown sensors
-                        if reading is None or reading == 'unknown':
-                            continue
-                        try:
-                            temp_value = float(reading)
-                            labels = (host, sensor_name)
-                            self.metrics['node_proxy_temperature_celsius'].set(temp_value, labels)
-                        except (ValueError, TypeError):
-                            continue
-
-                # Fan RPM metrics
-                for sys_id, fans_data in status.get('fans', {}).items():
-                    for fan_id, fan in fans_data.items():
-                        # Redfish uses 'Reading' field per Thermal schema
-                        # node-proxy normalizes it to lowercase 'reading'
-                        rpm = fan.get('reading')
-                        fan_name = fan.get('name', fan_id)
-                        if rpm is None or rpm == 'unknown':
-                            continue
-                        try:
-                            rpm_value = float(rpm)
-                            labels = (host, fan_name)
-                            self.metrics['node_proxy_fan_rpm'].set(rpm_value, labels)
-                        except (ValueError, TypeError):
-                            continue
-
-                # Firmware version metrics
-                firmwares = data.get('firmwares', {})
-                for fw_id, fw_info in firmwares.items():
-                    component = fw_info.get('name', fw_id)
-                    version = fw_info.get('version', 'unknown')
-                    if version and version != 'unknown':
-                        labels = (host, component, str(version))
-                        self.metrics['node_proxy_firmware_info'].set(1, labels)
+            report = raise_if_exception(self.node_proxy_fullreport())
+            firmware_report = raise_if_exception(self.node_proxy_firmware())
         except Exception as e:
-            self.log.error(f"Failed to collect hardware metrics: {str(e)}")
+            self.log.debug(f"node-proxy data not available: {e}")
+            return
+
+        for host, data in report.items():
+            status = data.get('status', {})
+
+            for sys_id, devices in status.get('storage', {}).items():
+                for device_id, device in devices.items():
+                    capacity = device.get('capacity_bytes', 0)
+                    labels = (
+                        host,
+                        device_id,
+                        device.get('model', 'unknown'),
+                        device.get('protocol', 'unknown')
+                    )
+                    self.metrics['node_proxy_storage_capacity_bytes'].set(capacity, labels)
+
+            for sys_id, cpus in status.get('processors', {}).items():
+                for cpu_id, cpu in cpus.items():
+                    cores = cpu.get('total_cores', 0)
+                    labels = (
+                        host,
+                        cpu_id,
+                        cpu.get('manufacturer', 'unknown'),
+                        cpu.get('model', 'unknown')
+                    )
+                    self.metrics['node_proxy_cpu_cores'].set(cores, labels)
+
+            for sys_id, dimms in status.get('memory', {}).items():
+                for dimm_id, dimm in dimms.items():
+                    capacity = dimm.get('capacity_mi_b', 0)
+                    labels = (
+                        host,
+                        dimm_id,
+                        dimm.get('memory_device_type', 'unknown'),
+                        dimm.get('manufacturer', 'unknown')
+                    )
+                    self.metrics['node_proxy_memory_capacity_mib'].set(capacity, labels)
+
+            for category in ['storage', 'processors', 'memory', 'power', 'fans', 'network']:
+                for sys_id, components in status.get(category, {}).items():
+                    for comp_id, comp in components.items():
+                        health_str = comp.get('status', {}).get('health', 'Unknown')
+                        if health_str == 'OK':
+                            health_value = 0
+                        elif health_str in ['Warning', 'Degraded']:
+                            health_value = 1
+                        else:
+                            health_value = 2
+
+                        labels = (host, comp_id, category)
+                        self.metrics['node_proxy_health'].set(health_value, labels)
+
+            for sys_id, sensors in status.get('temperatures', {}).items():
+                for sensor_id, sensor in sensors.items():
+                    reading = sensor.get('reading')
+                    sensor_name = sensor.get('name', sensor_id)
+                    if reading is None or reading == 'unknown':
+                        continue
+                    try:
+                        temp_value = float(reading)
+                        labels = (host, sensor_name)
+                        self.metrics['node_proxy_temperature_celsius'].set(temp_value, labels)
+                    except (ValueError, TypeError):
+                        continue
+
+            for sys_id, fans_data in status.get('fans', {}).items():
+                for fan_id, fan in fans_data.items():
+                    rpm = fan.get('reading')
+                    fan_name = fan.get('name', fan_id)
+                    if rpm is None or rpm == 'unknown':
+                        continue
+                    try:
+                        rpm_value = float(rpm)
+                        labels = (host, fan_name)
+                        self.metrics['node_proxy_fan_rpm'].set(rpm_value, labels)
+                    except (ValueError, TypeError):
+                        continue
+
+        for host, fw_data in firmware_report.items():
+            for fw_id, fw_info in fw_data.items():
+                component = fw_info.get('name', fw_id)
+                version = fw_info.get('version', 'unknown')
+                if version and version != 'unknown':
+                    labels = (host, component, str(version))
+                    self.metrics['node_proxy_firmware_info'].set(1, labels)
 
     @profile_method(True)
     def collect(self) -> str:

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -2066,7 +2066,7 @@ class Module(MgrModule, OrchestratorClientMixin):
     @profile_method(True)
     def get_hardware_metrics(self) -> None:
         """Collect hardware metrics from node-proxy KV store"""
-        NODE_PROXY_CACHE_PREFIX = 'node_proxy'
+        NODE_PROXY_CACHE_PREFIX = 'mgr/cephadm/node_proxy'
 
         try:
             for key, value in self.get_store_prefix(f'{NODE_PROXY_CACHE_PREFIX}/data').items():

--- a/src/pybind/mgr/prometheus/test_module.py
+++ b/src/pybind/mgr/prometheus/test_module.py
@@ -181,3 +181,293 @@ class ThreadSafeLRUCacheDictTest(TestCase):
         self.assertEqual(len(cache), 100)
         for i in range(100):
             self.assertEqual(cache[f'key{i}'], f'value{i}')
+
+
+MOCK_HW_FULLREPORT = {
+    'at3n2.tuc.stglabs.ibm.com': {
+        'host': 'at3n2.tuc.stglabs.ibm.com',
+        'sn': '11S03NK990YM30ZP58E02X',
+        'status': {
+            'storage': {'Self': {
+                'nvme_device0_nsid1': {
+                    'capacity_bytes': 512110190592,
+                    'model': 'Micron_2550_MTFDKBK512TGE',
+                    'protocol': 'NVMe',
+                    'serial_number': '24424BAA3C40',
+                    'firmware_version': 'V6MA001',
+                    'slot': '0',
+                    'status': {'health': 'OK', 'state': 'Enabled'},
+                },
+            }},
+            'processors': {'Self': {
+                'devtype1_cpu0': {
+                    'total_cores': 48,
+                    'total_threads': 96,
+                    'model': 'unknown',
+                    'manufacturer': 'Advanced Micro Devices, Inc.',
+                    'status': {'health': 'OK', 'state': 'Enabled'},
+                },
+            }},
+            'memory': {'Self': {
+                'devtype2_dimm0': {
+                    'memory_device_type': 'DDR5',
+                    'capacity_mi_b': 131072,
+                    'status': {'health': 'OK', 'state': 'Enabled'},
+                },
+            }},
+            'power': {'Self': {
+                '38': {
+                    'name': 'PSU1_PIN',
+                    'status': {'health': 'OK', 'state': 'Enabled'},
+                },
+                '39': {
+                    'name': 'PSU1_POUT',
+                    'status': {'health': 'OK', 'state': 'Enabled'},
+                },
+            }},
+            'network': {'Self': {
+                'networkinterfaces_devtype7_nic0': {
+                    'name': 'NetworkAdapter_0',
+                    'status': {'health': 'OK', 'state': 'Enabled'},
+                },
+            }},
+            'fans': {'Self': {
+                '0': {
+                    'name': 'FAN1_TACH_IN',
+                    'reading': 23940,
+                    'reading_units': 'RPM',
+                    'status': {'health': 'OK', 'state': 'Enabled'},
+                },
+            }},
+            'temperatures': {'Self': {
+                '0': {
+                    'name': 'C1_DCSCM_TEMP',
+                    'reading': 32,
+                    'reading_units': 'Cel',
+                    'status': {'health': 'OK', 'state': 'Enabled'},
+                },
+                '6': {
+                    'name': 'C1_CPU_TEMP',
+                    'reading': 47,
+                    'reading_units': 'Cel',
+                    'status': {'health': 'OK', 'state': 'Enabled'},
+                },
+            }},
+        },
+        'firmware': {
+            'bios': {
+                'name': 'BIOS',
+                'version': 'unknown',
+            },
+            'bmc': {
+                'name': 'BMC',
+                'version': '0.50.d57cfd',
+            },
+            'cpld': {
+                'name': 'CPLD',
+                'version': 'unknown',
+            },
+        },
+    }
+}
+
+
+class HardwareMetricsTest(TestCase):
+    """Tests for hardware metrics processing from node-proxy fullreport data."""
+
+    def setUp(self):
+        from prometheus.module import (
+            Module, HW_STORAGE_LABELS, HW_CPU_LABELS, HW_MEMORY_LABELS,
+            HW_HEALTH_LABELS, HW_TEMP_LABELS, HW_FAN_LABELS, HW_FIRMWARE_LABELS,
+        )
+        self.module = mock.MagicMock(spec=Module)
+        self.module.log = mock.MagicMock()
+        self.module.metrics = {
+            'hardware_storage_capacity_bytes': Metric(
+                'gauge', 'hardware_storage_capacity_bytes', '', HW_STORAGE_LABELS),
+            'hardware_cpu_cores': Metric(
+                'gauge', 'hardware_cpu_cores', '', HW_CPU_LABELS),
+            'hardware_memory_capacity_bytes': Metric(
+                'gauge', 'hardware_memory_capacity_bytes', '', HW_MEMORY_LABELS),
+            'hardware_health': Metric(
+                'gauge', 'hardware_health', '', HW_HEALTH_LABELS),
+            'hardware_temperature_celsius': Metric(
+                'gauge', 'hardware_temperature_celsius', '', HW_TEMP_LABELS),
+            'hardware_fan_rpm': Metric(
+                'gauge', 'hardware_fan_rpm', '', HW_FAN_LABELS),
+            'hardware_firmware_info': Metric(
+                'gauge', 'hardware_firmware_info', '', HW_FIRMWARE_LABELS),
+        }
+        self.hostname = 'at3n2.tuc.stglabs.ibm.com'
+        self.data = MOCK_HW_FULLREPORT[self.hostname]
+        self.status = self.data['status']
+        self.module._hw_get_health_value = Module._hw_get_health_value.__get__(self.module)
+        self.module._hw_set_health_metric = Module._hw_set_health_metric.__get__(self.module)
+        self.module._hw_iter_components = Module._hw_iter_components.__get__(self.module)
+        self.module._hw_set_sensor_metric = Module._hw_set_sensor_metric.__get__(self.module)
+        self.module._process_storage = Module._process_storage.__get__(self.module)
+        self.module._process_processors = Module._process_processors.__get__(self.module)
+        self.module._process_memory = Module._process_memory.__get__(self.module)
+        self.module._process_power_network = Module._process_power_network.__get__(self.module)
+        self.module._process_sensors = Module._process_sensors.__get__(self.module)
+        self.module._process_firmware = Module._process_firmware.__get__(self.module)
+
+    # --- _hw_get_health_value ---
+
+    def test_health_value_ok(self):
+        val = self.module._hw_get_health_value({'health': 'OK'})
+        self.assertEqual(val, 0)
+
+    def test_health_value_warning(self):
+        val = self.module._hw_get_health_value({'health': 'Warning'})
+        self.assertEqual(val, 1)
+
+    def test_health_value_critical(self):
+        val = self.module._hw_get_health_value({'health': 'Critical'})
+        self.assertEqual(val, 2)
+
+    def test_health_value_string_input(self):
+        val = self.module._hw_get_health_value('OK')
+        self.assertEqual(val, 0)
+
+    def test_health_value_unknown_logs_warning(self):
+        val = self.module._hw_get_health_value(
+            {'health': 'Exploded'}, 'host1', 'comp1', 'storage')
+        self.assertIsNone(val)
+        self.module.log.warning.assert_called_once()
+
+    def test_health_value_unknown_skips_metric(self):
+        self.module._hw_set_health_metric(
+            {'health': 'Exploded'}, 'host1', 'comp1', 'storage')
+        self.assertEqual(self.module.metrics['hardware_health'].value, {})
+
+    # --- _process_storage ---
+
+    def test_storage_capacity_and_labels(self):
+        self.module._process_storage(self.status, self.hostname)
+        expected_labels = (
+            self.hostname, 'nvme_device0_nsid1',
+            'Micron_2550_MTFDKBK512TGE', 'NVMe', 'V6MA001', '0', '24424BAA3C40',
+        )
+        self.assertEqual(
+            self.module.metrics['hardware_storage_capacity_bytes'].value[expected_labels],
+            512110190592,
+        )
+
+    def test_storage_sets_health(self):
+        self.module._process_storage(self.status, self.hostname)
+        health_labels = (self.hostname, 'nvme_device0_nsid1', 'storage')
+        self.assertEqual(
+            self.module.metrics['hardware_health'].value[health_labels], 0)
+
+    # --- _process_processors ---
+
+    def test_cpu_cores_and_threads_label(self):
+        self.module._process_processors(self.status, self.hostname)
+        expected_labels = (
+            self.hostname, 'devtype1_cpu0',
+            'Advanced Micro Devices, Inc.', 'unknown', 96,
+        )
+        self.assertEqual(
+            self.module.metrics['hardware_cpu_cores'].value[expected_labels], 48)
+
+    # --- _process_memory ---
+
+    def test_memory_mib_to_bytes_conversion(self):
+        self.module._process_memory(self.status, self.hostname)
+        expected_labels = (self.hostname, 'devtype2_dimm0', 'DDR5')
+        self.assertEqual(
+            self.module.metrics['hardware_memory_capacity_bytes'].value[expected_labels],
+            131072 * 1048576,
+        )
+
+    # --- _process_power_network ---
+
+    def test_power_uses_name_not_numeric_id(self):
+        """Power components use human-readable name (PSU1_PIN) not dict key (38)."""
+        self.module._process_power_network(self.status, self.hostname)
+        health = self.module.metrics['hardware_health'].value
+        self.assertIn((self.hostname, 'PSU1_PIN', 'power'), health)
+        self.assertIn((self.hostname, 'PSU1_POUT', 'power'), health)
+        self.assertNotIn((self.hostname, '38', 'power'), health)
+        self.assertNotIn((self.hostname, '39', 'power'), health)
+
+    def test_network_uses_comp_id_not_generic_name(self):
+        """Network uses descriptive comp_id, not generic 'NetworkAdapter_0'."""
+        self.module._process_power_network(self.status, self.hostname)
+        health = self.module.metrics['hardware_health'].value
+        self.assertIn(
+            (self.hostname, 'networkinterfaces_devtype7_nic0', 'network'), health)
+        self.assertNotIn(
+            (self.hostname, 'NetworkAdapter_0', 'network'), health)
+
+    # --- _process_sensors ---
+
+    def test_temperature_uses_sensor_name(self):
+        """Temperature reading uses 'C1_DCSCM_TEMP' not numeric key '0'."""
+        self.module._process_sensors(self.status, self.hostname)
+        temp = self.module.metrics['hardware_temperature_celsius'].value
+        self.assertIn((self.hostname, 'C1_DCSCM_TEMP'), temp)
+        self.assertEqual(temp[(self.hostname, 'C1_DCSCM_TEMP')], 32.0)
+        self.assertNotIn((self.hostname, '0'), temp)
+
+    def test_temperature_health_uses_sensor_name(self):
+        """Health metric for temperatures also uses sensor name, not numeric key."""
+        self.module._process_sensors(self.status, self.hostname)
+        health = self.module.metrics['hardware_health'].value
+        self.assertIn((self.hostname, 'C1_DCSCM_TEMP', 'temperatures'), health)
+        self.assertIn((self.hostname, 'C1_CPU_TEMP', 'temperatures'), health)
+        self.assertNotIn((self.hostname, '0', 'temperatures'), health)
+        self.assertNotIn((self.hostname, '6', 'temperatures'), health)
+
+    def test_fan_uses_fan_name(self):
+        """Fan reading uses 'FAN1_TACH_IN' not numeric key '0'."""
+        self.module._process_sensors(self.status, self.hostname)
+        fan = self.module.metrics['hardware_fan_rpm'].value
+        self.assertIn((self.hostname, 'FAN1_TACH_IN'), fan)
+        self.assertEqual(fan[(self.hostname, 'FAN1_TACH_IN')], 23940.0)
+
+    def test_sensor_unknown_reading_skipped(self):
+        """Sensors with 'unknown' reading should not set reading metric but still set health."""
+        status = {'temperatures': {'Self': {
+            '99': {
+                'name': 'GHOST_TEMP',
+                'reading': 'unknown',
+                'status': {'health': 'OK', 'state': 'Enabled'},
+            },
+        }}}
+        self.module._process_sensors(status, self.hostname)
+        self.assertNotIn(
+            (self.hostname, 'GHOST_TEMP'),
+            self.module.metrics['hardware_temperature_celsius'].value)
+        self.assertIn(
+            (self.hostname, 'GHOST_TEMP', 'temperatures'),
+            self.module.metrics['hardware_health'].value)
+
+    # --- _process_firmware ---
+
+    def test_firmware_known_version_exported(self):
+        self.module._process_firmware(self.hostname, self.data)
+        fw = self.module.metrics['hardware_firmware_info'].value
+        self.assertIn((self.hostname, 'BMC', '0.50.d57cfd'), fw)
+        self.assertEqual(fw[(self.hostname, 'BMC', '0.50.d57cfd')], 1)
+
+    def test_firmware_unknown_version_skipped(self):
+        """BIOS and CPLD with version='unknown' should not be exported."""
+        self.module._process_firmware(self.hostname, self.data)
+        fw = self.module.metrics['hardware_firmware_info'].value
+        for labels in fw:
+            self.assertNotEqual(labels[1], 'BIOS')
+            self.assertNotEqual(labels[1], 'CPLD')
+
+    # --- label count consistency ---
+
+    def test_storage_label_count_matches(self):
+        self.module._process_storage(self.status, self.hostname)
+        for labels in self.module.metrics['hardware_storage_capacity_bytes'].value:
+            self.assertEqual(len(labels), 7)
+
+    def test_cpu_label_count_matches(self):
+        self.module._process_processors(self.status, self.hostname)
+        for labels in self.module.metrics['hardware_cpu_cores'].value:
+            self.assertEqual(len(labels), 5)


### PR DESCRIPTION
- exports node proxy metrics to promethues
- adds hardware monitoring dashboard in grafana
- adds unit tests
https://tracker.ceph.com/issues/77723
<img width="1311" height="2625" alt="Screenshot 2026-07-01 at 02-43-56 Ceph Hardware - Overview - Dashboards - Grafana" src="https://github.com/user-attachments/assets/365ed3f2-850e-43a6-a739-9cbe07b06e26" />

