### PR TITLE
qa/nvme_loop: tolerate nvme list failures and stale loop state on teu…

### DIFF
--- a/qa/tasks/nvme_loop.py
+++ b/qa/tasks/nvme_loop.py
@@ -5,7 +5,6 @@ import json
 from io import StringIO
 from teuthology import misc as teuthology
 from teuthology import contextutil
-from teuthology.exceptions import CommandCrashedError
 from teuthology.orchestra import run
 
 
@@ -24,6 +23,19 @@ def task(ctx, config):
             continue
         devs = teuthology.get_scratch_devices(remote)
         devs_by_remote[remote] = devs
+        # Only drop loop fabrics controllers — never PCIe (or other) NVMe.
+        log.info('Cleaning up stale nvme_loop state on %s...', remote.shortname)
+        remote.run(
+            args=[
+                'bash', '-c',
+                'for d in /sys/class/nvme/nvme*; do '
+                '[ -e "$d/transport" ] || continue; '
+                'if [ "$(cat "$d/transport")" = loop ]; then '
+                'sudo nvme disconnect -d "$(basename "$d")"; '
+                'fi; done',
+            ],
+            check_status=False,
+        )
         base = '/sys/kernel/config/nvmet'
         remote.run(
             args=[
@@ -75,21 +87,21 @@ def task(ctx, config):
         # identify nvme_loops devices
         old_scratch_by_remote[remote] = remote.read_file('/scratch_devs')
 
-        with contextutil.safe_while(sleep=1, tries=15) as proceed:
+        with contextutil.safe_while(sleep=2, tries=60) as proceed:
             while proceed():
                 remote.run(args=['lsblk'], stdout=StringIO())
-                try:
-                    p = remote.run(
-                        args=['sudo', 'nvme', 'list', '-o', 'json'],
-                        stdout=StringIO(),
-                    )
-                except CommandCrashedError:
-                    log.warning(
-                        'nvme list -o json command failed, retrying...'
-                    )
-                    continue
-
+                p = remote.run(
+                    args=['sudo', 'nvme', 'list', '-o', 'json'],
+                    stdout=StringIO(),
+                    stderr=StringIO(),
+                    check_status=False,
+                )
                 new_devs = []
+                if p.exitstatus != 0:
+                    log.warning(
+                        'nvme list -o json exited %s, retrying...',
+                        p.exitstatus,
+                    )
                 # `nvme list -o json` will return one of the following output:
                 '''{
                      "Devices" : [
@@ -195,28 +207,52 @@ def task(ctx, config):
                   ]
                 }
                 '''
-                nvme_list = json.loads(p.stdout.getvalue())
-                for device in nvme_list['Devices']:
+                if p.exitstatus == 0:
                     try:
-                        # first try format 1 / older format
-                        dev = device['DevicePath']
-                        vendor = device['ModelNumber']
-                        if dev.startswith('/dev/') and vendor == 'Linux':
-                            new_devs.append(dev)
-                            bluestore_zap(remote, dev)
-                    except KeyError:
-                        for subsystem in device['Subsystems']:
-                            # format 2
-                            if 'Namespaces' in subsystem and subsystem['Namespaces']:
-                                dev = '/dev/' + subsystem['Namespaces'][0]['NameSpace']
-                            # try format 3 last
-                            else:
-                                dev = '/dev/' + subsystem['Controllers'][0]['Namespaces'][0]['NameSpace']
-                            # vendor is the same for format 2 and 3
-                            vendor = subsystem['Controllers'][0]['ModelNumber']
-                            if vendor == 'Linux':
-                                new_devs.append(dev)
-                                bluestore_zap(remote, dev)
+                        nvme_list = json.loads(p.stdout.getvalue())
+                    except (json.JSONDecodeError, ValueError):
+                        nvme_list = None
+                    if nvme_list:
+                        for device in nvme_list['Devices']:
+                            try:
+                                # first try format 1 / older format
+                                dev = device['DevicePath']
+                                vendor = device['ModelNumber']
+                                if dev.startswith('/dev/') and vendor == 'Linux':
+                                    new_devs.append(dev)
+                                    bluestore_zap(remote, dev)
+                            except KeyError:
+                                for subsystem in device['Subsystems']:
+                                    # format 2
+                                    if 'Namespaces' in subsystem and subsystem['Namespaces']:
+                                        dev = '/dev/' + subsystem['Namespaces'][0]['NameSpace']
+                                    # try format 3 last
+                                    else:
+                                        dev = '/dev/' + subsystem['Controllers'][0]['Namespaces'][0]['NameSpace']
+                                    # vendor is the same for format 2 and 3
+                                    vendor = subsystem['Controllers'][0]['ModelNumber']
+                                    if vendor == 'Linux':
+                                        new_devs.append(dev)
+                                        bluestore_zap(remote, dev)
+                if not new_devs:
+                    p_sysfs = remote.run(
+                        args=[
+                            'bash', '-c',
+                            'for model in /sys/class/nvme/nvme*/model; do '
+                            'if grep -q Linux "$model"; then '
+                            'ctrl=$(basename "$(dirname "$model")"); '
+                            'echo "/dev/${ctrl}n1"; fi; done',
+                        ],
+                        stdout=StringIO(),
+                        check_status=False,
+                    )
+                    for line in p_sysfs.stdout.getvalue().splitlines():
+                        if line.startswith('/dev/'):
+                            new_devs.append(line)
+                            bluestore_zap(remote, line)
+                if not new_devs:
+                    log.warning('no loop nvme devices found yet, retrying...')
+                    continue
                 log.info(f'new_devs {new_devs}')
                 assert len(new_devs) <= len(devs)
                 if len(new_devs) == len(devs):


### PR DESCRIPTION
…thology nodes

Proposed fix in qa/tasks/nvme_loop.py:
- pre-cleanup stale loop connections (nvme disconnect-all)
- use check_status=False on nvme list; parse JSON when present
- sysfs fallback for Linux loop model devices
- increase retry budget (~2 min)

Fixes: https://tracker.ceph.com/issues/77830


Reproduction with manual Steps on fedora43 and Verifying the new code change
to see if it will allign
1. created a fedora machine 

[root@ceph-node-0 ~]# cat /etc/fedora-release
Fedora release 43 (Forty Three)
[root@ceph-node-0 ~]# uname -r
6.17.1-300.fc43.x86_64

2. Install prerequisites
[root@ceph-node-0 ~]# dnf install -y nvme-cli util-linux
modprobe nvme_loop
modprobe nvmet
grep -E 'nvme_loop|nvmet' /proc/modules
Updating and loading repositories:
Repositories loaded.
Package "util-linux-2.41.1-17.fc43.x86_64" is already installed.

Package                                             Arch         Version                                              Repository                        Size
Installing:
 nvme-cli                                           x86_64       2.16-1.fc43                                          updates                        6.9 MiB
Installing dependencies:
 libnvme                                            x86_64       1.16.1-1.fc43                                        updates                      305.8 KiB

Transaction Summary:
 Installing:         2 packages

Total size of inbound packages is 1 MiB. Need to download 1 MiB.
After this operation, 7 MiB extra will be used (install 7 MiB, remove 0 B).
[1/2] libnvme-0:1.16.1-1.fc43.x86_64                                                                                100% | 284.7 KiB/s | 120.1 KiB |  00m00s
[2/2] nvme-cli-0:2.16-1.fc43.x86_64                                                                                 100% |   1.3 MiB/s |   1.1 MiB |  00m01s
------------------------------------------------------------------------------------------------------------------------------------------------------------
[2/2] Total                                                                                                         100% | 812.2 KiB/s |   1.2 MiB |  00m02s
Running transaction
[1/4] Verify package files                                                                                          100% | 100.0   B/s |   2.0   B |  00m00s
[2/4] Prepare transaction                                                                                           100% |  50.0   B/s |   2.0   B |  00m00s
[3/4] Installing libnvme-0:1.16.1-1.fc43.x86_64                                                                     100% |  14.3 MiB/s | 307.8 KiB |  00m00s
[4/4] Installing nvme-cli-0:2.16-1.fc43.x86_64                                                                      100% |   6.6 MiB/s |   7.0 MiB |  00m01s
Complete!
nvme_loop 24576 0 - Live 0xffffffffc0c97000
nvmet 278528 1 nvme_loop, Live 0xffffffffc0c7e000
nvme_fabrics 49152 1 nvme_loop, Live 0xffffffffc0c7a000
nvme_core 274432 3 nvme_loop,nvmet,nvme_fabrics, Live 0xffffffffc0c61000
nvme_keyring 20480 3 nvmet,nvme_fabrics,nvme_core, Live 0xffffffffc0c5d000
nvme_auth 32768 2 nvmet,nvme_core, Live 0xffffffffc0c5f000


3. Create scratch block devices
[root@ceph-node-0 ~]# mkdir -p /var/tmp/scratch-backing
for i in 1 2; do
  truncate -s 2G /var/tmp/scratch-backing/disk$i.img
  losetup -f /var/tmp/scratch-backing/disk$i.img
done
losetup -a
/dev/loop1: [0044]:41086 (/var/tmp/scratch-backing/disk2.img)
/dev/loop0: [0044]:41085 (/var/tmp/scratch-backing/disk1.img)

4. Set variables
# backing devices (what teuthology calls scratch devices)
DEVS=(/dev/loop0 /dev/loop1) 
HOST=hostnqn
PORT=1
BASE=/sys/kernel/config/nvmet
#Simulate teuthology’s scratch list:

printf '%s\n' "${DEVS[@]}" | tee /scratch_devs

##output:
/dev/loop0
/dev/loop1

4. Pre-cleanup new in the code we added
[root@ceph-node-0 ~]# nvme disconnect-all 2>/dev/null || true
[root@ceph-node-0 ~]# echo $?
0

5. NVMe-oF loop target setup (same as the task)
[root@ceph-node-0 ~]# grep '^nvme_loop' /proc/modules || modprobe nvme_loop
mkdir -p "${BASE}/hosts/${HOST}"
mkdir -p "${BASE}/ports/${PORT}"
echo loop | tee "${BASE}/ports/${PORT}/addr_trtype"
for dev in "${DEVS[@]}"; do
  short="${dev##*/}"
  echo "Connecting nvme_loop for ${dev} (subsystem ${short})..."
  mkdir -p "${BASE}/subsystems/${short}"
  echo 1 | tee "${BASE}/subsystems/${short}/attr_allow_any_host"
  mkdir -p "${BASE}/subsystems/${short}/namespaces/1"
  echo -n "${dev}" | tee "${BASE}/subsystems/${short}/namespaces/1/device_path"
  echo 1 | tee "${BASE}/subsystems/${short}/namespaces/1/enable"
  ln -sf "${BASE}/subsystems/${short}" "${BASE}/ports/${PORT}/subsystems/${short}"
  if ! nvme connect -t loop -n "${short}" -q "${HOST}"; then
    nvme connect -t loop -n "${short}"
  fi
done
lsblk
nvme_loop 24576 0 - Live 0xffffffffc0c97000
loop
Connecting nvme_loop for /dev/loop0 (subsystem loop0)...
1
/dev/loop01
connecting to device: nvme0
Connecting nvme_loop for /dev/loop1 (subsystem loop1)...
1
/dev/loop11
connecting to device: nvme1
NAME                                                                                            MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
loop0                                                                                             7:0    0    2G  0 loop
loop1                                                                                             7:1    0    2G  0 loop
sr0                                                                                              11:0    1  512K  0 rom
zram0                                                                                           251:0    0  5.8G  0 disk [SWAP]
vda                                                                                             253:0    0  100G  0 disk
├─vda1                                                                                          253:1    0    2M  0 part
├─vda2                                                                                          253:2    0  100M  0 part /boot/efi
├─vda3                                                                                          253:3    0    2G  0 part /boot
└─vda4                                                                                          253:4    0 97.9G  0 part /var/lib/containers/storage/overlay
                                                                                                                         /var
                                                                                                                         /home
                                                                                                                         /
vdb                                                                                             253:16   0   10G  0 disk
└─ceph--c4daff3e--d16c--43b8--9620--a673ab7f4ee1-osd--block--237bbaf0--fbad--48aa--a378--ea1d41eff8e1
                                                                                                252:0    0   10G  0 lvm
nvme0n1                                                                                         259:1    0    2G  0 disk
nvme1n1                                                                                         259:3    0    2G  0 disk

[root@ceph-node-0 ~]# for m in /sys/class/nvme/nvme*/model; do echo "$m: $(cat "$m")"; done
/sys/class/nvme/nvme0/model: Linux
/sys/class/nvme/nvme1/model: Linux

6. Happy path - json recovery 
Note: if jq is not install , install it : dnf install jq -y
[root@ceph-node-0 ~]# nvme list -o json | jq '.Devices[] | {path: .DevicePath?, model: .ModelNumber?}'
{
  "path": "/dev/nvme0n1",
  "model": "Linux"
}
{
  "path": "/dev/nvme1n1",
  "model": "Linux"
}

 7. Sysfs fallback (core of #77830)
 This is what the patch does when nvme list -o json fails:
 
 [root@ceph-node-0 ~]# echo "=== sysfs fallback ==="
for model in /sys/class/nvme/nvme*/model; do
  if grep -q Linux "$model"; then
    ctrl=$(basename "$(dirname "$model")")
    echo "/dev/${ctrl}n1"
  fi
done

###Output: 
=== sysfs fallback ===
/dev/nvme0n1
/dev/nvme1n1
 
 8. Simulate Pulpito failure — nvme list hard-fails
 This mimics trial051: devices exist, but nvme list -o json exits non-zero.
 
 [root@ceph-node-0 ~]# NVME_REAL=$(command -v nvme)
cp -a "$NVME_REAL" /tmp/nvme.real
cat > /tmp/nvme-fake <<'EOF'
#!/bin/bash
if [[ "$1" == "list" && "$2" == "-o" && "$3" == "json" ]]; then
  echo "simulated nvme list failure" >&2
  exit 1
fi
exec /tmp/nvme.real "$@"
EOF
chmod +x /tmp/nvme-fake
export PATH="/tmp:$PATH"
ln -sf /tmp/nvme-fake /tmp/nvme   # /tmp is first in PATH; teuthology calls `nvme` via sudo

# prove list fails
[root@ceph-node-0 ~]# sudo env PATH="/tmp:$PATH" nvme list -o json; echo "exit=$?"
simulated nvme list failure
exit=1

Now run the combined logic from your patch:

[root@ceph-node-0 ~]# NEW_DEVS=()
# nvme list (fails)
if sudo env PATH="/tmp:$PATH" nvme list -o json >/tmp/nvme.json 2>/tmp/nvme.err; then
  echo "unexpected: nvme list succeeded"
else
  echo "nvme list failed as expected: $(cat /tmp/nvme.err)"
fi
# sysfs fallback
mapfile -t NEW_DEVS < <(
  for model in /sys/class/nvme/nvme*/model; do
    if grep -q Linux "$model"; then
      ctrl=$(basename "$(dirname "$model")")
      echo "/dev/${ctrl}n1"
    fi
  done
)
echo "discovered via sysfs: ${NEW_DEVS[@]}"
echo "count=${#NEW_DEVS[@]} expected=${#DEVS[@]}"
nvme list failed as expected: simulated nvme list failure
discovered via sysfs: /dev/nvme0n1 /dev/nvme1n1
count=2 expected=2

Pass: count equals expected even though nvme list failed.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
