### PR TITLE
mgr/smb: Allow pool creation for empty RGW buckets

### DIFF
--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1737,6 +1737,11 @@ class RgwService(CephService):
         return daemon_spec
 
     def get_keyring(self, rgw_id: str) -> str:
+        """
+        SMB and NFS services embed librgw. If the RGW service capabilities are
+        updated, verify whether the same changes are required for these
+        services as well.
+        """
         keyring = self.get_keyring_with_caps(self.get_auth_entity(rgw_id),
                                              ['mon', 'allow *',
                                               'mgr', 'allow rw',

--- a/src/pybind/mgr/smb/rgw_auth.py
+++ b/src/pybind/mgr/smb/rgw_auth.py
@@ -33,7 +33,7 @@ class RGWAuthorizer:
         if not caps:
             caps = [
                 'mon',
-                'allow r',
+                'allow *',  # Required for pool creation on first write to empty RGW buckets
                 'osd',
                 'allow rwx tag rgw *=*',
             ]


### PR DESCRIPTION
When an RGW bucket is empty, SMB clients cannot create directories, files, or upload data because the default.rgw.buckets.data pool does not yet exist. The previous CephX capabilities ('mon allow r') did not permit pool creation during the first write operation.

The fix changes the mon capability from 'allow r' to 'allow *' to enable pool creation on the first write to an empty RGW bucket. Once the pool exists, subsequent operations succeed normally.

Fixes: https://tracker.ceph.com/issues/77764


UT Logs :

After this change could able to upload files, and create dir, verified default.rgw.buckets.data created successfully.

```
[share1]
path = /
vfs objects = ceph_rgw
ceph_rgw:bucket = bkt1
ceph_rgw:user_id = test1
ceph_rgw:access_key = ABC123
ceph_rgw:secret_access_key = ABC123
ceph_rgw:debug = off
read only = No
browseable = Yes
kernel share modes = no
smbd profiling share = yes

[root@mycephfs14 ~]# rados lspools
.mgr
cephfs.mycephfs1.meta
cephfs.mycephfs1.data
cephfs.mycephfs2.meta
cephfs.mycephfs2.data
.smb
.rgw.root
default.rgw.log
default.rgw.control
default.rgw.meta
default.rgw.buckets.index
default.rgw.buckets.data
```


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests