### PR TITLE
src/test/librados: enable FastEC tests with crimson

### DIFF
--- a/src/test/librados/TestCase.cc
+++ b/src/test/librados/TestCase.cc
@@ -174,7 +174,6 @@ rados_t RadosTestEC::s_cluster = NULL;
 
 void RadosTestEC::SetUpTestCase()
 {
-  SKIP_IF_CRIMSON();
   auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name()); 
   pool_name_default = get_temp_pool_name(pool_prefix);
   pool_name_fast = get_temp_pool_name(pool_prefix);
@@ -187,7 +186,6 @@ void RadosTestEC::SetUpTestCase()
 
 void RadosTestEC::TearDownTestCase()
 {
-  SKIP_IF_CRIMSON();
   ASSERT_EQ(0, destroy_ec_pool(pool_name_default, &s_cluster));
   ASSERT_EQ(0, destroy_ec_pool(pool_name_fast, &s_cluster));
   ASSERT_EQ(0, destroy_ec_pool(pool_name_fast_split, &s_cluster));
@@ -196,8 +194,6 @@ void RadosTestEC::TearDownTestCase()
 
 void RadosTestEC::SetUp()
 {
-  SKIP_IF_CRIMSON();
-
   const auto& params = GetParam();
   bool fast_ec = std::get<0>(params);
   bool split_ops = std::get<1>(params);
@@ -223,7 +219,6 @@ void RadosTestEC::SetUp()
 
 void RadosTestEC::TearDown()
 {
-  SKIP_IF_CRIMSON();
   if (cleanup) {
     cleanup_default_namespace(ioctx);
     cleanup_namespace(ioctx, nspace);

--- a/src/test/librados/aio.cc
+++ b/src/test/librados/aio.cc
@@ -1103,7 +1103,6 @@ public:
 class LibRadosAioEC : public ::testing::TestWithParam<std::tuple<bool, bool>> {};
 
 TEST_P(LibRadosAioEC, SimpleWrite) {
-  SKIP_IF_CRIMSON();
   AioTestDataEC test_data;
   rados_completion_t my_completion;
   const auto& params = GetParam();
@@ -1138,7 +1137,6 @@ TEST_P(LibRadosAioEC, SimpleWrite) {
 }
 
 TEST_P(LibRadosAioEC, WaitForComplete) {
-  SKIP_IF_CRIMSON();
   AioTestDataEC test_data;
   rados_completion_t my_completion;
   const auto& params = GetParam();
@@ -1158,7 +1156,6 @@ TEST_P(LibRadosAioEC, WaitForComplete) {
 }
 
 TEST_P(LibRadosAioEC, RoundTrip) {
-  SKIP_IF_CRIMSON();
   AioTestDataEC test_data;
   rados_completion_t my_completion;
   const auto& params = GetParam();
@@ -1194,7 +1191,6 @@ TEST_P(LibRadosAioEC, RoundTrip) {
 }
 
 TEST_P(LibRadosAioEC, RoundTrip2) {
-  SKIP_IF_CRIMSON();
   AioTestDataEC test_data;
   rados_completion_t my_completion;
   const auto& params = GetParam();
@@ -1304,7 +1300,6 @@ TEST_P(LibRadosAioEC, RoundTripAppend) {
 }
 
 TEST_P(LibRadosAioEC, IsComplete) {
-  SKIP_IF_CRIMSON();
   AioTestDataEC test_data;
   rados_completion_t my_completion;
   const auto& params = GetParam();
@@ -1347,7 +1342,6 @@ TEST_P(LibRadosAioEC, IsComplete) {
 }
 
 TEST_P(LibRadosAioEC, IsSafe) {
-  SKIP_IF_CRIMSON();
   AioTestDataEC test_data;
   rados_completion_t my_completion;
   const auto& params = GetParam();
@@ -1390,7 +1384,6 @@ TEST_P(LibRadosAioEC, IsSafe) {
 }
 
 TEST_P(LibRadosAioEC, ReturnValue) {
-  SKIP_IF_CRIMSON();
   AioTestDataEC test_data;
   rados_completion_t my_completion;
   const auto& params = GetParam();
@@ -1412,7 +1405,6 @@ TEST_P(LibRadosAioEC, ReturnValue) {
 }
 
 TEST_P(LibRadosAioEC, Flush) {
-  SKIP_IF_CRIMSON();
   AioTestDataEC test_data;
   rados_completion_t my_completion;
   const auto& params = GetParam();
@@ -1445,7 +1437,6 @@ TEST_P(LibRadosAioEC, Flush) {
 }
 
 TEST_P(LibRadosAioEC, FlushAsync) {
-  SKIP_IF_CRIMSON();
   AioTestDataEC test_data;
   rados_completion_t my_completion;
   const auto& params = GetParam();
@@ -1487,7 +1478,6 @@ TEST_P(LibRadosAioEC, FlushAsync) {
 }
 
 TEST_P(LibRadosAioEC, RoundTripWriteFull) {
-  SKIP_IF_CRIMSON();
   AioTestDataEC test_data;
   rados_completion_t my_completion, my_completion2, my_completion3;
   const auto& params = GetParam();
@@ -1534,7 +1524,6 @@ TEST_P(LibRadosAioEC, RoundTripWriteFull) {
 }
 
 TEST_P(LibRadosAioEC, SimpleStat) {
-  SKIP_IF_CRIMSON();
   AioTestDataEC test_data;
   rados_completion_t my_completion;
   const auto& params = GetParam();
@@ -1571,7 +1560,6 @@ TEST_P(LibRadosAioEC, SimpleStat) {
 
 
 TEST_P(LibRadosAioEC, SimpleStatNS) {
-  SKIP_IF_CRIMSON();
   AioTestDataEC test_data;
   rados_completion_t my_completion;
   const auto& params = GetParam();
@@ -1635,7 +1623,6 @@ TEST_P(LibRadosAioEC, SimpleStatNS) {
 }
 
 TEST_P(LibRadosAioEC, StatRemove) {
-  SKIP_IF_CRIMSON();
   AioTestDataEC test_data;
   rados_completion_t my_completion;
   const auto& params = GetParam();
@@ -1694,7 +1681,6 @@ TEST_P(LibRadosAioEC, StatRemove) {
 }
 
 TEST_P(LibRadosAioEC, ExecuteClass) {
-  SKIP_IF_CRIMSON();
   AioTestDataEC test_data;
   rados_completion_t my_completion;
   const auto& params = GetParam();

--- a/src/test/librados/io.cc
+++ b/src/test/librados/io.cc
@@ -270,7 +270,6 @@ TEST_P(LibRadosIo, XattrIter) {
 }
 
 TEST_P(LibRadosIoEC, SimpleWrite) {
-  SKIP_IF_CRIMSON();
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_write(ioctx, "foo", buf, sizeof(buf), 0));
@@ -279,7 +278,6 @@ TEST_P(LibRadosIoEC, SimpleWrite) {
 }
 
 TEST_P(LibRadosIoEC, RoundTrip) {
-  SKIP_IF_CRIMSON();
   char buf[128];
   char buf2[128];
   memset(buf, 0xcc, sizeof(buf));
@@ -295,7 +293,6 @@ TEST_P(LibRadosIoEC, RoundTrip) {
 }
 
 TEST_P(LibRadosIoEC, OverlappingWriteRoundTrip) {
-  SKIP_IF_CRIMSON();
   int bsize = alignment;
   int dbsize = bsize * 2;
   char *buf = (char *)new char[dbsize];
@@ -320,7 +317,6 @@ TEST_P(LibRadosIoEC, OverlappingWriteRoundTrip) {
 }
 
 TEST_P(LibRadosIoEC, WriteFullRoundTrip) {
-  SKIP_IF_CRIMSON();
   char buf[128];
   char buf2[64];
   char buf3[128];
@@ -334,7 +330,6 @@ TEST_P(LibRadosIoEC, WriteFullRoundTrip) {
 }
 
 TEST_P(LibRadosIoEC, AppendRoundTrip) {
-  SKIP_IF_CRIMSON();
   char *buf = (char *)new char[alignment];
   char *buf2 = (char *)new char[alignment];
   char *buf3 = (char *)new char[alignment *2];
@@ -363,7 +358,6 @@ TEST_P(LibRadosIoEC, AppendRoundTrip) {
 }
 
 TEST_P(LibRadosIoEC, TruncTest) {
-  SKIP_IF_CRIMSON();
   char buf[128];
   char buf2[sizeof(buf)];
   memset(buf, 0xaa, sizeof(buf));
@@ -379,7 +373,6 @@ TEST_P(LibRadosIoEC, TruncTest) {
 }
 
 TEST_P(LibRadosIoEC, RemoveTest) {
-  SKIP_IF_CRIMSON();
   char buf[128];
   char buf2[sizeof(buf)];
   memset(buf, 0xaa, sizeof(buf));
@@ -390,7 +383,6 @@ TEST_P(LibRadosIoEC, RemoveTest) {
 }
 
 TEST_P(LibRadosIoEC, XattrsRoundTrip) {
-  SKIP_IF_CRIMSON();
   char buf[128];
   char attr1[] = "attr1";
   char attr1_buf[] = "foo bar baz";
@@ -404,7 +396,6 @@ TEST_P(LibRadosIoEC, XattrsRoundTrip) {
 }
 
 TEST_P(LibRadosIoEC, RmXattr) {
-  SKIP_IF_CRIMSON();
   char buf[128];
   char attr1[] = "attr1";
   char attr1_buf[] = "foo bar baz";
@@ -428,7 +419,6 @@ TEST_P(LibRadosIoEC, RmXattr) {
 }
 
 TEST_P(LibRadosIoEC, XattrIter) {
-  SKIP_IF_CRIMSON();
   char buf[128];
   char attr1[] = "attr1";
   char attr1_buf[] = "foo bar baz";


### PR DESCRIPTION
## Description
This commit enables the first batch of fast EC tests such that they are run for crimson OSDs. This is done towards an effort to establish reliable fast EC support in crimson.

These tests where previously enabled as part of another PR but ultimately were not merged due to insufficient confidence.


## Testing 

1. Run cmake with `-DWITH_TESTS=ON` flag set. The full command for reference: 
```
./do_cmake.sh -DWITH_CRIMSON=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_FLAGS="-fno-omit-frame-pointer" -DWITH_TESTS=ON -DWITH_MGR_DASHBOARD_FRONTEND=OFF
```
2. Build crimson and start a crimson cluster. 
3. Run the tests with `CRIMSON_COMPAT=1 ./bin/ceph_test_rados_api_aio --gtest_filter='*LibRadosAioEC*'`

The result: 

```
[==========] 64 tests from 1 test suite ran. (365515 ms total)
[  PASSED  ] 56 tests.
[  SKIPPED ] 8 tests, listed below:
[  SKIPPED ] LibRadosAioECParamCombination/LibRadosAioEC.RoundTripAppend/0
[  SKIPPED ] LibRadosAioECParamCombination/LibRadosAioEC.RoundTripAppend/1
[  SKIPPED ] LibRadosAioECParamCombination/LibRadosAioEC.RoundTripAppend/2
[  SKIPPED ] LibRadosAioECParamCombination/LibRadosAioEC.RoundTripAppend/3
[  SKIPPED ] LibRadosAioECParamCombination/LibRadosAioEC.MultiWrite/0
[  SKIPPED ] LibRadosAioECParamCombination/LibRadosAioEC.MultiWrite/1
[  SKIPPED ] LibRadosAioECParamCombination/LibRadosAioEC.MultiWrite/2
[  SKIPPED ] LibRadosAioECParamCombination/LibRadosAioEC.MultiWrite/3
```

## Current status
Out of the 64 tests that were initially blocked before this PR, 54 have been enabled. The rest of the 8 tests require some fixes on crimson fast EC code. They will be enabled in follow up PRs to address the issues. 

Towards: https://tracker.ceph.com/issues/77910





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [X] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
