### PR TITLE
crimson/osd/replicated_recovery_backend: fix use-after-move in stats

### DIFF
--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -919,14 +919,15 @@ ReplicatedRecoveryBackend::_handle_pull_response(
 		     push_op.data_included, push_op.data);
   bool complete = pull_info.is_complete();
   bool clear_omap = !push_op.before_progress.omap_complete;
+  const auto bytes_recovered = data.length();
+  const auto keys_recovered = push_op.omap_entries.size();
   co_await submit_push_data(pull_info.recovery_info,
 			    first, complete, clear_omap,
                             std::move(data_zeros), std::move(usable_intervals),
                             std::move(data), std::move(push_op.omap_header),
                             push_op.attrset, std::move(push_op.omap_entries), &t);
 
-  const auto bytes_recovered = data.length();
-  pull_info.stat.num_keys_recovered += push_op.omap_entries.size();
+  pull_info.stat.num_keys_recovered += keys_recovered;
   pull_info.stat.num_bytes_recovered += bytes_recovered;
 
   if (complete) {


### PR DESCRIPTION
`_handle_pull_response()` moved `data` and `push_op.omap_entries` into
`submit_push_data()` (which takes both by value) and only afterwards read
`data.length()` and `omap_entries.size()`. Both were moved-from by then, so
`num_bytes_recovered` and `num_keys_recovered` always increased by 0.

Capture the lengths before the move.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests