### PR TITLE
rgw/lc: serialize cloud-tier target bucket creation

### DIFF
--- a/src/rgw/driver/rados/rgw_lc_tier.cc
+++ b/src/rgw/driver/rados/rgw_lc_tier.cc
@@ -15,10 +15,12 @@
 #include "rgw_rest.h"
 #include "svc_zone.h"
 #include "rgw_rados.h"
+#include "common/async/shared_mutex.h"
 
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/asio/any_io_executor.hpp>
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
@@ -1559,29 +1561,62 @@ static int cloud_tier_create_bucket(RGWLCCloudTierCtx& tier_ctx) {
   return 0;
 }
 
+namespace {
+thread_local std::optional<
+    ceph::async::SharedMutex<boost::asio::any_io_executor>> tls_create_mtx;
+thread_local boost::asio::any_io_executor tls_create_mtx_ex;
+
+/*
+ * Rebound when the run's executor changes; that only happens at a run
+ * boundary, where no coroutine holds the lock.
+ */
+ceph::async::SharedMutex<boost::asio::any_io_executor>*
+cloud_target_create_mutex(boost::asio::any_io_executor ex)
+{
+  if (!tls_create_mtx || tls_create_mtx_ex != ex) {
+    tls_create_mtx.emplace(ex);
+    tls_create_mtx_ex = ex;
+  }
+  return &*tls_create_mtx;
+}
+} // namespace
+
 int rgw_cloud_tier_transfer_object(RGWLCCloudTierCtx& tier_ctx, std::set<std::string>& cloud_targets) {
   int ret = 0;
+  const std::string& name = tier_ctx.target_bucket_name;
 
-  // check if target bucket is in local cache
-  auto it = cloud_targets.find(tier_ctx.target_bucket_name);
-  tier_ctx.target_bucket_created = (it != cloud_targets.end());
+  if (cloud_targets.find(name) == cloud_targets.end()) {
+    std::optional<std::unique_lock<
+        ceph::async::SharedMutex<boost::asio::any_io_executor>>> lk;
+    if (tier_ctx.y) {
+      auto* mtx = cloud_target_create_mutex(
+          tier_ctx.y.get_yield_context().get_executor());
+      boost::system::error_code ec;
+      lk = mtx->async_lock(tier_ctx.y.get_yield_context()[ec]);
+      if (ec) {
+        ldpp_dout(tier_ctx.dpp, 5) << "cloud tier: target-bucket lock aborted: "
+                                   << ec.message() << dendl;
+        return -ECANCELED;
+      }
+    }
 
-  if (!tier_ctx.target_bucket_created) {
-    // not in cache; check if bucket exists on remote
-    ret = cloud_tier_bucket_exists(tier_ctx);
-    if (ret == -ENOENT) {
-      ret = cloud_tier_create_bucket(tier_ctx);
-      if (ret < 0) {
-        ldpp_dout(tier_ctx.dpp, 0) << "ERROR: failed to create target bucket on the cloud endpoint ret=" << ret << dendl;
+    if (cloud_targets.find(name) == cloud_targets.end()) {
+      // not in cache; check if bucket exists on remote
+      ret = cloud_tier_bucket_exists(tier_ctx);
+      if (ret == -ENOENT) {
+        ret = cloud_tier_create_bucket(tier_ctx);
+        if (ret < 0) {
+          ldpp_dout(tier_ctx.dpp, 0) << "ERROR: failed to create target bucket on the cloud endpoint ret=" << ret << dendl;
+          return ret;
+        }
+      } else if (ret < 0) {
+        ldpp_dout(tier_ctx.dpp, 0) << "ERROR: failed to check target bucket on the cloud endpoint ret=" << ret << dendl;
         return ret;
       }
-    } else if (ret < 0) {
-      ldpp_dout(tier_ctx.dpp, 0) << "ERROR: failed to check target bucket on the cloud endpoint ret=" << ret << dendl;
-      return ret;
+      cloud_targets.insert(name);
     }
-    tier_ctx.target_bucket_created = true;
-    cloud_targets.insert(tier_ctx.target_bucket_name);
   }
+  tier_ctx.target_bucket_created = true;
 
   /* Since multiple zones may try to transition the same object to the cloud,
    * verify if the object is already transitioned. And since its just a best


### PR DESCRIPTION
The first object transitioning to a cloud tier creates the target bucket on the remote endpoint, tracked in a per-worker set. The LC workpool runs many coroutines at once though, so they all miss the set and fire duplicate creates before any finishes, which some backends will fail. Serialize the create behind an async mutex: the first coroutine makes the bucket, the rest wait and read it from the set. The lock drops before the transfer so those stay concurrent.

This only surfaced after PR https://github.com/ceph/ceph/pull/68453 which let transitions actually yield instead of blocking the io_context and running one at a time.

Fixes: https://tracker.ceph.com/issues/77746

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [X] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
