### PR TITLE
umbrella: osd/scheduler: Classify subOp reads according to op priority for mClock

### DIFF
--- a/doc/rados/configuration/mclock-config-ref.rst
+++ b/doc/rados/configuration/mclock-config-ref.rst
@@ -128,7 +128,7 @@ built-in profiles may be enabled by following the steps mentioned in next sectio
 +------------------------+-------------+--------+-------+
 | background recovery    | 50%         | 1      | MAX   |
 +------------------------+-------------+--------+-------+
-| background best-effort | MIN         | 1      | 90%   |
+| background best-effort |  5%         | 2      | 90%   |
 +------------------------+-------------+--------+-------+
 
 high_client_ops
@@ -147,7 +147,7 @@ the resource control parameters set by the profile:
 +------------------------+-------------+--------+-------+
 | background recovery    | 40%         | 1      | MAX   |
 +------------------------+-------------+--------+-------+
-| background best-effort | MIN         | 1      | 70%   |
+| background best-effort |  5%         | 4      | 70%   |
 +------------------------+-------------+--------+-------+
 
 high_recovery_ops
@@ -165,7 +165,7 @@ parameters set by the profile:
 +------------------------+-------------+--------+-------+
 | background recovery    | 70%         | 2      | MAX   |
 +------------------------+-------------+--------+-------+
-| background best-effort | MIN         | 1      | MAX   |
+| background best-effort |  5%         | 2      | MAX   |
 +------------------------+-------------+--------+-------+
 
 .. note:: Across the built-in profiles, internal background best-effort clients

--- a/doc/rados/configuration/mclock-config-ref.rst
+++ b/doc/rados/configuration/mclock-config-ref.rst
@@ -4,22 +4,6 @@
 
 .. index:: mclock; configuration
 
-.. warning:: On large clusters with erasure-coded pools, operators may
-   observe slow ops during recovery or backfill (for example, when an
-   OSD is drained out). Under mClock, EC sub-operation reads issued
-   during recovery are currently routed through the ``immediate``
-   high-priority queue and bypass mClock throttling. When many OSDs
-   read concurrently from a single source OSD, this can saturate that
-   OSD's high-priority queue and starve client and background work.
-   As an interim measure, such deployments are advised to switch to
-   the ``WeightedPriorityQueue`` (``wpq``) scheduler. The change can
-   be applied cluster-wide and takes effect after each OSD is
-   restarted:
-
-   .. prompt:: bash #
-
-     ceph config set osd osd_op_queue wpq
-
 QoS support in Ceph is implemented using a queuing scheduler based on `the
 dmClock algorithm`_. See :ref:`dmclock-qos` section for more details.
 

--- a/src/common/mclock_common.cc
+++ b/src/common/mclock_common.cc
@@ -34,23 +34,29 @@ namespace dmc = crimson::dmclock;
 
 std::ostream &operator<<(std::ostream &lhs, const SchedulerClass &c)
 {
-  lhs << static_cast<size_t>(c);
+  lhs << static_cast<size_t>(c) << " (";
   switch (c) {
   case SchedulerClass::background_best_effort:
-    return lhs << "background_best_effort";
+    lhs << "background_best_effort";
+    break;
   case SchedulerClass::background_recovery:
-    return lhs << "background_recovery";
+    lhs << "background_recovery";
+    break;
   case SchedulerClass::client:
-    return lhs << "client";
+    lhs << "client";
+    break;
 #ifdef WITH_CRIMSON
   case SchedulerClass::repop:
-    return lhs << "repop";
+    lhs << "repop";
+    break;
 #endif
   case SchedulerClass::immediate:
-    return lhs << "immediate";
+    lhs << "immediate";
+    break;
   default:
-    return lhs;
+    lhs << "unknown";
   }
+  return lhs << ")";
 }
 
 std::ostream& operator<<(std::ostream& out,

--- a/src/common/mclock_common.cc
+++ b/src/common/mclock_common.cc
@@ -248,6 +248,7 @@ void MclockConfig::init_logger()
   PerfCountersBuilder m(cct, "mclock-shard-queue-" + std::to_string(shard_id),
                         l_mclock_first, l_mclock_last);
 
+  // scheduler class queue lengths
   m.add_u64_counter(l_mclock_immediate_queue_len, "mclock_immediate_queue_len",
                     "high_priority op count in mclock queue");
   m.add_u64_counter(l_mclock_client_queue_len, "mclock_client_queue_len",
@@ -258,6 +259,38 @@ void MclockConfig::init_logger()
                     "background_best_effort type op count in mclock queue");
   m.add_u64_counter(l_mclock_all_type_queue_len, "mclock_all_type_queue_len",
                     "all type op count in mclock queue");
+  // op specific counters
+  // peering
+  m.add_time_avg(l_mclock_peering_lat, "mclock_peering_lat",
+                 "peering op average latency in mclock high queue");
+  m.add_u64_counter(l_mclock_peering_len, "mclock_peering_len",
+                    "peering op count in mclock high queue");
+  // client op
+  m.add_time_avg(l_mclock_client_lat, "mclock_client_lat",
+                 "client op average latency in mclock queue");
+  // ec reads
+  m.add_u64_counter(l_mclock_ec_r_ops, "mclock_ec_r_ops",
+                    "ec read operations in mclock high queue");
+  m.add_time_avg(l_mclock_ec_r_lat, "mclock_ec_r_lat",
+                 "ec read latency in mclock high queue");
+  m.add_u64(l_mclock_ec_r_len, "mclock_ec_r_len",
+            "ec reads outstanding in mclock high queue");
+  // ec writes
+  m.add_u64_counter(l_mclock_ec_w_ops, "mclock_ec_w_ops",
+                    "ec write operations in mclock high queue");
+  m.add_time_avg(l_mclock_ec_w_lat, "mclock_ec_w_lat",
+                 "ec write latency in mclock high queue");
+  m.add_u64(l_mclock_ec_w_len, "mclock_ec_w_len",
+            "ec writes outstanding in mclock high queue");
+  // ec recovery reads
+  m.add_u64_counter(l_mclock_ec_rec_r_ops, "mclock_ec_rec_r_ops",
+                    "ec recovery read operations in mclock queue");
+  m.add_u64_counter(l_mclock_ec_rec_r_outb, "mclock_ec_rec_r_outb",
+                    "ec recovery read bytes", NULL, 0, unit_t(UNIT_BYTES));
+  m.add_time_avg(l_mclock_ec_rec_r_lat, "mclock_ec_rec_r_lat",
+                 "ec recovery read latency in mclock queue");
+  m.add_u64(l_mclock_ec_rec_r_len, "mclock_ec_rec_r_len",
+            "ec recovery reads outstanding in mclock queue");
 
   logger = m.create_perf_counters();
   cct->get_perfcounters_collection()->add(logger);
@@ -267,9 +300,23 @@ void MclockConfig::init_logger()
   logger->set(l_mclock_recovery_queue_len, 0);
   logger->set(l_mclock_best_effort_queue_len, 0);
   logger->set(l_mclock_all_type_queue_len, 0);
+  logger->set(l_mclock_peering_lat, 0);
+  logger->set(l_mclock_peering_len, 0);
+  logger->set(l_mclock_client_lat, 0);
+  logger->set(l_mclock_ec_r_ops, 0);
+  logger->set(l_mclock_ec_r_lat, 0);
+  logger->set(l_mclock_ec_r_len, 0);
+  logger->set(l_mclock_ec_w_ops, 0);
+  logger->set(l_mclock_ec_w_lat, 0);
+  logger->set(l_mclock_ec_w_len, 0);
+  logger->set(l_mclock_ec_rec_r_ops, 0);
+  logger->set(l_mclock_ec_rec_r_outb, 0);
+  logger->set(l_mclock_ec_rec_r_lat, 0);
+  logger->set(l_mclock_ec_rec_r_len, 0);
 }
 
-void MclockConfig::get_mclock_counter(scheduler_id_t id)
+void MclockConfig::get_mclock_counter(scheduler_id_t id,
+  scheduler_op_type_t op_type, uint64_t cost)
 {
   if (!logger) {
     return;
@@ -279,47 +326,84 @@ void MclockConfig::get_mclock_counter(scheduler_id_t id)
   logger->inc(l_mclock_all_type_queue_len);
 
   switch (id.class_id) {
-  case SchedulerClass::immediate:
+  case SchedulerClass::immediate: {
     logger->inc(l_mclock_immediate_queue_len);
+    if (op_type == scheduler_op_type_t::ec_read_op) {
+      logger->inc(l_mclock_ec_r_ops);
+      logger->inc(l_mclock_ec_r_len);
+    } else if (op_type == scheduler_op_type_t::ec_write_op) {
+      logger->inc(l_mclock_ec_w_ops);
+      logger->inc(l_mclock_ec_w_len);
+    } else if (op_type == scheduler_op_type_t::peering_op) {
+      logger->inc(l_mclock_peering_len);
+    }
     break;
+  }
   case SchedulerClass::client:
     logger->inc(l_mclock_client_queue_len);
     break;
   case SchedulerClass::background_recovery:
     logger->inc(l_mclock_recovery_queue_len);
     break;
-  case SchedulerClass::background_best_effort:
+  case SchedulerClass::background_best_effort: {
     logger->inc(l_mclock_best_effort_queue_len);
+    if (op_type == scheduler_op_type_t::ec_rec_read_op) {
+      logger->inc(l_mclock_ec_rec_r_ops);
+      logger->inc(l_mclock_ec_rec_r_outb, cost);
+      logger->inc(l_mclock_ec_rec_r_len);
+    }
     break;
-   default:
+  }
+  default:
     derr << __func__ << " unknown class_id=" << id.class_id
          << " unknown id=" << id << dendl;
     break;
   }
 }
 
-void MclockConfig::put_mclock_counter(scheduler_id_t id)
+void MclockConfig::put_mclock_counter(scheduler_id_t id,
+  scheduler_op_type_t op_type, utime_t time_queued)
 {
   if (!logger) {
     return;
   }
 
+  auto latency = ceph_clock_now() - time_queued;
+
   /* op leave mclock queue will -1 */
   logger->dec(l_mclock_all_type_queue_len);
 
   switch (id.class_id) {
-  case SchedulerClass::immediate:
+  case SchedulerClass::immediate: {
     logger->dec(l_mclock_immediate_queue_len);
+    if (op_type == scheduler_op_type_t::ec_read_op) {
+      logger->dec(l_mclock_ec_r_len);
+      logger->tinc(l_mclock_ec_r_lat, latency);
+    } else if (op_type == scheduler_op_type_t::ec_write_op) {
+      logger->dec(l_mclock_ec_w_len);
+      logger->tinc(l_mclock_ec_w_lat, latency);
+    } else if (op_type == scheduler_op_type_t::peering_op) {
+      logger->dec(l_mclock_peering_len);
+      logger->tinc(l_mclock_peering_lat, latency);
+    }
     break;
-  case SchedulerClass::client:
+  }
+  case SchedulerClass::client: {
     logger->dec(l_mclock_client_queue_len);
+    logger->tinc(l_mclock_client_lat, latency);
     break;
+  }
   case SchedulerClass::background_recovery:
     logger->dec(l_mclock_recovery_queue_len);
     break;
-  case SchedulerClass::background_best_effort:
+  case SchedulerClass::background_best_effort: {
     logger->dec(l_mclock_best_effort_queue_len);
+    if (op_type == scheduler_op_type_t::ec_rec_read_op) {
+      logger->dec(l_mclock_ec_rec_r_len);
+      logger->tinc(l_mclock_ec_rec_r_lat, latency);
+    }
     break;
+   }
    default:
     derr << __func__ << " unknown class_id=" << id.class_id
          << " unknown id=" << id << dendl;

--- a/src/common/mclock_common.h
+++ b/src/common/mclock_common.h
@@ -128,12 +128,12 @@ struct profile_t {
  * Background Recovery Allocation:
  *   reservation: 40% | weight: 1 | limit: 0 (max) |
  * Background Best Effort Allocation:
- *   reservation: 0 (min) | weight: 1 | limit: 70% |
+ *   reservation:  5% | weight: 4 | limit: 70% |
  */
 constexpr profile_t HIGH_CLIENT_OPS{
-  { .6, 2,  0 },
-  { .4, 1,  0 },
-  {  0, 1, .7 }
+  { .6,  2,  0 },
+  { .4,  1,  0 },
+  { .05, 4, .7 }
 };
 
 /**
@@ -144,12 +144,12 @@ constexpr profile_t HIGH_CLIENT_OPS{
  * Background Recovery Allocation:
  *   reservation: 70% | weight: 2 | limit: 0 (max) |
  * Background Best Effort Allocation:
- *   reservation: 0 (min) | weight: 1 | limit: 0 (max) |
+ *   reservation:  5% | weight: 2 | limit: 0 (max) |
  */
 constexpr profile_t HIGH_RECOVERY_OPS{
-  { .3, 1, 0 },
-  { .7, 2, 0 },
-  {  0, 1, 0 }
+  { .3,  1, 0 },
+  { .7,  2, 0 },
+  { .05, 2, 0 }
 };
 
 /**
@@ -160,12 +160,12 @@ constexpr profile_t HIGH_RECOVERY_OPS{
  * Background Recovery Allocation:
  *   reservation: 50% | weight: 1 | limit: 0 (max) |
  * Background Best Effort Allocation:
- *   reservation: 0 (min) | weight: 1 | limit: 90% |
+ *   reservation:  5% | weight: 2 | limit: 90% |
  */
 constexpr profile_t BALANCED{
-  { .5, 1, 0 },
-  { .5, 1, 0 },
-  {  0, 1, .9 }
+  { .5,  1,  0 },
+  { .5,  1,  0 },
+  { .05, 2, .9 }
 };
 
 struct client_profile_id_t {

--- a/src/common/mclock_common.h
+++ b/src/common/mclock_common.h
@@ -41,6 +41,15 @@ enum class scheduler_class_t : uint8_t {
   immediate,
 };
 
+// scheduler op types - used for perf counters
+enum class scheduler_op_type_t : uint8_t {
+  peering_op = 0,
+  ec_read_op,
+  ec_write_op,
+  ec_rec_read_op,
+  unknown,
+};
+
 #ifdef WITH_CRIMSON
 using SchedulerClass = scheduler_class_t;
 using MonClient = crimson::mon::Client;
@@ -50,11 +59,31 @@ using SchedulerClass = op_scheduler_class;
 
 enum {
   l_mclock_first = 15000,
+  // scheduler class queue lengths
   l_mclock_immediate_queue_len,
   l_mclock_client_queue_len,
   l_mclock_recovery_queue_len,
   l_mclock_best_effort_queue_len,
   l_mclock_all_type_queue_len,
+  // op specific counters
+  // peering
+  l_mclock_peering_lat,
+  l_mclock_peering_len,
+  // client ops
+  l_mclock_client_lat,
+  // ec reads
+  l_mclock_ec_r_ops,
+  l_mclock_ec_r_lat,
+  l_mclock_ec_r_len,
+  // ec writes
+  l_mclock_ec_w_ops,
+  l_mclock_ec_w_lat,
+  l_mclock_ec_w_len,
+  // ec recovery reads
+  l_mclock_ec_rec_r_ops,
+  l_mclock_ec_rec_r_outb,
+  l_mclock_ec_rec_r_lat,
+  l_mclock_ec_rec_r_len,
   l_mclock_last,
 };
 
@@ -222,8 +251,12 @@ public:
 
   void set_from_config();
   void init_logger();
-  void get_mclock_counter(scheduler_id_t id);
-  void put_mclock_counter(scheduler_id_t id);
+  void get_mclock_counter(scheduler_id_t id,
+                          scheduler_op_type_t op_type,
+                          uint64_t cost);
+  void put_mclock_counter(scheduler_id_t id,
+                          scheduler_op_type_t op_type,
+                          utime_t time_queued);
   double get_cost_per_io() const;
   double get_capacity_per_shard() const;
   void handle_conf_change(const ConfigProxy& conf,

--- a/src/messages/MOSDECSubOpRead.h
+++ b/src/messages/MOSDECSubOpRead.h
@@ -21,16 +21,26 @@
 
 class MOSDECSubOpRead : public MOSDFastDispatchOp {
 private:
-  static constexpr int HEAD_VERSION = 3;
+  static constexpr int HEAD_VERSION = 4;
   static constexpr int COMPAT_VERSION = 1;
 
 public:
   spg_t pgid;
   epoch_t map_epoch = 0, min_epoch = 0;
   ECSubRead op;
+  uint64_t cost = 0;
 
+  /**
+    * Calculate the cost of the SubOp read operation for mClock scheduler.
+    *
+    * @param *cct: *CephContext
+    * @param pair<int, int>&: subchunk_count and subchunk_size
+    */
+  void compute_cost(CephContext *cct, std::pair<int, int> &subchunk_info) {
+    cost = op.cost(cct, subchunk_info);
+  }
   int get_cost() const override {
-    return 0;
+    return cost;
   }
   epoch_t get_map_epoch() const override {
     return map_epoch;
@@ -58,6 +68,9 @@ public:
     } else {
       min_epoch = map_epoch;
     }
+    if (header.version >= 4) {
+      decode(cost, p);
+    }
   }
 
   void encode_payload(uint64_t features) override {
@@ -67,6 +80,9 @@ public:
     encode(op, payload, features);
     encode(min_epoch, payload);
     encode_trace(payload, features);
+    if (header.version >= 4) {
+      encode(cost, payload);
+    }
   }
 
   std::string_view get_type_name() const override { return "MOSDECSubOpRead"; }

--- a/src/osd/ECBackendL.cc
+++ b/src/osd/ECBackendL.cc
@@ -573,7 +573,18 @@ void ECBackendL::RecoveryBackend::continue_recovery_op(
       ceph_assert(!op.recovery_progress.data_complete);
       set<int> want(op.missing_on_shards.begin(), op.missing_on_shards.end());
       uint64_t from = op.recovery_progress.data_recovered_to;
+      /* When beginning recovery, the OI may not be known. As such the object
+       * size is not known. For the first read, attempt to read the default
+       * size.  If this is larger than the object sizes, then the OSD will
+       * return truncated reads.  If the object size is known, then attempt
+       * correctly sized reads, capped at recovery chunk size.
+       * (Ref: ECCommon.cc -> ECCommon::RecoveryBackend::continue_recovery_op())
+       */
       uint64_t amount = get_recovery_chunk_size();
+      if (op.obc) {
+        uint64_t remaining = op.obc->obs.oi.size - from;
+        amount = std::min(remaining, amount);
+      }
 
       if (op.recovery_progress.first && op.obc) {
         if (auto [r, attrs, size] = ecbackend->get_attrs_n_size_from_disk(op.hoid);

--- a/src/osd/ECCommon.cc
+++ b/src/osd/ECCommon.cc
@@ -524,6 +524,9 @@ void ECCommon::ReadPipeline::do_read_op(ReadOp &rop) {
   std::optional<ECSubRead> local_read_op;
   std::vector<std::pair<int, Message*>> m;
   m.reserve(messages.size());
+  std::pair<int, int> subchunk_info =
+    std::make_pair(ec_impl->get_sub_chunk_count(),
+      sinfo.get_chunk_size() / ec_impl->get_sub_chunk_count());
   for (auto &&[pg_shard, read]: messages) {
     rop.in_progress.insert(pg_shard);
     shard_to_read_map[pg_shard].insert(rop.tid);
@@ -547,6 +550,7 @@ void ECCommon::ReadPipeline::do_read_op(ReadOp &rop) {
       msg->trace.init("ec sub read", nullptr, &rop.trace);
       msg->trace.keyval("shard", pg_shard.shard.id);
     }
+    msg->compute_cost(cct, subchunk_info);
     m.push_back(std::make_pair(pg_shard.osd, msg));
     dout(10) << __func__ << ": will send msg " << *msg
              << " to osd." << pg_shard.osd << dendl;

--- a/src/osd/ECCommonL.cc
+++ b/src/osd/ECCommonL.cc
@@ -468,6 +468,9 @@ void ECCommonL::ReadPipeline::do_read_op(ReadOp &op)
 
   std::vector<std::pair<int, Message*>> m;
   m.reserve(messages.size());
+  std::pair<int, int> subchunk_info =
+    std::make_pair(ec_impl->get_sub_chunk_count(),
+      sinfo.get_chunk_size() / ec_impl->get_sub_chunk_count());
   for (map<pg_shard_t, ECSubRead>::iterator i = messages.begin();
        i != messages.end();
        ++i) {
@@ -489,6 +492,7 @@ void ECCommonL::ReadPipeline::do_read_op(ReadOp &op)
       msg->trace.init("ec sub read", nullptr, &op.trace);
       msg->trace.keyval("shard", i->first.shard.id);
     }
+    msg->compute_cost(cct, subchunk_info);
     m.push_back(std::make_pair(i->first.osd, msg));
   }
   if (!m.empty()) {

--- a/src/osd/ECMsgTypes.cc
+++ b/src/osd/ECMsgTypes.cc
@@ -15,6 +15,8 @@
 
 #include "ECMsgTypes.h"
 
+#include "common/ceph_context.h"
+
 using std::list;
 using std::make_pair;
 using std::map;
@@ -264,6 +266,66 @@ void ECSubRead::decode(bufferlist::const_iterator &bl)
     omap_headers_to_read.clear();
   }
   DECODE_FINISH(bl);
+}
+
+/**
+ * Calculate the cost of the SubOp read operation for mClock scheduler.
+ * Cost is calculated based on whether the complete chunk/shard
+ * or a subchunk needs to be read:
+ * Case 1. Read the complete chunk aligned length:
+ *  - Cost is set to the length of the chunk aligned extent size.
+ * Case 2. Fragmented reads:
+ *  - Cost is set by considering the subchunk length and count.
+ *
+ * Note: To retain the legacy behavior, a cost of '0' is returned as
+ *       before for WeightedPriorityQueue scheduler.
+ */
+uint64_t ECSubRead::cost(CephContext *cct, std::pair<int, int>& subchunk_info)
+{
+  uint64_t total_cost = 0;
+  /**
+   * While the cost is calculated by the primary shard with mClock
+   * scheduler being active, the replica shard could still be
+   * running on the legacy WPQ scheduler. In such a case, the
+   * replica shard's decoding logic would set the cost to 0, which
+   * is consistent with what the legacy WPQ scheduler expects.
+   *
+   * In the converse case, the primary shard running with the
+   * legacy WPQ scheduler sends a cost of 0. The replica shard
+   * running with mClock scheduler will interpret this and set
+   * the cost to 1 accordingly.
+   */
+  if (cct->_conf->osd_op_queue != "mclock_scheduler") {
+    return total_cost; // Legacy behavior for WPQ scheduler
+  }
+
+  uint64_t subchunk_size = subchunk_info.second;
+
+  for (auto &&[hoid, tl] : to_read) {
+    auto it = subchunks.find(hoid);
+    if (it == subchunks.end()) continue;
+
+    auto &sc = it->second;
+    if (sc.empty()) continue;
+
+    // Case 1: Optimized / Complete chunk aligned read
+    if (sc.size() == 1 && sc.front().second == subchunk_info.first) {
+      for ([[maybe_unused]] auto &&[offset, len, flags] : tl) {
+        total_cost += len;
+      }
+      continue;
+    }
+
+    // Case 2: Fragmented / Subchunk Reads
+    uint64_t fragmented_shard_bytes = 0;
+    for (auto &&k : sc) {
+      fragmented_shard_bytes += (uint64_t)k.second * subchunk_size;
+    }
+    total_cost += fragmented_shard_bytes * tl.size();
+  }
+
+  // Safety Boundary: mClock requires non-zero costs for tracking active ops
+  return std::max<uint64_t>(total_cost, 1ULL);
 }
 
 std::ostream &operator<<(

--- a/src/osd/ECMsgTypes.h
+++ b/src/osd/ECMsgTypes.h
@@ -119,6 +119,14 @@ struct ECSubRead {
   std::map<hobject_t, std::vector<std::pair<int, int>>> subchunks;
   std::set<hobject_t> omap_headers_to_read;
   std::map<hobject_t, std::pair<std::string, uint64_t>> omap_read_from;
+  /**
+    * Calculate the cost of the SubOp read operation for mClock scheduler.
+    *
+    * @param *cct: *CephContext
+    * @param pair<int, int>&: subchunk_count and subchunk_size
+    * @return uint64_t - Cost of EC SubOpRead (size in Bytes)
+    */
+  uint64_t cost(CephContext *cct, std::pair<int, int>& subchunk_info);
   void encode(ceph::buffer::list &bl, uint64_t features) const;
   void decode(ceph::buffer::list::const_iterator &bl);
   void dump(ceph::Formatter *f) const;

--- a/src/osd/scheduler/OpSchedulerItem.h
+++ b/src/osd/scheduler/OpSchedulerItem.h
@@ -237,12 +237,47 @@ public:
     return op;
   }
 
-   SchedulerClass get_scheduler_class() const final {
-    auto type = op->get_req()->get_type();
-    if (type == CEPH_MSG_OSD_OP ||
-	type == CEPH_MSG_OSD_BACKOFF) {
+  SchedulerClass get_scheduler_class() const final {
+    switch (op->get_req()->get_type()) {
+    case CEPH_MSG_OSD_OP:
+    case CEPH_MSG_OSD_BACKOFF:
       return SchedulerClass::client;
-    } else {
+    /**
+     * EC SubOp reads for mClock are now classed based on their priority.
+     * The primary reason is to prevent subOps from overwhelming the
+     * 'immediate' queue during OSD events like failures, removal,
+     * reweight and any operation that trigger recovery/backfills. A sudden
+     * and long enough sustained burst of subOps in the 'immediate' could
+     * result in slow ops since client ops are preempted due to ops in the
+     * higher priority 'immediate' queue.
+     *
+     * The new classification described below improves the scheduling
+     * of client and other classes of operation during recovery/backfill as
+     * they are no longer preempted by recovery EC subOps in the 'immediate'
+     * queue. EC SubOps are now handled as follows:
+     *
+     *  - EC SubOp reads generated during recovery will either go into the
+     *    'background_recovery' or 'background_best_effort' class based on
+     *    the recovery priority set for the op. EC SubOp reads generated due
+     *    to client will continue to be classified as 'immediate'.
+     *
+     *  - EC SubOp writes generated as a result of client operations will
+     *    continue to be classified as 'immediate'.
+     *
+     *  - EC SubOp replies are considered high priority and therefore
+     *    continue to be classed as 'immediate'.
+     *
+     *  Note: The 'cost' for EC subOp read operation is set according to
+     *  the amount of data to be read/written.
+     */
+    case MSG_OSD_EC_READ: {
+      auto prio = op->get_req()->get_priority();
+      if (prio <= PeeringState::recovery_msg_priority_t::FORCED) {
+        return priority_to_scheduler_class(prio);
+      }
+      [[fallthrough]];
+    }
+    default:
       return SchedulerClass::immediate;
     }
   }

--- a/src/osd/scheduler/OpSchedulerItem.h
+++ b/src/osd/scheduler/OpSchedulerItem.h
@@ -74,6 +74,9 @@ public:
 
     virtual void run(OSD *osd, OSDShard *sdata, PGRef& pg, ThreadPool::TPHandle &handle) = 0;
     virtual SchedulerClass get_scheduler_class() const = 0;
+    virtual utime_t get_time_queued() const {
+      return utime_t();
+    }
 
     virtual ~OpQueueable() {}
     friend std::ostream& operator<<(std::ostream& out, const OpQueueable& q) {
@@ -166,6 +169,10 @@ public:
     qos_cost = scaled_cost;
   }
 
+  utime_t get_time_queued() const {
+    return qitem ? qitem->get_time_queued() : utime_t();
+  }
+
   friend std::ostream& operator<<(std::ostream& out, const OpSchedulerItem& item) {
     out << "OpSchedulerItem("
         << item.get_ordering_token() << " " << *item.qitem;
@@ -220,10 +227,12 @@ public:
 };
 
 class PGOpItem : public PGOpQueueable {
+  utime_t time_queued;
   OpRequestRef op;
 
 public:
-  PGOpItem(spg_t pg, OpRequestRef op) : PGOpQueueable(pg), op(std::move(op)) {}
+  PGOpItem(spg_t pg, OpRequestRef op)
+    : PGOpQueueable(pg), time_queued(ceph_clock_now()), op(std::move(op)) {}
 
   std::ostream &print(std::ostream &rhs) const final {
     return rhs << "PGOpItem(op=" << *(op->get_req()) << ")";
@@ -282,13 +291,19 @@ public:
     }
   }
 
+  utime_t get_time_queued() const final{
+    return time_queued;
+  }
+
   void run(OSD *osd, OSDShard *sdata, PGRef& pg, ThreadPool::TPHandle &handle) final;
 };
 
 class PGPeeringItem : public PGOpQueueable {
+  utime_t time_queued;
   PGPeeringEventRef evt;
 public:
-  PGPeeringItem(spg_t pg, PGPeeringEventRef e) : PGOpQueueable(pg), evt(e) {}
+  PGPeeringItem(spg_t pg, PGPeeringEventRef e)
+    : PGOpQueueable(pg), time_queued(ceph_clock_now()), evt(e) {}
   std::ostream &print(std::ostream &rhs) const final {
     return rhs << "PGPeeringEvent(" << evt->get_desc() << ")";
   }
@@ -307,6 +322,9 @@ public:
   }
   SchedulerClass get_scheduler_class() const final {
     return SchedulerClass::immediate;
+  }
+  utime_t get_time_queued() const final{
+    return time_queued;
   }
 };
 
@@ -537,6 +555,9 @@ public:
   uint64_t get_reserved_pushes() const final {
     return reserved_pushes;
   }
+  utime_t get_time_queued() const final {
+    return time_queued;
+  }
   void run(
     OSD *osd, OSDShard *sdata, PGRef& pg, ThreadPool::TPHandle &handle) final;
   SchedulerClass get_scheduler_class() const final {
@@ -564,6 +585,9 @@ public:
   std::string print() const final {
     return fmt::format(
 	"PGRecoveryContext(pgid={} c={} epoch={})", get_pgid(), (void*)c.get(), epoch);
+  }
+  utime_t get_time_queued() const final {
+    return time_queued;
   }
   void run(
     OSD *osd, OSDShard *sdata, PGRef& pg, ThreadPool::TPHandle &handle) final;
@@ -632,6 +656,10 @@ public:
 
   SchedulerClass get_scheduler_class() const final {
     return priority_to_scheduler_class(op->get_req()->get_priority());
+  }
+
+  utime_t get_time_queued() const final {
+    return time_queued;
   }
 
   void run(OSD* osd, OSDShard* sdata, PGRef& pg, ThreadPool::TPHandle& handle)

--- a/src/osd/scheduler/mClockScheduler.cc
+++ b/src/osd/scheduler/mClockScheduler.cc
@@ -73,30 +73,71 @@ void mClockScheduler::dump(ceph::Formatter &f) const
   f.close_section();
 }
 
+scheduler_op_type_t
+mClockScheduler::get_scheduler_op_type(const OpSchedulerItem &item)
+{
+  if (item.is_peering()) {
+    return scheduler_op_type_t::peering_op;
+  }
+
+  const auto op = item.maybe_get_op();
+  if (!op.has_value() || !(*op) || !(*op)->get_req()) {
+    return scheduler_op_type_t::unknown;
+  }
+
+  scheduler_op_type_t sch_op_type = scheduler_op_type_t::unknown;
+  const auto op_type = (*op)->get_req()->get_type();
+  const auto id = get_scheduler_id(item);
+  switch (id.class_id) {
+  case SchedulerClass::immediate: {
+    if (op_type == MSG_OSD_EC_READ) {
+      sch_op_type = scheduler_op_type_t::ec_read_op;
+    } else if (op_type == MSG_OSD_EC_WRITE) {
+      sch_op_type = scheduler_op_type_t::ec_write_op;
+    }
+    break;
+  }
+  case SchedulerClass::background_best_effort: {
+    if (op_type == MSG_OSD_EC_READ) {
+      sch_op_type = scheduler_op_type_t::ec_rec_read_op;
+    }
+    break;
+  }
+  default:
+    break;
+  }
+
+  return sch_op_type;
+}
+
 void mClockScheduler::enqueue(OpSchedulerItem&& item)
 {
   auto id = get_scheduler_id(item);
   unsigned priority = item.get_priority();
-  
+  scheduler_op_type_t sch_op_type = get_scheduler_op_type(item);
+  auto item_cost = item.get_cost();
+
   // TODO: move this check into OpSchedulerItem, handle backwards compat
   if (SchedulerClass::immediate == id.class_id) {
     enqueue_high(immediate_class_priority, std::move(item));
   } else if (priority >= cutoff_priority) {
     enqueue_high(priority, std::move(item));
   } else {
-    auto cost = calc_scaled_cost(item.get_cost());
-    item.set_qos_cost(cost);
+    auto qos_cost = calc_scaled_cost(item_cost);
+    item.set_qos_cost(qos_cost);
     dout(20) << __func__ << " " << id
-             << " item_cost: " << item.get_cost()
-             << " scaled_cost: " << cost
+             << " item_cost: " << item_cost
+             << " scaled_cost: " << qos_cost
              << dendl;
+
+    // trigger perf counter calculations first
+    mclock_conf.get_mclock_counter(id, sch_op_type, item_cost);
 
     // Add item to scheduler queue
     scheduler.add_request(
       std::move(item),
       id,
-      cost);
-    mclock_conf.get_mclock_counter(id);
+      qos_cost);
   }
 
   dout(20) << __func__ << ": sched client_count: " << scheduler.client_count()
@@ -141,17 +182,20 @@ void mClockScheduler::enqueue_high(unsigned priority,
                                    OpSchedulerItem&& item,
 				   bool front)
 {
+  scheduler_op_type_t sch_op_type = get_scheduler_op_type(item);
+  scheduler_id_t id = scheduler_id_t {
+    SchedulerClass::immediate,
+    client_profile_id_t()
+  };
+
+  // trigger perf counter calculations first
+  mclock_conf.get_mclock_counter(id, sch_op_type, item.get_cost());
+
   if (front) {
     high_priority[priority].push_back(std::move(item));
   } else {
     high_priority[priority].push_front(std::move(item));
   }
-
-  scheduler_id_t id = scheduler_id_t {
-    SchedulerClass::immediate,
-    client_profile_id_t()
-  };
-  mclock_conf.get_mclock_counter(id);
 }
 
 WorkItem mClockScheduler::dequeue()
@@ -166,13 +210,15 @@ WorkItem mClockScheduler::dequeue()
       // maintain invariant, high priority entries are never empty
       high_priority.erase(iter);
     }
-    ceph_assert(std::get_if<OpSchedulerItem>(&ret));
+    auto *item_ptr = std::get_if<OpSchedulerItem>(&ret);
+    ceph_assert(item_ptr);
 
     scheduler_id_t id = scheduler_id_t {
       SchedulerClass::immediate,
       client_profile_id_t()
     };
-    mclock_conf.put_mclock_counter(id);
+    scheduler_op_type_t op_type = get_scheduler_op_type(*item_ptr);
+    mclock_conf.put_mclock_counter(id, op_type, item_ptr->get_time_queued());
     return ret;
   } else {
     mclock_queue_t::PullReq result = scheduler.pull_request();
@@ -186,7 +232,16 @@ WorkItem mClockScheduler::dequeue()
       ceph_assert(result.is_retn());
 
       auto &retn = result.get_retn();
-      mclock_conf.put_mclock_counter(retn.client);
+
+      // update perf counters
+      scheduler_op_type_t op_type = scheduler_op_type_t::unknown;
+      utime_t time_queued = utime_t();
+      if (retn.request) {
+        op_type = get_scheduler_op_type(*retn.request);
+        time_queued = retn.request->get_time_queued();
+      }
+      mclock_conf.put_mclock_counter(retn.client, op_type, time_queued);
+
       return std::move(*retn.request);
     }
   }

--- a/src/osd/scheduler/mClockScheduler.cc
+++ b/src/osd/scheduler/mClockScheduler.cc
@@ -112,12 +112,13 @@ void mClockScheduler::enqueue(OpSchedulerItem&& item)
     *_dout << ", priority " << fmt_prio(prio) << ": " << queue.size();
   }
   *_dout << dendl;
- dout(30) << __func__ << " mClockClients: "
-          << scheduler
-          << dendl;
- dout(30) << __func__ << " mClockQueues: { "
-          << display_queues() << " }"
-          << dendl;
+
+  dout(30) << __func__ << " mClockClients: "
+           << scheduler
+           << dendl;
+  dout(30) << __func__ << " mClockQueues: { "
+           << display_queues() << " }"
+           << dendl;
 }
 
 void mClockScheduler::enqueue_front(OpSchedulerItem&& item)

--- a/src/osd/scheduler/mClockScheduler.cc
+++ b/src/osd/scheduler/mClockScheduler.cc
@@ -99,11 +99,19 @@ void mClockScheduler::enqueue(OpSchedulerItem&& item)
     mclock_conf.get_mclock_counter(id);
   }
 
- dout(20) << __func__ << " client_count: " << scheduler.client_count()
-          << " queue_sizes: [ "
-	  << " high_priority_queue: " << high_priority.size()
-          << " sched: " << scheduler.request_count() << " ]"
-          << dendl;
+  dout(20) << __func__ << ": sched client_count: " << scheduler.client_count()
+           << " sched queue size: " << scheduler.request_count()
+           << dendl;
+
+  auto fmt_prio = [this](priority_t p) -> std::string {
+    return (p == immediate_class_priority) ? "MAX" : std::to_string(p);
+  };
+
+  dout(20) << __func__ << " high_priority queues: " << high_priority.size();
+  for (const auto& [prio, queue] : high_priority) {
+    *_dout << ", priority " << fmt_prio(prio) << ": " << queue.size();
+  }
+  *_dout << dendl;
  dout(30) << __func__ << " mClockClients: "
           << scheduler
           << dendl;

--- a/src/osd/scheduler/mClockScheduler.h
+++ b/src/osd/scheduler/mClockScheduler.h
@@ -149,6 +149,8 @@ public:
 private:
   // Enqueue the op to the high priority queue
   void enqueue_high(unsigned prio, OpSchedulerItem &&item, bool front = false);
+  // Return the scheduler op type - used to update perf counters
+  scheduler_op_type_t get_scheduler_op_type(const OpSchedulerItem &item);
 };
 
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77728

---

backport of https://github.com/ceph/ceph/pull/64618
parent tracker: https://tracker.ceph.com/issues/71655

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
