### PR TITLE
mgr/dashboard: support snapshot_id in clone API for group snapshots

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rbd.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd.py
@@ -317,7 +317,7 @@ class RbdSnapshot(RESTController):
     def clone(self, image_spec, snapshot_name, child_pool_name,
               child_image_name, child_namespace=None, obj_size=None, features=None,
               stripe_unit=None, stripe_count=None, data_pool=None,
-              configuration=None, metadata=None):
+              configuration=None, metadata=None, clone_by_snap_id=False):
         """
         Clones a snapshot to an image
         """
@@ -334,10 +334,25 @@ class RbdSnapshot(RESTController):
                 # Set features
                 feature_bitmask = format_features(features)
 
+                # When clone_by_snap_id is set, treat snapshot_name as a
+                # numeric snap ID and clone by ID. This is required for
+                # non-user namespace snapshots (e.g. group snapshots) which
+                # cannot be cloned by name. Passing an int to rbd.RBD().clone()
+                # triggers rbd_clone4 (by snap ID) instead of rbd_clone3.
+                # Clone format 2 is enforced here because this flag is intended
+                # for non-user namespace snapshots which cannot be protected
+                # (a prerequisite for clone format 1).
+                snap_ref = snapshot_name
+                clone_format = None
+                if clone_by_snap_id:
+                    snap_ref = int(snapshot_name)
+                    clone_format = 2
+
                 rbd_inst = rbd.RBD()
-                rbd_inst.clone(p_ioctx, image_name, snapshot_name, ioctx,
+                rbd_inst.clone(p_ioctx, image_name, snap_ref, ioctx,
                                child_image_name, feature_bitmask, l_order,
-                               stripe_unit, stripe_count, data_pool)
+                               stripe_unit, stripe_count, data_pool,
+                               clone_format=clone_format)
 
                 RbdConfiguration(pool_ioctx=ioctx, image_name=child_image_name).set_configuration(
                     configuration)

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -1198,6 +1198,9 @@ paths:
                   type: string
                 child_pool_name:
                   type: string
+                clone_by_snap_id:
+                  default: false
+                  type: boolean
                 configuration:
                   type: string
                 data_pool:


### PR DESCRIPTION
## Description

The clone API endpoint `POST /api/block/image/{image_spec}/snap/{snapshot_name}/clone` only accepted a snapshot name, which uses `rbd_clone3` (clone by name). This only works for snapshots in the user namespace.

Group snapshots (with `.group` prefix, in `RBD_SNAP_NAMESPACE_TYPE_GROUP` namespace) require `rbd_clone4` (clone by snap ID). The rbd Python binding already supports this — passing an `int` for `p_snapshot` triggers `rbd_clone4`.

This PR adds an optional `clone_by_snap_id` boolean flag to the clone endpoint. When set, the path parameter (`{snapshot_name}`) is treated as a numeric snap ID and passed directly as an `int` to `rbd.RBD().clone()`, triggering `rbd_clone4`. This makes the endpoint effectively `/api/block/image/{image_spec}/snap/{snap_name_or_id}/clone` where the path value is disambiguated by the flag.

Clone format 2 is enforced when this flag is set because non-user namespace snapshots cannot be protected (a prerequisite for clone format 1).

The change is fully backward-compatible: existing callers that do not pass the flag continue to work as before (clone by name).

## Approach

The API accepts an optional `clone_by_snap_id` boolean in the request body. When `true`:
1. The path parameter is interpreted as a numeric snap ID
2. It is passed as `int` to `rbd.RBD().clone()`, triggering `rbd_clone4` (by snap ID)
3. Clone format 2 is forced, since this flag is intended for non-user namespace snapshots which cannot be protected

This avoids:
- Name collision issues across snapshot namespaces (snap IDs are unique)
- Any need for extra I/O to look up the snap ID
- Dummy values in the URL — the path parameter is always meaningful

If `clone_by_snap_id` is not provided or `false`, behavior is unchanged (clone by name).

## Usage

```
POST /api/block/image/{pool}%2F{image}/snap/{snap_id}/clone
{
  "child_pool_name": "rbd",
  "child_image_name": "my-clone",
  "clone_by_snap_id": true
}
```

If `clone_by_snap_id` is omitted, the path parameter is treated as a snapshot name (existing behavior):
```
POST /api/block/image/{pool}%2F{image}/snap/{snapshot_name}/clone
{
  "child_pool_name": "rbd",
  "child_image_name": "my-clone"
}
```

## Changes

- `src/pybind/mgr/dashboard/controllers/rbd.py`: Added `clone_by_snap_id` flag; when set, treats path param as snap ID
- `src/pybind/mgr/dashboard/openapi.yaml`: Added `clone_by_snap_id` (boolean, default: false)

## Fixes

https://tracker.ceph.com/issues/77875