### PR TITLE
common/crc32c: stop using gp/tp as scratch in RISC-V Zbc CRC32C

### DIFF
--- a/src/common/crc32c_riscv_zbc_asm.h
+++ b/src/common/crc32c_riscv_zbc_asm.h
@@ -41,8 +41,8 @@
 #define BUF0LOW  s11
 
 #define X3K1LOW  ra
-#define X3K2HIGH gp
-#define X2K1LOW  tp
+#define X3K2HIGH a4
+#define X2K1LOW  a2
 #define X2K2HIGH s0
 #define X1K1LOW  s1
 #define X1K2HIGH a0
@@ -65,8 +65,6 @@
         addi sp, sp, -128
         sd a3, 120(sp)
         sd ra, 112(sp)
-        sd gp, 104(sp)
-        sd tp, 96(sp)
         sd s0, 88(sp)
         sd s1, 80(sp)
         sd s2, 72(sp)
@@ -105,6 +103,7 @@
         slli a3, a3, 6
         add a3, BUF, a3
         and LEN, LEN, 0x3f
+        sd LEN, 104(sp)
 
 .align 3
 .Lfold_4_loop:
@@ -194,8 +193,8 @@
         /* pop register values saved on stack */
         ld a3, 120(sp)
         ld ra, 112(sp)
-        ld gp, 104(sp)
-        ld tp, 96(sp)
+        ld LEN, 104(sp)
+        ld MU, .Lmu
         ld s0, 88(sp)
         ld s1, 80(sp)
         ld s2, 72(sp)


### PR DESCRIPTION
`crc32c_zbc`'s fold-by-four loop used `gp` (x3) and `tp` (x4) as scratch
for two folding temporaries. Save/restore around the loop is not enough:
they are ABI-reserved, so a signal delivered mid-loop runs its handler
with a corrupted `tp`, and the first TLS access there faults.

On riscv64 this reliably crashes the crimson/seastore unittests
`unittest-transaction-manager` and `unittest-omap-manager`, where
seastar's stall-detector timer fires often: the process dies with
SIGSEGV in the linker's TLS path with garbage in `gp`/`tp`.

ci: https://github.com/sunyuechi/ceph-ci/actions/runs/28567505118
The reason this wasn't caught before is that podman's default seccomp profile meant the hwprobe path was never exercised.

Fixes: https://tracker.ceph.com/issues/77904

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests