### PR TITLE
mds: fix stale used_bytes in subvolume metrics when quota is disabled

### DIFF
--- a/qa/tasks/cephfs/test_subvolume.py
+++ b/qa/tasks/cephfs/test_subvolume.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from time import sleep
 import os
@@ -994,4 +995,167 @@ class TestSubvolumeMetrics(CephFSTestCase):
         self.assertGreater(counters["used_bytes"], 0, "Expected used_bytes to remain tracked")
 
         # Cleanup
+        self.fs.run_ceph_cmd('fs', 'subvolume', 'rm', 'cephfs', subvol_name)
+
+    def test_subvolume_used_bytes_updates_after_quota_reset_to_zero(self):
+        """
+        Verify that used_bytes in subvolume metrics is reported correctly
+        after quota is reset to 0 (unlimited).
+
+        Reproducer for: https://tracker.ceph.com/issues/XXXXX
+        Steps:
+         1. Create subvolume with quota, write data, verify used_bytes in metrics
+         2. Reset quota to 0, wait for metrics window to expire (clean slate)
+         3. Write new data, verify used_bytes > 0 in fresh metrics
+        """
+        # Shrink the metrics window to 30s to speed up eviction
+        original_window = self.fs.get_ceph_cmd_stdout('config', 'get', 'mds',
+                                                      'subv_metrics_window_interval').strip()
+        self.fs.run_ceph_cmd('config', 'set', 'mds', 'subv_metrics_window_interval', '30')
+        self.addCleanup(self.fs.run_ceph_cmd, 'config', 'set', 'mds',
+                        'subv_metrics_window_interval', original_window)
+
+        subvol_name = "quota_zero_subv"
+        quota_2g = 2 * 1024 * 1024 * 1024  # 2 GiB
+        write_size = 100 * 1024 * 1024       # 100 MiB per write
+
+        # Phase 1: Create subvolume with 2G quota and write 100 MiB
+        self.fs.run_ceph_cmd('fs', 'subvolume', 'create', 'cephfs', subvol_name,
+                             "--size", str(quota_2g))
+
+        mount_point = self.mount_a.get_mount_point()
+        subvolume_fs_path = self.fs.get_ceph_cmd_stdout(
+            'fs', 'subvolume', 'getpath', 'cephfs', subvol_name).strip()
+        subvolume_fs_path = os.path.join(mount_point, subvolume_fs_path.strip('/'))
+
+        file1 = os.path.join(subvolume_fs_path, "f1")
+        self.mount_a.run_shell_payload("sudo fio "
+                                       "--name phase1 -rw=write "
+                                       "--bs=1M --numjobs=1 --time_based "
+                                       "--runtime=5s --verify=0 --size=100M "
+                                       f"--filename={file1}", wait=True)
+
+        # Wait for metrics to show quota=2G and used_bytes > 0
+        phase1_metrics = None
+        with safe_while(sleep=1, tries=30, action='wait for phase1 metrics') as proceed:
+            while proceed():
+                self.mount_a.run_shell_payload(
+                    f"sudo dd if=/dev/zero of={subvolume_fs_path}/trigger1 bs=4k count=1 conv=notrunc 2>/dev/null",
+                    wait=True)
+                phase1_metrics = self.get_subvolume_metrics()
+                if phase1_metrics:
+                    c = phase1_metrics[0]["counters"]
+                    if c["quota_bytes"] == quota_2g and c["used_bytes"] >= write_size:
+                        break
+
+        self.assertIsNotNone(phase1_metrics, "Expected metrics after phase 1 write")
+        phase1_used = phase1_metrics[0]["counters"]["used_bytes"]
+        log.info(f"Phase 1: quota={quota_2g}, used_bytes={phase1_used}")
+        self.assertGreaterEqual(phase1_used, write_size)
+
+        # Phase 2: Reset quota to 0, immediately write more data, and verify
+        # that used_bytes updates (doesn't stay frozen at phase1 value).
+        # This is the core bug: the cache retains stale used_bytes from phase1
+        # and the fresh rbytes value is ignored because cache != 0.
+        self.fs.run_ceph_cmd('fs', 'subvolume', 'resize', 'cephfs', subvol_name, 'inf')
+        log.info("Phase 2: quota reset to 0, writing another 100 MiB immediately...")
+
+        file2 = os.path.join(subvolume_fs_path, "f2")
+        self.mount_a.run_shell_payload("sudo fio "
+                                       "--name phase2 -rw=write "
+                                       "--bs=1M --numjobs=1 --time_based "
+                                       "--runtime=5s --verify=0 --size=100M "
+                                       f"--filename={file2}", wait=True)
+
+        # Poll for metrics with quota_bytes=0.
+        # Give extra time for any rstat propagation to complete.
+        # The bug: used_bytes stays frozen at ~phase1_used instead of growing.
+        phase2_metrics = None
+        with safe_while(sleep=2, tries=45,
+                        action='wait for metrics after quota=0 IO') as proceed:
+            while proceed():
+                self.mount_a.run_shell_payload(
+                    f"sudo dd if=/dev/zero of={subvolume_fs_path}/trigger2 bs=4k count=1 conv=notrunc 2>/dev/null",
+                    wait=True)
+                phase2_metrics = self.get_subvolume_metrics()
+                if phase2_metrics:
+                    c = phase2_metrics[0]["counters"]
+                    log.info(f"Phase 2 poll: quota_bytes={c['quota_bytes']}, "
+                             f"used_bytes={c['used_bytes']}")
+                    # Break when we see quota=0 AND either used_bytes updated
+                    # or we've given it enough time (used_bytes stuck = the bug)
+                    if c["quota_bytes"] == 0 and c["used_bytes"] > phase1_used:
+                        break
+                else:
+                    log.info("Phase 2 poll: no metrics returned")
+
+        self.assertIsNotNone(phase2_metrics,
+                             "Expected metrics after writing with quota=0")
+        counters = phase2_metrics[0]["counters"]
+
+        # Get ground truth from subvolume info
+        info_out = self.fs.get_ceph_cmd_stdout(
+            'fs', 'subvolume', 'info', 'cephfs', subvol_name)
+        info = json.loads(info_out)
+        actual_bytes_used = info["bytes_used"]
+        log.info(f"Phase 2 result: quota_bytes={counters['quota_bytes']}, "
+                 f"metrics used_bytes={counters['used_bytes']}, "
+                 f"subvolume info bytes_used={actual_bytes_used}, "
+                 f"phase1_used={phase1_used}")
+
+        self.assertEqual(counters["quota_bytes"], 0,
+                         "Expected quota_bytes=0 for unlimited subvolume")
+
+        # The key assertion: after writing ~200 MiB total, used_bytes must
+        # be greater than what it was after phase1. If it equals phase1_used,
+        # the bug is confirmed (cache is stale).
+        self.assertGreater(counters["used_bytes"], phase1_used,
+                           f"BUG: used_bytes ({counters['used_bytes']}) is frozen at "
+                           f"phase1 value ({phase1_used}) after quota reset to 0 + IO. "
+                           f"subvolume info shows actual bytes_used={actual_bytes_used}.")
+
+        # Phase 3: Change quota to a non-zero value, write more, verify used_bytes
+        # updates. This confirms the issue is specific to quota=0.
+        quota_3g = 3 * 1024 * 1024 * 1024  # 3 GiB
+        self.fs.run_ceph_cmd('fs', 'subvolume', 'resize', 'cephfs', subvol_name,
+                             str(quota_3g))
+        log.info(f"Phase 3: quota changed to {quota_3g}, writing another 100 MiB...")
+
+        phase2_used = counters["used_bytes"]
+        file3 = os.path.join(subvolume_fs_path, "f3")
+        self.mount_a.run_shell_payload("sudo fio "
+                                       "--name phase3 -rw=write "
+                                       "--bs=1M --numjobs=1 --time_based "
+                                       "--runtime=5s --verify=0 --size=100M "
+                                       f"--filename={file3}", wait=True)
+
+        phase3_metrics = None
+        with safe_while(sleep=2, tries=30,
+                        action='wait for metrics after quota=3G IO') as proceed:
+            while proceed():
+                self.mount_a.run_shell_payload(
+                    f"sudo dd if=/dev/zero of={subvolume_fs_path}/trigger3 bs=4k count=1 conv=notrunc 2>/dev/null",
+                    wait=True)
+                phase3_metrics = self.get_subvolume_metrics()
+                if phase3_metrics:
+                    c = phase3_metrics[0]["counters"]
+                    log.info(f"Phase 3 poll: quota_bytes={c['quota_bytes']}, "
+                             f"used_bytes={c['used_bytes']}")
+                    if c["quota_bytes"] == quota_3g and c["used_bytes"] > phase2_used:
+                        break
+                else:
+                    log.info("Phase 3 poll: no metrics returned")
+
+        self.assertIsNotNone(phase3_metrics,
+                             "Expected metrics after writing with quota=3G")
+        phase3_counters = phase3_metrics[0]["counters"]
+        log.info(f"Phase 3 result: quota_bytes={phase3_counters['quota_bytes']}, "
+                 f"used_bytes={phase3_counters['used_bytes']}")
+
+        self.assertEqual(phase3_counters["quota_bytes"], quota_3g)
+        self.assertGreater(phase3_counters["used_bytes"], phase2_used,
+                           f"Phase 3: used_bytes should update when quota is non-zero. "
+                           f"Got {phase3_counters['used_bytes']}, expected > {phase2_used}")
+
+        # cleanup
         self.fs.run_ceph_cmd('fs', 'subvolume', 'rm', 'cephfs', subvol_name)

--- a/src/mds/MetricsHandler.cc
+++ b/src/mds/MetricsHandler.cc
@@ -616,21 +616,22 @@ void MetricsHandler::aggregate_subvolume_metrics(const std::string& subvolume_pa
   // Lookup quota and used_bytes after aggregating I/O metrics
   if (!metrics_list.empty()) {
     inodeno_t subvolume_id = metrics_list.front().subvolume_id;
-    
-    // Get quota/used bytes from cache and update last activity time
+
+    // Get quota_bytes from cache and update last activity time
     auto it = subvolume_quota.find(subvolume_id);
     if (it != subvolume_quota.end()) {
       res.quota_bytes = it->second.quota_bytes;
-      res.used_bytes = it->second.used_bytes;
       it->second.last_activity = std::chrono::steady_clock::now();
     }
-    
-    // Fallback: if cache didn't have used_bytes, use the pre-fetched map
-    if (res.used_bytes == 0) {
-      auto used_it = subvol_used_bytes.find(subvolume_id);
-      if (used_it != subvol_used_bytes.end()) {
-        res.used_bytes = used_it->second;
-      }
+
+    // Always prefer the freshly fetched rbytes for used_bytes.
+    // The cache can become stale when quota is disabled (set to 0/unlimited)
+    // because broadcast_quota_to_client() stops updating it.
+    auto used_it = subvol_used_bytes.find(subvolume_id);
+    if (used_it != subvol_used_bytes.end()) {
+      res.used_bytes = used_it->second;
+    } else if (it != subvolume_quota.end()) {
+      res.used_bytes = it->second.used_bytes;
     }
   }
 


### PR DESCRIPTION
## Summary

- Fix `mds_subvolume_metrics` `used_bytes` freezing after a subvolume quota is reset to `0` (unlimited)
- Add a vstart regression test covering quota reset and subsequent IO

## Problem

When subvolume quota is reset to unlimited via `ceph fs subvolume resize ... inf` or `setfattr ceph.quota.max_bytes=0`, `used_bytes` in `ceph tell mds counter dump` → `mds_subvolume_metrics` stops updating after further IO. `ceph fs subvolume info bytes_used` remains correct.

## Root cause

`aggregate_subvolume_metrics()` preferred cached `used_bytes` from `subvolume_quota` over freshly fetched `rbytes` from `get_inode_rbytes()`. The fallback to live data only ran when `res.used_bytes == 0`.

When quota is disabled, `MDCache::broadcast_quota_to_client()` stops calling `maybe_update_subvolume_quota()` on rstat changes, so the cache keeps a stale non-zero `used_bytes` until eviction.

## Fix

Always prefer live `rbytes` for `used_bytes` in `aggregate_subvolume_metrics()`. Keep `quota_bytes` from the cache and use cached `used_bytes` only as a fallback when the live fetch is unavailable.

## Test

Added `TestSubvolumeMetrics.test_subvolume_used_bytes_updates_after_quota_reset_to_zero`:
1. Create subvolume with 2G quota, write 100 MiB, verify metrics
2. Reset quota to unlimited, write more data, assert `used_bytes` grows past the phase-1 value
3. Set quota to 3G, write again, assert `used_bytes` still updates

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
