### PR TITLE
rgw/posix: Implement SQLite lifecycle in POSIXUserDB

### DIFF
--- a/src/rgw/driver/posix/posixDB.h
+++ b/src/rgw/driver/posix/posixDB.h
@@ -30,8 +30,6 @@ namespace rgw { namespace store {
 class POSIXUserDB;
 class POSIXAccountDB;
 
-struct POSIXAccountDBOpAccountInfo : DBOpAccountInfo {};
-
 struct POSIXUserDBOpUserInfo : DBOpUserInfo {};
 
 struct POSIXUserDBOpInfo : DBOpInfo {};
@@ -41,6 +39,8 @@ struct POSIXUserDBOpUserPrepareInfo : DBOpUserPrepareInfo {};
 struct POSIXUserDBOpPrepareInfo : DBOpPrepareInfo {};
 
 struct POSIXUserDBOpPrepareParams : DBOpPrepareParams {};
+
+struct POSIXAccountDBOpAccountInfo : DBOpAccountInfo {};
 
 struct POSIXAccountDBOpInfo : DBOpInfo {};
 
@@ -151,6 +151,8 @@ class RemovePOSIXUserOp: public SQLRemoveUser {};
 class POSIXUserDB : public SQLiteDB {
   private:
     const std::string db_name;
+    const std::string lc_head_table;
+    const std::string lc_entry_table;
     rgw::sal::Driver* driver;
 
   protected:
@@ -166,6 +168,8 @@ class POSIXUserDB : public SQLiteDB {
 
     POSIXUserDB(std::string db_name, CephContext *_cct) : SQLiteDB(db_name, _cct),
 		db_name(db_name),
+		lc_head_table(db_name+"_lc_head_table"),
+		lc_entry_table(db_name+"_lc_entry_table"),
 		cct(_cct),
 		dp(_cct, ceph_subsys_rgw, "rgw POSIXUserDBStore backend: ")
                 { DB::set_context(cct); }
@@ -180,7 +184,9 @@ class POSIXUserDB : public SQLiteDB {
     virtual int InitPrepareParams(const DoutPrefixProvider *dpp,
                                   DBOpPrepareParams &p_params,
                                   DBOpParams* params) override { return 0; }
-    virtual int createLCTables(const DoutPrefixProvider *dpp) override { return 0; }
+    virtual int createLCTables(const DoutPrefixProvider *dpp) override { return SQLiteDB::createLCTables(dpp); }
+    const std::string getLCHeadTable() { return lc_head_table; }
+    const std::string getLCEntryTable() { return lc_entry_table; }
 
     virtual int ListAllBuckets(const DoutPrefixProvider *dpp, DBOpParams *params) override { return 0; }
     virtual int ListAllUsers(const DoutPrefixProvider *dpp, DBOpParams *params) override { return 0; }

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -23,6 +23,7 @@
 #include "include/scope_guard.h"
 #include "common/Clock.h" // for ceph_clock_now()
 #include "common/errno.h"
+#include "rgw_lc.h"
 
 #define dout_subsys ceph_subsys_rgw
 #define dout_context g_ceph_context
@@ -1970,6 +1971,19 @@ int POSIXDriver::initialize(CephContext *cct, const DoutPrefixProvider *dpp)
       }
     }
   }
+
+  lc = new RGWLC();
+  lc->initialize(cct, this);
+
+  if (use_lc_thread) { 
+    ret = userDB->createLCTables(dpp);
+    if (ret < 0) {
+      ldpp_dout(dpp, 0) << "Failed to create LC tables, ret=" << ret << dendl;
+      return ret;
+    }
+    lc->start_processor();
+  }
+
   ldpp_dout(dpp, 20) << "root_fd: " << root_dir->get_fd() << dendl;
   quota_handler = RGWQuotaHandler::generate_handler(dpp, this, true);
 
@@ -2197,6 +2211,11 @@ int POSIXDriver::list_all_zones(const DoutPrefixProvider* dpp,
 int POSIXDriver::cluster_stat(RGWClusterStat& stats)
 {
   return 0;
+}
+
+std::unique_ptr<Lifecycle> POSIXDriver::get_lifecycle(void)
+{
+  return std::make_unique<POSIXLifecycle>(this);
 }
 
 std::unique_ptr<Writer> POSIXDriver::get_append_writer(const DoutPrefixProvider *dpp,
@@ -2941,8 +2960,17 @@ int POSIXBucket::write_attrs(const DoutPrefixProvider* dpp, optional_yield y)
   // Bucket info is stored as an attribute, but not in attrs[]
   bufferlist bl;
   encode(info, bl);
-  Attrs extra_attrs;
+  Attrs orig_attrs, extra_attrs;
   extra_attrs[RGW_POSIX_ATTR_BUCKET_INFO] = bl;
+
+  ret = dir->read_attrs(dpp, y, orig_attrs);
+
+  for (auto attr : orig_attrs) {
+    if (auto found = attrs.find(attr.first); found == attrs.end()) {
+      /* Attribute needs to be erased */
+      remove_x_attr(dpp, y, dir->get_fd(), attr.first, get_name());
+    }
+  }
 
   return dir->write_attrs(dpp, y, attrs, &extra_attrs);
 }
@@ -4624,6 +4652,58 @@ int POSIXAtomicWriter::complete(size_t accounted_size, const std::string& etag,
                                             (exists ? 0 : 1), orig_size, accounted_size);
 
   return 0;
+}
+
+int POSIXLifecycle::get_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                              const std::string& oid, const std::string& marker,
+                              LCEntry& entry)
+{
+  return driver->get_user_db()->get_entry(oid, marker, entry);
+}
+
+int POSIXLifecycle::get_next_entry(const DoutPrefixProvider* dpp, optional_yield y,
+				   const std::string& oid, const std::string& marker,
+                                   LCEntry& entry)
+{
+  return driver->get_user_db()->get_next_entry(oid, marker, entry);
+}
+
+int POSIXLifecycle::set_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                              const std::string& oid, const LCEntry& entry)
+{
+  return driver->get_user_db()->set_entry(oid, entry);
+}
+
+int POSIXLifecycle::list_entries(const DoutPrefixProvider* dpp, optional_yield y,
+				const std::string& oid, const std::string& marker,
+                                uint32_t max_entries, std::vector<LCEntry>& entries)
+{
+  return driver->get_user_db()->list_entries(oid, marker, max_entries, entries);
+}
+
+int POSIXLifecycle::rm_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                             const std::string& oid, const LCEntry& entry)
+{
+  return driver->get_user_db()->rm_entry(oid, entry);
+}
+
+int POSIXLifecycle::get_head(const DoutPrefixProvider* dpp, optional_yield y,
+                             const std::string& oid, LCHead& head)
+{
+  return driver->get_user_db()->get_head(oid, head);
+}
+
+int POSIXLifecycle::put_head(const DoutPrefixProvider* dpp, optional_yield y,
+                             const std::string& oid, const LCHead& head)
+{
+  return driver->get_user_db()->put_head(oid, head);
+}
+
+std::unique_ptr<LCSerializer> POSIXLifecycle::get_serializer(const std::string& lock_name,
+                                                             const std::string& oid,
+                                                             const std::string& cookie)
+{
+  return std::make_unique<LCPOSIXSerializer>(driver, oid, lock_name, cookie);
 }
 
 } } // namespace rgw::sal

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -24,6 +24,8 @@
 #include "bucket_cache.h"
 #include "posixDB.h"
 
+class RGWLC;
+
 namespace rgw { namespace sal {
 
 class POSIXDriver;
@@ -484,6 +486,8 @@ protected:
   int root_fd;
   RGWSyncModuleInstanceRef sync_module;
   RGWQuotaHandler* quota_handler{nullptr};
+  RGWLC* lc{nullptr};
+  bool use_lc_thread;
 
 public:
   POSIXDriver(CephContext *_cct) : StoreDriver(), cct(_cct), zone(this)
@@ -500,6 +504,11 @@ public:
 
   void set_context(CephContext *_cct) {
     cct = _cct;
+  }
+
+  POSIXDriver& set_run_lc_thread(bool _use_lc_thread) {
+    use_lc_thread = _use_lc_thread;
+    return *this;
   }
 
   virtual int initialize(CephContext *cct, const DoutPrefixProvider *dpp);
@@ -654,7 +663,7 @@ public:
   virtual int get_zonegroup(const std::string& id, std::unique_ptr<ZoneGroup>* zonegroup) override;
   virtual int list_all_zones(const DoutPrefixProvider* dpp, std::list<std::string>& zone_ids) override;
   virtual int cluster_stat(RGWClusterStat& stats) override;
-  virtual std::unique_ptr<Lifecycle> get_lifecycle(void) override { return nullptr; } // TODO: implement
+  virtual std::unique_ptr<Lifecycle> get_lifecycle(void) override;
   virtual std::unique_ptr<Restore> get_restore(void) { return nullptr; }
   virtual bool process_expired_objects(const DoutPrefixProvider *dpp, optional_yield y) override { return 0; }
 
@@ -684,7 +693,7 @@ public:
 				      optional_yield y,
 				      const std::string& topic_queue) override { return -ENOTSUP; }
 
-  virtual RGWLC* get_rgwlc(void) override { return NULL; } // TODO: Lifecycle not currently supported
+  virtual RGWLC* get_rgwlc(void) override { return lc; }
   virtual rgw::restore::Restore* get_rgwrestore(void) { return nullptr; }
   virtual RGWCoroutinesManagerRegistry* get_cr_registry() override { return NULL; }
 
@@ -1432,6 +1441,45 @@ public:
 
   virtual int try_lock(const DoutPrefixProvider *dpp, ceph::timespan dur, optional_yield y) override;
   virtual int unlock(const DoutPrefixProvider* dpp, optional_yield y) override;
+};
+
+class LCPOSIXSerializer : public StoreLCSerializer {
+public:
+  LCPOSIXSerializer(POSIXDriver* driver, const std::string& oid, const std::string& lock_name, const std::string& cookie) {}
+
+  virtual int try_lock(const DoutPrefixProvider* dpp, ceph::timespan dur, optional_yield y) override { return 0; }
+  virtual int unlock(const DoutPrefixProvider* dpp, optional_yield y) override { return 0; }
+};
+
+class POSIXLifecycle : public Lifecycle {
+  POSIXDriver* driver;
+
+public:
+  POSIXLifecycle(POSIXDriver* _driver) : driver(_driver) {}
+  virtual ~POSIXLifecycle() = default;
+
+  virtual int get_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                        const std::string& oid, const std::string& marker,
+                        LCEntry& entry) override;
+  virtual int get_next_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                             const std::string& oid, const std::string& marker,
+                             LCEntry& entry) override;
+  virtual int set_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                        const std::string& oid, const LCEntry& entry) override;
+  virtual int list_entries(const DoutPrefixProvider* dpp, optional_yield y,
+                           const std::string& oid, const std::string& marker,
+                           uint32_t max_entries,
+                           std::vector<LCEntry>& entries) override;
+  virtual int rm_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                       const std::string& oid, const LCEntry& entry) override;
+  virtual int get_head(const DoutPrefixProvider* dpp, optional_yield y,
+                       const std::string& oid, LCHead& head) override;
+  virtual int put_head(const DoutPrefixProvider* dpp, optional_yield y,
+                       const std::string& oid, const LCHead& head) override;
+
+  virtual std::unique_ptr<LCSerializer> get_serializer(const std::string& lock_name,
+                                                       const std::string& oid,
+                                                       const std::string& cookie) override;
 };
 
 } } // namespace rgw::sal


### PR DESCRIPTION
This PR implements the solution presented in the [following doc](https://gist.github.com/mattbenjamin/e29ee92fff169b7ac0344eb2906fb81a). Instead of using JSON files to maintain LC data in POSIX, the POSIXUserDb has been extended to also instantiate SQLite LC head and entry tables. The lifecycle SAL interface has been modified to employ SQLite logic (taken from the DBStore interface) for maintaining these tables.

Local testing that was completed:
- setlifecycle
- getlifecycle
- dellifecycle
- radosgw-admin lc list
- radosgw-admin lc get
- Workflow: putting objects into buckets with lifecycle active, waiting for the lifecycle duration to pass, and checking if the object was still present in the bucket

Note: `radosgw-admin lc process` is not implemented in DBStore/SQLite, so it is omitted in this PR as well.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
