### PR TITLE
mgr/dashboard: cephfs mirror add remove path action

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -1481,6 +1481,24 @@ class CephFSMirror(RESTController):
             )
         return json.loads(out) if out else {}
 
+    @EndpointDoc("Remove a directory path from snapshot mirroring",
+                 parameters={
+                     'fs_name': (str, 'File system name'),
+                     'path': (str, 'Directory path to remove from mirroring'),
+                 })
+    @Endpoint('DELETE', path='/directory', query_params=['fs_name', 'path'])
+    @DeletePermission
+    def remove_directory(self, fs_name: str, path: str):
+        error_code, out, err = mgr.remote(
+            'mirroring', 'snapshot_mirror_remove_dir', fs_name, path)
+        if error_code != 0:
+            raise DashboardException(
+                msg=f'Failed to remove mirroring path {path}: {err}',
+                code=error_code,
+                component='cephfs.mirror'
+            )
+        return json.loads(out) if out else {}
+
     @EndpointDoc("List snapshot mirrored directories",
                  parameters={
                      'fs_name': (str, 'File system name'),

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.html
@@ -8,7 +8,19 @@
     [autoReload]="5000"
     [toolHeader]="true"
     [searchableObjects]="true"
+    [showInlineActions]="false"
+    selectionType="single"
+    (updateSelection)="updateSelection($event)"
     (fetchData)="loadMirrorPaths()">
+
+    <cd-table-actions
+      [permission]="permission"
+      [selection]="selection"
+      class="table-actions"
+      id="cephfs-actions"
+      [tableActions]="tableActions"
+    >
+    </cd-table-actions>
 
     <ng-template
       #pathTpl

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.spec.ts
@@ -5,10 +5,16 @@ import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testin
 import { ActivatedRoute, convertToParamMap } from '@angular/router';
 import { of, throwError } from 'rxjs';
 
-import { MirrorStatusResponse } from '~/app/shared/models/cephfs.model';
 import { CephfsService } from '~/app/shared/api/cephfs.service';
+import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component';
+import { DeletionImpact } from '~/app/shared/enum/delete-confirmation-modal-impact.enum';
+import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
+import { MirrorStatusResponse } from '~/app/shared/models/cephfs.model';
 import { CephfsSnapshotScheduleService } from '~/app/shared/api/cephfs-snapshot-schedule.service';
 import { FormatterService } from '~/app/shared/services/formatter.service';
+import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
+import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
+import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { CephfsMirroringFsMirrorPathsComponent } from './cephfs-mirroring-fs-mirror-paths.component';
 import { HttpClientModule } from '@angular/common/http';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -113,7 +119,8 @@ describe('CephfsMirroringFsMirrorPathsComponent', () => {
 
   beforeEach(async () => {
     const cephfsServiceMock = {
-      getMirrorStatus: jest.fn()
+      getMirrorStatus: jest.fn(),
+      removeMirrorDirectory: jest.fn().mockReturnValue(of({}))
     };
 
     const snapshotScheduleServiceMock = {
@@ -165,6 +172,22 @@ describe('CephfsMirroringFsMirrorPathsComponent', () => {
               paramMap: of(convertToParamMap({ fsName: 'test-fs' }))
             }
           }
+        },
+        {
+          provide: AuthStorageService,
+          useValue: {
+            getPermissions: () => ({
+              cephfsMirror: { read: true, create: true, update: true, delete: true }
+            })
+          }
+        },
+        {
+          provide: ModalCdsService,
+          useValue: { show: jest.fn() }
+        },
+        {
+          provide: TaskWrapperService,
+          useValue: { wrapTaskAroundCall: jest.fn((args) => args.call) }
         }
       ],
       schemas: [NO_ERRORS_SCHEMA],
@@ -504,9 +527,9 @@ describe('CephfsMirroringFsMirrorPathsComponent', () => {
 
   describe('onSelectionChange', () => {
     it('should update selection', () => {
-      const mockSelection = { selected: [{ path: '/test' }] } as any;
+      const mockSelection = new CdTableSelection([{ path: '/test' }]);
 
-      component.selection = mockSelection;
+      component.updateSelection(mockSelection);
 
       expect(component.selection).toBe(mockSelection);
     });
@@ -1019,6 +1042,24 @@ describe('CephfsMirroringFsMirrorPathsComponent', () => {
           false
         );
       }));
+    });
+  });
+  describe('removePathModal', () => {
+    it('should open high-impact deletion modal for selected path', () => {
+      const modalService = TestBed.inject(ModalCdsService);
+      component.selection = new CdTableSelection([{ path: '/path1' }]);
+      component.fsName = 'test-fs';
+
+      component.removePathModal();
+
+      expect(modalService.show).toHaveBeenCalledWith(
+        DeleteConfirmationModalComponent,
+        expect.objectContaining({
+          impact: DeletionImpact.high,
+          itemNames: ['/path1'],
+          actionDescription: 'remove'
+        })
+      );
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.ts
@@ -4,18 +4,27 @@ import {
   OnDestroy,
   TemplateRef,
   ViewChild,
-  ViewEncapsulation
+  ViewEncapsulation,
+  inject
 } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Subscription } from 'rxjs';
+import { tap } from 'rxjs/operators';
 import { CephfsService } from '~/app/shared/api/cephfs.service';
 import { CephfsSnapshotScheduleService } from '~/app/shared/api/cephfs-snapshot-schedule.service';
+import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component';
+import { DeletionImpact } from '~/app/shared/enum/delete-confirmation-modal-impact.enum';
+import { Icons, ICON_TYPE } from '~/app/shared/enum/icons.enum';
+import { CdTableAction } from '~/app/shared/models/cd-table-action';
 import { CdTableColumn } from '~/app/shared/models/cd-table-column';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
-import { ICON_TYPE } from '~/app/shared/enum/icons.enum';
+import { FinishedTask } from '~/app/shared/models/finished-task';
 import { FormatterService } from '~/app/shared/services/formatter.service';
 import { MirrorDirStatus, MirrorStatusResponse } from '~/app/shared/models/cephfs.model';
 import { MirrorPathSchedule } from '~/app/shared/models/snapshot-schedule';
+import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
+import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
+import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 
 interface MirrorPath {
   path: string;
@@ -58,9 +67,18 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
   @ViewChild('currentSyncSnapshotTpl', { static: true })
   currentSyncSnapshotTpl!: TemplateRef<unknown>;
 
+  private cephfsService = inject(CephfsService);
+  private route = inject(ActivatedRoute);
+  private formatterService = inject(FormatterService);
+  private authStorageService = inject(AuthStorageService);
+  private cdsModalService = inject(ModalCdsService);
+  private taskWrapper = inject(TaskWrapperService);
+
   columns: CdTableColumn[] = [];
   mirrorPaths: MirrorPath[] = [];
   selection = new CdTableSelection();
+  tableActions: CdTableAction[] = [];
+  permission = this.authStorageService.getPermissions().cephfsMirror;
   selectedPath: MirrorPath | null = null;
   sidePanelOpen = false;
   fsName: string = '';
@@ -71,15 +89,9 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
   private subscriptions = new Subscription();
   private mirrorPathsSubscription?: Subscription;
 
-  constructor(
-    private cephfsService: CephfsService,
-    private snapshotScheduleService: CephfsSnapshotScheduleService,
-    private route: ActivatedRoute,
-    private formatterService: FormatterService
-  ) {}
-
   ngOnInit(): void {
     this.initializeColumns();
+    this.initializeTableActions();
     this.fetchFsName();
   }
 
@@ -122,6 +134,48 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
         sortable: true
       }
     ];
+  }
+
+  initializeTableActions(): void {
+    this.tableActions = [
+      {
+        name: $localize`Remove path`,
+        permission: 'delete',
+        icon: Icons.destroy,
+        click: () => this.removePathModal(),
+        disable: (selection: CdTableSelection) => !selection.hasSingleSelection
+      }
+    ];
+  }
+
+  updateSelection(selection: CdTableSelection): void {
+    this.selection = selection;
+  }
+
+  removePathModal(): void {
+    const path = this.selection.first().path;
+    this.cdsModalService.show(DeleteConfirmationModalComponent, {
+      impact: DeletionImpact.high,
+      itemDescription: $localize`mirror path`,
+      itemNames: [path],
+      actionDescription: 'remove',
+      submitActionObservable: () =>
+        this.taskWrapper
+          .wrapTaskAroundCall({
+            task: new FinishedTask('cephfs/mirroring/path/remove', {
+              fsName: this.fsName,
+              path
+            }),
+            call: this.cephfsService.removeMirrorDirectory(this.fsName, path).pipe(
+              tap(() => {
+                if (this.selectedPath?.path === path) {
+                  this.closeSidePanel();
+                }
+                this.loadMirrorPaths();
+              })
+            )
+          })
+    });
   }
 
   private fetchFsName(): void {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.spec.ts
@@ -20,7 +20,7 @@ describe('CephfsMirroringListComponent', () => {
   };
 
   const authStorageServiceMock = {
-    getPermissions: jest.fn().mockReturnValue({ cephfs: {} as Permission })
+    getPermissions: jest.fn().mockReturnValue({ cephfsMirror: {} as Permission })
   };
 
   beforeEach(async () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.ts
@@ -33,7 +33,7 @@ export class CephfsMirroringListComponent implements OnInit, OnDestroy {
   tableActions: CdTableAction[];
   isSetupModalOpen = false;
   selection = new CdTableSelection();
-  permission = this.authStorageService.getPermissions().cephfs;
+  permission = this.authStorageService.getPermissions().cephfsMirror;
   isPrepareModalOpen = false;
   jumpInTiles: MirroringJumpInTile[] = [];
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.spec.ts
@@ -135,4 +135,17 @@ describe('CephfsService', () => {
     const req = httpTesting.expectOne('api/cephfs/mirror/directory/testfs');
     expect(req.request.method).toBe('GET');
   });
+
+  it('should remove mirror directory using query parameters', () => {
+    const path = '/volumes/Group1/A1/64446b51-d39b-436b-991f-0f8e713067ff';
+    service.removeMirrorDirectory('testfs', path).subscribe();
+    const req = httpTesting.expectOne(
+      (request) =>
+        request.url === 'api/cephfs/mirror/directory' &&
+        request.params.get('fs_name') === 'testfs' &&
+        request.params.get('path') === path
+    );
+    expect(req.request.method).toBe('DELETE');
+    expect(req.request.body).toBeNull();
+  });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.ts
@@ -184,4 +184,10 @@ export class CephfsService {
   listMirrorDirectories(@cdEncodeNot fsName: string): Observable<string[]> {
     return this.http.get<string[]>(`${this.baseURL}/mirror/directory/${fsName}`);
   }
+
+  removeMirrorDirectory(@cdEncodeNot fsName: string, @cdEncodeNot path: string): Observable<any> {
+    return this.http.delete(`${this.baseURL}/mirror/directory`, {
+      params: { fs_name: fsName, path }
+    });
+  }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/permissions.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/permissions.ts
@@ -23,6 +23,7 @@ export class Permissions {
   rbdMirroring: Permission;
   rgw: Permission;
   cephfs: Permission;
+  cephfsMirror: Permission;
   manager: Permission;
   log: Permission;
   user: Permission;
@@ -43,6 +44,7 @@ export class Permissions {
     this.rbdMirroring = new Permission(serverPermissions['rbd-mirroring']);
     this.rgw = new Permission(serverPermissions['rgw']);
     this.cephfs = new Permission(serverPermissions['cephfs']);
+    this.cephfsMirror = new Permission(serverPermissions['cephfs-mirror']);
     this.manager = new Permission(serverPermissions['manager']);
     this.log = new Permission(serverPermissions['log']);
     this.user = new Permission(serverPermissions['user']);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.ts
@@ -330,6 +330,10 @@ export class TaskMessageService {
       ),
       (metadata) => $localize`filesystem mirroring for '${metadata.fsName}'`
     ),
+    'cephfs/mirroring/path/remove': this.newTaskMessage(
+      this.commonOperations.remove,
+      (metadata) => $localize`mirror path '${metadata.path}' from '${metadata.fsName}'`
+    ),
     // RGW operations
     'rgw/bucket/delete': this.newTaskMessage(this.commonOperations.delete, (metadata) => {
       return $localize`${metadata.bucket_names[0]}`;

--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -272,8 +272,9 @@ POOL_MGR_ROLE = Role(
 
 # CephFS manager role provides all permissions for CephFS related scopes
 CEPHFS_MGR_ROLE = Role(
-    'cephfs-manager', 'allows full permissions for the cephfs scope', {
+    'cephfs-manager', 'allows full permissions for the cephfs and cephfs-mirror scopes', {
         Scope.CEPHFS: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
+        Scope.CEPHFS_MIRROR: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
         Scope.GRAFANA: [_P.READ],
         Scope.PROMETHEUS: [_P.READ]
     })

--- a/src/pybind/mgr/dashboard/tests/test_cephfs.py
+++ b/src/pybind/mgr/dashboard/tests/test_cephfs.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
+import urllib.parse
 from collections import defaultdict
 
 try:
@@ -277,6 +278,37 @@ class CephFSMirrorTest(ControllerTestCase):
         self.assertIn('Failed to add mirroring path', response.get('detail', ''))
         self.assertIn(error_message, response.get('detail', ''))
         mgr.remote.assert_called_once_with('mirroring', 'snapshot_mirror_add_dir', fs_name, path)
+
+    def test_remove_directory_success(self):
+        fs_name = 'test_fs'
+        path = '/volumes/g1/sv1'
+        expected_result = {}
+        mock_output = json.dumps(expected_result)
+        mgr.remote = Mock(return_value=(0, mock_output, ''))
+
+        self._delete(
+            f'/api/cephfs/mirror/directory?fs_name={fs_name}&path={urllib.parse.quote(path)}'
+        )
+        self.assertStatus(200)
+        self.assertJsonBody(expected_result)
+        mgr.remote.assert_called_once_with(
+            'mirroring', 'snapshot_mirror_remove_dir', fs_name, path)
+
+    def test_remove_directory_error(self):
+        fs_name = 'test_fs'
+        path = '/volumes/g1/sv1'
+        error_message = 'directory not tracked'
+        mgr.remote = Mock(return_value=(1, '', error_message))
+
+        self._delete(
+            f'/api/cephfs/mirror/directory?fs_name={fs_name}&path={urllib.parse.quote(path)}'
+        )
+        self.assertStatus(400)
+        response = self.json_body()
+        self.assertIn('Failed to remove mirroring path', response.get('detail', ''))
+        self.assertIn(error_message, response.get('detail', ''))
+        mgr.remote.assert_called_once_with(
+            'mirroring', 'snapshot_mirror_remove_dir', fs_name, path)
 
     def test_list_directories_success(self):
         fs_name = 'test_fs'


### PR DESCRIPTION

[screen-capture (11).webm](https://github.com/user-attachments/assets/63a671bb-8acf-474c-966a-9faea3c0abff)



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
