### PR TITLE
crimson/mon/MonClient: fix use-after-free in run_command

### DIFF
--- a/src/crimson/mon/MonClient.cc
+++ b/src/crimson/mon/MonClient.cc
@@ -5,6 +5,7 @@
 
 #include <random>
 #include <fmt/ranges.h>
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/shared_future.hh>
@@ -1076,10 +1077,10 @@ Client::run_command(std::string&& cmd,
   m->set_tid(tid);
   m->cmd = {std::move(cmd)};
   m->set_data(std::move(bl));
-  auto& command = mon_commands.emplace_back(crimson::make_message<MMonCommand>(*m));
-  return send_message(std::move(m)).then([&result=command.result] {
-    return result.get_future();
-  });
+  auto fut = mon_commands.emplace_back(crimson::make_message<MMonCommand>(*m))
+                 .result.get_future();
+  co_await send_message(std::move(m));
+  co_return co_await std::move(fut);
 }
 
 seastar::future<> Client::send_message(MessageURef m)


### PR DESCRIPTION
`run_command()` captured a reference to the just-emplaced `mon_commands`
element into the `send_message()` continuation. `mon_commands` is a
`std::vector`, so a concurrent `run_command()` could reallocate it and
invalidate the reference before the continuation ran, dereferencing freed
memory.

No caller issues concurrent commands today, but the pattern is unsafe.
Take the result future before issuing the message and capture that instead
of the element.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests