### PR TITLE
mgr/dashboard: fix stale nvmeof spec tests from a semantic merge conflict

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component.spec.ts
@@ -103,6 +103,13 @@ describe('NvmeofGatewayGroupFilterComponent', () => {
     expect(component.placeholder).toBe('Unable to fetch Gateway groups');
   });
 
+  it('should call preventDefault on the error when the API call fails', () => {
+    const err = { preventDefault: jest.fn() };
+    (nvmeofService.listGatewayGroups as jest.Mock).mockReturnValue(throwError(err));
+    fixture.detectChanges();
+    expect(err.preventDefault).toHaveBeenCalled();
+  });
+
   it('should render a cds-combo-box', () => {
     fixture.detectChanges();
     const combo = fixture.nativeElement.querySelector('cds-combo-box');

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.spec.ts
@@ -148,28 +148,6 @@ describe('NvmeofNamespacesListComponent', () => {
       done();
     });
 
-    component.listNamespaces();
-  });
-
-  it('should default to first group and keep default placeholder when groups exist', () => {
-    component.group = null;
-    component.gwGroups = [{ content: 'g1', selected: false }] as any;
-
-    component.updateGroupSelectionState();
-
-    expect(component.group).toBe('g1');
-    expect(component.gwGroupsEmpty).toBe(false);
-    expect(component.gwGroupPlaceholder).toBe('Enter group name');
-  });
-
-  it('should set error placeholder and call preventDefault on group fetch failure', () => {
-    const preventDefault = jasmine.createSpy('preventDefault');
-
-    component.handleGatewayGroupsError({ preventDefault });
-
-    expect(component.gwGroups).toEqual([]);
-    expect(component.gwGroupsEmpty).toBe(true);
-    expect(component.gwGroupPlaceholder).toBe('Unable to fetch Gateway groups');
-    expect(preventDefault).toHaveBeenCalled();
+    component.fetchData();
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.spec.ts
@@ -160,39 +160,4 @@ describe('NvmeofSubsystemsComponent', () => {
   it('should set first group as default initially', () => {
     expect(component.group).toBe('default');
   });
-
-  it('should mark only current group as selected', () => {
-    component.group = 'foo';
-    component.gwGroups = [{ content: 'default' }, { content: 'foo' }] as any;
-
-    component.updateGroupSelectionState();
-
-    expect(component.gwGroups).toEqual([
-      { content: 'default', selected: false },
-      { content: 'foo', selected: true }
-    ]);
-  });
-
-  it('should clear selected group and refresh subsystem list', () => {
-    component.group = 'default';
-    const getSubsystemsSpy = spyOn(component, 'getSubsystems');
-
-    component.onGroupClear();
-
-    expect(component.group).toBeNull();
-    expect(getSubsystemsSpy).toHaveBeenCalled();
-  });
-
-  it('should set error placeholder and prevent default on groups load error', () => {
-    const preventDefault = jasmine.createSpy('preventDefault');
-    component.context = { error: jasmine.createSpy('error') } as any;
-
-    component.handleGatewayGroupsError({ preventDefault });
-
-    expect(component.gwGroups).toEqual([]);
-    expect(component.gwGroupsEmpty).toBe(true);
-    expect(component.gwGroupPlaceholder).toBe('Unable to fetch Gateway groups');
-    expect(preventDefault).toHaveBeenCalled();
-    expect(component.context.error).toHaveBeenCalled();
-  });
 });


### PR DESCRIPTION
mgr-dashboard-frontend-unittests has been failing on main since 2026-07-01, unrelated to whatever PR triggers it. Bisected to cfe12305fb1, the merge commit for PR #68180.

6182e67ea4 ("mgr/dashboard: NVMe Onboarding Setup Cards") moved gateway group selection out of NvmeofSubsystemsComponent and NvmeofNamespacesListComponent into a new NvmeofGatewayGroupFilterComponent, dropping gwGroups, updateGroupSelectionState, handleGatewayGroupsError, onGroupClear, and getSubsystems from both. Clean on its own.

PR #68180 forked from main in April, before that refactor existed, and added three new tests against the old API. Also clean on its own, and never rebased. Both PRs only touch lines the other doesn't, so when #68180 merged 34 minutes after 6182e67ea4, git's 3-way merge combined them without a conflict. The merge is the only place the bug exists: new tests calling methods the sibling parent had already deleted. TypeError at runtime, TS2339/TS2551 from tsc, every run since. CI never caught it: GitHub was showing #68180's make check as green from a run a full day older than 6182e67ea4.

nvmeof-namespaces-list.component.spec.ts: the dedup test is real, current logic, it just called the old listNamespaces() instead of fetchData(). Fixed the call. The other two duplicate NvmeofGatewayGroupFilterComponent's own spec; removed.

nvmeof-subsystems.component.spec.ts: same story, all three duplicate the filter component's spec; removed.

Both removed error tests also checked preventDefault() on the error object, which had no coverage elsewhere. Added that to
NvmeofGatewayGroupFilterComponent's spec, and hit a second bug while writing it: the file's throwError(() => err) is the RxJS 7 factory overload, this project is on RxJS 6.6.3, so it was emitting the arrow function itself as the error. The existing error test never noticed since it only checks side effects, not the error's identity. Used throwError(err) instead.

Verified: jest passes on all three spec files (was 6 failing), tsc -p tsconfig.spec.json --noEmit is clean (was 17 errors), full block/nvmeof sweep is 29/29 suites, 216/216 tests.

Fixes: cfe12305fb1





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
