### PR TITLE
umbrella: mgr: handle SIGTERM/SIGINT in standby mgr to avoid CEPHADM_FAILED_DAEMON

### DIFF
--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -153,11 +153,18 @@ int MgrStandby::asok_command(std::string_view cmd, const cmdmap_t& cmdmap, Forma
   }
 }
 
+static void handle_standby_mgr_signal(int signum)
+{
+  derr << " *** Got signal " << sig_str(signum) << " ***" << dendl;
+  _exit(0);
+}
+
 int MgrStandby::init()
 {
   init_async_signal_handler();
   register_async_signal_handler(SIGHUP, sighup_handler);
-
+  register_async_signal_handler_oneshot(SIGTERM, handle_standby_mgr_signal);
+  register_async_signal_handler_oneshot(SIGINT, handle_standby_mgr_signal);
   cct->_conf.add_observer(this);
 
   std::lock_guard l(lock);
@@ -495,6 +502,8 @@ int MgrStandby::main(vector<const char *> args)
 
   // Disable signal handlers
   unregister_async_signal_handler(SIGHUP, sighup_handler);
+  unregister_async_signal_handler(SIGTERM, handle_standby_mgr_signal);
+  unregister_async_signal_handler(SIGINT, handle_standby_mgr_signal);
   shutdown_async_signal_handler();
 
   return 0;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77755

---

backport of https://github.com/ceph/ceph/pull/69456
parent tracker: https://tracker.ceph.com/issues/77116

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh