### PR TITLE
ceph-volume: fix udev alias handling in LVM membership detection

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -477,6 +477,45 @@ class TestDevice(object):
         assert not disk.used_by_ceph
 
     @patch("ceph_volume.util.disk.has_bluestore_label", lambda x: False)
+    def test_is_lvm_member_with_udev_alias(self, fake_call, device_info, monkeypatch):
+        """
+        Test that is_lvm_member correctly identifies LVM membership when
+        the PV name returned by LVM is a udev alias (e.g., /dev/disk-ssd)
+        rather than the actual device path (e.g., /dev/sdc).
+        
+        This simulates the container environment where LVM returns udev aliases.
+        """
+        # Device is accessed via its real path
+        lsblk = {"TYPE": "disk", "NAME": "sdc"}
+        data = {"/dev/sdc": {"size": "10737418240"}}
+        device_info(devices=data, lsblk=lsblk)
+        
+        # Simulate LVM returning a udev alias as pv_name
+        vg = api.VolumeGroup(
+            pv_name='/dev/disk-ssd',  # udev alias
+            vg_name='ceph-vg',
+            vg_free_count=1000,
+            vg_extent_size=4194304
+        )
+        monkeypatch.setattr("ceph_volume.util.device.lvm.get_all_devices_vgs", lambda: [vg])
+        
+        # Mock get_device_lvs to return empty list (mock the correct module)
+        monkeypatch.setattr("ceph_volume.util.device.lvm.get_device_lvs", lambda x: [])
+        
+        # Mock os.path.realpath to simulate the alias resolving to the real path
+        original_realpath = os.path.realpath
+        def mock_realpath(path):
+            if path == '/dev/disk-ssd':
+                return '/dev/sdc'
+            return original_realpath(path)
+        monkeypatch.setattr(os.path, 'realpath', mock_realpath)
+        
+        disk = device.Device("/dev/sdc")
+        assert disk.is_lvm_member
+        assert len(disk.vgs) == 1
+        assert disk.vgs[0].vg_name == 'ceph-vg'
+
+    @patch("ceph_volume.util.disk.has_bluestore_label", lambda x: False)
     def test_get_device_id(self, fake_call, device_info):
         lsblk = {"TYPE": "disk", "NAME": "sda"}
         device_info(lsblk=lsblk)

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -369,7 +369,7 @@ class Device(object):
                 self.all_devices_vgs = lvm.get_all_devices_vgs()
             for path in device_to_check:
                 for dev_vg in self.all_devices_vgs:
-                    if dev_vg.pv_name == path:
+                    if os.path.realpath(dev_vg.pv_name) == os.path.realpath(path):
                         vgs = [dev_vg]
                 if vgs:
                     self.vgs.extend(vgs)


### PR DESCRIPTION
When ceph-volume runs in a container environment where /run/udev is mounted, LVM may return udev aliases (e.g., /dev/disk-ssd) instead of actual device paths (e.g., /dev/sdc). This caused the LVM membership detection to fail because direct string comparison would not match.

The fix uses os.path.realpath() to normalize both paths before comparison, ensuring correct matching regardless of whether LVM returns aliases or real paths.

Added test case test_is_lvm_member_with_udev_alias to verify the fix works correctly with udev aliases.

Fixes: https://tracker.ceph.com/issues/77864





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
