### PR TITLE
osd: report -EINVAL to on_finish in asok_route_to_pg catch

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2760,7 +2760,7 @@ int OSD::asok_route_to_pg(
   } catch (const TOPNSPC::common::bad_cmd_get& e) {
     (*target_pg)->unlock();
     ss << e.what();
-    on_finish(ret, ss.str(), outbl);
+    on_finish(-EINVAL, ss.str(), outbl);
     return -EINVAL;
   }
 }


### PR DESCRIPTION
On a `bad_cmd_get` failure, `asok_route_to_pg` returned -EINVAL but passed
the stale locate result (0) to `on_finish`, so callers saw success. Pass
-EINVAL to `on_finish` too.

Only reachable via the "scrubdebug" asok command (the sole user of
`asok_route_to_pg`) when a parameter fails type parsing.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests