### PR TITLE
crimson/osd: add per-class mClock scheduler perf counters

### DIFF
--- a/src/crimson/osd/osd_operation.cc
+++ b/src/crimson/osd/osd_operation.cc
@@ -167,9 +167,61 @@ void OperationThrottler::start()
   return;
 }
 
+void OperationThrottler::register_metrics(const std::string &sched_type) {
+  namespace sm = seastar::metrics;
+
+  LOG_PREFIX(OperationThrottler::register_metrics);
+  INFO("registering metrics for scheduler {}", sched_type);
+  const std::string group_name =
+    (sched_type == "mclock_scheduler") ? "osd_mclock" : "osd_wpq";
+
+  for (auto& [op_class, name] : {
+    std::pair{SchedulerClass::background_recovery,    "background_recovery"},
+    std::pair{SchedulerClass::background_best_effort, "background_best_effort"},
+    std::pair{SchedulerClass::client,                 "client"},
+    std::pair{SchedulerClass::repop,                  "repop"},
+    std::pair{SchedulerClass::immediate,              "immediate"},
+  }) {
+    auto label = sm::label("op_class")(name);
+    metrics.add_group(group_name, {
+      sm::make_counter("throttled_ops",
+        [this, op_class] { return throttled_ops[op_class]; },
+        sm::description("ops delayed by mClock scheduler"), {label}),
+      sm::make_counter("total_wait_ms",
+        [this, op_class] { return total_wait_ms[op_class]; },
+        sm::description("total ms spent waiting in mClock"), {label}),
+      sm::make_gauge("max_wait_ms",
+        [this, op_class] { return max_wait_ms[op_class]; },
+        sm::description("max wait ms in mClock by op class"), {label}),
+      sm::make_histogram("throttle_wait_latency",
+        [this, op_class]() -> seastar::metrics::histogram& {
+          return wait_hist[op_class]; },
+        sm::description("mClock throttle wait distribution"), {label}),
+    });
+  }
+}
+
+
 OperationThrottler::OperationThrottler(ConfigProxy &conf)
 {
   conf.add_observer(this);
+  for (auto op_class : {SchedulerClass::background_recovery,
+                        SchedulerClass::background_best_effort,
+                        SchedulerClass::client,
+                        SchedulerClass::repop,
+                        SchedulerClass::immediate}) {
+    wait_hist[op_class].buckets = {
+      {0, 1},
+      {0, 5},
+      {0, 10},
+      {0, 50},
+      {0, 100},
+      {0, 500},
+      {0, 1000},
+    };
+  }
+  register_metrics(conf.get_val<std::string>("osd_op_queue"));
+
 }
 
 void OperationThrottler::initialize_scheduler(CephContext *cct, ConfigProxy &conf, bool is_rotational, int whoami)
@@ -260,6 +312,26 @@ seastar::future<> OperationThrottler::stop()
   started = false;
 
   co_return;
+}
+
+void OperationThrottler::record_throttle_wait(
+  SchedulerClass op_class, uint64_t wait_ms)
+{
+  if (wait_ms == 0) {
+    return;
+  }
+  throttled_ops[op_class]++;
+  total_wait_ms[op_class] += wait_ms;
+  max_wait_ms[op_class] = std::max(max_wait_ms[op_class], wait_ms);
+
+  auto& h = wait_hist[op_class];
+  h.sample_count++;
+  h.sample_sum += wait_ms;
+  for (auto& bucket : h.buckets) {
+    if (wait_ms <= bucket.upper_bound) {
+      bucket.count++;
+    }
+  }
 }
 
 void OperationThrottler::dump_detail(Formatter *f) const

--- a/src/crimson/osd/osd_operation.h
+++ b/src/crimson/osd/osd_operation.h
@@ -362,6 +362,13 @@ class OperationThrottler : public BlockerT<OperationThrottler>,
   friend BlockerT<OperationThrottler>;
   static constexpr const char* type_name = "OperationThrottler";
 
+  // Perf counters used to capture mClock throttling behavior per op class
+  std::unordered_map<SchedulerClass, uint64_t> throttled_ops;
+  std::unordered_map<SchedulerClass, uint64_t> total_wait_ms;
+  std::unordered_map<SchedulerClass, uint64_t> max_wait_ms;
+  std::unordered_map<SchedulerClass, seastar::metrics::histogram> wait_hist;
+  seastar::metrics::metric_groups metrics;
+
 public:
   OperationThrottler(ConfigProxy &conf);
   void start();
@@ -396,14 +403,19 @@ public:
     }
   };
 
+  void record_throttle_wait(SchedulerClass op_class, uint64_t wait_ms);
   auto get_throttle(crimson::osd::scheduler::params_t params) {
+    auto start = seastar::steady_clock_type::now();
     return acquire_throttle(
       params
-    ).then([this] {
+    ).then([this, start, klass = params.klass] {
+      auto wait_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+      seastar::steady_clock_type::now() - start).count();
+      record_throttle_wait(klass, wait_ms);
       return ThrottleReleaser{this};
     });
   }
-
+  void register_metrics(const std::string &sched_type);
   void initialize_scheduler(CephContext* cct, ConfigProxy &conf, bool is_rotational, int whoami);
 private:
   void dump_detail(Formatter *f) const final;


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/77806





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
