### PR TITLE
mgr/dashboard: Add compression panels and PSU temperature

### DIFF
--- a/monitoring/ceph-mixin/dashboards/hardware.libsonnet
+++ b/monitoring/ceph-mixin/dashboards/hardware.libsonnet
@@ -82,9 +82,10 @@ local g = import 'grafonnet/grafana.libsonnet';
         )
         .addTarget($.addTargetSchema(
           'max(ceph_hardware_health)',
-          legendFormat='__auto'
+          legendFormat='Health'
         ))
         + {
+          description: 'Overall hardware health across all hosts',
           fieldConfig: {
             defaults: {
               mappings: [
@@ -116,8 +117,9 @@ local g = import 'grafonnet/grafana.libsonnet';
         ])
         .addTarget($.addTargetSchema(
           'max(ceph_hardware_temperature_celsius{sensor_name=~".*CPU_TEMP"})',
-          legendFormat='__auto'
-        )),
+          legendFormat='CPU'
+        ))
+        + { description: 'Highest CPU temperature across all hosts' },
 
         // BMC Versions
         $.pieChartPanel(
@@ -220,8 +222,9 @@ local g = import 'grafonnet/grafana.libsonnet';
           gridPosition={ h: 4, w: 2, x: 0, y: 5 }
         ).addTarget($.addTargetSchema(
           'count(count by(hostname) (ceph_hardware_health))',
-          legendFormat='__auto'
-        )),
+          legendFormat='Hosts'
+        ))
+        + { description: 'Total hosts with hardware monitoring' },
 
         // Drives
         $.addStatPanel(
@@ -231,8 +234,9 @@ local g = import 'grafonnet/grafana.libsonnet';
           gridPosition={ h: 4, w: 2, x: 2, y: 5 }
         ).addTarget($.addTargetSchema(
           'count(ceph_hardware_storage_capacity_bytes)',
-          legendFormat='__auto'
-        )),
+          legendFormat='Drives'
+        ))
+        + { description: 'Total storage drives detected' },
 
         // NVMe Temp
         $.addGaugePanel(
@@ -250,8 +254,9 @@ local g = import 'grafonnet/grafana.libsonnet';
         ])
         .addTarget($.addTargetSchema(
           'max(ceph_hardware_temperature_celsius{sensor_name=~"NVME.*_TEMP"})',
-          legendFormat='__auto'
-        )),
+          legendFormat='NVMe'
+        ))
+        + { description: 'Highest NVMe drive temperature across all hosts' },
       ] },
 
       // Row 2: Host Overview
@@ -264,9 +269,10 @@ local g = import 'grafonnet/grafana.libsonnet';
           gridPosition={ h: 3, w: 2, x: 0, y: 2 }
         ).addTarget($.addTargetSchema(
           'max(ceph_hardware_health{hostname=~"$hostname",category="power"})',
-          legendFormat='__auto'
+          legendFormat='Power'
         ))
         + {
+          description: 'Power supply health status',
           fieldConfig: {
             defaults: {
               mappings: [
@@ -287,9 +293,10 @@ local g = import 'grafonnet/grafana.libsonnet';
           gridPosition={ h: 4, w: 3, x: 2, y: 2 }
         ).addTarget($.addTargetSchema(
           'max(ceph_hardware_temperature_celsius{hostname=~"$hostname", sensor_name=~".*MB_TEMP.*"})',
-          legendFormat='__auto'
+          legendFormat='Motherboard'
         ))
         + {
+          description: 'Highest motherboard temperature',
           fieldConfig+: { defaults+: { thresholds: { mode: 'absolute', steps: [{ color: 'green' }, { color: '#EAB839', value: 70 }, { color: 'red', value: 80 }] } } },
           options+: { colorMode: 'none', graphMode: 'area' },
         },
@@ -302,9 +309,10 @@ local g = import 'grafonnet/grafana.libsonnet';
           gridPosition={ h: 4, w: 3, x: 5, y: 2 }
         ).addTarget($.addTargetSchema(
           'avg(ceph_hardware_temperature_celsius{hostname=~"$hostname", sensor_name=~".*CPU_TEMP"})',
-          legendFormat='__auto'
+          legendFormat='CPU'
         ))
         + {
+          description: 'Average CPU temperature',
           fieldConfig+: { defaults+: { max: 85, min: 0, thresholds: { mode: 'absolute', steps: [{ color: 'green' }, { color: '#EAB839', value: 80 }, { color: 'semi-dark-red', value: 90 }] } } },
           options+: { colorMode: 'none', graphMode: 'area' },
         },
@@ -317,9 +325,10 @@ local g = import 'grafonnet/grafana.libsonnet';
           gridPosition={ h: 4, w: 3, x: 8, y: 2 }
         ).addTarget($.addTargetSchema(
           'max(ceph_hardware_temperature_celsius{hostname=~"$hostname", sensor_name=~".*DIMM.*_TEMP"})',
-          legendFormat='__auto'
+          legendFormat='DIMM'
         ))
         + {
+          description: 'Highest DIMM temperature',
           fieldConfig+: { defaults+: { max: 88, min: 0, thresholds: { mode: 'absolute', steps: [{ color: 'green' }, { color: 'yellow', value: 70 }, { color: 'semi-dark-red', value: 80 }] } } },
           options+: { colorMode: 'none', graphMode: 'area' },
         },
@@ -332,9 +341,12 @@ local g = import 'grafonnet/grafana.libsonnet';
           gridPosition={ h: 4, w: 3, x: 11, y: 2 }
         ).addTarget($.addTargetSchema(
           'count(ceph_hardware_fan_rpm{hostname=~"$hostname", fan_name=~"PSU.*"})',
-          legendFormat='__auto'
+          legendFormat='PSU Fans'
         ))
-        + { options+: { colorMode: 'none', graphMode: 'none' } },
+        + {
+          description: 'Number of PSU fans detected',
+          options+: { colorMode: 'none', graphMode: 'none' },
+        },
 
         // AVG PSU Temperature
         $.addStatPanel(
@@ -344,9 +356,10 @@ local g = import 'grafonnet/grafana.libsonnet';
           gridPosition={ h: 4, w: 3, x: 14, y: 2 }
         ).addTarget($.addTargetSchema(
           'avg(ceph_hardware_temperature_celsius{hostname=~"$hostname", sensor_name=~"PSU.*_TEMP.*"})',
-          legendFormat='__auto'
+          legendFormat='PSU'
         ))
         + {
+          description: 'Average power supply temperature',
           fieldConfig+: { defaults+: { color: { fixedColor: 'blue', mode: 'fixed' }, max: 100, min: 0, thresholds: { mode: 'absolute', steps: [{ color: 'green' }, { color: 'yellow', value: 80 }, { color: 'semi-dark-red', value: 90 }] } } },
           options+: { colorMode: 'none', graphMode: 'area' },
         },
@@ -359,9 +372,10 @@ local g = import 'grafonnet/grafana.libsonnet';
           gridPosition={ h: 4, w: 3, x: 17, y: 2 }
         ).addTarget($.addTargetSchema(
           'count(ceph_hardware_storage_capacity_bytes{hostname=~"$hostname", protocol="NVMe"})',
-          legendFormat='__auto'
+          legendFormat='NVMe'
         ))
         + {
+          description: 'Number of NVMe drives detected',
           fieldConfig+: { defaults+: { color: { fixedColor: 'blue', mode: 'thresholds' }, thresholds: { mode: 'absolute', steps: [{ color: 'green' }, { color: '#EAB839', value: 70 }, { color: 'semi-dark-red', value: 78 }] } } },
           options+: { colorMode: 'none', graphMode: 'none' },
         },
@@ -374,9 +388,10 @@ local g = import 'grafonnet/grafana.libsonnet';
           gridPosition={ h: 4, w: 3, x: 20, y: 2 }
         ).addTarget($.addTargetSchema(
           'max(ceph_hardware_temperature_celsius{hostname=~"$hostname", sensor_name=~"NVME.*"})',
-          legendFormat='__auto'
+          legendFormat='NVMe'
         ))
         + {
+          description: 'Highest NVMe drive temperature',
           fieldConfig+: { defaults+: { color: { fixedColor: 'blue', mode: 'thresholds' }, max: 85, min: 0, thresholds: { mode: 'absolute', steps: [{ color: 'green' }, { color: '#EAB839', value: 70 }, { color: 'semi-dark-red', value: 78 }] } } },
           options+: { colorMode: 'none', graphMode: 'area' },
         },
@@ -389,9 +404,10 @@ local g = import 'grafonnet/grafana.libsonnet';
           gridPosition={ h: 3, w: 2, x: 0, y: 5 }
         ).addTarget($.addTargetSchema(
           'max(ceph_hardware_health{hostname=~"$hostname",category="network"})',
-          legendFormat='__auto'
+          legendFormat='Network'
         ))
         + {
+          description: 'Network adapter health status',
           fieldConfig: {
             defaults: {
               mappings: [
@@ -412,9 +428,10 @@ local g = import 'grafonnet/grafana.libsonnet';
           gridPosition={ h: 3, w: 2, x: 0, y: 8 }
         ).addTarget($.addTargetSchema(
           'max(ceph_hardware_health{hostname=~"$hostname",category="fans"})',
-          legendFormat='__auto'
+          legendFormat='Cooling'
         ))
         + {
+          description: 'Cooling fans health status',
           fieldConfig: {
             defaults: {
               mappings: [
@@ -435,9 +452,10 @@ local g = import 'grafonnet/grafana.libsonnet';
           gridPosition={ h: 3, w: 2, x: 0, y: 11 }
         ).addTarget($.addTargetSchema(
           'max(ceph_hardware_health{hostname=~"$hostname",category="storage"})',
-          legendFormat='__auto'
+          legendFormat='Drives'
         ))
         + {
+          description: 'Storage drives health status',
           fieldConfig: {
             defaults: {
               mappings: [
@@ -467,7 +485,7 @@ local g = import 'grafonnet/grafana.libsonnet';
         )
         .addTarget($.addTargetSchema(
           'ceph_hardware_storage_capacity_bytes{hostname=~"$hostname"}',
-          legendFormat='__auto',
+          legendFormat='',
           instant=true
         ) + { format: 'table' })
         .addTransformations([
@@ -509,7 +527,7 @@ local g = import 'grafonnet/grafana.libsonnet';
         )
         .addTarget($.addTargetSchema(
           'ceph_hardware_firmware_info{hostname=~"$hostname"}',
-          legendFormat='__auto',
+          legendFormat='',
           instant=true
         ) + { format: 'table' })
         .addTransformations([

--- a/monitoring/ceph-mixin/dashboards/hardware.libsonnet
+++ b/monitoring/ceph-mixin/dashboards/hardware.libsonnet
@@ -670,6 +670,27 @@ local g = import 'grafonnet/grafana.libsonnet';
             { alias: 'Critical', color: 'dark-red', dashes: true, fill: 0 },
           ],
         },
+
+        // PSU Temperatures
+        g.graphPanel.new(
+          title='PSU Temperatures',
+          datasource='$datasource',
+          format='celsius',
+        ).addTarget(
+          g.prometheus.target(
+            'ceph_hardware_temperature_celsius{hostname=~"$hostname", sensor_name=~"PSU.*_TEMP.*"}',
+            legendFormat='{{sensor_name}}'
+          )
+        ).addTarget(
+          g.prometheus.target('vector(65)', legendFormat='Critical')
+        )
+        + {
+          gridPos: { x: 0, y: 20, w: 12, h: 8 },
+          yaxes: [{ min: 0 }, {}],
+          seriesOverrides: [
+            { alias: 'Critical', color: 'dark-red', dashes: true, fill: 0 },
+          ],
+        },
       ] },
 
       // Row 5: FAN Speed History

--- a/monitoring/ceph-mixin/dashboards_out/ceph-hardware-compression.json
+++ b/monitoring/ceph-mixin/dashboards_out/ceph-hardware-compression.json
@@ -1,0 +1,1518 @@
+{
+  "__inputs": [],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "12.3.1"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "piechart",
+      "name": "Pie chart",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Hardware compression monitoring: track compression ratios, capacity savings, and physical storage utilization across compression-capable OSDs.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Amount of physical storage capacity saved through hardware compression.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 1099511627776
+              },
+              {
+                "color": "green",
+                "value": 10995116277760
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(ceph_extblkdev_dev_log_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}) - sum(ceph_extblkdev_dev_phy_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"})",
+          "instant": false,
+          "legendFormat": "Storage Saved",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Storage Saved",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Ratio of logical data to physical storage after compression. Higher values indicate better compression efficiency.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "orange",
+                "value": 1.1
+              },
+              {
+                "color": "yellow",
+                "value": 1.2
+              },
+              {
+                "color": "blue",
+                "value": 1.5
+              },
+              {
+                "color": "green",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(ceph_extblkdev_dev_log_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}) / clamp_min(sum(ceph_extblkdev_dev_phy_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}), 1)",
+          "instant": false,
+          "legendFormat": "Compression Ratio",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Compression Ratio (X:1)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Percentage of storage capacity saved through compression. Shows cost savings and infrastructure efficiency.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 25
+              },
+              {
+                "color": "green",
+                "value": 50
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "100 * (1 - sum(ceph_extblkdev_dev_phy_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}) / clamp_min(sum(ceph_extblkdev_dev_log_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}), 1))",
+          "instant": false,
+          "legendFormat": "Efficiency",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Compression Efficiency %",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Current usage of physical storage capacity. Monitor this for capacity planning and expansion decisions.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "orange",
+                "value": 80
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "100 * sum(ceph_extblkdev_dev_phy_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}) / clamp_min(sum(ceph_extblkdev_dev_phy_size{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}), 1)",
+          "instant": false,
+          "legendFormat": "Physical Utilization",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Physical Utilization %",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 101,
+      "panels": [],
+      "title": "Capacity",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Breakdown of physical storage: used versus available across compression-enabled OSDs.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "unit": "bytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Used"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "Used"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Free"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "Free"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 7
+      },
+      "id": 21,
+      "options": {
+        "displayLabels": [
+          "percent"
+        ],
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true,
+          "values": []
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "sort": "none",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(ceph_extblkdev_dev_phy_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"})",
+          "instant": false,
+          "legendFormat": "Used",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(ceph_extblkdev_dev_phy_size{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}) - sum(ceph_extblkdev_dev_phy_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Free",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Physical Capacity",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Total data written before compression is applied. What users and applications see.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3.5,
+        "w": 9,
+        "x": 15,
+        "y": 7
+      },
+      "id": 23,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(ceph_extblkdev_dev_log_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"})",
+          "instant": false,
+          "legendFormat": "Logical Used",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Logical Used",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Actual physical storage consumed after compression. Shows real storage used on hardware.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3.5,
+        "w": 9,
+        "x": 6,
+        "y": 7
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(ceph_extblkdev_dev_phy_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"})",
+          "instant": false,
+          "legendFormat": "Physical Used",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Physical Used",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Total physical storage capacity across all compression-capable OSDs.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3.5,
+        "w": 4.5,
+        "x": 15,
+        "y": 10.5
+      },
+      "id": 25,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(ceph_extblkdev_dev_phy_size{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"})",
+          "instant": false,
+          "legendFormat": "Physical Total",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Physical Total",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of OSDs with hardware compression capabilities detected.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-blue",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3.5,
+        "w": 4.5,
+        "x": 19.5,
+        "y": 10.5
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "count(ceph_extblkdev_dev_phy_size{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"})",
+          "instant": false,
+          "legendFormat": "OSDs",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Compression OSDs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Available physical storage capacity. Indicates remaining space for data growth.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "orange",
+                "value": 10995116277760
+              },
+              {
+                "color": "yellow",
+                "value": 54975581388800
+              },
+              {
+                "color": "green",
+                "value": 109951162777600
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3.5,
+        "w": 9,
+        "x": 6,
+        "y": 10.5
+      },
+      "id": 24,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(ceph_extblkdev_dev_phy_size{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}) - sum(ceph_extblkdev_dev_phy_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"})",
+          "instant": false,
+          "legendFormat": "Physical Free",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Physical Free",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 102,
+      "panels": [],
+      "title": "Trends & Analysis",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Historical compression effectiveness over time. Stable trend indicates consistent workload. Declining ratios suggest more incompressible data.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "none",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none",
+          "maxWidth": 400
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "round(sum(ceph_extblkdev_dev_log_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}) / sum(ceph_extblkdev_dev_phy_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}), 0.01)",
+          "instant": false,
+          "legendFormat": "Compression Ratio",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Compression Ratio Trend",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Storage capacity saved during the current time window. Shows rate of savings accumulation from compression.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(sum(ceph_extblkdev_dev_log_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}) - sum(ceph_extblkdev_dev_phy_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"})) - min_over_time((sum(ceph_extblkdev_dev_log_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}) - sum(ceph_extblkdev_dev_phy_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}))[$__range:])",
+          "instant": false,
+          "legendFormat": "Storage Saved",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Storage Saved Trend",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 103,
+      "panels": [],
+      "title": "OSD Utilization",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Physical Size"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Physical Used"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Logical Used"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Capacity Saved"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "Compression.*Ratio"
+            },
+            "properties": [
+              {
+                "id": "decimals",
+                "value": 2
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "color-text"
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": null
+                    },
+                    {
+                      "color": "orange",
+                      "value": 1.1
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 1.2
+                    },
+                    {
+                      "color": "blue",
+                      "value": 1.5
+                    },
+                    {
+                      "color": "green",
+                      "value": 2
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 15,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "ceph_extblkdev_dev_phy_size{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "Physical Size",
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "ceph_extblkdev_dev_phy_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "Physical Used",
+          "range": false,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "ceph_extblkdev_dev_log_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "Logical Used",
+          "range": false,
+          "refId": "C"
+        }
+      ],
+      "title": "",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "ceph_daemon",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true,
+              "__name__ 1": true,
+              "__name__ 2": true,
+              "__name__ 3": true,
+              "cluster 1": true,
+              "cluster 2": true,
+              "cluster 3": true,
+              "instance 1": true,
+              "instance 2": true,
+              "instance 3": true,
+              "job 1": true,
+              "job 2": true,
+              "job 3": true
+            },
+            "indexByName": {
+              "ceph_daemon": 0,
+              "Value #A": 1,
+              "Value #B": 2,
+              "Value #C": 3,
+              "Capacity Saved": 4,
+              "Compression Ratio": 5
+            },
+            "renameByName": {
+              "Value #A": "Physical Size",
+              "Value #B": "Physical Used",
+              "Value #C": "Logical Used",
+              "ceph_daemon": "OSD"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Compression Ratio",
+            "binary": {
+              "left": "Logical Used",
+              "operator": "/",
+              "right": "Physical Used"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Capacity Saved",
+            "binary": {
+              "left": "Logical Used",
+              "operator": "-",
+              "right": "Physical Used"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "OSD": 0,
+              "Physical Size": 1,
+              "Physical Used": 2,
+              "Logical Used": 3,
+              "Capacity Saved": 4,
+              "Compression Ratio": 5
+            },
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 42,
+  "tags": [
+    "ceph",
+    "storage",
+    "compression",
+    "hardware",
+    "capacity"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(ceph_extblkdev_dev_phy_size, cluster)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Cluster",
+        "multi": true,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(ceph_extblkdev_dev_phy_size, cluster)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(ceph_extblkdev_dev_phy_size{cluster=~\"$cluster\"}, instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Instance",
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values(ceph_extblkdev_dev_phy_size{cluster=~\"$cluster\"}, instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(ceph_extblkdev_dev_phy_size{cluster=~\"$cluster\", instance=~\"$instance\"}, ceph_daemon)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "OSD",
+        "multi": true,
+        "name": "osd",
+        "options": [],
+        "query": {
+          "query": "label_values(ceph_extblkdev_dev_phy_size{cluster=~\"$cluster\", instance=~\"$instance\"}, ceph_daemon)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 3,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Ceph Hardware - Cluster-Wide Compression",
+  "uid": "ceph-hw-compression-v2",
+  "version": 1,
+  "weekStart": ""
+}

--- a/monitoring/ceph-mixin/dashboards_out/hardware.json
+++ b/monitoring/ceph-mixin/dashboards_out/hardware.json
@@ -51,7 +51,7 @@
             {
                "colors": null,
                "datasource": "$datasource",
-               "description": "",
+               "description": "Overall hardware health across all hosts",
                "fieldConfig": {
                   "defaults": {
                      "mappings": [
@@ -120,7 +120,7 @@
                      "expr": "max(ceph_hardware_health)",
                      "format": "time_series",
                      "intervalFactor": 1,
-                     "legendFormat": "__auto",
+                     "legendFormat": "Health",
                      "refId": "A"
                   }
                ],
@@ -130,7 +130,7 @@
             },
             {
                "datasource": "$datasource",
-               "description": "",
+               "description": "Highest CPU temperature across all hosts",
                "fieldConfig": {
                   "defaults": {
                      "links": [ ],
@@ -183,7 +183,7 @@
                      "expr": "max(ceph_hardware_temperature_celsius{sensor_name=~\".*CPU_TEMP\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
-                     "legendFormat": "__auto",
+                     "legendFormat": "CPU",
                      "refId": "A"
                   }
                ],
@@ -409,7 +409,7 @@
             {
                "colors": null,
                "datasource": "$datasource",
-               "description": "",
+               "description": "Total hosts with hardware monitoring",
                "fieldConfig": {
                   "defaults": {
                      "decimals": 0,
@@ -450,7 +450,7 @@
                      "expr": "count(count by(hostname) (ceph_hardware_health))",
                      "format": "time_series",
                      "intervalFactor": 1,
-                     "legendFormat": "__auto",
+                     "legendFormat": "Hosts",
                      "refId": "A"
                   }
                ],
@@ -461,7 +461,7 @@
             {
                "colors": null,
                "datasource": "$datasource",
-               "description": "",
+               "description": "Total storage drives detected",
                "fieldConfig": {
                   "defaults": {
                      "decimals": 0,
@@ -502,7 +502,7 @@
                      "expr": "count(ceph_hardware_storage_capacity_bytes)",
                      "format": "time_series",
                      "intervalFactor": 1,
-                     "legendFormat": "__auto",
+                     "legendFormat": "Drives",
                      "refId": "A"
                   }
                ],
@@ -512,7 +512,7 @@
             },
             {
                "datasource": "$datasource",
-               "description": "",
+               "description": "Highest NVMe drive temperature across all hosts",
                "fieldConfig": {
                   "defaults": {
                      "links": [ ],
@@ -565,7 +565,7 @@
                      "expr": "max(ceph_hardware_temperature_celsius{sensor_name=~\"NVME.*_TEMP\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
-                     "legendFormat": "__auto",
+                     "legendFormat": "NVMe",
                      "refId": "A"
                   }
                ],
@@ -596,7 +596,7 @@
             {
                "colors": null,
                "datasource": "$datasource",
-               "description": "",
+               "description": "Power supply health status",
                "fieldConfig": {
                   "defaults": {
                      "mappings": [
@@ -665,7 +665,7 @@
                      "expr": "max(ceph_hardware_health{hostname=~\"$hostname\",category=\"power\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
-                     "legendFormat": "__auto",
+                     "legendFormat": "Power",
                      "refId": "A"
                   }
                ],
@@ -676,7 +676,7 @@
             {
                "colors": null,
                "datasource": "$datasource",
-               "description": "",
+               "description": "Highest motherboard temperature",
                "fieldConfig": {
                   "defaults": {
                      "decimals": 0,
@@ -729,7 +729,7 @@
                      "expr": "max(ceph_hardware_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\".*MB_TEMP.*\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
-                     "legendFormat": "__auto",
+                     "legendFormat": "Motherboard",
                      "refId": "A"
                   }
                ],
@@ -740,7 +740,7 @@
             {
                "colors": null,
                "datasource": "$datasource",
-               "description": "",
+               "description": "Average CPU temperature",
                "fieldConfig": {
                   "defaults": {
                      "decimals": 0,
@@ -795,7 +795,7 @@
                      "expr": "avg(ceph_hardware_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\".*CPU_TEMP\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
-                     "legendFormat": "__auto",
+                     "legendFormat": "CPU",
                      "refId": "A"
                   }
                ],
@@ -806,7 +806,7 @@
             {
                "colors": null,
                "datasource": "$datasource",
-               "description": "",
+               "description": "Highest DIMM temperature",
                "fieldConfig": {
                   "defaults": {
                      "decimals": 0,
@@ -861,7 +861,7 @@
                      "expr": "max(ceph_hardware_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\".*DIMM.*_TEMP\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
-                     "legendFormat": "__auto",
+                     "legendFormat": "DIMM",
                      "refId": "A"
                   }
                ],
@@ -872,7 +872,7 @@
             {
                "colors": null,
                "datasource": "$datasource",
-               "description": "",
+               "description": "Number of PSU fans detected",
                "fieldConfig": {
                   "defaults": {
                      "decimals": 0,
@@ -913,7 +913,7 @@
                      "expr": "count(ceph_hardware_fan_rpm{hostname=~\"$hostname\", fan_name=~\"PSU.*\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
-                     "legendFormat": "__auto",
+                     "legendFormat": "PSU Fans",
                      "refId": "A"
                   }
                ],
@@ -924,7 +924,7 @@
             {
                "colors": null,
                "datasource": "$datasource",
-               "description": "",
+               "description": "Average power supply temperature",
                "fieldConfig": {
                   "defaults": {
                      "color": {
@@ -983,7 +983,7 @@
                      "expr": "avg(ceph_hardware_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\"PSU.*_TEMP.*\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
-                     "legendFormat": "__auto",
+                     "legendFormat": "PSU",
                      "refId": "A"
                   }
                ],
@@ -994,7 +994,7 @@
             {
                "colors": null,
                "datasource": "$datasource",
-               "description": "",
+               "description": "Number of NVMe drives detected",
                "fieldConfig": {
                   "defaults": {
                      "color": {
@@ -1051,7 +1051,7 @@
                      "expr": "count(ceph_hardware_storage_capacity_bytes{hostname=~\"$hostname\", protocol=\"NVMe\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
-                     "legendFormat": "__auto",
+                     "legendFormat": "NVMe",
                      "refId": "A"
                   }
                ],
@@ -1062,7 +1062,7 @@
             {
                "colors": null,
                "datasource": "$datasource",
-               "description": "",
+               "description": "Highest NVMe drive temperature",
                "fieldConfig": {
                   "defaults": {
                      "color": {
@@ -1121,7 +1121,7 @@
                      "expr": "max(ceph_hardware_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\"NVME.*\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
-                     "legendFormat": "__auto",
+                     "legendFormat": "NVMe",
                      "refId": "A"
                   }
                ],
@@ -1132,7 +1132,7 @@
             {
                "colors": null,
                "datasource": "$datasource",
-               "description": "",
+               "description": "Network adapter health status",
                "fieldConfig": {
                   "defaults": {
                      "mappings": [
@@ -1201,7 +1201,7 @@
                      "expr": "max(ceph_hardware_health{hostname=~\"$hostname\",category=\"network\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
-                     "legendFormat": "__auto",
+                     "legendFormat": "Network",
                      "refId": "A"
                   }
                ],
@@ -1212,7 +1212,7 @@
             {
                "colors": null,
                "datasource": "$datasource",
-               "description": "",
+               "description": "Cooling fans health status",
                "fieldConfig": {
                   "defaults": {
                      "mappings": [
@@ -1281,7 +1281,7 @@
                      "expr": "max(ceph_hardware_health{hostname=~\"$hostname\",category=\"fans\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
-                     "legendFormat": "__auto",
+                     "legendFormat": "Cooling",
                      "refId": "A"
                   }
                ],
@@ -1292,7 +1292,7 @@
             {
                "colors": null,
                "datasource": "$datasource",
-               "description": "",
+               "description": "Storage drives health status",
                "fieldConfig": {
                   "defaults": {
                      "mappings": [
@@ -1361,7 +1361,7 @@
                      "expr": "max(ceph_hardware_health{hostname=~\"$hostname\",category=\"storage\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
-                     "legendFormat": "__auto",
+                     "legendFormat": "Drives",
                      "refId": "A"
                   }
                ],
@@ -1416,7 +1416,7 @@
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 1,
-                     "legendFormat": "__auto",
+                     "legendFormat": "",
                      "refId": "A"
                   }
                ],
@@ -1493,7 +1493,7 @@
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 1,
-                     "legendFormat": "__auto",
+                     "legendFormat": "",
                      "refId": "A"
                   }
                ],

--- a/monitoring/ceph-mixin/dashboards_out/hardware.json
+++ b/monitoring/ceph-mixin/dashboards_out/hardware.json
@@ -2080,6 +2080,93 @@
                   },
                   { }
                ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 20
+               },
+               "id": 35,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [
+                  {
+                     "alias": "Critical",
+                     "color": "dark-red",
+                     "dashes": true,
+                     "fill": 0
+                  }
+               ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "ceph_hardware_temperature_celsius{hostname=~\"$hostname\", sensor_name=~\"PSU.*_TEMP.*\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{sensor_name}}",
+                     "refId": "A"
+                  },
+                  {
+                     "expr": "vector(65)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "Critical",
+                     "refId": "B"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "PSU Temperatures",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "min": 0
+                  },
+                  { }
+               ]
             }
          ],
          "repeat": null,
@@ -2099,7 +2186,7 @@
             "x": 0,
             "y": 4
          },
-         "id": 35,
+         "id": 36,
          "panels": [
             {
                "aliasColors": { },
@@ -2116,7 +2203,7 @@
                   "x": 0,
                   "y": 5
                },
-               "id": 36,
+               "id": 37,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -2201,7 +2288,7 @@
                   "x": 12,
                   "y": 5
                },
-               "id": 37,
+               "id": 38,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,

--- a/src/pybind/mgr/prometheus/test_module.py
+++ b/src/pybind/mgr/prometheus/test_module.py
@@ -184,8 +184,8 @@ class ThreadSafeLRUCacheDictTest(TestCase):
 
 
 MOCK_HW_FULLREPORT = {
-    'at3n2.tuc.stglabs.ibm.com': {
-        'host': 'at3n2.tuc.stglabs.ibm.com',
+    'host.example.com': {
+        'host': 'host.example.com',
         'sn': '11S03NK990YM30ZP58E02X',
         'status': {
             'storage': {'Self': {
@@ -298,7 +298,7 @@ class HardwareMetricsTest(TestCase):
             'hardware_firmware_info': Metric(
                 'gauge', 'hardware_firmware_info', '', HW_FIRMWARE_LABELS),
         }
-        self.hostname = 'at3n2.tuc.stglabs.ibm.com'
+        self.hostname = 'host.example.com'
         self.data = MOCK_HW_FULLREPORT[self.hostname]
         self.status = self.data['status']
         self.module._hw_get_health_value = Module._hw_get_health_value.__get__(self.module)


### PR DESCRIPTION
- also fixes bug with tooltip showing metric on panels
  before:
   <img width="1317" height="362" alt="Screenshot From 2026-06-26 05-15-47" src="https://github.com/user-attachments/assets/7d94f8f9-fd4a-47af-8118-696bc8ff761c" />
  after:
  <img width="611" height="313" alt="image" src="https://github.com/user-attachments/assets/f623faca-4b93-4519-8c2f-f2bec6ff06b0" />

- adds PSU graphs: https://github.com/ceph/ceph/pull/69753/changes/1be067414e8e30774c8cdd4e105aa2dc38d7ebf9
<img width="746" height="321" alt="Screenshot From 2026-06-26 04-34-53" src="https://github.com/user-attachments/assets/4ebcf6a1-8b72-42cf-9ad0-cbfd97e24d4f" />

- adds compression panel: 
<img width="1865" height="1445" alt="Screenshot 2026-07-03 at 00-37-43 Ceph Hardware - Cluster-wide Compression - Dashboards - Grafana" src="https://github.com/user-attachments/assets/693115b9-5ffa-403b-b145-822151064277" />



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>