### PR TITLE
mgr/dashboard: fix cephfs mirror add path issues

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-add-mirroring-path/mirroring-path-utils.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-add-mirroring-path/mirroring-path-utils.spec.ts
@@ -2,72 +2,44 @@ import { MirroringPathUtils } from './mirroring-path-utils';
 import { PathEntry } from './mirroring-path.model';
 
 describe('MirroringPathUtils', () => {
-  describe('mirroringPathsOverlap', () => {
+  describe('pathsOverlap', () => {
     it('should detect exact, ancestor, and descendant overlap', () => {
-      expect(MirroringPathUtils.mirroringPathsOverlap('/volumes/g1/sv1', '/volumes/g1/sv1')).toBe(
-        true
-      );
-      expect(
-        MirroringPathUtils.mirroringPathsOverlap('/volumes/g1/sv1/dir', '/volumes/g1/sv1')
-      ).toBe(true);
-      expect(
-        MirroringPathUtils.mirroringPathsOverlap('/volumes/g1/sv1', '/volumes/g1/sv1/dir')
-      ).toBe(true);
-      expect(MirroringPathUtils.mirroringPathsOverlap('/volumes/g1/sv1', '/volumes/g2/sv1')).toBe(
-        false
-      );
+      expect(MirroringPathUtils.pathsOverlap('/volumes/g1/sv1', '/volumes/g1/sv1')).toBe(true);
+      expect(MirroringPathUtils.pathsOverlap('/volumes/g1/sv1/dir', '/volumes/g1/sv1')).toBe(true);
+      expect(MirroringPathUtils.pathsOverlap('/volumes/g1/sv1', '/volumes/g1/sv1/dir')).toBe(true);
+      expect(MirroringPathUtils.pathsOverlap('/volumes/g1/sv1', '/volumes/g2/sv1')).toBe(false);
     });
   });
 
-  describe('isMirroringPathTracked', () => {
-    it('should match resolved subvolume paths against tracked paths', () => {
-      const tracked = MirroringPathUtils.toTrackedPathSet([
-        '/volumes/cs/g1/64446b51-d39b-436b-991f-0f8e713067ff'
-      ]);
-      expect(MirroringPathUtils.isMirroringPathTracked('/volumes/g1/my-subvol', tracked)).toBe(
-        false
-      );
-      expect(
-        MirroringPathUtils.isMirroringPathTracked(
-          '/volumes/cs/g1/64446b51-d39b-436b-991f-0f8e713067ff',
-          tracked
-        )
-      ).toBe(true);
+  describe('isPathTracked', () => {
+    it('should match tracked paths and their descendants', () => {
+      const tracked = new Set(['/volumes/g1/sv1']);
+      expect(MirroringPathUtils.isPathTracked('/volumes/g1/sv1', tracked)).toBe(true);
+      expect(MirroringPathUtils.isPathTracked('/volumes/g1/sv1/dir', tracked)).toBe(true);
+      expect(MirroringPathUtils.isPathTracked('/volumes/g1/sv2', tracked)).toBe(false);
     });
   });
 
-  describe('isGroupPathMirrored', () => {
-    it('should only match exact group paths', () => {
-      const tracked = MirroringPathUtils.toTrackedPathSet(['/volumes/g1/sv1']);
-      expect(MirroringPathUtils.isGroupPathMirrored('/volumes/g1', tracked)).toBe(false);
-      expect(MirroringPathUtils.isGroupPathMirrored('/volumes/g1/sv1', tracked)).toBe(true);
+  describe('buildPathFromSegments', () => {
+    it('should build a path from selected segments', () => {
+      expect(MirroringPathUtils.buildPathFromSegments(['g1', 'sv1'])).toBe('/volumes/g1/sv1');
+      expect(MirroringPathUtils.buildPathFromSegments([])).toBe('');
     });
   });
 
-  describe('getMirrorPath', () => {
-    it('should require a dir selection before returning a resolved subvolume path', () => {
+  describe('getSelectedSegments', () => {
+    it('should return only selected level values', () => {
       const entry: PathEntry = {
-        fullPath: '/volumes/Group1/B1iu7',
+        fullPath: '/volumes/g1/sv1',
         expanded: true,
-        subvolumePath: '/volumes/Group1/B1iu7',
-        resolvedSubvolumeRoot: '/volumes/Group1/B1iu7/0ef49a41-2569-41d7-80a6-7849910e62cb',
         levels: [
-          { options: ['Group1'], selected: 'Group1', kind: 'group' },
-          { options: ['B1iu7'], selected: 'B1iu7', kind: 'subvolume' }
+          { options: ['g1'], selected: 'g1' },
+          { options: ['sv1', 'sv2'], selected: 'sv1' },
+          { options: [], selected: '' }
         ]
       };
 
-      expect(MirroringPathUtils.getMirrorPath(entry)).toBe('');
-
-      entry.levels.push({
-        options: ['0ef49a41-2569-41d7-80a6-7849910e62cb'],
-        selected: '0ef49a41-2569-41d7-80a6-7849910e62cb',
-        kind: 'dir'
-      });
-
-      expect(MirroringPathUtils.getMirrorPath(entry)).toBe(
-        '/volumes/Group1/B1iu7/0ef49a41-2569-41d7-80a6-7849910e62cb'
-      );
+      expect(MirroringPathUtils.getSelectedSegments(entry)).toEqual(['g1', 'sv1']);
     });
   });
 
@@ -79,15 +51,6 @@ describe('MirroringPathUtils', () => {
         )
       ).toBe(true);
       expect(MirroringPathUtils.isAlreadyTrackedMirrorError('permission denied')).toBe(false);
-    });
-  });
-
-  describe('parseMirrorDirectoryList', () => {
-    it('should parse array and json string responses', () => {
-      expect(MirroringPathUtils.parseMirrorDirectoryList(['/volumes/a'])).toEqual(['/volumes/a']);
-      expect(MirroringPathUtils.parseMirrorDirectoryList(JSON.stringify(['/volumes/b']))).toEqual([
-        '/volumes/b'
-      ]);
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-add-mirroring-path/mirroring-path-utils.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-add-mirroring-path/mirroring-path-utils.ts
@@ -1,191 +1,57 @@
-import { DEFAULT_SUBVOLUME_GROUP } from '~/app/shared/constants/cephfs.constant';
-
 import { PathEntry } from './mirroring-path.model';
 
+const VOLUMES_ROOT = '/volumes';
+
 export class MirroringPathUtils {
-  static normalizeMirroringPath(path: string): string {
-    if (!path || path === '/') {
+  static normalizePath(path: string): string {
+    if (!path) {
+      return '';
+    }
+    if (path === '/') {
       return '/';
     }
     return path.trim().replace(/\/+$/, '');
   }
 
-  static normalizeGroupOptionName(groupName: string): string {
-    return !groupName ? DEFAULT_SUBVOLUME_GROUP : groupName;
+  static joinPath(parent: string, name: string): string {
+    const normalizedParent = MirroringPathUtils.normalizePath(parent);
+    if (normalizedParent === '/') {
+      return `/${name}`;
+    }
+    return `${normalizedParent}/${name}`;
   }
 
-  static buildGroupPath(groupName: string): string {
-    return `/volumes/${groupName || DEFAULT_SUBVOLUME_GROUP}`;
-  }
-
-  static buildSubvolumePath(groupName: string, subvolName: string): string {
-    return `/volumes/${groupName || DEFAULT_SUBVOLUME_GROUP}/${subvolName}`;
-  }
-
-  static splitResolvedSubvolumePath(resolvedPath: string): string {
-    const segments = MirroringPathUtils.normalizeMirroringPath(resolvedPath)
-      .split('/')
-      .filter(Boolean);
-    segments.pop();
-    return segments.length ? `/${segments.join('/')}` : '/';
-  }
-
-  static subvolumeNeedsDirSelection(
-    groupName: string,
-    subvolName: string,
-    resolvedPath?: string | null
-  ): boolean {
-    if (!resolvedPath) {
-      return false;
-    }
-    return (
-      MirroringPathUtils.normalizeMirroringPath(resolvedPath) !==
-      MirroringPathUtils.normalizeMirroringPath(
-        MirroringPathUtils.buildSubvolumePath(groupName, subvolName)
-      )
-    );
-  }
-
-  static withResolvedDisplayPath(entry: PathEntry): PathEntry {
-    const groupLevel = entry.levels.find((level) => level.kind === 'group');
-    const subvolLevel = entry.levels.find((level) => level.kind === 'subvolume');
-
-    if (!groupLevel?.selected) {
-      return {
-        ...entry,
-        fullPath: '',
-        subvolumePath: undefined,
-        resolvedSubvolumeRoot: undefined
-      };
-    }
-
-    if (!subvolLevel?.selected) {
-      return {
-        ...entry,
-        subvolumePath: undefined,
-        resolvedSubvolumeRoot: undefined,
-        fullPath: MirroringPathUtils.buildGroupPath(groupLevel.selected)
-      };
-    }
-
-    const dirSegments = entry.levels
-      .filter((level) => level.kind === 'dir' && level.selected)
-      .map((level) => level.selected);
-
-    const logicalSubvolumePath = MirroringPathUtils.buildSubvolumePath(
-      groupLevel.selected,
-      subvolLevel.selected
-    );
-
-    if (!dirSegments.length) {
-      return {
-        ...entry,
-        fullPath: logicalSubvolumePath
-      };
-    }
-
-    if (entry.subvolumePath) {
-      return {
-        ...entry,
-        fullPath: MirroringPathUtils.joinMirroringPath(entry.subvolumePath, dirSegments.join('/'))
-      };
-    }
-
-    return {
-      ...entry,
-      fullPath: MirroringPathUtils.joinMirroringPath(logicalSubvolumePath, dirSegments.join('/'))
-    };
-  }
-
-  static getMirrorPath(entry: PathEntry): string {
-    const groupLevel = entry.levels.find((level) => level.kind === 'group');
-    const subvolLevel = entry.levels.find((level) => level.kind === 'subvolume');
-    const dirSegments = entry.levels
-      .filter((level) => level.kind === 'dir' && level.selected)
-      .map((level) => level.selected);
-
-    if (subvolLevel?.selected && groupLevel?.selected && entry.resolvedSubvolumeRoot) {
-      const needsDir = MirroringPathUtils.subvolumeNeedsDirSelection(
-        groupLevel.selected,
-        subvolLevel.selected,
-        entry.resolvedSubvolumeRoot
-      );
-
-      if (!dirSegments.length) {
-        return needsDir ? '' : entry.resolvedSubvolumeRoot;
-      }
-
-      const parentPath =
-        entry.subvolumePath ??
-        MirroringPathUtils.splitResolvedSubvolumePath(entry.resolvedSubvolumeRoot);
-      return MirroringPathUtils.normalizeMirroringPath(
-        MirroringPathUtils.joinMirroringPath(parentPath, dirSegments.join('/'))
-      );
-    }
-
-    if (!entry.fullPath) {
+  static buildPathFromSegments(segments: string[]): string {
+    if (!segments.length) {
       return '';
     }
-
-    return MirroringPathUtils.normalizeMirroringPath(entry.fullPath);
+    return `${VOLUMES_ROOT}/${segments.join('/')}`;
   }
 
-  static toTrackedPathSet(paths: string[]): Set<string> {
-    return new Set(paths.map(MirroringPathUtils.normalizeMirroringPath).filter(Boolean));
+  static getSelectedSegments(entry: PathEntry): string[] {
+    return entry.levels.map((level) => level.selected).filter(Boolean);
   }
 
-  static mirroringPathsOverlap(a: string, b: string): boolean {
-    const left = MirroringPathUtils.normalizeMirroringPath(a);
-    const right = MirroringPathUtils.normalizeMirroringPath(b);
+  static pathsOverlap(a: string, b: string): boolean {
+    const left = MirroringPathUtils.normalizePath(a);
+    const right = MirroringPathUtils.normalizePath(b);
     if (!left || !right) {
       return false;
     }
     return left === right || left.startsWith(`${right}/`) || right.startsWith(`${left}/`);
   }
 
-  static isMirroringPathTracked(path: string, trackedPaths: Set<string>): boolean {
-    const normalized = MirroringPathUtils.normalizeMirroringPath(path);
+  static isPathTracked(path: string, trackedPaths: Set<string>): boolean {
+    const normalized = MirroringPathUtils.normalizePath(path);
     if (!normalized || !trackedPaths.size) {
       return false;
     }
-
     for (const tracked of trackedPaths) {
-      if (MirroringPathUtils.mirroringPathsOverlap(normalized, tracked)) {
+      if (MirroringPathUtils.pathsOverlap(normalized, tracked)) {
         return true;
       }
     }
-
     return false;
-  }
-
-  static isGroupPathMirrored(groupPath: string, trackedPaths: Set<string>): boolean {
-    const normalized = MirroringPathUtils.normalizeMirroringPath(groupPath);
-    if (!normalized || !trackedPaths.size) {
-      return false;
-    }
-    return trackedPaths.has(normalized);
-  }
-
-  static joinMirroringPath(parentPath: string, name: string): string {
-    const parent = MirroringPathUtils.normalizeMirroringPath(parentPath);
-    if (parent === '/') {
-      return `/${name}`;
-    }
-    return `${parent}/${name}`;
-  }
-
-  static parseMirrorDirectoryList(response: unknown): string[] {
-    if (Array.isArray(response)) {
-      return response.filter((path): path is string => typeof path === 'string');
-    }
-    if (typeof response === 'string') {
-      try {
-        return MirroringPathUtils.parseMirrorDirectoryList(JSON.parse(response));
-      } catch {
-        return [];
-      }
-    }
-    return [];
   }
 
   static isAlreadyTrackedMirrorError(message: string): boolean {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-add-mirroring-path/mirroring-path.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-add-mirroring-path/mirroring-path.model.ts
@@ -1,26 +1,18 @@
-export interface DirTreeEntry {
-  name: string;
-  parent: string;
-}
-
-export interface DirLevel {
+export interface PathLevel {
   options: string[];
   selected: string;
-  kind: 'group' | 'subvolume' | 'dir';
 }
 
 export interface PathEntry {
   fullPath: string;
-  levels: DirLevel[];
+  levels: PathLevel[];
   expanded: boolean;
-  subvolumePath?: string;
-  resolvedSubvolumeRoot?: string;
 }
 
-export function createPathEntry(groupOptions: string[], expanded = true): PathEntry {
+export function createPathEntry(expanded = true): PathEntry {
   return {
     fullPath: '',
-    levels: [{ options: groupOptions, selected: '', kind: 'group' }],
+    levels: [{ options: [], selected: '' }],
     expanded
   };
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-add-mirroring-path/mirroring-paths-step/mirroring-paths-step.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-add-mirroring-path/mirroring-paths-step/mirroring-paths-step.component.html
@@ -72,15 +72,31 @@
               @if (lvl > 0) {
                 <span class="cds--type-body-compact-01 path-separator">/</span>
               }
-              <cds-select [label]="''"
-                          [value]="level.selected"
-                          (valueChange)="onLevelChange(i, lvl, $event)">
-                <option value=""
-                        i18n>-- Select --</option>
-                @for (opt of level.options; track opt) {
-                  <option [value]="opt">{{ opt }}</option>
-                }
-              </cds-select>
+              @if (isLevelLoading(i, lvl) && !level.options.length) {
+                <cds-loading [isActive]="true"
+                             [overlay]="false"
+                             size="sm">
+                </cds-loading>
+              } @else {
+                <cds-select [label]="''"
+                            [value]="level.selected"
+                            (valueChange)="onLevelChange(i, lvl, $event)">
+                  <option value=""
+                          i18n>-- Select --</option>
+                  @for (opt of level.options; track opt) {
+                    <option [value]="opt">{{ opt }}</option>
+                  }
+                </cds-select>
+              }
+            }
+            @if (isLevelLoading(i, entry.levels.length)) {
+              @if (entry.levels.length) {
+                <span class="cds--type-body-compact-01 path-separator">/</span>
+              }
+              <cds-loading [isActive]="true"
+                           [overlay]="false"
+                           size="sm">
+              </cds-loading>
             }
           </div>
         </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-add-mirroring-path/mirroring-paths-step/mirroring-paths-step.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-add-mirroring-path/mirroring-paths-step/mirroring-paths-step.component.spec.ts
@@ -5,8 +5,6 @@ import { of } from 'rxjs';
 
 import { MirroringPathsStepComponent } from './mirroring-paths-step.component';
 import { CephfsService } from '~/app/shared/api/cephfs.service';
-import { CephfsSubvolumeGroupService } from '~/app/shared/api/cephfs-subvolume-group.service';
-import { DEFAULT_SUBVOLUME_GROUP } from '~/app/shared/constants/cephfs.constant';
 import { createPathEntry } from '../mirroring-path.model';
 
 describe('MirroringPathsStepComponent', () => {
@@ -19,9 +17,20 @@ describe('MirroringPathsStepComponent', () => {
     listMirrorDirectories: jest.fn().mockReturnValue(of([]))
   };
 
-  const subvolumeGroupServiceMock = {
-    get: jest.fn().mockReturnValue(of([]))
-  };
+  function mockLsDirTree(): void {
+    cephfsServiceMock.lsDir.mockImplementation((_id: number, path: string) => {
+      if (path === '/volumes') {
+        return of([{ name: 'g1', parent: '/volumes' }]);
+      }
+      if (path === '/volumes/g1') {
+        return of([
+          { name: 'sv1', parent: '/volumes/g1' },
+          { name: 'sv2', parent: '/volumes/g1' }
+        ]);
+      }
+      return of([]);
+    });
+  }
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -29,10 +38,7 @@ describe('MirroringPathsStepComponent', () => {
     await TestBed.configureTestingModule({
       declarations: [MirroringPathsStepComponent],
       imports: [ReactiveFormsModule],
-      providers: [
-        { provide: CephfsService, useValue: cephfsServiceMock },
-        { provide: CephfsSubvolumeGroupService, useValue: subvolumeGroupServiceMock }
-      ],
+      providers: [{ provide: CephfsService, useValue: cephfsServiceMock }],
       schemas: [NO_ERRORS_SCHEMA]
     })
       .overrideComponent(MirroringPathsStepComponent, {
@@ -63,14 +69,8 @@ describe('MirroringPathsStepComponent', () => {
     expect(component.pathsError).toContain('Select at least one path');
   });
 
-  it('should expose inline validation when only already mirrored paths are selected', fakeAsync(() => {
-    subvolumeGroupServiceMock.get.mockReturnValue(of([{ name: 'g1' }]));
-    cephfsServiceMock.lsDir.mockReturnValue(
-      of([
-        { name: 'g1', parent: '/volumes' },
-        { name: 'sv1', parent: '/volumes/g1' }
-      ])
-    );
+  it('should hide already mirrored paths from dropdown options', fakeAsync(() => {
+    mockLsDirTree();
     cephfsServiceMock.listMirrorDirectories.mockReturnValue(of(['/volumes/g1/sv1']));
 
     component.fsName = 'testfs';
@@ -79,6 +79,23 @@ describe('MirroringPathsStepComponent', () => {
     tick();
 
     component.onLevelChange(0, 0, 'g1');
+    tick();
+
+    expect(component.paths[0].levels[1].options).toEqual(['sv2']);
+  }));
+
+  it('should expose inline validation when only already mirrored paths are selected', fakeAsync(() => {
+    mockLsDirTree();
+    cephfsServiceMock.listMirrorDirectories.mockReturnValue(of(['/volumes/g1/sv1']));
+
+    component.fsName = 'testfs';
+    component.fsId = 1;
+    component.ngOnInit();
+    tick();
+
+    component.onLevelChange(0, 0, 'g1');
+    tick();
+    component.paths[0].levels[1].options = ['sv1'];
     component.onLevelChange(0, 1, 'sv1');
     component.pathsControl.markAsTouched();
 
@@ -89,33 +106,26 @@ describe('MirroringPathsStepComponent', () => {
   it('should not load initial data when fsName is missing', () => {
     component.ngOnInit();
 
-    expect(subvolumeGroupServiceMock.get).not.toHaveBeenCalled();
     expect(cephfsServiceMock.lsDir).not.toHaveBeenCalled();
     expect(cephfsServiceMock.listMirrorDirectories).not.toHaveBeenCalled();
   });
 
-  it('should load groups, directory tree, and tracked paths on init', fakeAsync(() => {
-    subvolumeGroupServiceMock.get.mockReturnValue(of([{ name: 'g1' }, { name: 'g2' }]));
-    cephfsServiceMock.lsDir.mockReturnValue(
-      of([
-        { name: 'g1', parent: '/volumes' },
-        { name: 'sv1', parent: '/volumes/g1' }
-      ])
-    );
-    cephfsServiceMock.listMirrorDirectories.mockReturnValue(of(['/volumes/g1/sv1']));
+  it('should load root options and tracked paths on init', fakeAsync(() => {
+    mockLsDirTree();
+    cephfsServiceMock.listMirrorDirectories.mockReturnValue(of([]));
 
     component.fsName = 'testfs';
     component.fsId = 1;
     component.ngOnInit();
     tick();
 
-    expect(subvolumeGroupServiceMock.get).toHaveBeenCalledWith('testfs', false);
-    expect(cephfsServiceMock.lsDir).toHaveBeenCalledWith(1, '/volumes', 3);
+    expect(cephfsServiceMock.lsDir).toHaveBeenCalledWith(1, '/volumes', 1);
     expect(cephfsServiceMock.listMirrorDirectories).toHaveBeenCalledWith('testfs');
-    expect(component.paths[0].levels[0].options).toEqual([DEFAULT_SUBVOLUME_GROUP, 'g1', 'g2']);
+    expect(component.paths[0].levels[0].options).toEqual(['g1']);
   }));
 
   it('should resolve fsId from cephfsService when fsId input is not set', fakeAsync(() => {
+    mockLsDirTree();
     cephfsServiceMock.list.mockReturnValue(of([{ id: 5, mdsmap: { fs_name: 'testfs' } }]));
 
     component.fsName = 'testfs';
@@ -124,17 +134,18 @@ describe('MirroringPathsStepComponent', () => {
 
     expect(cephfsServiceMock.list).toHaveBeenCalled();
     expect(component.fsId).toBe(5);
-    expect(cephfsServiceMock.lsDir).toHaveBeenCalledWith(5, '/volumes', 3);
+    expect(cephfsServiceMock.lsDir).toHaveBeenCalledWith(5, '/volumes', 1);
   }));
 
   it('should add and remove path entries', fakeAsync(() => {
-    subvolumeGroupServiceMock.get.mockReturnValue(of([{ name: 'g1' }]));
+    mockLsDirTree();
     component.fsName = 'testfs';
     component.fsId = 1;
     component.ngOnInit();
     tick();
 
     component.addPath();
+    tick();
     expect(component.paths.length).toBe(2);
 
     component.removePath(1);
@@ -142,7 +153,7 @@ describe('MirroringPathsStepComponent', () => {
   }));
 
   it('should toggle path expansion', () => {
-    component.paths = [createPathEntry([], true)];
+    component.paths = [createPathEntry(true)];
     expect(component.paths[0].expanded).toBe(true);
 
     component.toggleExpand(0);
@@ -150,14 +161,7 @@ describe('MirroringPathsStepComponent', () => {
   });
 
   it('should classify submit paths as toAdd or alreadyMirrored', fakeAsync(() => {
-    subvolumeGroupServiceMock.get.mockReturnValue(of([{ name: 'g1' }]));
-    cephfsServiceMock.lsDir.mockReturnValue(
-      of([
-        { name: 'g1', parent: '/volumes' },
-        { name: 'sv1', parent: '/volumes/g1' },
-        { name: 'sv2', parent: '/volumes/g1' }
-      ])
-    );
+    mockLsDirTree();
     cephfsServiceMock.listMirrorDirectories.mockReturnValue(of(['/volumes/g1/sv1']));
 
     component.fsName = 'testfs';
@@ -166,14 +170,9 @@ describe('MirroringPathsStepComponent', () => {
     tick();
 
     component.onLevelChange(0, 0, 'g1');
-    component.onLevelChange(0, 1, 'sv1');
-
-    expect(component.getSubmitPaths()).toEqual({
-      toAdd: [],
-      alreadyMirrored: ['/volumes/g1/sv1']
-    });
-
+    tick();
     component.onLevelChange(0, 1, 'sv2');
+
     expect(component.getSubmitPaths()).toEqual({
       toAdd: ['/volumes/g1/sv2'],
       alreadyMirrored: []
@@ -181,13 +180,7 @@ describe('MirroringPathsStepComponent', () => {
   }));
 
   it('should refresh tracked paths from the server', fakeAsync(() => {
-    subvolumeGroupServiceMock.get.mockReturnValue(of([{ name: 'g1' }]));
-    cephfsServiceMock.lsDir.mockReturnValue(
-      of([
-        { name: 'g1', parent: '/volumes' },
-        { name: 'sv1', parent: '/volumes/g1' }
-      ])
-    );
+    mockLsDirTree();
     cephfsServiceMock.listMirrorDirectories.mockReturnValue(of([]));
 
     component.fsName = 'testfs';
@@ -196,8 +189,9 @@ describe('MirroringPathsStepComponent', () => {
     tick();
 
     component.onLevelChange(0, 0, 'g1');
+    tick();
     component.onLevelChange(0, 1, 'sv1');
-    expect(component.getSubmitPaths().alreadyMirrored).toEqual([]);
+    expect(component.getSubmitPaths().toAdd).toEqual(['/volumes/g1/sv1']);
 
     cephfsServiceMock.listMirrorDirectories.mockReturnValue(of(['/volumes/g1/sv1']));
 
@@ -212,13 +206,7 @@ describe('MirroringPathsStepComponent', () => {
   }));
 
   it('should add tracked path locally after successful submit', fakeAsync(() => {
-    subvolumeGroupServiceMock.get.mockReturnValue(of([{ name: 'g1' }]));
-    cephfsServiceMock.lsDir.mockReturnValue(
-      of([
-        { name: 'g1', parent: '/volumes' },
-        { name: 'sv2', parent: '/volumes/g1' }
-      ])
-    );
+    mockLsDirTree();
 
     component.fsName = 'testfs';
     component.fsId = 1;
@@ -226,6 +214,7 @@ describe('MirroringPathsStepComponent', () => {
     tick();
 
     component.onLevelChange(0, 0, 'g1');
+    tick();
     component.onLevelChange(0, 1, 'sv2');
     expect(component.getSubmitPaths().toAdd).toEqual(['/volumes/g1/sv2']);
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-add-mirroring-path/mirroring-paths-step/mirroring-paths-step.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-add-mirroring-path/mirroring-paths-step/mirroring-paths-step.component.ts
@@ -2,16 +2,16 @@ import { Component, DestroyRef, inject, Input, OnInit } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl } from '@angular/forms';
 import { forkJoin, Observable, of } from 'rxjs';
-import { catchError, map, switchMap, take } from 'rxjs/operators';
+import { catchError, finalize, map, switchMap, take } from 'rxjs/operators';
 
-import { DEFAULT_SUBVOLUME_GROUP } from '~/app/shared/constants/cephfs.constant';
-import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { CephfsService } from '~/app/shared/api/cephfs.service';
-import { CephfsSubvolumeGroupService } from '~/app/shared/api/cephfs-subvolume-group.service';
-import { CephfsDir } from '~/app/shared/models/cephfs-directory-models';
+import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { TearsheetStep } from '~/app/shared/models/tearsheet-step';
 import { MirroringPathUtils } from '../mirroring-path-utils';
-import { createPathEntry, DirTreeEntry, PathEntry } from '../mirroring-path.model';
+import { createPathEntry, PathEntry } from '../mirroring-path.model';
+
+const VOLUMES_ROOT = '/volumes';
+const LS_DEPTH = 1;
 
 @Component({
   selector: 'cd-mirroring-paths-step',
@@ -25,21 +25,17 @@ export class MirroringPathsStepComponent implements OnInit, TearsheetStep {
 
   formGroup!: CdFormGroup;
   paths: PathEntry[] = [];
-  private trackedPaths = new Set<string>();
-  private cachedGroupNames: string[] = [];
-  private dirTree: DirTreeEntry[] = [];
-  private destroyRef = inject(DestroyRef);
+  loadingLevels: Record<string, true> = {};
 
-  constructor(
-    private cephfsService: CephfsService,
-    private subvolumeGroupService: CephfsSubvolumeGroupService
-  ) {}
+  private trackedPaths = new Set<string>();
+  private destroyRef = inject(DestroyRef);
+  private cephfsService = inject(CephfsService);
 
   ngOnInit(): void {
     this.formGroup = new CdFormGroup({
       pathsControl: new FormControl<string[]>([], { nonNullable: true })
     });
-    this.paths = [createPathEntry([])];
+    this.paths = [createPathEntry()];
     this.syncFormValue();
     this.loadInitialData();
   }
@@ -60,12 +56,12 @@ export class MirroringPathsStepComponent implements OnInit, TearsheetStep {
   }
 
   addPath(): void {
-    this.paths.push(createPathEntry([...this.filterAvailableGroupNames()]));
+    this.paths.push(createPathEntry());
+    this.loadLevelOptions(this.paths.length - 1, 0, VOLUMES_ROOT);
   }
 
   removePath(index: number): void {
     this.paths.splice(index, 1);
-    this.refreshGroupOptions();
     this.syncFormValue();
   }
 
@@ -73,48 +69,62 @@ export class MirroringPathsStepComponent implements OnInit, TearsheetStep {
     this.paths[index].expanded = !this.paths[index].expanded;
   }
 
+  isLevelLoading(pathIndex: number, levelIndex: number): boolean {
+    return !!this.loadingLevels[`${pathIndex}:${levelIndex}`];
+  }
+
   onLevelChange(pathIndex: number, levelIndex: number, selected: string): void {
     const entry = this.paths[pathIndex];
-    if (!entry) return;
+    if (!entry) {
+      return;
+    }
 
     const levels = entry.levels.map((level, i) =>
       i === levelIndex ? { ...level, selected } : level
     );
     levels.splice(levelIndex + 1);
 
-    const updatedEntry: PathEntry = { ...entry, levels };
+    const updated: PathEntry = {
+      ...entry,
+      levels,
+      fullPath: MirroringPathUtils.buildPathFromSegments(
+        levels.map((level) => level.selected).filter(Boolean)
+      )
+    };
+    this.paths[pathIndex] = updated;
 
     if (!selected) {
-      this.updatePath(pathIndex, MirroringPathUtils.withResolvedDisplayPath(updatedEntry));
+      this.syncFormValue();
       return;
     }
 
-    const kind = levels[levelIndex].kind;
-    if (kind === 'group') {
-      this.handleGroupSelection(pathIndex, updatedEntry, selected);
-    } else if (kind === 'subvolume') {
-      this.handleSubvolumeSelection(pathIndex, updatedEntry, selected);
-    } else {
-      this.handleDirSelection(pathIndex, MirroringPathUtils.withResolvedDisplayPath(updatedEntry));
-    }
+    this.loadLevelOptions(pathIndex, levelIndex + 1, updated.fullPath);
   }
 
   getSubmitPaths(): { toAdd: string[]; alreadyMirrored: string[] } {
     const toAdd: string[] = [];
     const alreadyMirrored: string[] = [];
-    this.paths.forEach((entry, i) => {
-      const rawPath = MirroringPathUtils.getMirrorPath(entry);
-      if (!rawPath) return;
-      const path = MirroringPathUtils.normalizeMirroringPath(rawPath);
-      if (this.isPathAvailable(path, i)) toAdd.push(path);
-      else if (MirroringPathUtils.isMirroringPathTracked(path, this.trackedPaths))
+
+    this.paths.forEach((entry, pathIndex) => {
+      if (!entry.fullPath) {
+        return;
+      }
+      const path = MirroringPathUtils.normalizePath(entry.fullPath);
+      if (!path) {
+        return;
+      }
+      if (MirroringPathUtils.isPathTracked(path, this.trackedPaths)) {
         alreadyMirrored.push(path);
+      } else if (this.isPathSelectable(path, pathIndex)) {
+        toAdd.push(path);
+      }
     });
+
     return { toAdd, alreadyMirrored };
   }
 
   addTrackedPath(path: string): void {
-    const normalized = MirroringPathUtils.normalizeMirroringPath(path);
+    const normalized = MirroringPathUtils.normalizePath(path);
     if (normalized) {
       this.trackedPaths.add(normalized);
       this.syncFormValue();
@@ -122,12 +132,12 @@ export class MirroringPathsStepComponent implements OnInit, TearsheetStep {
   }
 
   refreshTrackedPaths(): Observable<void> {
-    if (!this.fsName) return of(undefined);
+    if (!this.fsName) {
+      return of(undefined);
+    }
     return this.cephfsService.listMirrorDirectories(this.fsName).pipe(
-      map((response) => {
-        this.trackedPaths = MirroringPathUtils.toTrackedPathSet(
-          MirroringPathUtils.parseMirrorDirectoryList(response)
-        );
+      map((paths) => {
+        this.trackedPaths = new Set(paths.map(MirroringPathUtils.normalizePath).filter(Boolean));
         this.syncFormValue();
       }),
       catchError(() => of(undefined)),
@@ -135,86 +145,109 @@ export class MirroringPathsStepComponent implements OnInit, TearsheetStep {
     );
   }
 
-  private handleGroupSelection(pathIndex: number, entry: PathEntry, groupName: string): void {
-    const groupPath = MirroringPathUtils.buildGroupPath(groupName);
-    const updated = MirroringPathUtils.withResolvedDisplayPath({
-      ...entry,
-      subvolumePath: undefined,
-      resolvedSubvolumeRoot: undefined,
-      fullPath: groupPath
+  private loadInitialData(): void {
+    if (!this.fsName) {
+      return;
+    }
+
+    this.resolveFsId()
+      .pipe(
+        switchMap((fsId) =>
+          forkJoin([
+            of(fsId),
+            this.cephfsService.listMirrorDirectories(this.fsName).pipe(catchError(() => of([])))
+          ])
+        ),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe(([fsId, trackedList]) => {
+        this.trackedPaths = new Set(
+          trackedList.map(MirroringPathUtils.normalizePath).filter(Boolean)
+        );
+        if (fsId) {
+          this.loadLevelOptions(0, 0, VOLUMES_ROOT);
+        }
+      });
+  }
+
+  private resolveFsId(): Observable<number> {
+    if (this.fsId) {
+      return of(this.fsId);
+    }
+    return this.cephfsService.list().pipe(
+      map((filesystems: { id?: number; mdsmap?: { fs_name?: string } }[]) => {
+        const id = filesystems.find((fs) => fs.mdsmap?.fs_name === this.fsName)?.id ?? 0;
+        this.fsId = id;
+        return id;
+      }),
+      catchError(() => of(0))
+    );
+  }
+
+  private loadLevelOptions(pathIndex: number, levelIndex: number, parentPath: string): void {
+    if (!this.fsId) {
+      return;
+    }
+
+    const loadingKey = `${pathIndex}:${levelIndex}`;
+    this.loadingLevels = { ...this.loadingLevels, [loadingKey]: true };
+
+    this.cephfsService
+      .lsDir(this.fsId, parentPath, LS_DEPTH)
+      .pipe(
+        take(1),
+        catchError(() => of([])),
+        finalize(() => {
+          const { [loadingKey]: _, ...rest } = this.loadingLevels;
+          this.loadingLevels = rest;
+        }),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((dirs) => {
+        const entry = this.paths[pathIndex];
+        if (!entry) {
+          return;
+        }
+
+        const options = dirs
+          .map((dir) => dir.name)
+          .filter((name) =>
+            this.isPathSelectable(MirroringPathUtils.joinPath(parentPath, name), pathIndex)
+          )
+          .sort();
+
+        const levels = [...entry.levels];
+        if (levelIndex < levels.length) {
+          levels[levelIndex] = { ...levels[levelIndex], options };
+        } else if (options.length) {
+          levels.push({ options, selected: '' });
+        }
+
+        this.paths[pathIndex] = { ...entry, levels };
+        this.syncFormValue();
+      });
+  }
+
+  private isPathSelectable(path: string, pathIndex: number): boolean {
+    const normalized = MirroringPathUtils.normalizePath(path);
+    if (!normalized || MirroringPathUtils.isPathTracked(normalized, this.trackedPaths)) {
+      return false;
+    }
+
+    return !this.paths.some((entry, index) => {
+      if (index === pathIndex) {
+        return false;
+      }
+      const selected = MirroringPathUtils.normalizePath(entry.fullPath);
+      return selected && MirroringPathUtils.pathsOverlap(normalized, selected);
     });
-
-    const usedSubvols = this.getUsedSubvolumes(groupName, pathIndex);
-    const subvolNames = this.getChildNamesFromTree(groupPath).filter(
-      (name) =>
-        !usedSubvols.has(name) &&
-        !MirroringPathUtils.isMirroringPathTracked(
-          MirroringPathUtils.buildSubvolumePath(groupName, name),
-          this.trackedPaths
-        )
-    );
-
-    this.updatePath(pathIndex, {
-      ...updated,
-      levels: [
-        ...updated.levels,
-        { options: subvolNames, selected: '', kind: 'subvolume' as const }
-      ]
-    });
-  }
-
-  private handleSubvolumeSelection(pathIndex: number, entry: PathEntry, subvolName: string): void {
-    const groupName = entry.levels[0].selected;
-    const subvolPath = MirroringPathUtils.buildSubvolumePath(groupName, subvolName);
-    const dirChildren = this.getChildNamesFromTree(subvolPath).filter((name) =>
-      this.isPathAvailable(MirroringPathUtils.joinMirroringPath(subvolPath, name), pathIndex)
-    );
-
-    this.updatePath(
-      pathIndex,
-      MirroringPathUtils.withResolvedDisplayPath({
-        ...entry,
-        fullPath: subvolPath,
-        subvolumePath: subvolPath,
-        resolvedSubvolumeRoot: subvolPath,
-        levels: [
-          ...entry.levels.slice(0, 2),
-          ...(dirChildren.length
-            ? [{ options: dirChildren, selected: '', kind: 'dir' as const }]
-            : [])
-        ]
-      })
-    );
-  }
-
-  private handleDirSelection(pathIndex: number, entry: PathEntry): void {
-    const parentPath = MirroringPathUtils.normalizeMirroringPath(
-      MirroringPathUtils.getMirrorPath(entry) || entry.fullPath
-    );
-    const childNames = this.getChildNamesFromTree(parentPath).filter((name) =>
-      this.isPathAvailable(MirroringPathUtils.joinMirroringPath(parentPath, name), pathIndex)
-    );
-    this.updatePath(
-      pathIndex,
-      childNames.length
-        ? {
-            ...entry,
-            levels: [...entry.levels, { options: childNames, selected: '', kind: 'dir' as const }]
-          }
-        : entry
-    );
-  }
-
-  private updatePath(pathIndex: number, entry: PathEntry): void {
-    if (!this.paths[pathIndex]) return;
-    this.paths = this.paths.map((c, i) => (i === pathIndex ? entry : c));
-    this.syncFormValue();
   }
 
   private syncFormValue(): void {
     const { toAdd, alreadyMirrored } = this.getSubmitPaths();
     const control = this.pathsControl;
     control.setValue(toAdd, { emitEvent: false });
+
     if (toAdd.length) {
       control.setErrors(null);
     } else if (alreadyMirrored.length) {
@@ -222,113 +255,5 @@ export class MirroringPathsStepComponent implements OnInit, TearsheetStep {
     } else {
       control.setErrors({ required: true });
     }
-  }
-
-  private loadInitialData(): void {
-    if (!this.fsName) return;
-
-    this.resolveFs()
-      .pipe(
-        switchMap((fsId) =>
-          forkJoin([
-            this.subvolumeGroupService.get(this.fsName, false).pipe(catchError(() => of([]))),
-            fsId
-              ? this.cephfsService.lsDir(fsId, '/volumes', 3).pipe(catchError(() => of([])))
-              : of([]),
-            this.cephfsService.listMirrorDirectories(this.fsName).pipe(
-              map((r) => MirroringPathUtils.parseMirrorDirectoryList(r)),
-              catchError(() => of([] as string[]))
-            )
-          ])
-        ),
-        takeUntilDestroyed(this.destroyRef)
-      )
-      .subscribe(([groups, dirs, trackedList]: [{ name: string }[], CephfsDir[], string[]]) => {
-        this.dirTree = dirs.map(({ name, parent }) => ({ name, parent }));
-        this.trackedPaths = MirroringPathUtils.toTrackedPathSet(trackedList);
-
-        const groupNames = groups.map((g) => MirroringPathUtils.normalizeGroupOptionName(g.name));
-        if (!groupNames.includes(DEFAULT_SUBVOLUME_GROUP))
-          groupNames.unshift(DEFAULT_SUBVOLUME_GROUP);
-        this.cachedGroupNames = groupNames;
-
-        const available = this.filterAvailableGroupNames();
-        this.paths = this.paths.map((entry) => ({
-          ...entry,
-          levels: entry.levels.map((level, i) =>
-            i === 0 ? { ...level, options: available } : level
-          )
-        }));
-        this.syncFormValue();
-      });
-  }
-
-  private resolveFs(): Observable<number> {
-    return this.fsId
-      ? of(this.fsId)
-      : this.cephfsService.list().pipe(
-          map(
-            (fs: { id?: number; mdsmap?: { fs_name?: string } }[]) =>
-              fs.find((f) => f.mdsmap?.fs_name === this.fsName)?.id ?? 0
-          ),
-          map((id) => {
-            this.fsId = id;
-            return id;
-          }),
-          catchError(() => of(0))
-        );
-  }
-
-  private refreshGroupOptions(): void {
-    const available = this.filterAvailableGroupNames();
-    this.paths = this.paths.map((entry) => ({
-      ...entry,
-      levels: entry.levels.map((level, i) => (i === 0 ? { ...level, options: available } : level))
-    }));
-  }
-
-  private filterAvailableGroupNames(): string[] {
-    return this.cachedGroupNames.filter(
-      (name) =>
-        !MirroringPathUtils.isGroupPathMirrored(
-          MirroringPathUtils.buildGroupPath(name),
-          this.trackedPaths
-        )
-    );
-  }
-
-  private getUsedSubvolumes(groupName: string, excludeIndex: number): Set<string> {
-    const used = new Set<string>();
-    this.paths.forEach((entry, i) => {
-      if (i === excludeIndex) return;
-      const group = entry.levels.find((l) => l.kind === 'group');
-      const subvol = entry.levels.find((l) => l.kind === 'subvolume');
-      if (group?.selected === groupName && subvol?.selected) used.add(subvol.selected);
-    });
-    return used;
-  }
-
-  private getChildNamesFromTree(parentPath: string): string[] {
-    const normalized = MirroringPathUtils.normalizeMirroringPath(parentPath);
-    return this.dirTree
-      .filter((d) => MirroringPathUtils.normalizeMirroringPath(d.parent) === normalized)
-      .map((d) => d.name)
-      .filter(Boolean)
-      .sort();
-  }
-
-  private isPathAvailable(path: string, pathIndex: number): boolean {
-    const normalized = MirroringPathUtils.normalizeMirroringPath(path);
-    return (
-      !!normalized &&
-      !MirroringPathUtils.isMirroringPathTracked(normalized, this.trackedPaths) &&
-      !this.paths.some((entry, i) => {
-        if (i === pathIndex) return false;
-        const selected = MirroringPathUtils.normalizeMirroringPath(
-          MirroringPathUtils.getMirrorPath(entry)
-        );
-        return selected && MirroringPathUtils.mirroringPathsOverlap(normalized, selected);
-      })
-    );
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.ts
@@ -13,7 +13,7 @@ import { CdTableColumn } from '~/app/shared/models/cd-table-column';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
 import { ICON_TYPE } from '~/app/shared/enum/icons.enum';
 import { FormatterService } from '~/app/shared/services/formatter.service';
-import { MirrorStatusResponse } from '~/app/shared/models/cephfs.model';
+import { MirrorDirStatus, MirrorStatusResponse } from '~/app/shared/models/cephfs.model';
 
 interface MirrorPath {
   path: string;
@@ -37,58 +37,6 @@ interface MirrorPath {
   datasyncQueueWaitDuration?: string;
   avgReadThroughput?: string;
   avgWriteThroughput?: string;
-}
-
-interface PathData {
-  peer: Record<string, PeerInfo>;
-}
-
-interface PeerInfo {
-  state: string;
-  current_sync_snap?: CurrentSyncSnap;
-  current_syncing_snap?: CurrentSyncSnap;
-  last_synced_snap?: LastSyncedSnap;
-  snaps_synced?: number;
-  snaps_deleted?: number;
-  snaps_renamed?: number;
-}
-
-interface CurrentSyncSnap {
-  id?: number;
-  name: string;
-  'sync-mode'?: string;
-  avg_read_throughput_bytes?: string;
-  avg_write_throughput_bytes?: string;
-  crawl?: {
-    state?: string;
-    duration?: string;
-  };
-  datasync_queue_wait?: {
-    state?: string;
-    duration?: string;
-  };
-  bytes?: {
-    sync_bytes?: string;
-    total_bytes?: string;
-    sync_percent?: string;
-  };
-  files?: {
-    sync_files?: number;
-    total_files?: number;
-    sync_percent?: string;
-  };
-  eta?: string;
-}
-
-interface LastSyncedSnap {
-  id?: number;
-  name: string;
-  crawl_duration?: string;
-  datasync_queue_wait_duration?: string;
-  sync_duration?: string;
-  sync_time_stamp?: string;
-  sync_bytes?: string;
-  sync_files?: number;
 }
 
 @Component({
@@ -212,10 +160,12 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
 
     for (const path in data.metrics) {
       if (Object.prototype.hasOwnProperty.call(data.metrics, path)) {
-        const pathData = data.metrics[path] as PathData;
+        const pathData = data.metrics[path];
 
         // Skip invalid entries
-        if (!pathData?.peer) continue;
+        if (!pathData?.peer) {
+          continue;
+        }
 
         const peerInfo = this.extractPeerInfo(pathData);
         if (!peerInfo) continue;
@@ -260,12 +210,14 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
     return 0;
   }
 
-  private extractPeerInfo(pathData: PathData): PeerInfo | null {
+  private extractPeerInfo(pathData: {
+    peer?: Record<string, MirrorDirStatus>;
+  }): MirrorDirStatus | null {
     const peerEntries = Object.entries(pathData.peer ?? {});
     return peerEntries.length > 0 ? peerEntries[0][1] : null;
   }
 
-  private buildMirrorPath(path: string, peerInfo: PeerInfo): MirrorPath {
+  private buildMirrorPath(path: string, peerInfo: MirrorDirStatus): MirrorPath {
     const currentSnap = peerInfo.current_syncing_snap ?? peerInfo.current_sync_snap;
     const filesSynced = currentSnap?.files?.sync_files ?? 0;
     const totalFiles = currentSnap?.files?.total_files ?? 0;
@@ -290,7 +242,10 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
       currentSyncEta: currentSnap?.eta,
       currentSyncMode: currentSnap?.['sync-mode'],
       lastSyncedSnapshot: peerInfo.last_synced_snap?.name ?? '-',
-      lastSyncedTime: peerInfo.last_synced_snap?.sync_time_stamp,
+      lastSyncedTime:
+        peerInfo.last_synced_snap?.sync_time_stamp != null
+          ? String(peerInfo.last_synced_snap.sync_time_stamp)
+          : undefined,
       snapshotCount: peerInfo.snaps_synced ?? 0,
       checkpointCount: peerInfo.snaps_deleted ?? 0,
       renamedSnapshotCount: peerInfo.snaps_renamed ?? 0,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs.module.ts
@@ -66,8 +66,7 @@ import {
   TreeviewModule,
   TabsModule,
   NotificationModule,
-  ProgressBarModule,
-  FileUploaderModule
+  ProgressBarModule
 } from 'carbon-components-angular';
 
 import AddIcon from '@carbon/icons/es/add/32';
@@ -125,8 +124,7 @@ import FolderIcon16 from '@carbon/icons/es/folder/16';
     TilesModule,
     TagModule,
     NotificationModule,
-    ProgressBarModule,
-    FileUploaderModule
+    ProgressBarModule
   ],
   declarations: [
     CephfsDetailComponent,

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.spec.ts
@@ -64,12 +64,6 @@ describe('CephfsService', () => {
     httpTesting.expectOne('ui-api/cephfs/2/ls_dir?depth=2&path=%252Fsome%252Fpath');
   });
 
-  it('should call statfs', () => {
-    service.statfs(1, '/volumes/g1/sv1').subscribe();
-    const req = httpTesting.expectOne('api/cephfs/1/statfs?path=%252Fvolumes%252Fg1%252Fsv1');
-    expect(req.request.method).toBe('GET');
-  });
-
   it('should call mkSnapshot', () => {
     service.mkSnapshot(3, '/some/path').subscribe();
     const req = httpTesting.expectOne('api/cephfs/3/snapshot?path=%252Fsome%252Fpath');

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.ts
@@ -5,70 +5,9 @@ import _ from 'lodash';
 import { Observable } from 'rxjs';
 
 import { cdEncode, cdEncodeNot } from '../decorators/cd-encode';
-import { CephfsDir, CephfsDirStatfs, CephfsQuotas } from '../models/cephfs-directory-models';
+import { CephfsDir, CephfsQuotas } from '../models/cephfs-directory-models';
 import { shareReplay } from 'rxjs/operators';
 import { Daemon, MirrorPeerList, MirrorStatusResponse } from '../models/cephfs.model';
-
-export interface SnapshotMirrorStatusResponse {
-  metrics: {
-    [path: string]: {
-      peer: {
-        [peerId: string]: {
-          state: string;
-          current_sync_snap?: {
-            name: string;
-            files?: string | number;
-            bytes?: string | number;
-            eta_completion?: string;
-            files_synced?: number;
-            total_files?: number;
-            bytes_synced?: number;
-            total_bytes?: number;
-          };
-          current_syncing_snap?: {
-            id?: number;
-            name: string;
-            'sync-mode'?: string;
-            avg_read_throughput_bytes?: string;
-            avg_write_throughput_bytes?: string;
-            crawl?: {
-              state?: string;
-              duration?: string;
-            };
-            datasync_queue_wait?: {
-              state?: string;
-              duration?: string;
-            };
-            bytes?: {
-              sync_bytes?: string;
-              total_bytes?: string;
-              sync_percent?: string;
-            };
-            files?: {
-              sync_files?: number;
-              total_files?: number;
-              sync_percent?: string;
-            };
-            eta?: string;
-          };
-          last_synced_snap?: {
-            id: number;
-            name: string;
-            crawl_duration?: string;
-            datasync_queue_wait_duration?: string;
-            sync_duration?: string;
-            sync_time_stamp?: string;
-            sync_bytes?: string;
-            sync_files?: number;
-          };
-          snaps_synced?: number;
-          snaps_deleted?: number;
-          snaps_renamed?: number;
-        };
-      };
-    };
-  };
-}
 
 @cdEncode
 @Injectable({
@@ -90,11 +29,6 @@ export class CephfsService {
       apiPath += `&path=${encodeURIComponent(path)}`;
     }
     return this.http.get<CephfsDir[]>(apiPath).pipe(shareReplay());
-  }
-
-  statfs(id: number, path: string): Observable<CephfsDirStatfs> {
-    const params = new HttpParams().set('path', path);
-    return this.http.get<CephfsDirStatfs>(`${this.baseURL}/${id}/statfs`, { params });
   }
 
   getCephfs(id: number) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cephfs.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cephfs.model.ts
@@ -150,11 +150,55 @@ export interface MirrorSyncedSnap {
   sync_time_stamp?: number | string;
 }
 
+export interface MirrorSyncProgress {
+  state?: string;
+  duration?: string;
+}
+
+export interface MirrorSyncSnapBytes {
+  sync_bytes?: string;
+  total_bytes?: string;
+  sync_percent?: string;
+}
+
+export interface MirrorSyncSnapFiles {
+  sync_files?: number;
+  total_files?: number;
+  sync_percent?: string;
+}
+
+export interface MirrorCurrentSyncingSnap {
+  id?: number;
+  name: string;
+  'sync-mode'?: string;
+  avg_read_throughput_bytes?: string;
+  avg_write_throughput_bytes?: string;
+  crawl?: MirrorSyncProgress;
+  datasync_queue_wait?: MirrorSyncProgress;
+  bytes?: MirrorSyncSnapBytes;
+  files?: MirrorSyncSnapFiles;
+  eta?: string;
+}
+
+export interface MirrorLastSyncedSnap {
+  id?: number;
+  name?: string;
+  crawl_duration?: string;
+  datasync_queue_wait_duration?: string;
+  sync_duration?: string;
+  sync_time_stamp?: number | string;
+  sync_bytes?: number | string;
+  sync_files?: number;
+}
+
 export interface MirrorDirStatus {
   state?: string;
-  last_synced_snap?: MirrorSyncedSnap;
-  current_syncing_snap?: MirrorSyncedSnap;
+  last_synced_snap?: MirrorLastSyncedSnap;
+  current_syncing_snap?: MirrorCurrentSyncingSnap;
+  current_sync_snap?: MirrorCurrentSyncingSnap;
   snaps_synced?: number;
+  snaps_deleted?: number;
+  snaps_renamed?: number;
   metrics_updated_at?: number | string;
 }
 


### PR DESCRIPTION
mgr/dashboard: fix add path issues
  - Add loading indicator on path selection
  - Use ls_dir depth 1 lazy load on drop selection,
  - Hide already selected and mirrored paths
  - Remove unnecessary subvolumegroup api calls and saving tree on memory
  
  
[screen-capture (10).webm](https://github.com/user-attachments/assets/353eef7a-d9a4-402b-88af-f845d75f0e2e)


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
