### PR TITLE
mgr/orchestrator: add `ceph orch spec schema` for ServiceSpec

### DIFF
--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -18,9 +18,14 @@ except ImportError:
 from ceph.deployment.inventory import Device  # noqa: F401; pylint: disable=unused-variable
 from ceph.deployment.drive_group import DriveGroupSpec, DeviceSelection, OSDMethod, OSDType
 from ceph.deployment.service_spec import PlacementSpec, ServiceSpec, service_spec_allow_invalid_from_json, TracingSpec
+from ceph.deployment.service_spec_schema import (
+    build_service_spec_schema,
+    format_service_spec_schema_plain,
+)
 from ceph.deployment.hostspec import SpecValidationError
 from ceph.deployment.utils import unwrap_ipv6
 from ceph.utils import datetime_now
+from orchestrator._interface import service_to_daemon_types
 from ceph.cephadm.images import NonCephImageServiceTypes
 from mgr_util import (
     is_valid_container_image_ref,
@@ -983,6 +988,22 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
         completion = self.zap_device(hostname, path)
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
+
+    @OrchestratorCLICommand.Read('orch spec schema')
+    def _spec_schema(self,
+                     service_type: Optional[str] = None,
+                     format: Format = Format.plain) -> HandleCommandResult:
+        """
+        Show ServiceSpec field metadata (types, defaults, service-specific options).
+        """
+        try:
+            schema = build_service_spec_schema(service_type, service_to_daemon_types)
+        except ValueError as e:
+            return HandleCommandResult(-errno.EINVAL, '', str(e))
+
+        if format != Format.plain:
+            return HandleCommandResult(stdout=to_format(schema, format, many=False, cls=None))
+        return HandleCommandResult(stdout=format_service_spec_schema_plain(schema))
 
     @OrchestratorCLICommand.Read('orch ls')
     def _list_services(self,

--- a/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
+++ b/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
@@ -422,3 +422,16 @@ class TestApplyOAuth2ProxyYaml:
             'provider_display_name, client_id, client_secret.'
         ) in res.stderr
         mock_apply_misc.assert_not_called()
+
+
+
+@pytest.mark.parametrize('service_type,expected_daemon_types', [
+    ('ingress', ['haproxy', 'keepalived']),
+    ('jaeger-tracing', ['elasticsearch', 'jaeger-query', 'jaeger-collector', 'jaeger-agent']),
+])
+def test_service_spec_schema_uses_daemon_type_resolver(service_type, expected_daemon_types):
+    from orchestrator import service_to_daemon_types
+    from ceph.deployment.service_spec_schema import build_service_spec_schema
+
+    schema = build_service_spec_schema(service_type, service_to_daemon_types)
+    assert schema['daemon_types'] == expected_daemon_types

--- a/src/python-common/ceph/deployment/service_spec_schema.py
+++ b/src/python-common/ceph/deployment/service_spec_schema.py
@@ -1,0 +1,167 @@
+import inspect
+from typing import Any, Callable, Dict, List, Optional, Type, Union, get_args, get_origin
+
+from ceph.deployment.service_spec import ServiceSpec
+
+
+def _format_type(annotation: Any) -> str:
+    if annotation is inspect.Parameter.empty:
+        return 'Any'
+    if isinstance(annotation, str):
+        return annotation
+    origin = get_origin(annotation)
+    if origin is Union:
+        args = get_args(annotation)
+        non_none = [a for a in args if a is not type(None)]
+        if len(non_none) == 1 and len(args) == 2:
+            return f'Optional[{_format_type(non_none[0])}]'
+        return f"Union[{', '.join(_format_type(a) for a in args)}]"
+    if origin in (list, List):
+        args = get_args(annotation)
+        if args:
+            return f'List[{_format_type(args[0])}]'
+        return 'List'
+    if origin in (dict, Dict):
+        args = get_args(annotation)
+        if len(args) == 2:
+            return f'Dict[{_format_type(args[0])}, {_format_type(args[1])}]'
+        return 'Dict'
+    if hasattr(annotation, '__name__'):
+        return annotation.__name__
+    return str(annotation).replace('typing.', '')
+
+
+def _default_value(default: Any) -> Any:
+    if default is inspect.Parameter.empty:
+        return None
+    if isinstance(default, (str, int, float, bool)) or default is None:
+        return default
+    if isinstance(default, (list, dict)):
+        return default
+    return repr(default)
+
+
+def _init_param_names(cls: Type[ServiceSpec]) -> List[str]:
+    try:
+        sig = inspect.signature(cls.__init__)
+    except (TypeError, ValueError):
+        return []
+    return [name for name in sig.parameters if name != 'self']
+
+
+def _field_metadata(cls: Type[ServiceSpec], param_name: str) -> Dict[str, Any]:
+    param = inspect.signature(cls.__init__).parameters[param_name]
+    default = param.default
+    field: Dict[str, Any] = {
+        'type': _format_type(param.annotation),
+        'required': default is inspect.Parameter.empty,
+    }
+    if default is not inspect.Parameter.empty:
+        field['default'] = _default_value(default)
+    else:
+        field['default'] = None
+    return field
+
+
+def _class_summary_description(cls: Type[ServiceSpec]) -> Optional[str]:
+    doc = inspect.getdoc(cls)
+    if not doc:
+        return None
+    line = doc.strip().splitlines()[0].strip()
+    return line or None
+
+
+def _service_spec_base_params() -> List[str]:
+    return [p for p in _init_param_names(ServiceSpec) if p != 'service_type']
+
+
+def build_service_type_schema(
+        service_type: str,
+        daemon_type_resolver: Optional[Callable[[str], List[str]]] = None) -> Dict[str, Any]:
+    """Build schema metadata for a single service type."""
+    if service_type not in ServiceSpec.KNOWN_SERVICE_TYPES:
+        raise ValueError(f'Unknown service type: {service_type}')
+
+    spec_class = ServiceSpec._cls(service_type)
+    base_params = set(_service_spec_base_params())
+    param_names = _init_param_names(spec_class)
+
+    top_level: Dict[str, Any] = {}
+    spec_fields: Dict[str, Any] = {}
+
+    for name in param_names:
+        if name == 'service_type':
+            continue
+        meta = _field_metadata(spec_class, name)
+        if name in base_params:
+            top_level[name] = meta
+        else:
+            spec_fields[name] = meta
+
+    if daemon_type_resolver:
+        daemon_types = daemon_type_resolver(service_type)
+    else:
+        daemon_types = [service_type]
+
+    cert_meta = ServiceSpec.REQUIRES_CERTIFICATES.get(service_type)
+    schema: Dict[str, Any] = {
+        'service_type': service_type,
+        'spec_class': spec_class.__name__,
+        'requires_service_id': service_type in ServiceSpec.REQUIRES_SERVICE_ID
+        or service_type == 'osd',
+        'daemon_types': daemon_types,
+        'description': _class_summary_description(spec_class),
+        'fields': top_level,
+    }
+    if cert_meta:
+        schema['requires_certificates'] = dict(cert_meta)
+    if spec_fields:
+        schema['spec'] = spec_fields
+    return schema
+
+
+def build_service_spec_schema(
+        service_type: Optional[str] = None,
+        daemon_type_resolver: Optional[Callable[[str], List[str]]] = None) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
+    """Build schema metadata for one or all service types."""
+    if service_type:
+        return build_service_type_schema(service_type, daemon_type_resolver)
+    return [build_service_type_schema(st, daemon_type_resolver)
+            for st in ServiceSpec.KNOWN_SERVICE_TYPES]
+
+
+def _append_field_lines(lines: List[str], fields: Dict[str, Any], prefix: str) -> None:
+    for name, meta in sorted(fields.items()):
+        req = 'required' if meta.get('required') else 'optional'
+        default = meta.get('default')
+        default_str = 'null' if default is None else repr(default)
+        lines.append(
+            f"{prefix}{name}: type={meta['type']}, {req}, default={default_str}")
+
+
+def format_service_spec_schema_plain(
+        schema: Union[Dict[str, Any], List[Dict[str, Any]]]) -> str:
+    """Format schema metadata as human-readable plain text."""
+    entries = schema if isinstance(schema, list) else [schema]
+    chunks: List[str] = []
+    for entry in entries:
+        lines = [
+            f"service_type: {entry['service_type']}",
+            f"spec_class: {entry['spec_class']}",
+            f"requires_service_id: {str(entry['requires_service_id']).lower()}",
+            f"daemon_types: {entry['daemon_types']}",
+        ]
+        if entry.get('description'):
+            lines.append(f"description: {entry['description']}")
+        if entry.get('requires_certificates'):
+            lines.append(f"requires_certificates: {entry['requires_certificates']}")
+
+        lines.append('fields:')
+        _append_field_lines(lines, entry.get('fields', {}), '  ')
+
+        spec_block = entry.get('spec')
+        if spec_block:
+            lines.append('spec:')
+            _append_field_lines(lines, spec_block, '  ')
+        chunks.append('\n'.join(lines))
+    return '\n---\n'.join(chunks) + ('\n' if chunks else '')

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -25,6 +25,10 @@ from ceph.deployment.service_spec import (
 )
 from ceph.deployment.drive_group import DriveGroupSpec
 from ceph.deployment.hostspec import SpecValidationError
+from ceph.deployment.service_spec_schema import (
+    build_service_spec_schema,
+    format_service_spec_schema_plain,
+)
 
 
 @pytest.mark.parametrize("test_input,expected, require_network",
@@ -1639,3 +1643,42 @@ def test_tuned_profile_spec_profile_name_validation(spec_yaml, expect_error, err
         assert spec.placement is not None
         # round-trip
         assert TunedProfileSpec.from_json(spec.to_json()).profile_name == spec.profile_name
+
+
+def test_service_spec_schema_all_known_types():
+    schemas = build_service_spec_schema()
+    assert len(schemas) == len(ServiceSpec.KNOWN_SERVICE_TYPES)
+    returned = {s['service_type'] for s in schemas}
+    assert returned == set(ServiceSpec.KNOWN_SERVICE_TYPES)
+    for entry in schemas:
+        assert entry['spec_class']
+        assert 'fields' in entry
+        assert isinstance(entry['daemon_types'], list)
+
+
+def test_service_spec_schema_osd():
+    osd = build_service_spec_schema('osd')
+    assert osd['spec_class'] == 'DriveGroupSpec'
+    assert osd['requires_service_id'] is True
+    assert 'encrypted' in osd['spec']
+    assert osd['spec']['encrypted']['default'] is False
+    assert 'placement' in osd['fields']
+
+
+def test_service_spec_schema_rgw():
+    rgw = build_service_spec_schema('rgw')
+    assert rgw['requires_service_id'] is True
+    assert rgw['requires_certificates']['user_cert_allowed'] is True
+    assert 'rgw_realm' in rgw['spec']
+
+
+def test_service_spec_schema_unknown_type():
+    with pytest.raises(ValueError, match='Unknown service type'):
+        build_service_spec_schema('not-a-service')
+
+
+def test_service_spec_schema_plain_format():
+    text = format_service_spec_schema_plain(build_service_spec_schema('mgr'))
+    assert 'service_type: mgr' in text
+    assert 'spec_class: ServiceSpec' in text
+    assert 'fields:' in text


### PR DESCRIPTION
# mgr/orchestrator: add `ceph orch spec schema` for ServiceSpec

Expose ServiceSpec field metadata (types, defaults, required flags, and per-service spec options) via a new CLI command, derived from existing Python class signatures to stay in sync without duplicating definitions.

## Usage:
```shell
  ceph orch spec schema
  ceph orch spec schema --service_type rgw --format json
  ceph orch spec schema --service_type osd --format yaml
```

## Example output (plain, `ceph orch spec schema --service_type rgw`):
```yaml
      service_type: rgw
      spec_class: RGWSpec
      requires_service_id: true
      daemon_types: ['rgw']
      fields:
        placement: type=Optional[PlacementSpec], optional, default=null
        config: type=Optional[Dict[str, str]], optional, default=null
      spec:
        rgw_realm: type=Optional[str], optional, default=null
        rgw_zone: type=Optional[str], optional, default=null
```
    
## Example output (json excerpt, `ceph orch spec schema --service_type rgw --format json`):
```json
      {
        "service_type": "rgw",
        "spec_class": "RGWSpec",
        "requires_service_id": true,
        "fields": {
          "placement": {"type": "Optional[PlacementSpec]", "required": false, "default": null}
        },
        "spec": {
          "rgw_realm": {"type": "Optional[str]", "required": false, "default": null}
        }
      }
```    
## Example output (yaml excerpt, `ceph orch spec schema --service_type osd --format yaml`):
```yaml
      service_type: osd
      spec_class: DriveGroupSpec
      requires_service_id: true
      spec:
        data_devices:
          type: Any
          required: false
          default: null
        encrypted:
          type: Any
          required: false
          default: false
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
