### PR TITLE
mgr/cephadm: add feature-based REDEPLOY logic for SMB services

### DIFF
--- a/src/pybind/mgr/cephadm/services/smb.py
+++ b/src/pybind/mgr/cephadm/services/smb.py
@@ -36,6 +36,8 @@ from .cephadmservice import (
 )
 from ..tlsobject_types import TLSCredentials, EMPTY_TLS_CREDENTIALS
 from ..schedule import DaemonPlacement
+from cephadm import utils
+from dataclasses import replace
 
 if TYPE_CHECKING:
     from ..module import CephadmOrchestrator
@@ -300,7 +302,7 @@ class SMBService(CephService):
 
         logger.debug('smb generate_config: %r', config_blobs)
         self._configure_cluster_meta(smb_spec, daemon_spec)
-        deps = self.get_dependencies(self.mgr, smb_spec)
+        deps = sorted(self.get_dependencies(self.mgr, smb_spec))
         return config_blobs, deps
 
     def _cert_or_uri(self, data: Optional[str]) -> Optional[str]:
@@ -534,7 +536,26 @@ class SMBService(CephService):
         for ccc in smb_spec.ceph_cluster_configs or []:
             value = _hash_ceph_cluster_config(ccc)
             out.append(Dep.META(f'ceph_cluster_config.{ccc.alias}', value))
+        # Add features as a dependency
+        out.append(Dep.FIELD('features', ','.join(sorted(smb_spec.features or []))))
         return out
+
+    def choose_next_action(
+        self,
+        scheduled_action: utils.Action,
+        daemon_type: Optional[str],
+        spec: Optional[ServiceSpec],
+        curr_deps: List[str],
+        last_deps: List[str],
+        daemon: Optional[DaemonDescription] = None,
+    ) -> utils.NextDaemonStep:
+        step = super().choose_next_action(
+            scheduled_action, daemon_type, spec, curr_deps, last_deps)
+        if step.action is utils.Action.RECONFIG:
+            sym_diff = set(curr_deps).symmetric_difference(last_deps)
+            if any(d.startswith(Dep.FIELD('features', '')) for d in sym_diff):
+                return replace(step, action=utils.Action.REDEPLOY)
+        return step
 
 
 Network = Union[ipaddress.IPv4Network, ipaddress.IPv6Network]

--- a/src/pybind/mgr/cephadm/tests/services/test_smb.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_smb.py
@@ -233,5 +233,6 @@ def test_smb_get_dependencies(cephadm_module):
 
     deps = SMBService.get_dependencies(cephadm_module, spec, spec.service_type)
     assert deps == [
-        'smb+meta:ceph_cluster_config.exo=sha256:859b001f76df4d184b858b9c3e323ca8ff85a311414d0405f4484d17aa481ef3'
+        'smb+meta:ceph_cluster_config.exo=sha256:859b001f76df4d184b858b9c3e323ca8ff85a311414d0405f4484d17aa481ef3',
+        'smb+field:features=domain'
     ]


### PR DESCRIPTION
Implement intelligent action selection for SMB daemon updates by tracking feature changes as dependencies. When SMB service features change (e.g., adding cephfs-proxy, remote-control, keybridge), the system now triggers a REDEPLOY instead of RECONFIG, as these changes require container structure modifications.

Fixes: https://tracker.ceph.com/issues/77762


## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

