### PR TITLE
crimson/osd: skip store flush for empty peering transactions

### DIFF
--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -1093,9 +1093,6 @@ seastar::future<> ShardServices::dispatch_context_transaction(
   LOG_PREFIX(OSDSingletonState::dispatch_context_transaction);
   if (ctx.transaction.empty()) {
     DEBUG("empty transaction");
-    co_await crimson::os::with_store_do_transaction(
-      get_store(store_index),
-      col, ceph::os::Transaction{});
     Context* on_commit(
       ceph::os::Transaction::collect_all_contexts(ctx.transaction));
     if (on_commit) {


### PR DESCRIPTION
dispatch_context_transaction() submits a real empty transaction to AlienStore even when the peering context has no store ops. This goes through the AlienCollection lock and thread pool slot machinery. Under load from broadcast_map_to_pgs (many PGAdvanceMap operations running concurrently with recovery), some of these empty transactions get stuck inside AlienStore's pipeline and never reach BlueStore, causing PGAdvanceMap to hang at complete_rctx indefinitely.

Fix by skipping the store round-trip for empty transactions. The on_commit callbacks are still collected and fired, preserving the fix from b0f5e1086a6 ("crimson/osd/pg: also trigger callbacks for empty peering transactions"). The store flush that commit added was incidental to the callback fix and is unnecessary here: the peering pipeline's exclusive process stage already guarantees that prior peering transactions on the same PG have completed.
