### PR TITLE
osd/ECOmapJournal: bind by reference when clearing omap keys

### DIFF
--- a/src/osd/ECOmapJournal.cc
+++ b/src/osd/ECOmapJournal.cc
@@ -234,7 +234,7 @@ void ECOmapJournal::process_entries(const hobject_t &hoid) {
     // Clear omap if specified
     if (entry_iter->clear_omap) {
       // Mark all keys as removed
-      for (auto [_, value] : key_map[hoid]) {
+      for (auto &[_, value] : key_map[hoid]) {
         value.update_value(entry_iter->version, std::nullopt);
       }
 

--- a/src/test/osd/test_ec_omap_journal.cc
+++ b/src/test/osd/test_ec_omap_journal.cc
@@ -519,6 +519,32 @@ TEST(ecomapjournal, ClearOmap) {
   EXPECT_TRUE(ranges.at("") == std::nullopt);
 }
 
+TEST(ecomapjournal, ClearOmapTombstonesCachedKeys) {
+  MockDoutPrefixProvider dpp;
+  ECOmapJournal journal(dpp);
+  const hobject_t hoid("obj_clear_cached", CEPH_NOSNAP, 1, 0, "nspace");
+
+  // Process an insert first so the keys land in the cached key_map.
+  journal.add_entry(hoid, create_insert_entry(eversion_t(1, 1), 1, 3));
+  {
+    auto [updates, ranges] = journal.get_value_updates(hoid);
+    ASSERT_TRUE(updates.at(make_key(1)).value.has_value());
+    ASSERT_TRUE(updates.at(make_key(2)).value.has_value());
+    ASSERT_TRUE(updates.at(make_key(3)).value.has_value());
+  }
+
+  // A later clear_omap must mark the already-cached keys as tombstones.
+  journal.add_entry(hoid, ECOmapJournalEntry(eversion_t(1, 2), true, std::nullopt, {}));
+
+  auto [updates, ranges] = journal.get_value_updates(hoid);
+  ASSERT_TRUE(updates.contains(make_key(1)));
+  ASSERT_TRUE(updates.contains(make_key(2)));
+  ASSERT_TRUE(updates.contains(make_key(3)));
+  EXPECT_FALSE(updates.at(make_key(1)).value.has_value());
+  EXPECT_FALSE(updates.at(make_key(2)).value.has_value());
+  EXPECT_FALSE(updates.at(make_key(3)).value.has_value());
+}
+
 TEST(ecomapjournal, append_delete_clears_maps)
 {
   MockDoutPrefixProvider dpp;


### PR DESCRIPTION
The `clear_omap` loop bound each `key_map` entry by value, so
`update_value()` mutated a copy and cached keys were never marked
removed:

As a result `clear_omap` had no effect on already-cached keys: cleared
omap keys retained stale values and were returned on read.

Introduced-by: 7289e4d2ece ("osd: Add ECOmapJournal class and relocate OmapUpdateType enum class")
Fixes: https://tracker.ceph.com/issues/77750

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
</content>
</invoke>