### PR TITLE
umbrella: ceph.spec.in: add update-alternatives as runtime dep and correct macro call

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -2776,7 +2776,7 @@ fi
 
 %preun osd-crimson
 if [ $1 -eq 0 ]; then
-    ${_sbindir}/update-alternatives --remove ceph-osd %{_bindir}/ceph-osd-crimson
+    %{_sbindir}/update-alternatives --remove ceph-osd %{_bindir}/ceph-osd-crimson
 fi
 %endif
 
@@ -2786,7 +2786,7 @@ fi
 
 %preun osd-classic
 if [ $1 -eq 0 ]; then
-    ${_sbindir}/update-alternatives --remove ceph-osd %{_bindir}/ceph-osd-classic
+    %{_sbindir}/update-alternatives --remove ceph-osd %{_bindir}/ceph-osd-classic
 fi
 
 %files volume

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1281,6 +1281,8 @@ Group:		System/Filesystems
 %endif
 Requires:   ceph-osd = %{_epoch_prefix}%{version}-%{release}
 Obsoletes:  ceph-osd < %{_epoch_prefix}%{version}-%{release}
+Requires(posttrans): %{_sbindir}/update-alternatives
+Requires(preun): %{_sbindir}/update-alternatives
 %description osd-classic
 classic-osd is the object storage daemon for the Ceph distributed file
 system.  It is responsible for storing objects on a local file system
@@ -1301,6 +1303,8 @@ Requires:	binutils
 Requires:	c-ares%{?_isa} >= %{c_ares_min_version}
 %endif
 Requires:	protobuf
+Requires(posttrans): %{_sbindir}/update-alternatives
+Requires(preun): %{_sbindir}/update-alternatives
 %description osd-crimson
 crimson-osd is the object storage daemon for the Ceph distributed file
 system.  It is responsible for storing objects on a local file system


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77360

---

backport of https://github.com/ceph/ceph/pull/69408
parent tracker: https://tracker.ceph.com/issues/77323

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh