### PR TITLE
umbrella: mgr: ActivePyModules does not set Description in labeled get_perf_schema_python

### DIFF
--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -1171,7 +1171,7 @@ PyObject* ActivePyModules::get_perf_schema_python(
     size_t pos = type.path.rfind('.');
     std::string sub_counter_name = type.path.substr(pos + 1, type.path.length());
     Formatter::ObjectSection counter_section(*f, sub_counter_name);
-    f->create_unique("description", type.description);
+    f->dump_string("description", type.description);
     if (!type.nick.empty()) {
       f->dump_string("nick", type.nick);
     }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77795

---

backport of https://github.com/ceph/ceph/pull/68435
parent tracker: https://tracker.ceph.com/issues/76048

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh