### PR TITLE
ceph.spec.in: drop rhel 8 support and use pkgconfig() when possible

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -150,7 +150,6 @@
 
 %{!?_udevrulesdir: %global _udevrulesdir /lib/udev/rules.d}
 %{!?tmpfiles_create: %global tmpfiles_create systemd-tmpfiles --create}
-%{!?python3_pkgversion: %global python3_pkgversion 3}
 %{!?python3_version_nodots: %global python3_version_nodots 3}
 %{!?python3_version: %global python3_version 3}
 %global c_ares_min_version 1.28.0
@@ -307,12 +306,12 @@ BuildRequires:	patch
 BuildRequires:	perl
 BuildRequires:	pkgconfig
 BuildRequires:  procps
-BuildRequires:	python%{python3_pkgversion}
-BuildRequires:	python%{python3_pkgversion}-devel
-BuildRequires:	python%{python3_pkgversion}-setuptools
-BuildRequires:	python%{python3_pkgversion}-Cython
-BuildRequires:	python%{python3_pkgversion}-pip
-BuildRequires:	python%{python3_pkgversion}-wheel
+BuildRequires:	python3
+BuildRequires:	python3-devel
+BuildRequires:	python3-setuptools
+BuildRequires:	python3-Cython
+BuildRequires:	python3-pip
+BuildRequires:	python3-wheel
 BuildRequires:	pkgconfig(snappy)
 BuildRequires:	pkgconfig(sqlite3)
 BuildRequires:	sudo
@@ -341,14 +340,14 @@ Requires:  %{luarocks_package_name}
 BuildRequires:  hostname
 BuildRequires:  jq
 BuildRequires:	pkgconfig(uuid)
-BuildRequires:	python%{python3_pkgversion}dist(bcrypt)
-BuildRequires:	python%{python3_pkgversion}dist(requests)
-BuildRequires:	python%{python3_pkgversion}dist(python-dateutil)
-BuildRequires:	python%{python3_pkgversion}dist(coverage)
-BuildRequires:	python%{python3_pkgversion}dist(pyopenssl)
+BuildRequires:	python3dist(bcrypt)
+BuildRequires:	python3dist(requests)
+BuildRequires:	python3dist(python-dateutil)
+BuildRequires:	python3dist(coverage)
+BuildRequires:	python3dist(pyopenssl)
 BuildRequires:	socat
-BuildRequires:	python%{python3_pkgversion}dist(asyncssh)
-BuildRequires:	python%{python3_pkgversion}dist(natsort)
+BuildRequires:	python3dist(asyncssh)
+BuildRequires:	python3dist(natsort)
 %endif
 BuildRequires:	pkgconfig(thrift) >= 0.13.0
 BuildRequires:  pkgconfig(re2)
@@ -395,9 +394,9 @@ BuildRequires:  gcc-toolset-%{gts_version}-libubsan-devel
 BuildRequires:  gcc-toolset-%{gts_version}-libasan-devel
 %endif
 %endif
-BuildRequires:	python%{python3_pkgversion}dist(prettytable)
-BuildRequires:	python%{python3_pkgversion}dist(pyyaml)
-BuildRequires:	python%{python3_pkgversion}dist(sphinx)
+BuildRequires:	python3dist(prettytable)
+BuildRequires:	python3dist(pyyaml)
+BuildRequires:	python3dist(sphinx)
 #################################################################################
 # distro-conditional dependencies
 #################################################################################
@@ -426,15 +425,15 @@ BuildRequires:  ninja-build
 BuildRequires:  numactl-devel
 #BuildRequires:  krb5-devel
 BuildRequires:  CUnit-devel
-BuildRequires:	python%{python3_pkgversion}-devel
+BuildRequires:	python3-devel
 %endif
 # distro-conditional make check dependencies
 %if 0%{with make_check}
 BuildRequires:	golang
 BuildRequires:	pkgconfig(xmlsec1)
 BuildRequires:	pkgconfig(xmlsec1-openssl)
-BuildRequires:	python%{python3_pkgversion}dist(cherrypy)
-BuildRequires:	python%{python3_pkgversion}dist(routes)
+BuildRequires:	python3dist(cherrypy)
+BuildRequires:	python3dist(routes)
 %if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
 BuildRequires:	/usr/bin/promtool
 BuildRequires:	libtool-ltdl-devel
@@ -443,8 +442,8 @@ BuildRequires:	xmlsec1
 BuildRequires:	xmlsec1-nss
 %endif
 BuildRequires:	xmlsec1-openssl
-BuildRequires:	python%{python3_pkgversion}dist(scipy)
-BuildRequires:	python%{python3_pkgversion}dist(pyopenssl)
+BuildRequires:	python3dist(scipy)
+BuildRequires:	python3dist(pyopenssl)
 %endif
 BuildRequires:	jsonnet
 %if 0%{?suse_version}
@@ -452,7 +451,7 @@ BuildRequires:	golang-github-prometheus-prometheus
 BuildRequires:	libxmlsec1-1
 BuildRequires:	libxmlsec1-nss1
 BuildRequires:	libxmlsec1-openssl1
-BuildRequires:	python%{python3_pkgversion}-numpy-devel
+BuildRequires:	python3-numpy-devel
 %endif
 %endif
 # lttng and babeltrace for rbd-replay-prep
@@ -525,7 +524,7 @@ Base is the package that includes all the files shared amongst ceph servers
 Summary:        Utility to bootstrap Ceph clusters
 BuildArch:      noarch
 Requires:       lvm2
-Requires:       python%{python3_pkgversion}
+Requires:       python3
 Requires:       openssh-server
 Requires:       which
 %if 0%{?weak_deps}
@@ -541,14 +540,14 @@ Recommends:     podman >= 2.0.2
 %if 0%{with cephadm_bundling}
 %if 0%{without cephadm_pip_deps}
 # Zipapp built from system RPMs at build time; bundled zipapp is self-contained at runtime.
-BuildRequires: python%{python3_pkgversion}dist(jinja2) >= 2.10
-BuildRequires: python%{python3_pkgversion}dist(pyyaml)
+BuildRequires: python3dist(jinja2) >= 2.10
+BuildRequires: python3dist(pyyaml)
 %endif
 %dnl end without cephadm_pip_deps (CEPHADM_BUNDLED_DEPENDENCIES=rpm)
 %else
 # Unbundled cephadm: host must provide yaml and jinja2 at runtime.
-Requires: python%{python3_pkgversion}dist(jinja2) >= 2.10
-Requires: python%{python3_pkgversion}dist(pyyaml)
+Requires: python3dist(jinja2) >= 2.10
+Requires: python3dist(pyyaml)
 %endif
 %dnl end with cephadm_bundling
 %description -n cephadm
@@ -563,13 +562,13 @@ Group:		System/Filesystems
 Requires:	librbd1 = %{_epoch_prefix}%{version}-%{release}
 Requires:	librados2 = %{_epoch_prefix}%{version}-%{release}
 Requires:	libcephfs2 = %{_epoch_prefix}%{version}-%{release}
-Requires:	python%{python3_pkgversion}-rados = %{_epoch_prefix}%{version}-%{release}
-Requires:	python%{python3_pkgversion}-rbd = %{_epoch_prefix}%{version}-%{release}
-Requires:	python%{python3_pkgversion}-cephfs = %{_epoch_prefix}%{version}-%{release}
-Requires:	python%{python3_pkgversion}-rgw = %{_epoch_prefix}%{version}-%{release}
-Requires:	python%{python3_pkgversion}-ceph-argparse = %{_epoch_prefix}%{version}-%{release}
-Requires:	python%{python3_pkgversion}-ceph-common = %{_epoch_prefix}%{version}-%{release}
-Requires:	python%{python3_pkgversion}dist(prettytable)
+Requires:	python3-rados = %{_epoch_prefix}%{version}-%{release}
+Requires:	python3-rbd = %{_epoch_prefix}%{version}-%{release}
+Requires:	python3-cephfs = %{_epoch_prefix}%{version}-%{release}
+Requires:	python3-rgw = %{_epoch_prefix}%{version}-%{release}
+Requires:	python3-ceph-argparse = %{_epoch_prefix}%{version}-%{release}
+Requires:	python3-ceph-common = %{_epoch_prefix}%{version}-%{release}
+Requires:	python3dist(prettytable)
 %if 0%{with libradosstriper}
 Requires:	libradosstriper1 = %{_epoch_prefix}%{version}-%{release}
 %endif
@@ -667,18 +666,18 @@ Requires:       ceph-mgr-smb = %{_epoch_prefix}%{version}-%{release}
 Requires:       ceph-grafana-dashboards = %{_epoch_prefix}%{version}-%{release}
 Requires:       ceph-prometheus-alerts = %{_epoch_prefix}%{version}-%{release}
 %if 0%{?fedora} || 0%{?rhel}
-Requires:       python%{python3_pkgversion}dist(grpcio)
-Requires:       python%{python3_pkgversion}dist(grpcio-tools)
-Requires:       python%{python3_pkgversion}dist(jmespath)
-Requires:       python%{python3_pkgversion}dist(xmltodict)
+Requires:       python3dist(grpcio)
+Requires:       python3dist(grpcio-tools)
+Requires:       python3dist(jmespath)
+Requires:       python3dist(xmltodict)
 %endif
-Requires:       python%{python3_pkgversion}dist(cherrypy)
-Requires:       python%{python3_pkgversion}dist(routes)
+Requires:       python3dist(cherrypy)
+Requires:       python3dist(routes)
 %if 0%{?weak_deps}
-Recommends:     python%{python3_pkgversion}dist(python3-saml)
+Recommends:     python3dist(python3-saml)
 %if 0%{?fedora}
-Recommends:     python%{python3_pkgversion}dist(grpcio)
-Recommends:     python%{python3_pkgversion}dist(grpcio-tools)
+Recommends:     python3dist(grpcio)
+Recommends:     python3dist(grpcio-tools)
 %endif
 %endif
 %description mgr-dashboard
@@ -694,11 +693,11 @@ BuildArch:      noarch
 Group:          System/Filesystems
 %endif
 Requires:       ceph-mgr = %{_epoch_prefix}%{version}-%{release}
-Requires:       python%{python3_pkgversion}dist(numpy)
+Requires:       python3dist(numpy)
 %if 0%{?fedora} || 0%{?suse_version} || 0%{?openEuler}
-Requires:       python%{python3_pkgversion}dist(scikit-learn)
+Requires:       python3dist(scikit-learn)
 %endif
-Requires:       python%{python3_pkgversion}dist(scipy)
+Requires:       python3dist(scipy)
 %description mgr-diskprediction-local
 ceph-mgr-diskprediction-local is a ceph-mgr module that tries to predict
 disk failures using local algorithms and machine-learning databases.
@@ -709,10 +708,10 @@ BuildArch:      noarch
 %if 0%{?suse_version}
 Group:          System/Filesystems
 %endif
-Requires:       python%{python3_pkgversion}dist(prettytable)
-Requires:       python%{python3_pkgversion}dist(requests)
-Requires:       python%{python3_pkgversion}dist(python-dateutil)
-Requires:       python%{python3_pkgversion}dist(pyyaml)
+Requires:       python3dist(prettytable)
+Requires:       python3dist(requests)
+Requires:       python3dist(python-dateutil)
+Requires:       python3dist(pyyaml)
 %if 0%{?weak_deps}
 Recommends:	ceph-mgr-rook = %{_epoch_prefix}%{version}-%{release}
 %endif
@@ -760,8 +759,8 @@ Group:          System/Filesystems
 %endif
 Requires:       ceph-mgr = %{_epoch_prefix}%{version}-%{release}
 Requires:       ceph-mgr-nfs = %{_epoch_prefix}%{version}-%{release}
-Requires:       python%{python3_pkgversion}dist(kubernetes)
-Requires:       python%{python3_pkgversion}dist(jsonpatch)
+Requires:       python3dist(kubernetes)
+Requires:       python3dist(jsonpatch)
 %description mgr-rook
 ceph-mgr-rook is a ceph-mgr module for orchestration functions using
 a Rook backend.
@@ -773,7 +772,7 @@ Summary:        Ceph Manager module to orchestrate ceph-events to kubernetes' ev
 Group:          System/Filesystems
 %endif
 Requires:       ceph-mgr = %{_epoch_prefix}%{version}-%{release}
-Requires:       python%{python3_pkgversion}dist(kubernetes)
+Requires:       python3dist(kubernetes)
 %description mgr-k8sevents
 ceph-mgr-k8sevents is a ceph-mgr module that sends every ceph-events
 to kubernetes' events API
@@ -787,13 +786,13 @@ Group:          System/Filesystems
 Requires:       ceph-mgr = %{_epoch_prefix}%{version}-%{release}
 Requires:       ceph-mgr-nfs = %{_epoch_prefix}%{version}-%{release}
 Requires:       ceph-mgr-smb = %{_epoch_prefix}%{version}-%{release}
-Requires:       python%{python3_pkgversion}dist(asyncssh)
-Requires:       python%{python3_pkgversion}dist(bcrypt)
-Requires:       python%{python3_pkgversion}dist(natsort)
-Requires:       python%{python3_pkgversion}dist(pyopenssl)
+Requires:       python3dist(asyncssh)
+Requires:       python3dist(bcrypt)
+Requires:       python3dist(natsort)
+Requires:       python3dist(pyopenssl)
 Requires:       cephadm = %{_epoch_prefix}%{version}-%{release}
-Requires:       python%{python3_pkgversion}dist(cherrypy)
-Requires:       python%{python3_pkgversion}dist(jinja2)
+Requires:       python3dist(cherrypy)
+Requires:       python3dist(jinja2)
 %if 0%{?suse_version}
 Requires:       openssh
 %endif
@@ -835,7 +834,7 @@ Group:          System/Filesystems
 %endif
 Requires:       ceph-mgr = %{_epoch_prefix}%{version}-%{release}
 %if 0%{?weak_deps}
-Recommends:     python%{python3_pkgversion}dist(influxdb)
+Recommends:     python3dist(influxdb)
 %endif
 Obsoletes:      ceph-mgr-modules-core < %{_epoch_prefix}%{version}-%{release}
 %description mgr-influx
@@ -933,7 +932,7 @@ Summary:        Ceph Manager module for OSD performance counter queries
 Group:          System/Filesystems
 %endif
 Requires:       ceph-mgr = %{_epoch_prefix}%{version}-%{release}
-Requires:       python%{python3_pkgversion}dist(prettytable)
+Requires:       python3dist(prettytable)
 Obsoletes:      ceph-mgr-modules-core < %{_epoch_prefix}%{version}-%{release}
 %description mgr-osd-perf-query
 ceph-mgr-osd-perf-query is a ceph-mgr module that exposes OSD
@@ -959,7 +958,7 @@ Group:          System/Filesystems
 %endif
 Requires:       ceph-mgr = %{_epoch_prefix}%{version}-%{release}
 Obsoletes:      ceph-mgr-modules-core < %{_epoch_prefix}%{version}-%{release}
-Requires:       python%{python3_pkgversion}dist(cherrypy)
+Requires:       python3dist(cherrypy)
 %description mgr-prometheus
 ceph-mgr-prometheus is a ceph-mgr module that exposes cluster metrics
 in Prometheus exposition format.
@@ -1054,7 +1053,7 @@ Summary:	Ceph fuse-based client
 Group:		System/Filesystems
 %endif
 Requires:       fuse3
-Requires:	python%{python3_pkgversion}
+Requires:	python3
 %description fuse
 FUSE based client for Ceph distributed network file system
 
@@ -1146,7 +1145,7 @@ service as well as the OpenStack Object Storage ("Swift") API.
 %package -n cephfs-top
 Summary:    top(1) like utility for Ceph Filesystem
 BuildArch:  noarch
-Requires:   python%{python3_pkgversion}-rados
+Requires:   python3-rados
 %description -n cephfs-top
 This package provides a top(1) like utility to display Ceph Filesystem metrics
 in realtime.
@@ -1237,8 +1236,8 @@ Requires: lvm2
 Requires: parted
 Requires: util-linux
 Requires: xfsprogs
-Requires: python%{python3_pkgversion}-setuptools
-Requires: python%{python3_pkgversion}-ceph-common = %{_epoch_prefix}%{version}-%{release}
+Requires: python3-setuptools
+Requires: python3-ceph-common = %{_epoch_prefix}%{version}-%{release}
 %description volume
 This package contains a tool to deploy OSD with different devices like
 lvm or physical disks, and trying to follow a predictable, and robust
@@ -1305,31 +1304,31 @@ Obsoletes:	librgw2-devel < %{_epoch_prefix}%{version}-%{release}
 This package contains libraries and headers needed to develop programs
 that use RADOS gateway client library.
 
-%package -n python%{python3_pkgversion}-rgw
+%package -n python3-rgw
 Summary:	Python 3 libraries for the RADOS gateway
 %if 0%{?suse_version}
 Group:		Development/Libraries/Python
 %endif
 Requires:	librgw2 = %{_epoch_prefix}%{version}-%{release}
-Requires:	python%{python3_pkgversion}-rados = %{_epoch_prefix}%{version}-%{release}
-%{?python_provide:%python_provide python%{python3_pkgversion}-rgw}
+Requires:	python3-rados = %{_epoch_prefix}%{version}-%{release}
+%{?python_provide:%python_provide python3-rgw}
 Provides:	python-rgw = %{_epoch_prefix}%{version}-%{release}
 Obsoletes:	python-rgw < %{_epoch_prefix}%{version}-%{release}
-%description -n python%{python3_pkgversion}-rgw
+%description -n python3-rgw
 This package contains Python 3 libraries for interacting with Ceph RADOS
 gateway.
 
-%package -n python%{python3_pkgversion}-rados
+%package -n python3-rados
 Summary:	Python 3 libraries for the RADOS object store
 %if 0%{?suse_version}
 Group:		Development/Libraries/Python
 %endif
-Requires:	python%{python3_pkgversion}
+Requires:	python3
 Requires:	librados2 = %{_epoch_prefix}%{version}-%{release}
-%{?python_provide:%python_provide python%{python3_pkgversion}-rados}
+%{?python_provide:%python_provide python3-rados}
 Provides:	python-rados = %{_epoch_prefix}%{version}-%{release}
 Obsoletes:	python-rados < %{_epoch_prefix}%{version}-%{release}
-%description -n python%{python3_pkgversion}-rados
+%description -n python3-rados
 This package contains Python 3 libraries for interacting with Ceph RADOS
 object store.
 
@@ -1420,17 +1419,17 @@ Obsoletes:	librbd1-devel < %{_epoch_prefix}%{version}-%{release}
 This package contains libraries and headers needed to develop programs
 that use RADOS block device.
 
-%package -n python%{python3_pkgversion}-rbd
+%package -n python3-rbd
 Summary:	Python 3 libraries for the RADOS block device
 %if 0%{?suse_version}
 Group:		Development/Libraries/Python
 %endif
 Requires:	librbd1 = %{_epoch_prefix}%{version}-%{release}
-Requires:	python%{python3_pkgversion}-rados = %{_epoch_prefix}%{version}-%{release}
-%{?python_provide:%python_provide python%{python3_pkgversion}-rbd}
+Requires:	python3-rados = %{_epoch_prefix}%{version}-%{release}
+%{?python_provide:%python_provide python3-rbd}
 Provides:	python-rbd = %{_epoch_prefix}%{version}-%{release}
 Obsoletes:	python-rbd < %{_epoch_prefix}%{version}-%{release}
-%description -n python%{python3_pkgversion}-rbd
+%description -n python3-rbd
 This package contains Python 3 libraries for interacting with Ceph RADOS
 block device.
 
@@ -1486,55 +1485,55 @@ Obsoletes:	libcephfs2-devel < %{_epoch_prefix}%{version}-%{release}
 This package contains libraries and headers needed to develop programs
 that use Ceph distributed file system.
 
-%package -n python%{python3_pkgversion}-cephfs
+%package -n python3-cephfs
 Summary:	Python 3 libraries for Ceph distributed file system
 %if 0%{?suse_version}
 Group:		Development/Libraries/Python
 %endif
 Requires:	libcephfs2 = %{_epoch_prefix}%{version}-%{release}
-Requires:	python%{python3_pkgversion}-rados = %{_epoch_prefix}%{version}-%{release}
-Requires:	python%{python3_pkgversion}-ceph-argparse = %{_epoch_prefix}%{version}-%{release}
-%{?python_provide:%python_provide python%{python3_pkgversion}-cephfs}
+Requires:	python3-rados = %{_epoch_prefix}%{version}-%{release}
+Requires:	python3-ceph-argparse = %{_epoch_prefix}%{version}-%{release}
+%{?python_provide:%python_provide python3-cephfs}
 Provides:	python-cephfs = %{_epoch_prefix}%{version}-%{release}
 Obsoletes:	python-cephfs < %{_epoch_prefix}%{version}-%{release}
-%description -n python%{python3_pkgversion}-cephfs
+%description -n python3-cephfs
 This package contains Python 3 libraries for interacting with Ceph distributed
 file system.
 
-%package -n python%{python3_pkgversion}-ceph-argparse
+%package -n python3-ceph-argparse
 Summary:	Python 3 utility libraries for Ceph CLI
 %if 0%{?suse_version}
 Group:		Development/Libraries/Python
 %endif
-%{?python_provide:%python_provide python%{python3_pkgversion}-ceph-argparse}
-%description -n python%{python3_pkgversion}-ceph-argparse
+%{?python_provide:%python_provide python3-ceph-argparse}
+%description -n python3-ceph-argparse
 This package contains types and routines for Python 3 used by the Ceph CLI as
 well as the RESTful interface. These have to do with querying the daemons for
 command-description information, validating user command input against those
 descriptions, and submitting the command to the appropriate daemon.
 
-%package -n python%{python3_pkgversion}-ceph-common
+%package -n python3-ceph-common
 Summary:	Python 3 utility libraries for Ceph
-Requires:       python%{python3_pkgversion}dist(pyyaml)
+Requires:       python3dist(pyyaml)
 %if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
 %if %{with pypkg}
-Recommends:     python%{python3_pkgversion}-ceph-smb-ctl
+Recommends:     python3-ceph-smb-ctl
 %endif
 %endif
 %if 0%{?suse_version}
 Group:		Development/Libraries/Python
 %endif
-%{?python_provide:%python_provide python%{python3_pkgversion}-ceph-common}
-%description -n python%{python3_pkgversion}-ceph-common
+%{?python_provide:%python_provide python3-ceph-common}
+%description -n python3-ceph-common
 This package contains data structures, classes and functions used by Ceph.
 It also contains utilities used for the cephadm orchestrator.
 
 %if 0%{with cephfs_shell}
 %package -n cephfs-shell
 Summary:    Interactive shell for Ceph file system
-Requires:   python%{python3_pkgversion}dist(cmd2)
-Requires:   python%{python3_pkgversion}dist(colorama)
-Requires:   python%{python3_pkgversion}-cephfs
+Requires:   python3dist(cmd2)
+Requires:   python3dist(colorama)
+Requires:   python3-cephfs
 %description -n cephfs-shell
 This package contains an interactive tool that allows accessing a Ceph
 file system without mounting it  by providing a nice pseudo-shell which
@@ -1664,20 +1663,20 @@ Group:          System/Monitoring
 This package provides a Ceph hardware monitoring agent.
 
 %if %{with pypkg}
-%package -n python%{python3_pkgversion}-ceph-smb-ctl
+%package -n python3-ceph-smb-ctl
 Summary:        Ceph SMB Service Remote-Control Client
 BuildArch:      noarch
 %if 0%{?suse_version}
 Group:          System/Filesystems
 %endif
-Requires:       python%{python3_pkgversion}-ceph-common = %{_epoch_prefix}%{version}-%{release}
-Requires:       python%{python3_pkgversion}dist(grpcio)
-Requires:       python%{python3_pkgversion}dist(grpcio-reflection)
-%description -n python%{python3_pkgversion}-ceph-smb-ctl
+Requires:       python3-ceph-common = %{_epoch_prefix}%{version}-%{release}
+Requires:       python3dist(grpcio)
+Requires:       python3dist(grpcio-reflection)
+%description -n python3-ceph-smb-ctl
 This package provides a tool to interact with Ceph's SMB Service Remote-Control
 gRPC API as a client.
 %endif
-%dnl end package python%{python3_pkgversion}-ceph-smb-ctl
+%dnl end package python3-ceph-smb-ctl
 
 #################################################################################
 # common
@@ -2798,7 +2797,7 @@ fi
 %{_includedir}/rados/cls_flags.hpp
 %{_includedir}/rados/cls_traits.hpp
 
-%files -n python%{python3_pkgversion}-rados
+%files -n python3-rados
 %{python3_sitearch}/rados.cpython*.so
 %{python3_sitearch}/rados-*.dist-info
 
@@ -2870,11 +2869,11 @@ fi
 %{_libdir}/librgw_rados_tp.so
 %endif
 
-%files -n python%{python3_pkgversion}-rgw
+%files -n python3-rgw
 %{python3_sitearch}/rgw.cpython*.so
 %{python3_sitearch}/rgw-*.dist-info
 
-%files -n python%{python3_pkgversion}-rbd
+%files -n python3-rbd
 %{python3_sitearch}/rbd.cpython*.so
 %{python3_sitearch}/rbd-*.dist-info
 
@@ -2911,17 +2910,17 @@ fi
 %{_libdir}/libcephfs_proxy.so
 %{_libdir}/pkgconfig/cephfs.pc
 
-%files -n python%{python3_pkgversion}-cephfs
+%files -n python3-cephfs
 %{python3_sitearch}/cephfs.cpython*.so
 %{python3_sitearch}/cephfs-*.dist-info
 
-%files -n python%{python3_pkgversion}-ceph-argparse
+%files -n python3-ceph-argparse
 %{python3_sitelib}/ceph_argparse.py
 %{python3_sitelib}/__pycache__/ceph_argparse.cpython*.py*
 %{python3_sitelib}/ceph_daemon.py
 %{python3_sitelib}/__pycache__/ceph_daemon.cpython*.py*
 
-%files -n python%{python3_pkgversion}-ceph-common
+%files -n python3-ceph-common
 %{python3_sitelib}/ceph
 %{python3_sitelib}/ceph-*.%{?with_pypkg:dist}%{!?with_pypkg:egg}-info
 
@@ -3121,7 +3120,7 @@ exit 0
 %{python3_sitelib}/ceph_node_proxy-*
 
 %if %{with pypkg}
-%files -n python%{python3_pkgversion}-ceph-smb-ctl
+%files -n python3-ceph-smb-ctl
 %{_bindir}/ceph-smb-ctl
 %endif
 

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -341,14 +341,14 @@ Requires:  %{luarocks_package_name}
 BuildRequires:  hostname
 BuildRequires:  jq
 BuildRequires:	pkgconfig(uuid)
-BuildRequires:	python%{python3_pkgversion}-bcrypt
-BuildRequires:	python%{python3_pkgversion}-requests
-BuildRequires:	python%{python3_pkgversion}-dateutil
-BuildRequires:	python%{python3_pkgversion}-coverage
-BuildRequires:	python%{python3_pkgversion}-pyOpenSSL
+BuildRequires:	python%{python3_pkgversion}dist(bcrypt)
+BuildRequires:	python%{python3_pkgversion}dist(requests)
+BuildRequires:	python%{python3_pkgversion}dist(python-dateutil)
+BuildRequires:	python%{python3_pkgversion}dist(coverage)
+BuildRequires:	python%{python3_pkgversion}dist(pyopenssl)
 BuildRequires:	socat
-BuildRequires:	python%{python3_pkgversion}-asyncssh
-BuildRequires:	python%{python3_pkgversion}-natsort
+BuildRequires:	python%{python3_pkgversion}dist(asyncssh)
+BuildRequires:	python%{python3_pkgversion}dist(natsort)
 %endif
 BuildRequires:	pkgconfig(thrift) >= 0.13.0
 BuildRequires:  pkgconfig(re2)
@@ -395,6 +395,9 @@ BuildRequires:  gcc-toolset-%{gts_version}-libubsan-devel
 BuildRequires:  gcc-toolset-%{gts_version}-libasan-devel
 %endif
 %endif
+BuildRequires:	python%{python3_pkgversion}dist(prettytable)
+BuildRequires:	python%{python3_pkgversion}dist(pyyaml)
+BuildRequires:	python%{python3_pkgversion}dist(sphinx)
 #################################################################################
 # distro-conditional dependencies
 #################################################################################
@@ -411,9 +414,6 @@ BuildRequires:  ninja
 #BuildRequires:  krb5
 #BuildRequires:  krb5-devel
 BuildRequires:  cunit-devel
-BuildRequires:	python%{python3_pkgversion}-PrettyTable
-BuildRequires:	python%{python3_pkgversion}-PyYAML
-BuildRequires:	python%{python3_pkgversion}-Sphinx
 # for prometheus-alerts
 BuildRequires:  golang-github-prometheus-prometheus
 BuildRequires:	jsonnet
@@ -427,15 +427,14 @@ BuildRequires:  numactl-devel
 #BuildRequires:  krb5-devel
 BuildRequires:  CUnit-devel
 BuildRequires:	python%{python3_pkgversion}-devel
-BuildRequires:	python%{python3_pkgversion}-prettytable
-BuildRequires:	python%{python3_pkgversion}-pyyaml
-BuildRequires:	python%{python3_pkgversion}-sphinx
 %endif
 # distro-conditional make check dependencies
 %if 0%{with make_check}
 BuildRequires:	golang
 BuildRequires:	pkgconfig(xmlsec1)
 BuildRequires:	pkgconfig(xmlsec1-openssl)
+BuildRequires:	python%{python3_pkgversion}dist(cherrypy)
+BuildRequires:	python%{python3_pkgversion}dist(routes)
 %if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
 BuildRequires:	/usr/bin/promtool
 BuildRequires:	libtool-ltdl-devel
@@ -444,10 +443,8 @@ BuildRequires:	xmlsec1
 BuildRequires:	xmlsec1-nss
 %endif
 BuildRequires:	xmlsec1-openssl
-BuildRequires:	python%{python3_pkgversion}-cherrypy
-BuildRequires:	python%{python3_pkgversion}-routes
-BuildRequires:	python%{python3_pkgversion}-scipy
-BuildRequires:	python%{python3_pkgversion}-pyOpenSSL
+BuildRequires:	python%{python3_pkgversion}dist(scipy)
+BuildRequires:	python%{python3_pkgversion}dist(pyopenssl)
 %endif
 BuildRequires:	jsonnet
 %if 0%{?suse_version}
@@ -455,8 +452,6 @@ BuildRequires:	golang-github-prometheus-prometheus
 BuildRequires:	libxmlsec1-1
 BuildRequires:	libxmlsec1-nss1
 BuildRequires:	libxmlsec1-openssl1
-BuildRequires:	python%{python3_pkgversion}-CherryPy
-BuildRequires:	python%{python3_pkgversion}-Routes
 BuildRequires:	python%{python3_pkgversion}-numpy-devel
 %endif
 %endif
@@ -546,27 +541,14 @@ Recommends:     podman >= 2.0.2
 %if 0%{with cephadm_bundling}
 %if 0%{without cephadm_pip_deps}
 # Zipapp built from system RPMs at build time; bundled zipapp is self-contained at runtime.
-# SUSE and RHEL/Fedora use different PyPI RPM names (Jinja2/PyYAML vs jinja2/pyyaml).
-%if 0%{?suse_version}
-BuildRequires: python%{python3_pkgversion}-Jinja2 >= 2.10
-BuildRequires: python%{python3_pkgversion}-PyYAML
-%else
-BuildRequires: python%{python3_pkgversion}-jinja2 >= 2.10
-BuildRequires: python%{python3_pkgversion}-pyyaml
-%endif
-%dnl suse/else: rpm bundle, distinct RPM names only (not duplicate stanzas)
+BuildRequires: python%{python3_pkgversion}dist(jinja2) >= 2.10
+BuildRequires: python%{python3_pkgversion}dist(pyyaml)
 %endif
 %dnl end without cephadm_pip_deps (CEPHADM_BUNDLED_DEPENDENCIES=rpm)
 %else
 # Unbundled cephadm: host must provide yaml and jinja2 at runtime.
-%if 0%{?suse_version}
-Requires: python%{python3_pkgversion}-Jinja2 >= 2.10
-Requires: python%{python3_pkgversion}-PyYAML
-%else
-Requires: python%{python3_pkgversion}-jinja2 >= 2.10
-Requires: python%{python3_pkgversion}-pyyaml
-%endif
-%dnl suse/else: unbundled cephadm (CEPHADM_BUNDLED_DEPENDENCIES=none)
+Requires: python%{python3_pkgversion}dist(jinja2) >= 2.10
+Requires: python%{python3_pkgversion}dist(pyyaml)
 %endif
 %dnl end with cephadm_bundling
 %description -n cephadm
@@ -587,12 +569,7 @@ Requires:	python%{python3_pkgversion}-cephfs = %{_epoch_prefix}%{version}-%{rele
 Requires:	python%{python3_pkgversion}-rgw = %{_epoch_prefix}%{version}-%{release}
 Requires:	python%{python3_pkgversion}-ceph-argparse = %{_epoch_prefix}%{version}-%{release}
 Requires:	python%{python3_pkgversion}-ceph-common = %{_epoch_prefix}%{version}-%{release}
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
-Requires:	python%{python3_pkgversion}-prettytable
-%endif
-%if 0%{?suse_version}
-Requires:	python%{python3_pkgversion}-PrettyTable
-%endif
+Requires:	python%{python3_pkgversion}dist(prettytable)
 %if 0%{with libradosstriper}
 Requires:	libradosstriper1 = %{_epoch_prefix}%{version}-%{release}
 %endif
@@ -690,26 +667,19 @@ Requires:       ceph-mgr-smb = %{_epoch_prefix}%{version}-%{release}
 Requires:       ceph-grafana-dashboards = %{_epoch_prefix}%{version}-%{release}
 Requires:       ceph-prometheus-alerts = %{_epoch_prefix}%{version}-%{release}
 %if 0%{?fedora} || 0%{?rhel}
-Requires:       python%{python3_pkgversion}-grpcio
-Requires:       python%{python3_pkgversion}-grpcio-tools
-Requires:       python%{python3_pkgversion}-jmespath
-Requires:       python%{python3_pkgversion}-xmltodict
+Requires:       python%{python3_pkgversion}dist(grpcio)
+Requires:       python%{python3_pkgversion}dist(grpcio-tools)
+Requires:       python%{python3_pkgversion}dist(jmespath)
+Requires:       python%{python3_pkgversion}dist(xmltodict)
 %endif
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
-Requires:       python%{python3_pkgversion}-cherrypy
-Requires:       python%{python3_pkgversion}-routes
+Requires:       python%{python3_pkgversion}dist(cherrypy)
+Requires:       python%{python3_pkgversion}dist(routes)
 %if 0%{?weak_deps}
-Recommends:     python%{python3_pkgversion}-saml
+Recommends:     python%{python3_pkgversion}dist(python3-saml)
 %if 0%{?fedora}
-Recommends:     python%{python3_pkgversion}-grpcio
-Recommends:     python%{python3_pkgversion}-grpcio-tools
+Recommends:     python%{python3_pkgversion}dist(grpcio)
+Recommends:     python%{python3_pkgversion}dist(grpcio-tools)
 %endif
-%endif
-%endif
-%if 0%{?suse_version}
-Requires:       python%{python3_pkgversion}-CherryPy
-Requires:       python%{python3_pkgversion}-Routes
-Recommends:     python%{python3_pkgversion}-python3-saml
 %endif
 %description mgr-dashboard
 ceph-mgr-dashboard is a manager module, providing a web-based application
@@ -724,11 +694,11 @@ BuildArch:      noarch
 Group:          System/Filesystems
 %endif
 Requires:       ceph-mgr = %{_epoch_prefix}%{version}-%{release}
-Requires:       python%{python3_pkgversion}-numpy
+Requires:       python%{python3_pkgversion}dist(numpy)
 %if 0%{?fedora} || 0%{?suse_version} || 0%{?openEuler}
-Requires:       python%{python3_pkgversion}-scikit-learn
+Requires:       python%{python3_pkgversion}dist(scikit-learn)
 %endif
-Requires:       python3-scipy
+Requires:       python%{python3_pkgversion}dist(scipy)
 %description mgr-diskprediction-local
 ceph-mgr-diskprediction-local is a ceph-mgr module that tries to predict
 disk failures using local algorithms and machine-learning databases.
@@ -739,15 +709,10 @@ BuildArch:      noarch
 %if 0%{?suse_version}
 Group:          System/Filesystems
 %endif
-Requires:       python%{python3_pkgversion}-prettytable
-Requires:       python%{python3_pkgversion}-requests
-Requires:       python%{python3_pkgversion}-dateutil
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
-Requires:       python%{python3_pkgversion}-pyyaml
-%endif
-%if 0%{?suse_version}
-Requires:       python%{python3_pkgversion}-PyYAML
-%endif
+Requires:       python%{python3_pkgversion}dist(prettytable)
+Requires:       python%{python3_pkgversion}dist(requests)
+Requires:       python%{python3_pkgversion}dist(python-dateutil)
+Requires:       python%{python3_pkgversion}dist(pyyaml)
 %if 0%{?weak_deps}
 Recommends:	ceph-mgr-rook = %{_epoch_prefix}%{version}-%{release}
 %endif
@@ -795,8 +760,8 @@ Group:          System/Filesystems
 %endif
 Requires:       ceph-mgr = %{_epoch_prefix}%{version}-%{release}
 Requires:       ceph-mgr-nfs = %{_epoch_prefix}%{version}-%{release}
-Requires:       python%{python3_pkgversion}-kubernetes
-Requires:       python%{python3_pkgversion}-jsonpatch
+Requires:       python%{python3_pkgversion}dist(kubernetes)
+Requires:       python%{python3_pkgversion}dist(jsonpatch)
 %description mgr-rook
 ceph-mgr-rook is a ceph-mgr module for orchestration functions using
 a Rook backend.
@@ -808,7 +773,7 @@ Summary:        Ceph Manager module to orchestrate ceph-events to kubernetes' ev
 Group:          System/Filesystems
 %endif
 Requires:       ceph-mgr = %{_epoch_prefix}%{version}-%{release}
-Requires:       python%{python3_pkgversion}-kubernetes
+Requires:       python%{python3_pkgversion}dist(kubernetes)
 %description mgr-k8sevents
 ceph-mgr-k8sevents is a ceph-mgr module that sends every ceph-events
 to kubernetes' events API
@@ -822,20 +787,18 @@ Group:          System/Filesystems
 Requires:       ceph-mgr = %{_epoch_prefix}%{version}-%{release}
 Requires:       ceph-mgr-nfs = %{_epoch_prefix}%{version}-%{release}
 Requires:       ceph-mgr-smb = %{_epoch_prefix}%{version}-%{release}
-Requires:       python%{python3_pkgversion}-asyncssh
-Requires:       python%{python3_pkgversion}-bcrypt
-Requires:       python%{python3_pkgversion}-natsort
-Requires:       python%{python3_pkgversion}-pyOpenSSL
+Requires:       python%{python3_pkgversion}dist(asyncssh)
+Requires:       python%{python3_pkgversion}dist(bcrypt)
+Requires:       python%{python3_pkgversion}dist(natsort)
+Requires:       python%{python3_pkgversion}dist(pyopenssl)
 Requires:       cephadm = %{_epoch_prefix}%{version}-%{release}
+Requires:       python%{python3_pkgversion}dist(cherrypy)
+Requires:       python%{python3_pkgversion}dist(jinja2)
 %if 0%{?suse_version}
 Requires:       openssh
-Requires:       python%{python3_pkgversion}-CherryPy
-Requires:       python%{python3_pkgversion}-Jinja2
 %endif
 %if 0%{?rhel} || 0%{?fedora} || 0%{?openEuler}
 Requires:       openssh-clients
-Requires:       python%{python3_pkgversion}-cherrypy
-Requires:       python%{python3_pkgversion}-jinja2
 %endif
 %description mgr-cephadm
 ceph-mgr-cephadm is a ceph-mgr module for orchestration functions using
@@ -872,7 +835,7 @@ Group:          System/Filesystems
 %endif
 Requires:       ceph-mgr = %{_epoch_prefix}%{version}-%{release}
 %if 0%{?weak_deps}
-Recommends:     python%{python3_pkgversion}-influxdb
+Recommends:     python%{python3_pkgversion}dist(influxdb)
 %endif
 Obsoletes:      ceph-mgr-modules-core < %{_epoch_prefix}%{version}-%{release}
 %description mgr-influx
@@ -970,7 +933,7 @@ Summary:        Ceph Manager module for OSD performance counter queries
 Group:          System/Filesystems
 %endif
 Requires:       ceph-mgr = %{_epoch_prefix}%{version}-%{release}
-Requires:       python%{python3_pkgversion}-prettytable
+Requires:       python%{python3_pkgversion}dist(prettytable)
 Obsoletes:      ceph-mgr-modules-core < %{_epoch_prefix}%{version}-%{release}
 %description mgr-osd-perf-query
 ceph-mgr-osd-perf-query is a ceph-mgr module that exposes OSD
@@ -996,12 +959,7 @@ Group:          System/Filesystems
 %endif
 Requires:       ceph-mgr = %{_epoch_prefix}%{version}-%{release}
 Obsoletes:      ceph-mgr-modules-core < %{_epoch_prefix}%{version}-%{release}
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
-Requires:       python%{python3_pkgversion}-cherrypy
-%endif
-%if 0%{?suse_version}
-Requires:       python%{python3_pkgversion}-CherryPy
-%endif
+Requires:       python%{python3_pkgversion}dist(cherrypy)
 %description mgr-prometheus
 ceph-mgr-prometheus is a ceph-mgr module that exposes cluster metrics
 in Prometheus exposition format.
@@ -1557,14 +1515,11 @@ descriptions, and submitting the command to the appropriate daemon.
 
 %package -n python%{python3_pkgversion}-ceph-common
 Summary:	Python 3 utility libraries for Ceph
+Requires:       python%{python3_pkgversion}dist(pyyaml)
 %if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
-Requires:       python%{python3_pkgversion}-pyyaml
 %if %{with pypkg}
 Recommends:     python%{python3_pkgversion}-ceph-smb-ctl
 %endif
-%endif
-%if 0%{?suse_version}
-Requires:       python%{python3_pkgversion}-PyYAML
 %endif
 %if 0%{?suse_version}
 Group:		Development/Libraries/Python
@@ -1577,8 +1532,8 @@ It also contains utilities used for the cephadm orchestrator.
 %if 0%{with cephfs_shell}
 %package -n cephfs-shell
 Summary:    Interactive shell for Ceph file system
-Requires:   python%{python3_pkgversion}-cmd2
-Requires:   python%{python3_pkgversion}-colorama
+Requires:   python%{python3_pkgversion}dist(cmd2)
+Requires:   python%{python3_pkgversion}dist(colorama)
 Requires:   python%{python3_pkgversion}-cephfs
 %description -n cephfs-shell
 This package contains an interactive tool that allows accessing a Ceph
@@ -1716,8 +1671,8 @@ BuildArch:      noarch
 Group:          System/Filesystems
 %endif
 Requires:       python%{python3_pkgversion}-ceph-common = %{_epoch_prefix}%{version}-%{release}
-Requires:       python%{python3_pkgversion}-grpcio
-Requires:       python%{python3_pkgversion}-grpcio-reflection
+Requires:       python%{python3_pkgversion}dist(grpcio)
+Requires:       python%{python3_pkgversion}dist(grpcio-reflection)
 %description -n python%{python3_pkgversion}-ceph-smb-ctl
 This package provides a tool to interact with Ceph's SMB Service Remote-Control
 gRPC API as a client.

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -35,7 +35,7 @@
 %bcond_with rbd_rwl_cache
 %endif
 %if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
-%if (0%{?rhel} && 0%{?rhel} < 9) || 0%{?openEuler}
+%if 0%{?openEuler}
 %bcond_with system_pmdk
 %else
 %ifarch s390x aarch64
@@ -97,23 +97,21 @@
 %else
 %bcond_without jaeger
 %endif
-%if 0%{?fedora} || 0%{?suse_version} >= 1500 || 0%{?rhel} >= 9
+%if 0%{?fedora} || 0%{?suse_version} >= 1500 || 0%{?rhel}
 # distros that ship cmd2 and/or colorama
 %bcond_without cephfs_shell
 %else
 # distros that do _not_ ship cmd2/colorama
 %bcond_with cephfs_shell
 %endif
-%if 0%{?fedora} || 0%{?rhel} >= 9
+%if 0%{?fedora} || 0%{?rhel}
 %bcond_without system_arrow
 %else
-# for centos 8, utf8proc-devel comes from the subversion-devel module which isn't available in EPEL8
-# this is tracked in https://bugzilla.redhat.com/2152265
 %bcond_with system_arrow
 %endif
 # qat only supported for intel devices
 %ifarch x86_64
-%if 0%{?fedora} || 0%{?rhel} >= 9
+%if 0%{?fedora} || 0%{?rhel}
 %bcond_without system_qat
 %else
 # not fedora/rhel
@@ -123,7 +121,7 @@
 # not x86_64
 %bcond_with system_qat
 %endif
-%if 0%{?fedora} || 0%{?suse_version} || 0%{?rhel} >= 8 || 0%{?openEuler}
+%if 0%{?fedora} || 0%{?suse_version} || 0%{?rhel} || 0%{?openEuler}
 %global weak_deps 1
 %endif
 %if %{with selinux}
@@ -275,11 +273,8 @@ BuildRequires:  libatomic
 %endif
 %if 0%{with tcmalloc}
 # libprofiler did not build on ppc64le until 2.7.90
-%if 0%{?fedora} || 0%{?rhel} >= 8 || 0%{?openEuler}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
 BuildRequires:	gperftools-devel >= 2.7.90
-%endif
-%if 0%{?rhel} && 0%{?rhel} < 8
-BuildRequires:	gperftools-devel >= 2.6.1
 %endif
 %if 0%{?suse_version}
 BuildRequires:	gperftools-devel >= 2.4
@@ -515,7 +510,7 @@ BuildRequires:  libcryptopp-devel
 BuildRequires:  libnuma-devel
 %endif
 %endif
-%if 0%{?rhel} >= 9
+%if 0%{?rhel}
 BuildRequires: python-rpm-macros
 %endif
 
@@ -547,13 +542,6 @@ Requires:      logrotate
 Requires:      psmisc
 Requires:      util-linux
 Requires:      which
-%if 0%{?rhel} && 0%{?rhel} < 8
-# The following is necessary due to tracker 36508 and can be removed once the
-# associated upstream bugs are resolved.
-%if 0%{with tcmalloc}
-Requires:      gperftools-libs >= 2.6.1
-%endif
-%endif
 %if 0%{?weak_deps}
 Recommends:    chrony
 Recommends:    nvme-cli
@@ -729,7 +717,7 @@ Requires:       ceph-mgr = %{_epoch_prefix}%{version}-%{release}
 Requires:       ceph-mgr-smb = %{_epoch_prefix}%{version}-%{release}
 Requires:       ceph-grafana-dashboards = %{_epoch_prefix}%{version}-%{release}
 Requires:       ceph-prometheus-alerts = %{_epoch_prefix}%{version}-%{release}
-%if 0%{?fedora} || 0%{?rhel} >= 9
+%if 0%{?fedora} || 0%{?rhel}
 Requires:       python%{python3_pkgversion}-grpcio
 Requires:       python%{python3_pkgversion}-grpcio-tools
 Requires:       python%{python3_pkgversion}-jmespath
@@ -740,7 +728,7 @@ Requires:       python%{python3_pkgversion}-cherrypy
 Requires:       python%{python3_pkgversion}-routes
 %if 0%{?weak_deps}
 Recommends:     python%{python3_pkgversion}-saml
-%if 0%{?fedora} || (0%{?rhel} && 0%{?rhel} <= 8)
+%if 0%{?fedora}
 Recommends:     python%{python3_pkgversion}-grpcio
 Recommends:     python%{python3_pkgversion}-grpcio-tools
 %endif
@@ -782,16 +770,11 @@ Group:          System/Filesystems
 Requires:       python%{python3_pkgversion}-prettytable
 Requires:       python%{python3_pkgversion}-requests
 Requires:       python%{python3_pkgversion}-dateutil
-%if 0%{?fedora} || 0%{?rhel} >= 8 || 0%{?openEuler}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
 Requires:       python%{python3_pkgversion}-pyyaml
 %endif
 %if 0%{?suse_version}
 Requires:       python%{python3_pkgversion}-PyYAML
-%endif
-# RHEL8 has python 3.6 and that lacks dataclasses in the stdlib, so pull in the
-# backport dataclasses module instead.
-%if 0%{?rhel} && 0%{?rhel} <= 8
-Requires:       python%{python3_pkgversion}-dataclasses
 %endif
 %if 0%{?weak_deps}
 Recommends:	ceph-mgr-rook = %{_epoch_prefix}%{version}-%{release}
@@ -1041,7 +1024,7 @@ Group:          System/Filesystems
 %endif
 Requires:       ceph-mgr = %{_epoch_prefix}%{version}-%{release}
 Obsoletes:      ceph-mgr-modules-core < %{_epoch_prefix}%{version}-%{release}
-%if 0%{?fedora} || 0%{?rhel} >= 8 || 0%{?openEuler}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
 Requires:       python%{python3_pkgversion}-cherrypy
 %endif
 %if 0%{?suse_version}
@@ -1602,7 +1585,7 @@ descriptions, and submitting the command to the appropriate daemon.
 
 %package -n python%{python3_pkgversion}-ceph-common
 Summary:	Python 3 utility libraries for Ceph
-%if 0%{?fedora} || 0%{?rhel} >= 8 || 0%{?openEuler}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
 Requires:       python%{python3_pkgversion}-pyyaml
 %if %{with pypkg}
 Recommends:     python%{python3_pkgversion}-ceph-smb-ctl
@@ -1996,7 +1979,7 @@ install -m 0644 -D udev/50-rbd.rules %{buildroot}%{_udevrulesdir}/50-rbd.rules
 # sudoers.d
 install -m 0440 -D sudoers.d/ceph-smartctl %{buildroot}%{_sysconfdir}/sudoers.d/ceph-smartctl
 
-%if 0%{?rhel} >= 8 || 0%{?openEuler}
+%if 0%{?rhel} || 0%{?openEuler}
 # Undefine -P flag as it is only supported with python version >= 3.11
 %undefine _py3_shebang_P
 
@@ -2038,7 +2021,7 @@ install -m 644 -D -t %{buildroot}%{_datadir}/snmp/mibs monitoring/snmp/CEPH-MIB.
 %fdupes %{buildroot}%{_prefix}
 %endif
 
-%if 0%{?rhel} == 8 || 0%{?openEuler}
+%if 0%{?openEuler}
 %py_byte_compile %{__python3} %{buildroot}%{python3_sitelib}
 %endif
 

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -254,7 +254,7 @@ BuildRequires:	gperf
 BuildRequires:  cmake > 3.5
 BuildRequires:	pkgconfig(fuse3)
 BuildRequires:	git
-BuildRequires:	grpc-devel
+BuildRequires:	pkgconfig(grpc++)
 # Before 13.3, an lto bug resulted in a segfault in SafeTimer and perhaps
 # elsewhere. Require the fixed version so we can reenable lto. See
 # ceph bug https://tracker.ceph.com/issues/63867
@@ -281,21 +281,28 @@ BuildRequires:	gperftools-devel >= 2.4
 %endif
 %endif
 BuildRequires:	libaio-devel
-BuildRequires:	libblkid-devel >= 2.17
-BuildRequires:	cryptsetup-devel
-BuildRequires:	libnbd-devel
-BuildRequires:	libcurl-devel
-BuildRequires:	libcap-devel
-BuildRequires:	libcap-ng-devel
-BuildRequires:	fmt-devel >= 6.2.1
+BuildRequires:	pkgconfig(blkid) >= 2.17
+BuildRequires:	pkgconfig(libcryptsetup)
+BuildRequires:	pkgconfig(libnbd)
+BuildRequires:	pkgconfig(libcurl)
+BuildRequires:	pkgconfig(libcap)
+BuildRequires:	pkgconfig(libcap-ng)
+BuildRequires:	pkgconfig(fmt) >= 6.2.1
 BuildRequires:	pkgconfig(libudev)
-BuildRequires:	libnl3-devel
-BuildRequires:	liboath-devel
+BuildRequires:	pkgconfig(nss)
+BuildRequires:	pkgconfig(libkeyutils)
+BuildRequires:	pkgconfig(openssl)
+BuildRequires:	pkgconfig(ldap)
+BuildRequires:	pkgconfig(libibverbs)
+BuildRequires:	pkgconfig(librdmacm)
+BuildRequires:	pkgconfig(liblz4) >= 1.7
+BuildRequires:	pkgconfig(libnl-3.0)
+BuildRequires:	pkgconfig(liboath)
 BuildRequires:	libtool
-BuildRequires:	libxml2-devel
+BuildRequires:	pkgconfig(libxml-2.0)
 BuildRequires:	make
-BuildRequires:	ncurses-devel
-BuildRequires:	libicu-devel
+BuildRequires:	pkgconfig(ncurses)
+BuildRequires:	pkgconfig(icu-uc)
 BuildRequires:	patch
 BuildRequires:	perl
 BuildRequires:	pkgconfig
@@ -306,25 +313,25 @@ BuildRequires:	python%{python3_pkgversion}-setuptools
 BuildRequires:	python%{python3_pkgversion}-Cython
 BuildRequires:	python%{python3_pkgversion}-pip
 BuildRequires:	python%{python3_pkgversion}-wheel
-BuildRequires:	snappy-devel
-BuildRequires:	sqlite-devel
+BuildRequires:	pkgconfig(snappy)
+BuildRequires:	pkgconfig(sqlite3)
 BuildRequires:	sudo
 BuildRequires:	pkgconfig(udev)
-BuildRequires:	valgrind-devel
+BuildRequires:	pkgconfig(valgrind)
 BuildRequires:	which
 BuildRequires:	xfsprogs-devel
 BuildRequires:	xmlstarlet
 BuildRequires:	nasm
-BuildRequires:	lua-devel
-BuildRequires:  lmdb-devel
+BuildRequires:	pkgconfig(lua)
+BuildRequires:  pkgconfig(lmdb)
 %if 0%{with crimson} || 0%{with jaeger}
-BuildRequires:  yaml-cpp-devel >= 0.6
+BuildRequires:  pkgconfig(yaml-cpp) >= 0.6
 %endif
 %if 0%{with amqp_endpoint}
-BuildRequires:  librabbitmq-devel
+BuildRequires:  pkgconfig(librabbitmq)
 %endif
 %if 0%{with kafka_endpoint}
-BuildRequires:  librdkafka-devel >= 1.1.0
+BuildRequires:  pkgconfig(rdkafka) >= 1.1.0
 %endif
 %if 0%{with lua_packages}
 Requires:  lua-devel
@@ -333,7 +340,7 @@ Requires:  %{luarocks_package_name}
 %if 0%{with make_check}
 BuildRequires:  hostname
 BuildRequires:  jq
-BuildRequires:	libuuid-devel
+BuildRequires:	pkgconfig(uuid)
 BuildRequires:	python%{python3_pkgversion}-bcrypt
 BuildRequires:	python%{python3_pkgversion}-requests
 BuildRequires:	python%{python3_pkgversion}-dateutil
@@ -343,53 +350,44 @@ BuildRequires:	socat
 BuildRequires:	python%{python3_pkgversion}-asyncssh
 BuildRequires:	python%{python3_pkgversion}-natsort
 %endif
-%if 0%{?suse_version}
-BuildRequires:  libthrift-devel >= 0.13.0
-%else
-BuildRequires:  thrift-devel >= 0.13.0
-%endif
-BuildRequires:  re2-devel
+BuildRequires:	pkgconfig(thrift) >= 0.13.0
+BuildRequires:  pkgconfig(re2)
 %if 0%{with jaeger}
 BuildRequires:  bison
 BuildRequires:  flex
-%if 0%{?fedora} || 0%{?rhel}
-BuildRequires:  json-devel
-%endif
-%if 0%{?suse_version}
-BuildRequires:  nlohmann_json-devel
-%endif
-BuildRequires:  libevent-devel
+BuildRequires:	pkgconfig(nlohmann_json)
+BuildRequires:  pkgconfig(libevent)
 %endif
 %if 0%{with system_pmdk}
 %if 0%{?suse_version}
-BuildRequires:  libndctl-devel >= 63
+BuildRequires:  pkgconfig(libndctl) >= 63
 %else
-BuildRequires:  ndctl-devel >= 63
-BuildRequires:  daxctl-devel >= 63
+BuildRequires:  pkgconfig(libndctl) >= 63
+BuildRequires:  pkgconfig(libdaxctl) >= 63
 %endif
-BuildRequires:  libpmem-devel
-BuildRequires:  libpmemobj-devel >= 1.8
+BuildRequires:  pkgconfig(libpmem)
+BuildRequires:  pkgconfig(libpmemobj) >= 1.8
 %endif
 %if 0%{with system_arrow}
-BuildRequires:  libarrow-devel
-BuildRequires:  parquet-libs-devel
-BuildRequires:  utf8proc-devel
+BuildRequires:  pkgconfig(arrow)
+BuildRequires:  pkgconfig(parquet)
+BuildRequires:  pkgconfig(libutf8proc)
 %endif
 %if 0%{with system_qat}
-BuildRequires:  qatlib-devel
-BuildRequires:  qatzip-devel
+BuildRequires:  pkgconfig(qatlib)
+BuildRequires:  pkgconfig(qatzip)
 %endif
 %if 0%{with crimson}
-BuildRequires:  c-ares-devel
-BuildRequires:  gnutls-devel
-BuildRequires:  hwloc-devel
-BuildRequires:  libpciaccess-devel
-BuildRequires:  lksctp-tools-devel
+BuildRequires:  pkgconfig(libcares)
+BuildRequires:  pkgconfig(gnutls)
+BuildRequires:  pkgconfig(hwloc)
+BuildRequires:  pkgconfig(pciaccess)
+BuildRequires:  pkgconfig(libsctp)
 BuildRequires:  ragel
 BuildRequires:  systemtap-sdt-devel
 BuildRequires:  libubsan
 BuildRequires:  libasan
-BuildRequires:  protobuf-devel
+BuildRequires:  pkgconfig(protobuf)
 BuildRequires:  protobuf-compiler
 %if 0%{?gts_version} > 0
 BuildRequires:  gcc-toolset-%{gts_version}-gcc-plugin-annobin
@@ -408,20 +406,14 @@ PreReq:		%fillup_prereq
 BuildRequires:	fdupes
 BuildRequires:  memory-constraints
 BuildRequires:	net-tools
-BuildRequires:	libbz2-devel
-BuildRequires:	mozilla-nss-devel
-BuildRequires:	keyutils-devel
-BuildRequires:  libopenssl-devel
+BuildRequires:	pkgconfig(bzip2)
 BuildRequires:  ninja
-BuildRequires:  openldap2-devel
 #BuildRequires:  krb5
 #BuildRequires:  krb5-devel
 BuildRequires:  cunit-devel
 BuildRequires:	python%{python3_pkgversion}-PrettyTable
 BuildRequires:	python%{python3_pkgversion}-PyYAML
 BuildRequires:	python%{python3_pkgversion}-Sphinx
-BuildRequires:  rdma-core-devel
-BuildRequires:	liblz4-devel >= 1.7
 # for prometheus-alerts
 BuildRequires:  golang-github-prometheus-prometheus
 BuildRequires:	jsonnet
@@ -429,36 +421,29 @@ BuildRequires:	jsonnet
 %if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
 Requires:	systemd
 BuildRequires:  boost-random
-BuildRequires:	nss-devel
-BuildRequires:	keyutils-libs-devel
 BuildRequires:  libatomic
-BuildRequires:	libibverbs-devel
-BuildRequires:  librdmacm-devel
 BuildRequires:  ninja-build
-BuildRequires:  openldap-devel
 BuildRequires:  numactl-devel
 #BuildRequires:  krb5-devel
-BuildRequires:  openssl-devel
 BuildRequires:  CUnit-devel
 BuildRequires:	python%{python3_pkgversion}-devel
 BuildRequires:	python%{python3_pkgversion}-prettytable
 BuildRequires:	python%{python3_pkgversion}-pyyaml
 BuildRequires:	python%{python3_pkgversion}-sphinx
-BuildRequires:	lz4-devel >= 1.7
 %endif
 # distro-conditional make check dependencies
 %if 0%{with make_check}
 BuildRequires:	golang
+BuildRequires:	pkgconfig(xmlsec1)
+BuildRequires:	pkgconfig(xmlsec1-openssl)
 %if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
 BuildRequires:	/usr/bin/promtool
 BuildRequires:	libtool-ltdl-devel
 BuildRequires:	xmlsec1
-BuildRequires:	xmlsec1-devel
 %ifarch x86_64
 BuildRequires:	xmlsec1-nss
 %endif
 BuildRequires:	xmlsec1-openssl
-BuildRequires:	xmlsec1-openssl-devel
 BuildRequires:	python%{python3_pkgversion}-cherrypy
 BuildRequires:	python%{python3_pkgversion}-routes
 BuildRequires:	python%{python3_pkgversion}-scipy
@@ -473,27 +458,14 @@ BuildRequires:	libxmlsec1-openssl1
 BuildRequires:	python%{python3_pkgversion}-CherryPy
 BuildRequires:	python%{python3_pkgversion}-Routes
 BuildRequires:	python%{python3_pkgversion}-numpy-devel
-BuildRequires:	xmlsec1-devel
-BuildRequires:	xmlsec1-openssl-devel
 %endif
 %endif
 # lttng and babeltrace for rbd-replay-prep
 %if %{with lttng}
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
-BuildRequires:	lttng-ust-devel
-BuildRequires:	libbabeltrace-devel
+BuildRequires:	pkgconfig(lttng-ust)
+BuildRequires:	pkgconfig(babeltrace)
 %endif
-%if 0%{?suse_version}
-BuildRequires:	lttng-ust-devel
-BuildRequires:  babeltrace-devel
-%endif
-%endif
-%if 0%{?suse_version}
-BuildRequires:	libexpat-devel
-%endif
-%if 0%{?rhel} || 0%{?fedora} || 0%{?openEuler}
-BuildRequires:	expat-devel
-%endif
+BuildRequires:	pkgconfig(expat)
 #hardened-cc1
 %if 0%{?fedora} || 0%{?rhel}
 BuildRequires:  redhat-rpm-config
@@ -502,11 +474,11 @@ BuildRequires:  redhat-rpm-config
 BuildRequires:  openEuler-rpm-config
 %endif
 %if 0%{with crimson}
-%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
-BuildRequires:  cryptopp-devel
-%endif
+# EPEL9's cryptopp-devel ships its pkgconfig file as cryptopp.pc (providing
+# pkgconfig(cryptopp)), while el10 and SUSE's cryptopp/libcryptopp-devel
+# provide pkgconfig(libcryptopp); accept either.
+BuildRequires:  (pkgconfig(libcryptopp) or pkgconfig(cryptopp))
 %if 0%{?suse_version}
-BuildRequires:  libcryptopp-devel
 BuildRequires:  libnuma-devel
 %endif
 %endif


### PR DESCRIPTION
Four ceph.spec.in cleanups:

1. drop RHEL <= 8 support
2. use `pkgconfig()` for library `BuildRequires`
3. use `python3dist()` for Python `BuildRequires`
4. drop `python3_pkgversion()` macro

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
