### PR TITLE
cephadm: make AppArmor kernel_security facts deterministic

### DIFF
--- a/src/cephadm/cephadmlib/host_facts.py
+++ b/src/cephadm/cephadmlib/host_facts.py
@@ -732,9 +732,12 @@ class HostFacts:
                             if mode in summary:
                                 summary[mode] += 1
                             else:
-                                summary[mode] = 0
+                                summary[mode] = 1
+                        mode_order = ('enforce', 'complain', 'prompt', 'kill', 'unconfined')
                         summary_str = ','.join(
-                            ['{} {}'.format(v, k) for k, v in summary.items()]
+                             '{} {}'.format(summary[mode], mode)
+                              for mode in mode_order
+                              if mode in summary
                         )
                         security = {**security, **summary}  # type: ignore
                         security['description'] += '({})'.format(summary_str)


### PR DESCRIPTION
This PR fixes a false-positive CEPHADM_CHECK_KERNEL_LSM warning caused by non-deterministic ordering in the generated AppArmor kernel_security.description.

CEPHADM_CHECK_KERNEL_LSM groups hosts by kernel_security["description"]. For AppArmor, that description was generated from summary.items(), so the resulting string depended on the order in which AppArmor profile modes were first encountered while reading /sys/kernel/security/apparmor/profiles.

As a result, two hosts with identical structured AppArmor facts could be reported as inconsistent if their description strings differed only by ordering.

Example observed gather-facts diff:

--- host-a
+++ host-b
@@
   "kernel_security": {
     "complain": 3,
-    "description": "AppArmor: Enabled(23 enforce,3 complain,87 unconfined)",
+    "description": "AppArmor: Enabled(23 enforce,87 unconfined,3 complain)",
     "enforce": 23,
     "type": "AppArmor",
     "unconfined": 87
   },

This PR makes the generated AppArmor description deterministic by emitting AppArmor modes in a fixed order.

It also fixes an apparent off-by-one issue in the AppArmor counters. When a mode is seen for the first time, the counter was initialized to 0; it should be initialized to 1.

Fixes: https://tracker.ceph.com/issues/77837

Signed-off-by: Herbert Faleiros herbert@faleiros.eti.br