### PR TITLE
ceph.spec.in: add support for openRuyi

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -273,7 +273,7 @@ BuildRequires:  libatomic
 %if 0%{with tcmalloc}
 # libprofiler did not build on ppc64le until 2.7.90
 %if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
-BuildRequires:	gperftools-devel >= 2.7.90
+BuildRequires:	pkgconfig(libtcmalloc) >= 2.7.90
 %endif
 %if 0%{?suse_version}
 BuildRequires:	gperftools-devel >= 2.4
@@ -309,7 +309,7 @@ BuildRequires:  procps
 BuildRequires:	python3
 BuildRequires:	python3-devel
 BuildRequires:	python3-setuptools
-BuildRequires:	python3-Cython
+BuildRequires:	python3dist(cython)
 BuildRequires:	python3-pip
 BuildRequires:	python3-wheel
 BuildRequires:	pkgconfig(snappy)
@@ -351,6 +351,7 @@ BuildRequires:	python3dist(natsort)
 %endif
 BuildRequires:	pkgconfig(thrift) >= 0.13.0
 BuildRequires:  pkgconfig(re2)
+BuildRequires:	pkgconfig(numa)
 %if 0%{with jaeger}
 BuildRequires:  bison
 BuildRequires:  flex
@@ -422,7 +423,6 @@ Requires:	systemd
 BuildRequires:  boost-random
 BuildRequires:  libatomic
 BuildRequires:  ninja-build
-BuildRequires:  numactl-devel
 #BuildRequires:  krb5-devel
 BuildRequires:  CUnit-devel
 BuildRequires:	python3-devel
@@ -472,9 +472,6 @@ BuildRequires:  openEuler-rpm-config
 # pkgconfig(cryptopp)), while el10 and SUSE's cryptopp/libcryptopp-devel
 # provide pkgconfig(libcryptopp); accept either.
 BuildRequires:  (pkgconfig(libcryptopp) or pkgconfig(cryptopp))
-%if 0%{?suse_version}
-BuildRequires:  libnuma-devel
-%endif
 %endif
 %if 0%{?rhel}
 BuildRequires: python-rpm-macros

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -34,8 +34,8 @@
 %else
 %bcond_with rbd_rwl_cache
 %endif
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
-%if 0%{?openEuler}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler} || 0%{?openruyi}
+%if 0%{?openEuler} || 0%{?openruyi}
 %bcond_with system_pmdk
 %else
 %ifarch s390x aarch64
@@ -44,7 +44,11 @@
 %bcond_without system_pmdk
 %endif
 %endif
+%if 0%{?openruyi}
+%bcond_with selinux
+%else
 %bcond_without selinux
+%endif
 %bcond_without amqp_endpoint
 %bcond_without kafka_endpoint
 %bcond_without lttng
@@ -97,7 +101,7 @@
 %else
 %bcond_without jaeger
 %endif
-%if 0%{?fedora} || 0%{?suse_version} >= 1500 || 0%{?rhel}
+%if 0%{?fedora} || 0%{?suse_version} >= 1500 || 0%{?rhel} || 0%{?openruyi}
 # distros that ship cmd2 and/or colorama
 %bcond_without cephfs_shell
 %else
@@ -133,7 +137,11 @@
 %{!?_selinux_policy_version: %global _selinux_policy_version 0.0.0}
 %endif
 %endif
+%if 0%{?openruyi}
+%bcond_with cephadm_bundling
+%else
 %bcond_without cephadm_bundling
+%endif
 %bcond_without cephadm_pip_deps
 %bcond_without dwz
 %if %{with dwz}
@@ -272,7 +280,7 @@ BuildRequires:  libatomic
 %endif
 %if 0%{with tcmalloc}
 # libprofiler did not build on ppc64le until 2.7.90
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler} || 0%{?openruyi}
 BuildRequires:	pkgconfig(libtcmalloc) >= 2.7.90
 %endif
 %if 0%{?suse_version}
@@ -348,6 +356,18 @@ BuildRequires:	python3dist(pyopenssl)
 BuildRequires:	socat
 BuildRequires:	python3dist(asyncssh)
 BuildRequires:	python3dist(natsort)
+%if 0%{?openruyi}
+BuildRequires:	python3dist(cryptography)
+BuildRequires:	python3dist(jsonpatch)
+BuildRequires:	python3dist(jinja2)
+BuildRequires:	python3dist(werkzeug)
+BuildRequires:	python3dist(mypy)
+BuildRequires:	python3dist(pecan)
+BuildRequires:	python3dist(requests-mock)
+BuildRequires:	python3dist(kubernetes)
+BuildRequires:	python3dist(asyncmock)
+BuildRequires:	python3dist(types-pyyaml)
+%endif
 %endif
 BuildRequires:	pkgconfig(thrift) >= 0.13.0
 BuildRequires:  pkgconfig(re2)
@@ -427,6 +447,9 @@ BuildRequires:  ninja-build
 BuildRequires:  CUnit-devel
 BuildRequires:	python3-devel
 %endif
+%if 0%{?openruyi}
+BuildRequires:	ninja
+%endif
 # distro-conditional make check dependencies
 %if 0%{with make_check}
 BuildRequires:	golang
@@ -444,6 +467,13 @@ BuildRequires:	xmlsec1-nss
 BuildRequires:	xmlsec1-openssl
 BuildRequires:	python3dist(scipy)
 BuildRequires:	python3dist(pyopenssl)
+%endif
+%if 0%{?openruyi}
+BuildRequires:	/usr/bin/promtool
+BuildRequires:	python3dist(scipy)
+BuildRequires:	python3dist(numpy)
+BuildRequires:	python3dist(tox)
+BuildRequires:	python3dist(pyfakefs)
 %endif
 BuildRequires:	jsonnet
 %if 0%{?suse_version}
@@ -662,7 +692,7 @@ Requires:       ceph-mgr = %{_epoch_prefix}%{version}-%{release}
 Requires:       ceph-mgr-smb = %{_epoch_prefix}%{version}-%{release}
 Requires:       ceph-grafana-dashboards = %{_epoch_prefix}%{version}-%{release}
 Requires:       ceph-prometheus-alerts = %{_epoch_prefix}%{version}-%{release}
-%if 0%{?fedora} || 0%{?rhel}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?openruyi}
 Requires:       python3dist(grpcio)
 Requires:       python3dist(grpcio-tools)
 Requires:       python3dist(jmespath)
@@ -691,7 +721,7 @@ Group:          System/Filesystems
 %endif
 Requires:       ceph-mgr = %{_epoch_prefix}%{version}-%{release}
 Requires:       python3dist(numpy)
-%if 0%{?fedora} || 0%{?suse_version} || 0%{?openEuler}
+%if 0%{?fedora} || 0%{?suse_version} || 0%{?openEuler} || 0%{?openruyi}
 Requires:       python3dist(scikit-learn)
 %endif
 Requires:       python3dist(scipy)
@@ -793,7 +823,7 @@ Requires:       python3dist(jinja2)
 %if 0%{?suse_version}
 Requires:       openssh
 %endif
-%if 0%{?rhel} || 0%{?fedora} || 0%{?openEuler}
+%if 0%{?rhel} || 0%{?fedora} || 0%{?openEuler} || 0%{?openruyi}
 Requires:       openssh-clients
 %endif
 %description mgr-cephadm
@@ -1847,6 +1877,9 @@ popd
 
 %if 0%{with make_check}
 %check
+%if 0%{?openruyi}
+export CEPH_PYTHON_SYSTEM_SITE=true
+%endif
 # run in-tree unittests
 pushd %{_vpath_builddir}
 ctest %{_smp_mflags}
@@ -1868,7 +1901,7 @@ mv %{buildroot}%{_bindir}/crimson-osd %{buildroot}%{_bindir}/ceph-osd-crimson
 mv %{buildroot}%{_bindir}/ceph-osd %{buildroot}%{_bindir}/ceph-osd-classic
 
 install -m 0644 -D src/etc-rbdmap %{buildroot}%{_sysconfdir}/ceph/rbdmap
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler} || 0%{?openruyi}
 install -m 0644 -D etc/sysconfig/ceph %{buildroot}%{_sysconfdir}/sysconfig/ceph
 %endif
 %if 0%{?suse_version}
@@ -1902,7 +1935,7 @@ install -m 0644 -D udev/50-rbd.rules %{buildroot}%{_udevrulesdir}/50-rbd.rules
 # sudoers.d
 install -m 0440 -D sudoers.d/ceph-smartctl %{buildroot}%{_sysconfdir}/sudoers.d/ceph-smartctl
 
-%if 0%{?rhel} || 0%{?openEuler}
+%if 0%{?rhel} || 0%{?openEuler} || 0%{?openruyi}
 # Undefine -P flag as it is only supported with python version >= 3.11
 %undefine _py3_shebang_P
 
@@ -1988,7 +2021,7 @@ rm -rf %{_vpath_builddir}
 %{_libdir}/libmgr_op_tp.so*
 %endif
 %config(noreplace) %{_sysconfdir}/logrotate.d/ceph
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler} || 0%{?openruyi}
 %config(noreplace) %{_sysconfdir}/sysconfig/ceph
 %endif
 %if 0%{?suse_version}
@@ -2021,7 +2054,7 @@ if [ $1 -eq 1 ] ; then
 /usr/bin/systemctl preset ceph.target ceph-crash.service >/dev/null 2>&1 || :
 fi
 %endif
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler} || 0%{?openruyi}
 %systemd_post ceph.target ceph-crash.service
 %endif
 if [ $1 -eq 1 ] ; then
@@ -2032,7 +2065,7 @@ fi
 %if 0%{?suse_version}
 %service_del_preun ceph.target ceph-crash.service
 %endif
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler} || 0%{?openruyi}
 %systemd_preun ceph.target ceph-crash.service
 %endif
 
@@ -2133,7 +2166,7 @@ exit 0
 %pre common
 CEPH_GROUP_ID=167
 CEPH_USER_ID=167
-%if 0%{?rhel} || 0%{?fedora} || 0%{?openEuler}
+%if 0%{?rhel} || 0%{?fedora} || 0%{?openEuler} || 0%{?openruyi}
 /usr/sbin/groupadd ceph -g $CEPH_GROUP_ID -o -r 2>/dev/null || :
 /usr/sbin/useradd ceph -u $CEPH_USER_ID -o -r -g ceph -s /sbin/nologin -c "Ceph daemons" -d %{_localstatedir}/lib/ceph 2>/dev/null || :
 %endif
@@ -2172,7 +2205,7 @@ if [ $1 -eq 1 ] ; then
   /usr/bin/systemctl preset ceph-mds@\*.service ceph-mds.target >/dev/null 2>&1 || :
 fi
 %endif
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler} || 0%{?openruyi}
 %systemd_post ceph-mds@\*.service ceph-mds.target
 %endif
 if [ $1 -eq 1 ] ; then
@@ -2183,7 +2216,7 @@ fi
 %if 0%{?suse_version}
 %service_del_preun ceph-mds@\*.service ceph-mds.target
 %endif
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler} || 0%{?openruyi}
 %systemd_preun ceph-mds@\*.service ceph-mds.target
 %endif
 
@@ -2220,7 +2253,7 @@ if [ $1 -eq 1 ] ; then
   /usr/bin/systemctl preset ceph-mgr@\*.service ceph-mgr.target >/dev/null 2>&1 || :
 fi
 %endif
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler} || 0%{?openruyi}
 %systemd_post ceph-mgr@\*.service ceph-mgr.target
 %endif
 if [ $1 -eq 1 ] ; then
@@ -2231,7 +2264,7 @@ fi
 %if 0%{?suse_version}
 %service_del_preun ceph-mgr@\*.service ceph-mgr.target
 %endif
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler} || 0%{?openruyi}
 %systemd_preun ceph-mgr@\*.service ceph-mgr.target
 %endif
 
@@ -2403,7 +2436,7 @@ if [ $1 -eq 1 ] ; then
   /usr/bin/systemctl preset ceph-mon@\*.service ceph-mon.target >/dev/null 2>&1 || :
 fi
 %endif
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler} || 0%{?openruyi}
 %systemd_post ceph-mon@\*.service ceph-mon.target
 %endif
 if [ $1 -eq 1 ] ; then
@@ -2414,7 +2447,7 @@ fi
 %if 0%{?suse_version}
 %service_del_preun ceph-mon@\*.service ceph-mon.target
 %endif
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler} || 0%{?openruyi}
 %systemd_preun ceph-mon@\*.service ceph-mon.target
 %endif
 
@@ -2455,7 +2488,7 @@ if [ $1 -eq 1 ] ; then
   /usr/bin/systemctl preset cephfs-mirror@\*.service cephfs-mirror.target >/dev/null 2>&1 || :
 fi
 %endif
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler} || 0%{?openruyi}
 %systemd_post cephfs-mirror@\*.service cephfs-mirror.target
 %endif
 if [ $1 -eq 1 ] ; then
@@ -2466,7 +2499,7 @@ fi
 %if 0%{?suse_version}
 %service_del_preun cephfs-mirror@\*.service cephfs-mirror.target
 %endif
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler} || 0%{?openruyi}
 %systemd_preun cephfs-mirror@\*.service cephfs-mirror.target
 %endif
 
@@ -2504,7 +2537,7 @@ if [ $1 -eq 1 ] ; then
   /usr/bin/systemctl preset ceph-rbd-mirror@\*.service ceph-rbd-mirror.target >/dev/null 2>&1 || :
 fi
 %endif
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler} || 0%{?openruyi}
 %systemd_post ceph-rbd-mirror@\*.service ceph-rbd-mirror.target
 %endif
 if [ $1 -eq 1 ] ; then
@@ -2515,7 +2548,7 @@ fi
 %if 0%{?suse_version}
 %service_del_preun ceph-rbd-mirror@\*.service ceph-rbd-mirror.target
 %endif
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler} || 0%{?openruyi}
 %systemd_preun ceph-rbd-mirror@\*.service ceph-rbd-mirror.target
 %endif
 
@@ -2545,7 +2578,7 @@ if [ $1 -eq 1 ] ; then
   /usr/bin/systemctl preset ceph-immutable-object-cache@\*.service ceph-immutable-object-cache.target >/dev/null 2>&1 || :
 fi
 %endif
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler} || 0%{?openruyi}
 %systemd_post ceph-immutable-object-cache@\*.service ceph-immutable-object-cache.target
 %endif
 if [ $1 -eq 1 ] ; then
@@ -2556,7 +2589,7 @@ fi
 %if 0%{?suse_version}
 %service_del_preun ceph-immutable-object-cache@\*.service ceph-immutable-object-cache.target
 %endif
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler} || 0%{?openruyi}
 %systemd_preun ceph-immutable-object-cache@\*.service ceph-immutable-object-cache.target
 %endif
 
@@ -2599,7 +2632,7 @@ if [ $1 -eq 1 ] ; then
   /usr/bin/systemctl preset ceph-radosgw@\*.service ceph-radosgw.target >/dev/null 2>&1 || :
 fi
 %endif
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler} || 0%{?openruyi}
 %systemd_post ceph-radosgw@\*.service ceph-radosgw.target
 %endif
 if [ $1 -eq 1 ] ; then
@@ -2610,7 +2643,7 @@ fi
 %if 0%{?suse_version}
 %service_del_preun ceph-radosgw@\*.service ceph-radosgw.target
 %endif
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler} || 0%{?openruyi}
 %systemd_preun ceph-radosgw@\*.service ceph-radosgw.target
 %endif
 
@@ -2644,7 +2677,7 @@ if [ $1 -eq 1 ] ; then
   /usr/bin/systemctl preset ceph-osd@\*.service ceph-osd.target >/dev/null 2>&1 || :
 fi
 %endif
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler} || 0%{?openruyi}
 %systemd_post ceph-osd@\*.service ceph-osd.target
 %endif
 if [ $1 -eq 1 ] ; then
@@ -2656,7 +2689,7 @@ fi
 %if 0%{?suse_version}
 %service_del_preun ceph-osd@\*.service ceph-osd.target
 %endif
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler} || 0%{?openruyi}
 %systemd_preun ceph-osd@\*.service ceph-osd.target
 %endif
 
@@ -2721,7 +2754,7 @@ if [ $1 -eq 1 ] ; then
   /usr/bin/systemctl preset ceph-volume@\*.service >/dev/null 2>&1 || :
 fi
 %endif
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler} || 0%{?openruyi}
 %systemd_post ceph-volume@\*.service
 %endif
 
@@ -2729,7 +2762,7 @@ fi
 %if 0%{?suse_version}
 %service_del_preun ceph-volume@\*.service
 %endif
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler} || 0%{?openruyi}
 %systemd_preun ceph-volume@\*.service
 %endif
 


### PR DESCRIPTION
openRuyi is a Linux distribution (primarily targeting RISC-V, also supporting
x86). It already packages Ceph downstream
(https://github.com/openRuyi-Project/openRuyi/tree/main/SPECS/ceph); this PR
upstreams the spec changes that packaging needs, so openRuyi ci can build from
ceph.spec.in directly instead of carrying a downstream patch.

All changes are guarded by `0%{?openruyi}`, so there is no behavior change for
any existing distro.

Enable building Ceph on it by:

- adding an `openruyi` bcond block to select the available feature set (%openruyi is a flag, not a version number. https://github.com/openRuyi-Project/openRuyi/blob/5c09703b2baac0a2894b00443557ec4e25e14bc5/SPECS/openruyi-release/macros.openruyi#L3)
- providing openRuyi BuildRequires via the `pkgconfig()` and
  `python3dist()` virtual provides its repositories ship;
- extending the existing fedora/rhel/openEuler conditionals to also match
  openruyi;
- exporting `CEPH_PYTHON_SYSTEM_SITE` during `%check` so the in-tree tests
  find the system Python modules.

Passed the RISC-V CI validation based on OpenRuyi: https://github.com/sunyuechi/ceph-ci/actions/runs/28265013707

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests