### PR TITLE
mgr/dashboard: add cephfs mirror disable action

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -1435,7 +1435,7 @@ class CephFSMirror(RESTController):
                      'fs_name': (str, 'File system name'),
                  },
                  responses={200: {}})
-    @RESTController.Collection('POST', path='/disable')
+    @RESTController.Collection('POST', path='/disable', status=200)
     @DeletePermission
     def disable(self, fs_name: str):
         error_code, out, err = mgr.remote('mirroring', 'snapshot_mirror_disable', fs_name)

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.html
@@ -77,3 +77,101 @@
 }
 
 <router-outlet name="modal"></router-outlet>
+
+<ng-template
+  #disableMirroringTpl
+  let-row="row"
+  let-hasPendingReplication="hasPendingReplication"
+>
+  @if (hasPendingReplication) {
+    <cd-alert-panel
+      type="warning"
+      spacingClass="cds-mb-3"
+      i18n
+    >
+      <p class="cds--type-heading-compact-01 cds-mb-1">
+        <strong>Some changes are still pending replication.</strong>
+      </p>
+      <p class="cds--type-body-compact-01 cds-mb-0">
+        Recent updates may not yet be replicated to the destination cluster.
+      </p>
+    </cd-alert-panel>
+  }
+  <div
+    cdsGrid
+    class="cds-mb-3"
+  >
+    <div cdsRow>
+      <div
+        cdsCol
+        [columnNumbers]="{ lg: 8, md: 8, sm: 8 }"
+      >
+        <p
+          class="cds--type-label-01 cds-mb-2"
+          i18n
+        >
+          Source filesystem
+        </p>
+        <div class="cds--type-body-compact-01">{{ row.local_fs_name }}</div>
+      </div>
+      <div
+        cdsCol
+        [columnNumbers]="{ lg: 6, md: 6, sm: 6 }"
+      >
+        <p
+          class="cds--type-label-01 cds-mb-2"
+          i18n
+        >
+          Destination cluster
+        </p>
+        <div class="cds--type-body-compact-01">{{ row.remote_cluster_name }}</div>
+      </div>
+    </div>
+    <div
+      cdsRow
+      class="cds-mt-3 cds-mb-6"
+    >
+      <div
+        cdsCol
+        [columnNumbers]="{ lg: 8, md: 8, sm: 8 }"
+      >
+        <p
+          class="cds--type-label-01 cds-mb-2"
+          i18n
+        >
+          Current sync status
+        </p>
+        <div class="cds--type-body-compact-01">
+          @if (row.sync_status === MirroringSyncStatus.SYNCING) {
+            <cd-icon
+              type="success"
+              class="cds-mr-1"
+            ></cd-icon>
+          }
+          @if (row.sync_status === MirroringSyncStatus.ERROR) {
+            <cd-icon
+              type="danger"
+              class="cds-mr-1"
+            ></cd-icon>
+          }
+          {{ row.sync_status_label }}
+        </div>
+      </div>
+      <div
+        cdsCol
+        [columnNumbers]="{ lg: 6, md: 6, sm: 6 }"
+      >
+        <p
+          class="cds--type-label-01 cds-mb-2"
+          i18n
+        >
+          Replication scope
+        </p>
+        <div class="cds--type-body-compact-01">
+          {{ row.directory_count }}
+          <ng-container i18n>{row.directory_count, plural, =1 {path} other {paths}}</ng-container>
+        </div>
+      </div>
+    </div>
+  </div>
+</ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.spec.ts
@@ -5,11 +5,72 @@ import { of } from 'rxjs';
 
 import { CephfsMirroringListComponent } from './cephfs-mirroring-list.component';
 import { CephfsService } from '~/app/shared/api/cephfs.service';
-import { Daemon, MirroringRow } from '~/app/shared/models/cephfs.model';
+import {
+  Daemon,
+  hasPendingReplication,
+  MirroringRow,
+  MirrorStatusResponse
+} from '~/app/shared/models/cephfs.model';
 import { RelativeDatePipe } from '~/app/shared/pipes/relative-date.pipe';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
 import { Permission } from '~/app/shared/models/permissions';
+import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
+import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
+import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component';
+import { DeletionImpact } from '~/app/shared/enum/delete-confirmation-modal-impact.enum';
+import { MirroringSyncStatus } from '~/app/shared/enum/cephfs-mirroring-sync-status.enum';
+
+describe('hasPendingReplication', () => {
+  const peerUuid = 'peer-uuid';
+
+  it('should return true when mirror status reports an active sync', () => {
+    const status: MirrorStatusResponse = {
+      metrics: {
+        '/dir': {
+          peer: {
+            [peerUuid]: { state: MirroringSyncStatus.SYNCING }
+          }
+        }
+      }
+    };
+    expect(hasPendingReplication(status, peerUuid)).toBe(true);
+  });
+
+  it('should return true when mirror status reports a current syncing snapshot', () => {
+    const status: MirrorStatusResponse = {
+      metrics: {
+        '/dir': {
+          peer: {
+            [peerUuid]: {
+              state: MirroringSyncStatus.IDLE,
+              current_syncing_snap: { name: 'snap1' }
+            }
+          }
+        }
+      }
+    };
+    expect(hasPendingReplication(status, peerUuid)).toBe(true);
+  });
+
+  it('should return false when idle with no active sync', () => {
+    const status: MirrorStatusResponse = {
+      metrics: {
+        '/dir': {
+          peer: {
+            [peerUuid]: { state: MirroringSyncStatus.IDLE }
+          }
+        }
+      }
+    };
+    expect(hasPendingReplication(status, peerUuid)).toBe(false);
+  });
+
+  it('should return false when status is unavailable', () => {
+    expect(hasPendingReplication(null, peerUuid)).toBe(false);
+    expect(hasPendingReplication({ metrics: {} }, undefined)).toBe(false);
+  });
+});
 
 describe('CephfsMirroringListComponent', () => {
   let component: CephfsMirroringListComponent;
@@ -18,7 +79,14 @@ describe('CephfsMirroringListComponent', () => {
 
   const cephfsServiceMock = {
     listDaemonStatus: jest.fn(),
+    disableMirror: jest.fn(),
     getMirrorStatus: jest.fn()
+  };
+  const modalServiceMock = {
+    show: jest.fn()
+  };
+  const taskWrapperMock = {
+    wrapTaskAroundCall: jest.fn()
   };
 
   const authStorageServiceMock = {
@@ -35,6 +103,8 @@ describe('CephfsMirroringListComponent', () => {
       providers: [
         { provide: CephfsService, useValue: cephfsServiceMock },
         { provide: AuthStorageService, useValue: authStorageServiceMock },
+        { provide: ModalCdsService, useValue: modalServiceMock },
+        { provide: TaskWrapperService, useValue: taskWrapperMock },
         RelativeDatePipe,
         {
           provide: Router,
@@ -94,7 +164,7 @@ describe('CephfsMirroringListComponent', () => {
                   client_name: 'clientA'
                 },
                 uuid: 'peer-uuid',
-                stats: undefined
+                stats: { failure_count: 0, recovery_count: 1 }
               }
             ],
             id: ''
@@ -141,6 +211,10 @@ describe('CephfsMirroringListComponent', () => {
         directory_count: 3,
         filesystem_id: 10,
         peer_uuid: 'peer-uuid',
+        failure_count: 0,
+        recovery_count: 1,
+        sync_status: MirroringSyncStatus.SYNCING,
+        sync_status_label: 'Syncing',
         id: '1-10',
         bytes_replicated: '1.00 MiB',
         last_sync: expect.any(String)
@@ -206,5 +280,49 @@ describe('CephfsMirroringListComponent', () => {
         }
       }
     ]);
+  });
+
+  it('should open disable mirroring confirmation modal with active sync warning', () => {
+    cephfsServiceMock.getMirrorStatus.mockReturnValue(
+      of({
+        metrics: {
+          '/dir': {
+            peer: {
+              'peer-uuid': { state: MirroringSyncStatus.SYNCING }
+            }
+          }
+        }
+      })
+    );
+
+    component.ngOnInit();
+    component.selection.selected = [
+      {
+        local_fs_name: 'fs1',
+        remote_cluster_name: 'clusterA',
+        directory_count: 4,
+        peer_uuid: 'peer-uuid',
+        failure_count: 0,
+        recovery_count: 0,
+        sync_status: MirroringSyncStatus.SYNCING,
+        sync_status_label: 'Syncing'
+      } as MirroringRow
+    ];
+
+    component.disableMirroringModal();
+
+    expect(cephfsServiceMock.getMirrorStatus).toHaveBeenCalledWith('fs1', undefined, 'peer-uuid');
+    expect(modalServiceMock.show).toHaveBeenCalledWith(
+      DeleteConfirmationModalComponent,
+      expect.objectContaining({
+        impact: DeletionImpact.high,
+        itemNames: ['fs1'],
+        actionDescription: 'disable',
+        submitText: 'Disable',
+        bodyContext: expect.objectContaining({
+          hasPendingReplication: true
+        })
+      })
+    );
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.ts
@@ -1,25 +1,42 @@
-import { Component, inject, OnDestroy, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
+import {
+  Component,
+  inject,
+  OnDestroy,
+  OnInit,
+  TemplateRef,
+  ViewChild,
+  ViewEncapsulation
+} from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
-import { forkJoin, Observable, of, Subject } from 'rxjs';
+import { forkJoin, Observable, of, Subject, Subscriber } from 'rxjs';
 import { catchError, filter, map, switchMap, takeUntil } from 'rxjs/operators';
 
 import { CephfsService } from '~/app/shared/api/cephfs.service';
+import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component';
 import { CEPHFS_MIRRORING_URL } from '~/app/shared/constants/cephfs.constant';
+import { MirroringSyncStatus } from '~/app/shared/enum/cephfs-mirroring-sync-status.enum';
 import { Icons } from '~/app/shared/enum/icons.enum';
 import { TableComponent } from '~/app/shared/datatable/table/table.component';
 import { CellTemplate } from '~/app/shared/enum/cell-template.enum';
+import { DeletionImpact } from '~/app/shared/enum/delete-confirmation-modal-impact.enum';
 import { CdTableAction } from '~/app/shared/models/cd-table-action';
 import { CdTableColumn } from '~/app/shared/models/cd-table-column';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
 import {
+  CONFIRM_DISABLE,
+  CONFIRM_DISABLE_MESSAGE,
   Daemon,
   Filesystem,
+  hasPendingReplication,
   MirroringRow,
   MirrorStatusResponse,
   Peer
 } from '~/app/shared/models/cephfs.model';
+import { FinishedTask } from '~/app/shared/models/finished-task';
 import { RelativeDatePipe } from '~/app/shared/pipes/relative-date.pipe';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
+import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
+import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { MirroringSyncUtils } from '../mirroring-sync-utils';
 import { MirroringJumpInTile } from './cephfs-mirroring-list.model';
 
@@ -32,9 +49,13 @@ import { MirroringJumpInTile } from './cephfs-mirroring-list.model';
 })
 export class CephfsMirroringListComponent implements OnInit, OnDestroy {
   @ViewChild('table', { static: true }) table: TableComponent;
+  @ViewChild('disableMirroringTpl', { static: true })
+  disableMirroringTpl: TemplateRef<any>;
 
   private cephfsService = inject(CephfsService);
   private authStorageService = inject(AuthStorageService);
+  private modalService = inject(ModalCdsService);
+  private taskWrapper = inject(TaskWrapperService);
   private router = inject(Router);
   private relativeDatePipe = inject(RelativeDatePipe);
 
@@ -45,6 +66,7 @@ export class CephfsMirroringListComponent implements OnInit, OnDestroy {
   permission = this.authStorageService.getPermissions().cephfsMirror;
   isPrepareModalOpen = false;
   jumpInTiles: MirroringJumpInTile[] = [];
+  MirroringSyncStatus = MirroringSyncStatus;
 
   private subject$ = new Subject<void>();
   private destroy$ = new Subject<void>();
@@ -81,6 +103,14 @@ export class CephfsMirroringListComponent implements OnInit, OnDestroy {
         icon: Icons.add,
         click: () => this.openAddPath(),
         disable: (selection: CdTableSelection) => !selection.hasSingleSelection
+      },
+      {
+        name: $localize`Disable mirroring`,
+        permission: 'delete',
+        icon: Icons.destroy,
+        click: () => this.disableMirroringModal(),
+        disable: (selection: CdTableSelection) => !selection.hasSingleSelection,
+        canBePrimary: () => false
       }
     ];
     this.previousUrl = this.router.url;
@@ -149,6 +179,60 @@ export class CephfsMirroringListComponent implements OnInit, OnDestroy {
         }
       }
     ]);
+  }
+
+  disableMirroringModal(): void {
+    const row = this.selection.first() as MirroringRow;
+    const fsName = row.local_fs_name;
+    const peerUuid = row.peer_uuid;
+
+    const status$ = peerUuid
+      ? this.cephfsService
+          .getMirrorStatus(fsName, undefined, peerUuid)
+          .pipe(catchError(() => of(null)))
+      : of(null);
+
+    status$.subscribe((status) => {
+      const pendingReplication = hasPendingReplication(status, peerUuid);
+
+      this.openDisableMirroringModal(row, fsName, pendingReplication);
+    });
+  }
+
+  private openDisableMirroringModal(
+    row: MirroringRow,
+    fsName: string,
+    hasPendingReplicationFlag: boolean
+  ): void {
+    this.modalService.show(DeleteConfirmationModalComponent, {
+      impact: DeletionImpact.high,
+      itemDescription: $localize`mirroring`,
+      itemNames: [fsName],
+      actionDescription: $localize`disable`,
+      bodyTemplate: this.disableMirroringTpl,
+      bodyContext: {
+        row,
+        confirmHeading: CONFIRM_DISABLE,
+        deletionMessage: CONFIRM_DISABLE_MESSAGE,
+        hasPendingReplication: hasPendingReplicationFlag
+      },
+      submitText: $localize`Disable`,
+      submitActionObservable: () =>
+        new Observable((observer: Subscriber<any>) => {
+          this.taskWrapper
+            .wrapTaskAroundCall({
+              task: new FinishedTask('cephfs/mirroring/disable', { fsName }),
+              call: this.cephfsService.disableMirror(fsName)
+            })
+            .subscribe({
+              error: (resp) => observer.error(resp),
+              complete: () => {
+                this.loadDaemonStatus();
+                observer.complete();
+              }
+            });
+        })
+    });
   }
 
   private buildJumpInTiles(): MirroringJumpInTile[] {
@@ -229,6 +313,9 @@ export class CephfsMirroringListComponent implements OnInit, OnDestroy {
   }
 
   private peerToRow(daemon: Daemon, fs: Filesystem, peer: Peer): MirroringRow {
+    const failureCount = peer.stats?.failure_count ?? 0;
+    const recoveryCount = peer.stats?.recovery_count ?? 0;
+
     return {
       remote_cluster_name: peer.remote?.cluster_name ?? '-',
       local_fs_name: fs.name,
@@ -237,6 +324,10 @@ export class CephfsMirroringListComponent implements OnInit, OnDestroy {
       directory_count: fs.directory_count ?? 0,
       filesystem_id: fs.filesystem_id,
       peer_uuid: peer.uuid,
+      failure_count: failureCount,
+      recovery_count: recoveryCount,
+      sync_status: failureCount > 0 ? MirroringSyncStatus.ERROR : MirroringSyncStatus.SYNCING,
+      sync_status_label: failureCount > 0 ? $localize`Error` : $localize`Syncing`,
       id: `${daemon.daemon_id}-${fs.filesystem_id}`
     };
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.spec.ts
@@ -189,4 +189,11 @@ describe('CephfsService', () => {
     expect(req.request.method).toBe('DELETE');
     expect(req.request.body).toBeNull();
   });
+
+  it('should disable mirroring for a filesystem', () => {
+    service.disableMirror('my fs').subscribe();
+    const req = httpTesting.expectOne('api/cephfs/mirror/disable');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ fs_name: 'my fs' });
+  });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component.html
@@ -156,7 +156,11 @@
         : !deletionForm.controls.confirmation.value)
     "
     [submitBtnType]="
-      actionDescription === 'delete' || actionDescription === 'remove' ? 'danger' : 'primary'
+      actionDescription === 'delete' ||
+      actionDescription === 'remove' ||
+      actionDescription === 'disable'
+        ? 'danger'
+        : 'primary'
     "
   ></cd-form-button-panel>
 </cds-modal>
@@ -171,9 +175,12 @@
     <h2
       class="cds--type-heading-03"
       cdsModalHeaderHeading
-      i18n
     >
-      Confirm {{ actionDescription }}
+      @if (bodyContext?.confirmHeading) {
+        {{ bodyContext.confirmHeading }}
+      } @else {
+        <ng-container i18n>Confirm {{ actionDescription }}</ng-container>
+      }
     </h2>
   } @else {
     <h3

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/cephfs-mirroring-sync-status.enum.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/cephfs-mirroring-sync-status.enum.ts
@@ -1,0 +1,6 @@
+export enum MirroringSyncStatus {
+  SYNCING = 'syncing',
+  IDLE = 'idle',
+  ERROR = 'error',
+  NONE = 'none'
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cephfs.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cephfs.model.ts
@@ -1,3 +1,5 @@
+import { MirroringSyncStatus } from '../enum/cephfs-mirroring-sync-status.enum';
+
 export interface MountData {
   clusterFSID: string;
   fsName: string;
@@ -53,6 +55,10 @@ export interface MirroringRow {
   filesystem_id?: number;
   peer_uuid?: string;
   peerId?: string;
+  failure_count?: number;
+  recovery_count?: number;
+  sync_status?: MirroringSyncStatus;
+  sync_status_label?: string;
   id?: string;
   bytes_replicated?: string;
   last_sync?: string;
@@ -240,6 +246,19 @@ export interface MirrorStatusResponse {
   metrics?: MirrorStatusMetrics;
 }
 
+export function hasPendingReplication(
+  status: MirrorStatusResponse | null | undefined,
+  peerUuid?: string
+): boolean {
+  if (!status?.metrics || !peerUuid) {
+    return false;
+  }
+  return Object.values(status.metrics).some((dirMetric) => {
+    const metric = dirMetric?.peer?.[peerUuid];
+    return metric?.state === MirroringSyncStatus.SYNCING || !!metric?.current_syncing_snap;
+  });
+}
+
 export type MirrorCheckpointStatus = 'created' | 'complete' | 'failed' | 'unknown';
 
 export interface MirrorCheckpoint {
@@ -314,6 +333,9 @@ export interface BootstrapTokenResponse {
   token?: string;
   data?: string;
 }
+
+export const CONFIRM_DISABLE = $localize`Confirm disable`;
+export const CONFIRM_DISABLE_MESSAGE = $localize`Replication to the destination cluster will stop for this filesystem. Existing replicated data will remain available unless deleted but will no longer stay synchronized.`;
 
 export const CLIENT_PREFIX = 'client.';
 export const MAX_TYPEAHEAD_SUGGESTIONS = 10;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/delete-confirmation.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/delete-confirmation.model.ts
@@ -4,6 +4,7 @@ export interface DeleteConfirmationBodyContext {
   inputLabel?: string;
   inputPlaceholder?: string;
   deletionMessage?: string;
+  confirmHeading?: string;
   /** When set on a high-impact delete, user must check an extra acknowledgement before submit. */
   forceDeleteAcknowledgementMessage?: string;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.ts
@@ -344,6 +344,14 @@ export class TaskMessageService {
       (metadata) =>
         $localize`checkpoint for snapshot '${metadata.snapName}' on path '${metadata.path}'`
     ),
+    'cephfs/mirroring/disable': this.newTaskMessage(
+      new TaskMessageOperation(
+        $localize`Disabling`,
+        $localize`disable`,
+        $localize`Successfully disabled`
+      ),
+      (metadata) => $localize`mirroring for '${metadata.fsName}'`
+    ),
     // RGW operations
     'rgw/bucket/delete': this.newTaskMessage(this.commonOperations.delete, (metadata) => {
       return $localize`${metadata.bucket_names[0]}`;


### PR DESCRIPTION

<img width="800" height="513" alt="image" src="https://github.com/user-attachments/assets/ccbe9df9-29d9-4b8e-8b88-3a96fd01116b" />


[screen-capture (6).webm](https://github.com/user-attachments/assets/8743e05e-4789-4c26-83ad-dcd9f6020ca0)



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
