### PR TITLE
crimson/osd/ec_backend: fix transaction translation

### DIFF
--- a/src/crimson/osd/ec_backend.cc
+++ b/src/crimson/osd/ec_backend.cc
@@ -107,7 +107,7 @@ struct ECCrimsonOp : ECCommon::RMWPipeline::Op {
   PGTransactionUPtr t;
   const PGLog &pg_log;
 
-  static PGTransactionUPtr transate_transaction(
+  static PGTransactionUPtr translate_transaction(
     ceph::os::Transaction&& t,
     crimson::osd::ObjectContextRef &&obc)
   {
@@ -248,7 +248,7 @@ struct ECCrimsonOp : ECCommon::RMWPipeline::Op {
               const PGLog &pg_log,
        ECCommon::RMWPipeline& rmw_pipeline)
     : Op(rmw_pipeline),
-      t(transate_transaction(std::move(t), std::move(obc))),
+      t(translate_transaction(std::move(t), std::move(obc))),
       pg_log(pg_log) {
   }
 

--- a/src/crimson/osd/ec_backend.cc
+++ b/src/crimson/osd/ec_backend.cc
@@ -160,6 +160,7 @@ struct ECCrimsonOp : ECCommon::RMWPipeline::Op {
 	break;
       case ceph::os::Transaction::OP_OMAP_CLEAR:
 	t_pg->omap_clear(i.get_oid(op->oid).hobj);
+	break;
       case ceph::os::Transaction::OP_OMAP_SETKEYS:
 	{
 	std::map<std::string, ceph::bufferlist> aset;
@@ -211,6 +212,7 @@ struct ECCrimsonOp : ECCommon::RMWPipeline::Op {
 			  op->off,
 			  op->len,
 			  op->dest_off);
+	break;
       case ceph::os::Transaction::OP_CLONE:
 	t_pg->clone(i.get_oid(op->dest_oid).hobj, i.get_oid(op->oid).hobj);
         break;

--- a/src/crimson/osd/ec_backend.cc
+++ b/src/crimson/osd/ec_backend.cc
@@ -176,6 +176,12 @@ struct ECCrimsonOp : ECCommon::RMWPipeline::Op {
 	}
 	break;
       case ceph::os::Transaction::OP_OMAP_RMKEYRANGE:
+	{
+	std::string first = i.decode_string();
+	std::string last = i.decode_string();
+	t_pg->omap_rmkeyrange(i.get_oid(op->oid).hobj, first, last);
+	}
+	break;
       case ceph::os::Transaction::OP_OMAP_SETHEADER:
 	{
 	ceph::bufferlist bl;


### PR DESCRIPTION
- **add missing break** — `OP_OMAP_CLEAR` and `OP_CLONERANGE2` lacked a
  `break` and fell through. `OP_OMAP_CLEAR` fell into `OP_OMAP_SETKEYS` and
  decoded an attrset it never encoded, corrupting the decode stream; `OP_CLONERANGE2`
  fell into `OP_CLONE` and tripped `ceph_assert(op.is_none() || op.is_delete())`.

- **fix OP_OMAP_RMKEYRANGE** — it was handled in the `OP_OMAP_SETHEADER` case,
  decoding one bufferlist, but it encodes first/last as two strings. Give it its
  own case that decodes both strings and calls the two-string
  `omap_rmkeyrange()` overload.

- **fix typo** — rename `transate_transaction()` to `translate_transaction()`.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
