### PR TITLE
blk/spdk: call spdk_env_opts_init() before setting pci options

### DIFF
--- a/src/blk/spdk/NVMEDevice.cc
+++ b/src/blk/spdk/NVMEDevice.cc
@@ -593,6 +593,8 @@ int NVMEManager::try_get(const spdk_nvme_transport_id& trid, SharedDriverData **
         struct spdk_pci_addr addr;
         int r;
 
+        spdk_env_opts_init(&opts);
+
         bool local_pci_device = false;
         int rc = spdk_pci_addr_parse(&addr, trid.traddr);
         if (!rc) {
@@ -605,7 +607,6 @@ int NVMEManager::try_get(const spdk_nvme_transport_id& trid, SharedDriverData **
           opts.num_pci_addr = 1;
         }
 
-	spdk_env_opts_init(&opts);
         opts.name = "nvme-device-manager";
         opts.core_mask = coremask_arg.c_str();
 #if SPDK_VERSION >= SPDK_VERSION_NUM(21, 1, 0)


### PR DESCRIPTION
`spdk_env_opts_init()` reinitializes the whole `spdk_env_opts` struct,
so calling it *after* filling in `pci_allowed`/`pci_whitelist` and
`num_pci_addr` overwrites those fields. As a result the per-OSD PCI
device restriction never took effect.

It was introduced in 27b7ccacd4d ("blk/spdk: Add the
support to use nvme device provided by NVMe-of Target").

Fixes: https://tracker.ceph.com/issues/77802

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests