### PR TITLE
rgw: fix three inverted condition checks

### DIFF
--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -4577,7 +4577,7 @@ int POSIXAtomicWriter::complete(size_t accounted_size, const std::string& etag,
   if (if_nomatch) {
     if (strcmp(if_nomatch, "*") == 0) {
       // test the object is not existing
-      if (!exists) {
+      if (exists) {
 	return -ERR_PRECONDITION_FAILED;
       }
     } else {

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -8358,7 +8358,7 @@ void RGWDeleteMultiObj::execute(optional_yield y)
     bool has_versioned = false;
     for (auto object : multi_delete->objects) {
       const string& instance = object.get_version_id();
-      if (instance.empty()) {
+      if (!instance.empty()) {
         has_versioned = true;
         break;
       }

--- a/src/rgw/rgw_sts.cc
+++ b/src/rgw/rgw_sts.cc
@@ -282,7 +282,7 @@ int AssumeRoleRequest::validate_input(const DoutPrefixProvider *dpp) const
       return -EINVAL;
     }
   }
-  if (! tokenCode.empty() && tokenCode.size() == TOKEN_CODE_SIZE) {
+  if (! tokenCode.empty() && tokenCode.size() != TOKEN_CODE_SIZE) {
     ldpp_dout(dpp, 0) << "Either token code is empty or token code size is invalid: " << tokenCode.size() << dendl;
     return -EINVAL;
   }


### PR DESCRIPTION
**rgw: fix inverted MFA check in DeleteMultiObj**

A versioned delete carries a non-empty version-id, but the MFA guard
flagged the empty case: versioned deletes bypassed MFA while plain
deletes wrongly required it. Test `!instance.empty()`.

**rgw/posix: fix inverted If-None-Match check allowing overwrite**

`If-None-Match: *` must fail when the object exists, but the posix writer
did the opposite, disabling overwrite protection. Return
`PRECONDITION_FAILED` when the object exists.

**rgw/sts: fix inverted tokenCode length validation**

`validate_input()` rejected the valid `TOKEN_CODE_SIZE` length and accepted
all others. Compare with `!=` so only a wrong length is rejected.

Fixes: https://tracker.ceph.com/issues/77869
Fixes: https://tracker.ceph.com/issues/77871
Fixes: https://tracker.ceph.com/issues/77872

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests