### PR TITLE
ceph-volume: make raw list resilient to a single device aborting show-label

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/raw/list.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/list.py
@@ -22,8 +22,9 @@ def direct_report(devices: Optional[_List[str]] = None) -> Dict[str, Any]:
     _list = List([])
     return _list.generate(devices)
 
-def _get_bluestore_info(devices: _List[str]) -> Dict[str, Any]:
-    result: Dict[str, Any] = {}
+def _show_label(devices: _List[str]) -> Optional[Dict[str, Any]]:
+    """Run ``ceph-bluestore-tool show-label`` for ``devices`` and return the parsed
+    JSON, or ``None`` if the tool failed (non-zero rc / unparseable output)."""
     command: _List[str] = ['ceph-bluestore-tool',
                            'show-label', '--bdev_aio_poll_ms=1']
     for device in devices:
@@ -31,12 +32,34 @@ def _get_bluestore_info(devices: _List[str]) -> Dict[str, Any]:
     out, err, rc = process.call(command, verbose_on_failure=False)
     if rc:
         logger.debug(f"ceph-bluestore-tool couldn't detect any BlueStore device.\n{out}\n{err}")
-    else:
-        oj = json.loads(''.join(out))
+        return None
+    try:
+        return json.loads(''.join(out))
+    except ValueError as e:
+        logger.debug(f"failed to parse ceph-bluestore-tool show-label output: {e}\n{out}")
+        return None
+
+
+def _get_bluestore_info(devices: _List[str]) -> Dict[str, Any]:
+    result: Dict[str, Any] = {}
+    oj = _show_label(devices)
+    if oj is None and len(devices) > 1:
+        # A single batched ``show-label`` invocation aborts entirely (non-zero rc)
+        # if *any* one device makes ceph-bluestore-tool crash -- e.g. a tiny or
+        # zero-length partition trips a ``is_valid_io`` ceph_assert. That would hide
+        # every valid OSD on the node (``raw list`` returns ``{}``). Fall back to
+        # probing each device individually so a single bad device cannot mask the rest.
+        logger.debug('batched show-label failed; falling back to per-device probing')
+        oj = {}
+        for device in devices:
+            single = _show_label([device])
+            if single:
+                oj.update(single)
+    if oj:
         for device in devices:
             if device not in oj:
                 # should be impossible, so warn
-                logger.warning(f'skipping device {device} because it is not reported in ceph-bluestore-tool output: {out}')
+                logger.warning(f'skipping device {device} because it is not reported in ceph-bluestore-tool output: {oj}')
             if oj.get(device):
                 try:
                     osd_uuid = oj[device]['osd_uuid']
@@ -44,9 +67,8 @@ def _get_bluestore_info(devices: _List[str]) -> Dict[str, Any]:
                 except KeyError as e:
                     # this will appear for devices that have a bluestore header but aren't valid OSDs
                     # for example, due to incomplete rollback of OSDs: https://tracker.ceph.com/issues/51869
-                    logger.error(f'device {device} does not have all BlueStore data needed to be a valid OSD: {out}\n{e}')
+                    logger.error(f'device {device} does not have all BlueStore data needed to be a valid OSD: {e}')
     return result
-
 
 class List(object):
 


### PR DESCRIPTION
**Disclaimer**: This is an LLM-generated PR.
The root of this PR is rook/rook#17716

I have a cluster where this consistently/deterministically happened, and I let the LLM give it a shot.
That being said, let me know if you want this in a different format or other information.

Happy to provide.
This change **solves** the ceph/osd issue.

Maybe this is also only an edge case you're happy to accept, and just document it. 
As e.g. a 1 KiB partition should not be that common ;)

---


## What

`ceph-volume raw list` (no device argument) can return `{}` even when the node has
perfectly valid BlueStore OSDs, hiding **every** OSD on the host.

## Root cause

No-arg `raw list` collects every block device (`lsblk_all`) and probes them in a
**single** batched `ceph-bluestore-tool show-label --dev <d1> --dev <d2> …` call in
`_get_bluestore_info()`. If **any one** of those devices makes `ceph-bluestore-tool`
abort, the whole batched command exits non-zero and the function discards all output
(returns `{}`).

A device smaller than a bdev label (e.g. a 1 KiB partition) trips
`KernelDevice::aio_read`'s `ceph_assert(is_valid_io(off, len))` and the process dies
with SIGABRT:

```
bdev is_valid_io 0~1000 block_size 1000 size 0
KernelDevice.cc:1447: FAILED ceph_assert(is_valid_io(off, len))
*** Caught signal (Aborted) **
```

So a single tiny partition anywhere on the host makes `raw list` report no OSDs at all.

## Impact

After a fresh `raw prepare`, the operator's `raw list` returns `{}` → "0 osd devices
configured": the OSDs are on disk but no daemons start. This is the ceph-volume side
of rook/rook#17716 (rook/rook#17733 works around it from the rook side, but the
listing should be robust on its own).

## Reproducer

Ceph v20.2.2 (Tentacle); a host with 3 prepared BlueStore OSDs (two whole NVMe drives
+ an OS-disk tail partition) plus a **1 KiB** partition (an MBR/GPT marker on the OS
disk):

- `ceph-volume raw list` → `{}`
- `ceph-volume raw list /dev/nvmeXn1` → returns the OSD fine
- `ceph-bluestore-tool show-label --dev /dev/<1KiB-part>` → SIGABRT (rc 134)

## Fix

Fall back to probing each device individually when the batched `show-label` fails, so
one bad device can no longer mask the rest. The happy path (one batched call) is
unchanged.

## Validation

- Debug pod on the affected host: after the patch `ceph-volume raw list` returns all 3
  OSDs (was `{}`).
- End-to-end on a live rook-ceph cluster: with the patched ceph-volume the 3 bulk OSDs
  registered and the `CephBlockPool` went `Ready`.
