### PR TITLE
crimson/osd: fix backfill deadlock in BackfillState::Waiting

### DIFF
--- a/src/crimson/osd/backfill_state.cc
+++ b/src/crimson/osd/backfill_state.cc
@@ -398,7 +398,13 @@ BackfillState::Enqueuing::Enqueuing(my_context ctx)
 
   do {
     if (!backfill_listener().budget_available()) {
-      post_event(RequestWaiting{});
+      if (backfill_state().progress_tracker->tracked_objects_completed()) {
+        INFODPP("backfill budget unavailable with nothing in flight, "
+                "entering BudgetBlocked", pg());
+        post_event(RequestBudgetBlocked{});
+      } else {
+        post_event(RequestWaiting{});
+      }
       return;
     } else if (should_rescan_replicas(backfill_state().peer_backfill_info,
 				      primary_bi)) {
@@ -649,6 +655,51 @@ BackfillState::Waiting::react(Triggered evt)
   if (backfill_state().on_resumed()) {
     DEBUGDPP("Backfill resumed, going Enqueuing", pg());
     return transit<Enqueuing>();
+  }
+  return discard_event();
+}
+
+// -- BudgetBlocked
+BackfillState::BudgetBlocked::BudgetBlocked(my_context ctx)
+  : my_base(ctx)
+{
+  LOG_PREFIX(BackfillState::BudgetBlocked::BudgetBlocked);
+  DEBUGDPP("budget unavailable with nothing in flight, "
+           "waiting for throttle slot to become available", pg());
+  backfill_listener().request_budget_retry();
+}
+
+boost::statechart::result
+BackfillState::BudgetBlocked::react(SuspendBackfill evt)
+{
+  LOG_PREFIX(BackfillState::BudgetBlocked::react::SuspendBackfill);
+  DEBUGDPP("suspended within BudgetBlocked", pg());
+  backfill_state().on_suspended();
+  return discard_event();
+}
+
+boost::statechart::result
+BackfillState::BudgetBlocked::react(Triggered evt)
+{
+  LOG_PREFIX(BackfillState::BudgetBlocked::react::Triggered);
+  ceph_assert(backfill_state().is_suspended());
+  if (backfill_state().on_resumed()) {
+    DEBUGDPP("Backfill resumed, going Enqueuing", pg());
+    return transit<Enqueuing>();
+  }
+  return discard_event();
+}
+
+boost::statechart::result
+BackfillState::BudgetBlocked::react(BudgetAvailable evt)
+{
+  LOG_PREFIX(BackfillState::BudgetBlocked::react::BudgetAvailable);
+  DEBUGDPP("BudgetBlocked::react() on BudgetAvailable", pg());
+  if (!backfill_state().is_suspended()) {
+    return transit<Enqueuing>();
+  } else {
+    DEBUGDPP("backfill suspended, not going Enqueuing", pg());
+    backfill_state().go_enqueuing_on_resume();
   }
   return discard_event();
 }

--- a/src/crimson/osd/backfill_state.h
+++ b/src/crimson/osd/backfill_state.h
@@ -63,6 +63,12 @@ struct BackfillState {
   struct SuspendBackfill : sc::event<SuspendBackfill> {
   };
 
+  struct RequestBudgetBlocked : sc::event<RequestBudgetBlocked> {
+  };
+
+  struct BudgetAvailable : sc::event<BudgetAvailable> {
+  };
+
 private:
   // internal events
   struct RequestPrimaryScanning : sc::event<RequestPrimaryScanning> {
@@ -84,6 +90,7 @@ public:
   struct ReplicasScanning;
   struct Waiting;
   struct Done;
+  struct BudgetBlocked;
 
   struct BackfillMachine : sc::state_machine<BackfillMachine, Initial> {
     BackfillMachine(BackfillState& backfill_state,
@@ -157,6 +164,7 @@ public:
       sc::transition<RequestPrimaryScanning, PrimaryScanning>,
       sc::transition<RequestReplicasScanning, ReplicasScanning>,
       sc::transition<RequestWaiting, Waiting>,
+      sc::transition<RequestBudgetBlocked, BudgetBlocked>,
       sc::transition<sc::event_base, Crashed>>;
     explicit Enqueuing(my_context);
 
@@ -281,6 +289,19 @@ public:
     }
   };
 
+  struct BudgetBlocked : sc::state<BudgetBlocked, BackfillMachine>,
+                         StateHelper<BudgetBlocked> {
+    using reactions = boost::mpl::list<
+      sc::custom_reaction<BudgetAvailable>,
+      sc::custom_reaction<SuspendBackfill>,
+      sc::custom_reaction<Triggered>,
+      sc::transition<sc::event_base, Crashed>>;
+    explicit BudgetBlocked(my_context ctx);
+    sc::result react(BudgetAvailable);
+    sc::result react(SuspendBackfill);
+    sc::result react(Triggered);
+  };
+
   BackfillState(BackfillListener& backfill_listener,
                 std::unique_ptr<PeeringFacade> peering_state,
                 std::unique_ptr<PGFacade> pg);
@@ -387,6 +408,8 @@ struct BackfillState::BackfillListener {
 
   virtual void backfilled() = 0;
 
+  virtual void request_budget_retry() = 0;
+
   virtual ~BackfillListener() = default;
 };
 
@@ -486,6 +509,8 @@ public:
 
 #if FMT_VERSION >= 90000
 template <> struct fmt::formatter<crimson::osd::BackfillState::PGFacade>
+  : fmt::ostream_formatter {};
+template <> struct fmt::formatter<crimson::osd::BackfillState::BudgetBlocked>
   : fmt::ostream_formatter {};
 #endif
 

--- a/src/crimson/osd/pg_recovery.cc
+++ b/src/crimson/osd/pg_recovery.cc
@@ -593,6 +593,9 @@ void PGRecovery::enqueue_push(
   if (!added)
     return;
   peering_state.prepare_backfill_for_missing(obj, v, peers);
+  // release the budget_retry_releaser now that we're dispatching a real
+  // push -- recover_object_with_throttle will acquire its own slot
+  budget_retry_releaser.reset();
   std::ignore = recover_object_with_throttle(obj, v).\
   handle_exception_interruptible([] (auto) {
     ceph_abort_msg("got exception on backfill's push");
@@ -618,6 +621,10 @@ void PGRecovery::enqueue_drop(
 {
   LOG_PREFIX(PGRecovery::update_peers_last_backfill);
   DEBUGDPP("obj={} v={} target={}", *pg->get_dpp(), obj, v, target);
+  // release the budget_retry_releaser now that we're dispatching work
+  // (same as enqueue_push) -- slot was held to guarantee Enqueuing
+  // found budget available, drops don't need their own throttle slot
+  budget_retry_releaser.reset();
   // allocate a pair if target is seen for the first time
   auto& req = backfill_drop_requests[target];
   if (!req) {
@@ -705,9 +712,46 @@ bool PGRecovery::budget_available() const
   return ss.throttle_available();
 }
 
+PGRecovery::interruptible_future<>
+PGRecovery::do_request_budget_retry()
+{
+  LOG_PREFIX(PGRecovery::do_request_budget_retry);
+  DEBUGDPP("budget unavailable with nothing in flight, "
+           "waiting for throttle slot", *pg->get_dpp());
+  auto releaser = co_await get_backfill_throttle();
+  budget_retry_in_flight = false;
+  if (!backfill_state) {
+    DEBUGDPP("backfill_state is null, skipping BudgetAvailable "
+             "(pg cleaned or interval changed)", *pg->get_dpp());
+    co_return;
+  }
+  // hold the releaser so the slot stays acquired until Enqueuing
+  budget_retry_releaser.emplace(std::move(releaser));
+  if (backfill_state->is_triggered()) {
+    backfill_state->post_event(
+      BackfillState::BudgetAvailable{}.intrusive_from_this());
+  } else {
+    backfill_state->process_event(
+      BackfillState::BudgetAvailable{}.intrusive_from_this());
+  }
+}
+
+void PGRecovery::request_budget_retry()
+{
+  LOG_PREFIX(PGRecovery::request_budget_retry);
+  if (budget_retry_in_flight) {
+    DEBUGDPP("budget retry already in flight, skipping", *pg->get_dpp());
+    return;
+  }
+  budget_retry_in_flight = true;
+  std::ignore = do_request_budget_retry();
+}
+
 void PGRecovery::on_pg_clean()
 {
   replica_scan_throttle_releasers.clear();
+  budget_retry_releaser.reset();
+  budget_retry_in_flight = false;
   backfill_state.reset();
 }
 
@@ -775,6 +819,8 @@ void PGRecovery::on_activate_complete()
   LOG_PREFIX(PGRecovery::on_activate_complete);
   DEBUGDPP("backfill_state={}", *pg->get_dpp(), fmt::ptr(backfill_state.get()));
   replica_scan_throttle_releasers.clear();
+  budget_retry_releaser.reset();
+  budget_retry_in_flight = false;
   backfill_state.reset();
 }
 

--- a/src/crimson/osd/pg_recovery.h
+++ b/src/crimson/osd/pg_recovery.h
@@ -126,13 +126,15 @@ private:
     return backend->recover_object(soid, need);
   }
 
+  interruptible_future<> do_request_budget_retry();
+
   // backfill begin
   std::unique_ptr<crimson::osd::BackfillState> backfill_state;
   std::map<pg_shard_t,
            MURef<MOSDPGBackfillRemove>> backfill_drop_requests;
   std::map<pg_shard_t,
            OperationThrottler::ThrottleReleaser> replica_scan_throttle_releasers;
-
+  std::optional<OperationThrottler::ThrottleReleaser> budget_retry_releaser;
   template <class EventT>
   void start_backfill_recovery(
     const EventT& evt);
@@ -154,6 +156,7 @@ private:
   void update_peers_last_backfill(
     const hobject_t& new_last_backfill) final;
   bool budget_available() const final;
+  void request_budget_retry() final;
 
   template <typename T>
   void start_peering_event_operation_listener(T &&evt, float delay = 0);
@@ -163,6 +166,7 @@ private:
 
   friend crimson::osd::BackfillState::PGFacade;
   friend crimson::osd::PG;
+  bool budget_retry_in_flight = false;
   // backfill end
 };
 

--- a/src/test/crimson/test_backfill.cc
+++ b/src/test/crimson/test_backfill.cc
@@ -176,6 +176,7 @@ class BackfillFixture : public crimson::osd::BackfillState::BackfillListener {
     const hobject_t& new_last_backfill) override;
 
   bool budget_available() const override;
+  void request_budget_retry() override;
 
 public:
   MOCK_METHOD(void, backfilled, (), (override));
@@ -431,6 +432,13 @@ void BackfillFixture::update_peers_last_backfill(
 bool BackfillFixture::budget_available() const
 {
   return true;
+}
+
+void BackfillFixture::request_budget_retry()
+{
+  // budget_available() always returns true in tests so BudgetBlocked
+  // should never be entered and this should never be called
+  ceph_abort_msg("request_budget_retry called unexpectedly in test");
 }
 
 struct BackfillFixtureBuilder {


### PR DESCRIPTION
crimson/osd: fix backfill deadlock in BackfillState::Waiting
    
    BackfillState::Enqueuing unconditionally posts RequestWaiting{}
    when budget available return false. Waiting can exit only via
    ObjectPushed which requires an in-flight push. If the budget
    is exhausted with no pushes in flight no objectPush will ever
    arrive and the PG stalls permanently.
    
    Solution: Introduce a dedicated BudgetBlocked state. When budget_available()
    is false and tracked_objects_completed()==true post RequestBudgetBlocked{}
    instead of RequestWaiting{}.BudgetBlocked calls get_backfill_throttle()
    to suspend until a slots free up, then fires BudgetAvailable{} which
    transitions directly back to Enqueuing to dispatch the next batch of pushes.
    
    Fixes: https://tracker.ceph.com/issues/77804





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
