### PR TITLE
cephadm: bind node-exporter and ceph-exporter to configured networks

### DIFF
--- a/doc/cephadm/services/monitoring.rst
+++ b/doc/cephadm/services/monitoring.rst
@@ -184,6 +184,39 @@ example spec file:
       port: 4200
       protocol: http
 
+Restricting the bind address
+............................
+
+For ``prometheus``, ``grafana``, ``alertmanager``, ``node-exporter`` and
+``ceph-exporter`` you can additionally restrict the address the daemon binds to
+so that it only listens on an IP belonging to one of the ``networks`` listed in
+the spec. Set ``only_bind_port_on_networks: true`` in the ``spec`` section.
+cephadm then resolves a per-host IP inside the configured network (via the
+same mechanism used to pick a daemon's address) and binds the daemon's
+listening socket to that IP only, instead of all interfaces.
+
+This is useful when a host has both a non-routable daemon network (for example
+an IPv6 ULA) and a publicly-routable interface, and you do not want the
+exporters reachable on the routable interface.
+
+example spec files:
+
+.. code-block:: yaml
+
+    service_type: node-exporter
+    networks:
+    - fd70:c853:8a8d::/64
+    spec:
+      only_bind_port_on_networks: true
+
+.. code-block:: yaml
+
+    service_type: ceph-exporter
+    networks:
+    - fd70:c853:8a8d::/64
+    spec:
+      only_bind_port_on_networks: true
+
 .. _cephadm_monitoring-images:
 
 .. _cephadm_default_images:

--- a/src/cephadm/cephadmlib/daemons/monitoring.py
+++ b/src/cephadm/cephadmlib/daemons/monitoring.py
@@ -324,6 +324,9 @@ class Monitoring(ContainerDaemonForm):
                 r += [f'--web.config.file={config["web_config"]}']
             except KeyError:
                 pass
+            ip_to_bind_to = config.get('ip_to_bind_to', '')
+            if ip_to_bind_to:
+                r += [f'--web.listen-address={str(EndPoint(ip_to_bind_to, port))}']
             r += [
                 '--path.procfs=/host/proc',
                 '--path.sysfs=/host/sys',

--- a/src/cephadm/tests/test_deploy.py
+++ b/src/cephadm/tests/test_deploy.py
@@ -517,6 +517,62 @@ def test_deploy_ceph_exporter_container(cephadm_fs, funkypatch):
         assert f.read() == 'YYYYYY'
 
 
+def test_deploy_ceph_exporter_container_binds_to_network(cephadm_fs, funkypatch):
+    _common_patches(funkypatch)
+    _get_ip_addresses = funkypatch.patch('cephadmlib.net_utils.get_ip_addresses')
+    _get_ip_addresses.return_value = (['10.10.10.10'], [])
+    _make_run_dir = funkypatch.patch('cephadmlib.file_utils.make_run_dir')
+    fsid = 'b01dbeef-701d-9abe-0000-e1e5a47004a7'
+    with with_cephadm_ctx([]) as ctx:
+        ctx.container_engine = mock_podman()
+        ctx.fsid = fsid
+        ctx.name = 'ceph-exporter.zaq'
+        ctx.image = 'quay.io/ceph/ceph:latest'
+        ctx.reconfig = False
+        ctx.allow_ptrace = False
+        ctx.osd_fsid = '00000000-0000-0000-0000-000000000000'
+        ctx.config_blobs = {
+            'config': 'XXXXXXX',
+            'keyring': 'YYYYYY',
+            'addrs': '1.2.3.4',
+        }
+
+        vrc = pathlib.Path('/var/run/ceph')
+        (vrc / fsid).mkdir(parents=True)
+
+        _cephadm._common_deploy(ctx)
+
+    basedir = pathlib.Path(f'/var/lib/ceph/{fsid}/ceph-exporter.zaq')
+    with open(basedir / 'unit.run') as f:
+        runfile_lines = f.read().splitlines()
+    # the configured 'addrs' restricts the ceph-exporter bind address
+    assert '--addrs=1.2.3.4' in runfile_lines[-1]
+    assert '--addrs=0.0.0.0' not in runfile_lines[-1]
+
+
+def test_deploy_node_exporter_container_binds_to_network(cephadm_fs, funkypatch):
+    _common_patches(funkypatch)
+    _get_ip_addresses = funkypatch.patch('cephadmlib.net_utils.get_ip_addresses')
+    _get_ip_addresses.return_value = (['10.10.10.10'], [])
+    fsid = 'b01dbeef-701d-9abe-0000-e1e5a47004a7'
+    with with_cephadm_ctx([]) as ctx:
+        ctx.container_engine = mock_podman()
+        ctx.fsid = fsid
+        ctx.name = 'node-exporter.fire'
+        ctx.image = 'quay.io/titans/node-exporter:latest'
+        ctx.reconfig = False
+        ctx.config_blobs = {
+            'ip_to_bind_to': '1.2.3.4',
+        }
+        _cephadm._common_deploy(ctx)
+
+    basedir = pathlib.Path(f'/var/lib/ceph/{fsid}/node-exporter.fire')
+    with open(basedir / 'unit.run') as f:
+        runfile_lines = f.read().splitlines()
+    # the resolved network IP restricts the node-exporter listen address
+    assert '--web.listen-address=1.2.3.4:9100' in runfile_lines[-1]
+
+
 def test_deploy_and_rm_iscsi(cephadm_fs, funkypatch):
     # Test that the deploy and remove paths for iscsi (which has sidecar container)
     # create and remove the correct unit files.

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1946,6 +1946,17 @@ class CephExporterService(CephService):
             exporter_config.update({'prio-limit': f'{spec.prio_limit}'})
         if spec.stats_period:
             exporter_config.update({'stats-period': f'{spec.stats_period}'})
+        if spec.only_bind_port_on_networks and spec.networks:
+            assert daemon_spec.host is not None
+            ip_to_bind_to = self.mgr.get_first_matching_network_ip(daemon_spec.host, spec) or ''
+            if ip_to_bind_to:
+                exporter_config.update({'addrs': ip_to_bind_to})
+            else:
+                logger.warning(
+                    f'Failed to find ip in {spec.networks} for host {daemon_spec.host}. '
+                    f'{daemon_spec.name()} will bind to all IPs')
+        elif spec.addrs:
+            exporter_config.update({'addrs': spec.addrs})
 
         security_enabled, _, _ = self.mgr._get_security_config()
         if security_enabled:

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -12,7 +12,7 @@ from cephadm.tlsobject_types import TLSCredentials
 
 from orchestrator import DaemonDescription
 from ceph.deployment.service_spec import AlertManagerSpec, GrafanaSpec, ServiceSpec, \
-    SNMPGatewaySpec, PrometheusSpec, MgmtGatewaySpec
+    SNMPGatewaySpec, PrometheusSpec, MgmtGatewaySpec, MonitoringSpec
 from cephadm.services.cephadmservice import (
     CephadmDaemonDeploySpec,
     CephadmService,
@@ -858,6 +858,20 @@ class NodeExporterService(CephadmService):
         deps += [d.name() for d in self.mgr.cache.get_daemons_by_service('mgmt-gateway')]
         deps += [f'secure_monitoring_stack:{self.mgr.secure_monitoring_stack}']
         security_enabled, mgmt_gw_enabled, _ = self.mgr._get_security_config()
+
+        spec = cast(MonitoringSpec, self.mgr.spec_store[daemon_spec.service_name].spec)
+        port = daemon_spec.ports[0] if daemon_spec.ports else self.DEFAULT_SERVICE_PORT
+        ip_to_bind_to = ''
+        if spec.only_bind_port_on_networks and spec.networks:
+            assert daemon_spec.host is not None
+            ip_to_bind_to = self.mgr.get_first_matching_network_ip(daemon_spec.host, spec) or ''
+            if ip_to_bind_to:
+                daemon_spec.port_ips = {str(port): ip_to_bind_to}
+            else:
+                logger.warning(
+                    f'Failed to find ip in {spec.networks} for host {daemon_spec.host}. '
+                    f'{daemon_spec.name()} will bind to all IPs')
+
         if security_enabled:
             tls_pair = self.get_certificates(daemon_spec)
             r = {
@@ -872,6 +886,9 @@ class NodeExporterService(CephadmService):
             }
         else:
             r = {}
+
+        if ip_to_bind_to:
+            r['ip_to_bind_to'] = ip_to_bind_to
 
         return r, deps
 

--- a/src/pybind/mgr/cephadm/tests/services/test_monitoring.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_monitoring.py
@@ -576,6 +576,55 @@ class TestMonitoring:
                     use_current_daemon_image=False,
                 )
 
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("socket.getfqdn")
+    def test_node_exporter_binds_to_network(
+        self,
+        mock_getfqdn,
+        _run_cephadm,
+        cephadm_module: CephadmOrchestrator,
+    ):
+        _run_cephadm.side_effect = async_side_effect(("{}", "", 0))
+        mock_getfqdn.return_value = 'host1.test'
+
+        with with_host(cephadm_module, "test"):
+            cephadm_module.cache.update_host_networks('test', {
+                '1.2.3.0/24': {
+                    'if0': ['1.2.3.1']
+                },
+            })
+            with with_service(cephadm_module, MonitoringSpec('node-exporter',
+                                                             networks=['1.2.3.0/24'],
+                                                             only_bind_port_on_networks=True)):
+                stdin = json.loads(_run_cephadm.call_args.kwargs['stdin'])
+                assert stdin['params']['port_ips'] == {'9100': '1.2.3.1'}
+                assert stdin['config_blobs']['ip_to_bind_to'] == '1.2.3.1'
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("socket.getfqdn")
+    @patch('cephadm.services.cephadmservice.CephExporterService.get_keyring_with_caps',
+           Mock(return_value='[client.ceph-exporter.test]\nkey = fake-secret\n'))
+    def test_ceph_exporter_binds_to_network(
+        self,
+        mock_getfqdn,
+        _run_cephadm,
+        cephadm_module: CephadmOrchestrator,
+    ):
+        _run_cephadm.side_effect = async_side_effect(("{}", "", 0))
+        mock_getfqdn.return_value = 'host1.test'
+
+        with with_host(cephadm_module, "test"):
+            cephadm_module.cache.update_host_networks('test', {
+                '1.2.3.0/24': {
+                    'if0': ['1.2.3.1']
+                },
+            })
+            with with_service(cephadm_module, CephExporterSpec('ceph-exporter',
+                                                               networks=['1.2.3.0/24'],
+                                                               only_bind_port_on_networks=True)):
+                stdin = json.loads(_run_cephadm.call_args.kwargs['stdin'])
+                assert stdin['config_blobs']['addrs'] == '1.2.3.1'
+
     @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
            lambda instance, dspec, ips=None, fqdns=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
     @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: cephadm_root_ca)

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -3105,6 +3105,7 @@ class MonitoringSpec(ServiceSpec):
                  certificate_source: Optional[str] = None,
                  ssl: Optional[bool] = True,
                  networks: Optional[List[str]] = None,
+                 only_bind_port_on_networks: bool = False,
                  placement: Optional[PlacementSpec] = None,
                  unmanaged: bool = False,
                  preview_only: bool = False,
@@ -3132,6 +3133,12 @@ class MonitoringSpec(ServiceSpec):
 
         self.service_type = service_type
         self.port = port
+
+        # whether ports daemons for this service bind to should
+        # bind to only the networks listed in networks param, or
+        # to all networks. Defaults to false which is saying to bind
+        # on all networks.
+        self.only_bind_port_on_networks = only_bind_port_on_networks
 
     def get_port_start(self) -> List[int]:
         return [self.get_port()]
@@ -3700,6 +3707,8 @@ class CephExporterSpec(ServiceSpec):
                  ssl: Optional[bool] = True,
                  unmanaged: bool = False,
                  preview_only: bool = False,
+                 networks: Optional[List[str]] = None,
+                 only_bind_port_on_networks: bool = False,
                  extra_container_args: Optional[GeneralArgList] = None,
                  extra_entrypoint_args: Optional[GeneralArgList] = None,
                  ):
@@ -3712,6 +3721,7 @@ class CephExporterSpec(ServiceSpec):
             placement=placement,
             unmanaged=unmanaged,
             preview_only=preview_only,
+            networks=networks,
             extra_container_args=extra_container_args,
             extra_entrypoint_args=extra_entrypoint_args)
 
@@ -3721,6 +3731,8 @@ class CephExporterSpec(ServiceSpec):
         self.port = port
         self.prio_limit = prio_limit
         self.stats_period = stats_period
+        # if true, bind only to an IP in `networks` rather than all interfaces
+        self.only_bind_port_on_networks = only_bind_port_on_networks
 
     def get_port_start(self) -> List[int]:
         return [self.port or 9926]

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -582,6 +582,33 @@ def test_alertmanager_spec_2():
     assert 'default_webhook_urls' in spec.user_data.keys()
 
 
+def test_node_exporter_only_bind_port_on_networks():
+    spec = ServiceSpec.from_json({
+        'service_type': 'node-exporter',
+        'networks': ['fd00::/64'],
+        'spec': {'only_bind_port_on_networks': True},
+    })
+    assert spec.networks == ['fd00::/64']
+    assert spec.only_bind_port_on_networks is True
+    # survives a JSON round-trip
+    rt = ServiceSpec.from_json(spec.to_json())
+    assert rt.networks == ['fd00::/64']
+    assert rt.only_bind_port_on_networks is True
+
+
+def test_ceph_exporter_networks_spec():
+    spec = ServiceSpec.from_json({
+        'service_type': 'ceph-exporter',
+        'networks': ['fd00::/64'],
+        'spec': {'only_bind_port_on_networks': True},
+    })
+    assert spec.networks == ['fd00::/64']
+    assert spec.only_bind_port_on_networks is True
+    rt = ServiceSpec.from_json(spec.to_json())
+    assert rt.networks == ['fd00::/64']
+    assert rt.only_bind_port_on_networks is True
+
+
 def test_nfs_spec_rdma_default():
     """NFS spec without RDMA: enable_rdma is False, get_port_start returns 2 ports."""
     spec = NFSServiceSpec(service_id='mynfs', placement=PlacementSpec(count=1))


### PR DESCRIPTION
## What / Why

In cephadm, `prometheus`, `grafana` and `alertmanager` can be pinned to a specific
network: set `networks:` on the service spec together with
`spec.only_bind_port_on_networks: true`. cephadm then resolves a per-host IP inside
that network via `get_first_matching_network_ip()` and restricts the daemon's
listening socket to that IP.

`node-exporter` (:9100) and `ceph-exporter` (:9926) had **no equivalent** — they
always bound to all interfaces, with no spec-level way to restrict them. On a cluster
whose daemon network is a non-routable ULA (e.g. an IPv6 `fd00::/…` range) but whose
hosts also carry a globally-routable address, these two exporters were reachable on
the routable interface, leaking host/daemon metrics. Existing mitigations (host
firewall, `secure_monitoring_stack` mTLS) don't actually restrict the bind address.

## Changes

Honor the same pattern already used by prometheus/grafana/alertmanager for both
exporters:

- `MonitoringSpec` (used directly by `node-exporter`) and `CephExporterSpec` gain
  `only_bind_port_on_networks`; `CephExporterSpec` now also accepts and forwards
  `networks` (previously it raised `EINVAL` when `networks` was set).
- `NodeExporterService.generate_config` resolves the per-host IP and threads it to the
  daemon, which binds via `--web.listen-address=[ip]:9100`.
- `CephExporterService.prepare_create` sets `addrs`, which the ceph-exporter daemon
  binds via `--addrs`. (This also gives the previously-unused `CephExporterSpec.addrs`
  field an effect as a fallback.)

## Example spec

```yaml
service_type: node-exporter
networks:
  - fd70:c853:8a8d::/64
spec:
  only_bind_port_on_networks: true
---
service_type: ceph-exporter
networks:
  - fd70:c853:8a8d::/64
spec:
  only_bind_port_on_networks: true
```

## Tests

- python-common: round-trip/parsing tests for both specs.
- mgr (`test_monitoring.py`): assert the resolved IP flows into `port_ips` /
  `config_blobs` for node-exporter and `addrs` for ceph-exporter.
- cephadm (`test_deploy.py`): assert the rendered `unit.run` contains
  `--web.listen-address=<ip>:9100` and `--addrs=<ip>` respectively.

## Checklist
- Tracker (select at least one)
  - [x] New feature (ticket optional)
- Component impact
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
- Tests (select at least one)
  - [x] Includes unit test(s)
