### PR TITLE
tentacle: mgr: fix PyObject leak in the remote() pickle calls

### DIFF
--- a/src/mgr/ActivePyModule.cc
+++ b/src/mgr/ActivePyModule.cc
@@ -142,11 +142,7 @@ std::optional<std::vector<std::byte>> ActivePyModule::dispatch_remote(
 
   auto pmodule = py_module->pPickleModule;
   auto pickled_args_bytes = py_bytes_from_span(pickled_args);
-  auto args = PyObject_CallMethodObjArgs(
-    pmodule,
-    PyUnicode_FromString("loads"),
-    pickled_args_bytes,
-    nullptr);
+  auto args = PyObject_CallMethod(pmodule, "loads", "(O)", pickled_args_bytes);
   Py_DECREF(pickled_args_bytes);
   if (args == nullptr) {
     std::string caller = "ActivePyModule::dispatch_remote "s + method;
@@ -156,11 +152,7 @@ std::optional<std::vector<std::byte>> ActivePyModule::dispatch_remote(
   }
 
   auto pickled_kwargs_bytes = py_bytes_from_span(pickled_kwargs);
-  auto kwargs = PyObject_CallMethodObjArgs(
-    pmodule,
-    PyUnicode_FromString("loads"),
-    pickled_kwargs_bytes,
-    nullptr);
+  auto kwargs = PyObject_CallMethod(pmodule, "loads", "(O)", pickled_kwargs_bytes);
   Py_DECREF(pickled_kwargs_bytes);
   if (kwargs == nullptr) {
     std::string caller = "ActivePyModule::dispatch_remote "s + method;
@@ -195,11 +187,7 @@ std::optional<std::vector<std::byte>> ActivePyModule::dispatch_remote(
   }
   dout(20) << "Success calling '" << method << "'" << dendl;
 
-  auto pickled_ret = PyObject_CallMethodObjArgs(
-    pmodule,
-    PyUnicode_FromString("dumps"),
-    ret,
-    nullptr);
+  auto pickled_ret = PyObject_CallMethod(pmodule, "dumps", "(O)", ret);
   Py_DECREF(ret);
   if (pickled_ret == nullptr) {
     std::string caller = "ActivePyModule::dispatch_remote "s + method;

--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -849,11 +849,7 @@ ceph_dispatch_remote(BaseMgrModule *self, PyObject *args)
   }
 
   auto pmodule = self->this_module->py_module->pPickleModule;
-  auto pickled_args = PyObject_CallMethodObjArgs(
-    pmodule,
-    PyUnicode_FromString("dumps"),
-    remote_args,
-    nullptr);
+  auto pickled_args = PyObject_CallMethod(pmodule, "dumps", "(O)", remote_args);
   if (pickled_args == nullptr) {
     std::string caller = "ceph_dispatch_remote "s + " " + method;
     std::string err = handle_pyerror(true, other_module, caller);
@@ -863,11 +859,7 @@ ceph_dispatch_remote(BaseMgrModule *self, PyObject *args)
   }
   std::span<std::byte const> pickled_args_span = py_bytes_as_span(pickled_args);
 
-  auto pickled_kwargs = PyObject_CallMethodObjArgs(
-    pmodule,
-    PyUnicode_FromString("dumps"),
-    remote_kwargs,
-    nullptr);
+  auto pickled_kwargs = PyObject_CallMethod(pmodule, "dumps", "(O)", remote_kwargs);
   if (pickled_kwargs == nullptr) {
     std::string caller = "ceph_dispatch_remote "s + " " + method;
     std::string err = handle_pyerror(true, other_module, caller);
@@ -918,11 +910,7 @@ ceph_dispatch_remote(BaseMgrModule *self, PyObject *args)
   }
 
   auto pickled_ret_bytes = py_bytes_from_vec(*maybe_pickled_ret);
-  auto ret = PyObject_CallMethodObjArgs(
-    pmodule,
-    PyUnicode_FromString("loads"),
-    pickled_ret_bytes,
-    nullptr);
+  auto ret = PyObject_CallMethod(pmodule, "loads", "(O)", pickled_ret_bytes);
   if (ret == nullptr) {
     std::string caller = "ceph_dispatch_remote "s + " " + method;
     std::string err = handle_pyerror(true, other_module, caller);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77775

---

backport of https://github.com/ceph/ceph/pull/69755
parent tracker: https://tracker.ceph.com/issues/77724

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh