### PR TITLE
os/bluestore: add performance counters for the ObjectStore interface

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6677,9 +6677,9 @@ void BlueStore::_init_logger()
   b.add_time_avg(l_bluestore_clone_lat, "clone_lat",
     "Average clone/clone_range operation latency",
     "clon", PerfCountersBuilder::PRIO_USEFUL);
-  b.add_time_avg(l_bluestore_attr_lat, "attr_lat",
+  b.add_time_avg(l_bluestore_change_attr_lat, "chgattr_lat",
     "Average setattr/setattrs/rmattr/rmattrs latency",
-    "attr", PerfCountersBuilder::PRIO_USEFUL);
+    "chg", PerfCountersBuilder::PRIO_USEFUL);
   b.add_time_avg(l_bluestore_touch_lat, "touch_lat",
     "Average touch latency",
     "tuch", PerfCountersBuilder::PRIO_USEFUL);
@@ -13923,12 +13923,14 @@ bool BlueStore::collection_exists(const coll_t& c)
 {
   auto start = mono_clock::now();
   std::shared_lock l(coll_lock);
-  return coll_map.count(c);
+  bool exists = coll_map.count(c);
   logger->tinc_with_max(l_bluestore_collection_lat, mono_clock::now() - start);
+  return exists;
 }
 
 int BlueStore::collection_empty(CollectionHandle& ch, bool *empty)
 {
+  // collection_empty delegates to collection_list; measuring both would double-count.
   dout(15) << __func__ << " " << ch->cid << dendl;
   vector<ghobject_t> ls;
   ghobject_t next;
@@ -18527,7 +18529,7 @@ int BlueStore::_setattr(TransContext *txc,
   b.reassign_to_mempool(mempool::mempool_bluestore_cache_meta);
 
   txc->write_onode(o);
-  logger->tinc_with_max(l_bluestore_attr_lat, mono_clock::now() - start);
+  logger->tinc_with_max(l_bluestore_change_attr_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << c->cid << " " << o->oid
 	   << " " << name << " (" << val.length() << " bytes)"
 	   << " = " << r << dendl;
@@ -18556,7 +18558,7 @@ int BlueStore::_setattrs(TransContext *txc,
     }
   }
   txc->write_onode(o);
-  logger->tinc_with_max(l_bluestore_attr_lat, mono_clock::now() - start);
+  logger->tinc_with_max(l_bluestore_change_attr_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << c->cid << " " << o->oid
 	   << " " << aset.size() << " keys"
 	   << " = " << r << dendl;
@@ -18581,7 +18583,7 @@ int BlueStore::_rmattr(TransContext *txc,
   txc->write_onode(o);
 
 out:
-  logger->tinc_with_max(l_bluestore_attr_lat, mono_clock::now() - start);
+  logger->tinc_with_max(l_bluestore_change_attr_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << c->cid << " " << o->oid
 	   << " " << name << " = " << r << dendl;
   return r;
@@ -18602,7 +18604,7 @@ int BlueStore::_rmattrs(TransContext *txc,
   txc->write_onode(o);
 
  out:
-  logger->tinc_with_max(l_bluestore_attr_lat, mono_clock::now() - start);
+  logger->tinc_with_max(l_bluestore_change_attr_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << c->cid << " " << o->oid << " = " << r << dendl;
   return r;
 }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6661,43 +6661,43 @@ void BlueStore::_init_logger()
     "tr_l", PerfCountersBuilder::PRIO_USEFUL);
   b.add_time_avg(l_bluestore_exists_lat, "exists_lat",
     "Average exists call latency",
-    "ex_l", PerfCountersBuilder::PRIO_USEFUL);
+    "exst", PerfCountersBuilder::PRIO_USEFUL);
   b.add_time_avg(l_bluestore_stat_lat, "stat_lat",
     "Average stat call latency",
-    "st_l", PerfCountersBuilder::PRIO_USEFUL);
+    "stat", PerfCountersBuilder::PRIO_USEFUL);
   b.add_time_avg(l_bluestore_getattr_lat, "getattr_lat",
     "Average getattr/getattrs call latency",
-    "ga_l", PerfCountersBuilder::PRIO_USEFUL);
+    "gatr", PerfCountersBuilder::PRIO_USEFUL);
   b.add_time_avg(l_bluestore_fiemap_lat, "fiemap_lat",
     "Average fiemap call latency",
-    "fm_l", PerfCountersBuilder::PRIO_USEFUL);
+    "fmap", PerfCountersBuilder::PRIO_USEFUL);
   b.add_time_avg(l_bluestore_omap_get_lat, "omap_get_lat",
     "Average omap read (omap_get/omap_get_header/omap_check_keys) latency",
-    "og_l", PerfCountersBuilder::PRIO_USEFUL);
+    "omgt", PerfCountersBuilder::PRIO_USEFUL);
   b.add_time_avg(l_bluestore_clone_lat, "clone_lat",
     "Average clone/clone_range operation latency",
-    "clnl", PerfCountersBuilder::PRIO_USEFUL);
+    "clon", PerfCountersBuilder::PRIO_USEFUL);
   b.add_time_avg(l_bluestore_attr_lat, "attr_lat",
     "Average setattr/setattrs/rmattr/rmattrs latency",
-    "at_l", PerfCountersBuilder::PRIO_USEFUL);
+    "attr", PerfCountersBuilder::PRIO_USEFUL);
   b.add_time_avg(l_bluestore_touch_lat, "touch_lat",
     "Average touch latency",
-    "to_l", PerfCountersBuilder::PRIO_USEFUL);
+    "tuch", PerfCountersBuilder::PRIO_USEFUL);
   b.add_time_avg(l_bluestore_zero_lat, "zero_lat",
     "Average zero latency",
-    "ze_l", PerfCountersBuilder::PRIO_USEFUL);
+    "zero", PerfCountersBuilder::PRIO_USEFUL);
   b.add_time_avg(l_bluestore_omap_set_lat, "omap_set_lat",
     "Average omap write (setkeys/setheader/rmkeys/rmkey_range) latency",
-    "os_l", PerfCountersBuilder::PRIO_USEFUL);
+    "omst", PerfCountersBuilder::PRIO_USEFUL);
   b.add_time_avg(l_bluestore_rename_lat, "rename_lat",
     "Average rename latency",
-    "rn_l", PerfCountersBuilder::PRIO_USEFUL);
+    "rnam", PerfCountersBuilder::PRIO_USEFUL);
   b.add_time_avg(l_bluestore_collection_lat, "collection_lat",
     "Average collection metadata query latency (list/exists/bits)",
-    "co_l", PerfCountersBuilder::PRIO_USEFUL);
+    "coll", PerfCountersBuilder::PRIO_USEFUL);
   b.add_time_avg(l_bluestore_other_write_lat, "other_write_lat",
     "Average latency of other/rare write ops (set_alloc_hint, set_collection_opts, collection create/remove/split/merge)",
-    "ot_l", PerfCountersBuilder::PRIO_USEFUL);
+    "othw", PerfCountersBuilder::PRIO_USEFUL);
   //****************************************
 
   // slow op count
@@ -12734,10 +12734,7 @@ bool BlueStore::exists(CollectionHandle &c_, const ghobject_t& oid)
     if (!o || !o->exists)
       r = false;
   }
-  log_latency(__func__,
-    l_bluestore_exists_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age);
+  logger->tinc_with_max(l_bluestore_exists_lat, mono_clock::now() - start);
   return r;
 }
 
@@ -12750,17 +12747,14 @@ int BlueStore::stat(
   Collection *c = static_cast<Collection *>(c_.get());
   if (!c->exists)
     return -ENOENT;
-  auto start = mono_clock::now();
   dout(10) << __func__ << " " << c->get_cid() << " " << oid << dendl;
+  auto start = mono_clock::now();
 
   {
     std::shared_lock l(c->lock);
     OnodeRef o = c->get_onode(oid, false);
     if (!o || !o->exists) {
-      log_latency(__func__,
-        l_bluestore_stat_lat,
-        mono_clock::now() - start,
-        cct->_conf->bluestore_log_op_age);
+      logger->tinc_with_max(l_bluestore_stat_lat, mono_clock::now() - start);
       return -ENOENT;
     }
     st->st_size = o->onode.size;
@@ -12774,10 +12768,7 @@ int BlueStore::stat(
     r = -EIO;
     derr << __func__ << " " << c->cid << " " << oid << " INJECT EIO" << dendl;
   }
-  log_latency(__func__,
-    l_bluestore_stat_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age);
+  logger->tinc_with_max(l_bluestore_stat_lat, mono_clock::now() - start);
   return r;
 }
 
@@ -12853,9 +12844,7 @@ int BlueStore::set_collection_opts(
   if (c->pool_opts.get(pool_opts_t::COMPRESSION_REQUIRED_RATIO, &dval)) {
     c->compression_req_ratio = dval;
   }
-  log_latency(__func__, l_bluestore_other_write_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age);
+  logger->tinc_with_max(l_bluestore_other_write_lat, mono_clock::now() - start);
   return 0;
 }
 
@@ -13509,10 +13498,7 @@ int BlueStore::_fiemap(
 
     OnodeRef o = c->get_onode(oid, false);
     if (!o || !o->exists) {
-      log_latency(__func__,
-        l_bluestore_fiemap_lat,
-        mono_clock::now() - start,
-        cct->_conf->bluestore_log_op_age);
+      logger->tinc_with_max(l_bluestore_fiemap_lat, mono_clock::now() - start);
       return -ENOENT;
     }
     _dump_onode<30>(cct, *o);
@@ -13562,10 +13548,7 @@ int BlueStore::_fiemap(
   }
 
  out:
-  log_latency(__func__,
-    l_bluestore_fiemap_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age);
+  logger->tinc_with_max(l_bluestore_fiemap_lat, mono_clock::now() - start);
   dout(20) << __func__ << " 0x" << std::hex << offset << "~" << length
 	   << " size = 0x(" << destset << ")" << std::dec << dendl;
   return 0;
@@ -13882,10 +13865,7 @@ int BlueStore::getattr(
     r = -EIO;
     derr << __func__ << " " << c->cid << " " << oid << " INJECT EIO" << dendl;
   }
-  log_latency(__func__,
-    l_bluestore_getattr_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age);
+  logger->tinc_with_max(l_bluestore_getattr_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << c->cid << " " << oid << " " << name
 	   << " = " << r << dendl;
   return r;
@@ -13922,10 +13902,7 @@ int BlueStore::getattrs(
     r = -EIO;
     derr << __func__ << " " << c->cid << " " << oid << " INJECT EIO" << dendl;
   }
-  log_latency(__func__,
-    l_bluestore_getattr_lat,  // give getattr and getattrs a shared counter
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age);
+  logger->tinc_with_max(l_bluestore_getattr_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << c->cid << " " << oid
 	   << " = " << r << dendl;
   return r;
@@ -13938,9 +13915,7 @@ int BlueStore::list_collections(vector<coll_t>& ls)
   ls.reserve(coll_map.size());
   for (auto p = coll_map.begin(); p != coll_map.end(); ++p)
     ls.push_back(p->first);
-  log_latency(__func__, l_bluestore_collection_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age);
+  logger->tinc_with_max(l_bluestore_collection_lat, mono_clock::now() - start);
   return 0;
 }
 
@@ -13948,10 +13923,8 @@ bool BlueStore::collection_exists(const coll_t& c)
 {
   auto start = mono_clock::now();
   std::shared_lock l(coll_lock);
-  log_latency(__func__, l_bluestore_collection_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age);
   return coll_map.count(c);
+  logger->tinc_with_max(l_bluestore_collection_lat, mono_clock::now() - start);
 }
 
 int BlueStore::collection_empty(CollectionHandle& ch, bool *empty)
@@ -13977,9 +13950,7 @@ int BlueStore::collection_bits(CollectionHandle& ch)
   auto start = mono_clock::now();
   Collection *c = static_cast<Collection*>(ch.get());
   std::shared_lock l(c->lock);
-  log_latency(__func__, l_bluestore_collection_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age);
+  logger->tinc_with_max(l_bluestore_collection_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << ch->cid << " = " << c->cnode.bits << dendl;
   return c->cnode.bits;
 }
@@ -14138,11 +14109,9 @@ int BlueStore::omap_get(
 {
   Collection *c = static_cast<Collection *>(c_.get());
   auto start = mono_clock::now();
-  int r = _omap_get(c, oid, header, out);   // 1. call, but capture the result instead of returning it
-  log_latency(__func__, l_bluestore_omap_get_lat,
-    mono_clock::now() - start,              // 2. now there's a place to stop the clock + log
-    cct->_conf->bluestore_log_op_age);
-  return r;                                 // 3. then return the captured value
+  int r = _omap_get(c, oid, header, out);
+  logger->tinc_with_max(l_bluestore_omap_get_lat, mono_clock::now() - start);
+  return r;
 }
 
 int BlueStore::_omap_get(
@@ -14243,10 +14212,7 @@ int BlueStore::omap_get_header(
     }
   }
  out:
-  log_latency(__func__,
-    l_bluestore_omap_get_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age);
+  logger->tinc_with_max(l_bluestore_omap_get_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << c->get_cid() << " oid " << oid << " = " << r
 	   << dendl;
   return r;
@@ -14346,10 +14312,7 @@ int BlueStore::omap_check_keys(
     }
   }
  out:
-  log_latency(__func__,
-    l_bluestore_omap_get_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age);
+  logger->tinc_with_max(l_bluestore_omap_get_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << c->get_cid() << " oid " << oid << " = " << r
 	   << dendl;
   return r;
@@ -16645,17 +16608,7 @@ int BlueStore::_touch(TransContext *txc,
   auto start = mono_clock::now();
   _assign_nid(txc, o);
   txc->write_onode(o);
-  log_latency_fn(
-    __func__,
-    l_bluestore_touch_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age,
-    [&](const ceph::timespan& lat) {
-      ostringstream ostr;
-      ostr << ", lat = " << timespan_str(lat)
-        << " cid =" << c->cid << " oid =" << o->oid;
-      return ostr.str();
-    });
+  logger->tinc_with_max(l_bluestore_touch_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << c->cid << " " << o->oid << " = " << r << dendl;
   return r;
 }
@@ -18288,17 +18241,7 @@ int BlueStore::_zero(TransContext *txc,
     _assign_nid(txc, o);
     r = _do_zero(txc, c, o, offset, length);
   }
-  log_latency_fn(
-    __func__,
-    l_bluestore_zero_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age,
-    [&](const ceph::timespan& lat) {
-      ostringstream ostr;
-      ostr << ", lat = " << timespan_str(lat)
-        << " cid =" << c->cid << " oid =" << o->oid;
-      return ostr.str();
-    });
+  logger->tinc_with_max(l_bluestore_zero_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << c->cid << " " << o->oid
 	   << " 0x" << std::hex << offset << "~" << length << std::dec
 	   << " = " << r << dendl;
@@ -18584,17 +18527,7 @@ int BlueStore::_setattr(TransContext *txc,
   b.reassign_to_mempool(mempool::mempool_bluestore_cache_meta);
 
   txc->write_onode(o);
-  log_latency_fn(
-    __func__,
-    l_bluestore_attr_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age,
-    [&](const ceph::timespan& lat) {
-      ostringstream ostr;
-      ostr << ", lat = " << timespan_str(lat)
-        << " cid =" << c->cid << " oid =" << o->oid;
-      return ostr.str();
-    });
+  logger->tinc_with_max(l_bluestore_attr_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << c->cid << " " << o->oid
 	   << " " << name << " (" << val.length() << " bytes)"
 	   << " = " << r << dendl;
@@ -18623,17 +18556,7 @@ int BlueStore::_setattrs(TransContext *txc,
     }
   }
   txc->write_onode(o);
-  log_latency_fn(
-    __func__,
-    l_bluestore_attr_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age,
-    [&](const ceph::timespan& lat) {
-      ostringstream ostr;
-      ostr << ", lat = " << timespan_str(lat)
-        << " cid =" << c->cid << " oid =" << o->oid;
-      return ostr.str();
-    });
+  logger->tinc_with_max(l_bluestore_attr_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << c->cid << " " << o->oid
 	   << " " << aset.size() << " keys"
 	   << " = " << r << dendl;
@@ -18658,15 +18581,7 @@ int BlueStore::_rmattr(TransContext *txc,
   txc->write_onode(o);
 
 out:
-  log_latency_fn(
-    __func__, l_bluestore_attr_lat,
-    mono_clock::now() - start, cct->_conf->bluestore_log_op_age,
-    [&](const ceph::timespan& lat) {
-      ostringstream ostr;
-      ostr << ", lat = " << timespan_str(lat)
-        << " cid =" << c->cid << " oid =" << o->oid;
-      return ostr.str();
-    });
+  logger->tinc_with_max(l_bluestore_attr_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << c->cid << " " << o->oid
 	   << " " << name << " = " << r << dendl;
   return r;
@@ -18687,15 +18602,7 @@ int BlueStore::_rmattrs(TransContext *txc,
   txc->write_onode(o);
 
  out:
-  log_latency_fn(
-    __func__, l_bluestore_attr_lat,
-    mono_clock::now() - start, cct->_conf->bluestore_log_op_age,
-    [&](const ceph::timespan& lat) {
-      ostringstream ostr;
-      ostr << ", lat = " << timespan_str(lat)
-        << " cid =" << c->cid << " oid =" << o->oid;
-      return ostr.str();
-    });
+  logger->tinc_with_max(l_bluestore_attr_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << c->cid << " " << o->oid << " = " << r << dendl;
   return r;
 }
@@ -18782,17 +18689,7 @@ int BlueStore::_omap_setkeys(TransContext *txc,
   logger->inc(l_bluestore_omap_setkeys_records, num0);
   logger->inc(l_bluestore_omap_setkeys_bytes, total_bytes);
   r = 0;
-  log_latency_fn(
-    __func__,
-    l_bluestore_omap_set_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age,
-    [&](const ceph::timespan& lat) {
-      ostringstream ostr;
-      ostr << ", lat = " << timespan_str(lat)
-        << " cid =" << c->cid << " oid =" << o->oid;
-      return ostr.str();
-    });
+  logger->tinc_with_max(l_bluestore_omap_set_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << c->cid << " " << o->oid << " = " << r << dendl;
   return r;
 }
@@ -18828,17 +18725,7 @@ int BlueStore::_omap_setheader(TransContext *txc,
   logger->inc(l_bluestore_omap_setheader_count);
   logger->inc(l_bluestore_omap_setheader_bytes, bl.length());
   r = 0;
-  log_latency_fn(
-    __func__,
-    l_bluestore_omap_set_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age,
-    [&](const ceph::timespan& lat) {
-      ostringstream ostr;
-      ostr << ", lat = " << timespan_str(lat)
-        << " cid =" << c->cid << " oid =" << o->oid;
-      return ostr.str();
-    });
+  logger->tinc_with_max(l_bluestore_omap_set_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << c->cid << " " << o->oid << " = " << r << dendl;
   return r;
 }
@@ -18876,17 +18763,7 @@ int BlueStore::_omap_rmkeys(TransContext *txc,
   txc->note_modified_object(o);
 
  out:
-  log_latency_fn(
-    __func__,
-    l_bluestore_omap_set_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age,
-    [&](const ceph::timespan& lat) {
-      ostringstream ostr;
-      ostr << ", lat = " << timespan_str(lat)
-        << " cid =" << c->cid << " oid =" << o->oid;
-      return ostr.str();
-    });
+  logger->tinc_with_max(l_bluestore_omap_set_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << c->cid << " " << o->oid << " = " << r << dendl;
   return r;
 }
@@ -18917,17 +18794,7 @@ int BlueStore::_omap_rmkey_range(TransContext *txc,
   txc->note_modified_object(o);
 
  out:
-  log_latency_fn(
-    __func__,
-    l_bluestore_omap_set_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age,
-    [&](const ceph::timespan& lat) {
-      ostringstream ostr;
-      ostr << ", lat = " << timespan_str(lat)
-        << " cid =" << c->cid << " oid =" << o->oid;
-      return ostr.str();
-    });
+  logger->tinc_with_max(l_bluestore_omap_set_lat, mono_clock::now() - start);
   return r;
 }
 
@@ -18950,9 +18817,7 @@ int BlueStore::_set_alloc_hint(
   o->onode.expected_write_size = expected_write_size;
   o->onode.alloc_hint_flags = flags;
   txc->write_onode(o);
-  log_latency(__func__, l_bluestore_other_write_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age);
+  logger->tinc_with_max(l_bluestore_other_write_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << c->cid << " " << o->oid
 	   << " object_size " << expected_object_size
 	   << " write_size " << expected_write_size
@@ -19040,20 +18905,7 @@ int BlueStore::_clone(TransContext *txc,
   r = 0;
 
  out:
-  log_latency_fn(
-    __func__,
-    l_bluestore_clone_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age,
-    [&](const ceph::timespan& lat) {
-      ostringstream ostr;
-      ostr << ", lat = " << timespan_str(lat)
-        << " cid =" << c->cid
-        << " old_oid =" << oldo->oid
-        << " new_oid =" << newo->oid;
-      return ostr.str();
-    }
-  );
+  logger->tinc_with_max(l_bluestore_clone_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << c->cid << " " << oldo->oid << " -> "
 	   << newo->oid << " = " << r << dendl;
   return r;
@@ -19132,23 +18984,7 @@ int BlueStore::_clone_range(TransContext *txc,
   r = 0;
 
  out:
-  log_latency_fn(
-    __func__,
-    l_bluestore_clone_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age,
-    [&](const ceph::timespan& lat) {
-      ostringstream ostr;
-      ostr << ", lat = " << timespan_str(lat)
-        << " cid =" << c->cid
-        << " old_oid =" << oldo->oid
-        << " new_oid =" << newo->oid
-        << " srcoff = 0x" << std::hex << srcoff
-        << " length = 0x" << length
-        << " dstoff = 0x" << dstoff;
-      return ostr.str();
-    }
-  );
+  logger->tinc_with_max(l_bluestore_clone_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << c->cid << " " << oldo->oid << " -> "
 	   << newo->oid << " from 0x" << std::hex << srcoff << "~" << length
 	   << " to offset 0x" << dstoff << std::dec
@@ -19208,20 +19044,7 @@ int BlueStore::_rename(TransContext *txc,
   txc->note_modified_object(oldo);
 
  out:
-  log_latency_fn(
-    __func__,
-    l_bluestore_rename_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age,
-    [&](const ceph::timespan& lat) {
-      ostringstream ostr;
-      ostr << ", lat = " << timespan_str(lat)
-        << " cid =" << c->cid
-        << " old_oid =" << old_oid
-        << " new_oid =" << new_oid;
-      return ostr.str();
-    }
-  );
+  logger->tinc_with_max(l_bluestore_rename_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << c->cid << " " << old_oid << " -> "
 	   << new_oid << " = " << r << dendl;
   return r;
@@ -19258,9 +19081,7 @@ int BlueStore::_create_collection(
   r = 0;
 
  out:
-  log_latency(__func__, l_bluestore_other_write_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age);
+  logger->tinc_with_max(l_bluestore_other_write_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << cid << " bits " << bits << " = " << r << dendl;
   return r;
 }
@@ -19326,9 +19147,7 @@ int BlueStore::_remove_collection(TransContext *txc, const coll_t &cid,
     }
   }
 out:
-  log_latency(__func__, l_bluestore_other_write_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age);
+  logger->tinc_with_max(l_bluestore_other_write_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << cid << " = " << r << dendl;
   return r;
 }
@@ -19392,9 +19211,7 @@ int BlueStore::_split_collection(TransContext *txc,
   encode(c->cnode, bl);
   txc->t->set(PREFIX_COLL, stringify(c->cid), bl);
 
-  log_latency(__func__, l_bluestore_other_write_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age);
+  logger->tinc_with_max(l_bluestore_other_write_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << c->cid << " to " << d->cid << " "
 	   << " bits " << bits << " = " << r << dendl;
   return r;
@@ -19452,9 +19269,7 @@ int BlueStore::_merge_collection(
   encode(d->cnode, bl);
   txc->t->set(PREFIX_COLL, stringify(d->cid), bl);
 
-  log_latency(__func__, l_bluestore_other_write_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age);
+  logger->tinc_with_max(l_bluestore_other_write_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << cid << " to " << d->cid << " "
 	   << " bits " << bits << " = " << r << dendl;
   return r;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6659,6 +6659,45 @@ void BlueStore::_init_logger()
   b.add_time_avg(l_bluestore_truncate_lat, "truncate_lat",
     "Average truncate latency",
     "tr_l", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_exists_lat, "exists_lat",
+    "Average exists call latency",
+    "ex_l", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_stat_lat, "stat_lat",
+    "Average stat call latency",
+    "st_l", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_getattr_lat, "getattr_lat",
+    "Average getattr/getattrs call latency",
+    "ga_l", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_fiemap_lat, "fiemap_lat",
+    "Average fiemap call latency",
+    "fm_l", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_omap_get_lat, "omap_get_lat",
+    "Average omap read (omap_get/omap_get_header/omap_check_keys) latency",
+    "og_l", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_clone_lat, "clone_lat",
+    "Average clone/clone_range operation latency",
+    "clnl", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_attr_lat, "attr_lat",
+    "Average setattr/setattrs/rmattr/rmattrs latency",
+    "at_l", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_touch_lat, "touch_lat",
+    "Average touch latency",
+    "to_l", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_zero_lat, "zero_lat",
+    "Average zero latency",
+    "ze_l", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_omap_set_lat, "omap_set_lat",
+    "Average omap write (setkeys/setheader/rmkeys/rmkey_range) latency",
+    "os_l", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_rename_lat, "rename_lat",
+    "Average rename latency",
+    "rn_l", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_collection_lat, "collection_lat",
+    "Average collection metadata query latency (list/exists/bits)",
+    "co_l", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_other_write_lat, "other_write_lat",
+    "Average latency of other/rare write ops (set_alloc_hint, set_collection_opts, collection create/remove/split/merge)",
+    "ot_l", PerfCountersBuilder::PRIO_USEFUL);
   //****************************************
 
   // slow op count
@@ -12686,6 +12725,7 @@ bool BlueStore::exists(CollectionHandle &c_, const ghobject_t& oid)
   if (!c->exists)
     return false;
 
+  auto start = mono_clock::now();
   bool r = true;
 
   {
@@ -12694,7 +12734,10 @@ bool BlueStore::exists(CollectionHandle &c_, const ghobject_t& oid)
     if (!o || !o->exists)
       r = false;
   }
-
+  log_latency(__func__,
+    l_bluestore_exists_lat,
+    mono_clock::now() - start,
+    cct->_conf->bluestore_log_op_age);
   return r;
 }
 
@@ -12707,13 +12750,19 @@ int BlueStore::stat(
   Collection *c = static_cast<Collection *>(c_.get());
   if (!c->exists)
     return -ENOENT;
+  auto start = mono_clock::now();
   dout(10) << __func__ << " " << c->get_cid() << " " << oid << dendl;
 
   {
     std::shared_lock l(c->lock);
     OnodeRef o = c->get_onode(oid, false);
-    if (!o || !o->exists)
+    if (!o || !o->exists) {
+      log_latency(__func__,
+        l_bluestore_stat_lat,
+        mono_clock::now() - start,
+        cct->_conf->bluestore_log_op_age);
       return -ENOENT;
+    }
     st->st_size = o->onode.size;
     st->st_blksize = 4096;
     st->st_blocks = (st->st_size + st->st_blksize - 1) / st->st_blksize;
@@ -12725,8 +12774,13 @@ int BlueStore::stat(
     r = -EIO;
     derr << __func__ << " " << c->cid << " " << oid << " INJECT EIO" << dendl;
   }
+  log_latency(__func__,
+    l_bluestore_stat_lat,
+    mono_clock::now() - start,
+    cct->_conf->bluestore_log_op_age);
   return r;
 }
+
 int BlueStore::set_collection_opts(
   CollectionHandle& ch,
   const pool_opts_t& opts)
@@ -12735,6 +12789,7 @@ int BlueStore::set_collection_opts(
   dout(15) << __func__ << " " << ch->cid << " options " << opts << dendl;
   if (!c->exists)
     return -ENOENT;
+  auto start = mono_clock::now();
   std::unique_lock l{c->lock};
   c->pool_opts = opts;
 
@@ -12798,6 +12853,9 @@ int BlueStore::set_collection_opts(
   if (c->pool_opts.get(pool_opts_t::COMPRESSION_REQUIRED_RATIO, &dval)) {
     c->compression_req_ratio = dval;
   }
+  log_latency(__func__, l_bluestore_other_write_lat,
+    mono_clock::now() - start,
+    cct->_conf->bluestore_log_op_age);
   return 0;
 }
 
@@ -13445,11 +13503,16 @@ int BlueStore::_fiemap(
   Collection *c = static_cast<Collection *>(c_.get());
   if (!c->exists)
     return -ENOENT;
+  auto start = mono_clock::now();
   {
     std::shared_lock l(c->lock);
 
     OnodeRef o = c->get_onode(oid, false);
     if (!o || !o->exists) {
+      log_latency(__func__,
+        l_bluestore_fiemap_lat,
+        mono_clock::now() - start,
+        cct->_conf->bluestore_log_op_age);
       return -ENOENT;
     }
     _dump_onode<30>(cct, *o);
@@ -13499,6 +13562,10 @@ int BlueStore::_fiemap(
   }
 
  out:
+  log_latency(__func__,
+    l_bluestore_fiemap_lat,
+    mono_clock::now() - start,
+    cct->_conf->bluestore_log_op_age);
   dout(20) << __func__ << " 0x" << std::hex << offset << "~" << length
 	   << " size = 0x(" << destset << ")" << std::dec << dendl;
   return 0;
@@ -13791,7 +13858,7 @@ int BlueStore::getattr(
   dout(15) << __func__ << " " << c->cid << " " << oid << " " << name << dendl;
   if (!c->exists)
     return -ENOENT;
-
+  auto start = mono_clock::now();
   int r;
   {
     std::shared_lock l(c->lock);
@@ -13815,6 +13882,10 @@ int BlueStore::getattr(
     r = -EIO;
     derr << __func__ << " " << c->cid << " " << oid << " INJECT EIO" << dendl;
   }
+  log_latency(__func__,
+    l_bluestore_getattr_lat,
+    mono_clock::now() - start,
+    cct->_conf->bluestore_log_op_age);
   dout(10) << __func__ << " " << c->cid << " " << oid << " " << name
 	   << " = " << r << dendl;
   return r;
@@ -13829,7 +13900,7 @@ int BlueStore::getattrs(
   dout(15) << __func__ << " " << c->cid << " " << oid << dendl;
   if (!c->exists)
     return -ENOENT;
-
+  auto start = mono_clock::now();
   int r;
   {
     std::shared_lock l(c->lock);
@@ -13851,6 +13922,10 @@ int BlueStore::getattrs(
     r = -EIO;
     derr << __func__ << " " << c->cid << " " << oid << " INJECT EIO" << dendl;
   }
+  log_latency(__func__,
+    l_bluestore_getattr_lat,  // give getattr and getattrs a shared counter
+    mono_clock::now() - start,
+    cct->_conf->bluestore_log_op_age);
   dout(10) << __func__ << " " << c->cid << " " << oid
 	   << " = " << r << dendl;
   return r;
@@ -13858,16 +13933,24 @@ int BlueStore::getattrs(
 
 int BlueStore::list_collections(vector<coll_t>& ls)
 {
+  auto start = mono_clock::now();
   std::shared_lock l(coll_lock);
   ls.reserve(coll_map.size());
   for (auto p = coll_map.begin(); p != coll_map.end(); ++p)
     ls.push_back(p->first);
+  log_latency(__func__, l_bluestore_collection_lat,
+    mono_clock::now() - start,
+    cct->_conf->bluestore_log_op_age);
   return 0;
 }
 
 bool BlueStore::collection_exists(const coll_t& c)
 {
+  auto start = mono_clock::now();
   std::shared_lock l(coll_lock);
+  log_latency(__func__, l_bluestore_collection_lat,
+    mono_clock::now() - start,
+    cct->_conf->bluestore_log_op_age);
   return coll_map.count(c);
 }
 
@@ -13891,8 +13974,12 @@ int BlueStore::collection_empty(CollectionHandle& ch, bool *empty)
 int BlueStore::collection_bits(CollectionHandle& ch)
 {
   dout(15) << __func__ << " " << ch->cid << dendl;
+  auto start = mono_clock::now();
   Collection *c = static_cast<Collection*>(ch.get());
   std::shared_lock l(c->lock);
+  log_latency(__func__, l_bluestore_collection_lat,
+    mono_clock::now() - start,
+    cct->_conf->bluestore_log_op_age);
   dout(10) << __func__ << " " << ch->cid << " = " << c->cnode.bits << dendl;
   return c->cnode.bits;
 }
@@ -14050,7 +14137,12 @@ int BlueStore::omap_get(
   )
 {
   Collection *c = static_cast<Collection *>(c_.get());
-  return _omap_get(c, oid, header, out);
+  auto start = mono_clock::now();
+  int r = _omap_get(c, oid, header, out);   // 1. call, but capture the result instead of returning it
+  log_latency(__func__, l_bluestore_omap_get_lat,
+    mono_clock::now() - start,              // 2. now there's a place to stop the clock + log
+    cct->_conf->bluestore_log_op_age);
+  return r;                                 // 3. then return the captured value
 }
 
 int BlueStore::_omap_get(
@@ -14130,6 +14222,7 @@ int BlueStore::omap_get_header(
   dout(15) << __func__ << " " << c->get_cid() << " oid " << oid << dendl;
   if (!c->exists)
     return -ENOENT;
+  auto start = mono_clock::now();
   std::shared_lock l(c->lock);
   int r = 0;
   OnodeRef o = c->get_onode(oid, false);
@@ -14150,6 +14243,10 @@ int BlueStore::omap_get_header(
     }
   }
  out:
+  log_latency(__func__,
+    l_bluestore_omap_get_lat,
+    mono_clock::now() - start,
+    cct->_conf->bluestore_log_op_age);
   dout(10) << __func__ << " " << c->get_cid() << " oid " << oid << " = " << r
 	   << dendl;
   return r;
@@ -14217,6 +14314,7 @@ int BlueStore::omap_check_keys(
   dout(15) << __func__ << " " << c->get_cid() << " oid " << oid << dendl;
   if (!c->exists)
     return -ENOENT;
+  auto start = mono_clock::now();
   std::shared_lock l(c->lock);
   int r = 0;
   string final_key;
@@ -14248,6 +14346,10 @@ int BlueStore::omap_check_keys(
     }
   }
  out:
+  log_latency(__func__,
+    l_bluestore_omap_get_lat,
+    mono_clock::now() - start,
+    cct->_conf->bluestore_log_op_age);
   dout(10) << __func__ << " " << c->get_cid() << " oid " << oid << " = " << r
 	   << dendl;
   return r;
@@ -16540,8 +16642,20 @@ int BlueStore::_touch(TransContext *txc,
 {
   dout(15) << __func__ << " " << c->cid << " " << o->oid << dendl;
   int r = 0;
+  auto start = mono_clock::now();
   _assign_nid(txc, o);
   txc->write_onode(o);
+  log_latency_fn(
+    __func__,
+    l_bluestore_touch_lat,
+    mono_clock::now() - start,
+    cct->_conf->bluestore_log_op_age,
+    [&](const ceph::timespan& lat) {
+      ostringstream ostr;
+      ostr << ", lat = " << timespan_str(lat)
+        << " cid =" << c->cid << " oid =" << o->oid;
+      return ostr.str();
+    });
   dout(10) << __func__ << " " << c->cid << " " << o->oid << " = " << r << dendl;
   return r;
 }
@@ -18166,6 +18280,7 @@ int BlueStore::_zero(TransContext *txc,
   dout(15) << __func__ << " " << c->cid << " " << o->oid
 	   << " 0x" << std::hex << offset << "~" << length << std::dec
 	   << dendl;
+  auto start = mono_clock::now();
   int r = 0;
   if (offset + length >= OBJECT_MAX_SIZE) {
     r = -E2BIG;
@@ -18173,6 +18288,17 @@ int BlueStore::_zero(TransContext *txc,
     _assign_nid(txc, o);
     r = _do_zero(txc, c, o, offset, length);
   }
+  log_latency_fn(
+    __func__,
+    l_bluestore_zero_lat,
+    mono_clock::now() - start,
+    cct->_conf->bluestore_log_op_age,
+    [&](const ceph::timespan& lat) {
+      ostringstream ostr;
+      ostr << ", lat = " << timespan_str(lat)
+        << " cid =" << c->cid << " oid =" << o->oid;
+      return ostr.str();
+    });
   dout(10) << __func__ << " " << c->cid << " " << o->oid
 	   << " 0x" << std::hex << offset << "~" << length << std::dec
 	   << " = " << r << dendl;
@@ -18444,6 +18570,7 @@ int BlueStore::_setattr(TransContext *txc,
   dout(15) << __func__ << " " << c->cid << " " << o->oid
 	   << " " << name << " (" << val.length() << " bytes)"
 	   << dendl;
+  auto start = mono_clock::now();
   int r = 0;
   auto& b = o->onode.attrs[name.c_str()];
   if (val.length() == 0) {
@@ -18457,6 +18584,17 @@ int BlueStore::_setattr(TransContext *txc,
   b.reassign_to_mempool(mempool::mempool_bluestore_cache_meta);
 
   txc->write_onode(o);
+  log_latency_fn(
+    __func__,
+    l_bluestore_attr_lat,
+    mono_clock::now() - start,
+    cct->_conf->bluestore_log_op_age,
+    [&](const ceph::timespan& lat) {
+      ostringstream ostr;
+      ostr << ", lat = " << timespan_str(lat)
+        << " cid =" << c->cid << " oid =" << o->oid;
+      return ostr.str();
+    });
   dout(10) << __func__ << " " << c->cid << " " << o->oid
 	   << " " << name << " (" << val.length() << " bytes)"
 	   << " = " << r << dendl;
@@ -18471,6 +18609,7 @@ int BlueStore::_setattrs(TransContext *txc,
   dout(15) << __func__ << " " << c->cid << " " << o->oid
 	   << " " << aset.size() << " keys"
 	   << dendl;
+  auto start = mono_clock::now();
   int r = 0;
   for (map<string,bufferptr>::const_iterator p = aset.begin();
        p != aset.end(); ++p) {
@@ -18484,6 +18623,17 @@ int BlueStore::_setattrs(TransContext *txc,
     }
   }
   txc->write_onode(o);
+  log_latency_fn(
+    __func__,
+    l_bluestore_attr_lat,
+    mono_clock::now() - start,
+    cct->_conf->bluestore_log_op_age,
+    [&](const ceph::timespan& lat) {
+      ostringstream ostr;
+      ostr << ", lat = " << timespan_str(lat)
+        << " cid =" << c->cid << " oid =" << o->oid;
+      return ostr.str();
+    });
   dout(10) << __func__ << " " << c->cid << " " << o->oid
 	   << " " << aset.size() << " keys"
 	   << " = " << r << dendl;
@@ -18498,6 +18648,7 @@ int BlueStore::_rmattr(TransContext *txc,
 {
   dout(15) << __func__ << " " << c->cid << " " << o->oid
 	   << " " << name << dendl;
+  auto start = mono_clock::now();
   int r = 0;
   auto it = o->onode.attrs.find(name.c_str());
   if (it == o->onode.attrs.end())
@@ -18506,7 +18657,16 @@ int BlueStore::_rmattr(TransContext *txc,
   o->onode.attrs.erase(it);
   txc->write_onode(o);
 
- out:
+out:
+  log_latency_fn(
+    __func__, l_bluestore_attr_lat,
+    mono_clock::now() - start, cct->_conf->bluestore_log_op_age,
+    [&](const ceph::timespan& lat) {
+      ostringstream ostr;
+      ostr << ", lat = " << timespan_str(lat)
+        << " cid =" << c->cid << " oid =" << o->oid;
+      return ostr.str();
+    });
   dout(10) << __func__ << " " << c->cid << " " << o->oid
 	   << " " << name << " = " << r << dendl;
   return r;
@@ -18517,6 +18677,7 @@ int BlueStore::_rmattrs(TransContext *txc,
 			OnodeRef& o)
 {
   dout(15) << __func__ << " " << c->cid << " " << o->oid << dendl;
+  auto start = mono_clock::now();
   int r = 0;
 
   if (o->onode.attrs.empty())
@@ -18526,6 +18687,15 @@ int BlueStore::_rmattrs(TransContext *txc,
   txc->write_onode(o);
 
  out:
+  log_latency_fn(
+    __func__, l_bluestore_attr_lat,
+    mono_clock::now() - start, cct->_conf->bluestore_log_op_age,
+    [&](const ceph::timespan& lat) {
+      ostringstream ostr;
+      ostr << ", lat = " << timespan_str(lat)
+        << " cid =" << c->cid << " oid =" << o->oid;
+      return ostr.str();
+    });
   dout(10) << __func__ << " " << c->cid << " " << o->oid << " = " << r << dendl;
   return r;
 }
@@ -18569,6 +18739,7 @@ int BlueStore::_omap_setkeys(TransContext *txc,
 			     bufferlist &bl)
 {
   dout(15) << __func__ << " " << c->cid << " " << o->oid << dendl;
+  auto start = mono_clock::now();
   int r;
   auto p = bl.cbegin();
   __u32 num;
@@ -18611,6 +18782,17 @@ int BlueStore::_omap_setkeys(TransContext *txc,
   logger->inc(l_bluestore_omap_setkeys_records, num0);
   logger->inc(l_bluestore_omap_setkeys_bytes, total_bytes);
   r = 0;
+  log_latency_fn(
+    __func__,
+    l_bluestore_omap_set_lat,
+    mono_clock::now() - start,
+    cct->_conf->bluestore_log_op_age,
+    [&](const ceph::timespan& lat) {
+      ostringstream ostr;
+      ostr << ", lat = " << timespan_str(lat)
+        << " cid =" << c->cid << " oid =" << o->oid;
+      return ostr.str();
+    });
   dout(10) << __func__ << " " << c->cid << " " << o->oid << " = " << r << dendl;
   return r;
 }
@@ -18621,6 +18803,7 @@ int BlueStore::_omap_setheader(TransContext *txc,
 			       bufferlist& bl)
 {
   dout(15) << __func__ << " " << c->cid << " " << o->oid << dendl;
+  auto start = mono_clock::now();
   int r;
   string key;
   if (!o->onode.has_omap()) {
@@ -18645,6 +18828,17 @@ int BlueStore::_omap_setheader(TransContext *txc,
   logger->inc(l_bluestore_omap_setheader_count);
   logger->inc(l_bluestore_omap_setheader_bytes, bl.length());
   r = 0;
+  log_latency_fn(
+    __func__,
+    l_bluestore_omap_set_lat,
+    mono_clock::now() - start,
+    cct->_conf->bluestore_log_op_age,
+    [&](const ceph::timespan& lat) {
+      ostringstream ostr;
+      ostr << ", lat = " << timespan_str(lat)
+        << " cid =" << c->cid << " oid =" << o->oid;
+      return ostr.str();
+    });
   dout(10) << __func__ << " " << c->cid << " " << o->oid << " = " << r << dendl;
   return r;
 }
@@ -18655,6 +18849,7 @@ int BlueStore::_omap_rmkeys(TransContext *txc,
 			    bufferlist& bl)
 {
   dout(15) << __func__ << " " << c->cid << " " << o->oid << dendl;
+  auto start = mono_clock::now();
   int r = 0;
   auto p = bl.cbegin();
   __u32 num;
@@ -18681,6 +18876,17 @@ int BlueStore::_omap_rmkeys(TransContext *txc,
   txc->note_modified_object(o);
 
  out:
+  log_latency_fn(
+    __func__,
+    l_bluestore_omap_set_lat,
+    mono_clock::now() - start,
+    cct->_conf->bluestore_log_op_age,
+    [&](const ceph::timespan& lat) {
+      ostringstream ostr;
+      ostr << ", lat = " << timespan_str(lat)
+        << " cid =" << c->cid << " oid =" << o->oid;
+      return ostr.str();
+    });
   dout(10) << __func__ << " " << c->cid << " " << o->oid << " = " << r << dendl;
   return r;
 }
@@ -18691,6 +18897,7 @@ int BlueStore::_omap_rmkey_range(TransContext *txc,
 				 const string& first, const string& last)
 {
   dout(15) << __func__ << " " << c->cid << " " << o->oid << dendl;
+  auto start = mono_clock::now();
   string key_first, key_last;
   int r = 0;
   if (!o->onode.has_omap()) {
@@ -18710,6 +18917,17 @@ int BlueStore::_omap_rmkey_range(TransContext *txc,
   txc->note_modified_object(o);
 
  out:
+  log_latency_fn(
+    __func__,
+    l_bluestore_omap_set_lat,
+    mono_clock::now() - start,
+    cct->_conf->bluestore_log_op_age,
+    [&](const ceph::timespan& lat) {
+      ostringstream ostr;
+      ostr << ", lat = " << timespan_str(lat)
+        << " cid =" << c->cid << " oid =" << o->oid;
+      return ostr.str();
+    });
   return r;
 }
 
@@ -18726,11 +18944,15 @@ int BlueStore::_set_alloc_hint(
 	   << " write_size " << expected_write_size
 	   << " flags " << ceph_osd_alloc_hint_flag_string(flags)
 	   << dendl;
+  auto start = mono_clock::now();
   int r = 0;
   o->onode.expected_object_size = expected_object_size;
   o->onode.expected_write_size = expected_write_size;
   o->onode.alloc_hint_flags = flags;
   txc->write_onode(o);
+  log_latency(__func__, l_bluestore_other_write_lat,
+    mono_clock::now() - start,
+    cct->_conf->bluestore_log_op_age);
   dout(10) << __func__ << " " << c->cid << " " << o->oid
 	   << " object_size " << expected_object_size
 	   << " write_size " << expected_write_size
@@ -18752,7 +18974,7 @@ int BlueStore::_clone(TransContext *txc,
 	 << " and " << newo->oid << dendl;
     return -EINVAL;
   }
-
+  auto start = mono_clock::now();
   _assign_nid(txc, newo);
 
   // clone data
@@ -18818,6 +19040,20 @@ int BlueStore::_clone(TransContext *txc,
   r = 0;
 
  out:
+  log_latency_fn(
+    __func__,
+    l_bluestore_clone_lat,
+    mono_clock::now() - start,
+    cct->_conf->bluestore_log_op_age,
+    [&](const ceph::timespan& lat) {
+      ostringstream ostr;
+      ostr << ", lat = " << timespan_str(lat)
+        << " cid =" << c->cid
+        << " old_oid =" << oldo->oid
+        << " new_oid =" << newo->oid;
+      return ostr.str();
+    }
+  );
   dout(10) << __func__ << " " << c->cid << " " << oldo->oid << " -> "
 	   << newo->oid << " = " << r << dendl;
   return r;
@@ -18864,7 +19100,7 @@ int BlueStore::_clone_range(TransContext *txc,
 	   << newo->oid << " from 0x" << std::hex << srcoff << "~" << length
 	   << " to offset 0x" << dstoff << std::dec << dendl;
   int r = 0;
-
+  auto start = mono_clock::now();
   if (srcoff + length >= OBJECT_MAX_SIZE ||
       dstoff + length >= OBJECT_MAX_SIZE) {
     r = -E2BIG;
@@ -18896,6 +19132,23 @@ int BlueStore::_clone_range(TransContext *txc,
   r = 0;
 
  out:
+  log_latency_fn(
+    __func__,
+    l_bluestore_clone_lat,
+    mono_clock::now() - start,
+    cct->_conf->bluestore_log_op_age,
+    [&](const ceph::timespan& lat) {
+      ostringstream ostr;
+      ostr << ", lat = " << timespan_str(lat)
+        << " cid =" << c->cid
+        << " old_oid =" << oldo->oid
+        << " new_oid =" << newo->oid
+        << " srcoff = 0x" << std::hex << srcoff
+        << " length = 0x" << length
+        << " dstoff = 0x" << dstoff;
+      return ostr.str();
+    }
+  );
   dout(10) << __func__ << " " << c->cid << " " << oldo->oid << " -> "
 	   << newo->oid << " from 0x" << std::hex << srcoff << "~" << length
 	   << " to offset 0x" << dstoff << std::dec
@@ -18911,6 +19164,7 @@ int BlueStore::_rename(TransContext *txc,
 {
   dout(15) << __func__ << " " << c->cid << " " << oldo->oid << " -> "
 	   << new_oid << dendl;
+  auto start = mono_clock::now();
   int r;
   ghobject_t old_oid = oldo->oid;
   mempool::bluestore_cache_meta::string new_okey;
@@ -18954,6 +19208,20 @@ int BlueStore::_rename(TransContext *txc,
   txc->note_modified_object(oldo);
 
  out:
+  log_latency_fn(
+    __func__,
+    l_bluestore_rename_lat,
+    mono_clock::now() - start,
+    cct->_conf->bluestore_log_op_age,
+    [&](const ceph::timespan& lat) {
+      ostringstream ostr;
+      ostr << ", lat = " << timespan_str(lat)
+        << " cid =" << c->cid
+        << " old_oid =" << old_oid
+        << " new_oid =" << new_oid;
+      return ostr.str();
+    }
+  );
   dout(10) << __func__ << " " << c->cid << " " << old_oid << " -> "
 	   << new_oid << " = " << r << dendl;
   return r;
@@ -18968,6 +19236,7 @@ int BlueStore::_create_collection(
   CollectionRef *c)
 {
   dout(15) << __func__ << " " << cid << " bits " << bits << dendl;
+  auto start = mono_clock::now();
   int r;
   bufferlist bl;
 
@@ -18989,6 +19258,9 @@ int BlueStore::_create_collection(
   r = 0;
 
  out:
+  log_latency(__func__, l_bluestore_other_write_lat,
+    mono_clock::now() - start,
+    cct->_conf->bluestore_log_op_age);
   dout(10) << __func__ << " " << cid << " bits " << bits << " = " << r << dendl;
   return r;
 }
@@ -18997,6 +19269,7 @@ int BlueStore::_remove_collection(TransContext *txc, const coll_t &cid,
 				  CollectionRef *c)
 {
   dout(15) << __func__ << " " << cid << dendl;
+  auto start = mono_clock::now();
   int r;
 
   (*c)->flush_all_but_last();
@@ -19053,6 +19326,9 @@ int BlueStore::_remove_collection(TransContext *txc, const coll_t &cid,
     }
   }
 out:
+  log_latency(__func__, l_bluestore_other_write_lat,
+    mono_clock::now() - start,
+    cct->_conf->bluestore_log_op_age);
   dout(10) << __func__ << " " << cid << " = " << r << dendl;
   return r;
 }
@@ -19075,6 +19351,7 @@ int BlueStore::_split_collection(TransContext *txc,
 {
   dout(15) << __func__ << " " << c->cid << " to " << d->cid << " "
 	   << " bits " << bits << dendl;
+  auto start = mono_clock::now();
   std::unique_lock l(c->lock);
   std::unique_lock l2(d->lock);
   int r;
@@ -19115,6 +19392,9 @@ int BlueStore::_split_collection(TransContext *txc,
   encode(c->cnode, bl);
   txc->t->set(PREFIX_COLL, stringify(c->cid), bl);
 
+  log_latency(__func__, l_bluestore_other_write_lat,
+    mono_clock::now() - start,
+    cct->_conf->bluestore_log_op_age);
   dout(10) << __func__ << " " << c->cid << " to " << d->cid << " "
 	   << " bits " << bits << " = " << r << dendl;
   return r;
@@ -19128,6 +19408,7 @@ int BlueStore::_merge_collection(
 {
   dout(15) << __func__ << " " << (*c)->cid << " to " << d->cid
 	   << " bits " << bits << dendl;
+  auto start = mono_clock::now();
   std::unique_lock l((*c)->lock);
   std::unique_lock l2(d->lock);
   int r;
@@ -19171,6 +19452,9 @@ int BlueStore::_merge_collection(
   encode(d->cnode, bl);
   txc->t->set(PREFIX_COLL, stringify(d->cid), bl);
 
+  log_latency(__func__, l_bluestore_other_write_lat,
+    mono_clock::now() - start,
+    cct->_conf->bluestore_log_op_age);
   dout(10) << __func__ << " " << cid << " to " << d->cid << " "
 	   << " bits " << bits << " = " << r << dendl;
   return r;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6695,9 +6695,18 @@ void BlueStore::_init_logger()
   b.add_time_avg(l_bluestore_collection_lat, "collection_lat",
     "Average collection metadata query latency (list/exists/bits)",
     "coll", PerfCountersBuilder::PRIO_USEFUL);
-  b.add_time_avg(l_bluestore_other_write_lat, "other_write_lat",
-    "Average latency of other/rare write ops (set_alloc_hint, set_collection_opts, collection create/remove/split/merge)",
-    "othw", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_other_ops_lat, "other_ops_lat",
+    "Average latency of other/rare write ops (set_alloc_hint, set_collection_opts, collection create)",
+    "otho", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_split_collection_lat, "split_collection_lat",
+    "Average split_collection latency",
+    "spcl", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_merge_collection_lat, "merge_collection_lat",
+    "Average merge_collection latency",
+    "mgcl", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_remove_collection_lat, "remove_collection_lat",
+    "Average remove_collection latency",
+    "rmcl", PerfCountersBuilder::PRIO_USEFUL);
   //****************************************
 
   // slow op count
@@ -12844,7 +12853,7 @@ int BlueStore::set_collection_opts(
   if (c->pool_opts.get(pool_opts_t::COMPRESSION_REQUIRED_RATIO, &dval)) {
     c->compression_req_ratio = dval;
   }
-  logger->tinc_with_max(l_bluestore_other_write_lat, mono_clock::now() - start);
+  logger->tinc_with_max(l_bluestore_other_ops_lat, mono_clock::now() - start);
   return 0;
 }
 
@@ -18819,7 +18828,7 @@ int BlueStore::_set_alloc_hint(
   o->onode.expected_write_size = expected_write_size;
   o->onode.alloc_hint_flags = flags;
   txc->write_onode(o);
-  logger->tinc_with_max(l_bluestore_other_write_lat, mono_clock::now() - start);
+  logger->tinc_with_max(l_bluestore_other_ops_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << c->cid << " " << o->oid
 	   << " object_size " << expected_object_size
 	   << " write_size " << expected_write_size
@@ -19083,7 +19092,7 @@ int BlueStore::_create_collection(
   r = 0;
 
  out:
-  logger->tinc_with_max(l_bluestore_other_write_lat, mono_clock::now() - start);
+  logger->tinc_with_max(l_bluestore_other_ops_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << cid << " bits " << bits << " = " << r << dendl;
   return r;
 }
@@ -19149,7 +19158,7 @@ int BlueStore::_remove_collection(TransContext *txc, const coll_t &cid,
     }
   }
 out:
-  logger->tinc_with_max(l_bluestore_other_write_lat, mono_clock::now() - start);
+  logger->tinc_with_max(l_bluestore_remove_collection_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << cid << " = " << r << dendl;
   return r;
 }
@@ -19213,7 +19222,7 @@ int BlueStore::_split_collection(TransContext *txc,
   encode(c->cnode, bl);
   txc->t->set(PREFIX_COLL, stringify(c->cid), bl);
 
-  logger->tinc_with_max(l_bluestore_other_write_lat, mono_clock::now() - start);
+  logger->tinc_with_max(l_bluestore_split_collection_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << c->cid << " to " << d->cid << " "
 	   << " bits " << bits << " = " << r << dendl;
   return r;
@@ -19271,7 +19280,7 @@ int BlueStore::_merge_collection(
   encode(d->cnode, bl);
   txc->t->set(PREFIX_COLL, stringify(d->cid), bl);
 
-  logger->tinc_with_max(l_bluestore_other_write_lat, mono_clock::now() - start);
+  logger->tinc_with_max(l_bluestore_merge_collection_lat, mono_clock::now() - start);
   dout(10) << __func__ << " " << cid << " to " << d->cid << " "
 	   << " bits " << bits << " = " << r << dendl;
   return r;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -233,7 +233,7 @@ enum {
   l_bluestore_fiemap_lat,
   l_bluestore_omap_get_lat,
   l_bluestore_clone_lat,
-  l_bluestore_attr_lat,      // shared: setattr/setattrs/rmattr/rmattrs
+  l_bluestore_change_attr_lat,      // shared: setattr/setattrs/rmattr/rmattrs
   l_bluestore_touch_lat,
   l_bluestore_zero_lat,
   l_bluestore_omap_set_lat,   // shared: omap setkeys/setheader/rmkeys/rmkey_range

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -238,7 +238,7 @@ enum {
   l_bluestore_zero_lat,
   l_bluestore_omap_set_lat,   // shared: omap setkeys/setheader/rmkeys/rmkey_range
   l_bluestore_rename_lat,
-  l_bluestore_collection_lat,   // shared read: list/exists/empty/bits
+  l_bluestore_collection_lat,   // shared read: list/exists/bits
   l_bluestore_other_write_lat,        // shared write: set_alloc_hint, set_collection_opts, collection create/remove/split/merge
   //****************************************
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -227,6 +227,19 @@ enum {
   l_bluestore_clist_lat,
   l_bluestore_remove_lat,
   l_bluestore_truncate_lat,
+  l_bluestore_exists_lat,
+  l_bluestore_stat_lat,
+  l_bluestore_getattr_lat,      // shared: getattr/getattrs
+  l_bluestore_fiemap_lat,
+  l_bluestore_omap_get_lat,
+  l_bluestore_clone_lat,
+  l_bluestore_attr_lat,      // shared: setattr/setattrs/rmattr/rmattrs
+  l_bluestore_touch_lat,
+  l_bluestore_zero_lat,
+  l_bluestore_omap_set_lat,   // shared: omap setkeys/setheader/rmkeys/rmkey_range
+  l_bluestore_rename_lat,
+  l_bluestore_collection_lat,   // shared read: list/exists/empty/bits
+  l_bluestore_other_write_lat,        // shared write: set_alloc_hint, set_collection_opts, collection create/remove/split/merge
   //****************************************
 
   // allocation stats

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -239,7 +239,10 @@ enum {
   l_bluestore_omap_set_lat,   // shared: omap setkeys/setheader/rmkeys/rmkey_range
   l_bluestore_rename_lat,
   l_bluestore_collection_lat,   // shared read: list/exists/bits
-  l_bluestore_other_write_lat,        // shared write: set_alloc_hint, set_collection_opts, collection create/remove/split/merge
+  l_bluestore_other_ops_lat,        // shared write: set_alloc_hint, set_collection_opts, collection create
+  l_bluestore_split_collection_lat,
+  l_bluestore_merge_collection_lat,
+  l_bluestore_remove_collection_lat,
   //****************************************
 
   // allocation stats

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -1864,7 +1864,7 @@ TEST_P(StoreTest, InterfacePerfCounters) {
       t.clone(cid, oid, coid);
       t.clone_range(cid, oid, coid, 0, 4096, 0); }); });
 
-  check("attr_lat (setattr+setattrs+rmattr+rmattrs)", l_bluestore_attr_lat, 4, [&]{
+  check("chgattr_lat (setattr+setattrs+rmattr+rmattrs)", l_bluestore_change_attr_lat, 4, [&]{
     bufferlist v; v.append("x");
     std::map<std::string, bufferptr, std::less<>> aset{{"b", bufferptr("y", 1)}};
     submit([&](auto& t){

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -1774,6 +1774,121 @@ TEST_P(StoreTestSpecificAUSize, ReproBug41901Test) {
   }
 }
 
+TEST_P(StoreTest, InterfacePerfCounters) {
+  if (string(GetParam()) != "bluestore")
+    GTEST_SKIP() << "bluestore-only perf counters";
+
+  const PerfCounters* logger = store->get_perf_counters();
+  auto cnt    = [logger](int idx){ return logger->get_tavg_ns(idx).second; };  // # calls
+  auto sum_ns = [logger](int idx){ return logger->get_tavg_ns(idx).first;  };  // total ns
+
+  coll_t cid;
+  // clone src/dst must share the same explicit hobject hash (123) or _clone -EINVALs.
+  ghobject_t oid (hobject_t(sobject_t("obj",  CEPH_NOSNAP), "key", 123, -1, ""));
+  ghobject_t coid(hobject_t(sobject_t("obj2", CEPH_NOSNAP), "key", 123, -1, ""));
+  ghobject_t roid(hobject_t(sobject_t("obj3", CEPH_NOSNAP), "key", 123, -1, ""));
+  ghobject_t miss(hobject_t(sobject_t("missing", CEPH_NOSNAP)));
+  auto ch = store->create_new_collection(cid);
+
+  // build+run a transaction
+  auto submit = [&](auto&& fn) {
+    ObjectStore::Transaction t; fn(t);
+    ASSERT_EQ(0, queue_transaction(store, ch, std::move(t)));
+  };
+  // baseline -> run fn -> assert counter advanced by `want` (prints avg latency for demo)
+  auto check = [&](const char* name, int idx, uint64_t want, auto&& fn) {
+    uint64_t before = cnt(idx);
+    fn();
+    uint64_t after = cnt(idx);
+    double avg_us = after ? (double)sum_ns(idx) / after / 1000.0 : 0.0;
+    std::cout << "  " << name << ": +" << (after - before)
+              << " (expected +" << want << "), avg " << avg_us << " us\n";
+    EXPECT_EQ(before + want, after) << name;
+  };
+
+  // setup: a populated object (data + attr + omap)
+  submit([&](auto& t){
+    t.create_collection(cid, 0);
+    t.touch(cid, oid);
+    bufferlist bl; bl.append(string(4096, 'a'));
+    t.write(cid, oid, 0, bl.length(), bl);
+    bufferlist av; av.append("v");
+    t.setattr(cid, oid, "a", av);
+    map<string,bufferlist> om{{"k", av}};
+    t.omap_setkeys(cid, oid, om);
+  });
+
+  // ---- read side ----
+  check("exists_lat", l_bluestore_exists_lat, 2, [&]{
+    store->exists(ch, miss); store->exists(ch, oid); });
+
+  check("stat_lat", l_bluestore_stat_lat, 2, [&]{
+    struct stat st;
+    store->stat(ch, miss, &st);            // -ENOENT still counts
+    store->stat(ch, oid, &st); });
+
+  check("getattr_lat (getattr+getattrs)", l_bluestore_getattr_lat, 2, [&]{
+    bufferptr bp; store->getattr(ch, oid, "a", bp);
+    std::map<std::string, bufferptr, std::less<>> aset;
+    store->getattrs(ch, oid, aset); });
+
+  check("fiemap_lat", l_bluestore_fiemap_lat, 1, [&]{
+    bufferlist bl; store->fiemap(ch, oid, 0, 4096, bl); });
+
+  check("omap_get_lat (get+header+check_keys)", l_bluestore_omap_get_lat, 3, [&]{
+    bufferlist header; map<string,bufferlist> out;
+    store->omap_get(ch, oid, &header, &out);
+    store->omap_get_header(ch, oid, &header);
+    set<string> keys{"k"}, got;
+    store->omap_check_keys(ch, oid, keys, &got); });
+
+  check("collection_lat (list+exists+bits)", l_bluestore_collection_lat, 3, [&]{
+    vector<coll_t> ls; store->list_collections(ls);
+    store->collection_exists(cid);
+    store->collection_bits(ch); });
+
+  // regression guard: collection_empty delegates to collection_list (already measured
+  // as clist_lat), so it must NOT bump collection_lat.
+  check("collection_empty stays uncounted", l_bluestore_collection_lat, 0, [&]{
+    bool empty; store->collection_empty(ch, &empty); });
+
+  // ---- write side ----
+  check("touch_lat", l_bluestore_touch_lat, 1, [&]{
+    submit([&](auto& t){ t.touch(cid, oid); }); });
+
+  check("zero_lat", l_bluestore_zero_lat, 1, [&]{
+    submit([&](auto& t){ t.zero(cid, oid, 0, 4096); }); });
+
+  check("clone_lat (clone+clone_range)", l_bluestore_clone_lat, 2, [&]{
+    submit([&](auto& t){
+      t.clone(cid, oid, coid);
+      t.clone_range(cid, oid, coid, 0, 4096, 0); }); });
+
+  check("attr_lat (setattr+setattrs+rmattr+rmattrs)", l_bluestore_attr_lat, 4, [&]{
+    bufferlist v; v.append("x");
+    std::map<std::string, bufferptr, std::less<>> aset{{"b", bufferptr("y", 1)}};
+    submit([&](auto& t){
+      t.setattr(cid, oid, "a", v);
+      t.setattrs(cid, oid, aset);
+      t.rmattr(cid, oid, "a");
+      t.rmattrs(cid, oid); }); });
+
+  check("omap_set_lat (setkeys+setheader+rmkeys+rmkeyrange)", l_bluestore_omap_set_lat, 4, [&]{
+    bufferlist v; v.append("x");
+    map<string,bufferlist> om{{"k1", v}, {"k2", v}};
+    set<string> rm{"k1"};
+    submit([&](auto& t){
+      t.omap_setkeys(cid, oid, om);
+      t.omap_setheader(cid, oid, v);
+      t.omap_rmkeys(cid, oid, rm);
+      t.omap_rmkeyrange(cid, oid, "k2", "k9"); }); });
+
+  check("rename_lat", l_bluestore_rename_lat, 1, [&]{
+    submit([&](auto& t){ t.collection_move_rename(cid, coid, cid, roid); }); });
+
+  check("other_write_lat (set_alloc_hint)", l_bluestore_other_write_lat, 1, [&]{
+    submit([&](auto& t){ t.set_alloc_hint(cid, oid, 4096, 4096, 0); }); });
+}
 
 TEST_P(StoreTestSpecificAUSize, BluestoreStatFSTest) {
   if(string(GetParam()) != "bluestore")

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -1782,20 +1782,21 @@ TEST_P(StoreTest, InterfacePerfCounters) {
   auto cnt    = [logger](int idx){ return logger->get_tavg_ns(idx).second; };  // # calls
   auto sum_ns = [logger](int idx){ return logger->get_tavg_ns(idx).first;  };  // total ns
 
-  coll_t cid;
-  // clone src/dst must share the same explicit hobject hash (123) or _clone -EINVALs.
-  ghobject_t oid (hobject_t(sobject_t("obj",  CEPH_NOSNAP), "key", 123, -1, ""));
-  ghobject_t coid(hobject_t(sobject_t("obj2", CEPH_NOSNAP), "key", 123, -1, ""));
-  ghobject_t roid(hobject_t(sobject_t("obj3", CEPH_NOSNAP), "key", 123, -1, ""));
-  ghobject_t miss(hobject_t(sobject_t("missing", CEPH_NOSNAP)));
+  // pg, not meta: split/merge_collection assert is_pg() on src and dest.
+  const int bits = 2;
+  coll_t cid(spg_t(pg_t(0, 4373), shard_id_t::NO_SHARD));
+  // hash 0 so get_onode's oid.match() passes; one shared hash keeps _clone valid.
+  ghobject_t oid (hobject_t(sobject_t("obj",  CEPH_NOSNAP), "key", 0, 4373, ""));
+  ghobject_t coid(hobject_t(sobject_t("obj2", CEPH_NOSNAP), "key", 0, 4373, ""));
+  ghobject_t roid(hobject_t(sobject_t("obj3", CEPH_NOSNAP), "key", 0, 4373, ""));
+  ghobject_t miss(hobject_t(sobject_t("missing", CEPH_NOSNAP), "key", 0, 4373, ""));
   auto ch = store->create_new_collection(cid);
 
-  // build+run a transaction
   auto submit = [&](auto&& fn) {
     ObjectStore::Transaction t; fn(t);
     ASSERT_EQ(0, queue_transaction(store, ch, std::move(t)));
   };
-  // baseline -> run fn -> assert counter advanced by `want` (prints avg latency for demo)
+  // run fn, assert the counter advanced by `want`, print avg latency
   auto check = [&](const char* name, int idx, uint64_t want, auto&& fn) {
     uint64_t before = cnt(idx);
     fn();
@@ -1808,7 +1809,7 @@ TEST_P(StoreTest, InterfacePerfCounters) {
 
   // setup: a populated object (data + attr + omap)
   submit([&](auto& t){
-    t.create_collection(cid, 0);
+    t.create_collection(cid, bits);
     t.touch(cid, oid);
     bufferlist bl; bl.append(string(4096, 'a'));
     t.write(cid, oid, 0, bl.length(), bl);
@@ -1847,8 +1848,8 @@ TEST_P(StoreTest, InterfacePerfCounters) {
     store->collection_exists(cid);
     store->collection_bits(ch); });
 
-  // regression guard: collection_empty delegates to collection_list (already measured
-  // as clist_lat), so it must NOT bump collection_lat.
+  // collection_empty delegates to collection_list (counted as clist_lat), so it
+  // must not bump collection_lat -- guards against double counting.
   check("collection_empty stays uncounted", l_bluestore_collection_lat, 0, [&]{
     bool empty; store->collection_empty(ch, &empty); });
 
@@ -1886,8 +1887,34 @@ TEST_P(StoreTest, InterfacePerfCounters) {
   check("rename_lat", l_bluestore_rename_lat, 1, [&]{
     submit([&](auto& t){ t.collection_move_rename(cid, coid, cid, roid); }); });
 
-  check("other_write_lat (set_alloc_hint)", l_bluestore_other_write_lat, 1, [&]{
+  check("other_ops_lat (set_alloc_hint)", l_bluestore_other_ops_lat, 1, [&]{
     submit([&](auto& t){ t.set_alloc_hint(cid, oid, 4096, 4096, 0); }); });
+
+  // ---- collection ops ----
+  // split dest must be fresh, empty, and created at bits+1.
+  coll_t pb(spg_t(pg_t(1 << bits, 4373), shard_id_t::NO_SHARD));
+  store->create_new_collection(pb);
+
+  check("split_collection_lat", l_bluestore_split_collection_lat, 1, [&]{
+    submit([&](auto& t){
+      t.create_collection(pb, bits + 1);
+      t.split_collection(cid, bits + 1, 1 << bits, pb); }); });
+
+  check("merge_collection_lat", l_bluestore_merge_collection_lat, 1, [&]{
+    submit([&](auto& t){ t.merge_collection(pb, cid, bits); }); });
+
+  // merge consumed pb; recreate it empty. _remove_collection calls
+  // flush_all_but_last() on pb's own sequencer, so queue on chb, not ch.
+  check("remove_collection_lat", l_bluestore_remove_collection_lat, 1, [&]{
+    auto chb = store->create_new_collection(pb);
+    {
+      ObjectStore::Transaction t; t.create_collection(pb, bits);
+      ASSERT_EQ(0, queue_transaction(store, chb, std::move(t)));
+    }
+    {
+      ObjectStore::Transaction t; t.remove_collection(pb);
+      ASSERT_EQ(0, queue_transaction(store, chb, std::move(t)));
+    } });
 }
 
 TEST_P(StoreTestSpecificAUSize, BluestoreStatFSTest) {


### PR DESCRIPTION
Most BlueStore ObjectStore interface methods already report latency through performance counters, but several operations were not measured. This change adds latency counters for the remaining read-side methods and write-side transaction handlers. Instrumentation is placed at the handler level rather than shared _do* helpers to avoid double-counting, and functions with multiple exit paths (stat, _fiemap) log latency at each return. collection_empty intentionally has no counter of its own, as it delegates to the already-measured collection_list.

Counter names use 4-char mnemonics (exst, stat, gatr, fmap, omgt, coll, tuch, zero, clon, attr, omst, rnam, othw) for readability in perf dump output.

Verified with unit test StoreTest.InterfacePerfCounters which confirms all counters increment at expected call counts and measures realistic latencies on a fresh store.

Fixes: https://tracker.ceph.com/issues/77226
Signed-off-by: Emily Leson <etleson10@gmail.com>


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
