### PR TITLE
Revert "Reapply "qa/rgw/crypt: disable failing kmip testing""

### DIFF
--- a/qa/suites/rgw/crypt/2-kms/kmip.yaml
+++ b/qa/suites/rgw/crypt/2-kms/kmip.yaml
@@ -1,0 +1,37 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        rgw crypt s3 kms backend: kmip
+        rgw crypt kmip ca path: /etc/ceph/kmiproot.crt
+        rgw crypt kmip client cert: /etc/ceph/kmip-client.crt
+        rgw crypt kmip client key: /etc/ceph/kmip-client.key
+        rgw crypt kmip kms key template: pykmip-$keyid
+  rgw:
+    client.0:
+      use-pykmip-role: client.0
+
+tasks:
+- openssl_keys:
+    kmiproot:
+      client: client.0
+      cn: kmiproot
+      key-type: rsa:4096
+    kmip-server:
+      client: client.0
+      ca: kmiproot
+    kmip-client:
+      client: client.0
+      ca: kmiproot
+      cn: rgw-client
+- exec:
+    client.0:
+      - chmod 644 /home/ubuntu/cephtest/ca/kmip-client.key
+- pykmip:
+    client.0:
+      clientca: kmiproot
+      servercert: kmip-server
+      clientcert: kmip-client
+      secrets:
+      - name: pykmip-my-key-1
+      - name: pykmip-my-key-2

--- a/qa/tasks/pykmip.py
+++ b/qa/tasks/pykmip.py
@@ -65,7 +65,7 @@ def download(ctx, config):
 
     for (client, cconf) in config.items():
         branch = cconf.get('force-branch', 'master')
-        repo = cconf.get('force-repo', 'https://github.com/OpenKMIP/PyKMIP')
+        repo = cconf.get('force-repo', 'https://github.com/ceph/PyKMIP')
         sha1 = cconf.get('sha1')
         log.info("Using branch '%s' for pykmip", branch)
         log.info('sha1=%s', sha1)


### PR DESCRIPTION
~~testing reenablement of kmip backend in rgw/crypt using fix from https://github.com/ceph/PyKMIP/pull/1~~

point the pykmip task to the ceph fork of the PyKMIP repo, which carries fixes for newer python. this allows us to reenable testing of the kmip backend for server-side encryption

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
