### PR TITLE
qa/workunits: skip unpublished stable repos in test_repos.sh

### DIFF
--- a/qa/workunits/cephadm/test_repos.sh
+++ b/qa/workunits/cephadm/test_repos.sh
@@ -30,16 +30,51 @@ function test_install_uninstall() {
 	      sudo zypper -n remove cephadm )
 }
 
-sudo $CEPHADM -v add-repo --release quincy
-test_install_uninstall
-sudo $CEPHADM -v rm-repo
+function test_release() {
+    local release=$1
+    sudo $CEPHADM -v add-repo --release "$release"
+    test_install_uninstall
+    sudo $CEPHADM -v rm-repo
+}
+
+REPO_URL="${REPO_URL:-https://download.ceph.com}"
+
+function release_published() {
+    local release=$1
+    local base
+
+    if grep -q debian /etc/*-release; then
+        . /etc/os-release
+        base="${REPO_URL}/debian-${release}/dists/${VERSION_CODENAME}"
+        curl -sf -o /dev/null "${base}/InRelease" && return 0
+        curl -sf -o /dev/null "${base}/Release" && return 0
+        return 1
+    elif grep -q rhel /etc/*-release; then
+        . /etc/os-release
+        curl -sf -o /dev/null \
+            "${REPO_URL}/rpm-${release}/el${VERSION_ID%%.*}/noarch/repodata/repomd.xml"
+    else
+        return 1
+    fi
+}
+
+function test_release_if_published() {
+    local release=$1
+    if ! release_published "$release"; then
+        echo "Skipping release $release (not published for this distro)"
+        return 0
+    fi
+    test_release "$release"
+}
 
 sudo $CEPHADM -v add-repo --dev main
 test_install_uninstall
 sudo $CEPHADM -v rm-repo
 
-sudo $CEPHADM -v add-repo --release 17.2.7
-test_install_uninstall
-sudo $CEPHADM -v rm-repo
+test_release_if_published reef
+test_release_if_published 18.2.8
+test_release_if_published squid
+test_release_if_published 19.2.4
+test_release_if_published tentacle
 
 echo OK.


### PR DESCRIPTION
The cephadm workunits suite started running test_cephadm_repos on Ubuntu 24.04 (codename noble). test_repos.sh always called add-repo --release quincy first, without checking whether that repo exists for the host OS.

On noble, cephadm configures deb https://download.ceph.com/debian-quincy/ noble main. apt-get update then fails with 404 because Ceph never published quincy packages for noble. For example, teuthology job 319347 failed on the first line of the test:

  https://qa-proxy.ceph.com/teuthology/rkachach-2026-06-27_08:00:42-orch:cephadm-wip-rkachach-testing-3-2026-06-26-1442-distro-default-trial/319347/teuthology.log

  orch:cephadm/workunits/{0-distro/ubuntu_24.04 ... task/test_cephadm_repos}
  VERSION_CODENAME=noble
  E: The repository 'https://download.ceph.com/debian-quincy noble Release'
  does not have a Release file.

Ubuntu 22.04 is jammy; Ubuntu 24.04 is noble. The test worked on jammy because debian-quincy includes jammy, but noble is not listed under debian-quincy or debian-reef on download.ceph.com. Only newer trees such as debian-tentacle include noble.

Probe download.ceph.com before each stable add-repo and skip releases that are not published for the current codename or EL version. Run --dev main first, then quincy, 17.2.7, reef, 18.2.7, and tentacle when available.

Tested manually on Ubuntu 22.04, Ubuntu 24.04 and rhel9 by running:

  bash qa/workunits/cephadm/test_repos.sh

Fixes: http://tracker.ceph.com/issues/77248
Signed-off-by: Yael Azulay <yazulay@redhat.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
