### PR TITLE
tools/rados: fix stdio/stream cleanup

### DIFF
--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -2581,7 +2581,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
       }
       formatter->flush(*outstream);
     }
-    if (!stdout) {
+    if (!use_stdout) {
       delete outstream;
     }
   }

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -4091,7 +4091,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
 
     ret = PoolDump(file_fd).dump(&io_ctx);
 
-    if (file_fd != STDIN_FILENO) {
+    if (file_fd != STDOUT_FILENO) {
       VOID_TEMP_FAILURE_RETRY(::close(file_fd));
     }
 

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -649,7 +649,7 @@ static int do_put(IoCtx& io_ctx,
   }
   ret = 0;
  out:
-  if (fd != STDOUT_FILENO)
+  if (fd != STDIN_FILENO)
     VOID_TEMP_FAILURE_RETRY(close(fd));
   return ret;
 }
@@ -684,7 +684,7 @@ static int do_append(IoCtx& io_ctx,
   }
   ret = 0;
 out:
-  if (fd != STDOUT_FILENO)
+  if (fd != STDIN_FILENO)
     VOID_TEMP_FAILURE_RETRY(close(fd));
   return ret;
 }


### PR DESCRIPTION
- `put`/`append` from '-' set fd to STDIN_FILENO, but cleanup guarded
  close() on STDOUT_FILENO (always true), closing stdin instead.
- `ls` tested the libc FILE* `stdout` (never null) instead of the
  `use_stdout` flag, so the ofstream was never deleted when writing to
  a file, leaking it and leaving its buffer unflushed.
- `export` to '-' set file_fd to STDOUT_FILENO, but cleanup guarded
  close() on STDIN_FILENO (always true), closing stdout.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests