### PR TITLE
librbd: fix use-after-free in trash purge on image open error

### DIFF
--- a/src/librbd/api/Trash.cc
+++ b/src/librbd/api/Trash.cc
@@ -487,6 +487,7 @@ int Trash<I>::purge(IoCtx& io_ctx, time_t expire_ts,
           } else if (r < 0) {
             lderr(cct) << "failed to open image " << it << ": "
                        << cpp_strerror(r) << dendl;
+            continue;
           }
 
           r = librbd::api::DiffIterate<I>::diff_iterate(


### PR DESCRIPTION
When `ImageState::open()` fails with an error other than -ENOENT, it
asynchronously deletes the ImageCtx before returning. The trash purge
loop only skipped the -ENOENT case and fell through on every other
error, dereferencing the already-freed ictx in `diff_iterate()` and
`state->close()`. Add the missing `continue` so a failed open is skipped.

The fall-through dates back to 504f4e78, which split `if (r < 0)
continue` to log non-ENOENT errors but dropped the continue.

Fixes: https://tracker.ceph.com/issues/77836

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests