### PR TITLE
common/web_cache: switch from std::shared_mutex to ceph::shared_mutex 

### DIFF
--- a/src/common/web_cache.h
+++ b/src/common/web_cache.h
@@ -30,6 +30,7 @@
 #include <utility>
 
 #include "common/ceph_context.h"
+#include "common/ceph_mutex.h"
 #include "common/ceph_time.h"
 #include "include/ceph_assert.h"
 #include "include/common_fwd.h"
@@ -129,7 +130,8 @@ class WebCache {
   std::unordered_map<Key, Node> _lookup;
   SieveQueue _sieve_queue;
   Node* _sieve_hand;
-  mutable std::shared_mutex _cache_mutex;
+  mutable ceph::shared_mutex _cache_mutex =
+      ceph::make_shared_mutex("WebCache::_cache_mutex");
 
  protected:
   // sieve_evict removes the next node using the SIEVE algorithm from
@@ -218,7 +220,7 @@ class WebCache {
 
   friend std::ostream& operator<<(
       std::ostream& os, const WebCache<Key, Value>& cache) {
-    std::shared_lock<std::shared_mutex> lock(cache._cache_mutex);
+    std::shared_lock lock(cache._cache_mutex);
     const auto now = ceph::real_clock::now();
     os << "$" << cache._name << "[";
 
@@ -354,14 +356,14 @@ PerfCounters* WebCache<Key, Value>::initialize_perf_counters(
 
 template <typename Key, typename Value>
 size_t WebCache<Key, Value>::size() const {
-  std::shared_lock<std::shared_mutex> lock(_cache_mutex);
+  std::shared_lock lock(_cache_mutex);
   ceph_assert(_lookup.size() == _sieve_queue.size());
   return _lookup.size();
 }
 
 template <typename Key, typename Value>
 size_t WebCache<Key, Value>::clear() {
-  std::lock_guard<std::shared_mutex> lock(_cache_mutex);
+  std::lock_guard lock(_cache_mutex);
   perf_inc(Metric::clear);
   const size_t size_before = _sieve_queue.size();
   _sieve_queue.clear();
@@ -378,7 +380,7 @@ template <typename Key, typename Value>
 ceph::real_time WebCache<Key, Value>::add(const Key& key, ValuePtr value) {
   // cache hit - fast under read lock
   {
-    std::shared_lock<std::shared_mutex> lock(_cache_mutex);
+    std::shared_lock lock(_cache_mutex);
     if (auto search = _lookup.find(key); search != _lookup.end()) {
       perf_inc(Metric::hit);
       search->second.visited = true;
@@ -387,7 +389,7 @@ ceph::real_time WebCache<Key, Value>::add(const Key& key, ValuePtr value) {
   }
   // miss, take unique lock
   {
-    std::lock_guard<std::shared_mutex> lock(_cache_mutex);
+    std::lock_guard lock(_cache_mutex);
     return insert_or_existing_unmutexed(key, value).expires_at;
   }
 }
@@ -396,7 +398,7 @@ template <typename Key, typename Value>
 WebCache<Key, Value>::ValuePtr WebCache<Key, Value>::lookup_or(
     const Key& key, ValuePtr new_val) {
   {
-    std::shared_lock<std::shared_mutex> cache_lock(_cache_mutex);
+    std::shared_lock cache_lock(_cache_mutex);
     auto maybe_value = lookup_unmutexed(key);
     if (maybe_value.has_value()) {
       perf_inc(Metric::hit);
@@ -406,7 +408,7 @@ WebCache<Key, Value>::ValuePtr WebCache<Key, Value>::lookup_or(
 
   // miss, take unique lock
   {
-    std::lock_guard<std::shared_mutex> lock(_cache_mutex);
+    std::lock_guard lock(_cache_mutex);
     return insert_or_existing_unmutexed(key, new_val).value;
   }
 }
@@ -414,7 +416,7 @@ WebCache<Key, Value>::ValuePtr WebCache<Key, Value>::lookup_or(
 template <typename Key, typename Value>
 bool WebCache<Key, Value>::update_ttl_if(
     const Key& key, const ValuePtr& val, ceph::timespan new_ttl) {
-  std::lock_guard<std::shared_mutex> lock(_cache_mutex);
+  std::lock_guard lock(_cache_mutex);
   if (auto search = _lookup.find(key);
       (search != _lookup.end() && search->second.value == val)) {
     search->second.expires_at = ceph::real_clock::now() + new_ttl;
@@ -426,7 +428,7 @@ bool WebCache<Key, Value>::update_ttl_if(
 template <typename Key, typename Value>
 bool WebCache<Key, Value>::remove_if(
     const Key& key, const ValuePtr& expected_val) {
-  std::lock_guard<std::shared_mutex> lock(_cache_mutex);
+  std::lock_guard lock(_cache_mutex);
   if (auto search = _lookup.find(key);
       (search != _lookup.end() && search->second.value == expected_val)) {
     auto [_, hand_moved] =
@@ -500,7 +502,7 @@ WebCache<Key, Value>::sieve_remove_unmutexed(
 template <typename Key, typename Value>
 std::optional<typename WebCache<Key, Value>::ValuePtr>
 WebCache<Key, Value>::lookup(const Key& key) {
-  std::shared_lock<std::shared_mutex> lock(_cache_mutex);
+  std::shared_lock lock(_cache_mutex);
   auto result = lookup_unmutexed(key);
   if (result.has_value()) {
     perf_inc(Metric::hit);
@@ -537,7 +539,7 @@ typename WebCache<Key, Value>::Node* WebCache<Key, Value>::sieve_expire_erase_un
 
 template <typename Key, typename Value>
 size_t WebCache<Key, Value>::expire_erase() {
-  std::lock_guard<std::shared_mutex> lock(_cache_mutex);
+  std::lock_guard lock(_cache_mutex);
   const auto expiration_cutoff = ceph::real_clock::now();
   const auto lookup_size_before = _lookup.size();
   SieveQueue expired;

--- a/src/test/common/test_web_cache.cc
+++ b/src/test/common/test_web_cache.cc
@@ -446,6 +446,13 @@ TEST_F(WebCacheTest, SieveAllVisited) {
 }
 
 class WebCacheConcurrencyTest : public WebCacheTest {
+ protected:
+  // 4x oversubscription is enough to race the threads. The original *100
+  // (3200 on CI) made exclusive-lock tests O(N^2) and timed out on Windows.
+  static unsigned stress_thread_count() {
+    return std::max(std::thread::hardware_concurrency() * 4, 32u);
+  }
+
   void TearDown() override {
     if (_uut->perf() != nullptr) {
       JSONFormatter f(true);
@@ -458,8 +465,7 @@ class WebCacheConcurrencyTest : public WebCacheTest {
 
 TEST_F(WebCacheConcurrencyTest, BasicAddSame) {
   reset_cache_system_mode(100);
-  const auto num_threads =
-      std::max(std::thread::hardware_concurrency() * 100, 100U);
+  const auto num_threads = stress_thread_count();
   std::vector<std::thread> threads;
   for (size_t i = 0; i < num_threads; ++i) {
     threads.emplace_back([&]() {
@@ -478,8 +484,7 @@ TEST_F(WebCacheConcurrencyTest, BasicAddSame) {
 
 TEST_F(WebCacheConcurrencyTest, BasicAddUnique) {
   reset_cache_system_mode(100);
-  const auto num_threads =
-      std::max(std::thread::hardware_concurrency() * 100, 100U);
+  const auto num_threads = stress_thread_count();
   std::vector<std::thread> threads;
   for (size_t i = 0; i < num_threads; ++i) {
     threads.emplace_back([&]() {
@@ -504,8 +509,7 @@ TEST_F(WebCacheConcurrencyTest, StampedeSyncCallOnce) {
   webcache::WebCache<std::string, CacheValue> cache(
       _cct.get(), "test_web_cache", 100);
   std::atomic_int fetches = 0;
-  const auto num_threads =
-      std::max(std::thread::hardware_concurrency() * 100, 100U);
+  const auto num_threads = stress_thread_count();
   std::vector<std::thread> threads;
   for (size_t i = 0; i < num_threads; ++i) {
     threads.emplace_back([&]() {
@@ -542,8 +546,7 @@ TEST_F(WebCacheConcurrencyTest, StampedeMutex) {
   webcache::WebCache<std::string, CacheValue> cache(
       _cct.get(), "test_web_cache", 100);
   std::atomic_int fetches = 0;
-  const auto num_threads =
-      std::max(std::thread::hardware_concurrency() * 100, 100U);
+  const auto num_threads = stress_thread_count();
   std::vector<std::thread> threads;
   for (size_t i = 0; i < num_threads; ++i) {
     threads.emplace_back([&]() {


### PR DESCRIPTION
This change was inspired by a failing Windows test: `unittest_web_cache` times out at the 1800s per-test limit on WebCacheConcurrencyTest.BasicAddUnique.

Root cause: the test spawns hardware_concurrency() * 100 threads, 3200 on the 32-vCPU CI hosts, and BasicAddUnique inserts a distinct key per iteration, so every `add()` takes the cache's exclusive lock. On Windows (mingw-llvm/libc++), `std::shared_mutex` wakes every waiting writer on each unlock instead of one, so N contending writers cost O(N^2) wakeups. At N=3200 that blows the budget. Linux doesn't hit this: glibc's `std::shared_mutex` is `pthread_rwlock_t`, which hands off to a single writer per unlock.

There are two changes in this changeset:

1. test/common: reduce WebCache stress-test thread count: The tests only need enough threads to race. Capping oversubscription at 4x instead of 100x keeps the O(N^2) cost under the timeout on Windows.
2. common/web_cache: use `ceph::shared_mutex` instead of std::shared_mutex: Idiom alignment, not a second fix. On the failing mingw-llvm build, `ceph::shared_mutex` still resolves to `std::shared_mutex`, so this has no effect on the timeout. It adds lockdep tracking in debug builds and matches how every other rwlock in the tree is declared.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
