### PR TITLE
qa/tasks/nvme_loop: fall back to sysfs-based discovery if needed

### DIFF
--- a/qa/tasks/nvme_loop.py
+++ b/qa/tasks/nvme_loop.py
@@ -24,6 +24,7 @@ def task(ctx, config):
             continue
         devs = teuthology.get_scratch_devices(remote)
         devs_by_remote[remote] = devs
+        existing_nvme_devs = set(discover_devs_via_sysfs(remote))
         base = '/sys/kernel/config/nvmet'
         remote.run(
             args=[
@@ -75,11 +76,6 @@ def task(ctx, config):
         # identify nvme_loops devices
         old_scratch_by_remote[remote] = remote.read_file('/scratch_devs')
 
-        # nqn used for each scratch device when connecting it above; used
-        # as a fallback identifier if `nvme list -o json` is unreliable
-        # (see sysfs fallback below).
-        nqns_by_dev = {dev: dev.split('/')[-1] for dev in devs}
-
         new_devs = []
         json_failures = 0
         # after this many consecutive `nvme list -o json` crashes, stop
@@ -96,7 +92,10 @@ def task(ctx, config):
                         f'nvme list -o json crashed {json_failures} times '
                         'in a row; falling back to sysfs-based discovery'
                     )
-                    new_devs = discover_devs_via_sysfs(remote, nqns_by_dev)
+                    new_devs = sorted(
+                        set(discover_devs_via_sysfs(remote))
+                        - existing_nvme_devs
+                    )
                     for dev in new_devs:
                         bluestore_zap(remote, dev)
                     log.info(f'new_devs (sysfs fallback) {new_devs}')
@@ -281,61 +280,33 @@ def task(ctx, config):
             )
 
 
-def discover_devs_via_sysfs(remote, nqns_by_dev: dict) -> list:
+def discover_devs_via_sysfs(remote) -> list:
     """
-    Fallback nvme_loop device discovery that does not rely on
-    `nvme list -o json`, which has been observed to segfault on some
-    kernels (e.g. 6.8.0-* on ubuntu_24.04), exhausting safe_while retries
-    before any device discovery could succeed.
+    Return visible NVMe namespace block devices from /sys/class/block.
 
-    Each nvme_loop subsystem is created (see above) using the scratch
-    device's basename as both the subsystem directory name and the NQN
-    passed to `nvme connect -n <nqn>`. After connecting, the resulting
-    in-kernel NVMe controller exposes that NQN at
-    /sys/class/nvme/nvmeX/subsysnqn, and its namespace block device(s)
-    live in /sys/class/nvme/nvmeX/nvmeXnY. This walks sysfs directly to
-    map each expected NQN back to its /dev/nvmeXnY path, with no
-    dependency on nvme-cli's (crash-prone) JSON formatter.
-
-    :param nqns_by_dev: mapping of original scratch device path
-        (e.g. '/dev/sdb') -> nqn used to connect it (e.g. 'sdb')
-    :returns: list of discovered /dev/nvmeXnY paths, one per nqn found
+    Walking /sys/class/nvme/nvmeX/nvmeXnY is not reliable with native
+    NVMe multipath, where controller-path and namespace-head devices can
+    use different names. Only namespace-head devices (nvmeXnY) are
+    returned; partitions and controller-path devices are ignored.
     """
     out = StringIO()
     remote.run(
         args=[
             'bash', '-c',
-            'for d in /sys/class/nvme/nvme*/; do '
-            'c=$(basename "$d"); '
-            'n=$(cat "${d}subsysnqn" 2>/dev/null); '
-            'for ns in "${d}"${c}n*; do '
-            '[ -e "$ns" ] && echo "${c}|${n}|$(basename "$ns")"; '
-            'done; '
+            'for d in /sys/class/block/nvme*n*; do '
+            '[ -e "$d" ] || continue; '
+            'n=$(basename "$d"); '
+            '[[ "$n" =~ ^nvme[0-9]+n[0-9]+$ ]] && echo "/dev/$n"; '
             'done'
         ],
         stdout=out,
         check_status=False,
     )
-
-    nqn_to_dev = {}
-    for line in out.getvalue().splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            _ctrl, nqn, ns = line.split('|', 2)
-        except ValueError:
-            continue
-        # first namespace seen for a given nqn wins; nvme_loop subsystems
-        # here are only ever set up with a single namespace (see above)
-        nqn_to_dev.setdefault(nqn, f'/dev/{ns}')
-
-    new_devs = []
-    for nqn in nqns_by_dev.values():
-        dev = nqn_to_dev.get(nqn)
-        if dev:
-            new_devs.append(dev)
-    return new_devs
+    return [
+        line.strip()
+        for line in out.getvalue().splitlines()
+        if line.strip()
+    ]
 
 
 def bluestore_zap(remote, device: str) -> None:

--- a/qa/tasks/nvme_loop.py
+++ b/qa/tasks/nvme_loop.py
@@ -75,20 +75,50 @@ def task(ctx, config):
         # identify nvme_loops devices
         old_scratch_by_remote[remote] = remote.read_file('/scratch_devs')
 
+        # nqn used for each scratch device when connecting it above; used
+        # as a fallback identifier if `nvme list -o json` is unreliable
+        # (see sysfs fallback below).
+        nqns_by_dev = {dev: dev.split('/')[-1] for dev in devs}
+
+        new_devs = []
+        json_failures = 0
+        # after this many consecutive `nvme list -o json` crashes, stop
+        # retrying the (apparently broken) command and fall back to
+        # discovering devices directly via sysfs instead.
+        max_json_failures = 5
+
         with contextutil.safe_while(sleep=1, tries=15) as proceed:
             while proceed():
                 remote.run(args=['lsblk'], stdout=StringIO())
+
+                if json_failures >= max_json_failures:
+                    log.warning(
+                        f'nvme list -o json crashed {json_failures} times '
+                        'in a row; falling back to sysfs-based discovery'
+                    )
+                    new_devs = discover_devs_via_sysfs(remote, nqns_by_dev)
+                    for dev in new_devs:
+                        bluestore_zap(remote, dev)
+                    log.info(f'new_devs (sysfs fallback) {new_devs}')
+                    assert len(new_devs) <= len(devs)
+                    if len(new_devs) == len(devs):
+                        break
+                    continue
+
                 try:
                     p = remote.run(
                         args=['sudo', 'nvme', 'list', '-o', 'json'],
                         stdout=StringIO(),
                     )
                 except CommandCrashedError:
+                    json_failures += 1
                     log.warning(
-                        'nvme list -o json command failed, retrying...'
+                        f'nvme list -o json command failed '
+                        f'({json_failures}/{max_json_failures}), retrying...'
                     )
                     continue
 
+                json_failures = 0
                 new_devs = []
                 # `nvme list -o json` will return one of the following output:
                 '''{
@@ -249,6 +279,64 @@ def task(ctx, config):
                 data=old_scratch_by_remote[remote],
                 sudo=True
             )
+
+
+def discover_devs_via_sysfs(remote, nqns_by_dev: dict) -> list:
+    """
+    Fallback nvme_loop device discovery that does not rely on
+    `nvme list -o json`, which has been observed to segfault on some
+    kernels (e.g. 6.8.0-* on ubuntu_24.04), exhausting safe_while retries
+    before any device discovery could succeed.
+
+    Each nvme_loop subsystem is created (see above) using the scratch
+    device's basename as both the subsystem directory name and the NQN
+    passed to `nvme connect -n <nqn>`. After connecting, the resulting
+    in-kernel NVMe controller exposes that NQN at
+    /sys/class/nvme/nvmeX/subsysnqn, and its namespace block device(s)
+    live in /sys/class/nvme/nvmeX/nvmeXnY. This walks sysfs directly to
+    map each expected NQN back to its /dev/nvmeXnY path, with no
+    dependency on nvme-cli's (crash-prone) JSON formatter.
+
+    :param nqns_by_dev: mapping of original scratch device path
+        (e.g. '/dev/sdb') -> nqn used to connect it (e.g. 'sdb')
+    :returns: list of discovered /dev/nvmeXnY paths, one per nqn found
+    """
+    out = StringIO()
+    remote.run(
+        args=[
+            'bash', '-c',
+            'for d in /sys/class/nvme/nvme*/; do '
+            'c=$(basename "$d"); '
+            'n=$(cat "${d}subsysnqn" 2>/dev/null); '
+            'for ns in "${d}"${c}n*; do '
+            '[ -e "$ns" ] && echo "${c}|${n}|$(basename "$ns")"; '
+            'done; '
+            'done'
+        ],
+        stdout=out,
+        check_status=False,
+    )
+
+    nqn_to_dev = {}
+    for line in out.getvalue().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            _ctrl, nqn, ns = line.split('|', 2)
+        except ValueError:
+            continue
+        # first namespace seen for a given nqn wins; nvme_loop subsystems
+        # here are only ever set up with a single namespace (see above)
+        nqn_to_dev.setdefault(nqn, f'/dev/{ns}')
+
+    new_devs = []
+    for nqn in nqns_by_dev.values():
+        dev = nqn_to_dev.get(nqn)
+        if dev:
+            new_devs.append(dev)
+    return new_devs
+
 
 def bluestore_zap(remote, device: str) -> None:
     for offset in [0, 1073741824, 10737418240]:

--- a/qa/tasks/nvme_loop.py
+++ b/qa/tasks/nvme_loop.py
@@ -24,6 +24,7 @@ def task(ctx, config):
             continue
         devs = teuthology.get_scratch_devices(remote)
         devs_by_remote[remote] = devs
+        expected_nqns = {dev.split('/')[-1] for dev in devs}
         existing_nvme_devs = set(discover_devs_via_sysfs(remote))
         base = '/sys/kernel/config/nvmet'
         remote.run(
@@ -93,7 +94,7 @@ def task(ctx, config):
                         'in a row; falling back to sysfs-based discovery'
                     )
                     new_devs = sorted(
-                        set(discover_devs_via_sysfs(remote))
+                        set(discover_devs_via_sysfs_by_nqn(remote, expected_nqns))
                         - existing_nvme_devs
                     )
                     for dev in new_devs:
@@ -307,6 +308,43 @@ def discover_devs_via_sysfs(remote) -> list:
         for line in out.getvalue().splitlines()
         if line.strip()
     ]
+
+
+def discover_devs_via_sysfs_by_nqn(remote, expected_nqns) -> list:
+    """
+    Return visible NVMe namespace heads for the expected subsystems.
+
+    The nvme_loop task uses each scratch-device basename as the subsystem
+    NQN. Walk /sys/class/nvme-subsystem so discovery remains compatible
+    with native NVMe multipath while excluding unrelated NVMe devices.
+    """
+    out = StringIO()
+    remote.run(
+        args=[
+            'bash', '-c',
+            'for s in /sys/class/nvme-subsystem/nvme-subsys*; do '
+            '[ -e "$s" ] || continue; '
+            'nqn=$(cat "$s/subsysnqn" 2>/dev/null) || continue; '
+            'for d in "$s"/nvme*n*; do '
+            '[ -e "$d" ] || continue; '
+            'n=$(basename "$d"); '
+            '[[ "$n" =~ ^nvme[0-9]+n[0-9]+$ ]] '
+            '&& printf "%s\\t/dev/%s\\n" "$nqn" "$n"; '
+            'done; '
+            'done'
+        ],
+        stdout=out,
+        check_status=False,
+    )
+    devices = []
+    for line in out.getvalue().splitlines():
+        try:
+            nqn, dev = line.split('\t', 1)
+        except ValueError:
+            continue
+        if nqn in expected_nqns:
+            devices.append(dev)
+    return devices
 
 
 def bluestore_zap(remote, device: str) -> None:


### PR DESCRIPTION
## Summary

Add a sysfs-based fallback to `qa/tasks/nvme_loop.py` for discovering NVMe loop namespace devices when `nvme list -o json` repeatedly fails.

The fallback is compatible with native NVMe multipath and restricts discovery to namespace heads belonging to the NVMe subsystems created by the task.

## Problem

On some systems, `nvme list -o json` can fail even though the NVMe loop devices were successfully created.

The original fallback walked controller-specific paths under `/sys/class/nvme`, which is unreliable with native NVMe multipath because namespace-head and controller-path device names can differ.

A later fallback based only on the set of newly appearing `/sys/class/block/nvme*n*` devices fixed the multipath issue, but could also include unrelated NVMe namespaces that appeared during setup.

Since discovered devices are later passed to `bluestore_zap()`, the fallback needs to ensure that only namespaces belonging to the task are selected.

## Fix

The task now:

* records the existing NVMe namespace heads before creating the loop devices
* derives the expected subsystem NQNs from the scratch-device basenames
* walks `/sys/class/nvme-subsystem/nvme-subsys*`
* reads each subsystem's `subsysnqn`
* returns only namespace-head devices matching the expected subsystem NQNs
* subtracts the pre-existing namespace set before using the discovered devices

This keeps the discovery compatible with native NVMe multipath while excluding unrelated NVMe devices.

The normal `nvme list -o json` path remains unchanged and the sysfs logic is only used after repeated `nvme list` failures.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
