### PR TITLE
doc: document 'lazyio' mount option for kclient and ceph-fuse

### DIFF
--- a/doc/cephfs/client-config-ref.rst
+++ b/doc/cephfs/client-config-ref.rst
@@ -62,6 +62,7 @@ Client Config Reference
 .. confval:: client_snapdir
 .. confval:: client_tick_interval
 .. confval:: client_use_random_mds
+.. confval:: client_force_lazyio
 .. confval:: fuse_default_permissions
 .. confval:: fuse_max_write
 .. confval:: fuse_disable_pagecache

--- a/doc/cephfs/lazyio.rst
+++ b/doc/cephfs/lazyio.rst
@@ -2,6 +2,16 @@
 LazyIO
 ======
 
+.. warning::
+   LazyIO relaxes CephFS cache coherency guarantees.  Applications may read
+   stale data, and overlapping writes from different clients may produce
+   undefined behavior or silent data corruption.  Do not use this feature
+   unless you fully understand its consequences and are handling your own
+   data consistency — for example, via explicit
+   ``lazyio_propagate()`` / ``lazyio_synchronize()`` calls and
+   application-level barriers.  This feature is intended only for HPC and
+   similar specialized workloads that coordinate I/O externally.
+
 LazyIO relaxes POSIX semantics. Buffered reads/writes are allowed even when a
 file is opened by multiple applications on multiple clients. Applications are
 responsible for managing cache coherency themselves.
@@ -13,11 +23,23 @@ Enable LazyIO
 
 LazyIO can be enabled in the following ways.
 
-- ``client_force_lazyio`` option enables LAZY_IO globally for libcephfs and
-  ceph-fuse mount. This is strictly a startup flag.
+- ``client_force_lazyio`` option enables LazyIO globally for libcephfs and
+  ceph-fuse mount. This option takes effect only at mount time and cannot
+  be changed at runtime. LazyIO allows buffered reads and writes via the
+  page cache even when multiple clients hold the file open, which can
+  significantly improve I/O throughput for applications that manage their
+  own data consistency. For ceph-fuse, pass
+  ``--client_force_lazyio`` on the command line. For ``/etc/fstab``, add
+  ``ceph.client_force_lazyio=true`` to the options column.
 
-- ``ceph_lazyio(...)`` and ``ceph_ll_lazyio(...)`` enable LAZY_IO for file handle
-  in libcephfs.
+- ``lazyio`` / ``nolazyio`` mount option enables LazyIO globally for the
+  kernel CephFS client (kclient).  Pass it via ``mount -o lazyio`` or
+  add it to ``/etc/fstab``.  This is the kclient equivalent of
+  ``client_force_lazyio`` and supports remount.  Available since Linux
+  v6.22.
+
+- ``ceph_lazyio(...)`` and ``ceph_ll_lazyio(...)`` enable LazyIO for a file
+  handle in libcephfs.
 
 Using LazyIO
 ============

--- a/doc/cephfs/mount-using-fuse.rst
+++ b/doc/cephfs/mount-using-fuse.rst
@@ -63,6 +63,16 @@ If you serve more than one CephFS file system from your Ceph cluster, use the op
 
     ceph-fuse --id foo --client_fs mycephfs2 /mnt/mycephfs2
 
+To enable LazyIO globally for all regular file opens, use
+``--client_force_lazyio``::
+
+    ceph-fuse --id foo --client_force_lazyio /mnt/mycephfs
+
+.. warning::
+   LazyIO relaxes CephFS cache coherency guarantees.  Only use it for
+   specialized workloads (such as HPC) that manage their own data
+   consistency.  See :doc:`/cephfs/lazyio` for details.
+
 You may also add a ``client_fs`` setting to your ``ceph.conf``. Alternatively, the option
 ``--client_mds_namespace`` is supported for backward compatibility.
 

--- a/doc/cephfs/mount-using-kernel-driver.rst
+++ b/doc/cephfs/mount-using-kernel-driver.rst
@@ -185,8 +185,8 @@ helper will attempt to find a secret for the given ``name`` in one of the
 configured keyrings.
 
 See `User Management`_ for details on CephX user management and the mount.ceph_
-manual for a list of the options it recognizes. For troubleshooting, see
-:ref:`kernel_mount_debugging`.
+manual for a list of the options it recognizes, including the ``lazyio`` mount
+option. For troubleshooting, see :ref:`kernel_mount_debugging`.
 
 .. _fstab: ../fstab/#kernel-driver
 .. _Mount CephFS\: Prerequisites: ../mount-prerequisites

--- a/doc/cephfs/posix.rst
+++ b/doc/cephfs/posix.rst
@@ -11,6 +11,13 @@ when they are on different hosts as when they are on the same host.
 However, there are a few places where CephFS diverges from strict
 POSIX semantics for various reasons:
 
+- **LazyIO:** When the ``lazyio`` (kernel) or ``client_force_lazyio``
+  (ceph-fuse / libcephfs) option is enabled, the client relaxes cache
+  coherency.  Buffered I/O via the page cache is permitted even when
+  multiple clients hold the file open for write, and applications may
+  read stale data.  This is an opt-in relaxation intended for HPC and
+  similar specialized workloads.  See :doc:`/cephfs/lazyio`.
+
 - If a client is writing to a file and fails, its writes are not
   necessarily atomic. That is, the client may call write(2) on a file
   opened with O_SYNC with an 8 MB buffer and then crash and the write

--- a/doc/man/8/ceph-fuse.rst
+++ b/doc/man/8/ceph-fuse.rst
@@ -78,6 +78,28 @@ Any options not recognized by ceph-fuse will be passed on to libfuse.
 
    Disable multi-threaded operation.
 
+.. option:: --client_force_lazyio
+
+   Enable LazyIO globally for all regular file opens on this mount.  When
+   set, the client requests ``CEPH_CAP_FILE_LAZYIO`` from the MDS, which
+   allows buffered reads and writes via the page cache even when multiple
+   clients hold the file open for write — at the expense of cache
+   coherency.  Applications are responsible for managing data
+   consistency themselves via
+   ``ceph_lazyio_propagate()`` / ``ceph_lazyio_synchronize()``.
+
+   .. warning::
+      Do not use this option unless you fully understand its
+      consequences and are handling your own data consistency.  LazyIO
+      relaxes CephFS cache coherency guarantees.  Applications may read
+      stale data, and overlapping writes from different clients may
+      produce undefined behavior.  Improper use can lead to silent data
+      corruption.  This option is intended only for HPC and similar
+      specialized workloads that can tolerate relaxed consistency and
+      where the application coordinates I/O externally.
+
+   Default: off.
+
 .. option:: --client_fs
 
    Pass the name of Ceph FS to be mounted. Not passing this option mounts the

--- a/doc/man/8/mount.ceph.rst
+++ b/doc/man/8/mount.ceph.rst
@@ -144,6 +144,28 @@ Advanced
 :command:`ip`
     my ip
 
+:command:`lazyio`
+    Enable LazyIO globally for all regular file opens on this mount. When
+    set, the client requests ``CEPH_CAP_FILE_LAZYIO`` from the MDS, which
+    allows buffered reads and writes via the page cache even when multiple
+    clients hold the file open for write — at the expense of cache
+    coherency. This is the kclient equivalent of the
+    ``client_force_lazyio`` option in ceph-fuse.
+
+    **WARNING:** Do not use this option unless you fully understand its
+    consequences and are handling your own data consistency. LazyIO
+    relaxes the usual CephFS cache coherency guarantees. Applications may
+    read stale data, and overlapping writes from different clients may
+    result in undefined behavior. Improper use can lead to silent data
+    corruption. This option is intended only for HPC and similar
+    specialized workloads that can tolerate relaxed consistency and where
+    the application coordinates I/O externally.
+
+    Default: off (since 6.22).
+
+:command:`nolazyio`
+    Disable LazyIO (the default).
+
 :command:`noasyncreaddir`
     no dcache readdir
 
@@ -303,6 +325,7 @@ Feature Availability
 
 The ``recover_session=`` option was added to mainline Linux kernels in v5.4.
 ``wsync`` and ``nowsync`` were added in v5.7.
+``lazyio`` and ``nolazyio`` were added in v6.22.
 
 See also
 ========

--- a/doc/man/8/mount.fuse.ceph.rst
+++ b/doc/man/8/mount.fuse.ceph.rst
@@ -25,6 +25,7 @@ To use mount.fuse.ceph, add an entry in ``/etc/fstab`` like::
   none      /mnt/ceph   fuse.ceph   ceph.id=admin,_netdev,defaults  0 0
   none      /mnt/ceph   fuse.ceph   ceph.name=client.admin,_netdev,defaults  0 0
   none      /mnt/ceph   fuse.ceph   ceph.id=myuser,ceph.conf=/etc/ceph/foo.conf,_netdev,defaults  0 0
+  none      /mnt/ceph   fuse.ceph   ceph.id=myuser,ceph.client_force_lazyio=true,_netdev,defaults  0 0
 
 ceph-fuse options are specified in the ``OPTIONS`` column and must begin
 with '``ceph.``' prefix. This way ceph related fs options will be passed to


### PR DESCRIPTION
Add documentation for the new 'lazyio' / 'nolazyio' kernel mount option and update the existing client_force_lazyio docs across all relevant pages:

All user-facing additions include warnings that LazyIO is intended only for HPC and similar specialized workloads that manage their own data consistency.

Fixes: https://tracker.ceph.com/issues/77594





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
