### PR TITLE
mgr/cephadm: Fix WWW-Authenticate Header Parsing to Remove Trailing Whitespace and Avoid 400 Errors

### DIFF
--- a/src/pybind/mgr/cephadm/registry.py
+++ b/src/pybind/mgr/cephadm/registry.py
@@ -1,3 +1,4 @@
+import shlex
 import requests
 from typing import List, Dict, Tuple
 from requests import Response
@@ -26,12 +27,38 @@ class Registry:
         raise ValueError(f'Unknown token reply {ret}')
 
     def parse_www_authenticate(self, text: str) -> Tuple[str, Dict[str, str]]:
-        # 'Www-Authenticate': 'Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:ceph/ceph:pull"'
+        """
+        Parse Bearer authentication parameters from a WWW-Authenticate header.
+
+        Some registries (e.g. IBM Container Registry) return headers with
+        spaces after commas:
+            Bearer realm=https://cp.icr.io/oauth/token, service=registry, scope=...
+        shlex.split() handles quoted strings natively and treats commas and
+        spaces as delimiters, so both quoted and unquoted values work without
+        any custom regex.
+        """
         r: Dict[str, str] = {}
-        for token in text.split(','):
-            key, value = token.split('=', 1)
-            r[key] = value.strip('"')
-        realm = r.pop('Bearer realm')
+
+        # Strip the scheme token ("Bearer ") before parsing key=value pairs.
+        bearer_prefix = 'Bearer '
+        if text.startswith(bearer_prefix):
+            text = text[len(bearer_prefix):]
+
+        # shlex splits on whitespace and respects quoted strings.
+        # Replace commas with spaces so they act as plain delimiters, but
+        # only outside quoted strings — shlex handles this correctly.
+        lex = shlex.shlex(text, posix=True)
+        lex.whitespace = ', '
+        lex.whitespace_split = True
+        for token in lex:
+            if '=' in token:
+                key, _, value = token.partition('=')
+                r[key.strip()] = value
+
+        if 'realm' not in r:
+            raise ValueError(f'No realm found in WWW-Authenticate header: {text}')
+
+        realm = r.pop('realm')
         return realm, r
 
     def get_tags(self, image: str) -> List[str]:

--- a/src/pybind/mgr/cephadm/tests/test_registry.py
+++ b/src/pybind/mgr/cephadm/tests/test_registry.py
@@ -1,0 +1,76 @@
+import pytest
+from cephadm.registry import Registry
+
+
+class TestParseWWWAuthenticate:
+    """Tests for Registry.parse_www_authenticate()."""
+
+    def test_standard_docker_registry_header(self):
+        """Standard Docker Hub header with quoted values."""
+        registry = Registry('docker.io')
+        header = 'Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:ceph/ceph:pull"'
+        realm, params = registry.parse_www_authenticate(header)
+        assert realm == 'https://auth.docker.io/token'
+        assert params == {
+            'service': 'registry.docker.io',
+            'scope': 'repository:ceph/ceph:pull',
+        }
+
+    def test_ibm_container_registry_header(self):
+        """IBM ICR returns unquoted values with spaces after commas — the actual bug."""
+        registry = Registry('cp.icr.io')
+        header = 'Bearer realm=https://cp.icr.io/oauth/token, service=registry, scope=repository:cp/ibm-ceph/ceph-8-rhel9:pull'
+        realm, params = registry.parse_www_authenticate(header)
+        assert realm == 'https://cp.icr.io/oauth/token'
+        assert params == {
+            'service': 'registry',
+            'scope': 'repository:cp/ibm-ceph/ceph-8-rhel9:pull',
+        }
+
+    def test_quoted_scope_with_comma(self):
+        """Quoted values that contain commas (e.g. pull,push) must not be split."""
+        registry = Registry('example.com')
+        header = 'Bearer realm="https://auth.example.com/token",service="registry",scope="repository:ceph/ceph:pull,push"'
+        realm, params = registry.parse_www_authenticate(header)
+        assert realm == 'https://auth.example.com/token'
+        assert params == {
+            'service': 'registry',
+            'scope': 'repository:ceph/ceph:pull,push',
+        }
+
+    def test_mixed_quoted_and_unquoted_values(self):
+        """Header mixing quoted and unquoted values."""
+        registry = Registry('example.com')
+        header = 'Bearer realm="https://auth.example.com/token",service=registry,scope="repository:ceph/ceph:pull"'
+        realm, params = registry.parse_www_authenticate(header)
+        assert realm == 'https://auth.example.com/token'
+        assert params == {
+            'service': 'registry',
+            'scope': 'repository:ceph/ceph:pull',
+        }
+
+    def test_missing_realm_raises_error(self):
+        """Missing realm must raise ValueError."""
+        registry = Registry('example.com')
+        header = 'Bearer service="registry",scope="repository:ceph/ceph:pull"'
+        with pytest.raises(ValueError, match='No realm found in WWW-Authenticate header'):
+            registry.parse_www_authenticate(header)
+
+    def test_no_bearer_prefix(self):
+        """Header without 'Bearer ' prefix is still parseable."""
+        registry = Registry('example.com')
+        header = 'realm="https://auth.example.com/token",service="registry"'
+        realm, params = registry.parse_www_authenticate(header)
+        assert realm == 'https://auth.example.com/token'
+        assert params == {'service': 'registry'}
+
+    def test_quay_io_header(self):
+        """Quay.io style header."""
+        registry = Registry('quay.io')
+        header = 'Bearer realm="https://quay.io/v2/auth",service="quay.io",scope="repository:ceph/ceph:pull"'
+        realm, params = registry.parse_www_authenticate(header)
+        assert realm == 'https://quay.io/v2/auth'
+        assert params == {
+            'service': 'quay.io',
+            'scope': 'repository:ceph/ceph:pull',
+        }


### PR DESCRIPTION

mgr/cephadm: Fix Parsing WWW-Authenticate header to remove trailing whitespace to avoid 400 error

mgr/cephadm: Observed that IBM Container Registry (cp.icr.io) returns WWW-Authenticate headers with spaces after commas. The current parsing logic does not trim these spaces, causing authentication parameters to be incorrectly interpreted and resulting in malformed OAuth token requests that fail with HTTP 400 errors.

BM Container Registry returns WWW-Authenticate headers with spaces after commas:

Bearer realm="https://cp.icr.io/oauth/token", service="registry", scope="repository:cp/ibm-ceph/ceph-8-rhel9:pull"
The current implementation splits by comma but doesn't strip whitespace, resulting in parameter keys with leading spaces ( service, scope). This creates malformed OAuth URLs that fail with HTTP 400.

Fixes: https://tracker.ceph.com/issues/77780
Signed-off-by: Swati Thombe <swati.thombe@ibm.com>


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
