### PR TITLE
mgr/volumes: add --namespace-isolated support for subvolumegroup create

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -3,8 +3,10 @@
   the group directory is placed in a separate RADOS namespace, and all subvolumes
   subsequently created within that group automatically inherit RADOS namespace
   isolation without needing the ``--namespace-isolated`` flag on each
-  ``fs subvolume create`` invocation. This provides per-tenant RADOS-level security
-  isolation at the subvolume group granularity.
+  ``fs subvolume create`` invocation. An optional ``--pool-namespace`` flag allows
+  specifying an explicit RADOS namespace to override the auto-generated name.
+  This provides per-tenant RADOS-level security isolation at the subvolume group
+  granularity.
 
 * CephFS: The ``client_force_lazyio`` configuration option is now correctly marked
   as not supporting runtime updates. Previously, the configuration schema indicated

--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,3 +1,11 @@
+* CephFS: The ``fs subvolumegroup create`` command now supports the
+  ``--namespace-isolated`` option. When a subvolume group is created with this flag,
+  the group directory is placed in a separate RADOS namespace, and all subvolumes
+  subsequently created within that group automatically inherit RADOS namespace
+  isolation without needing the ``--namespace-isolated`` flag on each
+  ``fs subvolume create`` invocation. This provides per-tenant RADOS-level security
+  isolation at the subvolume group granularity.
+
 * CephFS: The ``client_force_lazyio`` configuration option is now correctly marked
   as not supporting runtime updates. Previously, the configuration schema indicated
   this option could be changed at runtime, but changes had no effect on opened file

--- a/doc/cephfs/fs-volumes.rst
+++ b/doc/cephfs/fs-volumes.rst
@@ -216,7 +216,7 @@ Create a subvolume group by running a command of the following form:
 
 .. prompt:: bash #
 
-   ceph fs subvolumegroup create <vol_name> <group_name> [--size <size_in_bytes>] [--pool_layout <data_pool_name>] [--uid <uid>] [--gid <gid>] [--mode <octal_mode>] [--normalization <form>] [--casesensitive <bool>] [--namespace-isolated]
+   ceph fs subvolumegroup create <vol_name> <group_name> [--size <size_in_bytes>] [--pool_layout <data_pool_name>] [--uid <uid>] [--gid <gid>] [--mode <octal_mode>] [--normalization <form>] [--casesensitive <bool>] [--namespace-isolated] [--pool-namespace <namespace>]
 
 The command succeeds even if the subvolume group already exists.
 
@@ -260,6 +260,12 @@ own unique RADOS namespace (``fsvolumens__<group>_<subvolume>``) without
 needing the ``--namespace-isolated`` flag on the ``fs subvolume create``
 command. This provides security isolation at the RADOS level for all
 subvolumes belonging to the group.
+
+An explicit RADOS namespace can be specified via the ``--pool-namespace``
+option (e.g. ``--pool-namespace my-custom-ns``), which overrides the
+auto-generated namespace. This is useful when a RADOS namespace has been
+pre-created by an administrator and needs to be associated with a specific
+subvolume group.
 
 To check if a subvolume group has namespace isolation enabled, use the
 ``fs subvolumegroup info`` command and look for the ``pool_namespace``

--- a/doc/cephfs/fs-volumes.rst
+++ b/doc/cephfs/fs-volumes.rst
@@ -216,7 +216,7 @@ Create a subvolume group by running a command of the following form:
 
 .. prompt:: bash #
 
-   ceph fs subvolumegroup create <vol_name> <group_name> [--size <size_in_bytes>] [--pool_layout <data_pool_name>] [--uid <uid>] [--gid <gid>] [--mode <octal_mode>] [--normalization <form>] [--casesensitive <bool>]
+   ceph fs subvolumegroup create <vol_name> <group_name> [--size <size_in_bytes>] [--pool_layout <data_pool_name>] [--uid <uid>] [--gid <gid>] [--mode <octal_mode>] [--normalization <form>] [--casesensitive <bool>] [--namespace-isolated]
 
 The command succeeds even if the subvolume group already exists.
 
@@ -250,6 +250,20 @@ file. The case of the file name used when the file was created is preserved.
 
 .. note:: Setting ``--casesensitive=0`` option implicitly enables
    Unicode normalization on the subvolume group.
+
+A subvolume group can be created in a separate RADOS namespace by specifying
+the ``--namespace-isolated`` option. When a subvolume group has namespace
+isolation enabled, the group directory is placed in its own RADOS namespace
+(``fsvolumens__<group>``), and any subvolume subsequently created within that
+group automatically inherits namespace isolation -- each subvolume gets its
+own unique RADOS namespace (``fsvolumens__<group>_<subvolume>``) without
+needing the ``--namespace-isolated`` flag on the ``fs subvolume create``
+command. This provides security isolation at the RADOS level for all
+subvolumes belonging to the group.
+
+To check if a subvolume group has namespace isolation enabled, use the
+``fs subvolumegroup info`` command and look for the ``pool_namespace``
+field in the output.
 
 Remove a subvolume group by running a command of the following form:
 
@@ -302,6 +316,8 @@ The output format is JSON and contains fields as follows:
 * ``bytes_used``: current used size of the subvolume group in bytes
 * ``created_at``: creation time of the subvolume group in the format "YYYY-MM-DD HH:MM:SS"
 * ``data_pool``: data pool to which the subvolume group belongs
+* ``pool_namespace``: RADOS namespace of the subvolume group if namespace isolation is
+  enabled, otherwise empty string
 
 Check for the presence of a given subvolume group by running a command of the
 following form:

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -1544,6 +1544,82 @@ class TestSubvolumeGroups(TestVolumesHelper):
 
         self._fs_cmd("subvolumegroup", "rm", self.volname, group)
 
+    def test_subvolume_group_create_with_custom_pool_namespace(self):
+        """
+        Create subvolume group with --namespace-isolated and
+        --pool-namespace to specify an explicit RADOS namespace.
+        Verify the custom namespace is used instead of the auto-generated one.
+        """
+        group = self._gen_subvol_grp_name()
+        custom_ns = "my-custom-namespace"
+        self._fs_cmd("subvolumegroup", "create", self.volname, group,
+                     "--namespace-isolated",
+                     "--pool-namespace", custom_ns)
+
+        # verify group has custom pool_namespace, not auto-generated
+        group_info = json.loads(self._get_subvolume_group_info(self.volname, group))
+        self.assertEqual(group_info["pool_namespace"], custom_ns)
+
+        self._fs_cmd("subvolumegroup", "rm", self.volname, group)
+
+    def test_subvolume_inherit_from_custom_pool_namespace_group(self):
+        """
+        Create subvolume group with --namespace-isolated and an explicit
+        --pool-namespace. Then create a subvolume in that group. Verify the
+        subvolume inherits namespace isolation (its own namespace is still
+        auto-generated based on group name).
+        """
+        sv = self._gen_subvol_name()
+        svg = self._gen_subvol_grp_name()
+        custom_ns = "my-custom-namespace"
+        self._fs_cmd("subvolumegroup", "create", self.volname, svg,
+                     "--namespace-isolated",
+                     "--pool-namespace", custom_ns)
+
+        # create subvolume WITHOUT --namespace-isolated
+        self._fs_cmd("subvolume", "create", self.volname, sv, svg)
+
+        # verify group has custom pool_namespace
+        group_info = json.loads(self._get_subvolume_group_info(self.volname, svg))
+        self.assertEqual(group_info["pool_namespace"], custom_ns)
+
+        # verify subvolume inherits namespace isolation with auto-generated ns
+        subvol_info = json.loads(self._get_subvolume_info(self.volname, sv, svg))
+        self.assertIn("pool_namespace", subvol_info)
+        expected_ns = f'fsvolumens__{svg}_{sv}'
+        self.assertEqual(subvol_info["pool_namespace"], expected_ns)
+
+        # cleanup
+        self._fs_cmd("subvolume", "rm", self.volname, sv, svg)
+        self._fs_cmd("subvolumegroup", "rm", self.volname, svg)
+        self._wait_for_trash_empty()
+
+    def test_subvolume_group_create_idempotence_custom_pool_namespace(self):
+        """
+        Re-running subvolumegroup create with --pool-namespace on an
+        existing group that already has namespace isolation should
+        update the pool_namespace to the new custom value.
+        """
+        group = self._gen_subvol_grp_name()
+        # create with --namespace-isolated (auto-generated namespace)
+        self._fs_cmd("subvolumegroup", "create", self.volname, group,
+                     "--namespace-isolated")
+
+        group_info = json.loads(self._get_subvolume_group_info(self.volname, group))
+        self.assertEqual(group_info["pool_namespace"],
+                         f'fsvolumens__{group}')
+
+        # re-create with --pool-namespace to override
+        custom_ns = "my-custom-namespace"
+        self._fs_cmd("subvolumegroup", "create", self.volname, group,
+                     "--namespace-isolated",
+                     "--pool-namespace", custom_ns)
+
+        group_info = json.loads(self._get_subvolume_group_info(self.volname, group))
+        self.assertEqual(group_info["pool_namespace"], custom_ns)
+
+        self._fs_cmd("subvolumegroup", "rm", self.volname, group)
+
     def test_subvolume_group_create_idempotence_resize(self):
         # create group
         group = self._gen_subvol_grp_name()

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -1354,7 +1354,7 @@ class TestSubvolumeGroups(TestVolumesHelper):
         # tests the 'fs subvolumegroup info' command
 
         group_md = ["atime", "bytes_pcent", "bytes_quota", "bytes_used", "created_at", "ctime",
-                     "data_pool", "gid", "mode", "mon_addrs", "mtime", "uid"]
+                     "data_pool", "gid", "mode", "mon_addrs", "mtime", "pool_namespace", "uid"]
 
         # create group
         group = self._gen_subvol_grp_name()
@@ -1457,6 +1457,91 @@ class TestSubvolumeGroups(TestVolumesHelper):
             self.assertEqual(int(desired_pool), newid) # old kernel returns id
 
         # remove group
+        self._fs_cmd("subvolumegroup", "rm", self.volname, group)
+
+    def test_subvolume_group_create_with_namespace_isolation(self):
+        """
+        Create subvolume group with --namespace-isolated and verify
+        the pool_namespace xattr is set on the group directory.
+        """
+        group = self._gen_subvol_grp_name()
+        self._fs_cmd("subvolumegroup", "create", self.volname, group,
+                     "--namespace-isolated")
+
+        # verify group has pool_namespace xattr
+        group_info = json.loads(self._get_subvolume_group_info(self.volname, group))
+        self.assertIn("pool_namespace", group_info)
+        self.assertEqual(group_info["pool_namespace"],
+                         f'fsvolumens__{group}')
+
+        self._fs_cmd("subvolumegroup", "rm", self.volname, group)
+
+    def test_subvolume_namespace_inheritance_from_group(self):
+        """
+        Create subvolume group with --namespace-isolated, then create
+        a subvolume without --namespace-isolated in that group.
+        Verify the subvolume inherits namespace isolation and gets its
+        own unique namespace.
+        """
+        sv = self._gen_subvol_name()
+        svg = self._gen_subvol_grp_name()
+        self._fs_cmd("subvolumegroup", "create", self.volname, svg,
+                     "--namespace-isolated")
+
+        # create subvolume WITHOUT --namespace-isolated
+        self._fs_cmd("subvolume", "create", self.volname, sv, svg)
+
+        # verify subvolume inherits namespace isolation
+        subvol_info = json.loads(self._get_subvolume_info(self.volname, sv, svg))
+        self.assertIn("pool_namespace", subvol_info)
+        expected_ns = f'fsvolumens__{svg}_{sv}'
+        self.assertEqual(subvol_info["pool_namespace"], expected_ns)
+
+        # cleanup
+        self._fs_cmd("subvolume", "rm", self.volname, sv, svg)
+        self._fs_cmd("subvolumegroup", "rm", self.volname, svg)
+        self._wait_for_trash_empty()
+
+    def test_subvolume_explicit_namespace_isolation_in_nonisolated_group(self):
+        """
+        Creating a subvolume with explicit --namespace-isolated should
+        still work in a group that was created without --namespace-isolated.
+        """
+        sv = self._gen_subvol_name()
+        svg = self._gen_subvol_grp_name()
+        # group WITHOUT namespace-isolated
+        self._fs_cmd("subvolumegroup", "create", self.volname, svg)
+
+        # subvolume WITH --namespace-isolated
+        self._fs_cmd("subvolume", "create", self.volname, sv, svg,
+                     "--namespace-isolated")
+
+        subvol_info = json.loads(self._get_subvolume_info(self.volname, sv, svg))
+        expected_ns = f'fsvolumens__{svg}_{sv}'
+        self.assertEqual(subvol_info["pool_namespace"], expected_ns)
+
+        self._fs_cmd("subvolume", "rm", self.volname, sv, svg)
+        self._fs_cmd("subvolumegroup", "rm", self.volname, svg)
+        self._wait_for_trash_empty()
+
+    def test_subvolume_group_create_idempotence_namespace_isolation(self):
+        """
+        Re-running subvolumegroup create with --namespace-isolated on
+        an existing group (idempotent) should succeed and add the
+        pool_namespace xattr.
+        """
+        group = self._gen_subvol_grp_name()
+        # create without isolation
+        self._fs_cmd("subvolumegroup", "create", self.volname, group)
+
+        # re-create with --namespace-isolated (idempotent)
+        self._fs_cmd("subvolumegroup", "create", self.volname, group,
+                     "--namespace-isolated")
+
+        group_info = json.loads(self._get_subvolume_group_info(self.volname, group))
+        self.assertEqual(group_info["pool_namespace"],
+                         f'fsvolumens__{group}')
+
         self._fs_cmd("subvolumegroup", "rm", self.volname, group)
 
     def test_subvolume_group_create_idempotence_resize(self):

--- a/src/pybind/mgr/volumes/fs/operations/group.py
+++ b/src/pybind/mgr/volumes/fs/operations/group.py
@@ -137,6 +137,13 @@ class Group(GroupTemplate):
         except cephfs.NoData:
             casesensitive = True
 
+        try:
+            pool_namespace = self.fs.getxattr(self.path,
+                                               'ceph.dir.layout.pool_namespace'
+                                               ).decode('utf-8')
+        except cephfs.NoData:
+            pool_namespace = ""
+
         return {'uid': int(st["uid"]),
                 'gid': int(st["gid"]),
                 'atime': str(st["atime"]),
@@ -144,6 +151,7 @@ class Group(GroupTemplate):
                 'ctime': str(st["ctime"]),
                 'mode': int(st["mode"]),
                 'data_pool': data_pool,
+                'pool_namespace': pool_namespace,
                 'created_at': str(st["btime"]),
                 'bytes_quota': "infinite" if nsize == 0 else nsize,
                 'bytes_used': int(usedbytes),
@@ -251,7 +259,16 @@ def set_group_attrs(fs, path, attrs):
         except cephfs.Error as e:
             raise VolumeException(-e.args[0], e.args[1])
 
-def create_group(fs, vol_spec, groupname, size, pool, mode, uid, gid, normalization, casesensitive):
+    # set pool namespace (for namespace isolation)
+    pool_namespace = attrs.get("pool_namespace")
+    if pool_namespace is not None:
+        try:
+            fs.setxattr(path, 'ceph.dir.layout.pool_namespace',
+                         pool_namespace.encode('utf-8'), 0)
+        except cephfs.Error as e:
+            raise VolumeException(-e.args[0], e.args[1])
+
+def create_group(fs, vol_spec, groupname, size, pool, mode, uid, gid, normalization, casesensitive, namespace_isolated=False):
     """
     create a subvolume group.
 
@@ -265,6 +282,7 @@ def create_group(fs, vol_spec, groupname, size, pool, mode, uid, gid, normalizat
     :param gid: the group identifier
     :param normalization: the unicode normalization form to use (nfd, nfc, nfkd or nfkc)
     :param casesensitive: whether to make the subvolume case insensitive or not
+    :param namespace_isolated: whether to enable RADOS namespace isolation for the group
     :return: None
     """
     group = Group(fs, vol_spec, groupname)
@@ -283,6 +301,8 @@ def create_group(fs, vol_spec, groupname, size, pool, mode, uid, gid, normalizat
             'normalization': normalization,
             'casesensitive': casesensitive,
         }
+        if namespace_isolated:
+            attrs['pool_namespace'] = f'{vol_spec.fs_namespace}_{groupname}'
         set_group_attrs(fs, path, attrs)
     except (cephfs.Error, VolumeException) as e:
         try:

--- a/src/pybind/mgr/volumes/fs/operations/group.py
+++ b/src/pybind/mgr/volumes/fs/operations/group.py
@@ -268,7 +268,7 @@ def set_group_attrs(fs, path, attrs):
         except cephfs.Error as e:
             raise VolumeException(-e.args[0], e.args[1])
 
-def create_group(fs, vol_spec, groupname, size, pool, mode, uid, gid, normalization, casesensitive, namespace_isolated=False):
+def create_group(fs, vol_spec, groupname, size, pool, mode, uid, gid, normalization, casesensitive, namespace_isolated=False, pool_namespace=None):
     """
     create a subvolume group.
 
@@ -283,6 +283,7 @@ def create_group(fs, vol_spec, groupname, size, pool, mode, uid, gid, normalizat
     :param normalization: the unicode normalization form to use (nfd, nfc, nfkd or nfkc)
     :param casesensitive: whether to make the subvolume case insensitive or not
     :param namespace_isolated: whether to enable RADOS namespace isolation for the group
+    :param pool_namespace: an explicit RADOS namespace to use; if None, auto-generated from group name
     :return: None
     """
     group = Group(fs, vol_spec, groupname)
@@ -302,7 +303,7 @@ def create_group(fs, vol_spec, groupname, size, pool, mode, uid, gid, normalizat
             'casesensitive': casesensitive,
         }
         if namespace_isolated:
-            attrs['pool_namespace'] = f'{vol_spec.fs_namespace}_{groupname}'
+            attrs['pool_namespace'] = pool_namespace or f'{vol_spec.fs_namespace}_{groupname}'
         set_group_attrs(fs, path, attrs)
     except (cephfs.Error, VolumeException) as e:
         try:

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -237,6 +237,15 @@ class VolumeClient(CephfsClient["Module"]):
         casesensitive = kwargs['casesensitive']
         enctag = kwargs['enctag'] or '' # if not set, default to empty string
 
+        # inherit namespace isolation from group if not explicitly specified
+        if not isolate_nspace:
+            try:
+                fs_handle.getxattr(group.path,
+                                    'ceph.dir.layout.pool_namespace')
+                isolate_nspace = True
+            except (cephfs.NoData, cephfs.Error):
+                pass
+
         oct_mode = octal_str_to_decimal_int(mode)
 
         try:
@@ -1156,6 +1165,7 @@ class VolumeClient(CephfsClient["Module"]):
         mode      = kwargs['mode']
         normalization = kwargs['normalization']
         casesensitive = kwargs['casesensitive']
+        namespace_isolated = kwargs.get('namespace_isolated', False)
 
         try:
             with open_volume(self, volname) as fs_handle:
@@ -1171,11 +1181,13 @@ class VolumeClient(CephfsClient["Module"]):
                             'normalization': normalization,
                             'casesensitive': casesensitive,
                         }
+                        if namespace_isolated:
+                            attrs['pool_namespace'] = f'{self.volspec.fs_namespace}_{groupname}'
                         set_group_attrs(fs_handle, group.path, attrs)
                 except VolumeException as ve:
                     if ve.errno == -errno.ENOENT:
                         oct_mode = octal_str_to_decimal_int(mode)
-                        create_group(fs_handle, self.volspec, groupname, size, pool, oct_mode, uid, gid, normalization, casesensitive)
+                        create_group(fs_handle, self.volspec, groupname, size, pool, oct_mode, uid, gid, normalization, casesensitive, namespace_isolated)
                     else:
                         raise
         except VolumeException as ve:

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -1166,6 +1166,7 @@ class VolumeClient(CephfsClient["Module"]):
         normalization = kwargs['normalization']
         casesensitive = kwargs['casesensitive']
         namespace_isolated = kwargs.get('namespace_isolated', False)
+        pool_namespace = kwargs.get('pool_namespace', None)
 
         try:
             with open_volume(self, volname) as fs_handle:
@@ -1182,12 +1183,12 @@ class VolumeClient(CephfsClient["Module"]):
                             'casesensitive': casesensitive,
                         }
                         if namespace_isolated:
-                            attrs['pool_namespace'] = f'{self.volspec.fs_namespace}_{groupname}'
+                            attrs['pool_namespace'] = pool_namespace or f'{self.volspec.fs_namespace}_{groupname}'
                         set_group_attrs(fs_handle, group.path, attrs)
                 except VolumeException as ve:
                     if ve.errno == -errno.ENOENT:
                         oct_mode = octal_str_to_decimal_int(mode)
-                        create_group(fs_handle, self.volspec, groupname, size, pool, oct_mode, uid, gid, normalization, casesensitive, namespace_isolated)
+                        create_group(fs_handle, self.volspec, groupname, size, pool, oct_mode, uid, gid, normalization, casesensitive, namespace_isolated, pool_namespace)
                     else:
                         raise
         except VolumeException as ve:

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -97,10 +97,13 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                    'name=mode,type=CephString,req=false '
                    'name=normalization,type=CephChoices,strings=nfd|nfc|nfkd|nfkc,req=false '
                    'name=casesensitive,type=CephBool,req=false '
-                   'name=namespace_isolated,type=CephBool,req=false ',
+                   'name=namespace_isolated,type=CephBool,req=false '
+                   'name=pool_namespace,type=CephString,req=false ',
             'desc': "Create a CephFS subvolume group in a volume, and optionally, "
                     "with a specific data pool layout, a specific numeric mode, "
-                    "and in separate RADOS namespace",
+                    "and in separate RADOS namespace. The pool_namespace parameter "
+                    "specifies an explicit RADOS namespace to use when "
+                    "--namespace-isolated is set; if omitted, it is auto-generated",
             'perm': 'rw'
         },
         {
@@ -780,7 +783,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             uid=cmd.get('uid', None), gid=cmd.get('gid', None),
             normalization=cmd.get('normalization', None),
             casesensitive=cmd.get('casesensitive', None),
-            namespace_isolated=cmd.get('namespace_isolated', False))
+            namespace_isolated=cmd.get('namespace_isolated', False),
+            pool_namespace=cmd.get('pool_namespace', None))
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolumegroup_rm(self, inbuf, cmd):

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -96,9 +96,11 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                    'name=gid,type=CephInt,req=false '
                    'name=mode,type=CephString,req=false '
                    'name=normalization,type=CephChoices,strings=nfd|nfc|nfkd|nfkc,req=false '
-                   'name=casesensitive,type=CephBool,req=false ',
+                   'name=casesensitive,type=CephBool,req=false '
+                   'name=namespace_isolated,type=CephBool,req=false ',
             'desc': "Create a CephFS subvolume group in a volume, and optionally, "
-                    "with a specific data pool layout, and a specific numeric mode",
+                    "with a specific data pool layout, a specific numeric mode, "
+                    "and in separate RADOS namespace",
             'perm': 'rw'
         },
         {
@@ -777,7 +779,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             pool_layout=cmd.get('pool_layout', None), mode=cmd.get('mode', '755'),
             uid=cmd.get('uid', None), gid=cmd.get('gid', None),
             normalization=cmd.get('normalization', None),
-            casesensitive=cmd.get('casesensitive', None))
+            casesensitive=cmd.get('casesensitive', None),
+            namespace_isolated=cmd.get('namespace_isolated', False))
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolumegroup_rm(self, inbuf, cmd):


### PR DESCRIPTION
Add '--namespace-isolated' flag to 'fs subvolumegroup create' command. When a subvolume group is created with this flag, the group directory gets a 'ceph.dir.layout.pool_namespace' xattr, and all subvolumes subsequently created within that group automatically inherit RADOS namespace isolation without needing the flag on each 'subvolume create'.

The namespace format follows the existing convention:
- Group namespace: fsvolumens_<group>
- Subvolume namespace: fsvolumens_<group>_<subvolume>

Fixes: https://tracker.ceph.com/issues/79292
Fixes: https://github.com/rook/rook/issues/17571





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
