### PR TITLE
mgr/nfs:Code change made cluster_qos_port an optional field for NFS colocation ports

### DIFF
--- a/doc/cephadm/services/nfs.rst
+++ b/doc/cephadm/services/nfs.rst
@@ -167,8 +167,9 @@ In this configuration, 4 daemons total are deployed (2 per host), distributed ac
      ``monitoring_port`` from the spec.
    * The number of entries in ``colocation_ports`` should be ``count - 1``,
      to cover the node down scenario (or ``count_per_host - 1`` when using ``count_per_host``).
-   * Each entry must specify ``data_port``, ``monitoring_port``, and ``qos_cluster_port``.
+   * Each entry must specify ``data_port``, ``monitoring_port``.
      When ``enable_rdma`` is true, each entry must also include ``rdma_port``.
+     Similarly, qos_cluster_port is only required when QoS features are configured.
    * If ``colocation_ports`` is not specified, ports will be automatically
      incremented for colocated daemons (e.g., 2049 → 2050 → 2051 for data ports,
      and 9587 → 9588 → 9589 for monitoring ports).

--- a/src/pybind/mgr/cephadm/tests/services/test_nfs.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nfs.py
@@ -591,15 +591,15 @@ class TestNFS:
 
 def test_nfs_colocation_ports_validation():
     """Test validation of colocation_ports in NFSServiceSpec"""
-    # Valid case: correct number of colocation_ports (count=3, need 2 additional)
+    # Valid case: correct number of colocation_ports (count=3, need 2 additional) without QoS
     spec = NFSServiceSpec(
         service_id='mynfs',
         placement=PlacementSpec(count=3),
         port=2049,
         monitoring_port=9587,
         colocation_ports=[
-            {'data_port': 3049, 'monitoring_port': 9588, 'cluster_qos_port': 31312},
-            {'data_port': 4049, 'monitoring_port': 9589, 'cluster_qos_port': 31313}
+            {'data_port': 3049, 'monitoring_port': 9588},
+            {'data_port': 4049, 'monitoring_port': 9589}
         ]
     )
     spec.validate()  # Should not raise
@@ -611,7 +611,7 @@ def test_nfs_colocation_ports_validation():
             placement=PlacementSpec(count=4),
             port=2049,
             monitoring_port=9587,
-            colocation_ports=[{'data_port': 3049, 'monitoring_port': 9588, 'cluster_qos_port': 31312}]
+            colocation_ports=[{'data_port': 3049, 'monitoring_port': 9588}]
         )
         spec.validate()
     assert "colocation_ports requires 3 entries for count=4 (got 1)" in str(e.value)
@@ -625,7 +625,7 @@ def test_nfs_colocation_ports_validation():
             monitoring_port=9587,
             colocation_ports=[
                 {'data_port': 3049},  # Missing monitoring_port
-                {'data_port': 4049, 'monitoring_port': 9589, 'cluster_qos_port': 31312}
+                {'data_port': 4049, 'monitoring_port': 9589}
             ]
         )
         spec.validate()
@@ -643,8 +643,8 @@ def test_nfs_colocation_ports_validation_with_rdma():
         enable_rdma=True,
         rdma_port=20049,
         colocation_ports=[
-            {'data_port': 3049, 'monitoring_port': 9588, 'cluster_qos_port': 31312, 'rdma_port': 20050},
-            {'data_port': 4049, 'monitoring_port': 9589, 'cluster_qos_port': 31313, 'rdma_port': 20051},
+            {'data_port': 3049, 'monitoring_port': 9588, 'rdma_port': 20050},
+            {'data_port': 4049, 'monitoring_port': 9589, 'rdma_port': 20051},
         ]
     )
     spec.validate()
@@ -658,12 +658,47 @@ def test_nfs_colocation_ports_validation_with_rdma():
             monitoring_port=9587,
             enable_rdma=True,
             colocation_ports=[
-                {'data_port': 3049, 'monitoring_port': 9588, 'cluster_qos_port': 31312},  # missing rdma_port
-                {'data_port': 4049, 'monitoring_port': 9589, 'cluster_qos_port': 31313, 'rdma_port': 20051},
+                {'data_port': 3049, 'monitoring_port': 9588},  # missing rdma_port
+                {'data_port': 4049, 'monitoring_port': 9589, 'rdma_port': 20051},
             ]
         )
         spec.validate()
     assert "missing required fields: rdma_port" in str(e.value)
+
+
+def test_nfs_colocation_ports_validation_with_qos():
+    """Test colocation_ports with QoS requires cluster_qos_port in each entry."""
+    # Valid: QoS enabled, count=3, 2 colocation entries with data_port, monitoring_port, cluster_qos_port
+    spec = NFSServiceSpec(
+        service_id='mynfs',
+        placement=PlacementSpec(count=3),
+        port=2049,
+        monitoring_port=9587,
+        cluster_qos_config={'enable_qos': True, 'enable_bw_control': True, 'qos_type': 'PerShare'},
+        cluster_qos_port=31311,
+        colocation_ports=[
+            {'data_port': 3049, 'monitoring_port': 9588, 'cluster_qos_port': 31312},
+            {'data_port': 4049, 'monitoring_port': 9589, 'cluster_qos_port': 31313},
+        ]
+    )
+    spec.validate()
+
+    # Invalid: QoS enabled but colocation entry missing cluster_qos_port
+    with pytest.raises(SpecValidationError) as e:
+        spec = NFSServiceSpec(
+            service_id='mynfs',
+            placement=PlacementSpec(count=3),
+            port=2049,
+            monitoring_port=9587,
+            cluster_qos_config={'enable_qos': True, 'enable_bw_control': True, 'qos_type': 'PerShare'},
+            cluster_qos_port=31311,
+            colocation_ports=[
+                {'data_port': 3049, 'monitoring_port': 9588},  # missing cluster_qos_port
+                {'data_port': 4049, 'monitoring_port': 9589, 'cluster_qos_port': 31313},
+            ]
+        )
+        spec.validate()
+    assert "missing required fields: cluster_qos_port" in str(e.value)
 
 
 @patch("cephadm.services.nfs.NFSService.run_grace_tool", MagicMock())

--- a/src/pybind/mgr/cephadm/tests/test_scheduling.py
+++ b/src/pybind/mgr/cephadm/tests/test_scheduling.py
@@ -675,8 +675,8 @@ class NodeAssignmentTest(NamedTuple):
             [],
             {},
             {0: {0: None}, 1: {0: None}, 2: {0: None}},
-            ['nfs:host3(rank=0.0 *:2049,9587,31311)', 'nfs:host2(rank=1.0 *:2049,9587,31311)', 'nfs:host1(rank=2.0 *:2049,9587,31311)'],
-            ['nfs:host3(rank=0.0 *:2049,9587,31311)', 'nfs:host2(rank=1.0 *:2049,9587,31311)', 'nfs:host1(rank=2.0 *:2049,9587,31311)'],
+            ['nfs:host3(rank=0.0 *:2049,9587)', 'nfs:host2(rank=1.0 *:2049,9587)', 'nfs:host1(rank=2.0 *:2049,9587)'],
+            ['nfs:host3(rank=0.0 *:2049,9587)', 'nfs:host2(rank=1.0 *:2049,9587)', 'nfs:host1(rank=2.0 *:2049,9587)'],
             []
         ),
         # 21: ranked, exist
@@ -689,8 +689,8 @@ class NodeAssignmentTest(NamedTuple):
             ],
             {0: {1: '0.1'}},
             {0: {1: '0.1'}, 1: {0: None}, 2: {0: None}},
-            ['nfs:host1(rank=0.1 *:2049,9587,31311)', 'nfs:host3(rank=1.0 *:2049,9587,31311)', 'nfs:host2(rank=2.0 *:2049,9587,31311)'],
-            ['nfs:host3(rank=1.0 *:2049,9587,31311)', 'nfs:host2(rank=2.0 *:2049,9587,31311)'],
+            ['nfs:host1(rank=0.1 *:2049,9587)', 'nfs:host3(rank=1.0 *:2049,9587)', 'nfs:host2(rank=2.0 *:2049,9587)'],
+            ['nfs:host3(rank=1.0 *:2049,9587)', 'nfs:host2(rank=2.0 *:2049,9587)'],
             []
         ),
         # ranked, exist, different ranks
@@ -704,8 +704,8 @@ class NodeAssignmentTest(NamedTuple):
             ],
             {0: {1: '0.1'}, 1: {1: '1.1'}},
             {0: {1: '0.1'}, 1: {1: '1.1'}, 2: {0: None}},
-            ['nfs:host1(rank=0.1 *:2049,9587,31311)', 'nfs:host2(rank=1.1 *:2049,9587,31311)', 'nfs:host3(rank=2.0 *:2049,9587,31311)'],
-            ['nfs:host3(rank=2.0 *:2049,9587,31311)'],
+            ['nfs:host1(rank=0.1 *:2049,9587)', 'nfs:host2(rank=1.1 *:2049,9587)', 'nfs:host3(rank=2.0 *:2049,9587)'],
+            ['nfs:host3(rank=2.0 *:2049,9587)'],
             []
         ),
         # ranked, exist, different ranks (2)
@@ -719,8 +719,8 @@ class NodeAssignmentTest(NamedTuple):
             ],
             {0: {1: '0.1'}, 1: {1: '1.1'}},
             {0: {1: '0.1'}, 1: {1: '1.1'}, 2: {0: None}},
-            ['nfs:host1(rank=0.1 *:2049,9587,31311)', 'nfs:host3(rank=1.1 *:2049,9587,31311)', 'nfs:host2(rank=2.0 *:2049,9587,31311)'],
-            ['nfs:host2(rank=2.0 *:2049,9587,31311)'],
+            ['nfs:host1(rank=0.1 *:2049,9587)', 'nfs:host3(rank=1.1 *:2049,9587)', 'nfs:host2(rank=2.0 *:2049,9587)'],
+            ['nfs:host2(rank=2.0 *:2049,9587)'],
             []
         ),
         # ranked, exist, extra ranks
@@ -735,8 +735,8 @@ class NodeAssignmentTest(NamedTuple):
             ],
             {0: {5: '0.5'}, 1: {5: '1.5'}},
             {0: {5: '0.5'}, 1: {5: '1.5'}, 2: {0: None}},
-            ['nfs:host1(rank=0.5 *:2049,9587,31311)', 'nfs:host2(rank=1.5 *:2049,9587,31311)', 'nfs:host3(rank=2.0 *:2049,9587,31311)'],
-            ['nfs:host3(rank=2.0 *:2049,9587,31311)'],
+            ['nfs:host1(rank=0.5 *:2049,9587)', 'nfs:host2(rank=1.5 *:2049,9587)', 'nfs:host3(rank=2.0 *:2049,9587)'],
+            ['nfs:host3(rank=2.0 *:2049,9587)'],
             ['nfs.4.5']
         ),
         # 25: ranked, exist, extra ranks (scale down: kill off high rank)
@@ -751,7 +751,7 @@ class NodeAssignmentTest(NamedTuple):
             ],
             {0: {5: '0.5'}, 1: {5: '1.5'}, 2: {5: '2.5'}},
             {0: {5: '0.5'}, 1: {5: '1.5'}, 2: {5: '2.5'}},
-            ['nfs:host1(rank=0.5 *:2049,9587,31311)', 'nfs:host2(rank=1.5 *:2049,9587,31311)'],
+            ['nfs:host1(rank=0.5 *:2049,9587)', 'nfs:host2(rank=1.5 *:2049,9587)'],
             [],
             ['nfs.2.5']
         ),
@@ -767,8 +767,8 @@ class NodeAssignmentTest(NamedTuple):
             ],
             {0: {5: '0.5'}, 1: {5: '1.5'}, 2: {5: '2.5'}},
             {0: {5: '0.5'}, 1: {5: '1.5', 6: None}, 2: {5: '2.5'}},
-            ['nfs:host1(rank=0.5 *:2049,9587,31311)', 'nfs:host3(rank=1.6 *:2049,9587,31311)'],
-            ['nfs:host3(rank=1.6 *:2049,9587,31311)'],
+            ['nfs:host1(rank=0.5 *:2049,9587)', 'nfs:host3(rank=1.6 *:2049,9587)'],
+            ['nfs:host3(rank=1.6 *:2049,9587)'],
             ['nfs.2.5', 'nfs.1.5']
         ),
         # ranked, exist, duplicate rank
@@ -783,8 +783,8 @@ class NodeAssignmentTest(NamedTuple):
             ],
             {0: {0: '0.0'}, 1: {2: '1.2'}},
             {0: {0: '0.0'}, 1: {2: '1.2'}, 2: {0: None}},
-            ['nfs:host1(rank=0.0 *:2049,9587,31311)', 'nfs:host3(rank=1.2 *:2049,9587,31311)', 'nfs:host2(rank=2.0 *:2049,9587,31311)'],
-            ['nfs:host2(rank=2.0 *:2049,9587,31311)'],
+            ['nfs:host1(rank=0.0 *:2049,9587)', 'nfs:host3(rank=1.2 *:2049,9587)', 'nfs:host2(rank=2.0 *:2049,9587)'],
+            ['nfs:host2(rank=2.0 *:2049,9587)'],
             ['nfs.1.1']
         ),
         # 28: ranked, all gens stale (failure during update cycle)
@@ -798,8 +798,8 @@ class NodeAssignmentTest(NamedTuple):
             ],
             {0: {2: '0.2'}, 1: {2: '1.2', 3: '1.3'}},
             {0: {2: '0.2'}, 1: {2: '1.2', 3: '1.3', 4: None}},
-            ['nfs:host1(rank=0.2 *:2049,9587,31311)', 'nfs:host3(rank=1.4 *:2049,9587,31311)'],
-            ['nfs:host3(rank=1.4 *:2049,9587,31311)'],
+            ['nfs:host1(rank=0.2 *:2049,9587)', 'nfs:host3(rank=1.4 *:2049,9587)'],
+            ['nfs:host3(rank=1.4 *:2049,9587)'],
             ['nfs.1.2']
         ),
         # ranked, not enough hosts (with colocation, 4th daemon can be placed)
@@ -813,8 +813,8 @@ class NodeAssignmentTest(NamedTuple):
             ],
             {0: {2: '0.2'}, 1: {2: '1.2'}},
             {0: {2: '0.2'}, 1: {2: '1.2'}, 2: {0: None}, 3: {0: None}},
-            ['nfs:host1(rank=0.2 *:2049,9587,31311)', 'nfs:host2(rank=1.2 *:2049,9587,31311)', 'nfs:host3(rank=2.0 *:2049,9587,31311)', 'nfs:host3(rank=3.0 *:2050,9588,31312)'],
-            ['nfs:host3(rank=2.0 *:2049,9587,31311)', 'nfs:host3(rank=3.0 *:2050,9588,31312)'],
+            ['nfs:host1(rank=0.2 *:2049,9587)', 'nfs:host2(rank=1.2 *:2049,9587)', 'nfs:host3(rank=2.0 *:2049,9587)', 'nfs:host3(rank=3.0 *:2050,9588)'],
+            ['nfs:host3(rank=2.0 *:2049,9587)', 'nfs:host3(rank=3.0 *:2050,9588)'],
             []
         ),
         # ranked, scale down
@@ -829,8 +829,8 @@ class NodeAssignmentTest(NamedTuple):
             ],
             {0: {2: '0.2'}, 1: {2: '1.2'}, 2: {2: '2.2'}},
             {0: {2: '0.2', 3: None}, 1: {2: '1.2'}, 2: {2: '2.2'}},
-            ['nfs:host2(rank=0.3 *:2049,9587,31311)'],
-            ['nfs:host2(rank=0.3 *:2049,9587,31311)'],
+            ['nfs:host2(rank=0.3 *:2049,9587)'],
+            ['nfs:host2(rank=0.3 *:2049,9587)'],
             ['nfs.0.2', 'nfs.1.2', 'nfs.2.2']
         ),
         # NFS colocation - count > hosts, ports should increment
@@ -841,10 +841,10 @@ class NodeAssignmentTest(NamedTuple):
             [],
             {},
             {0: {0: None}, 1: {0: None}, 2: {0: None}, 3: {0: None}},
-            ['nfs:host2(rank=0.0 *:2049,9587,31311)', 'nfs:host1(rank=1.0 *:2049,9587,31311)',
-             'nfs:host2(rank=2.0 *:2050,9588,31312)', 'nfs:host1(rank=3.0 *:2050,9588,31312)'],
-            ['nfs:host2(rank=0.0 *:2049,9587,31311)', 'nfs:host1(rank=1.0 *:2049,9587,31311)',
-             'nfs:host2(rank=2.0 *:2050,9588,31312)', 'nfs:host1(rank=3.0 *:2050,9588,31312)'],
+            ['nfs:host2(rank=0.0 *:2049,9587)', 'nfs:host1(rank=1.0 *:2049,9587)',
+             'nfs:host2(rank=2.0 *:2050,9588)', 'nfs:host1(rank=3.0 *:2050,9588)'],
+            ['nfs:host2(rank=0.0 *:2049,9587)', 'nfs:host1(rank=1.0 *:2049,9587)',
+             'nfs:host2(rank=2.0 *:2050,9588)', 'nfs:host1(rank=3.0 *:2050,9588)'],
             []
         ),
         # NFS colocation with existing daemons
@@ -853,14 +853,14 @@ class NodeAssignmentTest(NamedTuple):
             PlacementSpec(count=4),
             'host1 host2'.split(),
             [
-                DaemonDescription('nfs', '0.1', 'host1', rank=0, rank_generation=1, ports=[2049, 9587, 31311]),
-                DaemonDescription('nfs', '1.1', 'host2', rank=1, rank_generation=1, ports=[2049, 9587, 31311]),
+                DaemonDescription('nfs', '0.1', 'host1', rank=0, rank_generation=1, ports=[2049, 9587]),
+                DaemonDescription('nfs', '1.1', 'host2', rank=1, rank_generation=1, ports=[2049, 9587]),
             ],
             {0: {1: '0.1'}, 1: {1: '1.1'}},
             {0: {1: '0.1'}, 1: {1: '1.1'}, 2: {0: None}, 3: {0: None}},
-            ['nfs:host1(rank=0.1 *:2049,9587,31311)', 'nfs:host2(rank=1.1 *:2049,9587,31311)',
-             'nfs:host2(rank=2.0 *:2050,9588,31312)', 'nfs:host1(rank=3.0 *:2050,9588,31312)'],
-            ['nfs:host2(rank=2.0 *:2050,9588,31312)', 'nfs:host1(rank=3.0 *:2050,9588,31312)'],
+            ['nfs:host1(rank=0.1 *:2049,9587)', 'nfs:host2(rank=1.1 *:2049,9587)',
+             'nfs:host2(rank=2.0 *:2050,9588)', 'nfs:host1(rank=3.0 *:2050,9588)'],
+            ['nfs:host2(rank=2.0 *:2050,9588)', 'nfs:host1(rank=3.0 *:2050,9588)'],
             []
         ),
         # NFS colocation with custom ports
@@ -871,10 +871,10 @@ class NodeAssignmentTest(NamedTuple):
             [],
             {},
             {0: {0: None}, 1: {0: None}, 2: {0: None}, 3: {0: None}},
-            ['nfs:host2(rank=0.0 *:2049,9587,31311)', 'nfs:host1(rank=1.0 *:2049,9587,31311)',
-             'nfs:host2(rank=2.0 *:3049,9588,31315)', 'nfs:host1(rank=3.0 *:3049,9588,31315)'],
-            ['nfs:host2(rank=0.0 *:2049,9587,31311)', 'nfs:host1(rank=1.0 *:2049,9587,31311)',
-             'nfs:host2(rank=2.0 *:3049,9588,31315)', 'nfs:host1(rank=3.0 *:3049,9588,31315)'],
+            ['nfs:host2(rank=0.0 *:2049,9587)', 'nfs:host1(rank=1.0 *:2049,9587)',
+             'nfs:host2(rank=2.0 *:3049,9588)', 'nfs:host1(rank=3.0 *:3049,9588)'],
+            ['nfs:host2(rank=0.0 *:2049,9587)', 'nfs:host1(rank=1.0 *:2049,9587)',
+             'nfs:host2(rank=2.0 *:3049,9588)', 'nfs:host1(rank=3.0 *:3049,9588)'],
             []
         ),
     ])
@@ -895,7 +895,7 @@ def test_node_assignment(service_type, placement, hosts, daemons, rank_map, post
         # Check if this is the custom ports test by looking at expected ports
         if expected and any('3049' in str(e) for e in expected):
             # Custom colocation ports test case
-            # First daemon uses base ports (port, monitoring_port, cluster_qos_port)
+            # First daemon uses base ports (port, monitoring_port)
             # colocation_ports defines ADDITIONAL daemons only
             spec = NFSServiceSpec(service_type=service_type,
                                   service_id=service_id,
@@ -903,10 +903,10 @@ def test_node_assignment(service_type, placement, hosts, daemons, rank_map, post
                                   port=2049,
                                   monitoring_port=9587,
                                   colocation_ports=[
-                                      {'data_port': 3049, 'monitoring_port': 9588, 'cluster_qos_port': 31315},
-                                      {'data_port': 3050, 'monitoring_port': 9589, 'cluster_qos_port': 31316},
-                                      {'data_port': 3051, 'monitoring_port': 9590, 'cluster_qos_port': 31317},
-                                      {'data_port': 3052, 'monitoring_port': 9591, 'cluster_qos_port': 31318}
+                                      {'data_port': 3049, 'monitoring_port': 9588},
+                                      {'data_port': 3050, 'monitoring_port': 9589},
+                                      {'data_port': 3051, 'monitoring_port': 9590},
+                                      {'data_port': 3052, 'monitoring_port': 9591}
                                   ])
         else:
             spec = ServiceSpec(service_type=service_type,
@@ -1978,7 +1978,7 @@ def test_blocking_daemon_host(
             ],
             [],
             None,
-            ['nfs:host1(*:2049,9587,31311)'],
+            ['nfs:host1(*:2049,9587)'],
             [],
             ['nfs.nfs2']  # to_remove
         ),
@@ -2022,7 +2022,7 @@ def test_blocking_daemon_host(
                 DaemonDescription('keepalived', 'ingress4', 'host4'),
             ],
             None,
-            ['nfs:host3(*:2049,9587,31311)', 'nfs:host4(*:2049,9587,31311)'],
+            ['nfs:host3(*:2049,9587)', 'nfs:host4(*:2049,9587)'],
             [],
             ['nfs.nfs1', 'nfs.nfs2']  # to_remove
         ),
@@ -2042,7 +2042,7 @@ def test_blocking_daemon_host(
                 DaemonDescription('keepalived', 'ingress3', 'host3'),
             ],
             {0: {1: '0.1', 2: '0.2'}, 1: {1: '1.1'}},
-            ['nfs:host1(rank=0.2 *:2049,9587,31311)', 'nfs:host3(rank=1.1 *:2049,9587,31311)'],
+            ['nfs:host1(rank=0.2 *:2049,9587)', 'nfs:host3(rank=1.1 *:2049,9587)'],
             [],
             ['nfs.0.1']
         ),

--- a/src/pybind/mgr/cephadm/tests/test_scheduling.py
+++ b/src/pybind/mgr/cephadm/tests/test_scheduling.py
@@ -872,9 +872,9 @@ class NodeAssignmentTest(NamedTuple):
             {},
             {0: {0: None}, 1: {0: None}, 2: {0: None}, 3: {0: None}},
             ['nfs:host2(rank=0.0 *:2049,9587,31311)', 'nfs:host1(rank=1.0 *:2049,9587,31311)',
-             'nfs:host2(rank=2.0 *:3049,9588,31315)', 'nfs:host1(rank=3.0 *:3049,9588,31315)'],
+             'nfs:host2(rank=2.0 *:3049,9588)', 'nfs:host1(rank=3.0 *:3049,9588)'],
             ['nfs:host2(rank=0.0 *:2049,9587,31311)', 'nfs:host1(rank=1.0 *:2049,9587,31311)',
-             'nfs:host2(rank=2.0 *:3049,9588,31315)', 'nfs:host1(rank=3.0 *:3049,9588,31315)'],
+             'nfs:host2(rank=2.0 *:3049,9588)', 'nfs:host1(rank=3.0 *:3049,9588)'],
             []
         ),
     ])
@@ -895,7 +895,7 @@ def test_node_assignment(service_type, placement, hosts, daemons, rank_map, post
         # Check if this is the custom ports test by looking at expected ports
         if expected and any('3049' in str(e) for e in expected):
             # Custom colocation ports test case
-            # First daemon uses base ports (port, monitoring_port, cluster_qos_port)
+            # First daemon uses base ports (port, monitoring_port)
             # colocation_ports defines ADDITIONAL daemons only
             spec = NFSServiceSpec(service_type=service_type,
                                   service_id=service_id,
@@ -903,10 +903,10 @@ def test_node_assignment(service_type, placement, hosts, daemons, rank_map, post
                                   port=2049,
                                   monitoring_port=9587,
                                   colocation_ports=[
-                                      {'data_port': 3049, 'monitoring_port': 9588, 'cluster_qos_port': 31315},
-                                      {'data_port': 3050, 'monitoring_port': 9589, 'cluster_qos_port': 31316},
-                                      {'data_port': 3051, 'monitoring_port': 9590, 'cluster_qos_port': 31317},
-                                      {'data_port': 3052, 'monitoring_port': 9591, 'cluster_qos_port': 31318}
+                                      {'data_port': 3049, 'monitoring_port': 9588},
+                                      {'data_port': 3050, 'monitoring_port': 9589},
+                                      {'data_port': 3051, 'monitoring_port': 9590},
+                                      {'data_port': 3052, 'monitoring_port': 9591}
                                   ])
         else:
             spec = ServiceSpec(service_type=service_type,

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1376,13 +1376,7 @@ yaml.add_representer(ServiceSpec, ServiceSpec.yaml_representer)
 
 
 class NFSServiceSpec(ServiceSpec):
-    COLOCATION_PORT_FIELDS = ['data_port', 'monitoring_port', 'cluster_qos_port']
-    COLOCATION_PORT_FIELDS_WITH_RDMA = [
-        'data_port',
-        'monitoring_port',
-        'cluster_qos_port',
-        'rdma_port'
-    ]
+    COLOCATION_PORT_FIELDS = ['data_port', 'monitoring_port']
 
     def __init__(self,
                  service_type: str = 'nfs',
@@ -1460,13 +1454,18 @@ class NFSServiceSpec(ServiceSpec):
         self.tls_min_version = tls_min_version
 
     def get_colocation_port_fields(self) -> List[str]:
-        """Return port fields for colocation; include rdma_port when RDMA is enabled."""
+        """Return port fields for colocation; include rdma_port when RDMA is enabled and cluster_qos_port when QoS is configured."""
+        fields = list(self.COLOCATION_PORT_FIELDS)
+        if self.cluster_qos_config:
+            fields.append('cluster_qos_port')
         if self.enable_rdma:
-            return self.COLOCATION_PORT_FIELDS_WITH_RDMA
-        return self.COLOCATION_PORT_FIELDS
+            fields.append('rdma_port')
+        return fields
 
     def get_port_start(self) -> List[int]:
-        ports = [self.port or 2049, self.monitoring_port or 9587, self.cluster_qos_port or 31311]
+        ports = [self.port or 2049, self.monitoring_port or 9587]
+        if self.cluster_qos_config:
+            ports.append(self.cluster_qos_port or 31311)
         if self.enable_rdma:
             ports.append(self.rdma_port or 20049)
         return ports
@@ -1479,7 +1478,7 @@ class NFSServiceSpec(ServiceSpec):
         if not self.colocation_ports:
             return []
         fields = self.get_colocation_port_fields()
-        return [[port_dict[field] for field in fields]
+        return [[port_dict.get(field, 0) for field in fields]
                 for port_dict in self.colocation_ports]
 
     def rados_config_name(self):

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1376,13 +1376,7 @@ yaml.add_representer(ServiceSpec, ServiceSpec.yaml_representer)
 
 
 class NFSServiceSpec(ServiceSpec):
-    COLOCATION_PORT_FIELDS = ['data_port', 'monitoring_port', 'cluster_qos_port']
-    COLOCATION_PORT_FIELDS_WITH_RDMA = [
-        'data_port',
-        'monitoring_port',
-        'cluster_qos_port',
-        'rdma_port'
-    ]
+    COLOCATION_PORT_FIELDS = ['data_port', 'monitoring_port']
 
     def __init__(self,
                  service_type: str = 'nfs',
@@ -1460,10 +1454,14 @@ class NFSServiceSpec(ServiceSpec):
         self.tls_min_version = tls_min_version
 
     def get_colocation_port_fields(self) -> List[str]:
-        """Return port fields for colocation; include rdma_port when RDMA is enabled."""
+        """Return port fields for colocation; cluster_qos_port added when QoS is configured,
+        rdma_port added when RDMA is enabled."""
+        fields = list(self.COLOCATION_PORT_FIELDS)
+        if self.cluster_qos_config:
+            fields.append('cluster_qos_port')
         if self.enable_rdma:
-            return self.COLOCATION_PORT_FIELDS_WITH_RDMA
-        return self.COLOCATION_PORT_FIELDS
+            fields.append('rdma_port')
+        return fields
 
     def get_port_start(self) -> List[int]:
         ports = [self.port or 2049, self.monitoring_port or 9587, self.cluster_qos_port or 31311]
@@ -1479,7 +1477,7 @@ class NFSServiceSpec(ServiceSpec):
         if not self.colocation_ports:
             return []
         fields = self.get_colocation_port_fields()
-        return [[port_dict[field] for field in fields]
+        return [[port_dict.get(field, 0) for field in fields]
                 for port_dict in self.colocation_ports]
 
     def rados_config_name(self):
@@ -1509,18 +1507,20 @@ class NFSServiceSpec(ServiceSpec):
                         f"count={self.placement.count} (got {actual}). First daemon uses base "
                         "ports, remaining need custom ports."
                     )
-        # Validate that each entry has the required port fields
+        # cluster_qos_port is required per colocation entry only when QoS is configured.
         fields = self.get_colocation_port_fields()
+        required_fields = [f for f in fields
+                           if f != 'cluster_qos_port' or self.cluster_qos_config]
         for idx, port_dict in enumerate(self.colocation_ports):
             if not isinstance(port_dict, dict):
                 raise SpecValidationError(
                     f"colocation_ports[{idx}] must be a dict with "
-                    f"fields: {', '.join(fields)}"
+                    f"fields: {', '.join(required_fields)}"
                 )
-            missing = [f for f in fields if f not in port_dict]
+            missing = [f for f in required_fields if f not in port_dict]
             if missing:
                 missing_str = ', '.join(missing)
-                format_str = ', '.join(f'{f!r}: <port>' for f in fields)
+                format_str = ', '.join(f'{f!r}: <port>' for f in required_fields)
                 raise SpecValidationError(
                     f"Invalid NFS spec: colocation_ports[{idx}] missing required "
                     f"fields: {missing_str}. Expected format: {{{format_str}}}"

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -582,12 +582,13 @@ def test_alertmanager_spec_2():
 
 
 def test_nfs_spec_rdma_default():
-    """NFS spec without RDMA: enable_rdma is False, get_port_start returns 2 ports."""
+    """NFS spec without RDMA or QoS: get_port_start returns 2 ports."""
     spec = NFSServiceSpec(service_id='mynfs', placement=PlacementSpec(count=1))
     assert spec.enable_rdma is False
     assert spec.rdma_port is None
-    assert spec.get_port_start() == [2049, 9587, 31311]
-    assert spec.get_colocation_port_fields() == ['data_port', 'monitoring_port', 'cluster_qos_port']
+    assert spec.cluster_qos_config is None
+    assert spec.get_port_start() == [2049, 9587]
+    assert spec.get_colocation_port_fields() == ['data_port', 'monitoring_port']
 
 
 def test_nfs_spec_rdma_enabled():
@@ -599,8 +600,8 @@ def test_nfs_spec_rdma_enabled():
     )
     assert spec.enable_rdma is True
     assert spec.rdma_port is None
-    assert spec.get_port_start() == [2049, 9587, 31311, 20049]
-    assert spec.get_colocation_port_fields() == ['data_port', 'monitoring_port', 'cluster_qos_port', 'rdma_port']
+    assert spec.get_port_start() == [2049, 9587, 20049]
+    assert spec.get_colocation_port_fields() == ['data_port', 'monitoring_port', 'rdma_port']
 
 
 def test_nfs_spec_rdma_custom_port():
@@ -615,7 +616,37 @@ def test_nfs_spec_rdma_custom_port():
     )
     assert spec.enable_rdma is True
     assert spec.rdma_port == 20050
-    assert spec.get_port_start() == [3049, 9588, 31311, 20050]
+    assert spec.get_port_start() == [3049, 9588, 20050]
+
+
+def test_nfs_spec_qos_enabled():
+    """NFS spec with QoS: cluster_qos_port is included in colocation fields."""
+    spec = NFSServiceSpec(
+        service_id='mynfs',
+        placement=PlacementSpec(count=1),
+        cluster_qos_config={'enable_qos': True, 'enable_bw_control': True},
+        cluster_qos_port=31312,
+    )
+    assert spec.cluster_qos_config is not None
+    assert spec.cluster_qos_port == 31312
+    assert spec.get_port_start() == [2049, 9587, 31312]
+    assert spec.get_colocation_port_fields() == ['data_port', 'monitoring_port', 'cluster_qos_port']
+
+
+def test_nfs_spec_qos_and_rdma():
+    """NFS spec with both QoS and RDMA enabled."""
+    spec = NFSServiceSpec(
+        service_id='mynfs',
+        placement=PlacementSpec(count=1),
+        cluster_qos_config={'enable_qos': True, 'enable_bw_control': True},
+        cluster_qos_port=31312,
+        enable_rdma=True,
+        rdma_port=20050,
+    )
+    assert spec.cluster_qos_config is not None
+    assert spec.enable_rdma is True
+    assert spec.get_port_start() == [2049, 9587, 31312, 20050]
+    assert spec.get_colocation_port_fields() == ['data_port', 'monitoring_port', 'cluster_qos_port', 'rdma_port']
 
 
 def test_nfs_spec_from_json_rdma():

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -582,16 +582,17 @@ def test_alertmanager_spec_2():
 
 
 def test_nfs_spec_rdma_default():
-    """NFS spec without RDMA: enable_rdma is False, get_port_start returns 2 ports."""
+    """NFS spec without RDMA or QoS: get_port_start always includes cluster_qos_port (31311)."""
     spec = NFSServiceSpec(service_id='mynfs', placement=PlacementSpec(count=1))
     assert spec.enable_rdma is False
     assert spec.rdma_port is None
+    assert spec.cluster_qos_config is None
     assert spec.get_port_start() == [2049, 9587, 31311]
-    assert spec.get_colocation_port_fields() == ['data_port', 'monitoring_port', 'cluster_qos_port']
+    assert spec.get_colocation_port_fields() == ['data_port', 'monitoring_port']
 
 
 def test_nfs_spec_rdma_enabled():
-    """NFS spec with enable_rdma: get_port_start returns 3 ports, default rdma_port 20049."""
+    """NFS spec with enable_rdma: get_port_start returns 4 ports including cluster_qos_port."""
     spec = NFSServiceSpec(
         service_id='mynfs',
         placement=PlacementSpec(count=1),
@@ -600,7 +601,7 @@ def test_nfs_spec_rdma_enabled():
     assert spec.enable_rdma is True
     assert spec.rdma_port is None
     assert spec.get_port_start() == [2049, 9587, 31311, 20049]
-    assert spec.get_colocation_port_fields() == ['data_port', 'monitoring_port', 'cluster_qos_port', 'rdma_port']
+    assert spec.get_colocation_port_fields() == ['data_port', 'monitoring_port', 'rdma_port']
 
 
 def test_nfs_spec_rdma_custom_port():
@@ -616,6 +617,36 @@ def test_nfs_spec_rdma_custom_port():
     assert spec.enable_rdma is True
     assert spec.rdma_port == 20050
     assert spec.get_port_start() == [3049, 9588, 31311, 20050]
+
+
+def test_nfs_spec_qos_enabled():
+    """NFS spec with QoS: cluster_qos_port is included in colocation fields."""
+    spec = NFSServiceSpec(
+        service_id='mynfs',
+        placement=PlacementSpec(count=1),
+        cluster_qos_config={'enable_qos': True, 'enable_bw_control': True},
+        cluster_qos_port=31312,
+    )
+    assert spec.cluster_qos_config is not None
+    assert spec.cluster_qos_port == 31312
+    assert spec.get_port_start() == [2049, 9587, 31312]
+    assert spec.get_colocation_port_fields() == ['data_port', 'monitoring_port', 'cluster_qos_port']
+
+
+def test_nfs_spec_qos_and_rdma():
+    """NFS spec with both QoS and RDMA enabled."""
+    spec = NFSServiceSpec(
+        service_id='mynfs',
+        placement=PlacementSpec(count=1),
+        cluster_qos_config={'enable_qos': True, 'enable_bw_control': True},
+        cluster_qos_port=31312,
+        enable_rdma=True,
+        rdma_port=20050,
+    )
+    assert spec.cluster_qos_config is not None
+    assert spec.enable_rdma is True
+    assert spec.get_port_start() == [2049, 9587, 31312, 20050]
+    assert spec.get_colocation_port_fields() == ['data_port', 'monitoring_port', 'cluster_qos_port', 'rdma_port']
 
 
 def test_nfs_spec_from_json_rdma():


### PR DESCRIPTION
mgr/nfs:Code change made cluster_qos_port an optional field for NFS colocation ports

Signed-off-by: Pooja Dwivedi pooja.dwivedi@ibm.com
Fixes: https://tracker.ceph.com/issues/77726


### Description

Currently, cluster_qos_port is treated as a mandatory field when configuring NFS services with colocation ports via a specification file. If a user provides an NFS spec defining a colocation port but omits cluster_qos_port, the validation fails and throws the following error:
```
Error : "Invalid NFS spec: colocation_ports[0] missing required fields: cluster_qos_port. Expected format: {'data_port': <port>, 'monitoring_port': <port>, 'cluster_qos_port': <port>}"
```

This PR modifies the code to make the cluster_qos_port field optional rather than required. The schema now successfully parses and allows the colocation ports object to bypass validation if only data_port and monitoring_port are supplied.

### Testing 

Create NFS Spec with this yaml
```yaml
service_type: nfs
service_id: mynfs
placement:
  count: 4
  hosts: [ceph-node-0, ceph-node-1]
spec:
  port: 2049
  monitoring_port: 9587
  colocation_ports:
    - data_port: 3049          # Daemon 2
      monitoring_port: 9588
    - data_port: 4049          # Daemon 3
      monitoring_port: 9589
    - data_port: 5049          # Daemon 4
      monitoring_port: 9590
 ```
```
[ceph: root@ceph-node-0 /]# vi nfs.yaml
[ceph: root@ceph-node-0 /]# ceph orch apply -i nfs.yaml
Scheduled nfs.mynfs update...
```
NFS deployed with no validation error for QOS port.
```
[ceph: root@ceph-node-0 /]# ceph orch ps --daemon-type nfs
NAME                              HOST         PORTS        STATUS         REFRESHED  AGE  MEM USE  MEM LIM  VERSION    IMAGE ID      CONTAINER ID  
nfs.mynfs.0.0.ceph-node-1.ypxsjg  ceph-node-1  *:2049,9587  unknown          34s ago  47s        -        -  <unknown>  <unknown>     <unknown>     
nfs.mynfs.1.0.ceph-node-0.pfbdjk  ceph-node-0  *:2049,9587  running (39s)    33s ago  38s    11.5M        -  7.0        4815ae5f79b3  90cbbfd1ac05  
```


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
