### PR TITLE
mgr/cephadm: wait for active MDS during fail_fs upgrade

### DIFF
--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -1149,6 +1149,39 @@ class CephadmUpgrade:
                 image_settings[opt['section']] = opt['value']
         return image_settings
 
+    def _mds_in_rank_active(
+        self,
+        mdsmap: Dict[str, Any],
+        fs_name: Optional[str] = None,
+    ) -> bool:
+        for rank in mdsmap.get('in', []):
+            gid = mdsmap['up'].get(f'mds_{rank}')
+            if gid is None:
+                return False
+            mds = mdsmap['info'].get(f'gid_{gid}')
+            if mds is None or mds['state'] != 'up:active':
+                if fs_name and mds:
+                    self.mgr.log.info(
+                        'Upgrade: Waiting for fs %s mds.%s to be up:active (currently %s)',
+                        fs_name, mds['name'], mds['state'])
+                return False
+        return True
+
+    def _wait_for_fs_mdss_active(self, fs_name: str, timeout: int = 600) -> bool:
+        elapsed = 0
+        while elapsed < timeout:
+            fsmap = self.mgr.get("fs_map")
+            for fs in fsmap.get('filesystems', []):
+                mdsmap = fs['mdsmap']
+                if mdsmap['fs_name'] != fs_name:
+                    continue
+                if self._mds_in_rank_active(mdsmap, fs_name):
+                    return True
+                break
+            time.sleep(10)
+            elapsed += 10
+        return False
+
     def _prepare_for_mds_upgrade(
         self,
         target_major: str,
@@ -1196,8 +1229,13 @@ class CephadmUpgrade:
                             'fs_name': fs_name
                         })
                         if ret != 0:
+                            self.mgr.log.error(
+                                'Upgrade: fs fail for %s failed: %s', fs_name, err)
                             continue_upgrade = False
-                    continue
+                            continue
+                        continue_upgrade = False
+                        continue
+                    # fs already failed: fall through to wait for in-rank active
                 else:
                     self.mgr.log.info('Upgrade: Scaling down filesystem %s' % (
                         fs_name
@@ -1231,17 +1269,23 @@ class CephadmUpgrade:
                 # incompatible compatsets; the mons will not do any promotions.
                 # We must upgrade to continue.
             elif len(mdsmap['up']) > 0:
-                mdss = list(mdsmap['info'].values())
-                assert len(mdss) == 1
-                lone_mds = mdss[0]
-                if lone_mds['state'] != 'up:active':
-                    self.mgr.log.info('Upgrade: Waiting for mds.%s to be up:active (currently %s)' % (
-                        lone_mds['name'],
-                        lone_mds['state'],
-                    ))
-                    time.sleep(10)
-                    continue_upgrade = False
-                    continue
+                if self.upgrade_state.fail_fs and mdsmap['max_mds'] > 1:
+                    if not self._mds_in_rank_active(mdsmap, fs_name):
+                        time.sleep(10)
+                        continue_upgrade = False
+                        continue
+                else:
+                    mdss = list(mdsmap['info'].values())
+                    assert len(mdss) == 1
+                    lone_mds = mdss[0]
+                    if lone_mds['state'] != 'up:active':
+                        self.mgr.log.info('Upgrade: Waiting for mds.%s to be up:active (currently %s)' % (
+                            lone_mds['name'],
+                            lone_mds['state'],
+                        ))
+                        time.sleep(10)
+                        continue_upgrade = False
+                        continue
             else:
                 assert False
 
@@ -1655,6 +1699,10 @@ class CephadmUpgrade:
                     raise OrchestratorError("Failed to set"
                                             "fs joinable true"
                                             f"due to {e}")
+                if not self._wait_for_fs_mdss_active(fs_name):
+                    raise OrchestratorError(
+                        f'MDS daemons for filesystem {fs_name} did not become '
+                        f'up:active after fail_fs upgrade')
         elif self.upgrade_state.fs_original_max_mds:
             for fs in self.mgr.get("fs_map")['filesystems']:
                 fscid = fs["id"]


### PR DESCRIPTION
When fail_fs is enabled with max_mds > 1, _prepare_for_mds_upgrade() issued fs fail and then continued unconditionally, skipping the up:active wait. _complete_mds_upgrade() also set joinable=true without waiting for in-rank MDS to recover.

Wait for all in-rank MDS to reach up:active before proceeding with the upgrade and after re-joining the filesystem. Add fs.ready to the mds_upgrade_sequence verify task so ceph-fuse teardown does not race with MDS still in up:rejoin.

Fixes: https://tracker.ceph.com/issues/77835

Relevant Pulpito job: https://pulpito.ceph.com/rkachach-2026-06-27_08:00:42-orch:cephadm-wip-rkachach-testing-3-2026-06-26-1442-distro-default-trial/319357/

Description of Upgrade flow

`
Full flow: 
<img width="322" height="251" alt="image" src="https://github.com/user-attachments/assets/0d889c82-9f99-4a80-b4cb-43154e273a66" />

  `



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
