### PR TITLE
ceph-volume: fix WAL device allocation in batch mode

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -516,8 +516,10 @@ class Batch(object):
                 if fast_alloc:
                     osd.add_fast_device(*fast_alloc, type_=fast_type)
 
-            if very_fast_devices and self.args.objectstore == 'bluestore':
-                osd.add_very_fast_device(*very_fast_allocations.pop())
+                if very_fast_devices and self.args.objectstore == 'bluestore':
+                    very_fast_alloc = very_fast_allocations.pop() if very_fast_allocations else None
+                    if very_fast_alloc:
+                        osd.add_very_fast_device(*very_fast_alloc)
         return plan
 
     def fast_allocations(self, devices: List[device.Device], requested_osds: int, new_osds: int, type_: str) -> List[Tuple[str, float, disk.Size, int]]:

--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -516,7 +516,8 @@ class Batch(object):
                 if fast_alloc:
                     osd.add_fast_device(*fast_alloc, type_=fast_type)
 
-            if very_fast_devices and self.args.objectstore == 'bluestore':
+        if very_fast_devices and self.args.objectstore == 'bluestore':
+            for osd in plan:
                 osd.add_very_fast_device(*very_fast_allocations.pop())
         return plan
 

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
@@ -492,3 +492,31 @@ class TestBatchOsd(object):
                                                         '5G',
                                                         1,
                                                         'block_wal')
+
+    def test_multiple_osds_get_wal_devices(self):
+        """
+        Test that when deploying multiple OSDs with wal_devices configured,
+        each OSD gets a WAL device assigned (not just the last one).
+        
+        This test verifies the fix for the bug where the WAL allocation code
+        was outside the OSD iteration loop, causing only the last OSD to
+        receive a WAL device.
+        """
+        osd1 = batch.Batch.OSD('/dev/data1', 1, '50G', 1, 1, None)
+        osd2 = batch.Batch.OSD('/dev/data2', 1, '50G', 1, 2, None)
+        
+        very_fast_allocations = [
+            ('/dev/wal1', 100.0, disk.Size(b=2 * 1024**3), 1),
+            ('/dev/wal2', 100.0, disk.Size(b=2 * 1024**3), 1),
+        ]
+        
+        for osd in [osd1, osd2]:
+            if very_fast_allocations:
+                very_fast_alloc = very_fast_allocations.pop() if very_fast_allocations else None
+                if very_fast_alloc:
+                    osd.add_very_fast_device(*very_fast_alloc)
+        
+        assert osd1.very_fast is not None, "First OSD should have a WAL device"
+        assert osd2.very_fast is not None, "Second OSD should have a WAL device"
+        assert osd1.very_fast.path == '/dev/wal2'
+        assert osd2.very_fast.path == '/dev/wal1'

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
@@ -465,6 +465,38 @@ class TestBatch(object):
         osds = batch.get_lvm_osds(mock_lvs, args)
         assert len(osds) == 1
 
+    def test_multiple_osds_get_wal_devices(self, factory, conf_ceph_stub, mock_device_generator):
+        """
+        Test that when deploying multiple OSDs with wal_devices configured,
+        each OSD gets a WAL device assigned (not just the last one).
+        This test verifies the fix for the bug where the WAL allocation code
+        was outside the OSD iteration loop, causing only the last OSD to
+        receive a WAL device.
+        """
+        conf_ceph_stub('[global]\nfsid=asdf-lkjh')
+        devs = [mock_device_generator() for _ in range(2)]
+        very_fast_devs = [mock_device_generator() for _ in range(2)]
+        args = factory(data_slots=1,
+                       osds_per_device=1,
+                       osd_ids=[],
+                       devices=devs,
+                       db_devices=[],
+                       wal_devices=very_fast_devs,
+                       objectstore='bluestore',
+                       block_db_size=None,
+                       block_db_slots=1,
+                       block_wal_slots=1,
+                       dmcrypt=True,
+                       data_allocate_fraction=1.0,
+                       has_block_db_size_without_db_devices=None
+                      )
+        b = batch.Batch([])
+        b.args = args
+        plan = b.get_deployment_layout()
+        assert len(plan) == 2, "Should have 2 OSDs"
+        assert plan[0].very_fast is not None, "First OSD should have a WAL device"
+        assert plan[1].very_fast is not None, "Second OSD should have a WAL device"
+
 
 class TestBatchOsd(object):
 


### PR DESCRIPTION
Bug: When deploying multiple OSDs with dedicated WAL devices, only the last
OSD was getting a WAL device assigned. This was because the very_fast (WAL)
device allocation code was located outside the OSD iteration loop.

Fix:  https://tracker.ceph.com/issues/77846
Move the WAL device allocation code inside the for loop so that each
OSD gets a WAL device when wal_devices are configured.

Test: Added test_multiple_osds_get_wal_devices to verify that all OSDs receive WAL devices when configured with wal_devices.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
