### PR TITLE
common/pick_address: match against the current iface in pick_iface

### DIFF
--- a/src/common/pick_address.cc
+++ b/src/common/pick_address.cc
@@ -531,7 +531,7 @@ std::string pick_iface(CephContext *cct, const struct sockaddr_storage &network)
   auto free_ifa = make_scope_guard([ifa] { freeifaddrs(ifa); });
   const unsigned int prefix_len = std::max(sizeof(in_addr::s_addr), sizeof(in6_addr::s6_addr)) * CHAR_BIT;
   for (auto addr = ifa; addr != nullptr; addr = addr->ifa_next) {
-    if (matches_with_net(*ifa, (const struct sockaddr *) &network, prefix_len,
+    if (matches_with_net(*addr, (const struct sockaddr *) &network, prefix_len,
 			 CEPH_PICK_ADDRESS_IPV4 | CEPH_PICK_ADDRESS_IPV6)) {
       return addr->ifa_name;
     }


### PR DESCRIPTION
The loop iterates over addr but always passed the list head *ifa to
matches_with_net, so only the first interface is ever tested while the
iterated interface's name is returned. Match against *addr.

Fixes: https://tracker.ceph.com/issues/77847
## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests