### PR TITLE
cmake: use libc allocator for Seastar sanitizer builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -457,6 +457,23 @@ CMAKE_DEPENDENT_OPTION(WITH_CEPH_DEBUG_MUTEX "Use debug ceph::mutex with lockdep
 
 option(WITH_CPUTRACE "Enable Cputrace support via the admin socket" OFF)
 
+set(CEPH_WITH_SEASTAR_SANITIZER OFF)
+if(WITH_CRIMSON)
+  if(DEFINED Seastar_SANITIZE)
+    set(CEPH_SEASTAR_SANITIZE "${Seastar_SANITIZE}")
+  else()
+    set(CEPH_SEASTAR_SANITIZE "DEFAULT")
+  endif()
+  set(CEPH_SEASTAR_SANITIZER_TRUE_VALUES ON yes Yes YES true True TRUE)
+  set(CEPH_SEASTAR_SANITIZER_DEFAULT_VALUES DEFAULT default Default)
+  if("${CEPH_SEASTAR_SANITIZE}" IN_LIST CEPH_SEASTAR_SANITIZER_TRUE_VALUES)
+    set(CEPH_WITH_SEASTAR_SANITIZER ON)
+  elseif("${CEPH_SEASTAR_SANITIZE}" IN_LIST CEPH_SEASTAR_SANITIZER_DEFAULT_VALUES AND
+      CMAKE_BUILD_TYPE MATCHES "^(Debug|Sanitize|Fuzz)$")
+    set(CEPH_WITH_SEASTAR_SANITIZER ON)
+  endif()
+endif()
+
 #if allocator is set on command line make sure it matches below strings
 set(ALLOCATOR "" CACHE STRING
   "specify memory allocator to use. currently tcmalloc, tcmalloc_minimal, \
@@ -474,9 +491,10 @@ if(ALLOCATOR)
   elseif(NOT ALLOCATOR STREQUAL "libc")
     message(FATAL_ERROR "Unsupported allocator selected: ${ALLOCATOR}")
   endif()
-elseif(WITH_ASAN)
-  # Force libc: tcmalloc/jemalloc still export operator new/delete even when the
-  # sanitizer shadows malloc, so sanitizer-allocated memory is freed via tcmalloc and SIGSEGVs.
+elseif(WITH_ASAN OR CEPH_WITH_SEASTAR_SANITIZER)
+  # Force libc: tcmalloc/jemalloc still export operator new/delete even when a
+  # sanitizer shadows malloc. Crimson Debug/Sanitize/Fuzz builds also pick up
+  # ASan from Seastar's default sanitizer policy, even if WITH_ASAN is OFF.
   set(ALLOCATOR "libc")
 else(ALLOCATOR)
   find_package(gperftools 2.6.2)


### PR DESCRIPTION
Ceph's top-level allocator selection already forces ALLOCATOR=libc when WITH_ASAN=ON, but Crimson debug builds can still get ASAN/UBSAN through Seastar_SANITIZE=DEFAULT while WITH_ASAN remains OFF. In that case top-level CMake may still auto-select tcmalloc, making crimson-osd link both libasan/libubsan and libtcmalloc.

That combination reproduces the existing gperftools LSan report from MallocExtension::Initialize even for minimal commands such as crimson-osd --version and crimson-osd --help. This patch extends the allocator selection to also force libc when Crimson is enabled and Seastar sanitizers are active, including the default Debug/Sanitize/Fuzz case. Explicit -DALLOCATOR=... user overrides are preserved.

Verified with a Crimson Debug build: configure reports "allocator selected: libc", crimson-osd still links libasan/libubsan, no longer links libtcmalloc, and both --version and --help exit cleanly without LeakSanitizer reports.

Fixes: https://tracker.ceph.com/issues/77903





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
