### PR TITLE
mgr/dashboard: NVMe-oF – Subsystem Resource page enhancements

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-group-form/nvmeof-group-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-group-form/nvmeof-group-form.component.html
@@ -52,7 +52,7 @@
            class="form-item">
         <div cdsCol>
           <cds-checkbox id="enableCds"
-                        formControlName="enableEncryption"
+                        formControlName="enable_auth"
                         i18n>Enable encryption
           </cds-checkbox>
         </div>
@@ -74,13 +74,13 @@
                       cdValidate
                       #encryptionConfigRef="cdValidate"
                       [invalid]="encryptionConfigRef.isInvalid"
-                      formControlName="encryptionConfig"
+                      formControlName="encryptionKey"
                       cols="100"
                       rows="4"></textarea>
           </cds-textarea-label>
           <span
             class="invalid-feedback"
-            *ngIf="groupForm.showError('encryptionConfig', formDir, 'required')"
+            *ngIf="groupForm.showError('encryptionKey', formDir, 'required')"
             i18n>This field is required.</span>
         </div>
       </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-group-form/nvmeof-group-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-group-form/nvmeof-group-form.component.spec.ts
@@ -43,7 +43,9 @@ describe('NvmeofGroupFormComponent', () => {
         SelectModule
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
-    }).compileComponents();
+    })
+      .overrideTemplate(NvmeofGroupFormComponent, '')
+      .compileComponents();
 
     fixture = TestBed.createComponent(NvmeofGroupFormComponent);
     component = fixture.componentInstance;
@@ -159,7 +161,7 @@ describe('NvmeofGroupFormComponent', () => {
 
       component.groupForm.get('groupName').setValue('encrypted-group');
       component.groupForm.get('enableEncryption').setValue(true);
-      component.groupForm.get('encryptionConfig').setValue('encryption-key-123');
+      component.groupForm.get('encryptionKey').setValue('encryption-key-123');
       component.onSubmit();
 
       expect(cephServiceService.create).toHaveBeenCalledWith(

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-group-form/nvmeof-group-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-group-form/nvmeof-group-form.component.ts
@@ -145,12 +145,12 @@ export class NvmeofGroupFormComponent extends CdForm implements OnInit {
       this.groupForm.setErrors({ cdSubmitButton: true });
       return;
     }
-    let taskUrl = `service/${URLVerbs.CREATE}`;
-    const serviceName = `${formValues.groupName}`;
+    const taskUrl = `service/${URLVerbs.CREATE}`;
+    const serviceId = `${formValues.groupName}`;
 
     const serviceSpec: Record<string, any> = {
       service_type: 'nvmeof',
-      service_id: serviceName,
+      service_id: serviceId,
       group: formValues.groupName,
       placement: {
         hosts: selectedHostnames
@@ -173,7 +173,7 @@ export class NvmeofGroupFormComponent extends CdForm implements OnInit {
 
       if (formValues.pool) {
         serviceSpec['pool'] = formValues.pool;
-        serviceSpec['service_id'] = `${formValues.pool}.${serviceName}`;
+        serviceSpec['service_id'] = `${formValues.pool}.${formValues.groupName}`;
       }
 
       if (
@@ -195,7 +195,7 @@ export class NvmeofGroupFormComponent extends CdForm implements OnInit {
     this.taskWrapperService
       .wrapTaskAroundCall({
         task: new FinishedTask(taskUrl, {
-          service_name: `nvmeof.${serviceName}`
+          service_name: `nvmeof.${serviceId}`
         }),
         call: this.cephServiceService.create(serviceSpec)
       })

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystem-overview/nvmeof-subsystem-overview.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystem-overview/nvmeof-subsystem-overview.component.spec.ts
@@ -130,6 +130,7 @@ describe('NvmeofSubsystemOverviewComponent', () => {
     expect(component.subsystem.namespace_count).toBe(3);
     expect(component.subsystem.max_namespaces).toBe(256);
     expect(component.subsystem.gw_group).toBe('gateway-prod');
+    expect(component.subsystem.subtype).toBe('NVMe');
   }));
 
   it('should not fetch when subsystemNQN is missing', fakeAsync(async () => {
@@ -152,6 +153,7 @@ describe('NvmeofSubsystemOverviewComponent', () => {
     expect(labelTexts).toContain('Serial number');
     expect(labelTexts).toContain('Model Number');
     expect(labelTexts).toContain('Gateway group');
+    expect(labelTexts).toContain('Subsystem Type');
     expect(labelTexts).toContain('Host access');
     expect(labelTexts).toContain('Authentication');
     expect(labelTexts).toContain('Listeners');

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystem-overview/nvmeof-subsystem-overview.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystem-overview/nvmeof-subsystem-overview.component.ts
@@ -85,6 +85,12 @@ export class NvmeofSubsystemOverviewComponent implements OnInit {
         row: 1
       },
       {
+        label: $localize`Subsystem Type`,
+        value: this.subsystem.subtype,
+        type: 'text',
+        row: 2
+      },
+      {
         label: $localize`Host access`,
         value: this.subsystem.allow_any_host ?? false,
         type: 'host-access',

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.spec.ts
@@ -597,12 +597,13 @@ x4Ea7kGVgx9kWh5XjWz9wjZvY49UKIT5ppIAWPMbLl3UpfckiuNhTA==
         component.onSubmit();
         expect(cephServiceService.create).toHaveBeenCalledWith({
           service_type: 'nvmeof',
-          service_id: 'default',
+          service_id: 'rbd.default',
           placement: {},
           unmanaged: false,
           group: 'default',
           enable_auth: true,
           ssl: true,
+          pool: 'rbd',
           certificate_source: 'inline',
           root_ca_cert: 'root_ca_cert',
           client_cert: 'client_cert',

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
@@ -1198,6 +1198,10 @@ export class ServiceFormComponent extends CdForm implements OnInit {
 
     this.getDefaultPlacementCount(selectedServiceType);
 
+    if (selectedServiceType === 'nvmeof' && this.rbdPools?.length > 0) {
+      this.serviceForm.get('pool').setValue(this.rbdPools[0].pool_name);
+    }
+
     if (selectedServiceType === 'rgw') {
       this.setRgwFields();
     }
@@ -1374,13 +1378,14 @@ export class ServiceFormComponent extends CdForm implements OnInit {
           serviceSpec['ssl'] = true;
           serviceSpec['certificate_source'] =
             values['certificateType'] === CertificateType.internal ? 'cephadm-signed' : 'inline';
-          if (
-            values['certificateType'] === CertificateType.internal &&
-            values['custom_sans']?.length > 0
-          ) {
-            serviceSpec['custom_sans'] = values['custom_sans'];
+          if (values['certificateType'] === CertificateType.internal) {
+            if (values['custom_sans']?.length > 0) {
+              serviceSpec['custom_sans'] = values['custom_sans'];
+            }
           }
           if (values['certificateType'] === CertificateType.external) {
+            serviceSpec['pool'] = values['pool'];
+            serviceSpec['service_id'] = `${values['pool']}.${values['group']}`;
             serviceSpec['root_ca_cert'] = values['root_ca_cert'];
             serviceSpec['client_cert'] = values['client_cert'];
             serviceSpec['client_key'] = values['client_key'];

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
@@ -127,7 +127,7 @@
           }}
           @if (customFilter) {
           @for (filter of stagedCustomFilters; track filter.id; let i = $index) {
-            @if (isCustomFilterLabel()) {
+            @if (isCustomFilterString) {
               <div cdsRow
                    class="cds-mt-4 cds--type-body-02">
                 Filter {{ customFilter }}:

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
@@ -206,6 +206,9 @@ export class TableComponent implements AfterViewInit, OnInit, OnChanges, OnDestr
   */
   @Input()
   customFilter: boolean | string = false;
+  get isCustomFilterString(): boolean {
+    return typeof this.customFilter === 'string';
+  }
 
   isCustomFilterLabel(): boolean {
     return typeof this.customFilter === 'string';


### PR DESCRIPTION


https://github.com/user-attachments/assets/ee699bd0-3530-4c95-8377-03f03382108e

<img width="3840" height="2098" alt="image" src="https://github.com/user-attachments/assets/5f1adaa0-70f1-4e5b-ae94-cbfefb83177d" />

Fixes: https://tracker.ceph.com/issues/77789
Signed-off-by: pujaoshahu <pshahu@redhat.com>

Summary:

Redesigned the Subsystem Details overview to expose Host access and Authentication as separate configurable sections.
Added Edit actions for both Host access and Authentication, enabling users to modify these settings directly from the Overview page.
Displayed the current host access mode (e.g., Restrict to specific hosts) and authentication status (e.g., No authentication) for improved visibility.
Enhanced the subsystem management workflow by allowing authentication and host access settings to be viewed and updated in place, without navigating to a separate configuration page



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
