### PR TITLE
os/bluestore: tolerate corrupted onodes during fsck/repair

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -281,6 +281,11 @@
   on a devdax namespace (a character device such as ``/dev/dax0.0``) will no
   longer start, because no remaining backend can open one; reconfigure the
   namespace to fsdax with ``ndctl`` or re-provision them before upgrading.
+* BlueStore: fsck no longer aborts on an undecodable onode; it reports the object
+  and continues. Post-crash allocation recovery tolerates corruption only during
+  read-only fsck, gated by the new ``bluestore_accept_corrupted_onode_recovery``
+  option (``never`` or ``read-only``, default ``read-only``); mount, repair, and
+  ``ceph-bluestore-tool trim`` still abort.
 
 >=20.0.0
 

--- a/doc/rados/bluestore/fast-onode-scan.rst
+++ b/doc/rados/bluestore/fast-onode-scan.rst
@@ -48,6 +48,18 @@ Since RADOS objects are then the only only source of truth regarding underlying 
 the recovery procedure must iterate over all RADOS objects in order to determine used vs
 available device blocks.
 
+Corrupted onodes
+================
+
+Recovery must decode every onode, so a single corrupted encoding would abort it,
+leaving the OSD unable to start and ``fsck`` unable to inspect the store.
+Read-only ``fsck`` now skips such onodes and reports them as errors.
+
+Every other caller still aborts, since a skipped onode makes its blocks appear
+free and those paths persist or act destructively on the reconstructed allocation.
+
+.. confval:: bluestore_accept_corrupted_onode_recovery
+
 Multi-threaded recovery
 =======================
 

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -5491,6 +5491,23 @@ options:
     - startup
   see_also:
     - bluestore_allocation_recovery_threads
+- name: bluestore_accept_corrupted_onode_recovery
+  type: str
+  level: advanced
+  desc: How to handle undecodable onodes during allocation recovery
+  long_desc: Applies only to allocation recovery after an unclean shutdown.
+    Value 'never' makes recovery abort on any undecodable onode, even during
+    read-only fsck. Value 'read-only' lets read-only fsck skip and report such
+    onodes; the recovered allocation is never persisted in that mode. Mount,
+    repair, and trim always abort.
+  default: read-only
+  enum_values:
+  - never
+  - read-only
+  flags:
+    - startup
+  see_also:
+    - bluestore_allocation_recovery_threads
 - name: bluestore_debug_inject_allocation_from_file_failure
   type: float
   level: dev

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4246,12 +4246,15 @@ void BlueStore::ExtentMap::ExtentDecoderFull::consume_spanning_blob(
 
 BlueStore::Extent* BlueStore::ExtentMap::ExtentDecoderFull::get_next_extent()
 {
-  return new Extent();
+  pending_extent = std::make_unique<Extent>();
+  return pending_extent.get();
 }
 
 void BlueStore::ExtentMap::ExtentDecoderFull::add_extent(BlueStore::Extent* le)
 {
+  ceph_assert(le == pending_extent.get());
   extent_map.extent_map.insert(*le);
+  pending_extent.release();     // ownership now with the intrusive set
 }
 
 unsigned BlueStore::ExtentMap::decode_some(bufferlist& bl)
@@ -4959,11 +4962,12 @@ BlueStore::Onode* BlueStore::Onode::create_decode(
   bool use_onode_segmentation)
 {
   ceph_assert(v.length() || allow_empty);
-  Onode* on = new Onode(c.get(), oid, (const mempool::bluestore_cache_meta::string)(key));
+  auto on = std::unique_ptr<Onode>(
+    new Onode(c.get(), oid, (const mempool::bluestore_cache_meta::string)(key)));
 
   if (v.length()) {
     ExtentMap::ExtentDecoderFull edecoder(on->extent_map);
-    decode_raw(on, v, edecoder, use_onode_segmentation);
+    decode_raw(on.get(), v, edecoder, use_onode_segmentation);
 
     for (auto& i : on->onode.attrs) {
       i.second.reassign_to_mempool(mempool::mempool_bluestore_cache_meta);
@@ -4986,7 +4990,7 @@ BlueStore::Onode* BlueStore::Onode::create_decode(
     }
     on->onode.segment_size = segment_size;
   }
-  return on;
+  return on.release();
 }
 
 void BlueStore::Onode::flush()

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -21008,6 +21008,11 @@ int BlueStore::read_allocation_from_onodes(SimpleBitmap *sbmap, read_alloc_stats
                                 sb_info,
                                 min_alloc_size_order);
 
+  // Tolerate corrupt onodes only under read-only fsck: the rebuilt allocation
+  // is never destaged there, so skipping one can't wrongly free its blocks.
+  // Read-write (mount/repair) re-throws and stays fatal.
+  bool current_onode_valid = false;
+
   // iterate over all ONodes stored in RocksDB
   for (it->lower_bound(string()); it->valid(); it->next(), kv_count++) {
     // trace an even after every million processed objects (typically every 5-10 seconds)
@@ -21028,12 +21033,24 @@ int BlueStore::read_allocation_from_onodes(SimpleBitmap *sbmap, read_alloc_stats
       }
       edecoder.reset(oid,
         &stats.actual_pool_vstatfs[oid.hobj.get_logical_pool()]);
-      Onode dummy_on(cct);
-      Onode::decode_raw(&dummy_on,
-        it->value(),
-        edecoder,
-        segment_size != 0);
-      ++stats.onode_count;
+      current_onode_valid = false;
+      try {
+        bluestore_decode::throwing_guard g(db_was_opened_read_only);
+        Onode dummy_on(cct);
+        Onode::decode_raw(&dummy_on,
+          it->value(),
+          edecoder,
+          segment_size != 0);
+        current_onode_valid = true;
+        ++stats.onode_count;
+      } catch (const ceph::buffer::error& e) {
+        if (!db_was_opened_read_only) {
+          throw;
+        }
+        derr << __func__ << " skipping undecodable onode "
+             << pretty_binary_string(key) << ": " << e.what() << dendl;
+        continue;
+      }
     } else {
       uint32_t offset;
       int r = get_key_extent_shard(key, &okey, &offset);
@@ -21050,14 +21067,24 @@ int BlueStore::read_allocation_from_onodes(SimpleBitmap *sbmap, read_alloc_stats
              << dendl;
         return -EIO;
       }
-      if (oid != edecoder.get_oid()) {
+      if (!current_onode_valid || oid != edecoder.get_oid()) {
         derr << __func__ << " shard " << pretty_binary_string(okey)
              << " oid: " << oid
-             << " not from current oid: " << edecoder.get_oid() << dendl;
+             << " without a valid current onode" << dendl;
         continue;
       }
-      edecoder.decode_some(it->value(), nullptr);
-      ++stats.shard_count;
+      try {
+        bluestore_decode::throwing_guard g(db_was_opened_read_only);
+        edecoder.decode_some(it->value(), nullptr);
+        ++stats.shard_count;
+      } catch (const ceph::buffer::error& e) {
+        if (!db_was_opened_read_only) {
+          throw;
+        }
+        derr << __func__ << " skipping undecodable extent shard "
+             << pretty_binary_string(key) << ": " << e.what() << dendl;
+        continue;
+      }
     }
   }
   return 0;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7778,6 +7778,19 @@ bool BlueStore::is_statfs_recoverable() const
   return has_null_manager();
 }
 
+bool BlueStore::_alloc_recovery_tolerates_corruption() const
+{
+  auto level = cct->_conf.get_val<std::string>(
+    "bluestore_accept_corrupted_onode_recovery");
+  if (level == "never") {
+    return false;
+  }
+  // "read-only": only the fsck analysis path may skip undecodable onodes.
+  // Its recovered allocation is never destaged, so a skipped onode cannot
+  // wrongly free its blocks.
+  return alloc_recovery_policy == alloc_recovery_policy_t::tolerate_corrupt_onodes;
+}
+
 bool BlueStore::test_mount_in_use()
 {
   // most error conditions mean the mount is not in use (e.g., because
@@ -7993,8 +8006,12 @@ int BlueStore::_is_bluefs(bool create, bool* ret)
 * opens both DB and dependant super_meta, FreelistManager and allocator
 * in the proper order
 */
-int BlueStore::_open_db_and_around(bool read_only, bool to_repair)
+int BlueStore::_open_db_and_around(bool read_only, bool to_repair,
+                                   alloc_recovery_policy_t policy)
 {
+  alloc_recovery_policy = policy;
+  alloc_recovery_skipped_onodes = 0;
+
   dout(5) << __func__ << "::NCB::read_only=" << read_only << ", to_repair=" << to_repair << dendl;
   {
     string type;
@@ -11096,7 +11113,10 @@ int BlueStore::_fsck(BlueStore::FSCKDepth depth, bool repair, bluestore_stats_t 
 
   // in deep mode we need R/W write access to be able to replay deferred ops
   const bool read_only = !(repair || depth == FSCK_DEEP);
-  int r = _open_db_and_around(read_only);
+  int r = _open_db_and_around(read_only, false,
+    read_only ? alloc_recovery_policy_t::tolerate_corrupt_onodes
+              : alloc_recovery_policy_t::strict);
+
   if (r < 0) {
     return r;
   }
@@ -11163,6 +11183,11 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair, bluestore_
           << " start sb_tracker_hash_size:" << sb_hash_size
           << dendl;
   int64_t errors = 0;
+  if (uint64_t skipped = alloc_recovery_skipped_onodes.load(); skipped > 0) {
+    derr << __func__ << " " << skipped
+         << " onode(s) skipped during allocation recovery" << dendl;
+    errors += skipped;
+  }
   int64_t warnings = 0;
   unsigned repaired = 0;
 
@@ -20953,6 +20978,8 @@ void BlueStore::ExtentDecoderPartial::reset(const ghobject_t _oid,
 
 int BlueStore::read_allocation_from_onodes(SimpleBitmap *sbmap, read_alloc_stats_t& stats)
 {
+  const bool tolerate = _alloc_recovery_tolerates_corruption();
+
   sb_info_space_efficient_map_t sb_info;
   // iterate over all shared blobs
   auto it = db->get_iterator(PREFIX_SHARED_BLOB, KeyValueDB::ITERATOR_NOCACHE);
@@ -21008,9 +21035,9 @@ int BlueStore::read_allocation_from_onodes(SimpleBitmap *sbmap, read_alloc_stats
                                 sb_info,
                                 min_alloc_size_order);
 
-  // Tolerate corrupt onodes only under read-only fsck: the rebuilt allocation
-  // is never destaged there, so skipping one can't wrongly free its blocks.
-  // Read-write (mount/repair) re-throws and stays fatal.
+  // Tolerate undecodable onodes only when the caller opted in; only read-only
+  // fsck does, since its recovered allocation is never destaged. Every other
+  // caller aborts as before.
   bool current_onode_valid = false;
 
   // iterate over all ONodes stored in RocksDB
@@ -21035,7 +21062,7 @@ int BlueStore::read_allocation_from_onodes(SimpleBitmap *sbmap, read_alloc_stats
         &stats.actual_pool_vstatfs[oid.hobj.get_logical_pool()]);
       current_onode_valid = false;
       try {
-        bluestore_decode::throwing_guard g(db_was_opened_read_only);
+        bluestore_decode::throwing_guard g(tolerate);
         Onode dummy_on(cct);
         Onode::decode_raw(&dummy_on,
           it->value(),
@@ -21044,9 +21071,8 @@ int BlueStore::read_allocation_from_onodes(SimpleBitmap *sbmap, read_alloc_stats
         current_onode_valid = true;
         ++stats.onode_count;
       } catch (const ceph::buffer::error& e) {
-        if (!db_was_opened_read_only) {
-          throw;
-        }
+        if (!tolerate) { throw; }
+        ++alloc_recovery_skipped_onodes;
         derr << __func__ << " skipping undecodable onode "
              << pretty_binary_string(key) << ": " << e.what() << dendl;
         continue;
@@ -21074,13 +21100,11 @@ int BlueStore::read_allocation_from_onodes(SimpleBitmap *sbmap, read_alloc_stats
         continue;
       }
       try {
-        bluestore_decode::throwing_guard g(db_was_opened_read_only);
+        bluestore_decode::throwing_guard g(tolerate);
         edecoder.decode_some(it->value(), nullptr);
         ++stats.shard_count;
       } catch (const ceph::buffer::error& e) {
-        if (!db_was_opened_read_only) {
-          throw;
-        }
+        if (!tolerate) { throw; }
         derr << __func__ << " skipping undecodable extent shard "
              << pretty_binary_string(key) << ": " << e.what() << dendl;
         continue;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -9998,8 +9998,15 @@ void BlueStore::_fsck_foreach_shared_blob(
 	       << dendl;
 
       OnodeRef o;
-      o.reset(Onode::create_decode(c, oid, it->key(), it->value(), false, segment_size != 0));
-      o->extent_map.fault_range(db, 0, OBJECT_MAX_SIZE);
+      try {
+        bluestore_decode::tolerant_guard g;
+        o.reset(Onode::create_decode(c, oid, it->key(), it->value(), false, segment_size != 0));
+        o->extent_map.fault_range(db, 0, OBJECT_MAX_SIZE);
+      } catch (const ceph::buffer::error& e) {
+        derr << "fsck error: " << oid << " corrupted onode encoding: "
+             << e.what() << dendl;
+        continue;     // already reported by the shallow pass; skip here
+      }
 
       _dump_onode<30>(cct, *o);
 
@@ -10154,13 +10161,25 @@ BlueStore::OnodeRef BlueStore::fsck_check_objects_shallow(
 
   dout(10) << __func__ << "  " << oid << dendl;
   OnodeRef o;
-  o.reset(Onode::create_decode(c, oid, key, value, false, segment_size != 0));
+  try {
+    bluestore_decode::tolerant_guard g;
+    o.reset(Onode::create_decode(c, oid, key, value, false, segment_size != 0));
+    o->extent_map.fault_range(db, 0, OBJECT_MAX_SIZE);
+  } catch (const ceph::buffer::error& e) {
+    derr << "fsck error: " << oid << " corrupted onode encoding: "
+         << e.what() << dendl;
+    ++errors;
+    // NOTE(https://tracker.ceph.com/issues/77325): report-only. Physically
+    // removing the onode key would orphan its blocks — the extent map is
+    // undecodable, so fsck can't reclaim them (leaked extents + statfs drift).
+    // Removal/logical -EIO reclamation is the follow-up.
+    return OnodeRef();
+  }
   ++num_objects;
   ++pool_fsck_stat->num_objects;
   num_spanning_blobs += o->extent_map.spanning_blob_map.size();
-
-  o->extent_map.fault_range(db, 0, OBJECT_MAX_SIZE);
   _dump_onode<30>(cct, *o);
+
   // shards
   if (!o->extent_map.shards.empty()) {
     ++num_sharded_objects;
@@ -10921,7 +10940,10 @@ void BlueStore::_fsck_check_objects(
       }
 
       if (depth != FSCK_SHALLOW) {
-        ceph_assert(o != nullptr);
+        if (!o) {
+          // corrupted onode encoding: reported and skipped by the shallow check
+          continue;
+        }
         if (o->onode.nid) {
           if (o->onode.nid > nid_max) {
             derr << "fsck error: " << oid << " nid " << o->onode.nid
@@ -11555,9 +11577,15 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair, bluestore_
 	dout(20) << __func__ << " check misreference for col:" << c->cid
 		  << " obj:" << oid << dendl;
 
-        OnodeRef o;
-        o.reset(Onode::create_decode(c, oid, it->key(), it->value(), false, segment_size != 0));
-	o->extent_map.fault_range(db, 0, OBJECT_MAX_SIZE);
+  OnodeRef o;
+  try {
+    bluestore_decode::tolerant_guard g;
+    o.reset(Onode::create_decode(c, oid, it->key(), it->value(), false, segment_size != 0));
+    o->extent_map.fault_range(db, 0, OBJECT_MAX_SIZE);
+  } catch (const ceph::buffer::error& e) {
+    derr << "fsck error: " << oid << " corrupted onode encoding: " << e.what() << dendl;
+    continue;
+  }
 	mempool::bluestore_fsck::set<BlobRef> blobs;
 
 	for (auto& e : o->extent_map.extent_map) {
@@ -21001,10 +21029,14 @@ int BlueStore::read_allocation_from_onodes(SimpleBitmap *sbmap, read_alloc_stats
       edecoder.reset(oid,
         &stats.actual_pool_vstatfs[oid.hobj.get_logical_pool()]);
       Onode dummy_on(cct);
-      Onode::decode_raw(&dummy_on,
-        it->value(),
-        edecoder,
-        segment_size != 0);
+      try {
+        bluestore_decode::tolerant_guard g;
+        Onode::decode_raw(&dummy_on, it->value(), edecoder, segment_size != 0);
+      } catch (const ceph::buffer::error& e) {
+        derr << __func__ << " failed to decode onode "
+             << pretty_binary_string(okey) << ": " << e.what() << dendl;
+        continue;
+      }
       ++stats.onode_count;
     } else {
       uint32_t offset;
@@ -21028,7 +21060,14 @@ int BlueStore::read_allocation_from_onodes(SimpleBitmap *sbmap, read_alloc_stats
              << " not from current oid: " << edecoder.get_oid() << dendl;
         continue;
       }
-      edecoder.decode_some(it->value(), nullptr);
+      try {
+        bluestore_decode::tolerant_guard g;
+        edecoder.decode_some(it->value(), nullptr);
+      } catch (const ceph::buffer::error& e) {
+        derr << __func__ << " failed to decode extent shard "
+             << pretty_binary_string(key) << ": " << e.what() << dendl;
+        continue;
+      }
       ++stats.shard_count;
     }
   }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2334,7 +2334,7 @@ void BlueStore::Blob::get_ref(
   // references.  Otherwise one is neither unable to determine required
   // amount of counters in case of per-au tracking nor obtain min_release_size
   // for single counter mode.
-  ceph_assert(get_blob().get_logical_length() != 0);
+  ceph_assert_decode(get_blob().get_logical_length() != 0);
   dout(20) << __func__ << " 0x" << std::hex << offset << "~" << length
            << std::dec << " " << *this << dendl;
 
@@ -4160,7 +4160,7 @@ unsigned BlueStore::ExtentMap::ExtentDecoder::decode_some(
   // Version 2 differs from v1 in blob's ref_map
   // serialization only. Hence there is no specific
   // handling at ExtentMap level below.
-  ceph_assert(struct_v == 1 || struct_v == 2);
+  ceph_assert_decode(struct_v == 1 || struct_v == 2);
   denc_varint(num, p);
 
   extent_pos = 0;
@@ -4169,7 +4169,7 @@ unsigned BlueStore::ExtentMap::ExtentDecoder::decode_some(
     decode_extent(le, struct_v, p, c);
     add_extent(le);
   }
-  ceph_assert(extent_pos == num);
+  ceph_assert_decode(extent_pos == num);
   return num;
 }
 
@@ -4181,7 +4181,7 @@ void BlueStore::ExtentMap::ExtentDecoder::decode_spanning_blobs(
   // Version 2 differs from v1 in blob's ref_map
   // serialization only. Hence there is no specific
   // handling at ExtentMap level.
-  ceph_assert(struct_v == 1 || struct_v == 2);
+  ceph_assert_decode(struct_v == 1 || struct_v == 2);
 
   unsigned n;
   denc_varint(n, p);
@@ -4215,7 +4215,7 @@ void BlueStore::ExtentMap::ExtentDecoderFull::consume_blobid(
   if (spanning) {
     le->assign_blob(extent_map.get_spanning_blob(blobid));
   } else {
-    ceph_assert(blobid < blobs.size());
+    ceph_assert_decode(blobid < blobs.size());
     le->assign_blob(blobs[blobid]);
     // we build ref_map dynamically for non-spanning blobs
     le->blob->get_ref(
@@ -20818,7 +20818,7 @@ void BlueStore::ExtentDecoderPartial::_consume_new_blob(bool spanning,
   auto &blob = b->get_blob();
   if(spanning) {
     dout(20) << __func__ << " " << spanning << " " << b->id << dendl;
-    ceph_assert(b->id >= 0);
+    ceph_assert_decode(b->id >= 0);
     spanning_blobs[b->id] = b;
     ++stats.spanning_blob_count;
   } else {
@@ -20887,7 +20887,7 @@ void BlueStore::ExtentDecoderPartial::consume_blobid(Extent* le,
   dout(20) << __func__ << " " << spanning << " " << blobid << dendl;
   auto &map = spanning ? spanning_blobs : blobs;
   auto it = map.find(blobid);
-  ceph_assert(it != map.end());
+  ceph_assert_decode(it != map.end());
   per_pool_statfs->stored() += le->length;
   if (it->second->get_blob().is_compressed()) {
     per_pool_statfs->compressed_original() += le->length;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -9999,7 +9999,7 @@ void BlueStore::_fsck_foreach_shared_blob(
 
       OnodeRef o;
       try {
-        bluestore_decode::tolerant_guard g;
+        bluestore_decode::throwing_guard g;
         o.reset(Onode::create_decode(c, oid, it->key(), it->value(), false, segment_size != 0));
         o->extent_map.fault_range(db, 0, OBJECT_MAX_SIZE);
       } catch (const ceph::buffer::error& e) {
@@ -10162,7 +10162,7 @@ BlueStore::OnodeRef BlueStore::fsck_check_objects_shallow(
   dout(10) << __func__ << "  " << oid << dendl;
   OnodeRef o;
   try {
-    bluestore_decode::tolerant_guard g;
+    bluestore_decode::throwing_guard g;
     o.reset(Onode::create_decode(c, oid, key, value, false, segment_size != 0));
     o->extent_map.fault_range(db, 0, OBJECT_MAX_SIZE);
   } catch (const ceph::buffer::error& e) {
@@ -11579,7 +11579,7 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair, bluestore_
 
   OnodeRef o;
   try {
-    bluestore_decode::tolerant_guard g;
+    bluestore_decode::throwing_guard g;
     o.reset(Onode::create_decode(c, oid, it->key(), it->value(), false, segment_size != 0));
     o->extent_map.fault_range(db, 0, OBJECT_MAX_SIZE);
   } catch (const ceph::buffer::error& e) {
@@ -21029,14 +21029,10 @@ int BlueStore::read_allocation_from_onodes(SimpleBitmap *sbmap, read_alloc_stats
       edecoder.reset(oid,
         &stats.actual_pool_vstatfs[oid.hobj.get_logical_pool()]);
       Onode dummy_on(cct);
-      try {
-        bluestore_decode::tolerant_guard g;
-        Onode::decode_raw(&dummy_on, it->value(), edecoder, segment_size != 0);
-      } catch (const ceph::buffer::error& e) {
-        derr << __func__ << " failed to decode onode "
-             << pretty_binary_string(okey) << ": " << e.what() << dendl;
-        continue;
-      }
+      Onode::decode_raw(&dummy_on,
+        it->value(),
+        edecoder,
+        segment_size != 0);
       ++stats.onode_count;
     } else {
       uint32_t offset;
@@ -21060,14 +21056,7 @@ int BlueStore::read_allocation_from_onodes(SimpleBitmap *sbmap, read_alloc_stats
              << " not from current oid: " << edecoder.get_oid() << dendl;
         continue;
       }
-      try {
-        bluestore_decode::tolerant_guard g;
-        edecoder.decode_some(it->value(), nullptr);
-      } catch (const ceph::buffer::error& e) {
-        derr << __func__ << " failed to decode extent shard "
-             << pretty_binary_string(key) << ": " << e.what() << dendl;
-        continue;
-      }
+      edecoder.decode_some(it->value(), nullptr);
       ++stats.shard_count;
     }
   }

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1113,7 +1113,7 @@ public:
     void encode_spanning_blobs(ceph::buffer::list::contiguous_appender& p);
     BlobRef& get_spanning_blob(int id) {
       auto p = spanning_blob_map.find(id);
-      ceph_assert_decode(p != spanning_blob_map.end());   // was ceph_assert —> decoded blob id
+      ceph_assert_decode(p != spanning_blob_map.end());
       return p->second;
     }
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1113,7 +1113,7 @@ public:
     void encode_spanning_blobs(ceph::buffer::list::contiguous_appender& p);
     BlobRef& get_spanning_blob(int id) {
       auto p = spanning_blob_map.find(id);
-      ceph_assert(p != spanning_blob_map.end());
+      ceph_assert_decode(p != spanning_blob_map.end());   // was ceph_assert —> decoded blob id
       return p->second;
     }
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1083,6 +1083,9 @@ public:
     class ExtentDecoderFull : public ExtentDecoder {
       ExtentMap& extent_map;
       std::vector<BlobRef> blobs;
+      // owns the Extent from get_next_extent() until add_extent() inserts it,
+      // so a throw during decode_extent() can't leak it
+      std::unique_ptr<Extent> pending_extent;
     protected:
       BlobRef decode_create_blob(
         bptr_c_it_t& p,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2433,9 +2433,19 @@ private:
   int fsid_fd = -1;  ///< open handle (locked) to $path/fsid
   bool mounted = false;
 
+  // Whether a caller may tolerate undecodable onodes during allocation recovery
+  enum class alloc_recovery_policy_t {
+    strict,
+    tolerate_corrupt_onodes,
+  };
+
   // store open_db options:
   bool db_was_opened_read_only = true;
   bool need_to_destage_allocation_file = false;
+
+  alloc_recovery_policy_t alloc_recovery_policy = alloc_recovery_policy_t::strict;
+  std::atomic<uint64_t> alloc_recovery_skipped_onodes = {0};
+  bool _alloc_recovery_tolerates_corruption() const;
 
   ///< rwlock to protect coll_map/new_coll_map
   ceph::shared_mutex coll_lock = ceph::make_shared_mutex("BlueStore::coll_lock");
@@ -2872,7 +2882,8 @@ private:
   * opens both DB and dependant super_meta, FreelistManager and allocator
   * in the proper order
   */
-  int _open_db_and_around(bool read_only, bool to_repair = false);
+  int _open_db_and_around(bool read_only, bool to_repair = false,
+            alloc_recovery_policy_t policy = alloc_recovery_policy_t::strict);
   void _close_db_and_around();
   void _close_around_db();
 

--- a/src/os/bluestore/OnodeScan.cc
+++ b/src/os/bluestore/OnodeScan.cc
@@ -241,6 +241,9 @@ class BlueStore::OnodeScanMT {
     uint64_t count_interval = 100'000;
     Decoder_AllocationsAndStatFS edecoder(store, stats, *sbmap,
                                           store.min_alloc_size_order);
+    // Same read-only gating as read_allocation_from_onodes: tolerate a corrupt
+    // onode only when the rebuilt allocation won't be committed.
+    bool current_onode_valid = false;
     it->lower_bound(start_key);
     // skip to first key that is beginning of Onode
     while (it->valid() && is_extent_shard_key(it->key())) {
@@ -270,25 +273,64 @@ class BlueStore::OnodeScanMT {
         }
         edecoder.reset(oid,
                        &stats.actual_pool_vstatfs[oid.hobj.get_logical_pool()]);
-        Onode dummy_on(cct);
-        Onode::decode_raw(&dummy_on, it->value(), edecoder, store.segment_size != 0);
-        ++stats.onode_count;
+        current_onode_valid = false;
+        try {
+          bluestore_decode::throwing_guard g(store.db_was_opened_read_only);
+          Onode dummy_on(cct);
+          Onode::decode_raw(
+            &dummy_on,
+            it->value(),
+            edecoder,
+            store.segment_size != 0);
+          current_onode_valid = true;
+          ++stats.onode_count;
+        } catch (const ceph::buffer::error& e) {
+          if (!store.db_was_opened_read_only) {
+            throw;
+          }
+          derr << __func__ << " skipping undecodable onode "
+              << pretty_binary_string(key) << ": " << e.what() << dendl;
+          continue;
+        }
       } else {
         edecoder.reset_new_shard();
         uint32_t offset;
-        get_key_extent_shard(key, &okey, &offset);
-        int r = get_key_object(okey, &oid);
+        int r = get_key_extent_shard(key, &okey, &offset);
         if (r != 0) {
           derr << __func__
-               << " failed to decode onode key= " << pretty_binary_string(okey)
-               << " from extent key= " << pretty_binary_string(key) << dendl;
+              << " failed to decode extent shard key= " << pretty_binary_string(key) << dendl;
           continue;
         }
-        if (oid != edecoder.get_oid()) {
+        r = get_key_object(okey, &oid);
+        if (r != 0) {
+          derr << __func__
+              << " failed to decode onode key= "
+              << pretty_binary_string(okey)
+              << " from extent key= "
+              << pretty_binary_string(key) << dendl;
           continue;
         }
-        edecoder.decode_some(it->value(), nullptr);
-        ++stats.shard_count;
+        if (!current_onode_valid || oid != edecoder.get_oid()) {
+          derr << __func__ << " skipping extent shard "
+              << pretty_binary_string(key)
+              << " without a valid current onode" << dendl;
+          continue;
+        }
+        try {
+          bluestore_decode::throwing_guard g(
+            store.db_was_opened_read_only);
+          edecoder.decode_some(it->value(), nullptr);
+          ++stats.shard_count;
+        } catch (const ceph::buffer::error& e) {
+          if (!store.db_was_opened_read_only) {
+            throw;
+          }
+          derr << __func__
+              << " skipping undecodable extent shard "
+              << pretty_binary_string(key) << ": "
+              << e.what() << dendl;
+          continue;
+        }
       }
     }
     report_progress(0, kv_count - last_completed);

--- a/src/os/bluestore/OnodeScan.cc
+++ b/src/os/bluestore/OnodeScan.cc
@@ -241,9 +241,10 @@ class BlueStore::OnodeScanMT {
     uint64_t count_interval = 100'000;
     Decoder_AllocationsAndStatFS edecoder(store, stats, *sbmap,
                                           store.min_alloc_size_order);
-    // Same read-only gating as read_allocation_from_onodes: tolerate a corrupt
-    // onode only when the rebuilt allocation won't be committed.
+    // Same gating as read_allocation_from_onodes: only read-only fsck may
+    // tolerate an undecodable onode here.
     bool current_onode_valid = false;
+    const bool tolerate = store._alloc_recovery_tolerates_corruption();
     it->lower_bound(start_key);
     // skip to first key that is beginning of Onode
     while (it->valid() && is_extent_shard_key(it->key())) {
@@ -275,7 +276,7 @@ class BlueStore::OnodeScanMT {
                        &stats.actual_pool_vstatfs[oid.hobj.get_logical_pool()]);
         current_onode_valid = false;
         try {
-          bluestore_decode::throwing_guard g(store.db_was_opened_read_only);
+          bluestore_decode::throwing_guard g(tolerate);
           Onode dummy_on(cct);
           Onode::decode_raw(
             &dummy_on,
@@ -285,9 +286,8 @@ class BlueStore::OnodeScanMT {
           current_onode_valid = true;
           ++stats.onode_count;
         } catch (const ceph::buffer::error& e) {
-          if (!store.db_was_opened_read_only) {
-            throw;
-          }
+          if (!tolerate) { throw; }
+          ++store.alloc_recovery_skipped_onodes;
           derr << __func__ << " skipping undecodable onode "
               << pretty_binary_string(key) << ": " << e.what() << dendl;
           continue;
@@ -317,18 +317,13 @@ class BlueStore::OnodeScanMT {
           continue;
         }
         try {
-          bluestore_decode::throwing_guard g(
-            store.db_was_opened_read_only);
+          bluestore_decode::throwing_guard g(tolerate);
           edecoder.decode_some(it->value(), nullptr);
           ++stats.shard_count;
         } catch (const ceph::buffer::error& e) {
-          if (!store.db_was_opened_read_only) {
-            throw;
-          }
-          derr << __func__
-              << " skipping undecodable extent shard "
-              << pretty_binary_string(key) << ": "
-              << e.what() << dendl;
+          if (!tolerate) { throw; }
+          derr << __func__ << " skipping undecodable extent shard "
+              << pretty_binary_string(key) << ": " << e.what() << dendl;
           continue;
         }
       }

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -30,12 +30,12 @@ using ceph::Formatter;
 
 namespace bluestore_decode {
 
-thread_local bool tolerate_failures = false;
+thread_local bool throw_on_failure = false;
 
-[[noreturn]] void assert_fail(const char* assertion, const char* file,
+void assert_fail(const char* assertion, const char* file,
                               int line, const char* func)
 {
-  if (tolerate_failures) {
+  if (throw_on_failure) {
     throw ceph::buffer::malformed_input(
       std::string("decode assert failure: ") + assertion +
       " at " + file + ":" + std::to_string(line));

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -28,6 +28,23 @@ using ceph::bufferlist;
 using ceph::bufferptr;
 using ceph::Formatter;
 
+namespace bluestore_decode {
+
+thread_local bool tolerate_failures = false;
+
+[[noreturn]] void assert_fail(const char* assertion, const char* file,
+                              int line, const char* func)
+{
+  if (tolerate_failures) {
+    throw ceph::buffer::malformed_input(
+      std::string("decode assert failure: ") + assertion +
+      " at " + file + ":" + std::to_string(line));
+  }
+  ::ceph::__ceph_assert_fail(assertion, file, line, func);
+}
+
+} // namespace bluestore_decode
+
 //bluestore_stats_t
 
 std::ostream& operator<<(std::ostream& out, const bluestore_stats_t& s)

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -509,8 +509,8 @@ void bluestore_blob_use_tracker_t::release(uint32_t au_count, uint32_t* ptr) {
 void bluestore_blob_use_tracker_t::init(
   uint32_t full_length, uint32_t _au_size) {
   ceph_assert(!au_size || is_empty()); 
-  ceph_assert(_au_size > 0);
-  ceph_assert(full_length > 0);
+  ceph_assert_decode(_au_size > 0);
+  ceph_assert_decode(full_length > 0);
   clear();  
   uint32_t _num_au = round_up_to(full_length, _au_size) / _au_size;
   au_size = _au_size;

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -34,22 +34,18 @@
 
 // Decode-failure tolerance for BlueStore fsck/repair (tracker #77325).
 // Regular I/O keeps crashing on corrupt decode (coredump/backtrace);
-// fsck opts in via tolerant_guard, turning decode assert failures into
+// fsck opts in via throwing_guard, turning decode assert failures into
 // ceph::buffer::malformed_input which fsck catches.
 namespace bluestore_decode {
-extern thread_local bool tolerate_failures;
-struct tolerant_guard {
-  bool prev;
-  tolerant_guard()  : prev(tolerate_failures) { tolerate_failures = true; }
-  ~tolerant_guard() { tolerate_failures = prev; }
+extern thread_local bool throw_on_failure;
+struct throwing_guard {
+  throwing_guard()  { ceph_assert(!throw_on_failure); throw_on_failure = true; }
+  ~throwing_guard() { throw_on_failure = false; }
 };
-  [[noreturn]] void assert_fail(const char* assertion, const char* file,
-                                int line, const char* func);
+  void assert_fail(const char* assertion, const char* file,
+                   int line, const char* func);
 } // namespace bluestore_decode
 
-// Same shape as ceph_assert (include/ceph_assert.h): one predicate test,
-// cold [[noreturn]] call on failure. The thread-local is read only after
-// the predicate has already failed, so the success path is identical.
 #define ceph_assert_decode(expr)                                           \
   do {                                                                     \
     ((expr))                                                               \

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -39,8 +39,19 @@
 namespace bluestore_decode {
 extern thread_local bool throw_on_failure;
 struct throwing_guard {
-  throwing_guard()  { ceph_assert(!throw_on_failure); throw_on_failure = true; }
-  ~throwing_guard() { throw_on_failure = false; }
+  explicit throwing_guard(bool enable = true) : active(enable) {
+    if (active) {
+      ceph_assert(!throw_on_failure);
+      throw_on_failure = true;
+    }
+  }
+  ~throwing_guard() {
+    if (active) {
+      throw_on_failure = false;
+    }
+  }
+private:
+  bool active;
 };
   void assert_fail(const char* assertion, const char* file,
                    int line, const char* func);
@@ -182,6 +193,7 @@ struct denc_traits<PExtentVector> {
     unsigned num;
     denc_varint(num, p);
     v.clear();
+    ceph_assert_decode(num <= unsigned(p.get_end() - p.get_pos())); 
     v.resize(num);
     for (unsigned i=0; i<num; ++i) {
       denc(v[i], p);
@@ -510,6 +522,7 @@ struct bluestore_blob_use_tracker_t {
         num_au = 0;
         denc_varint(total_bytes, p);
       } else {
+        ceph_assert_decode(_num_au <= size_t(p.get_end() - p.get_pos()));
         allocate(_num_au);
         for (size_t i = 0; i < _num_au; ++i) {
 	  denc_varint(bytes_per_au[i], p);

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -30,6 +30,34 @@
 #include "include/ceph_hash.h"
 #include "include/intarith.h" // for round_up_to()
 
+#include "include/ceph_assert.h"
+
+// Decode-failure tolerance for BlueStore fsck/repair (tracker #77325).
+// Regular I/O keeps crashing on corrupt decode (coredump/backtrace);
+// fsck opts in via tolerant_guard, turning decode assert failures into
+// ceph::buffer::malformed_input which fsck catches.
+namespace bluestore_decode {
+extern thread_local bool tolerate_failures;
+struct tolerant_guard {
+  bool prev;
+  tolerant_guard()  : prev(tolerate_failures) { tolerate_failures = true; }
+  ~tolerant_guard() { tolerate_failures = prev; }
+};
+  [[noreturn]] void assert_fail(const char* assertion, const char* file,
+                                int line, const char* func);
+} // namespace bluestore_decode
+
+// Same shape as ceph_assert (include/ceph_assert.h): one predicate test,
+// cold [[noreturn]] call on failure. The thread-local is read only after
+// the predicate has already failed, so the success path is identical.
+#define ceph_assert_decode(expr)                                           \
+  do {                                                                     \
+    ((expr))                                                               \
+    ? _CEPH_ASSERT_VOID_CAST (0)                                           \
+      : ::bluestore_decode::assert_fail(__STRING(expr), __FILE__,          \
+                                        __LINE__, __CEPH_ASSERT_FUNCTION); \
+  } while (false)
+
 namespace ceph {
   class Formatter;
 }

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -33,9 +33,9 @@
 #include "include/ceph_assert.h"
 
 // Decode-failure tolerance for BlueStore fsck/repair (tracker #77325).
-// Regular I/O keeps crashing on corrupt decode (coredump/backtrace);
-// fsck opts in via throwing_guard, turning decode assert failures into
-// ceph::buffer::malformed_input which fsck catches.
+// Regular I/O still crashes on corrupt decode; a caller can opt in via
+// throwing_guard to get ceph::buffer::malformed_input instead, so it can
+// catch and report the failure rather than aborting.
 namespace bluestore_decode {
 extern thread_local bool throw_on_failure;
 struct throwing_guard {

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -11949,6 +11949,7 @@ TEST_P(CorruptedOnodesTest, Fsck_TolerateCorruptedOnodes)
   // deterministic onode encoding: segment_size==0 => FLAG_DEBUG_FORCE_V2
   SetVal(g_conf(), "bluestore_debug_onode_segmentation_random", "false");
   SetVal(g_conf(), "bluestore_onode_segment_size", "0");
+  SetVal(g_conf(), "bluestore_fsck_quick_fix_threads", "2");
   g_conf().apply_changes(nullptr);
   prepare_store();
 
@@ -11973,13 +11974,6 @@ TEST_P(CorruptedOnodesTest, Fsck_TolerateCorruptedOnodes)
                               make_bad_onode_val(kinds[i])));
   }
   umount();
-
-  // Deliverable: all four corrupt onodes are detected and fsck returns
-  // instead of aborting on the decode assert. Report-only in this change —
-  // the onodes are not removed (physical removal would orphan their blocks:
-  // the extent map is undecodable, so reclamation is the -EIO follow-up,
-  // tracker #77325), so fsck keeps reporting them rather than reaching a
-  // clean store.
   ASSERT_GE(store->fsck(false), 4);    // all four reported, no abort()
   cleanup_store();
 }
@@ -11994,7 +11988,6 @@ TEST_P(CorruptedOnodesTest, CorruptedOnode_RegularPathStillCrashes)
   SetVal(g_conf(), "bluestore_onode_segment_size", "0");
   g_conf().apply_changes(nullptr);
   prepare_store();
-
   // Persist the corruption, then fully tear down so no live store (threads,
   // open RocksDB) is cloned across the death-test fork.
   mount();
@@ -12003,7 +11996,6 @@ TEST_P(CorruptedOnodesTest, CorruptedOnode_RegularPathStillCrashes)
   ASSERT_TRUE(corrupt_onode(bs, "my_special_object",
                             make_bad_onode_val(BadKind::version)));
   umount();
-
   // Child does its own clean mount; the cold read must decode the corrupt
   // onode and abort via ceph_assert (no throwing_guard on the regular path).
   EXPECT_DEATH({
@@ -12016,7 +12008,77 @@ TEST_P(CorruptedOnodesTest, CorruptedOnode_RegularPathStillCrashes)
     (void)store->read(ch2, hoid, 0, 4, bl);
     umount();
   }, "");
+  cleanup_store();
+}
 
+
+TEST_P(CorruptedOnodesTest, Fsck_CreateDecodeThrow_DoesNotLeakOnode)
+{
+  SetVal(g_conf(), "bluestore_debug_inject_allocation_from_file_failure", "0");
+  prepare_store(); mount();
+  BlueStore* bs = dynamic_cast<BlueStore*>(store.get()); ceph_assert(bs);
+  // spanning-blob corruption throws INSIDE create_decode, before the raw
+  // Onode* reaches the OnodeRef -> exercises the unique_ptr<Onode> unwind.
+  ASSERT_TRUE(corrupt_onode(bs, "my_special_object",
+                            make_bad_onode_val(BadKind::spanning_id)));
+  umount();
+  auto onodes = []{ return int64_t(mempool::bluestore_cache_onode::allocated_items()); };
+  store->fsck(false);
+  int64_t before = onodes();
+  for (int i = 0; i < 20; ++i) EXPECT_GT(store->fsck(false), 0);
+  EXPECT_EQ(before, onodes());
+  cleanup_store();
+}
+
+TEST_P(CorruptedOnodesTest, Fsck_ExtentDecodeThrow_DoesNotLeakExtent)
+{
+  SetVal(g_conf(), "bluestore_debug_inject_allocation_from_file_failure", "0");
+  prepare_store(); mount();
+  BlueStore* bs = dynamic_cast<BlueStore*>(store.get()); ceph_assert(bs);
+  // extent-map corruption throws in decode_some while an Extent is pending
+  // in ExtentDecoderFull -> exercises the pending_extent unwind.
+  ASSERT_TRUE(corrupt_onode(bs, "my_special_object",
+                            make_bad_onode_val(BadKind::version)));
+  umount();
+  auto extents = []{ return int64_t(mempool::bluestore_extent::allocated_items()); };
+  store->fsck(false);
+  int64_t before = extents();
+  for (int i = 0; i < 20; ++i) EXPECT_GT(store->fsck(false), 0);
+  EXPECT_EQ(before, extents());
+  cleanup_store();
+}
+
+TEST_P(CorruptedOnodesTest, Fsck_ToleratesCorruptionDuringAllocationRecovery)
+{
+  SetVal(g_conf(), "bluestore_allocation_recovery_threads", "0"); // single-threaded
+  g_conf().apply_changes(nullptr);
+  prepare_store(); mount();
+  auto* bs = dynamic_cast<BlueStore*>(store.get()); ceph_assert(bs);
+  ASSERT_TRUE(corrupt_onode(bs, "my_special_object",
+                            make_bad_onode_val(BadKind::version)));
+  umount();
+  SetVal(g_conf(), "bluestore_debug_inject_allocation_from_file_failure", "1");
+  g_conf().apply_changes(nullptr);
+  EXPECT_GT(store->fsck(false), 0);
+  SetVal(g_conf(), "bluestore_debug_inject_allocation_from_file_failure", "0");
+  g_conf().apply_changes(nullptr);
+  cleanup_store();
+}
+
+TEST_P(CorruptedOnodesTest, Fsck_ToleratesCorruptionDuringAllocationRecoveryMT)
+{
+  SetVal(g_conf(), "bluestore_allocation_recovery_threads", "4"); // multi-threaded
+  g_conf().apply_changes(nullptr);
+  prepare_store(); mount();
+  auto* bs = dynamic_cast<BlueStore*>(store.get()); ceph_assert(bs);
+  ASSERT_TRUE(corrupt_onode(bs, "my_special_object",
+                            make_bad_onode_val(BadKind::version)));
+  umount();
+  SetVal(g_conf(), "bluestore_debug_inject_allocation_from_file_failure", "1");
+  g_conf().apply_changes(nullptr);
+  EXPECT_GT(store->fsck(false), 0);
+  SetVal(g_conf(), "bluestore_debug_inject_allocation_from_file_failure", "0");
+  g_conf().apply_changes(nullptr);
   cleanup_store();
 }
 

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -11942,7 +11942,7 @@ static bufferlist make_bad_onode_val(BadKind kind)
 }
 
 // One victim object per corruption shape, all in one store: fsck reports
-// them all without aborting, repair fixes, healthy objects survive.
+// them all without aborting.
 TEST_P(CorruptedOnodesTest, Fsck_TolerateCorruptedOnodes)
 {
   SetVal(g_conf(), "bluestore_debug_inject_allocation_from_file_failure", "0");
@@ -12050,7 +12050,10 @@ TEST_P(CorruptedOnodesTest, Fsck_ExtentDecodeThrow_DoesNotLeakExtent)
 
 TEST_P(CorruptedOnodesTest, Fsck_ToleratesCorruptionDuringAllocationRecovery)
 {
+  g_ceph_context->_conf._clear_safe_to_start_threads();
+  SetVal(g_conf(), "bluestore_debug_enforce_settings", "ssd");
   SetVal(g_conf(), "bluestore_allocation_recovery_threads", "0"); // single-threaded
+  // SetVal(g_conf(), "bluestore_allocation_recovery_threads", "4"); // multi-threaded
   g_conf().apply_changes(nullptr);
   prepare_store(); mount();
   auto* bs = dynamic_cast<BlueStore*>(store.get()); ceph_assert(bs);
@@ -12065,9 +12068,12 @@ TEST_P(CorruptedOnodesTest, Fsck_ToleratesCorruptionDuringAllocationRecovery)
   cleanup_store();
 }
 
-TEST_P(CorruptedOnodesTest, Fsck_ToleratesCorruptionDuringAllocationRecoveryMT)
+TEST_P(CorruptedOnodesTest, ColdOpen_StillAssertsOnCorruptOnode)
 {
-  SetVal(g_conf(), "bluestore_allocation_recovery_threads", "4"); // multi-threaded
+  g_ceph_context->_conf._clear_safe_to_start_threads();
+  GTEST_FLAG_SET(death_test_style, "threadsafe");   // mount() leaves threads running
+  SetVal(g_conf(), "bluestore_debug_enforce_settings", "ssd");
+  SetVal(g_conf(), "bluestore_allocation_recovery_threads", "0");
   g_conf().apply_changes(nullptr);
   prepare_store(); mount();
   auto* bs = dynamic_cast<BlueStore*>(store.get()); ceph_assert(bs);
@@ -12076,7 +12082,9 @@ TEST_P(CorruptedOnodesTest, Fsck_ToleratesCorruptionDuringAllocationRecoveryMT)
   umount();
   SetVal(g_conf(), "bluestore_debug_inject_allocation_from_file_failure", "1");
   g_conf().apply_changes(nullptr);
-  EXPECT_GT(store->fsck(false), 0);
+  // cold_open() is ceph-bluestore-tool trim's entry point: read-only, but it
+  // discards space based on the recovered allocation, so it must not tolerate.
+  ASSERT_DEATH(bs->cold_open(), "FAILED ceph_assert");
   SetVal(g_conf(), "bluestore_debug_inject_allocation_from_file_failure", "0");
   g_conf().apply_changes(nullptr);
   cleanup_store();

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -27,6 +27,8 @@
 #include <boost/random/binomial_distribution.hpp>
 #include <fmt/format.h>
 #include <gtest/gtest.h>
+#include <limits.h>
+#include <unistd.h>
 
 #include "global/global_context.h"
 #include "os/ObjectStore.h"
@@ -11982,7 +11984,7 @@ TEST_P(CorruptedOnodesTest, Fsck_TolerateCorruptedOnodes)
 // via ceph_assert (coredump/backtrace preserved).
 TEST_P(CorruptedOnodesTest, CorruptedOnode_RegularPathStillCrashes)
 {
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
+  GTEST_FLAG_SET(death_test_style, "threadsafe");
   SetVal(g_conf(), "bluestore_debug_inject_allocation_from_file_failure", "0");
   SetVal(g_conf(), "bluestore_debug_onode_segmentation_random", "false");
   SetVal(g_conf(), "bluestore_onode_segment_size", "0");
@@ -12007,7 +12009,7 @@ TEST_P(CorruptedOnodesTest, CorruptedOnode_RegularPathStillCrashes)
     bufferlist bl;
     (void)store->read(ch2, hoid, 0, 4, bl);
     umount();
-  }, "");
+  }, "FAILED ceph_assert");
   cleanup_store();
 }
 
@@ -13069,6 +13071,13 @@ int main(int argc, char **argv) {
   g_ceph_context->_conf.set_val_or_die(
     "enable_experimental_unrecoverable_data_corrupting_features", "*");
   g_ceph_context->_conf.apply_changes(nullptr);
+
+  char exe_path[PATH_MAX];
+  ssize_t exe_len = ::readlink("/proc/self/exe", exe_path, sizeof(exe_path) - 1);
+  if (exe_len > 0) {
+    exe_path[exe_len] = '\0';
+    argv[0] = exe_path;
+  }
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -11995,6 +11995,8 @@ TEST_P(CorruptedOnodesTest, CorruptedOnode_RegularPathStillCrashes)
   g_conf().apply_changes(nullptr);
   prepare_store();
 
+  // Persist the corruption, then fully tear down so no live store (threads,
+  // open RocksDB) is cloned across the death-test fork.
   mount();
   BlueStore* bs = dynamic_cast<BlueStore*>(store.get());
   ceph_assert(bs);
@@ -12002,15 +12004,19 @@ TEST_P(CorruptedOnodesTest, CorruptedOnode_RegularPathStillCrashes)
                             make_bad_onode_val(BadKind::version)));
   umount();
 
-  mount();                             // cold cache: read must decode
-  ch = store->open_collection(cid);
-  ghobject_t hoid(
-    hobject_t(sobject_t("my_special_object", CEPH_NOSNAP), "", 1, 222, ""));
-  hoid.hobj.set_hash(0x80000000);
-  bufferlist bl;
-  EXPECT_DEATH((void)store->read(ch, hoid, 0, 4, bl), "");
-  ch.reset();
-  umount();
+  // Child does its own clean mount; the cold read must decode the corrupt
+  // onode and abort via ceph_assert (no throwing_guard on the regular path).
+  EXPECT_DEATH({
+    mount();
+    auto ch2 = store->open_collection(cid);
+    ghobject_t hoid(
+      hobject_t(sobject_t("my_special_object", CEPH_NOSNAP), "", 1, 222, ""));
+    hoid.hobj.set_hash(0x80000000);
+    bufferlist bl;
+    (void)store->read(ch2, hoid, 0, 4, bl);
+    umount();
+  }, "");
+
   cleanup_store();
 }
 

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -11866,6 +11866,154 @@ TEST_P(CorruptedOnodesTest, Recover_TolerateMissingHeadShard)
   cleanup_store();
 }
 
+// Replaces the named object's onode value and drops its extent-map shard
+// keys (replacements are non-sharded; leftover "...x" shards would be
+// flagged stray and keep the post-repair fsck dirty).
+static bool corrupt_onode(BlueStore* bs, const std::string& name,
+                          const bufferlist& new_val)
+{
+  KeyValueDB* pdb = bs->get_kv();
+  KeyValueDB::Iterator it = pdb->get_iterator("O");
+  auto trans = pdb->get_transaction();
+  bool corrupted = false;
+  it->seek_to_first();
+  while (it->valid()) {
+    if (it->key().contains(name)) {
+      if (it->key().ends_with("o")) {
+        trans->set("O", it->key(), new_val);
+        corrupted = true;
+      } else if (it->key().ends_with("x")) {
+        trans->rm_single_key("O", it->key());
+      }
+    }
+    it->next();
+  }
+  pdb->submit_transaction_sync(trans);
+  return corrupted;
+}
+
+enum class BadKind { truncated, version, blobid, spanning_id };
+
+// truncated:   garbage header -> buffer::error from onode decode
+// version:     spanning-blobs struct_v neither 1 nor 2
+//              -> ceph_assert_decode in decode_spanning_blobs()
+// blobid:      extent references blobs[0] which was never defined
+//              -> ceph_assert_decode in ExtentDecoderFull::consume_blobid()
+// spanning_id: extent references spanning blob #1 which doesn't exist
+//              -> ceph_assert_decode in ExtentMap::get_spanning_blob()
+static bufferlist make_bad_onode_val(BadKind kind)
+{
+  bufferlist val;
+  if (kind == BadKind::truncated) {
+    val.append(std::string(4, '\xff'));
+    return val;
+  }
+  const uint64_t flag = bluestore_onode_t::FLAG_DEBUG_FORCE_V2;
+  bluestore_onode_t on;
+  on.nid = 1;
+  size_t bound = 0;
+  denc(on, bound, flag);
+  {
+    auto ap = val.get_contiguous_appender(bound, true);
+    denc(on, ap, flag);                 // valid onode header
+  }
+  if (kind == BadKind::version) {
+    val.append(static_cast<char>(0xff));
+    return val;
+  }
+  bufferlist inner;  // inline extent map: v2, one extent with a bad reference
+  {
+    auto ap = inner.get_contiguous_appender(8, true);
+    denc((__u8)2, ap);                  // extent-map struct_v
+    denc_varint(uint32_t(1), ap);       // num extents
+    // low bits: CONTIGUOUS|ZEROOFFSET|SAMELENGTH(|SPANNING); id = 1
+    denc_varint(uint32_t((1 << 4) | 0x7 |
+                         (kind == BadKind::spanning_id ? 0x8 : 0)), ap);
+  }
+  bufferlist tail;
+  {
+    auto ap = tail.get_contiguous_appender(8 + inner.length(), true);
+    denc((__u8)2, ap);                  // spanning-blobs struct_v (valid)
+    denc_varint(uint32_t(0), ap);       // no spanning blobs
+    denc(inner, ap);                    // inline_bl
+  }
+  val.append(tail);
+  return val;
+}
+
+// One victim object per corruption shape, all in one store: fsck reports
+// them all without aborting, repair fixes, healthy objects survive.
+TEST_P(CorruptedOnodesTest, Fsck_TolerateCorruptedOnodes)
+{
+  SetVal(g_conf(), "bluestore_debug_inject_allocation_from_file_failure", "0");
+  // deterministic onode encoding: segment_size==0 => FLAG_DEBUG_FORCE_V2
+  SetVal(g_conf(), "bluestore_debug_onode_segmentation_random", "false");
+  SetVal(g_conf(), "bluestore_onode_segment_size", "0");
+  g_conf().apply_changes(nullptr);
+  prepare_store();
+
+  mount();
+  const BadKind kinds[] = {BadKind::truncated, BadKind::version,
+                           BadKind::blobid, BadKind::spanning_id};
+  ch = store->open_collection(cid);
+  for (int i = 0; i < 4; i++) {
+    ghobject_t hoid(hobject_t(sobject_t("victim" + std::to_string(i),
+                                        CEPH_NOSNAP), "", 1, 222, ""));
+    hoid.hobj.set_hash(0x10000000u * (i + 1));
+    ASSERT_EQ(write_object(cid, ch, hoid, 0x1000), 0);
+  }
+  ch.reset();
+  umount();                            // flush kv queue so onodes hit rocksdb
+  mount();
+  BlueStore* bs = dynamic_cast<BlueStore*>(store.get());
+  ceph_assert(bs);
+
+  for (int i = 0; i < 4; i++) {
+    ASSERT_TRUE(corrupt_onode(bs, "victim" + std::to_string(i),
+                              make_bad_onode_val(kinds[i])));
+  }
+  umount();
+
+  // Deliverable: all four corrupt onodes are detected and fsck returns
+  // instead of aborting on the decode assert. Report-only in this change —
+  // the onodes are not removed (physical removal would orphan their blocks:
+  // the extent map is undecodable, so reclamation is the -EIO follow-up,
+  // tracker #77325), so fsck keeps reporting them rather than reaching a
+  // clean store.
+  ASSERT_GE(store->fsck(false), 4);    // all four reported, no abort()
+  cleanup_store();
+}
+
+// Regular I/O has no tolerant_guard: the same corruption must still abort
+// via ceph_assert (coredump/backtrace preserved).
+TEST_P(CorruptedOnodesTest, CorruptedOnode_RegularPathStillCrashes)
+{
+  testing::FLAGS_gtest_death_test_style = "threadsafe";
+  SetVal(g_conf(), "bluestore_debug_inject_allocation_from_file_failure", "0");
+  SetVal(g_conf(), "bluestore_debug_onode_segmentation_random", "false");
+  SetVal(g_conf(), "bluestore_onode_segment_size", "0");
+  g_conf().apply_changes(nullptr);
+  prepare_store();
+
+  mount();
+  BlueStore* bs = dynamic_cast<BlueStore*>(store.get());
+  ceph_assert(bs);
+  ASSERT_TRUE(corrupt_onode(bs, "my_special_object",
+                            make_bad_onode_val(BadKind::version)));
+  umount();
+
+  mount();                             // cold cache: read must decode
+  ch = store->open_collection(cid);
+  ghobject_t hoid(
+    hobject_t(sobject_t("my_special_object", CEPH_NOSNAP), "", 1, 222, ""));
+  hoid.hobj.set_hash(0x80000000);
+  bufferlist bl;
+  EXPECT_DEATH((void)store->read(ch, hoid, 0, 4, bl), "");
+  ch.reset();
+  umount();
+  cleanup_store();
+}
+
 TEST_P(CorruptedOnodesTest, Fsck_FixMissingHeadShard)
 {
   SetVal(g_conf(), "bluestore_debug_inject_allocation_from_file_failure", "0");

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -60,6 +60,40 @@ TEST(bluestore, sizeof) {
   cout << "map<char,char>\t" << sizeof(map<char, char>) << std::endl;
 }
 
+// Note: Reusable for future bit-flip fuzzing.
+static void expect_decode_tolerated(std::function<void()> decode,
+                                    bool expect_thrown = false) {
+  bool threw_buffer_error = false, escaped_std = false;
+  try {
+    bluestore_decode::throwing_guard g;
+    decode();
+  } catch (const ceph::buffer::error&) { threw_buffer_error = true; }
+    catch (const std::bad_alloc&)      { escaped_std = true; }
+    catch (const std::length_error&)   { escaped_std = true; }
+    EXPECT_FALSE(escaped_std)
+      << "corrupt decode escaped as a std:: allocation exception (uncaught OOM)";
+  if (expect_thrown) {
+    EXPECT_TRUE(threw_buffer_error) << "expected the guard to reject this input";
+  }
+}
+
+TEST(bluestore_blob_use_tracker_t, decode_bogus_au_count_throws_buffer_error) {
+  bufferlist bl;
+  { auto app = bl.get_contiguous_appender(16);
+    denc_varint((uint32_t)0x1000, app);        // au_size != 0 -> array branch
+    denc_varint((uint32_t)0xffffffff, app); }  // num_au straight from disk
+  bluestore_blob_use_tracker_t t;
+  expect_decode_tolerated([&]{ auto p = bl.front().begin_deep(); t.decode(p); }, true);
+}
+
+TEST(PExtentVector, decode_bogus_extent_count_throws_buffer_error) {
+  bufferlist bl;
+  { auto app = bl.get_contiguous_appender(8);
+    denc_varint((uint32_t)0xffffffff, app); }  // no payload
+  PExtentVector v;
+  expect_decode_tolerated([&]{ auto p = bl.front().begin_deep(); denc(v, p); }, true);
+}
+
 void dump_mempools() {
   ostringstream ostr;
   auto f =


### PR DESCRIPTION
BlueStore fsck aborts on the first corrupted onode because decode validation uses ceph_assert. This makes decode failures recoverable for fsck only, leaving the regular I/O path unchanged.

Design: ceph_assert_decode() behaves exactly like ceph_assert by default and only diverges when fsck opts in via an RAII throwing_guard, throwing ceph::buffer::malformed_input so corruption is reported and skipped. Only asserts validating on-disk data were converted; program invariants stay fatal. fsck catches ceph::buffer::error at the object-walk sites, and exception safety was fixed for the newly throwable paths.

Allocation recovery: the post-crash rebuild that scans onodes (read_allocation_from_onodes and its multithreaded OnodeScanMT variant) also tolerates corruption, since that is where a crash-on-corrupt-onode lands at next mount. Tolerance requires an explicit caller opt-in that only read-only fsck requests; mount, repair, and trim stay fatal, because they either persist the rebuilt allocation or use it destructively. The new bluestore_accept_corrupted_onode_recovery option (never / read-only, default read-only) lets an operator disable tolerance entirely.

Unbounded allocations: a corrupt on-disk count can drive an allocation throwing std::bad_alloc/length_error, which slips past the fsck catches. These are now bounds-checked against the remaining buffer.

Tests: CorruptedOnodesTest covers truncated headers, bad struct_v, dangling blob indexes, and missing spanning blobs, with a death test confirming the regular path still crashes. Leak-safety verified under ASan; the decode-count guards have unit tests on a reusable expect_decode_tolerated() helper so bit-flip fuzzing can drop in later. Allocation recovery is covered end to end, single- and multi-threaded, via bluestore_debug_enforce_settings=ssd to reach NCB mode, plus a test that cold_open() (trim's entry point) still aborts where read-only fsck skips.

Out of scope (follow-ups): -EIO removal of unrecoverable objects, framework-wide denc reserve(num) hardening, and two-phase repair.

Fixes: https://tracker.ceph.com/issues/77325

Signed-off-by: Emily Leson [etleson10@gmail.com](mailto:etleson10@gmail.com)

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
