### PR TITLE
rgw/s3: make AEAD chunk size configurable for sse

### DIFF
--- a/doc/radosgw/encryption.rst
+++ b/doc/radosgw/encryption.rst
@@ -56,33 +56,34 @@ The encryption algorithm for new objects can be configured with::
 GCM Encryption Format
 ---------------------
 
-AES-256-GCM encrypts data in 4 KB (4096 byte) chunks. Each chunk produces
-4112 bytes of ciphertext (4096 bytes of encrypted data plus a 16-byte
-authentication tag).
+AES-256-GCM encrypts data in fixed-size plaintext chunks. The chunk size
+is controlled by ``rgw_crypt_aead_chunk_size``; the only supported values
+are ``4096`` (4 KiB, the default) and ``65536`` (64 KiB). Each chunk
+produces ``chunk_size + 16`` bytes of ciphertext: the encrypted data
+followed by a 16-byte authentication tag. The chunk size used at upload
+time is recorded per object (in the ``rgw.crypt.prefetch-align`` xattr)
+and remains in effect for that object regardless of later config changes.
 
-.. list-table:: GCM Size Calculation Example
+.. list-table:: GCM Size Calculation Example (10,000-byte plaintext)
    :header-rows: 1
-   :widths: 40 30 30
+   :widths: 25 25 25 25
 
-   * - Description
-     - Size
-     - Notes
-   * - Original plaintext
-     - 10,000 bytes
-     - User's data
-   * - Number of chunks
-     - 3
-     - ⌈10000 ÷ 4096⌉
-   * - Authentication tags
+   * - chunk_size
+     - Number of chunks
+     - Authentication tags
+     - Encrypted on disk
+   * - 4 KiB (default)
+     - 3 (⌈10000 ÷ 4096⌉)
      - 48 bytes
-     - 3 chunks × 16 bytes
-   * - **Encrypted on disk**
-     - **10,048 bytes**
-     - plaintext + tags
+     - 10,048 bytes
+   * - 64 KiB
+     - 1
+     - 16 bytes
+     - 10,016 bytes
 
-The storage overhead is approximately 0.4% (16 bytes per 4 KB). S3 API
-responses always report the original plaintext size, so this overhead is
-transparent to clients.
+Storage overhead is ``16 / chunk_size``: about 0.4 % at 4 KiB and 0.025 %
+at 64 KiB. S3 API responses always report
+the original plaintext size, so this overhead is transparent to clients.
 
 Customer-Provided Keys
 ======================

--- a/qa/suites/rgw/crypt/aes/gcm-64k.yaml
+++ b/qa/suites/rgw/crypt/aes/gcm-64k.yaml
@@ -1,0 +1,6 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        rgw crypt sse algorithm: aes-256-gcm
+        rgw crypt aead chunk size: 65536

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3435,6 +3435,27 @@ options:
   - aes-256-cbc
   - aes-256-gcm
   with_legacy: true
+- name: rgw_crypt_aead_chunk_size
+  type: int
+  level: advanced
+  desc: Plaintext chunk size in bytes for AEAD (GCM) server-side encryption
+  long_desc: AEAD ciphers encrypt data in fixed-size chunks, each producing
+    chunk_size + 16 bytes on disk. 4 KiB (default) reduces work on small
+    ranged GETs; 64 KiB reduces per-chunk overhead and storage expansion.
+    Existing encrypted objects retain the chunk size recorded in
+    the rgw.crypt.prefetch-align xattr at upload time, regardless of
+    this setting. This value is read once at daemon startup.
+  default: 4096
+  enum_values:
+  - 4096
+  - 65536
+  services:
+  - rgw
+  see_also:
+  - rgw_crypt_sse_algorithm
+  flags:
+  - startup
+  with_legacy: true
 - name: rgw_crypt_sse_s3_backend
   type: str
   level: advanced

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -4285,10 +4285,18 @@ int RadosMultipartUpload::complete(const DoutPrefixProvider *dpp,
   // Check if this is AEAD encryption to track plaintext size
   bool is_aead = false;
   uint64_t plaintext_ofs = 0;
+  size_t aead_chunk_size = 0;
   auto mode_iter = attrs.find(RGW_ATTR_CRYPT_MODE);
   if (mode_iter != attrs.end()) {
     std::string crypt_mode = mode_iter->second.to_str();
     is_aead = is_aead_mode(crypt_mode);
+  }
+  if (is_aead) {
+    if (aead_chunk_size_from_attrs(attrs, &aead_chunk_size) != 0) {
+      ldpp_dout(dpp, 5) << "ERROR: complete_multipart: invalid or missing "
+                          "PREFETCH_ALIGN xattr" << dendl;
+      return -EIO;
+    }
   }
   // AEAD: (S3 part number, GCM salt) per selected part, in manifest-segment order.
   std::vector<std::pair<uint32_t, std::string>> part_keys;
@@ -4416,7 +4424,8 @@ int RadosMultipartUpload::complete(const DoutPrefixProvider *dpp,
           // For compressed parts, use the uncompressed size directly
           plaintext_ofs += obj_part.accounted_size;
         } else {
-          plaintext_ofs += aead_encrypted_to_plaintext_size(obj_part.size);
+          plaintext_ofs += aead_encrypted_to_plaintext_size(
+              obj_part.size, aead_chunk_size);
         }
       }
     }

--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -662,8 +662,6 @@ public:
   static const size_t AES_256_KEYSIZE = 256 / 8;        // 32 bytes
   static const size_t AES_256_IVSIZE = 96 / 8;          // 12 bytes (GCM standard)
   static const size_t GCM_TAG_SIZE = 128 / 8;           // 16 bytes
-  static const size_t CHUNK_SIZE = 4096;
-  static const size_t ENCRYPTED_CHUNK_SIZE = CHUNK_SIZE + GCM_TAG_SIZE; // 4112
 
   const DoutPrefixProvider* dpp;
 private:
@@ -675,12 +673,16 @@ private:
   bool salt_initialized = false;
   uint32_t part_number_ = 0;  // For multipart: ensures unique IVs across parts
   bool part_salt_applied_ = false;
+  size_t chunk_size;
+  size_t encrypted_chunk_size;
   std::once_flag gcm_accel_init_once;
   CryptoAccelRef gcm_accel;
 
 public:
   explicit AES_256_GCM(const DoutPrefixProvider* dpp, CephContext* cct)
-    : dpp(dpp), cct(cct) {
+    : dpp(dpp), cct(cct),
+      chunk_size(cct->_conf->rgw_crypt_aead_chunk_size),
+      encrypted_chunk_size(chunk_size + GCM_TAG_SIZE) {
     memset(salt, 0, AES_256_GCM_SALT_SIZE);
   }
 
@@ -878,11 +880,16 @@ public:
   }
 
   size_t get_block_size() override {
-    return CHUNK_SIZE;
+    return chunk_size;
   }
 
   size_t get_encrypted_block_size() override {
-    return ENCRYPTED_CHUNK_SIZE;
+    return encrypted_chunk_size;
+  }
+
+  void set_chunk_size(size_t bs) override {
+    chunk_size = bs;
+    encrypted_chunk_size = bs + GCM_TAG_SIZE;
   }
 
   // Encode chunk index as 8-byte big-endian AAD for chunk reordering protection.
@@ -900,7 +907,7 @@ public:
 
     std::call_once(gcm_accel_init_once, [this]() {
       static const size_t max_requests = g_ceph_context->_conf->rgw_thread_pool_size;
-      gcm_accel = get_crypto_accel(dpp, cct, CHUNK_SIZE, max_requests);
+      gcm_accel = get_crypto_accel(dpp, cct, chunk_size, max_requests);
       if (!gcm_accel) {
         failed_to_get_crypto_gcm.store(true, std::memory_order_release);
       }
@@ -962,7 +969,7 @@ public:
       }
 
       int written = 0;
-      ceph_assert(size <= CHUNK_SIZE);
+      ceph_assert(size <= chunk_size);
       if (1 != EVP_EncryptUpdate(ctx, out, &written, in, size)) {
         ldpp_dout(dpp, 5) << "EVP: EncryptUpdate failed" << dendl;
         return false;
@@ -994,7 +1001,7 @@ public:
       }
 
       int written = 0;
-      ceph_assert(size <= CHUNK_SIZE);
+      ceph_assert(size <= chunk_size);
       if (1 != EVP_DecryptUpdate(ctx, out, &written, in, size)) {
         ldpp_dout(dpp, 5) << "EVP: DecryptUpdate failed" << dendl;
         return false;
@@ -1068,16 +1075,16 @@ public:
                         << " missing per-part salt; refusing to encrypt" << dendl;
       return false;
     }
-    if (stream_offset % static_cast<off_t>(CHUNK_SIZE) != 0) {
+    if (stream_offset % static_cast<off_t>(chunk_size) != 0) {
       ldpp_dout(dpp, 0) << "GCM: stream_offset " << stream_offset
-                        << " not chunk-aligned (" << CHUNK_SIZE << ")" << dendl;
+                        << " not chunk-aligned (" << chunk_size << ")" << dendl;
       return false;
     }
 
-    // Calculate output size: each CHUNK_SIZE plaintext becomes CHUNK_SIZE + GCM_TAG_SIZE
-    size_t num_full_chunks = size / CHUNK_SIZE;
-    size_t remainder = size % CHUNK_SIZE;
-    size_t output_size = num_full_chunks * ENCRYPTED_CHUNK_SIZE;
+    // Calculate output size: each chunk_size plaintext becomes chunk_size + GCM_TAG_SIZE
+    size_t num_full_chunks = size / chunk_size;
+    size_t remainder = size % chunk_size;
+    size_t output_size = num_full_chunks * encrypted_chunk_size;
     if (remainder > 0) {
       output_size += remainder + GCM_TAG_SIZE;
     }
@@ -1122,29 +1129,29 @@ public:
     }
 
     // Process full chunks
-    for (size_t offset = 0; offset < num_full_chunks * CHUNK_SIZE; offset += CHUNK_SIZE) {
+    for (size_t offset = 0; offset < num_full_chunks * chunk_size; offset += chunk_size) {
       unsigned char iv[AES_256_IVSIZE];
       cursor.emit(iv);
       const unsigned char* input_ptr = input_raw + offset;
 
       unsigned char* ciphertext = buf_raw + out_pos;
-      unsigned char* tag = buf_raw + out_pos + CHUNK_SIZE;
+      unsigned char* tag = buf_raw + out_pos + chunk_size;
 
-      if (!gcm_transform(ciphertext, input_ptr, CHUNK_SIZE,
+      if (!gcm_transform(ciphertext, input_ptr, chunk_size,
                          iv, key, tag, cursor.chunk_index, true, y, accel, evp_ctx.get())) {
         ldpp_dout(dpp, 5) << "Failed to encrypt chunk at offset " << offset << dendl;
         return false;
       }
 
       cursor.advance();
-      out_pos += ENCRYPTED_CHUNK_SIZE;
+      out_pos += encrypted_chunk_size;
     }
 
     // Process remainder (if any)
     if (remainder > 0) {
       unsigned char iv[AES_256_IVSIZE];
       cursor.emit(iv);
-      const unsigned char* input_ptr = input_raw + num_full_chunks * CHUNK_SIZE;
+      const unsigned char* input_ptr = input_raw + num_full_chunks * chunk_size;
 
       unsigned char* ciphertext = buf_raw + out_pos;
       unsigned char* tag = buf_raw + out_pos + remainder;
@@ -1173,9 +1180,9 @@ public:
     output.clear();
 
     // Input is organized as encrypted chunks (ciphertext + tag)
-    size_t num_full_chunks = size / ENCRYPTED_CHUNK_SIZE;
-    size_t remainder = size % ENCRYPTED_CHUNK_SIZE;
-    size_t output_size = num_full_chunks * CHUNK_SIZE;
+    size_t num_full_chunks = size / encrypted_chunk_size;
+    size_t remainder = size % encrypted_chunk_size;
+    size_t output_size = num_full_chunks * chunk_size;
 
     if (remainder > 0) {
       if (remainder <= GCM_TAG_SIZE) {
@@ -1228,10 +1235,10 @@ public:
     for (size_t i = 0; i < num_full_chunks; i++) {
       unsigned char iv[AES_256_IVSIZE];
       cursor.emit(iv);
-      const unsigned char* chunk_ptr = input_raw + i * ENCRYPTED_CHUNK_SIZE;
+      const unsigned char* chunk_ptr = input_raw + i * encrypted_chunk_size;
 
-      if (!gcm_transform(buf_raw + out_pos, chunk_ptr, CHUNK_SIZE,
-                         iv, key, const_cast<unsigned char*>(chunk_ptr + CHUNK_SIZE),
+      if (!gcm_transform(buf_raw + out_pos, chunk_ptr, chunk_size,
+                         iv, key, const_cast<unsigned char*>(chunk_ptr + chunk_size),
                          cursor.chunk_index, false, y, accel, evp_ctx.get())) {
         ldpp_dout(dpp, 5) << "GCM: Failed to decrypt chunk " << i
                           << " - authentication failed" << dendl;
@@ -1239,7 +1246,7 @@ public:
       }
 
       cursor.advance();
-      out_pos += CHUNK_SIZE;
+      out_pos += chunk_size;
     }
 
     // Process remainder (if any)
@@ -1247,7 +1254,7 @@ public:
       size_t plaintext_size = remainder - GCM_TAG_SIZE;
       unsigned char iv[AES_256_IVSIZE];
       cursor.emit(iv);
-      const unsigned char* chunk_ptr = input_raw + num_full_chunks * ENCRYPTED_CHUNK_SIZE;
+      const unsigned char* chunk_ptr = input_raw + num_full_chunks * encrypted_chunk_size;
 
       if (!gcm_transform(buf_raw + out_pos, chunk_ptr, plaintext_size,
                          iv, key, const_cast<unsigned char*>(chunk_ptr + plaintext_size),
@@ -1293,7 +1300,7 @@ public:
   bool init_iv_cursor(iv_cursor& cursor, off_t stream_offset) {
     ceph_assert(salt_initialized);
     cursor.hi = part_number_;
-    cursor.lo = stream_offset / CHUNK_SIZE;
+    cursor.lo = stream_offset / chunk_size;
     cursor.chunk_index = cursor.lo;
     return true;
   }
@@ -1961,6 +1968,17 @@ bool rgw_get_aead_decrypted_size(const DoutPrefixProvider* dpp,
     return false;
   }
 
+  size_t chunk_size;
+  if (aead_chunk_size_from_attrs(attrs, &chunk_size) != 0) {
+    if (dpp) {
+      ldpp_dout(dpp, 1) << "rgw_get_aead_decrypted_size: invalid or "
+                          "missing PREFETCH_ALIGN xattr - size derivation "
+                          "skipped (subsequent GET will fail at decrypt)"
+                        << dendl;
+    }
+    return false;
+  }
+
   /* Try CRYPT_PARTS first (more accurate for multipart) */
   if (auto i = attrs.find(RGW_ATTR_CRYPT_PARTS); i != attrs.end()) {
     std::vector<size_t> parts_len;
@@ -1977,7 +1995,7 @@ bool rgw_get_aead_decrypted_size(const DoutPrefixProvider* dpp,
     if (!parts_len.empty()) {
       uint64_t total = 0;
       for (size_t enc_part : parts_len) {
-        total += aead_encrypted_to_plaintext_size(enc_part, dpp);
+        total += aead_encrypted_to_plaintext_size(enc_part, chunk_size, dpp);
       }
       *decrypted_size = total;
       return true;
@@ -1985,7 +2003,7 @@ bool rgw_get_aead_decrypted_size(const DoutPrefixProvider* dpp,
   }
 
   /* Fallback: calculate from total encrypted size */
-  *decrypted_size = aead_encrypted_to_plaintext_size(encrypted_size, dpp);
+  *decrypted_size = aead_encrypted_to_plaintext_size(encrypted_size, chunk_size, dpp);
   if (dpp) {
     ldpp_dout(dpp, 20) << "AEAD: calculated decrypted size " << *decrypted_size
                        << " from encrypted " << encrypted_size << dendl;
@@ -2104,10 +2122,11 @@ int rgw_s3_prepare_encrypt(req_state* s, optional_yield y,
       if (use_gcm) {
         set_attr(attrs, RGW_ATTR_CRYPT_MODE, "SSE-C-AES256-GCM");
         if (!block_crypt) {
-          // multipart-init: write prefetch align from AEAD constants
+          // multipart-init: write prefetch align from configured chunk size
+          const size_t bs = s->cct->_conf->rgw_crypt_aead_chunk_size;
           bufferlist align_bl;
-          encode(static_cast<uint32_t>(AEAD_CHUNK_SIZE), align_bl);
-          encode(static_cast<uint32_t>(AEAD_ENCRYPTED_CHUNK_SIZE), align_bl);
+          encode(static_cast<uint32_t>(bs), align_bl);
+          encode(static_cast<uint32_t>(bs + AEAD_TAG_SIZE), align_bl);
           attrs[RGW_ATTR_CRYPT_PREFETCH_ALIGN] = std::move(align_bl);
         }
         std::string salt = generate_gcm_salt(s, attrs);
@@ -2225,9 +2244,10 @@ int rgw_s3_prepare_encrypt(req_state* s, optional_yield y,
         if (use_gcm) {
           set_attr(attrs, RGW_ATTR_CRYPT_MODE, "SSE-KMS-GCM");
           if (!block_crypt) {
+            const size_t bs = s->cct->_conf->rgw_crypt_aead_chunk_size;
             bufferlist align_bl;
-            encode(static_cast<uint32_t>(AEAD_CHUNK_SIZE), align_bl);
-            encode(static_cast<uint32_t>(AEAD_ENCRYPTED_CHUNK_SIZE), align_bl);
+            encode(static_cast<uint32_t>(bs), align_bl);
+            encode(static_cast<uint32_t>(bs + AEAD_TAG_SIZE), align_bl);
             attrs[RGW_ATTR_CRYPT_PREFETCH_ALIGN] = std::move(align_bl);
           }
           std::string salt = generate_gcm_salt(s, attrs);
@@ -2323,9 +2343,10 @@ int rgw_s3_prepare_encrypt(req_state* s, optional_yield y,
       if (use_gcm) {
         set_attr(attrs, RGW_ATTR_CRYPT_MODE, "AES256-GCM");
         if (!block_crypt) {
+          const size_t bs = s->cct->_conf->rgw_crypt_aead_chunk_size;
           bufferlist align_bl;
-          encode(static_cast<uint32_t>(AEAD_CHUNK_SIZE), align_bl);
-          encode(static_cast<uint32_t>(AEAD_ENCRYPTED_CHUNK_SIZE), align_bl);
+          encode(static_cast<uint32_t>(bs), align_bl);
+          encode(static_cast<uint32_t>(bs + AEAD_TAG_SIZE), align_bl);
           attrs[RGW_ATTR_CRYPT_PREFETCH_ALIGN] = std::move(align_bl);
         }
         std::string salt = generate_gcm_salt(s, attrs);
@@ -2396,9 +2417,10 @@ int rgw_s3_prepare_encrypt(req_state* s, optional_yield y,
       if (use_gcm) {
         set_attr(attrs, RGW_ATTR_CRYPT_MODE, "RGW-AUTO-GCM");
         if (!block_crypt) {
+          const size_t bs = s->cct->_conf->rgw_crypt_aead_chunk_size;
           bufferlist align_bl;
-          encode(static_cast<uint32_t>(AEAD_CHUNK_SIZE), align_bl);
-          encode(static_cast<uint32_t>(AEAD_ENCRYPTED_CHUNK_SIZE), align_bl);
+          encode(static_cast<uint32_t>(bs), align_bl);
+          encode(static_cast<uint32_t>(bs + AEAD_TAG_SIZE), align_bl);
           attrs[RGW_ATTR_CRYPT_PREFETCH_ALIGN] = std::move(align_bl);
         }
         std::string salt = generate_gcm_salt(s, attrs);
@@ -2669,6 +2691,13 @@ int rgw_s3_prepare_decrypt(req_state* s, optional_yield y,
     if (stored_salt.empty()) return -EIO;
 
     auto gcm = std::make_unique<AES_256_GCM>(s, s->cct);
+    size_t chunk_size;
+    if (aead_chunk_size_from_attrs(attrs, &chunk_size) != 0) {
+      ldpp_dout(s, 5) << "ERROR: SSE-C-AES256-GCM: invalid or missing "
+                        "PREFETCH_ALIGN xattr" << dendl;
+      return -EIO;
+    }
+    gcm->set_chunk_size(chunk_size);
     gcm->set_salt(reinterpret_cast<const uint8_t*>(stored_salt.c_str()),
                    stored_salt.size());
     // Re-derive encryption key from user key + object identity
@@ -2772,6 +2801,14 @@ int rgw_s3_prepare_decrypt(req_state* s, optional_yield y,
       ::ceph::crypto::zeroize_for_security(actual_key.data(), actual_key.length());
       return -EIO;
     }
+    size_t chunk_size;
+    if (aead_chunk_size_from_attrs(attrs, &chunk_size) != 0) {
+      ldpp_dout(s, 5) << "ERROR: SSE-KMS-GCM: invalid or missing "
+                        "PREFETCH_ALIGN xattr" << dendl;
+      ::ceph::crypto::zeroize_for_security(actual_key.data(), actual_key.length());
+      return -EIO;
+    }
+    aes->set_chunk_size(chunk_size);
     std::string bucket_id, object_name;
     pick_gcm_identity(s, copy_source, src_identity, bucket_id, object_name);
     auto* gcm = dynamic_cast<AES_256_GCM*>(aes.get());
@@ -2855,6 +2892,13 @@ int rgw_s3_prepare_decrypt(req_state* s, optional_yield y,
     if (stored_salt.empty()) return -EIO;
 
     auto gcm = std::make_unique<AES_256_GCM>(s, s->cct);
+    size_t chunk_size;
+    if (aead_chunk_size_from_attrs(attrs, &chunk_size) != 0) {
+      ldpp_dout(s, 5) << "ERROR: RGW-AUTO-GCM: invalid or missing "
+                        "PREFETCH_ALIGN xattr" << dendl;
+      return -EIO;
+    }
+    gcm->set_chunk_size(chunk_size);
     gcm->set_salt(reinterpret_cast<const uint8_t*>(stored_salt.c_str()),
                    stored_salt.size());
 
@@ -2946,6 +2990,14 @@ int rgw_s3_prepare_decrypt(req_state* s, optional_yield y,
       ::ceph::crypto::zeroize_for_security(actual_key.data(), actual_key.length());
       return -EIO;
     }
+    size_t chunk_size;
+    if (aead_chunk_size_from_attrs(attrs, &chunk_size) != 0) {
+      ldpp_dout(s, 5) << "ERROR: AES256-GCM: invalid or missing "
+                        "PREFETCH_ALIGN xattr" << dendl;
+      ::ceph::crypto::zeroize_for_security(actual_key.data(), actual_key.length());
+      return -EIO;
+    }
+    aes->set_chunk_size(chunk_size);
     std::string bucket_id, object_name;
     pick_gcm_identity(s, copy_source, src_identity, bucket_id, object_name);
     auto* gcm = dynamic_cast<AES_256_GCM*>(aes.get());

--- a/src/rgw/rgw_crypt.h
+++ b/src/rgw/rgw_crypt.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <bit>
+#include <cerrno>
 #include <string_view>
 
 #include <rgw/rgw_op.h>
@@ -14,6 +16,7 @@
 #include <rgw/rgw_rest_s3.h>
 #include "rgw_putobj.h"
 #include "common/async/yield_context.h"
+#include "include/encoding.h"
 
 struct rgw_crypt_src_identity {
   std::string bucket_id;
@@ -107,6 +110,12 @@ public:
    */
   virtual void set_part_number(uint32_t part_number,
                                std::string_view part_salt = {}) {}
+
+  /**
+   * Set the AEAD plaintext chunk size for size-expanding ciphers.
+   * Default is no-op; non-AEAD ciphers have a fixed block size.
+   */
+  virtual void set_chunk_size(size_t chunk_size) {}
 };
 
 static const size_t AES_256_KEYSIZE = 256 / 8;
@@ -144,15 +153,50 @@ inline bool is_cbc_mode(const std::string& mode) {
 }
 
 /**
+ * Read and validate the AEAD chunk size from RGW_ATTR_CRYPT_PREFETCH_ALIGN.
+ * Returns 0 on success and writes the chunk size to *chunk_size_out.
+ * Returns -EIO if the xattr is absent, truncated, or carries invalid values
+ * (range, power-of-two, or mismatched plaintext/encrypted block sizes).
+ */
+inline int aead_chunk_size_from_attrs(
+    const std::map<std::string, ceph::bufferlist>& attrs,
+    size_t* chunk_size_out)
+{
+  auto i = attrs.find(RGW_ATTR_CRYPT_PREFETCH_ALIGN);
+  if (i == attrs.end()) {
+    return -EIO;
+  }
+  using ceph::decode;
+  uint32_t plain_bs = 0;
+  uint32_t enc_bs = 0;
+  try {
+    auto p = i->second.cbegin();
+    decode(plain_bs, p);
+    decode(enc_bs, p);
+  } catch (const ceph::buffer::error&) {
+    return -EIO;
+  }
+  const size_t bs = plain_bs;
+  if (bs < 4096 || bs > (1u << 20) ||
+      !std::has_single_bit(bs) ||
+      enc_bs != bs + AEAD_TAG_SIZE) {
+    return -EIO;
+  }
+  *chunk_size_out = bs;
+  return 0;
+}
+
+/**
  * Convert encrypted size to plaintext size for AEAD modes.
- * Each AEAD_CHUNK_SIZE-byte plaintext chunk becomes AEAD_ENCRYPTED_CHUNK_SIZE bytes
- * (plaintext + AEAD_TAG_SIZE-byte auth tag).
+ * Each chunk_size-byte plaintext chunk becomes chunk_size + AEAD_TAG_SIZE bytes.
  * Pass dpp to enable warning logging for malformed data.
  */
 inline uint64_t aead_encrypted_to_plaintext_size(uint64_t encrypted_size,
+                                                  size_t chunk_size,
                                                   const DoutPrefixProvider* dpp = nullptr) {
-  uint64_t full_chunks = encrypted_size / AEAD_ENCRYPTED_CHUNK_SIZE;
-  uint64_t remainder = encrypted_size % AEAD_ENCRYPTED_CHUNK_SIZE;
+  const size_t enc_chunk = chunk_size + AEAD_TAG_SIZE;
+  uint64_t full_chunks = encrypted_size / enc_chunk;
+  uint64_t remainder = encrypted_size % enc_chunk;
 
   if (remainder > 0 && remainder <= AEAD_TAG_SIZE) {
     // Malformed: partial chunk has no ciphertext, only tag bytes
@@ -162,20 +206,21 @@ inline uint64_t aead_encrypted_to_plaintext_size(uint64_t encrypted_size,
           << " is <= tag size " << AEAD_TAG_SIZE
           << " - data may be corrupted" << dendl;
     }
-    return full_chunks * AEAD_CHUNK_SIZE;
+    return full_chunks * chunk_size;
   }
 
   uint64_t partial = (remainder > AEAD_TAG_SIZE) ? (remainder - AEAD_TAG_SIZE) : 0;
-  return full_chunks * AEAD_CHUNK_SIZE + partial;
+  return full_chunks * chunk_size + partial;
 }
 
 /**
  * Convert plaintext size to encrypted size for AEAD modes.
- * Each AEAD_CHUNK_SIZE-byte plaintext chunk becomes AEAD_ENCRYPTED_CHUNK_SIZE bytes.
+ * Each chunk_size-byte plaintext chunk becomes chunk_size + AEAD_TAG_SIZE bytes.
  */
-inline uint64_t aead_plaintext_to_encrypted_size(uint64_t plaintext_size) {
+inline uint64_t aead_plaintext_to_encrypted_size(uint64_t plaintext_size,
+                                                  size_t chunk_size) {
   if (plaintext_size == 0) return 0;
-  uint64_t num_chunks = (plaintext_size + AEAD_CHUNK_SIZE - 1) / AEAD_CHUNK_SIZE;
+  uint64_t num_chunks = (plaintext_size + chunk_size - 1) / chunk_size;
   return plaintext_size + (num_chunks * AEAD_TAG_SIZE);
 }
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -10392,7 +10392,8 @@ int get_decrypt_filter(
     } else if (!attrs.count(RGW_ATTR_COMPRESSION)) {
       uint64_t orig_size = 0;
       if (rgw_get_aead_original_size(s, attrs, &orig_size)) {
-        encrypted_total_size = aead_plaintext_to_encrypted_size(orig_size);
+        encrypted_total_size = aead_plaintext_to_encrypted_size(
+            orig_size, block_crypt->get_block_size());
       }
     }
   }

--- a/src/test/rgw/test_rgw_crypto.cc
+++ b/src/test/rgw/test_rgw_crypto.cc
@@ -854,9 +854,10 @@ TEST(TestRGWCrypto, verify_AES_256_GCM_identity)
 
     auto aes(AES_256_GCM_create(&no_dpp, g_ceph_context, &key[0], 32));
     ASSERT_NE(aes.get(), nullptr);
+    aes->set_chunk_size(AEAD_CHUNK_SIZE);
 
     size_t block_size = aes->get_block_size();
-    ASSERT_EQ(block_size, 4096u);
+    ASSERT_EQ(block_size, AEAD_CHUNK_SIZE);
 
     for (size_t r = 97; r < 123 ; r++)
     {
@@ -875,7 +876,7 @@ TEST(TestRGWCrypto, verify_AES_256_GCM_identity)
       bufferlist encrypted;
       ASSERT_TRUE(aes->encrypt(input, begin, end - begin, encrypted, offset, null_yield));
 
-      size_t expected_encrypted_size = aead_plaintext_to_encrypted_size(end - begin);
+      size_t expected_encrypted_size = aead_plaintext_to_encrypted_size(end - begin, AEAD_CHUNK_SIZE);
       ASSERT_EQ(encrypted.length(), expected_encrypted_size);
 
       bufferlist decrypted;
@@ -898,6 +899,7 @@ TEST(TestRGWCrypto, verify_AES_256_GCM_chunk_sizes)
 
   auto aes(AES_256_GCM_create(&no_dpp, g_ceph_context, &key[0], 32));
   ASSERT_NE(aes.get(), nullptr);
+  aes->set_chunk_size(AEAD_CHUNK_SIZE);
 
   // Test various sizes to verify chunk + tag handling
   for (size_t size : {0, 1, 16, 4095, 4096, 4097, 8192, 10000})
@@ -913,7 +915,7 @@ TEST(TestRGWCrypto, verify_AES_256_GCM_chunk_sizes)
     bufferlist encrypted;
     ASSERT_TRUE(aes->encrypt(input, 0, size, encrypted, 0, null_yield));
 
-    size_t expected_size = aead_plaintext_to_encrypted_size(size);
+    size_t expected_size = aead_plaintext_to_encrypted_size(size, AEAD_CHUNK_SIZE);
     ASSERT_EQ(encrypted.length(), expected_size);
 
     bufferlist decrypted;
@@ -951,28 +953,28 @@ TEST(TestRGWCrypto, verify_AEAD_size_conversion)
   ASSERT_FALSE(is_cbc_mode("invalid"));
 
   // Test aead_plaintext_to_encrypted_size()
-  ASSERT_EQ(aead_plaintext_to_encrypted_size(0), 0UL);       // Zero bytes
-  ASSERT_EQ(aead_plaintext_to_encrypted_size(1), 17UL);      // 1 + 16 tag
-  ASSERT_EQ(aead_plaintext_to_encrypted_size(100), 116UL);   // 100 + 16 tag
-  ASSERT_EQ(aead_plaintext_to_encrypted_size(4095), 4111UL); // 4095 + 16 tag
-  ASSERT_EQ(aead_plaintext_to_encrypted_size(4096), 4112UL); // Full chunk
-  ASSERT_EQ(aead_plaintext_to_encrypted_size(4097), 4129UL); // 4097 + 32 tags (2 chunks)
-  ASSERT_EQ(aead_plaintext_to_encrypted_size(8192), 8224UL); // Two full chunks
+  ASSERT_EQ(aead_plaintext_to_encrypted_size(0, AEAD_CHUNK_SIZE), 0UL);       // Zero bytes
+  ASSERT_EQ(aead_plaintext_to_encrypted_size(1, AEAD_CHUNK_SIZE), 17UL);      // 1 + 16 tag
+  ASSERT_EQ(aead_plaintext_to_encrypted_size(100, AEAD_CHUNK_SIZE), 116UL);   // 100 + 16 tag
+  ASSERT_EQ(aead_plaintext_to_encrypted_size(4095, AEAD_CHUNK_SIZE), 4111UL); // 4095 + 16 tag
+  ASSERT_EQ(aead_plaintext_to_encrypted_size(4096, AEAD_CHUNK_SIZE), 4112UL); // Full chunk
+  ASSERT_EQ(aead_plaintext_to_encrypted_size(4097, AEAD_CHUNK_SIZE), 4129UL); // 4097 + 32 tags (2 chunks)
+  ASSERT_EQ(aead_plaintext_to_encrypted_size(8192, AEAD_CHUNK_SIZE), 8224UL); // Two full chunks
 
   // Test aead_encrypted_to_plaintext_size()
-  ASSERT_EQ(aead_encrypted_to_plaintext_size(0), 0UL);       // Zero bytes
-  ASSERT_EQ(aead_encrypted_to_plaintext_size(16), 0UL);      // Tag only -> 0 plaintext
-  ASSERT_EQ(aead_encrypted_to_plaintext_size(17), 1UL);      // 1 byte + tag
-  ASSERT_EQ(aead_encrypted_to_plaintext_size(100), 84UL);    // 100 - 16 tag
-  ASSERT_EQ(aead_encrypted_to_plaintext_size(4112), 4096UL); // Full chunk
-  ASSERT_EQ(aead_encrypted_to_plaintext_size(4212), 4180UL); // 4096 + 84 (one chunk + partial)
-  ASSERT_EQ(aead_encrypted_to_plaintext_size(8224), 8192UL); // Two full chunks
+  ASSERT_EQ(aead_encrypted_to_plaintext_size(0, AEAD_CHUNK_SIZE), 0UL);       // Zero bytes
+  ASSERT_EQ(aead_encrypted_to_plaintext_size(16, AEAD_CHUNK_SIZE), 0UL);      // Tag only -> 0 plaintext
+  ASSERT_EQ(aead_encrypted_to_plaintext_size(17, AEAD_CHUNK_SIZE), 1UL);      // 1 byte + tag
+  ASSERT_EQ(aead_encrypted_to_plaintext_size(100, AEAD_CHUNK_SIZE), 84UL);    // 100 - 16 tag
+  ASSERT_EQ(aead_encrypted_to_plaintext_size(4112, AEAD_CHUNK_SIZE), 4096UL); // Full chunk
+  ASSERT_EQ(aead_encrypted_to_plaintext_size(4212, AEAD_CHUNK_SIZE), 4180UL); // 4096 + 84 (one chunk + partial)
+  ASSERT_EQ(aead_encrypted_to_plaintext_size(8224, AEAD_CHUNK_SIZE), 8192UL); // Two full chunks
 
   // Test roundtrip: plaintext -> encrypted -> plaintext
   for (uint64_t plain : {0UL, 1UL, 16UL, 100UL, 4095UL, 4096UL, 4097UL,
                          8192UL, 10000UL, 1000000UL}) {
-    uint64_t enc = aead_plaintext_to_encrypted_size(plain);
-    uint64_t recovered = aead_encrypted_to_plaintext_size(enc);
+    uint64_t enc = aead_plaintext_to_encrypted_size(plain, AEAD_CHUNK_SIZE);
+    uint64_t recovered = aead_encrypted_to_plaintext_size(enc, AEAD_CHUNK_SIZE);
     ASSERT_EQ(plain, recovered)
       << "Roundtrip failed for plaintext=" << plain
       << " encrypted=" << enc << " recovered=" << recovered;
@@ -1014,6 +1016,7 @@ TEST(TestRGWCrypto, verify_AES_256_GCM_tag_verification)
 
   auto aes(AES_256_GCM_create(&no_dpp, g_ceph_context, &key[0], 32));
   ASSERT_NE(aes.get(), nullptr);
+  aes->set_chunk_size(AEAD_CHUNK_SIZE);
 
   const size_t size = 8192;  // 2 chunks
   buffer::ptr buf(size);
@@ -1295,6 +1298,7 @@ TEST(TestRGWCrypto, verify_AES_256_GCM_chunk_reorder_detection)
 
   auto aes(AES_256_GCM_create(&no_dpp, g_ceph_context, &key[0], 32));
   ASSERT_NE(aes.get(), nullptr);
+  aes->set_chunk_size(AEAD_CHUNK_SIZE);
 
   // Create 2 chunks of data (8192 bytes = 2 x 4096)
   const size_t size = 8192;
@@ -1341,6 +1345,7 @@ TEST(TestRGWCrypto, verify_AES_256_GCM_aad_roundtrip)
   for (size_t size : {4096u, 8192u, 12288u, 10000u}) {
     auto aes(AES_256_GCM_create(&no_dpp, g_ceph_context, &key[0], 32));
     ASSERT_NE(aes.get(), nullptr);
+    aes->set_chunk_size(AEAD_CHUNK_SIZE);
 
     buffer::ptr buf(size);
     char* p = buf.c_str();
@@ -1370,6 +1375,7 @@ TEST(TestRGWCrypto, verify_AES_256_GCM_aad_offset_mismatch)
 
   auto aes(AES_256_GCM_create(&no_dpp, g_ceph_context, &key[0], 32));
   ASSERT_NE(aes.get(), nullptr);
+  aes->set_chunk_size(AEAD_CHUNK_SIZE);
 
   const size_t size = 4096;
   buffer::ptr buf(size);
@@ -1451,7 +1457,7 @@ TEST(TestRGWCrypto, verify_PartLocation_multipart_cbc)
 TEST(TestRGWCrypto, verify_PartLocation_multipart_aead)
 {
   const size_t pp = 1024 * AEAD_CHUNK_SIZE;  // 4MB plaintext per part
-  const size_t ep = aead_plaintext_to_encrypted_size(pp);
+  const size_t ep = aead_plaintext_to_encrypted_size(pp, AEAD_CHUNK_SIZE);
   std::vector<size_t> parts = {ep, ep, ep};
   size_t idx; off_t ofs_in_part, cumulative;
 
@@ -1583,6 +1589,85 @@ TEST(TestRGWCrypto, verify_transition_encrypt_decrypt_roundtrip)
   }
 }
 
+// Helper to build a PREFETCH_ALIGN xattr value for a given (plain, enc) pair.
+static ceph::bufferlist make_prefetch_align(uint32_t plain_bs, uint32_t enc_bs)
+{
+  ceph::bufferlist bl;
+  ceph::encode(plain_bs, bl);
+  ceph::encode(enc_bs, bl);
+  return bl;
+}
+
+TEST(TestRGWCrypto, verify_AES_256_GCM_configurable_chunk_size)
+{
+  const NoDoutPrefix no_dpp(g_ceph_context, dout_subsys);
+  uint8_t key[32];
+  for (size_t i = 0; i < sizeof(key); i++) key[i] = i;
+
+  for (size_t bs : {4096u, 65536u}) {
+    auto enc(AES_256_GCM_create(&no_dpp, g_ceph_context, &key[0], 32));
+    ASSERT_NE(enc.get(), nullptr);
+    enc->set_chunk_size(bs);
+    ASSERT_EQ(enc->get_block_size(), bs);
+    ASSERT_EQ(enc->get_encrypted_block_size(), bs + 16);
+
+    const size_t plain_len = 5 * bs + 333;
+    ceph::bufferlist input;
+    input.append(std::string(plain_len, 'x'));
+    ceph::bufferlist encrypted;
+    ASSERT_TRUE(enc->encrypt(input, 0, plain_len, encrypted, 0, null_yield));
+
+    auto dec(AES_256_GCM_create(&no_dpp, g_ceph_context, &key[0], 32));
+    ASSERT_NE(dec.get(), nullptr);
+    dec->set_chunk_size(bs);
+    ceph::bufferlist decrypted;
+    ASSERT_TRUE(dec->decrypt(encrypted, 0, encrypted.length(), decrypted, 0, null_yield));
+    ASSERT_EQ(decrypted.length(), plain_len);
+    ASSERT_TRUE(memcmp(input.c_str(), decrypted.c_str(), plain_len) == 0);
+  }
+}
+
+TEST(TestRGWCrypto, aead_chunk_size_from_attrs_rejects_bad_input)
+{
+  std::map<std::string, ceph::bufferlist> attrs;
+  size_t out = 0;
+
+  // Absent xattr
+  EXPECT_EQ(aead_chunk_size_from_attrs(attrs, &out), -EIO);
+
+  // Truncated: only plain_bs encoded
+  {
+    ceph::bufferlist bl;
+    ceph::encode(uint32_t{4096}, bl);
+    attrs[RGW_ATTR_CRYPT_PREFETCH_ALIGN] = std::move(bl);
+    EXPECT_EQ(aead_chunk_size_from_attrs(attrs, &out), -EIO);
+  }
+
+  // Empty bufferlist
+  attrs[RGW_ATTR_CRYPT_PREFETCH_ALIGN] = ceph::bufferlist{};
+  EXPECT_EQ(aead_chunk_size_from_attrs(attrs, &out), -EIO);
+
+  // Each remaining case re-encodes a distinct invalid (plain, enc) pair.
+  struct bad { uint32_t plain; uint32_t enc; };
+  const bad cases[] = {
+    {2048, 2064},          // below MIN
+    {1u << 21, (1u << 21) + 16}, // above MAX
+    {5000, 5016},          // not power of two
+    {4096, 4096},          // enc_bs != plain + tag
+    {0, 16},               // zero plain
+  };
+  for (const auto& c : cases) {
+    attrs[RGW_ATTR_CRYPT_PREFETCH_ALIGN] = make_prefetch_align(c.plain, c.enc);
+    EXPECT_EQ(aead_chunk_size_from_attrs(attrs, &out), -EIO)
+        << "plain=" << c.plain << " enc=" << c.enc;
+  }
+
+  // Positive control
+  attrs[RGW_ATTR_CRYPT_PREFETCH_ALIGN] = make_prefetch_align(4096, 4112);
+  EXPECT_EQ(aead_chunk_size_from_attrs(attrs, &out), 0);
+  EXPECT_EQ(out, 4096u);
+}
+
 int main(int argc, char **argv) {
   auto args = argv_to_vec(argc, argv);
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
@@ -1593,4 +1678,3 @@ int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-


### PR DESCRIPTION
The chunk size for AES-256-GCM was hardcoded to 4 KiB. Add a startup-only option rgw_crypt_aead_chunk_size that picks between 4096 and 65536, defaulting to 4096. AES_256_GCM reads it from the config in the constructor instead of a class-scope constant.

The size used at upload is written to RGW_ATTR_CRYPT_PREFETCH_ALIGN, and the decrypt path reads it back, so each object stays at the size it was encrypted with regardless of later config changes.

Tests cover round-trip at both sizes and the validator's negative paths. Adds gcm-64k.yaml under qa/suites/rgw/crypt/aes/.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [X] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
