### PR TITLE
mgr/dashboard: restricting admin user to revoke its own admin permissions

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form-role.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form-role.model.ts
@@ -4,6 +4,7 @@ export class UserFormRoleModel implements SelectOption {
   name: string;
   description: string;
   selected = false;
+  disabled: boolean = false;
   scopes_permissions?: object;
   enabled: boolean;
   content: string;

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.html
@@ -217,6 +217,7 @@
       <div
         class="form-item"
         *ngIf="allRoles"
+        [class.roles-clear-disabled]="isAdminRoleProtected"
       >
         <cds-combo-box
           label="Roles"
@@ -233,9 +234,10 @@
           [cdRequiredField]="!isSSO ? 'Roles' : ''"
           [invalid]="!userForm.controls.roles.valid && userForm.controls.roles.dirty"
           [invalidText]="rolesError"
+          (clear)="onRolesClear()"
           i18n
         >
-          <cds-dropdown-list [listTpl]="roleItemTpl"></cds-dropdown-list>
+          <cds-dropdown-list></cds-dropdown-list>
         </cds-combo-box>
 
         <ng-template #rolesError>
@@ -243,29 +245,8 @@
             class="invalid-feedback"
             *ngIf="userForm.showError('roles', formDir, 'required')"
             i18n
-            >This field is required.</span>
-        </ng-template>        
-        
-        <ng-template #roleItemTpl
-                    let-item="item">
-          <div class="cds--form-item cds--checkbox-wrapper">
-            <label class="cds--checkbox-label"
-                  [attr.data-contained-checkbox-disabled]="item.disabled ? 'true' : null"
-                  [attr.data-contained-checkbox-state]="item.selected ? 'true' : 'false'"
-                  [ngbTooltip]="item.disabled ? roleTooltipTpl : null">
-              <input class="cds--checkbox"
-                    type="checkbox"
-                    [checked]="item.selected"
-                    [disabled]="item.disabled"
-                    tabindex="-1"/>
-              <span class="cds--checkbox-appearance"></span>
-              <span class="cds--checkbox-label-text">{{ item.content }}</span>
-            </label>
-          </div>
-        </ng-template>
-
-        <ng-template #roleTooltipTpl>
-          <span i18n>You cannot remove the administrator role from your own account.</span>
+            >This field is required.</span
+          >
         </ng-template>
       </div>
       <!-- Enabled -->

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.html
@@ -235,15 +235,37 @@
           [invalidText]="rolesError"
           i18n
         >
-          <cds-dropdown-list></cds-dropdown-list>
+          <cds-dropdown-list [listTpl]="roleItemTpl"></cds-dropdown-list>
         </cds-combo-box>
+
         <ng-template #rolesError>
           <span
             class="invalid-feedback"
             *ngIf="userForm.showError('roles', formDir, 'required')"
             i18n
-            >This field is required.</span
-          >
+            >This field is required.</span>
+        </ng-template>        
+        
+        <ng-template #roleItemTpl
+                    let-item="item">
+          <div class="cds--form-item cds--checkbox-wrapper">
+            <label class="cds--checkbox-label"
+                  [attr.data-contained-checkbox-disabled]="item.disabled ? 'true' : null"
+                  [attr.data-contained-checkbox-state]="item.selected ? 'true' : 'false'"
+                  [ngbTooltip]="item.disabled ? roleTooltipTpl : null">
+              <input class="cds--checkbox"
+                    type="checkbox"
+                    [checked]="item.selected"
+                    [disabled]="item.disabled"
+                    tabindex="-1"/>
+              <span class="cds--checkbox-appearance"></span>
+              <span class="cds--checkbox-label-text">{{ item.content }}</span>
+            </label>
+          </div>
+        </ng-template>
+
+        <ng-template #roleTooltipTpl>
+          <span i18n>You cannot remove the administrator role from your own account.</span>
         </ng-template>
       </div>
       <!-- Enabled -->

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.scss
@@ -1,0 +1,7 @@
+.roles-clear-disabled {
+  cds-combo-box .cds--list-box__selection--multi {
+    pointer-events: none;
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.spec.ts
@@ -205,6 +205,7 @@ describe('UserFormComponent', () => {
     beforeEach(() => {
       spyOn(userService, 'get').and.callFake(() => of(user));
       spyOn(TestBed.inject(RoleService), 'list').and.callFake(() => of(roles));
+      spyOn(TestBed.inject(AuthStorageService), 'getUsername').and.returnValue(user.username);
       setUrl('/user-management/users/edit/user1');
       spyOn(TestBed.inject(SettingsService), 'getStandardSettings').and.callFake(() =>
         of({
@@ -249,8 +250,19 @@ describe('UserFormComponent', () => {
       expect(form.get('confirmpassword').valid).toBeTruthy();
     });
 
+    it('should disable administrator role for current user', () => {
+      const administratorRole = component.allRoles.find((role) => role.name === 'administrator');
+      expect(administratorRole.disabled).toBeTruthy();
+      expect(component.disableRolesClearButton()).toBeTruthy();
+    });
+
+    it('should restore roles when clear is triggered for current user with protected admin role', () => {
+      formHelper.setValue('roles', []);
+      component.onRolesClear();
+      expect(form.getValue('roles')).toContain('administrator');
+    });
+
     it('should alert if user is removing needed role permission', () => {
-      spyOn(TestBed.inject(AuthStorageService), 'getUsername').and.callFake(() => user.username);
       let modalBodyTpl = null;
       spyOn(modalService, 'show').and.callFake((_content, initialState) => {
         modalBodyTpl = initialState.bodyTpl;
@@ -261,7 +273,6 @@ describe('UserFormComponent', () => {
     });
 
     it('should logout if current user roles have been changed', () => {
-      spyOn(TestBed.inject(AuthStorageService), 'getUsername').and.callFake(() => user.username);
       formHelper.setValue('roles', ['user-manager']);
       component.submit();
       const userReq = httpTesting.expectOne(`api/user/${user.username}`);
@@ -272,7 +283,6 @@ describe('UserFormComponent', () => {
     });
 
     it('should submit', () => {
-      spyOn(TestBed.inject(AuthStorageService), 'getUsername').and.callFake(() => user.username);
       component.submit();
       const userReq = httpTesting.expectOne(`api/user/${user.username}`);
       expect(userReq.request.method).toBe('PUT');

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.ts
@@ -180,6 +180,13 @@ export class UserFormComponent extends CdForm implements OnInit {
       this.userService.get(username).subscribe((userFormModel: UserFormModel) => {
         this.response = _.cloneDeep(userFormModel);
         this.setResponse(userFormModel);
+        if (this.authStorageService.getUsername() === username) {
+          this.allRoles = _.map(this.allRoles, (role) => {
+            role.disabled =
+              role.name.toLowerCase() === 'administrator' && this.isCurrentUser() ? true : false;
+            return role;
+          });
+        }
         this.loadingReady();
       });
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import { Component, OnInit, TemplateRef, ViewChild, ViewEncapsulation } from '@angular/core';
 import { Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 
@@ -33,7 +33,8 @@ import { UserFormModel } from './user-form.model';
   selector: 'cd-user-form',
   templateUrl: './user-form.component.html',
   styleUrls: ['./user-form.component.scss'],
-  standalone: false
+  standalone: false,
+  encapsulation: ViewEncapsulation.None
 })
 export class UserFormComponent extends CdForm implements OnInit {
   @ViewChild('removeSelfUserReadUpdatePermissionTpl', { static: true })
@@ -59,6 +60,8 @@ export class UserFormComponent extends CdForm implements OnInit {
   selectedRole: string[];
   passwordexp: boolean = false;
   isSSO = false;
+  isAdminRoleProtected: boolean = false;
+
   constructor(
     private authService: AuthService,
     private authStorageService: AuthStorageService,
@@ -180,13 +183,13 @@ export class UserFormComponent extends CdForm implements OnInit {
       this.userService.get(username).subscribe((userFormModel: UserFormModel) => {
         this.response = _.cloneDeep(userFormModel);
         this.setResponse(userFormModel);
-        if (this.authStorageService.getUsername() === username) {
-          this.allRoles = _.map(this.allRoles, (role) => {
-            role.disabled =
-              role.name.toLowerCase() === 'administrator' && this.isCurrentUser() ? true : false;
-            return role;
-          });
+        if (this.authStorageService.getUsername() === userFormModel.username) {
+          this.allRoles = _.map(this.allRoles, (role) => ({
+            ...role,
+            disabled: role.name.toLowerCase() === 'administrator'
+          }));
         }
+        this.isAdminRoleProtected = this.disableRolesClearButton();
         this.loadingReady();
       });
     });
@@ -274,6 +277,26 @@ export class UserFormComponent extends CdForm implements OnInit {
 
   public isCurrentUser(): boolean {
     return this.authStorageService.getUsername() === this.userForm.getValue('username');
+  }
+
+  disableRolesClearButton(): boolean {
+    if (!this.isCurrentUser() || !this.allRoles) {
+      return false;
+    }
+    const administratorRole = this.allRoles.find(
+      (role) => role.name.toLowerCase() === 'administrator'
+    );
+    return !!administratorRole?.disabled;
+  }
+
+  onRolesClear(): void {
+    if (!this.disableRolesClearButton()) {
+      return;
+    }
+    const roles = this.userForm.getValue('roles') ?? [];
+    if (!roles.includes('administrator')) {
+      this.userForm.get('roles').setValue([...roles, 'administrator'], { emitEvent: false });
+    }
   }
 
   private isUserChangingRoles(): boolean {


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/77813
Signed-off-by: Devika Babrekar <devika.babrekar@ibm.com>

Description:
Previously,  when admin user tried to revoke its own admin permission, user management screen use to go into loading phase without any action being performed.
To fix this, checkbox for admin permissions for current admin user is disabled under this PR.

<img width="3806" height="1985" alt="image" src="https://github.com/user-attachments/assets/52e2f917-6280-45b3-9dc9-3d44e643ca68" />


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
