### PR TITLE
nvmeof: fix data races on monitor-client state shared with the timer

### DIFF
--- a/src/nvmeof/NVMeofGwMonitorClient.cc
+++ b/src/nvmeof/NVMeofGwMonitorClient.cc
@@ -45,8 +45,8 @@ NVMeofGwMonitorClient::NVMeofGwMonitorClient(int argc, const char **argv) :
   gwmap_epoch(0),
   last_map_time(std::chrono::steady_clock::now()),
   reset_timestamp(std::chrono::steady_clock::now()),
-  start_time(last_map_time),
-  cluster_beacon_diff_included(0),
+  start_time(last_map_time.load()),
+  cluster_beacon_diff_included(false),
   poolctx(),
   monc{g_ceph_context, poolctx},
   client_messenger(Messenger::create(g_ceph_context, "async", entity_name_t::CLIENT(-1), "client", getpid())),
@@ -249,31 +249,33 @@ void NVMeofGwMonitorClient::send_beacon()
   BeaconSubsystems subsystem_diff = current_subsystems;
   determine_subsystem_changes(prev_beacon_subsystems, subsystem_diff);
 
-  auto group_key = std::make_pair(pool, group);
-  NvmeGwClientState old_gw_state;
-  // if already got gateway state in the map
-  if (first_beacon == false && get_gw_state("old map", map, group_key, name, old_gw_state))
+  // gw_in_map is published by the dispatch thread, so we avoid reading `map` here
+  if (!first_beacon && gw_in_map.load())
     gw_availability = ok ? gw_availability_t::GW_AVAILABLE : gw_availability_t::GW_UNAVAILABLE;
   dout(1) << "sending beacon as gid " << monc.get_global_id() << " availability " << (int)gw_availability <<
-    " osdmap_epoch " << osdmap_epoch << " gwmap_epoch " << gwmap_epoch << dendl;
+    " osdmap_epoch " << osdmap_epoch.load() << " gwmap_epoch " << gwmap_epoch.load() << dendl;
+
+  // snapshot the cluster feature once so the chosen payload and the format
+  // flag below stay consistent if the dispatch thread updates it mid-beacon.
+  const bool diff_included = cluster_beacon_diff_included.load();
 
   // Check if NVMEOF_BEACON_DIFF feature is supported by the cluster
-  dout(10) << fmt::format("NVMEOF_BEACON_DIFF supported: {}",  cluster_beacon_diff_included ? "yes" : "no") << dendl;
+  dout(10) << fmt::format("NVMEOF_BEACON_DIFF supported: {}",  diff_included ? "yes" : "no") << dendl;
 
   // Send beacon with appropriate version based on cluster features
   auto m = ceph::make_message<MNVMeofGwBeacon>(
       name,
       pool,
       group,
-      cluster_beacon_diff_included ? subsystem_diff : current_subsystems,
+      diff_included ? subsystem_diff : current_subsystems,
       gw_availability,
-      osdmap_epoch,
-      gwmap_epoch,
+      osdmap_epoch.load(),
+      gwmap_epoch.load(),
       beacon_sequence,
       // Pass affected features to the constructor
-      cluster_beacon_diff_included ? 1 : 0
+      diff_included ? 1 : 0
   );
-  dout(10) << "sending beacon with diff support: " << (cluster_beacon_diff_included ? "enabled" : "disabled") << dendl;
+  dout(10) << "sending beacon with diff support: " << (diff_included ? "enabled" : "disabled") << dendl;
   
   monc.send_mon_message(std::move(m));
   ++beacon_sequence;
@@ -284,7 +286,7 @@ void NVMeofGwMonitorClient::disconnect_panic()
 {
   auto disconnect_panic_duration = g_conf().get_val<std::chrono::seconds>("nvmeof_mon_client_disconnect_panic").count();
   auto now = std::chrono::steady_clock::now();
-  auto elapsed_seconds = std::chrono::duration_cast<std::chrono::seconds>(now - last_map_time).count();
+  auto elapsed_seconds = std::chrono::duration_cast<std::chrono::seconds>(now - last_map_time.load()).count();
   if (elapsed_seconds > disconnect_panic_duration) {
     dout(4) << "Triggering a panic upon disconnection from the monitor, elapsed " << elapsed_seconds << ", configured disconnect panic duration " << disconnect_panic_duration << dendl;
     throw std::runtime_error("Lost connection to the monitor (beacon timeout).");
@@ -294,7 +296,7 @@ void NVMeofGwMonitorClient::disconnect_panic()
 void NVMeofGwMonitorClient::connect_panic()
 {
   // Return immediately if the gateway was assigned group ID by the monitor
-  if (set_group_id) {
+  if (set_group_id.load()) {
     return;
   }
   // If the gateway has not been assigned a group ID, panic after timeout
@@ -415,10 +417,11 @@ void NVMeofGwMonitorClient::handle_nvmeof_gw_map(ceph::ref_t<MNVMeofGwMap> nmap)
   // ensure that the gateway state has not vanished
   ceph_assert(got_new_gw_state || !got_old_gw_state);
 
-  uint64_t old_cluster_beacon_diff_included = cluster_beacon_diff_included;
+  bool old_cluster_beacon_diff_included = cluster_beacon_diff_included.load();
   cluster_beacon_diff_included = (new_gw_state.map_features & NVMeofGwMap::FLAG_BEACONDIFF) != 0;
-  if (old_cluster_beacon_diff_included != cluster_beacon_diff_included) {
-    dout(0) << fmt::format("Updated cluster features: 0x{:x}", cluster_beacon_diff_included)
+  if (old_cluster_beacon_diff_included != cluster_beacon_diff_included.load()) {
+    dout(0) << fmt::format("Updated cluster features: NVMEOF_BEACON_DIFF {}",
+                           cluster_beacon_diff_included.load() ? "enabled" : "disabled")
             << dendl;
   }
 
@@ -443,13 +446,13 @@ void NVMeofGwMonitorClient::handle_nvmeof_gw_map(ceph::ref_t<MNVMeofGwMap> nmap)
       dout(10) << "Can not find new gw state" << dendl;
       return;
     }
-    ceph_assert(!set_group_id);
-    while (!set_group_id) {
+    ceph_assert(!set_group_id.load());
+    while (!set_group_id.load()) {
       NVMeofGwMonitorGroupClient monitor_group_client(
           grpc::CreateChannel(monitor_address, gw_creds()));
       dout(10) << "GRPC set_group_id: " <<  new_gw_state.group_id << dendl;
       set_group_id = monitor_group_client.set_group_id( new_gw_state.group_id);
-      if (!set_group_id) {
+      if (!set_group_id.load()) {
 	      dout(10) << "GRPC set_group_id failed" << dendl;
 	      auto retry_timeout = g_conf().get_val<uint64_t>("mon_nvmeofgw_set_group_id_retry");
 	      usleep(retry_timeout);
@@ -548,12 +551,15 @@ void NVMeofGwMonitorClient::handle_nvmeof_gw_map(ceph::ref_t<MNVMeofGwMap> nmap)
       }
     }
     // Update latest accepted osdmap epoch, for beacons
-    if (max_blocklist_epoch > osdmap_epoch) {
+    if (max_blocklist_epoch > osdmap_epoch.load()) {
       osdmap_epoch = max_blocklist_epoch;
-      dout(10) << "Ready for blocklist osd map epoch: " << osdmap_epoch << dendl;
+      dout(10) << "Ready for blocklist osd map epoch: " << osdmap_epoch.load() << dendl;
     }
   }
   map = new_map;
+  // publish, for the timer thread, whether this gateway is present in the
+  // committed map; see gw_in_map and send_beacon().
+  gw_in_map = got_new_gw_state;
 }
 
 Dispatcher::dispatch_result_t NVMeofGwMonitorClient::ms_dispatch2(const ref_t<Message>& m)

--- a/src/nvmeof/NVMeofGwMonitorClient.h
+++ b/src/nvmeof/NVMeofGwMonitorClient.h
@@ -30,6 +30,8 @@
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/security/credentials.h>
 
+#include <atomic>
+
 class NVMeofGwMonitorClient: public Dispatcher,
 		   public md_config_obs_t {
 private:
@@ -43,9 +45,11 @@ private:
   std::string client_cert;
   grpc::SslCredentialsOptions
               gw_ssl_opts;  // gateway grpc ssl options
-  epoch_t     osdmap_epoch; // last awaited osdmap_epoch
-  epoch_t     gwmap_epoch;  // last received gw map epoch
-  std::chrono::time_point<std::chrono::steady_clock>
+  // shared with the timer thread (send_beacon/disconnect_panic); atomic so the
+  // two threads need no common lock and `map` stays private to the dispatch thread
+  std::atomic<epoch_t> osdmap_epoch; // last awaited osdmap_epoch
+  std::atomic<epoch_t> gwmap_epoch;  // last received gw map epoch
+  std::atomic<std::chrono::time_point<std::chrono::steady_clock>>
               last_map_time; // used to panic on disconnect
   std::chrono::time_point<std::chrono::steady_clock>
                 reset_timestamp; // used to bypass some validations
@@ -53,10 +57,16 @@ private:
                 start_time; // used to panic on connect
 
   bool first_beacon = true;
-  bool set_group_id = false;
+  // written by the dispatch thread, read by the timer thread (connect_panic)
+  std::atomic<bool> set_group_id = false;
+  // published by the dispatch thread once this gateway appears in the gw map,
+  // read by the timer thread (send_beacon) instead of reading `map` directly
+  std::atomic<bool> gw_in_map = false;
   uint64_t beacon_sequence = 0;
   BeaconSubsystems prev_beacon_subsystems;
-  bool cluster_beacon_diff_included = 0;  // track cluster features for beacon encoding
+  // written by the dispatch thread, read by the timer thread (send_beacon);
+  // tracks cluster features for beacon encoding
+  std::atomic<bool> cluster_beacon_diff_included = false;
   // init gw ssl opts
   void init_gw_ssl_opts();
 


### PR DESCRIPTION
`send_beacon()` runs on the timer thread under beacon_lock, while `handle_nvmeof_gw_map()` runs on the dispatch thread under lock. both touch `osdmap_epoch`, `gwmap_epoch`, `last_map_time`, `set_group_id`, `cluster_beacon_diff_included` and the gw map, each written under one lock and read under the other.

only the gw map race matters in practice. send_beacon walks it with `get_gw_state()` while handle reassigns it with map = new_map, so a beacon can follow a freed node and crash the ceph-nvmeof-monitor-client. the beacons then stop, and if the restart outlasts the monitor's beacon grace the gateway is marked down and its namespaces fail over to a standby. the scalar races are word-sized stale reads with no observed symptom. nvmeof gateway deployments only.

user i/o is unaffected unless that failover fires, since the block data path never runs the racy code. on failover multipath hosts briefly repath to the standby and single-path ones stall on the owned namespaces, with no data loss or corruption either way.

make the shared scalars atomic and keep the map private to the dispatch thread. `send_beacon` only needs to know whether this gateway is in the map, so it reads an atomic gw_in_map flag that handle publishes instead of the map.

`send_beacon` also read `cluster_beacon_diff_included` twice per beacon, to pick the payload and to set its format flag, so a concurrent flip could tag a diff payload as full. snapshot it once.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
