### PR TITLE
mon/MgrMonitor: route 'mgr set' errors through 'out:'

### DIFF
--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -1204,18 +1204,21 @@ bool MgrMonitor::prepare_command(MonOpRequestRef op)
     std::string var;
     if (!cmd_getval(cmdmap, "var", var) || var.empty()) {
       ss << "Invalid variable";
-      return -EINVAL;
+      r = -EINVAL;
+      goto out;
     }
     string val;
     if (!cmd_getval(cmdmap, "val", val)) {
-      return -EINVAL;
+      r = -EINVAL;
+      goto out;
     }
 
     if (var == "down") {
       bool enable_down = false;
-      int r = parse_bool(val, &enable_down, ss);
-      if (r != 0) {
-        return r;
+      int ret = parse_bool(val, &enable_down, ss);
+      if (ret != 0) {
+        r = ret;
+        goto out;
       }
       if (enable_down) {
         bool has_active = !!pending_map.active_gid;
@@ -1234,7 +1237,9 @@ bool MgrMonitor::prepare_command(MonOpRequestRef op)
         }
       }
     } else {
-      return -EINVAL;
+      ss << "Unknown variable '" << var << "'";
+      r = -EINVAL;
+      goto out;
     }
   } else if (prefix == "mgr fail") {
     string who;


### PR DESCRIPTION
`prepare_command()` returns `bool`, where `true` means "pending changed,
propose it", not an error code. The `mgr set` error paths did
`return -EINVAL;`, so the non-zero value became `true` and got the
opposite meaning: no reply was ever sent and the client hung.

Set `r` and `goto out;` like the rest of the function, so the error is
reported back to the client. Also rename the `parse_bool()` result in the
`down` branch, which shadowed the outer `r`.

Fixes: https://tracker.ceph.com/issues/77850

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests