### PR TITLE
mgr/dashboard: add authentication user signals telemetry metric

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/auth.py
+++ b/src/pybind/mgr/dashboard/controllers/auth.py
@@ -78,6 +78,8 @@ class Auth(RESTController, ControllerAuthMixin):
                 logger.info('Login successful: %s', username)
                 mgr.ACCESS_CTRL_DB.reset_attempt(username)
                 mgr.ACCESS_CTRL_DB.save()
+                from ..services.telemetry import DashboardTelemetryService
+                DashboardTelemetryService.increment_login_count()
                 token = JwtManager.gen_token(username, ttl=ttl)
 
                 # For backward-compatibility: PyJWT versions < 2.0.0 return bytes.

--- a/src/pybind/mgr/dashboard/controllers/saml2.py
+++ b/src/pybind/mgr/dashboard/controllers/saml2.py
@@ -57,7 +57,8 @@ class Saml2(BaseController, ControllerAuthMixin):
                 mgr.ACCESS_CTRL_DB.get_user(username)
             except UserDoesNotExist:
                 raise cherrypy.HTTPRedirect("{}/#/sso/404".format(url_prefix))
-
+            from ..services.telemetry import DashboardTelemetryService
+            DashboardTelemetryService.increment_login_count()
             token = JwtManager.gen_token(username)
             JwtManager.set_user(JwtManager.decode_token(token))
 

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -360,6 +360,8 @@ class Module(MgrModule, CherryPyConfig):
         AuthManager.initialize()
         load_sso_db()
 
+        self.update_telemetry_metrics()
+
         conf_result = self.await_configuration()
         if conf_result is None:
             return
@@ -595,6 +597,14 @@ class Module(MgrModule, CherryPyConfig):
             'OAuth2 SSO has been automatically disabled because '
             'oauth2-proxy is no longer running.'
         )
+
+    def update_telemetry_metrics(self):
+        """
+        Update dashboard telemetry metrics in config-key store.
+        """
+        from .services.telemetry import DashboardTelemetryService
+
+        DashboardTelemetryService.refresh_authentication_user_signals()
 
     def notify(self, notify_type: NotifyType, notify_id):
         NotificationQueue.new_notification(str(notify_type), notify_id)

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -362,6 +362,8 @@ class Module(MgrModule, CherryPyConfig):
         AuthManager.initialize()
         load_sso_db()
 
+        self.update_telemetry_metrics()
+
         conf_result = self.await_configuration()
         if conf_result is None:
             return
@@ -597,6 +599,14 @@ class Module(MgrModule, CherryPyConfig):
             'OAuth2 SSO has been automatically disabled because '
             'oauth2-proxy is no longer running.'
         )
+
+    def update_telemetry_metrics(self):
+        """
+        Update dashboard telemetry metrics in config-key store.
+        """
+        from .services.telemetry import DashboardTelemetryService
+
+        DashboardTelemetryService.refresh_authentication_user_signals()
 
     def notify(self, notify_type: NotifyType, notify_id):
         NotificationQueue.new_notification(str(notify_type), notify_id)

--- a/src/pybind/mgr/dashboard/services/auth/oauth2.py
+++ b/src/pybind/mgr/dashboard/services/auth/oauth2.py
@@ -142,6 +142,8 @@ class OAuth2(SSOAuth):
         # set user last update to token time issued
         user.last_update = jwt_payload.get('iat', 0)
         cherrypy.request.user = user
+        from ..telemetry import DashboardTelemetryService
+        DashboardTelemetryService.increment_login_count()
 
     @classmethod
     def reset_user(cls):

--- a/src/pybind/mgr/dashboard/services/telemetry.py
+++ b/src/pybind/mgr/dashboard/services/telemetry.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+
+import json
+import logging
+from typing import TypedDict
+
+from .. import mgr
+from ..plugins.ttl_cache import ttl_cache
+from .auth import AuthType
+from .sso import load_sso_db
+
+logger = logging.getLogger('services.telemetry')
+
+
+class AuthenticationUserSignals(TypedDict):
+    oauth2_enabled: bool
+    saml2_enabled: bool
+    configured_users: int
+    login_count: int
+
+
+class DashboardTelemetryService:
+
+    KV_AUTHENTICATION_USER_SIGNALS = (
+        'telemetry/metrics/authentication_user_signals'
+    )
+    KV_LOGIN_COUNT = 'telemetry/login_count'
+
+    @classmethod
+    @ttl_cache(300, label='authentication_user_signals')
+    def get_authentication_user_signals(cls) -> AuthenticationUserSignals:
+        auth_raw = mgr.get_store(cls.KV_AUTHENTICATION_USER_SIGNALS)
+
+        if not auth_raw:
+            return cls._detect_and_cache_authentication_user_signals()
+
+        try:
+            return json.loads(auth_raw)
+        except (TypeError, json.JSONDecodeError):
+            logger.warning(
+                'telemetry: invalid cached authentication data; recomputing'
+            )
+            return cls._detect_and_cache_authentication_user_signals()
+
+    @classmethod
+    def _detect_and_cache_authentication_user_signals(
+        cls
+    ) -> AuthenticationUserSignals:
+
+        oauth2_enabled = False
+        saml2_enabled = False
+        configured_users = 0
+
+        try:
+            oauth2_enabled = bool(
+                mgr.get_module_option('sso_oauth2')
+            )
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(
+                'telemetry: failed to determine OAuth2 status: %s', e
+            )
+
+        try:
+            load_sso_db()
+            saml2_enabled = (
+                getattr(mgr.SSO_DB, 'protocol', None) == AuthType.SAML2
+            )
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(
+                'telemetry: failed to determine SAML2 status: %s', e
+            )
+
+        try:
+            from .access_control import load_access_control_db
+            load_access_control_db()
+            configured_users = len(mgr.ACCESS_CTRL_DB.users)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(
+                'telemetry: failed to determine configured users: %s', e
+            )
+
+        result: AuthenticationUserSignals = {
+            'oauth2_enabled': oauth2_enabled,
+            'saml2_enabled': saml2_enabled,
+            'configured_users': configured_users,
+            'login_count': cls.get_login_count(),
+        }
+
+        mgr.set_store(
+            cls.KV_AUTHENTICATION_USER_SIGNALS,
+            json.dumps(result)
+        )
+
+        return result
+
+    @classmethod
+    def refresh_authentication_user_signals(
+        cls
+    ) -> AuthenticationUserSignals:
+        return cls._detect_and_cache_authentication_user_signals()
+
+    @staticmethod
+    def get_login_count() -> int:
+        """
+        Read the persistent login counter.
+
+        Returns cumulative login count stored in the manager KV store.
+        """
+        try:
+            count_raw = mgr.get_store(
+                DashboardTelemetryService.KV_LOGIN_COUNT, '0'
+            )
+            return int(count_raw)
+        except (ValueError, TypeError) as e:
+            logger.warning('telemetry: failed to read login count: %s', e)
+            return 0
+
+    @classmethod
+    def increment_login_count(cls):
+        """
+        Increment the persistent login counter.
+        Called after successful authentication.
+
+        Note: This uses a read-modify-write pattern which may lose
+        increments during concurrent logins. Minor race is acceptable
+        since this is telemetry and login_count is an approximate
+        aggregate metric. Telemetry should never break dashboard
+        functionality, hence the broad exception handling.
+        """
+        try:
+            count = cls.get_login_count()
+            count += 1
+            mgr.set_store(cls.KV_LOGIN_COUNT, str(count))
+            cls._detect_and_cache_authentication_user_signals()
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning('telemetry: failed to increment login count: %s', e)

--- a/src/pybind/mgr/dashboard/services/telemetry.py
+++ b/src/pybind/mgr/dashboard/services/telemetry.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+
+import json
+import logging
+from typing import TypedDict
+
+from .. import mgr
+from ..plugins.ttl_cache import ttl_cache
+
+logger = logging.getLogger('services.telemetry')
+
+
+class AuthenticationUserSignals(TypedDict):  # pylint: disable=inherit-non-class
+    oauth2_enabled: bool
+    saml2_enabled: bool
+    configured_users: int
+    login_count: int
+
+
+class DashboardTelemetryService:
+
+    KV_AUTHENTICATION_USER_SIGNALS = (
+        'telemetry/metrics/authentication_user_signals'
+    )
+    KV_LOGIN_COUNT = 'telemetry/login_count'
+
+    @classmethod
+    @ttl_cache(300, label='authentication_user_signals')
+    def get_authentication_user_signals(cls) -> AuthenticationUserSignals:
+        auth_raw = mgr.get_store(cls.KV_AUTHENTICATION_USER_SIGNALS)
+
+        if not auth_raw:
+            return cls._detect_and_cache_authentication_user_signals()
+
+        try:
+            return json.loads(auth_raw)
+        except (TypeError, json.JSONDecodeError):
+            logger.warning(
+                'telemetry: invalid cached authentication data; recomputing'
+            )
+            return cls._detect_and_cache_authentication_user_signals()
+
+    @classmethod
+    def _detect_and_cache_authentication_user_signals(
+        cls
+    ) -> AuthenticationUserSignals:
+
+        oauth2_enabled = False
+        saml2_enabled = False
+        configured_users = 0
+
+        try:
+            oauth2_enabled = bool(
+                mgr.get_module_option('sso_oauth2')
+            )
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(
+                'telemetry: failed to determine OAuth2 status: %s', e
+            )
+
+        try:
+            saml2_enabled = (
+                mgr.SSO_DB is not None
+                and mgr.SSO_DB.protocol.value == 'saml2'
+            )
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(
+                'telemetry: failed to determine SAML2 status: %s', e
+            )
+
+        try:
+            configured_users = (
+                len(mgr.ACCESS_CTRL_DB.users)
+                if mgr.ACCESS_CTRL_DB is not None
+                else 0
+            )
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(
+                'telemetry: failed to determine configured users: %s', e
+            )
+
+        result: AuthenticationUserSignals = {
+            'oauth2_enabled': oauth2_enabled,
+            'saml2_enabled': saml2_enabled,
+            'configured_users': configured_users,
+            'login_count': cls.get_login_count(),
+        }
+
+        mgr.set_store(
+            cls.KV_AUTHENTICATION_USER_SIGNALS,
+            json.dumps(result)
+        )
+
+        return result
+
+    @classmethod
+    def refresh_authentication_user_signals(
+        cls
+    ) -> AuthenticationUserSignals:
+        return cls._detect_and_cache_authentication_user_signals()
+
+    @staticmethod
+    def get_login_count() -> int:
+        """
+        Read the persistent login counter.
+
+        Returns cumulative login count stored in the manager KV store.
+        """
+        try:
+            count_raw = mgr.get_store(
+                DashboardTelemetryService.KV_LOGIN_COUNT, '0'
+            )
+            return int(count_raw)
+        except (ValueError, TypeError) as e:
+            logger.warning('telemetry: failed to read login count: %s', e)
+            return 0
+
+    @classmethod
+    def increment_login_count(cls):
+        """
+        Increment the persistent login counter.
+        Called after successful authentication.
+
+        Note: This uses a read-modify-write pattern which may lose
+        increments during concurrent logins. Minor race is acceptable
+        since this is telemetry and login_count is an approximate
+        aggregate metric. Telemetry should never break dashboard
+        functionality, hence the broad exception handling.
+        """
+        try:
+            count = cls.get_login_count() + 1
+            mgr.set_store(cls.KV_LOGIN_COUNT, str(count))
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning('telemetry: failed to increment login count: %s', e)

--- a/src/pybind/mgr/dashboard/tests/test_telemetry_service.py
+++ b/src/pybind/mgr/dashboard/tests/test_telemetry_service.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+import json
+import unittest
+from unittest.mock import MagicMock
+
+from .. import mgr
+from ..services.auth import AuthType
+from ..services.telemetry import DashboardTelemetryService
+
+
+class TestDashboardTelemetryServiceAuthenticationSignals(unittest.TestCase):
+
+    def setUp(self):
+        mgr.get_store = MagicMock(return_value=None)
+        mgr.set_store = MagicMock()
+        mgr.get_module_option = MagicMock(return_value=False)
+        mgr.SSO_DB = None
+        mgr.ACCESS_CTRL_DB = None
+
+    def test_increment_login_count(self):
+        mgr.get_store = MagicMock(return_value='5')
+
+        DashboardTelemetryService.increment_login_count()
+
+        mgr.set_store.assert_called_once_with(
+            DashboardTelemetryService.KV_LOGIN_COUNT, '6'
+        )
+
+    def test_get_authentication_user_signals_returns_expected_values(self):
+        mgr.get_module_option.return_value = True
+
+        mgr.SSO_DB = MagicMock()
+        mgr.SSO_DB.protocol = AuthType.SAML2
+
+        mgr.ACCESS_CTRL_DB = MagicMock()
+        mgr.ACCESS_CTRL_DB.users = {
+            'user1': MagicMock(),
+            'user2': MagicMock(),
+        }
+
+        mgr.get_store = MagicMock(
+            side_effect=lambda key, *args: (
+                None
+                if key == DashboardTelemetryService.KV_AUTHENTICATION_USER_SIGNALS
+                else '10'
+            )
+        )
+
+        result = DashboardTelemetryService.get_authentication_user_signals()
+
+        self.assertEqual(
+            result,
+            {
+                'oauth2_enabled': True,
+                'saml2_enabled': True,
+                'configured_users': 2,
+                'login_count': 10,
+            }
+        )
+
+        mgr.set_store.assert_called_once_with(
+            DashboardTelemetryService.KV_AUTHENTICATION_USER_SIGNALS,
+            json.dumps(result)
+        )
+
+    def test_authentication_user_signals_fallback_when_kv_store_returns_none(self):
+        mgr.get_store = MagicMock(return_value=None)
+
+        mgr.SSO_DB = None
+        mgr.ACCESS_CTRL_DB = None
+
+        result = DashboardTelemetryService.get_authentication_user_signals()
+
+        self.assertEqual(
+            result,
+            {
+                'oauth2_enabled': False,
+                'saml2_enabled': False,
+                'configured_users': 0,
+                'login_count': 0,
+            }
+        )
+
+    def test_authentication_user_signals_fallback_when_kv_store_contains_invalid_json(self):
+        mgr.get_store = MagicMock(return_value='invalid-json')
+
+        mgr.SSO_DB = None
+        mgr.ACCESS_CTRL_DB = None
+
+        # Simulate the fallback performed by get_authentication_user_signals
+        # after detecting invalid cached JSON.
+        mgr.get_store.side_effect = [
+            'invalid-json',
+            '0',
+        ]
+
+        result = DashboardTelemetryService.get_authentication_user_signals()
+
+        self.assertEqual(
+            result,
+            {
+                'oauth2_enabled': False,
+                'saml2_enabled': False,
+                'configured_users': 0,
+                'login_count': 0,
+            }
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -573,7 +573,7 @@ class Module(MgrModule):
                     parsed_output = dict(zip(categories, values))
             else:
                 self.log.error('No heap stats available on {}.{}: {}'.format(daemon_type, daemon_id, outs))
-        
+
         return parsed_output
 
     def get_mempool(self, mode: str = 'separated') -> Dict[str, dict]:
@@ -1370,7 +1370,25 @@ class Module(MgrModule):
 
         # NOTE: We do not include the 'device' channel in this report; it is
         # sent to a different endpoint.
-
+        # -- Dashboard metrics --
+        try:
+            r, outb, outs = self.mon_command({
+                'prefix': 'config-key get',
+                'key': 'mgr/dashboard/telemetry/metrics/authentication_user_signals'
+            })
+            auth_raw = outb.strip() if r == 0 and outb else None
+            report.setdefault('dashboard', {})
+            report['dashboard']['authentication_user_signals'] = (
+                json.loads(auth_raw) if auth_raw else {}
+            )
+        except Exception as e:
+            self.log.warning(
+                'telemetry: failed to attach dashboard '
+                'authentication_user_signals: %s',
+                e
+            )
+         # -- End Dashboard metrics --  
+           
         return report
 
     def get_rook_data(self, report: Dict[str, object]) -> None:

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -598,7 +598,7 @@ class Module(MgrModule):
                     parsed_output = dict(zip(categories, values))
             else:
                 self.log.error('No heap stats available on {}.{}: {}'.format(daemon_type, daemon_id, outs))
-        
+
         return parsed_output
 
     def get_mempool(self, mode: str = 'separated') -> Dict[str, dict]:
@@ -1391,7 +1391,24 @@ class Module(MgrModule):
 
         # NOTE: We do not include the 'device' channel in this report; it is
         # sent to a different endpoint.
-
+        # -- Dashboard metrics --
+        try:
+            r, outb, outs = self.mon_command({
+                'prefix': 'config-key get',
+                'key': 'mgr/dashboard/telemetry/metrics/authentication_user_signals'
+            })
+            auth_raw = outb.strip() if r == 0 and outb else None
+            dashboard = cast(Dict[str, Any], report.setdefault('dashboard', {}))
+            dashboard['authentication_user_signals'] = (
+                json.loads(auth_raw) if auth_raw else {}
+            )
+        except Exception as e:
+            self.log.warning(
+                'telemetry: failed to attach dashboard '
+                'authentication_user_signals: %s',
+                e
+            )
+        # -- End Dashboard metrics --
         return report
 
     def get_rook_data(self, report: Dict[str, object]) -> None:


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/76930

## Summary

This change adds Dashboard authentication user signals telemetry metrics.

The implementation collects aggregated authentication-related signals from the Dashboard authentication subsystem and exposes them through the telemetry report.

Collected metrics:

* `oauth2_enabled`: indicates whether Dashboard OAuth2 authentication is configured and enabled.

* `saml2_enabled`: indicates whether Dashboard SAML2 authentication is configured and enabled.

* `configured_users`: reports the total number of configured Dashboard users.

* `login_count`: reports the cumulative number of successful Dashboard logins recorded by the Dashboard. The value is aggregated and contains no user-identifying information.

Telemetry flow:

```bash 
Dashboard authentication services -> Dashboard telemetry service -> mgr KV store -> telemetry module -> telemetry report
```

Example telemetry output:

```json
{
  "dashboard": {
    "authentication_user_signals": {
      "oauth2_enabled": false,
      "saml2_enabled": false,
      "configured_users": 2,
      "login_count": 37
    }
  }
}
```

## Validation

Verified on a cephadm test cluster.

```bash
ceph telemetry show | jq '.dashboard.authentication_user_signals'

ceph config-key get mgr/dashboard/telemetry/metrics/authentication_user_signals

```
Verified that:

* `configured_users` reflects the number of Dashboard users.
* `login_count` increments after successful Dashboard authentication.
* `oauth2_enabled` is reported correctly based on Dashboard OAuth2 configuration.
* `saml2_enabled` is reported correctly based on Dashboard SAML2 configuration.

> Note: This metric reports only aggregated authentication signals and does not include user identities, usernames, credentials, tokens, or any other personally identifiable information.


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
