### PR TITLE
squid: rgw/lc: warn against changing rgw_lc_max_objs once lifecycle is in use

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -429,7 +429,8 @@ options:
   level: advanced
   desc: Number of lifecycle data shards
   long_desc: Number of RADOS objects to use for storing lifecycle index. This affects
-    concurrency of lifecycle maintenance, as shards can be processed in parallel.
+    concurrency of lifecycle maintenance, as shards can be processed in parallel. Do not
+    change this value after deployment unless `radosgw-admin lc list` is empty.
   default: 32
   services:
   - rgw


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77749

---

backport of https://github.com/ceph/ceph/pull/69528
parent tracker: https://tracker.ceph.com/issues/77278

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh