### PR TITLE
tentacle:mgr/dashboard: Backport cephadm e2e test fixes 

### DIFF
--- a/src/pybind/mgr/dashboard/ci/cephadm/bootstrap-cluster.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/bootstrap-cluster.sh
@@ -5,7 +5,7 @@ set -x
 export PATH=/root/bin:$PATH
 mkdir /root/bin
 
-export CEPHADM_IMAGE='quay.ceph.io/ceph-ci/ceph:main'
+export CEPHADM_IMAGE='quay.ceph.io/ceph-ci/ceph:tentacle'
 
 CEPHADM="/root/bin/cephadm"
 CEPHADM_SRC="/mnt/{{ ceph_dev_folder }}/src/cephadm/cephadm"

--- a/src/pybind/mgr/dashboard/ci/cephadm/run-cephadm-e2e-tests.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/run-cephadm-e2e-tests.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 
 set -ex
 
@@ -9,7 +10,7 @@ set -ex
 : ${DASHBOARD_PORT:='8443'}
 
 get_vm_ip () {
-    local ip=$(kcli info vm "$1" -f ip -v | grep -Eo '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')
+    local ip=$(with_libvirt "kcli info vm \"$1\" -f ip -v" | grep -Eo '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')
     echo -n $ip
 }
 

--- a/src/pybind/mgr/dashboard/ci/cephadm/start-cluster.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/start-cluster.sh
@@ -74,7 +74,7 @@ with_libvirt "kcli create plan -f src/pybind/mgr/dashboard/ci/cephadm/ceph_clust
 
 : ${CLUSTER_DEBUG:=0}
 : ${DASHBOARD_CHECK_INTERVAL:=10}
-while [[ -z $(with_libvirt "kcli ssh -u root -- ceph-node-00 'journalctl --no-tail --no-pager -t cloud-init' | grep "kcli boot finished"") ]]; do
+while [[ -z $(with_libvirt "kcli ssh -u root -- ceph-node-00 'journalctl --no-tail --no-pager -t cloud-init' | grep 'kcli boot finished'") ]]; do
     sleep ${DASHBOARD_CHECK_INTERVAL}
     with_libvirt "kcli list vm"
     if [[ ${CLUSTER_DEBUG} != 0 ]]; then
@@ -84,10 +84,10 @@ while [[ -z $(with_libvirt "kcli ssh -u root -- ceph-node-00 'journalctl --no-ta
     with_libvirt "kcli ssh -u root -- ceph-node-00 'journalctl -n 100 --no-pager -t cloud-init'"
 done
 
-with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell "ceph config set mgr mgr/prometheus/exclude_perf_counters false"'"
+with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell ceph config set mgr mgr/prometheus/exclude_perf_counters false'"
 
 get_prometheus_running_count() {
-    echo $(with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell "ceph orch ls --service_name=prometheus --format=json"' | jq -r '.[] | .status.running'")
+    echo $(with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell ceph orch ls --service_name=prometheus --format=json' | jq -r '.[] | .status.running'")
 }
 
 # check if the prometheus daemon is running on jenkins node
@@ -112,8 +112,8 @@ if [[ -n "${JENKINS_HOME}" ]]; then
 
     # grafana ip address is set to the fqdn by default.
     # kcli is not working with that, so setting the IP manually.
-    with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell "ceph dashboard set-alertmanager-api-host http://192.168.100.100:9093"'"
-    with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell "ceph dashboard set-prometheus-api-host http://192.168.100.100:9095"'"
-    with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell "ceph dashboard set-grafana-api-url https://192.168.100.100:3000"'"
-    with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell "ceph orch apply node-exporter --placement 'count:2"'"'
+    with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell ceph dashboard set-alertmanager-api-host http://192.168.100.100:9093'"
+    with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell ceph dashboard set-prometheus-api-host http://192.168.100.100:9095'"
+    with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell ceph dashboard set-grafana-api-url https://192.168.100.100:3000'"
+    with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell ceph orch apply node-exporter --placement count:2'"
 fi

--- a/src/pybind/mgr/dashboard/ci/cephadm/start-cluster.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/start-cluster.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 
 set -eEx
 
@@ -12,16 +13,16 @@ on_error() {
         echo "Saving MGR logs:"
         echo
         mkdir -p ${CEPH_DEV_FOLDER}/logs
-        kcli ssh -u root -- ceph-node-00 'cephadm logs -n \$(cephadm ls | grep -Eo "mgr\.ceph[0-9a-z.-]+" | head -n 1) -- --no-tail --no-pager' > ${CEPH_DEV_FOLDER}/logs/mgr.cephadm.log
+        with_libvirt "kcli ssh -u root -- ceph-node-00 'cephadm logs -n \$(cephadm ls | grep -Eo "mgr\.ceph[0-9a-z.-]+" | head -n 1) -- --no-tail --no-pager' > ${CEPH_DEV_FOLDER}/logs/mgr.cephadm.log"
         for vm_id in {0..3}
         do
             local vm="ceph-node-0${vm_id}"
             echo "Saving journalctl from VM ${vm}:"
             echo
-            kcli ssh -u root -- ${vm} 'journalctl --no-tail --no-pager -t cloud-init' > ${CEPH_DEV_FOLDER}/logs/journal.ceph-node-0${vm_id}.log || true
+            with_libvirt "kcli ssh -u root -- ${vm} 'journalctl --no-tail --no-pager -t cloud-init' > ${CEPH_DEV_FOLDER}/logs/journal.ceph-node-0${vm_id}.log || true"
             echo "Saving container logs:"
             echo
-            kcli ssh -u root -- ${vm} 'podman logs --names --since 30s \$(podman ps -aq)' > ${CEPH_DEV_FOLDER}/logs/container.ceph-node-0${vm_id}.log || true
+            with_libvirt "kcli ssh -u root -- ${vm} 'podman logs --names --since 30s \$(podman ps -aq)' > ${CEPH_DEV_FOLDER}/logs/container.ceph-node-0${vm_id}.log || true"
         done
         echo "TEST FAILED."
     fi
@@ -43,7 +44,7 @@ for arg in "$@"; do
   esac
 done
 
-kcli delete plan -y ceph || true
+with_libvirt "kcli delete plan -y ceph || true"
 
 # Build dashboard frontend (required to start the module).
 cd ${CEPH_DEV_FOLDER}/src/pybind/mgr/dashboard/frontend
@@ -61,32 +62,32 @@ npm run build ${FRONTEND_BUILD_OPTS} &
 cd ${CEPH_DEV_FOLDER}
 : ${VM_IMAGE:='fedora42'}
 : ${VM_IMAGE_URL:='https://download.fedoraproject.org/pub/fedora/linux/releases/42/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-42-1.1.x86_64.qcow2'}
-kcli download image -p ceph-dashboard -u ${VM_IMAGE_URL} ${VM_IMAGE}
-kcli delete plan -y ceph || true
+with_libvirt "kcli download image -p ceph-dashboard -u ${VM_IMAGE_URL} ${VM_IMAGE}"
+with_libvirt "kcli delete plan -y ceph || true"
 # Compile cephadm locally for the shared_ceph_folder to pick it up
 cd ${CEPH_DEV_FOLDER}/src/cephadm
 ./build.sh ${CEPH_DEV_FOLDER}/src/cephadm/cephadm
 cd ${CEPH_DEV_FOLDER}
-kcli create plan -f src/pybind/mgr/dashboard/ci/cephadm/ceph_cluster.yml \
+with_libvirt "kcli create plan -f src/pybind/mgr/dashboard/ci/cephadm/ceph_cluster.yml \
     -P ceph_dev_folder=${CEPH_DEV_FOLDER} \
-    ${EXTRA_PARAMS} ceph
+    ${EXTRA_PARAMS} ceph"
 
 : ${CLUSTER_DEBUG:=0}
 : ${DASHBOARD_CHECK_INTERVAL:=10}
-while [[ -z $(kcli ssh -u root -- ceph-node-00 'journalctl --no-tail --no-pager -t cloud-init' | grep "kcli boot finished") ]]; do
+while [[ -z $(with_libvirt "kcli ssh -u root -- ceph-node-00 'journalctl --no-tail --no-pager -t cloud-init' | grep "kcli boot finished"") ]]; do
     sleep ${DASHBOARD_CHECK_INTERVAL}
-    kcli list vm
+    with_libvirt "kcli list vm"
     if [[ ${CLUSTER_DEBUG} != 0 ]]; then
-        kcli ssh -u root -- ceph-node-00 'podman ps -a'
-        kcli ssh -u root -- ceph-node-00 'podman logs --names --since 30s \$(podman ps -aq)'
+        with_libvirt "kcli ssh -u root -- ceph-node-00 'podman ps -a'"
+        with_libvirt "kcli ssh -u root -- ceph-node-00 'podman logs --names --since 30s \$(podman ps -aq)'"
     fi
-    kcli ssh -u root -- ceph-node-00 'journalctl -n 100 --no-pager -t cloud-init'
+    with_libvirt "kcli ssh -u root -- ceph-node-00 'journalctl -n 100 --no-pager -t cloud-init'"
 done
 
-kcli ssh -u root ceph-node-00 'cephadm shell "ceph config set mgr mgr/prometheus/exclude_perf_counters false"'
+with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell "ceph config set mgr mgr/prometheus/exclude_perf_counters false"'"
 
 get_prometheus_running_count() {
-    echo $(kcli ssh -u root ceph-node-00 'cephadm shell "ceph orch ls --service_name=prometheus --format=json"' | jq -r '.[] | .status.running')
+    echo $(with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell "ceph orch ls --service_name=prometheus --format=json"' | jq -r '.[] | .status.running'")
 }
 
 # check if the prometheus daemon is running on jenkins node
@@ -111,8 +112,8 @@ if [[ -n "${JENKINS_HOME}" ]]; then
 
     # grafana ip address is set to the fqdn by default.
     # kcli is not working with that, so setting the IP manually.
-    kcli ssh -u root ceph-node-00 'cephadm shell "ceph dashboard set-alertmanager-api-host http://192.168.100.100:9093"'
-    kcli ssh -u root ceph-node-00 'cephadm shell "ceph dashboard set-prometheus-api-host http://192.168.100.100:9095"'
-    kcli ssh -u root ceph-node-00 'cephadm shell "ceph dashboard set-grafana-api-url https://192.168.100.100:3000"'
-    kcli ssh -u root ceph-node-00 'cephadm shell "ceph orch apply node-exporter --placement 'count:2'"'
+    with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell "ceph dashboard set-alertmanager-api-host http://192.168.100.100:9093"'"
+    with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell "ceph dashboard set-prometheus-api-host http://192.168.100.100:9095"'"
+    with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell "ceph dashboard set-grafana-api-url https://192.168.100.100:3000"'"
+    with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell "ceph orch apply node-exporter --placement 'count:2"'"'
 fi

--- a/src/pybind/mgr/dashboard/ci/cephadm/utils.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/utils.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+with_libvirt() {
+    if [[ -n "${JENKINS_HOME}" ]]; then
+        sg libvirt -c "$1"
+    else
+        eval "$1"
+    fi
+}


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/68178/ https://github.com/ceph/ceph/pull/69116


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
