### PR TITLE
blk/aio: fix mismatched parenthesis in POSIX AIO submit path

### DIFF
--- a/src/blk/aio/aio.cc
+++ b/src/blk/aio/aio.cc
@@ -48,7 +48,7 @@ int aio_queue_t::submit_batch(aio_iter begin, aio_iter end,
     }
 #elif defined(HAVE_POSIXAIO)
     cur->priv = priv;
-    if ((cur->n_aiocb == 1) {
+    if (cur->n_aiocb == 1) {
       // TODO: consider batching multiple reads together with lio_listio
       cur->aio.aiocb.aio_sigevent.sigev_notify = SIGEV_KEVENT;
       cur->aio.aiocb.aio_sigevent.sigev_notify_kqueue = ctx;


### PR DESCRIPTION
The condition `if ((cur->n_aiocb == 1) {` has an unbalanced parenthesis
and fails to compile.

This code only builds on the `HAVE_POSIXAIO` (BSD) path, so the breakage
is normally hidden on Linux. It was introduced in 7b52409ed70 ("osd: Remove aios_size argument from
submit_batch").

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests