### PR TITLE
cephadm: bootstrap: wait for orchestrator module load before orch com…

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -52,6 +52,7 @@ from cephadmlib.constants import (
     DATA_DIR_MODE,
     DATEFMT,
     DEFAULT_RETRY,
+    BOOTSTRAP_MGR_MODULE_LOAD_RETRY,
     DEFAULT_TIMEOUT,
     LATEST_STABLE_RELEASE,
     LOGROTATE_DIR,
@@ -303,6 +304,57 @@ def is_available(ctx, what, func):
         logger.info('%s not available, waiting (%s/%s)...'
                     % (what, num, retry))
 
+        num += 1
+        time.sleep(2)
+
+
+def wait_for_mgr_modules_loaded(
+    cli: Callable,
+    module_names: Sequence[str],
+) -> None:
+    """
+    Wait until the given mgr modules are loaded in the active mgr.
+
+    Enabling a module updates the mgrmap before the active mgr finishes
+    loading Python modules.  Bootstrap should not run orchestrator commands
+    until orchestrator is out of pending_modules.
+
+    Uses up to BOOTSTRAP_MGR_MODULE_LOAD_RETRY waits of 2 seconds each
+    (~90 seconds total).  If modules are still pending when the limit is
+    reached, log a warning and return so bootstrap can continue; later orch
+    commands may still fail with a clearer error.
+    """
+    names = set(module_names)
+    label = 'mgr modules %s loaded' % ','.join(sorted(names))
+    retry = BOOTSTRAP_MGR_MODULE_LOAD_RETRY
+    wait_seconds = retry * 2
+    still_pending = names
+    logger.info('Waiting for %s...' % label)
+    num = 1
+    while True:
+        try:
+            out = cli(
+                ['tell', 'mgr', 'mgr_status'],
+                verbosity=CallVerbosity.QUIET_UNLESS_ERROR,
+            )
+            pending = set(json.loads(out).get('pending_modules', []))
+            still_pending = names & pending
+            if not still_pending:
+                logger.info('%s is available' % label)
+                return
+        except Exception as e:
+            logger.debug('tell mgr mgr_status failed: %s' % e)
+
+        if num > retry:
+            logger.warning(
+                '%s not available after %s tries (~%s seconds); '
+                'continuing bootstrap anyway (still pending: %s)'
+                % (label, retry, wait_seconds,
+                   ','.join(sorted(still_pending)) or 'unknown'))
+            return
+
+        logger.info('%s not available, waiting (%s/%s)...'
+                    % (label, num, retry))
         num += 1
         time.sleep(2)
 
@@ -2514,18 +2566,21 @@ def prepare_ssh(
 
 
 def enable_cephadm_mgr_module(
-    cli: Callable, wait_for_mgr_restart: Callable
+    cli: Callable,
+    wait_for_mgr_restart: Callable,
 ) -> None:
 
     logger.info('Enabling cephadm module...')
     cli(['mgr', 'module', 'enable', 'cephadm'])
-    wait_for_mgr_restart()
+    wait_for_mgr_restart(['cephadm'])
     # https://tracker.ceph.com/issues/67969
+    # https://tracker.ceph.com/issues/77148
     # luckily `ceph mgr module enable <module>` returns
     # a zero rc when the module is already enabled so
     # this is no issue even if it is unnecessary
     logger.info('Verifying orchestrator module is enabled...')
     cli(['mgr', 'module', 'enable', 'orchestrator'])
+    wait_for_mgr_restart(['orchestrator'])
     logger.info('Setting orchestrator backend to cephadm...')
     cli(['orch', 'set', 'backend', 'cephadm'])
 
@@ -2543,7 +2598,7 @@ def prepare_dashboard(
     # configuring dashboard parameters
     logger.info('Enabling the dashboard module...')
     cli(['mgr', 'module', 'enable', 'dashboard'])
-    wait_for_mgr_restart()
+    wait_for_mgr_restart(['dashboard'])
 
     # dashboard crt and key
     if ctx.dashboard_key and ctx.dashboard_crt:
@@ -2999,7 +3054,9 @@ def command_bootstrap(ctx):
             cli(['config', 'set', 'mgr', ldkey, value, '--force'])
 
     # wait for mgr to restart (after enabling a module)
-    def wait_for_mgr_restart() -> None:
+    def wait_for_mgr_restart(
+        module_names: Optional[Sequence[str]] = None,
+    ) -> None:
         # first get latest mgrmap epoch from the mon.  try newer 'mgr
         # stat' command first, then fall back to 'mgr dump' if
         # necessary
@@ -3022,6 +3079,8 @@ def command_bootstrap(ctx):
                 logger.debug('tell mgr mgr_status failed: %s' % e)
                 return False
         is_available(ctx, 'mgr epoch %d' % epoch, mgr_has_latest_epoch)
+        if module_names:
+            wait_for_mgr_modules_loaded(cli, module_names)
 
     enable_cephadm_mgr_module(cli, wait_for_mgr_restart)
 

--- a/src/cephadm/cephadmlib/constants.py
+++ b/src/cephadm/cephadmlib/constants.py
@@ -31,6 +31,7 @@ PIDS_LIMIT_UNLIMITED_PODMAN_VERSION = (3, 4, 1)
 CUSTOM_PS1 = r'[ceph: \u@\h \W]\$ '
 DEFAULT_TIMEOUT = None  # in seconds
 DEFAULT_RETRY = 15
+BOOTSTRAP_MGR_MODULE_LOAD_RETRY = 45  # 2s between tries -> ~90s max
 DATEFMT = '%Y-%m-%dT%H:%M:%S.%fZ'
 QUIET_LOG_LEVEL = 9  # DEBUG is 10, so using 9 to be lower level than DEBUG
 NO_DEPRECATED = False

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -447,14 +447,23 @@ class TestCephAdm(object):
         ctx.initial_dashboard_password = 'password'
         ctx.initial_dashboard_user = 'User'
         with pytest.raises(Exception):
-            _cephadm.prepare_dashboard(ctx, 0, 0, lambda _, extra_mounts=None, ___=None : '5', lambda : None)
+            _cephadm.prepare_dashboard(
+                ctx, 0, 0,
+                lambda _, extra_mounts=None, ___=None: '5',
+                lambda module_names=None: None)
 
         ctx.skip_firewalld = True
-        _cephadm.prepare_dashboard(ctx, 0, 0, lambda _, extra_mounts=None, ___=None : '5', lambda : None)
+        _cephadm.prepare_dashboard(
+            ctx, 0, 0,
+            lambda _, extra_mounts=None, ___=None: '5',
+            lambda module_names=None: None)
 
         ctx.skip_firewalld = False
         with pytest.raises(Exception):
-            _cephadm.prepare_dashboard(ctx, 0, 0, lambda _, extra_mounts=None, ___=None : '5', lambda : None)
+            _cephadm.prepare_dashboard(
+                ctx, 0, 0,
+                lambda _, extra_mounts=None, ___=None: '5',
+                lambda module_names=None: None)
 
     def test_to_deployment_container(self, funkypatch):
         """


### PR DESCRIPTION
on some slower envs could be a race condition while bootstrapping ceph cluster using cephadm
the scenario happens when trying to start the cluster we do not wait untill the modules finish loading
when running the code wait_for_mgr_restart()
then on slow hosts it could be that the next commands will fail.
the suggested solution from the opener to have a 60 seconds delay will work , but seems kind of not solid.
hence suggested a wait_for_mgr_modules_loaded function it will be called after enabling dashboard

Fixes: https://tracker.ceph.com/issues/77148
Signed-off-by: Kobi Ginon <kginon@redhat.com>

tested on a VM of type arm64 ubuntu based in azure 
root@kobiarm:/# uname -m
aarch64
root@kobiarm:/# uname -r
6.17.0-1018-azure

Manual: Azure ARM64 VM (Ubuntu), `quay.io/ceph/ceph:v20.2.1`, patched cephadm from source tree
Bootstrap logs show `Waiting for mgr modules orchestrator loaded...` succeeding before `orch set backend`
Bootstrap completes; `ceph -s` shows the below
Note: i know that we have some warn but this is because i did not wanted to create several VM's and complicates things here

root@kobiarm:/# ceph -s
  cluster:
    id:     0237eb06-73b2-11f1-a7ee-000d3a489f93
    health: HEALTH_WARN
            OSD count 1 < osd_pool_default_size 3

  services:
    mon: 1 daemons, quorum kobiarm (age 33m) [leader: kobiarm]
    mgr: kobiarm.gjqsbu(active, since 33m)
    osd: 1 osds: 1 up (since 19m), 1 in (since 19m)

  data:
    pools:   0 pools, 0 pgs
    objects: 0 objects, 0 B
    usage:   26 MiB used, 32 GiB / 32 GiB avail
    pgs:


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
