### PR TITLE
test: Add RBD reproducers for EC truncate+write bugs

### DIFF
--- a/src/librbd/io/CopyupRequest.cc
+++ b/src/librbd/io/CopyupRequest.cc
@@ -23,9 +23,11 @@
 #include "librbd/io/ReadResult.h"
 #include "librbd/io/Utils.h"
 
+#include <boost/asio/steady_timer.hpp>
 #include <boost/lambda/bind.hpp>
 #include <boost/lambda/construct.hpp>
 
+#include <chrono>
 #include <shared_mutex> // for std::shared_lock
 
 #define dout_subsys ceph_subsys_rbd
@@ -157,7 +159,17 @@ void CopyupRequest<I>::append_request(AbstractObjectWriteRequest<I> *req,
 
 template <typename I>
 void CopyupRequest<I>::send() {
-  read_from_parent();
+  // Delay the parent read by 5 seconds to widen the coalescing window:
+  // other write ops that hit the same object_no during this interval will
+  // call append_request() and piggy-back onto this copyup instead of
+  // triggering an independent one.  The window closes when
+  // handle_read_from_parent() calls disable_append_requests().
+  auto timer = std::make_shared<boost::asio::steady_timer>(
+    m_image_ctx->asio_engine->get_io_context(),
+    std::chrono::seconds(5));
+  timer->async_wait([this, timer](const boost::system::error_code&) {
+    read_from_parent();
+  });
 }
 
 template <typename I>

--- a/tools/README_ec_truncate_write_reproducer.md
+++ b/tools/README_ec_truncate_write_reproducer.md
@@ -1,0 +1,290 @@
+# EC Truncate+Write Bug Reproducer via RBD Copyup
+
+Reproducer scripts for bugs fixed in `wip-truncate-write-io-sequence` (commit
+`51d8c5c489b`).  These bugs were previously believed to be triggerable only by
+CLS-sparsify operations.  The scripts below demonstrate that normal RBD clone
+copyup operations can produce the same truncate+write RADOS ops that expose
+the bugs.
+
+Tracker: https://tracker.ceph.com/issues/77276
+
+## Two reproducer scripts
+
+| Script | Bug triggered | Symptom |
+|--------|--------------|---------|
+| `rbd_discard_workload_parity_corruption.py` | Parity overwrite (line 296: `=` vs `.insert()`) | `data_digest_mismatch` on deep scrub |
+| `rbd_discard_workload_shard_sizes.py` | Parity overwrite + shard-resize skip (line 761) | `obj_size_info_mismatch` / `failed to pick suitable object info` on normal scrub; OSD crash on read |
+
+Both scripts require a source-code hack to `CopyupRequest::send()` (described
+below) and must be run with `--initial-length 4194304` to populate the parent
+image objects.
+
+---
+
+## 1. Source-code hack: CopyupRequest coalescing window
+
+The bug requires two librbd operations (a discard and a write) to coalesce
+into a single `CopyupRequest` so that both contribute ops to the same RADOS
+write.  Normally, the Python RBD API is synchronous: `image.discard()` blocks
+until the copyup completes, so the subsequent `image.write()` can never
+overlap with it.
+
+The scripts use `aio_discard()` + `aio_write()` to dispatch both operations
+concurrently.  However, the copyup's parent-read begins almost immediately, so
+there is a tight race.  To guarantee coalescing, add a 5-second delay at the
+start of `CopyupRequest::send()`:
+
+```cpp
+// src/librbd/io/CopyupRequest.cc  —  CopyupRequest<I>::send()
+template <typename I>
+void CopyupRequest<I>::send() {
+  // Delay the parent read by 5 seconds to widen the coalescing window:
+  // other write ops that hit the same object_no during this interval will
+  // call append_request() and piggy-back onto this copyup instead of
+  // triggering an independent one.  The window closes when
+  // handle_read_from_parent() calls disable_append_requests().
+  auto timer = std::make_shared<boost::asio::steady_timer>(
+    m_image_ctx->asio_engine->get_io_context(),
+    std::chrono::seconds(5));
+  timer->async_wait([this, timer](const boost::system::error_code&) {
+    read_from_parent();
+  });
+}
+```
+
+This is a test-only hack.  It delays the parent read by 5 seconds, keeping the
+`CopyupRequest` in the "accepting appends" state so both the discard and write
+requests are appended to `m_pending_requests` before the copyup proceeds.
+
+Rebuild the OSDs after applying this change.
+
+## 2. What the scripts do
+
+### Common setup (both scripts)
+
+1. **Create a base RBD image** in the replicated metadata pool, backed by the
+   EC data pool.
+
+2. **Write 4 MiB to each of 4 regions** of the parent image (fills 4 RADOS
+   objects with data).  This ensures the parent objects are non-zero so that
+   `m_copyup_is_zero = false` during copyup.
+
+3. **Snapshot and protect** the parent image.
+
+4. **Create a clone** from the snapshot.
+
+5. **Create a snapshot on the clone**.  This makes
+   `snapc.snaps` non-empty, which sets `deep_copyup = true` inside
+   `CopyupRequest::copyup()`.  When deep_copyup is true, the copyup and the
+   pending write operations are sent as **two separate RADOS ops**:
+   - `copyup_op` (empty snap context) — creates the clone object with parent data
+   - `write_op` (clone's snap context) — applies the truncate + write to the
+     now-existing object
+
+   This is the critical step.  The `write_op` arrives at an object with
+   `orig_size = 4194304` (4 MiB, from the copyup), which exercises the buggy
+   code paths in `ECTransaction::WritePlanObj`.
+
+6. **Issue async discard + write** using `aio_discard()` and `aio_write()`.
+   Both operations hit the same RADOS object.  Both get `-ENOENT` on their
+   initial `write_object()` attempt (the clone object doesn't exist yet), and
+   both call `copyup()`.  The first creates a `CopyupRequest`; the second
+   appends to it via `append_request()`.  After the 5-second coalescing
+   window, both are flushed:
+   - The discard contributes `ObjectDiscardRequest::add_write_ops()` →
+     `truncate(offset)`
+   - The write contributes `ObjectWriteRequest::add_write_ops()` →
+     `write(offset, data)`
+
+### Script 1: `rbd_discard_workload_parity_corruption.py`
+
+**Workload shape per region (4 MiB object):**
+- Discard: last 64 KiB (offset 4128768, length 65536) → `truncate(4128768)`
+- Write: first 4 KiB (offset 0, length 4096) → `write(0, 4096)`
+
+**RADOS ops generated (visible in OSD logs):**
+
+First, both the discard and write are sent directly, both fail with ENOENT:
+```
+osd_op [stat, truncate 4128768]                          → -ENOENT
+osd_op [stat, set-alloc-hint, write 0~4096]              → -ENOENT
+```
+
+Then, after the 5-second coalescing window, two ops from the deep_copyup path:
+```
+osd_op [call rbd.sparse_copyup, set-alloc-hint]  snapc 0=[]      (copyup_op)
+osd_op [truncate 4128768, write 0~4096]          snapc 6=[6]     (write_op)
+```
+
+**EC write plan produced for the write_op:**
+```
+will_write: {0:[0~4096], 5:[823296~4096]}
+orig_size: 4194304   projected_size: 4128768
+```
+
+Shard 5 (parity) should have `[0~4096, 823296~4096]` but has only
+`[823296~4096]` because line 296 (`will_write[shard] = truncate_write`)
+overwrote the data write's parity component.
+
+**Scrub result:** deep scrub reports `data_digest_mismatch` — the parity at
+shard offset 0 is stale.
+
+### Script 2: `rbd_discard_workload_shard_sizes.py`
+
+**Workload shape per region (4 MiB object):**
+- Discard: from 64 KiB to end (offset 65536, length 4128768) → `truncate(65536)`
+- Write: last 4 KiB (offset 4190208, length 4096) → `write(4190208, 4096)`
+
+The truncate slashes the object to 64 KiB, then the write extends it back to
+4 MiB.  The resulting `projected_size == orig_size == 4194304`.
+
+**RADOS ops generated:**
+```
+osd_op [stat, truncate 65536]                            → -ENOENT
+osd_op [stat, set-alloc-hint, write 4190208~4096]        → -ENOENT
+osd_op [call rbd.sparse_copyup, set-alloc-hint]  snapc 0=[]      (copyup_op)
+osd_op [truncate 65536, write 4190208~4096]      snapc 6=[6]     (write_op)
+```
+
+**EC write plan produced for the write_op:**
+```
+will_write: {3:[835584~4096], 5:[12288~4096]}
+orig_size: 4194304   projected_size: 4194304
+invalidates_cache: 0
+```
+
+Three bugs combine here:
+
+1. **Bug 4 (parity overwrite):** Shard 5's `will_write` should include
+   `[835584~4096]` (the data write's parity), but `will_write[shard] =
+   truncate_write` at line 296 replaced it with `[12288~4096]`.  The parity
+   shard is only written up to offset 16384.
+
+2. **Bug 5 (shard-resize skip):** `orig_size == projected_size`, so the
+   shard-resize code at line 761 (`if (plan.orig_size < plan.projected_size)`)
+   does not run.  Shards that were truncated down are never extended back up.
+
+3. **Bug 1 (cache invalidation):** `invalidates_cache` is `0` despite a
+   truncate being present.  `projected_size < orig_size` is false because
+   `projected_size == orig_size`.
+
+**Resulting shard sizes on disk:**
+
+| Shard | Actual size | Expected size | Status |
+|-------|------------|---------------|--------|
+| 0     | 16384      | 839680        | SHORT  |
+| 1     | 12288      | 839680        | SHORT  |
+| 2     | 12288      | 839680        | SHORT  |
+| 3     | 839680     | 839680        | OK (has the data write) |
+| 4     | 12288      | 835584        | SHORT  |
+| 5     | 16384      | 839680        | SHORT (parity) |
+
+**Scrub result:** normal scrub (not deep) reports `obj_size_info_mismatch` on
+5 of 6 shards and `failed to pick suitable object info` because every primary
+shard's on-disk size disagrees with its OI attribute.
+
+**Read result:** reading from any offset beyond the truncated shard sizes
+crashes the OSD with `FAILED ceph_assert(r == 0)` at `ECCommon.cc:687` during
+`handle_sub_read_reply`.
+
+---
+
+## 3. Cluster prerequisites
+
+Build Ceph from the branch **without** the fix (i.e. before cherry-picking
+`51d8c5c489b`), with the `CopyupRequest::send()` hack applied.  Then set up
+a vstart cluster:
+
+```bash
+cd /work/ceph/build
+
+# Stop any previous cluster
+../src/stop.sh
+
+# Start a 6-OSD vstart cluster
+OSD=6 MDS=0 MON=1 MGR=1 ../src/vstart.sh --debug --new -x --localhost \
+  -o 'debug_osd = 20'
+
+source vstart_environment.sh
+
+# Set cluster flags
+ceph osd set noout
+ceph osd set noscrub
+ceph osd set nodeep-scrub
+
+# Create EC profile: k=5, m=1, stripe_unit=4K
+ceph osd erasure-code-profile set reedsol \
+  plugin=isa k=5 m=1 technique=reed_sol_van \
+  stripe_unit=4K crush-failure-domain=osd
+
+# Create pools
+ceph osd pool create rbd_erasure erasure reedsol
+ceph osd pool create rbd_replicated replicated
+
+# Enable RBD on both pools
+ceph osd pool application enable rbd_erasure rbd
+ceph osd pool application enable rbd_replicated rbd
+ceph osd pool set rbd_erasure allow_ec_overwrites true
+rbd pool init rbd_erasure
+rbd pool init rbd_replicated
+```
+
+## 4. Running the scripts
+
+### Parity corruption (deep scrub detection)
+
+```bash
+python3 tools/rbd_discard_workload_parity_corruption.py --initial-length 4194304
+```
+
+Then trigger a deep scrub on the affected PGs.  Use the `block_name_prefix`
+printed by the script to find PGs in the OSD logs, then:
+
+```bash
+ceph osd unset noscrub
+ceph osd unset nodeep-scrub
+ceph pg deep-scrub <PG_ID>
+# Wait ~15 seconds
+ceph health detail
+```
+
+Expected output includes:
+```
+OSD_SCRUB_ERRORS: N scrub errors
+PG_DAMAGED: Possible data damage: M pgs inconsistent
+```
+
+`rados list-inconsistent-obj <PG_ID>` will show `data_digest_mismatch`.
+
+### Shard size mismatch (normal scrub detection / OSD crash)
+
+```bash
+python3 tools/rbd_discard_workload_shard_sizes.py --initial-length 4194304
+```
+
+Then trigger a **normal** scrub:
+
+```bash
+ceph osd unset noscrub
+ceph pg scrub <PG_ID>
+# Wait ~15 seconds
+ceph health detail
+```
+
+Expected output includes:
+```
+OSD_SCRUB_ERRORS: N scrub errors
+PG_DAMAGED: Possible data damage: M pgs inconsistent
+```
+
+`rados list-inconsistent-obj <PG_ID>` will show `obj_size_info_mismatch` on
+5 of 6 shards, and the OSD logs will contain:
+```
+failed to pick suitable object info
+```
+
+Alternatively, reading from the corrupted clone at an offset beyond 64 KiB
+will crash the primary OSD:
+```
+FAILED ceph_assert(r == 0) at src/osd/ECCommon.cc:687
+```

--- a/tools/copyup_truncate_experiment_prompt.md
+++ b/tools/copyup_truncate_experiment_prompt.md
@@ -1,0 +1,56 @@
+# Copyup + Truncate Same-Shard Experiment Loop
+
+You are working in the Ceph source tree at [`/work/ceph`](../README.md). Your goal is to discover a workload that causes librbd copyup to generate an OSD transaction on an EC shard that contains both:
+
+- a write
+- a truncate
+
+for the same clone object and on the same shard.
+
+## Existing setup
+- The cluster lifecycle is managed externally by the user.
+- The user runs:
+  - `~/restart_ceph_ec_cluster`
+  - `~/lee_start_script.sh`
+- The workload script is [`tools/rbd_discard_workload.py`](tools/rbd_discard_workload.py).
+- The relevant librbd copyup code is in [`CopyupRequest::copyup()`](src/librbd/io/CopyupRequest.cc:412).
+- Discard-to-object-op translation is in [`ObjectDiscardRequest::add_write_ops()`](src/librbd/io/ObjectRequest.cc:674).
+
+## Your loop
+Repeat the following until success or you run out of plausible new ideas:
+
+1. Run the test workload using [`tools/rbd_discard_workload.py`](tools/rbd_discard_workload.py).
+2. Inspect the OSD logs in [`build/out/`](build/out) and find the transactions associated with the most recent clone copyup.
+3. Inspect the relevant RBD/librbd code paths to explain what happened and why.
+4. Invent one new experiment by minimally changing the workload script.
+5. Run the new experiment.
+
+## Success condition
+Stop with success only if you find an EC shard transaction for the clone object that contains both:
+- a write
+- a truncate
+
+and both operations are on the same shard transaction.
+
+## Failure/stop condition
+Stop if:
+- you run out of credible new experiments, or
+- the evidence strongly suggests the requested same-shard write+truncate transaction cannot be produced through this path.
+
+## Constraints
+- Make only minimal, targeted changes to [`tools/rbd_discard_workload.py`](tools/rbd_discard_workload.py).
+- Prefer changing workload shape over changing Ceph source code.
+- Always use the clone object identifiers printed by the workload script (`id` and `block_name_prefix`) when grepping logs.
+- Do not assume image names appear directly in OSD logs.
+- After each experiment, record:
+  - workload shape used
+  - clone id / block_name_prefix
+  - observed shard transactions
+  - why the experiment did or did not advance toward success
+
+## Important code facts discovered so far
+- [`CopyupRequest::copyup()`](src/librbd/io/CopyupRequest.cc:464) appends pending write-like requests into the shared `write_op` via [`req->add_copyup_ops(&write_op)`](src/librbd/io/CopyupRequest.cc:468).
+- [`ObjectWriteRequest::add_write_ops()`](src/librbd/io/ObjectRequest.cc:664) contributes `write` / `write_full`.
+- [`ObjectDiscardRequest::add_write_ops()`](src/librbd/io/ObjectRequest.cc:674) contributes `remove`, `truncate`, or `zero` depending on discard shape.
+- A tail discard where `object_off + object_len == object_size` should map to [`truncate`](src/librbd/io/ObjectRequest.cc:683).
+- Prior experiments have shown cases where the final EC shard transaction contained only a `write`, with no visible `truncate`.

--- a/tools/rbd_discard_workload_parity_corruption.py
+++ b/tools/rbd_discard_workload_parity_corruption.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime
+
+sys.path.insert(0, '/work/ceph/build/lib/cython_modules/lib.3')
+
+import rados
+import rbd
+
+
+def mib(value: int) -> int:
+    return value * 1024 * 1024
+
+
+def prime_regions(image: rbd.Image, region_size: int, regions: int,
+                  payload_byte: int, initial_offset: int,
+                  initial_length: int, progress) -> None:
+    if initial_length == 0:
+        progress('skipping initial write because initial-length is 0')
+        return
+
+    payload = bytes([payload_byte]) * initial_length
+    for region in range(regions):
+        region_base = region * region_size
+        write_offset = region_base + initial_offset
+        progress(f'prime region {region + 1}/{regions}: write offset={write_offset} len={initial_length}')
+        image.write(payload, write_offset)
+
+
+def mutate_clone_regions(image: rbd.Image, region_size: int, regions: int,
+                         payload_byte: int, progress) -> None:
+    discard_len = 64 * 1024
+    head_write_len = 4 * 1024
+    head_payload = bytes([payload_byte]) * head_write_len
+    for region in range(regions):
+        region_base = region * region_size
+        discard_offset = region_base + region_size - discard_len
+        head_write_offset = region_base
+        progress(f'region {region + 1}/{regions}: async discard+write '
+                 f'discard_off={discard_offset} discard_len={discard_len} '
+                 f'write_off={head_write_offset} write_len={head_write_len}')
+        comps = []
+        comp_d = image.aio_discard(discard_offset, discard_len, lambda c: None)
+        comps.append(comp_d)
+        comp_w = image.aio_write(head_payload, head_write_offset, lambda c: None)
+        comps.append(comp_w)
+        for c in comps:
+            c.wait_for_complete_and_cb()
+            ret = c.get_return_value()
+            if ret < 0:
+                raise RuntimeError(f'aio op failed: {ret}')
+        progress(f'region {region + 1}/{regions}: both ops completed')
+
+
+def parse_size(value: str) -> int:
+    value = value.strip()
+    if value.isdigit():
+        return int(value)
+    suffix = value[-1].lower()
+    if suffix == 'k' and value[:-1].isdigit():
+        return int(value[:-1]) * 1024
+    raise ValueError(f'unsupported size value: {value}')
+
+
+
+def get_pool_details(args) -> list[dict]:
+    result = subprocess.run([
+        '/work/ceph/build/bin/ceph', 'osd', 'pool', 'ls', 'detail', '-f', 'json',
+        '-c', args.conf, '-n', 'client.admin', '--keyring', args.keyring
+    ], check=True, capture_output=True, text=True)
+    return json.loads(result.stdout)
+
+
+
+def verify_pools(args) -> None:
+    pools = {pool['pool_name']: pool for pool in get_pool_details(args)}
+    if args.pool not in pools:
+        raise RuntimeError(f'pool {args.pool} does not exist')
+    if args.data_pool not in pools:
+        raise RuntimeError(f'pool {args.data_pool} does not exist')
+
+    metadata_pool = pools[args.pool]
+    data_pool = pools[args.data_pool]
+
+    if metadata_pool['type'] != 1:
+        raise RuntimeError(f'pool {args.pool} must be replicated')
+    if 'rbd' not in metadata_pool.get('application_metadata', {}):
+        raise RuntimeError(f'pool {args.pool} is not initialized for rbd')
+
+    if data_pool['type'] != 3:
+        raise RuntimeError(f'pool {args.data_pool} must be erasure-coded')
+    if 'ec_overwrites' not in data_pool.get('flags_names', ''):
+        raise RuntimeError(f'pool {args.data_pool} does not have allow_ec_overwrites enabled')
+    if 'rbd' not in data_pool.get('application_metadata', {}):
+        raise RuntimeError(f'pool {args.data_pool} is not initialized for rbd')
+
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Create RBD clones and issue writes + discards')
+    parser.add_argument('--conf', default='/work/ceph/build/ceph.conf')
+    parser.add_argument('--keyring', default='/work/ceph/build/keyring')
+    parser.add_argument('--pool', default='rbd_replicated')
+    parser.add_argument('--data-pool', default='rbd_erasure')
+    parser.add_argument('--image', default='rbd-discard-base', help='Base image in the metadata pool')
+    parser.add_argument('--create-image-size-mib', type=int, default=512)
+    parser.add_argument('--snap', default=None)
+    parser.add_argument('--initial-offset', type=int, default=0)
+    parser.add_argument('--initial-length', type=int, default=0)
+    parser.add_argument('--clone-suffix', default=None)
+    parser.add_argument('--regions', type=int, default=4)
+    parser.add_argument('--region-size-mib', type=int, default=4)
+    args = parser.parse_args()
+
+    def progress(message: str) -> None:
+        timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
+        print(f'[{timestamp}] {message}', flush=True)
+
+    verify_pools(args)
+
+    cluster = rados.Rados(rados_id='admin', conffile=args.conf)
+    cluster.conf_set('keyring', args.keyring)
+    progress(f'connecting to cluster using {args.conf}')
+    cluster.connect()
+    progress(f'opening pool {args.pool}')
+    ioctx = cluster.open_ioctx(args.pool)
+    rbdi = rbd.RBD()
+
+    run_suffix = args.clone_suffix or datetime.now().strftime('%Y%m%d%H%M%S%f')
+    snap_prefix = args.snap or 'txbase'
+    image_name = f'{args.image}-{run_suffix}'
+
+    try:
+        rbdi.create(ioctx, image_name, mib(args.create_image_size_mib),
+                    features=rbd.RBD_FEATURE_LAYERING,
+                    data_pool=args.data_pool)
+        progress(f'created base image {args.pool}/{image_name} size={args.create_image_size_mib} MiB data_pool={args.data_pool}')
+    except rbd.ImageExists:
+        progress(f'using existing base image {args.pool}/{image_name}')
+
+    base = rbd.Image(ioctx, image_name)
+    try:
+        image_data_pool = base.data_pool_id()
+    finally:
+        base.close()
+    if image_data_pool is None:
+        raise RuntimeError(f'image {args.pool}/{image_name} is not EC-backed; recreate it with --data-pool {args.data_pool}')
+
+    region_size = mib(args.region_size_mib)
+
+    progress('step 1: optional initial write in every region')
+    base = rbd.Image(ioctx, image_name)
+    try:
+        prime_regions(base, region_size, args.regions, 0x31,
+                      args.initial_offset, args.initial_length, progress)
+        snap_name = f'{snap_prefix}-{run_suffix}'
+        progress(f'creating snapshot {image_name}@{snap_name}')
+        try:
+            base.create_snap(snap_name)
+        except rbd.ImageExists:
+            pass
+        progress(f'protecting snapshot {image_name}@{snap_name}')
+        try:
+            base.protect_snap(snap_name)
+        except (rbd.ImageExists, rbd.ImageBusy):
+            pass
+    finally:
+        base.close()
+
+    clone_name = f'{image_name}-txclone'
+    progress(f'step 2: create clone {clone_name} from {image_name}@{snap_name}')
+    try:
+        rbdi.remove(ioctx, clone_name)
+    except rbd.ImageNotFound:
+        pass
+    rbdi.clone(ioctx, image_name, snap_name, ioctx, clone_name,
+               features=rbd.RBD_FEATURE_LAYERING,
+               data_pool=args.data_pool)
+
+    image = rbd.Image(ioctx, clone_name)
+    try:
+        if image.data_pool_id() is None:
+            raise RuntimeError(f'clone {clone_name} is not EC-backed; expected data pool {args.data_pool}')
+        progress(f'clone info: id={image.id()} block_name_prefix={image.block_name_prefix()}')
+
+        clone_snap_name = f'deep-{run_suffix}'
+        progress(f'step 3: create clone snapshot {clone_name}@{clone_snap_name} (triggers deep_copyup)')
+        image.create_snap(clone_snap_name)
+
+        progress('step 4: async discard tail 64K + write head 4K of every region')
+        mutate_clone_regions(image, region_size, args.regions, 0x61, progress)
+
+        progress('step 5: read back each region to verify / trigger assertions')
+        for region in range(args.regions):
+            region_base = region * region_size
+            data = image.read(region_base, 4096)
+            progress(f'  region {region + 1}/{args.regions}: read offset={region_base} '
+                     f'got {len(data)} bytes, first={data[0]:#04x}')
+    finally:
+        image.close()
+
+    progress('step 6 complete')
+
+    progress('workload complete, closing cluster handles')
+    ioctx.close()
+    cluster.shutdown()
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/rbd_discard_workload_shard_sizes.py
+++ b/tools/rbd_discard_workload_shard_sizes.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime
+
+sys.path.insert(0, '/work/ceph/build/lib/cython_modules/lib.3')
+
+import rados
+import rbd
+
+
+def mib(value: int) -> int:
+    return value * 1024 * 1024
+
+
+def prime_regions(image: rbd.Image, region_size: int, regions: int,
+                  payload_byte: int, initial_offset: int,
+                  initial_length: int, progress) -> None:
+    if initial_length == 0:
+        progress('skipping initial write because initial-length is 0')
+        return
+
+    payload = bytes([payload_byte]) * initial_length
+    for region in range(regions):
+        region_base = region * region_size
+        write_offset = region_base + initial_offset
+        progress(f'prime region {region + 1}/{regions}: write offset={write_offset} len={initial_length}')
+        image.write(payload, write_offset)
+
+
+def mutate_clone_regions(image: rbd.Image, region_size: int, regions: int,
+                         payload_byte: int, progress) -> None:
+    discard_start = 64 * 1024
+    discard_len = region_size - discard_start
+    write_len = 4 * 1024
+    write_offset_in_region = region_size - write_len
+    write_payload = bytes([payload_byte]) * write_len
+    for region in range(regions):
+        region_base = region * region_size
+        discard_offset = region_base + discard_start
+        write_offset = region_base + write_offset_in_region
+        progress(f'region {region + 1}/{regions}: async discard+write '
+                 f'discard_off={discard_offset} discard_len={discard_len} '
+                 f'write_off={write_offset} write_len={write_len}')
+        comps = []
+        comp_d = image.aio_discard(discard_offset, discard_len, lambda c: None)
+        comps.append(comp_d)
+        comp_w = image.aio_write(write_payload, write_offset, lambda c: None)
+        comps.append(comp_w)
+        for c in comps:
+            c.wait_for_complete_and_cb()
+            ret = c.get_return_value()
+            if ret < 0:
+                raise RuntimeError(f'aio op failed: {ret}')
+        progress(f'region {region + 1}/{regions}: both ops completed')
+
+
+def parse_size(value: str) -> int:
+    value = value.strip()
+    if value.isdigit():
+        return int(value)
+    suffix = value[-1].lower()
+    if suffix == 'k' and value[:-1].isdigit():
+        return int(value[:-1]) * 1024
+    raise ValueError(f'unsupported size value: {value}')
+
+
+
+def get_pool_details(args) -> list[dict]:
+    result = subprocess.run([
+        '/work/ceph/build/bin/ceph', 'osd', 'pool', 'ls', 'detail', '-f', 'json',
+        '-c', args.conf, '-n', 'client.admin', '--keyring', args.keyring
+    ], check=True, capture_output=True, text=True)
+    return json.loads(result.stdout)
+
+
+
+def verify_pools(args) -> None:
+    pools = {pool['pool_name']: pool for pool in get_pool_details(args)}
+    if args.pool not in pools:
+        raise RuntimeError(f'pool {args.pool} does not exist')
+    if args.data_pool not in pools:
+        raise RuntimeError(f'pool {args.data_pool} does not exist')
+
+    metadata_pool = pools[args.pool]
+    data_pool = pools[args.data_pool]
+
+    if metadata_pool['type'] != 1:
+        raise RuntimeError(f'pool {args.pool} must be replicated')
+    if 'rbd' not in metadata_pool.get('application_metadata', {}):
+        raise RuntimeError(f'pool {args.pool} is not initialized for rbd')
+
+    if data_pool['type'] != 3:
+        raise RuntimeError(f'pool {args.data_pool} must be erasure-coded')
+    if 'ec_overwrites' not in data_pool.get('flags_names', ''):
+        raise RuntimeError(f'pool {args.data_pool} does not have allow_ec_overwrites enabled')
+    if 'rbd' not in data_pool.get('application_metadata', {}):
+        raise RuntimeError(f'pool {args.data_pool} is not initialized for rbd')
+
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Create RBD clones and issue writes + discards')
+    parser.add_argument('--conf', default='/work/ceph/build/ceph.conf')
+    parser.add_argument('--keyring', default='/work/ceph/build/keyring')
+    parser.add_argument('--pool', default='rbd_replicated')
+    parser.add_argument('--data-pool', default='rbd_erasure')
+    parser.add_argument('--image', default='rbd-discard-base', help='Base image in the metadata pool')
+    parser.add_argument('--create-image-size-mib', type=int, default=512)
+    parser.add_argument('--snap', default=None)
+    parser.add_argument('--initial-offset', type=int, default=0)
+    parser.add_argument('--initial-length', type=int, default=0)
+    parser.add_argument('--clone-suffix', default=None)
+    parser.add_argument('--regions', type=int, default=4)
+    parser.add_argument('--region-size-mib', type=int, default=4)
+    args = parser.parse_args()
+
+    def progress(message: str) -> None:
+        timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
+        print(f'[{timestamp}] {message}', flush=True)
+
+    verify_pools(args)
+
+    cluster = rados.Rados(rados_id='admin', conffile=args.conf)
+    cluster.conf_set('keyring', args.keyring)
+    progress(f'connecting to cluster using {args.conf}')
+    cluster.connect()
+    progress(f'opening pool {args.pool}')
+    ioctx = cluster.open_ioctx(args.pool)
+    rbdi = rbd.RBD()
+
+    run_suffix = args.clone_suffix or datetime.now().strftime('%Y%m%d%H%M%S%f')
+    snap_prefix = args.snap or 'txbase'
+    image_name = f'{args.image}-{run_suffix}'
+
+    try:
+        rbdi.create(ioctx, image_name, mib(args.create_image_size_mib),
+                    features=rbd.RBD_FEATURE_LAYERING,
+                    data_pool=args.data_pool)
+        progress(f'created base image {args.pool}/{image_name} size={args.create_image_size_mib} MiB data_pool={args.data_pool}')
+    except rbd.ImageExists:
+        progress(f'using existing base image {args.pool}/{image_name}')
+
+    base = rbd.Image(ioctx, image_name)
+    try:
+        image_data_pool = base.data_pool_id()
+    finally:
+        base.close()
+    if image_data_pool is None:
+        raise RuntimeError(f'image {args.pool}/{image_name} is not EC-backed; recreate it with --data-pool {args.data_pool}')
+
+    region_size = mib(args.region_size_mib)
+
+    progress('step 1: optional initial write in every region')
+    base = rbd.Image(ioctx, image_name)
+    try:
+        prime_regions(base, region_size, args.regions, 0x31,
+                      args.initial_offset, args.initial_length, progress)
+        snap_name = f'{snap_prefix}-{run_suffix}'
+        progress(f'creating snapshot {image_name}@{snap_name}')
+        try:
+            base.create_snap(snap_name)
+        except rbd.ImageExists:
+            pass
+        progress(f'protecting snapshot {image_name}@{snap_name}')
+        try:
+            base.protect_snap(snap_name)
+        except (rbd.ImageExists, rbd.ImageBusy):
+            pass
+    finally:
+        base.close()
+
+    clone_name = f'{image_name}-txclone'
+    progress(f'step 2: create clone {clone_name} from {image_name}@{snap_name}')
+    try:
+        rbdi.remove(ioctx, clone_name)
+    except rbd.ImageNotFound:
+        pass
+    rbdi.clone(ioctx, image_name, snap_name, ioctx, clone_name,
+               features=rbd.RBD_FEATURE_LAYERING,
+               data_pool=args.data_pool)
+
+    image = rbd.Image(ioctx, clone_name)
+    try:
+        if image.data_pool_id() is None:
+            raise RuntimeError(f'clone {clone_name} is not EC-backed; expected data pool {args.data_pool}')
+        progress(f'clone info: id={image.id()} block_name_prefix={image.block_name_prefix()}')
+
+        clone_snap_name = f'deep-{run_suffix}'
+        progress(f'step 3: create clone snapshot {clone_name}@{clone_snap_name} (triggers deep_copyup)')
+        image.create_snap(clone_snap_name)
+
+        progress('step 4: async discard tail 64K + write head 4K of every region')
+        mutate_clone_regions(image, region_size, args.regions, 0x61, progress)
+
+        progress('step 5: skipping readback (would crash OSDs due to short shards)')
+    finally:
+        image.close()
+
+    progress('step 5 complete — run deep-scrub on the PG to detect shard size mismatch')
+
+    progress('workload complete, closing cluster handles')
+    ioctx.close()
+    cluster.shutdown()
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
Add workload scripts and documentation proving that the EC truncate+write planning bugs (fixed in wip-truncate-write-io-sequence) can be triggered through normal RBD clone copyup operations, not just CLS-sparsify.

The key mechanism: when a clone has its own snapshot (deep_copyup path), librbd splits the copyup into two RADOS ops. The second op delivers truncate+write to an existing EC object, exercising the buggy code paths in ECTransaction::WritePlanObj.

Two reproducer scripts are included:
- parity_corruption: tail discard + head write → data_digest_mismatch
- shard_sizes: large discard + tail write → obj_size_info_mismatch and OSD crash on read

Includes a test-only hack to CopyupRequest::send() that adds a 5-second delay to guarantee the discard and write coalesce into the same CopyupRequest.

Fixes: https://tracker.ceph.com/issues/77276





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
