### PR TITLE
mgr/dashboard: updating SMB rate limiting form fields

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-share-form/smb-share-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-share-form/smb-share-form.component.html
@@ -361,34 +361,34 @@
       >
         <div cdsCol>
           <cds-number
-            formControlName="read_delay_max"
+            formControlName="read_burst_mult"
             cdValidate
-            #readDelayRef="cdValidate"
-            label="Read delay max (s)"
+            #readBurstRef="cdValidate"
+            label="Read burst mult"
             i18n-label
-            [min]="0"
-            [max]="300"
-            helperText="Max allowed delay for read operations in seconds"
+            [min]="10"
+            [max]="100"
+            helperText="Burst multiplier for read operations, allowing temporary bursts above the configured limit."
             i18n-helperText
-            [invalid]="readDelayRef.isInvalid"
-            invalidText="Value must be between 0 and 300"
+            [invalid]="readBurstRef.isInvalid"
+            invalidText="Value must be between 10 and 100"
             i18n-invalidText
           >
           </cds-number>
         </div>
         <div cdsCol>
           <cds-number
-            formControlName="write_delay_max"
+            formControlName="write_burst_mult"
             cdValidate
-            #writeDelayRef="cdValidate"
-            label="Write delay max (s)"
+            #writeBurstRef="cdValidate"
+            label="Write burst mult"
             i18n-label
-            [min]="0"
-            [max]="300"
-            helperText="Max allowed delay for write operations in seconds"
+            [min]="10"
+            [max]="100"
+            helperText="Burst multiplier for write operations, allowing temporary bursts above the configured limit."
             i18n-helperText
-            [invalid]="writeDelayRef.isInvalid"
-            invalidText="Value must be between 0 and 300"
+            [invalid]="writeBurstRef.isInvalid"
+            invalidText="Value must be between 10 and 100"
             i18n-invalidText
           >
           </cds-number>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-share-form/smb-share-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-share-form/smb-share-form.component.spec.ts
@@ -42,6 +42,7 @@ describe('SmbShareFormComponent', () => {
 
     fixture = TestBed.createComponent(SmbShareFormComponent);
     component = fixture.componentInstance;
+    component.ngOnInit();
     fixture.detectChanges();
   });
 
@@ -50,7 +51,6 @@ describe('SmbShareFormComponent', () => {
   });
 
   it('should create the form', () => {
-    component.ngOnInit();
     expect(component.smbShareForm).toBeDefined();
     expect(component.smbShareForm.get('share_id')).toBeTruthy();
     expect(component.smbShareForm.get('volume')).toBeTruthy();
@@ -97,8 +97,8 @@ describe('SmbShareFormComponent', () => {
       read_bw_limit_unit: 'MiB',
       write_bw_limit: 0,
       write_bw_limit_unit: 'MiB',
-      read_delay_max: 30,
-      write_delay_max: 30
+      read_burst_mult: 15,
+      write_burst_mult: 15
     });
     component.submitAction();
     expect(component).toBeTruthy();
@@ -106,17 +106,16 @@ describe('SmbShareFormComponent', () => {
 
   describe('QoS', () => {
     it('should have QoS form controls with default values', () => {
-      component.ngOnInit();
       expect(component.smbShareForm.get('read_iops_limit')).toBeTruthy();
       expect(component.smbShareForm.get('write_iops_limit')).toBeTruthy();
       expect(component.smbShareForm.get('read_bw_limit')).toBeTruthy();
       expect(component.smbShareForm.get('read_bw_limit_unit')).toBeTruthy();
       expect(component.smbShareForm.get('write_bw_limit')).toBeTruthy();
       expect(component.smbShareForm.get('write_bw_limit_unit')).toBeTruthy();
-      expect(component.smbShareForm.get('read_delay_max')).toBeTruthy();
-      expect(component.smbShareForm.get('write_delay_max')).toBeTruthy();
+      expect(component.smbShareForm.get('read_burst_mult')).toBeTruthy();
+      expect(component.smbShareForm.get('write_burst_mult')).toBeTruthy();
       expect(component.smbShareForm.get('read_iops_limit').value).toBe(0);
-      expect(component.smbShareForm.get('write_delay_max').value).toBe(30);
+      expect(component.smbShareForm.get('write_burst_mult').value).toBe(15);
     });
 
     it('should include QoS fields in buildRequest when set', () => {
@@ -130,13 +129,13 @@ describe('SmbShareFormComponent', () => {
         write_iops_limit: 500,
         read_bw_limit: 100,
         read_bw_limit_unit: 'MiB',
-        write_delay_max: 60
+        write_burst_mult: 60
       });
       const request = component.buildRequest();
       expect(request.share_resource.cephfs.qos.read_iops_limit).toBe(1000);
       expect(request.share_resource.cephfs.qos.write_iops_limit).toBe(500);
       expect(request.share_resource.cephfs.qos.read_bw_limit).toBe(100 * 1024 * 1024);
-      expect(request.share_resource.cephfs.qos.write_delay_max).toBe(60);
+      expect(request.share_resource.cephfs.qos.write_burst_mult).toBe(60);
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-share-form/smb-share-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-share-form/smb-share-form.component.ts
@@ -33,8 +33,9 @@ const UNIT_TO_BYTES: Record<string, number> = {
   GiB: 2 ** 30,
   TiB: 2 ** 40
 };
-const QOS_DELAY_MAX = 300;
-const QOS_DELAY_DEFAULT = 30;
+const QOS_BURST_MULT_MIN = 10;
+const QOS_BURST_MULT_MAX = 100;
+const QOS_BURST_MULT_DEFAULT = 15;
 const QOS_BW_UNITS = ['KiB', 'MiB', 'GiB', 'TiB'];
 
 function getBwMaxForUnit(unit: string): number {
@@ -106,8 +107,8 @@ export class SmbShareFormComponent extends CdForm implements OnInit {
           browseable: this.shareResponse.browseable ?? true,
           read_iops_limit: qos?.read_iops_limit,
           write_iops_limit: qos?.write_iops_limit,
-          read_delay_max: qos?.read_delay_max,
-          write_delay_max: qos?.write_delay_max
+          read_burst_mult: qos?.read_burst_mult,
+          write_burst_mult: qos?.write_burst_mult
         });
         this.smbShareForm.get('share_id').disable();
         this.smbShareForm.get('name').disable();
@@ -167,13 +168,13 @@ export class SmbShareFormComponent extends CdForm implements OnInit {
       read_bw_limit_unit: new FormControl(QOS_BW_UNITS[1]),
       write_bw_limit: new FormControl(0, [Validators.min(0), Validators.max(this.writeBwMax)]),
       write_bw_limit_unit: new FormControl(QOS_BW_UNITS[1]),
-      read_delay_max: new FormControl(QOS_DELAY_DEFAULT, [
-        Validators.min(0),
-        Validators.max(QOS_DELAY_MAX)
+      read_burst_mult: new FormControl(QOS_BURST_MULT_DEFAULT, [
+        Validators.min(QOS_BURST_MULT_MIN),
+        Validators.max(QOS_BURST_MULT_MAX)
       ]),
-      write_delay_max: new FormControl(QOS_DELAY_DEFAULT, [
-        Validators.min(0),
-        Validators.max(QOS_DELAY_MAX)
+      write_burst_mult: new FormControl(QOS_BURST_MULT_DEFAULT, [
+        Validators.min(QOS_BURST_MULT_MIN),
+        Validators.max(QOS_BURST_MULT_MAX)
       ])
     });
   }
@@ -298,8 +299,8 @@ export class SmbShareFormComponent extends CdForm implements OnInit {
                 ' ' +
                 this.smbShareForm.get('write_bw_limit_unit').value
             ),
-            read_delay_max: rawFormValue.read_delay_max,
-            write_delay_max: rawFormValue.write_delay_max
+            read_burst_mult: rawFormValue.read_burst_mult,
+            write_burst_mult: rawFormValue.write_burst_mult
           }
         },
         browseable: rawFormValue.browseable,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb.model.ts
@@ -83,8 +83,8 @@ export interface SMBShareQoS {
   write_iops_limit?: number;
   read_bw_limit?: number;
   write_bw_limit?: number;
-  read_delay_max?: number;
-  write_delay_max?: number;
+  read_burst_mult?: number;
+  write_burst_mult?: number;
 }
 
 export interface SMBShare {


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/77815
Signed-off-by: Devika Babrekar <devika.babrekar@ibm.com>

Description:
Two input fields of SMB rate limiting form, Read delay max (s) and Write delay max (s) with default value as 30 are deprecated.
Instead, two new fields are introduced as follows:
Read burst mult and Write Burst Mult with default value as 15.

What these fields do?
read_burst_mult
Optional integer. Burst multiplier for read operations (value ÷ 10 = multiplier), allowing temporary bursts above the configured limit. Example: 20 = 2* the configured limit. Range: 10-100 (1* to 10*), default: 15 (1.5*).

write_burst_mult
Optional integer. Burst multiplier for write operations (value ÷ 10 = multiplier), allowing temporary bursts above the configured limit. Example: 20 = 2* the configured limit. Range: 10-100 (1* to 10*), default: 15 (1.5*).

https://github.com/user-attachments/assets/75721668-3605-4dc7-821d-cf183a853b25


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
