### PR TITLE
[WIP][DO NOT REVIEW] Adding ACME support into certmgr

### DIFF
--- a/src/pybind/mgr/cephadm/acme.py
+++ b/src/pybind/mgr/cephadm/acme.py
@@ -1,0 +1,127 @@
+import json
+import logging
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from ceph.utils import datetime_now, datetime_to_str, str_to_datetime
+from cephadm.tlsobject_types import TLSObjectManager
+
+if TYPE_CHECKING:
+    from cephadm.cert_mgr import CertInfo, Cert
+    from cephadm.module import CephadmOrchestrator
+
+logger = logging.getLogger(__name__)
+
+
+class ACMEManager:
+    """
+    ACME lifecycle coordination for cephadm-managed certificates.
+
+    The actual certificate/key material is stored in CertMgr/TLSObjectStore.
+    This class owns ACME-specific state such as HTTP-01 challenge tokens and,
+    later, account/order/finalization metadata.
+    """
+
+    CHALLENGE_STORE_PREFIX = 'cert_store.acme.challenge.'
+
+    def __init__(self, mgr: "CephadmOrchestrator") -> None:
+        self.mgr = mgr
+
+    def _challenge_key(self, token: str) -> str:
+        return self.CHALLENGE_STORE_PREFIX + token
+
+    def _load_challenge(self, token: str) -> Optional[Dict[str, Any]]:
+        raw = self.mgr.get_store(self._challenge_key(token))
+        if not raw:
+            return None
+        try:
+            data = json.loads(raw)
+        except Exception as e:
+            logger.warning('ACME: failed to decode HTTP-01 challenge token %r: %s', token, e)
+            return None
+        if not isinstance(data, dict):
+            logger.warning('ACME: invalid HTTP-01 challenge payload for token %r', token)
+            return None
+        return data
+
+    def get_http01_key_authorization(self, token: str) -> Optional[str]:
+        """Return key-authorization for a pending HTTP-01 token, or None."""
+        if not token:
+            return None
+        data = self._load_challenge(token)
+        if not data:
+            return None
+        expires = data.get('expires')
+        if isinstance(expires, str):
+            try:
+                if str_to_datetime(expires) < datetime_now():
+                    logger.info('ACME: HTTP-01 challenge token %r expired', token)
+                    self.remove_http01_challenge(token)
+                    return None
+            except Exception:
+                logger.debug('ACME: ignoring unparsable challenge expiration for token %r', token)
+        key_authorization = data.get('key_authorization')
+        return key_authorization if isinstance(key_authorization, str) else None
+
+    def set_http01_challenge(
+        self,
+        token: str,
+        key_authorization: str,
+        service_name: str,
+        expires: Optional[str] = None,
+        order_url: Optional[str] = None,
+    ) -> None:
+        """Persist an HTTP-01 challenge token for the challenge server."""
+        payload = {
+            'token': token,
+            'key_authorization': key_authorization,
+            'service_name': service_name,
+            'created': datetime_to_str(datetime_now()),
+        }
+        if expires:
+            payload['expires'] = expires
+        if order_url:
+            payload['order_url'] = order_url
+        self.mgr.set_store(self._challenge_key(token), json.dumps(payload))
+
+    def remove_http01_challenge(self, token: str) -> None:
+        self.mgr.set_store(self._challenge_key(token), None)
+
+    def list_http01_challenges(self, service_name: Optional[str] = None) -> Dict[str, Dict[str, Any]]:
+        challenges: Dict[str, Dict[str, Any]] = {}
+        for key, raw in self.mgr.get_store_prefix(self.CHALLENGE_STORE_PREFIX).items():
+            token = key[len(self.CHALLENGE_STORE_PREFIX):]
+            try:
+                data = json.loads(raw)
+            except Exception:
+                continue
+            if not isinstance(data, dict):
+                continue
+            if service_name and data.get('service_name') != service_name:
+                continue
+            challenges[token] = data
+        return challenges
+
+    def clear_service_challenges(self, service_name: str) -> None:
+        for token in self.list_http01_challenges(service_name):
+            self.remove_http01_challenge(token)
+
+    def cleanup_service(self, service_name: str) -> None:
+        self.clear_service_challenges(service_name)
+
+    def process_pending_orders(self) -> List[str]:
+        """
+        Process pending ACME orders.
+
+        This patch introduces the HTTP-01 serving/routing and metadata plumbing.
+        The ACME order/finalize client is intentionally left isolated here for a
+        follow-up implementation.
+        """
+        return []
+
+    def ensure_renewal(self, cert_info: "CertInfo", cert_obj: "Cert") -> bool:
+        logger.warning(
+            'ACME: certificate %s is managed_by=%s but ACME order/finalize support is not implemented yet',
+            cert_info.cert_name,
+            TLSObjectManager.ACME.value,
+        )
+        return False

--- a/src/pybind/mgr/cephadm/acme.py
+++ b/src/pybind/mgr/cephadm/acme.py
@@ -1,9 +1,19 @@
+import base64
+import hashlib
 import json
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+import time
+import urllib.error
+import urllib.request
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from cryptography.x509.oid import NameOID
 
 from ceph.utils import datetime_now, datetime_to_str, str_to_datetime
-from cephadm.tlsobject_types import TLSObjectManager
+from cephadm.tlsobject_types import TLSCredentials
 
 if TYPE_CHECKING:
     from cephadm.cert_mgr import CertInfo, Cert
@@ -12,34 +22,79 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class ACMEProtocolError(Exception):
+    pass
+
+
 class ACMEManager:
     """
     ACME lifecycle coordination for cephadm-managed certificates.
 
     The actual certificate/key material is stored in CertMgr/TLSObjectStore.
-    This class owns ACME-specific state such as HTTP-01 challenge tokens and,
-    later, account/order/finalization metadata.
+    This class owns ACME-specific state such as account keys, orders and
+    HTTP-01 challenge tokens.
     """
 
+    ACCOUNT_STORE_PREFIX = 'cert_store.acme.account.'
+    ORDER_STORE_PREFIX = 'cert_store.acme.order.'
+    CERT_META_STORE_PREFIX = 'cert_store.acme.cert.'
     CHALLENGE_STORE_PREFIX = 'cert_store.acme.challenge.'
+
+    DEFAULT_PROFILE_NAME = 'default'
+    DEFAULT_ACCOUNT_NAME = 'default'
+    DEFAULT_CERT_KEY_SIZE = 2048
+    DEFAULT_ACCOUNT_KEY_SIZE = 4096
+    HTTP_TIMEOUT = 30
+    ORDER_POLL_SECONDS = 3
+    ORDER_POLL_ATTEMPTS = 5
 
     def __init__(self, mgr: "CephadmOrchestrator") -> None:
         self.mgr = mgr
 
-    def _challenge_key(self, token: str) -> str:
-        return self.CHALLENGE_STORE_PREFIX + token
+    @staticmethod
+    def _b64url(data: bytes) -> str:
+        return base64.urlsafe_b64encode(data).decode('ascii').rstrip('=')
 
-    def _load_challenge(self, token: str) -> Optional[Dict[str, Any]]:
-        raw = self.mgr.get_store(self._challenge_key(token))
+    @staticmethod
+    def _json_dumps(data: Any) -> str:
+        return json.dumps(data, sort_keys=True, separators=(',', ':'))
+
+    @staticmethod
+    def _int_to_bytes(value: int) -> bytes:
+        return value.to_bytes((value.bit_length() + 7) // 8, 'big')
+
+    def _kv_get_json(self, key: str) -> Optional[Dict[str, Any]]:
+        raw = self.mgr.get_store(key)
         if not raw:
             return None
         try:
             data = json.loads(raw)
         except Exception as e:
-            logger.warning('ACME: failed to decode HTTP-01 challenge token %r: %s', token, e)
+            logger.warning('ACME: failed to decode store key %r: %s', key, e)
             return None
         if not isinstance(data, dict):
-            logger.warning('ACME: invalid HTTP-01 challenge payload for token %r', token)
+            logger.warning('ACME: invalid JSON payload for store key %r', key)
+            return None
+        return data
+
+    def _kv_set_json(self, key: str, payload: Dict[str, Any]) -> None:
+        self.mgr.set_store(key, json.dumps(payload, sort_keys=True))
+
+    def _challenge_key(self, token: str) -> str:
+        return self.CHALLENGE_STORE_PREFIX + token
+
+    def _order_key(self, service_name: str) -> str:
+        return self.ORDER_STORE_PREFIX + service_name
+
+    def _cert_meta_key(self, service_name: str) -> str:
+        return self.CERT_META_STORE_PREFIX + service_name
+
+    def _account_key(self, account_name: str) -> str:
+        return self.ACCOUNT_STORE_PREFIX + account_name
+
+    def _load_challenge(self, token: str) -> Optional[Dict[str, Any]]:
+        data = self._kv_get_json(self._challenge_key(token))
+        if not data:
             return None
         return data
 
@@ -81,7 +136,7 @@ class ACMEManager:
             payload['expires'] = expires
         if order_url:
             payload['order_url'] = order_url
-        self.mgr.set_store(self._challenge_key(token), json.dumps(payload))
+        self._kv_set_json(self._challenge_key(token), payload)
 
     def remove_http01_challenge(self, token: str) -> None:
         self.mgr.set_store(self._challenge_key(token), None)
@@ -107,21 +162,601 @@ class ACMEManager:
 
     def cleanup_service(self, service_name: str) -> None:
         self.clear_service_challenges(service_name)
+        self.mgr.set_store(self._order_key(service_name), None)
+        self.mgr.set_store(self._cert_meta_key(service_name), None)
+
+    def _load_private_key(self, pem: str) -> rsa.RSAPrivateKey:
+        key = serialization.load_pem_private_key(pem.encode('utf-8'), password=None)
+        if not isinstance(key, rsa.RSAPrivateKey):
+            raise ACMEProtocolError('Only RSA ACME keys are supported')
+        return key
+
+    def _generate_private_key_pem(self, key_size: int) -> str:
+        key = rsa.generate_private_key(public_exponent=65537, key_size=key_size)
+        return key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption(),
+        ).decode('utf-8')
+
+    def _jwk_from_private_key(self, key: rsa.RSAPrivateKey) -> Dict[str, str]:
+        numbers = key.public_key().public_numbers()
+        return {
+            'e': self._b64url(self._int_to_bytes(numbers.e)),
+            'kty': 'RSA',
+            'n': self._b64url(self._int_to_bytes(numbers.n)),
+        }
+
+    def _jwk_thumbprint(self, jwk: Dict[str, str]) -> str:
+        # RFC 7638 canonical JSON for RSA JWK members.
+        canonical = self._json_dumps({
+            'e': jwk['e'],
+            'kty': jwk['kty'],
+            'n': jwk['n'],
+        }).encode('utf-8')
+        return self._b64url(hashlib.sha256(canonical).digest())
+
+    def _http_request(
+        self,
+        url: str,
+        method: str = 'GET',
+        data: Optional[bytes] = None,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> Tuple[int, Dict[str, str], bytes]:
+        req = urllib.request.Request(url, data=data, headers=headers or {}, method=method)
+        try:
+            with urllib.request.urlopen(req, timeout=self.HTTP_TIMEOUT) as response:
+                return response.getcode(), dict(response.headers.items()), response.read()
+        except urllib.error.HTTPError as e:
+            body = e.read()
+            raise ACMEProtocolError(
+                'ACME HTTP request failed: method=%s url=%s status=%s body=%s' % (
+                    method, url, e.code, body.decode('utf-8', errors='replace')[:500]
+                )
+            ) from e
+        except urllib.error.URLError as e:
+            raise ACMEProtocolError(f'ACME HTTP request failed: method={method} url={url} error={e}') from e
+
+    def _get_directory(self, directory_url: str) -> Dict[str, Any]:
+        _, _, body = self._http_request(directory_url)
+        try:
+            directory = json.loads(body.decode('utf-8'))
+        except Exception as e:
+            raise ACMEProtocolError(f'Cannot parse ACME directory {directory_url}: {e}') from e
+        for required in ['newNonce', 'newAccount', 'newOrder']:
+            if required not in directory:
+                raise ACMEProtocolError(f'ACME directory {directory_url} is missing {required}')
+        return directory
+
+    def _get_nonce(self, directory: Dict[str, Any]) -> str:
+        nonce_url = directory['newNonce']
+        for method in ['HEAD', 'GET']:
+            try:
+                _, headers, _ = self._http_request(nonce_url, method=method)
+                nonce = headers.get('Replay-Nonce') or headers.get('replay-nonce')
+                if nonce:
+                    return nonce
+            except ACMEProtocolError:
+                if method == 'GET':
+                    raise
+        raise ACMEProtocolError('ACME server did not return Replay-Nonce')
+
+    def _jws_body(
+        self,
+        url: str,
+        payload: Optional[Dict[str, Any]],
+        account: Dict[str, Any],
+        directory: Dict[str, Any],
+        use_jwk: bool = False,
+    ) -> bytes:
+        key = self._load_private_key(account['private_key_pem'])
+        protected: Dict[str, Any] = {
+            'alg': 'RS256',
+            'nonce': self._get_nonce(directory),
+            'url': url,
+        }
+        if use_jwk:
+            protected['jwk'] = self._jwk_from_private_key(key)
+        else:
+            kid = account.get('account_url')
+            if not kid:
+                raise ACMEProtocolError('Cannot send ACME request without account URL')
+            protected['kid'] = kid
+
+        protected64 = self._b64url(self._json_dumps(protected).encode('utf-8'))
+        if payload is None:
+            payload64 = ''
+        else:
+            payload64 = self._b64url(self._json_dumps(payload).encode('utf-8'))
+        signing_input = f'{protected64}.{payload64}'.encode('ascii')
+        signature = key.sign(signing_input, padding.PKCS1v15(), hashes.SHA256())
+        body = {
+            'protected': protected64,
+            'payload': payload64,
+            'signature': self._b64url(signature),
+        }
+        return self._json_dumps(body).encode('utf-8')
+
+    def _post_jws(
+        self,
+        url: str,
+        payload: Optional[Dict[str, Any]],
+        account: Dict[str, Any],
+        directory: Dict[str, Any],
+        use_jwk: bool = False,
+        expect_json: bool = True,
+    ) -> Tuple[Optional[Any], Dict[str, str]]:
+        headers = {
+            'Content-Type': 'application/jose+json',
+            'Accept': 'application/json',
+            'User-Agent': 'cephadm-acme',
+        }
+        body = self._jws_body(url, payload, account, directory, use_jwk=use_jwk)
+        status, response_headers, response_body = self._http_request(url, method='POST', data=body, headers=headers)
+        if not response_body:
+            return None, response_headers
+        if expect_json:
+            try:
+                return json.loads(response_body.decode('utf-8')), response_headers
+            except Exception as e:
+                raise ACMEProtocolError(f'Cannot decode ACME JSON response from {url}: {e}') from e
+        return response_body.decode('utf-8'), response_headers
+
+    def _load_account(self, account_name: str) -> Optional[Dict[str, Any]]:
+        return self._kv_get_json(self._account_key(account_name))
+
+    def _save_account(self, account_name: str, account: Dict[str, Any]) -> None:
+        account['updated'] = datetime_to_str(datetime_now())
+        self._kv_set_json(self._account_key(account_name), account)
+
+    def _ensure_account(self, acme_cfg: Dict[str, Any], directory: Dict[str, Any]) -> Dict[str, Any]:
+        account_name = acme_cfg.get('account_name') or self.DEFAULT_ACCOUNT_NAME
+        directory_url = acme_cfg['directory_url']
+        account = self._load_account(account_name)
+        if account and account.get('directory_url') == directory_url and account.get('account_url'):
+            return account
+
+        if not account or account.get('directory_url') != directory_url:
+            private_key_pem = self._generate_private_key_pem(self.DEFAULT_ACCOUNT_KEY_SIZE)
+            key = self._load_private_key(private_key_pem)
+            jwk = self._jwk_from_private_key(key)
+            account = {
+                'account_name': account_name,
+                'directory_url': directory_url,
+                'private_key_pem': private_key_pem,
+                'jwk_thumbprint': self._jwk_thumbprint(jwk),
+                'created': datetime_to_str(datetime_now()),
+            }
+
+        payload: Dict[str, Any] = {'termsOfServiceAgreed': True}
+        email = acme_cfg.get('email')
+        if email:
+            payload['contact'] = [f'mailto:{email}']
+        response, headers = self._post_jws(
+            directory['newAccount'],
+            payload,
+            account,
+            directory,
+            use_jwk=True,
+            expect_json=True,
+        )
+        account_url = headers.get('Location') or headers.get('location')
+        if not account_url:
+            raise ACMEProtocolError('ACME newAccount response did not include Location header')
+        account['account_url'] = account_url
+        if isinstance(response, dict):
+            account['account_status'] = response.get('status')
+        self._save_account(account_name, account)
+        return account
+
+    def _load_acme_profiles(self) -> Dict[str, Dict[str, Any]]:
+        """Return cluster-level ACME profiles from the mgr module option.
+
+        The option accepts either a raw profile map::
+
+            {"default": {"directory_url": "..."}}
+
+        or a wrapper object::
+
+            {"profiles": {"default": {"directory_url": "..."}}}
+
+        The wrapper form leaves room for future top-level ACME settings while
+        keeping the first implementation easy to configure through a single
+        mgr module option.
+        """
+        raw_profiles = getattr(self.mgr, 'acme_profiles', '')
+        if not raw_profiles:
+            return {}
+        if isinstance(raw_profiles, str):
+            try:
+                parsed = json.loads(raw_profiles)
+            except Exception as e:
+                raise ACMEProtocolError(f'Cannot parse mgr/cephadm/acme_profiles JSON: {e}') from e
+        elif isinstance(raw_profiles, Mapping):
+            parsed = dict(raw_profiles)
+        else:
+            raise ACMEProtocolError('mgr/cephadm/acme_profiles must be a JSON object')
+
+        if not isinstance(parsed, dict):
+            raise ACMEProtocolError('mgr/cephadm/acme_profiles must decode to a JSON object')
+        if any(k in parsed for k in ['directory_url', 'email', 'account_name', 'terms_of_service_agreed']):
+            # Convenience form for a single default profile.
+            profiles = {self.DEFAULT_PROFILE_NAME: parsed}
+        else:
+            profiles = parsed.get('profiles', parsed)
+        if not isinstance(profiles, dict):
+            raise ACMEProtocolError('mgr/cephadm/acme_profiles profiles field must be a JSON object')
+
+        out: Dict[str, Dict[str, Any]] = {}
+        for name, profile in profiles.items():
+            if not isinstance(name, str) or not name.strip():
+                raise ACMEProtocolError('ACME profile names must be non-empty strings')
+            if not isinstance(profile, dict):
+                raise ACMEProtocolError(f'ACME profile {name!r} must be a JSON object')
+            out[name.strip()] = dict(profile)
+        return out
+
+    def _resolve_acme_config(self, acme_cfg: Dict[str, Any]) -> Dict[str, Any]:
+        """Merge cluster-level ACME profile config with service overrides.
+
+        Service specs carry the certificate request details, especially
+        ``domains`` and optionally ``profile``. CA/account parameters such as
+        directory_url, email, account_name and terms_of_service_agreed normally
+        come from the selected cluster-level profile, but the service may
+        override them for exceptional cases.
+        """
+        if not isinstance(acme_cfg, dict):
+            raise ACMEProtocolError('ACME service config must be an object')
+
+        profile_name = acme_cfg.get('profile') or self.DEFAULT_PROFILE_NAME
+        if not isinstance(profile_name, str) or not profile_name.strip():
+            raise ACMEProtocolError('ACME profile name must be a non-empty string')
+        profile_name = profile_name.strip()
+
+        profiles = self._load_acme_profiles()
+        profile_cfg = profiles.get(profile_name, {})
+        if profile_name != self.DEFAULT_PROFILE_NAME and not profile_cfg:
+            raise ACMEProtocolError(f'ACME profile {profile_name!r} is not configured')
+
+        merged: Dict[str, Any] = dict(profile_cfg)
+        for key, value in acme_cfg.items():
+            if key == 'profile':
+                continue
+            if value is not None:
+                merged[key] = value
+        merged['profile'] = profile_name
+        return self._normalize_acme_config(merged)
+
+    def _normalize_acme_config(self, acme_cfg: Dict[str, Any]) -> Dict[str, Any]:
+        domains_raw = acme_cfg.get('domains', [])
+        if not isinstance(domains_raw, list):
+            raise ACMEProtocolError('ACME config requires domains to be a list')
+        domains = sorted(set(d.strip().lower() for d in domains_raw if isinstance(d, str) and d.strip()))
+        if not domains:
+            raise ACMEProtocolError('ACME config requires at least one domain')
+
+        directory_url = acme_cfg.get('directory_url')
+        if not isinstance(directory_url, str) or not directory_url.strip():
+            profile = acme_cfg.get('profile') or self.DEFAULT_PROFILE_NAME
+            raise ACMEProtocolError(
+                f"ACME profile {profile!r} does not define a non-empty directory_url, "
+                "and the service did not override it"
+            )
+
+        terms_agreed = acme_cfg.get('terms_of_service_agreed')
+        if terms_agreed is not True:
+            profile = acme_cfg.get('profile') or self.DEFAULT_PROFILE_NAME
+            raise ACMEProtocolError(
+                f"ACME profile {profile!r} requires terms_of_service_agreed: true, "
+                "or the service must override it with true"
+            )
+
+        account_name = acme_cfg.get('account_name') or self.DEFAULT_ACCOUNT_NAME
+        if not isinstance(account_name, str) or not account_name.strip():
+            raise ACMEProtocolError('ACME account_name must be a non-empty string')
+
+        email = acme_cfg.get('email')
+        if email is not None and not isinstance(email, str):
+            raise ACMEProtocolError('ACME email must be a string when provided')
+
+        return {
+            'domains': domains,
+            'profile': acme_cfg.get('profile') or self.DEFAULT_PROFILE_NAME,
+            'directory_url': directory_url.strip(),
+            'email': email,
+            'account_name': account_name.strip(),
+            'terms_of_service_agreed': True,
+        }
+
+    def _save_cert_metadata(self, service_name: str, metadata: Dict[str, Any]) -> None:
+        metadata['updated'] = datetime_to_str(datetime_now())
+        self._kv_set_json(self._cert_meta_key(service_name), metadata)
+
+    def _load_cert_metadata(self, service_name: str) -> Optional[Dict[str, Any]]:
+        return self._kv_get_json(self._cert_meta_key(service_name))
+
+    def ensure_certificate(
+        self,
+        service_name: str,
+        cert_name: str,
+        key_name: str,
+        acme_cfg: Dict[str, Any],
+        force: bool = False,
+    ) -> None:
+        """Ensure an ACME order is queued for a service if needed.
+
+        This method is intentionally store-only. The network ACME operations
+        run later from the serve loop via process_pending_orders().
+        """
+        cfg = self._resolve_acme_config(acme_cfg)
+        metadata = {
+            'service_name': service_name,
+            'cert_name': cert_name,
+            'key_name': key_name,
+            'domains': cfg['domains'],
+            'profile': cfg['profile'],
+            'directory_url': cfg['directory_url'],
+            'email': cfg.get('email'),
+            'account_name': cfg['account_name'],
+            'terms_of_service_agreed': cfg['terms_of_service_agreed'],
+        }
+        self._save_cert_metadata(service_name, metadata)
+
+        order = self._kv_get_json(self._order_key(service_name))
+        if order and not force:
+            same_request = (
+                order.get('domains') == cfg['domains']
+                and order.get('directory_url') == cfg['directory_url']
+                and order.get('status') not in ['valid', 'failed']
+            )
+            if same_request:
+                return
+
+        self.clear_service_challenges(service_name)
+        private_key_pem = self._generate_private_key_pem(self.DEFAULT_CERT_KEY_SIZE)
+        now = datetime_to_str(datetime_now())
+        new_order = {
+            'service_name': service_name,
+            'cert_name': cert_name,
+            'key_name': key_name,
+            'domains': cfg['domains'],
+            'profile': cfg['profile'],
+            'directory_url': cfg['directory_url'],
+            'email': cfg.get('email'),
+            'account_name': cfg['account_name'],
+            'terms_of_service_agreed': cfg['terms_of_service_agreed'],
+            'private_key_pem': private_key_pem,
+            'status': 'needs-order',
+            'created': now,
+            'updated': now,
+        }
+        self._kv_set_json(self._order_key(service_name), new_order)
+        logger.info('ACME: queued HTTP-01 order for %s domains=%s', service_name, ','.join(cfg['domains']))
+
+    def _create_csr_der(self, private_key_pem: str, domains: List[str]) -> bytes:
+        key = self._load_private_key(private_key_pem)
+        subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, domains[0])])
+        san = x509.SubjectAlternativeName([x509.DNSName(d) for d in domains])
+        csr = (
+            x509.CertificateSigningRequestBuilder()
+            .subject_name(subject)
+            .add_extension(san, critical=False)
+            .sign(key, hashes.SHA256())
+        )
+        return csr.public_bytes(serialization.Encoding.DER)
+
+    def _save_order(self, service_name: str, order: Dict[str, Any]) -> None:
+        order['updated'] = datetime_to_str(datetime_now())
+        self._kv_set_json(self._order_key(service_name), order)
+
+    def _fail_order(self, service_name: str, order: Dict[str, Any], error: str) -> None:
+        order['status'] = 'failed'
+        order['error'] = error
+        logger.error('ACME: order failed for %s: %s', service_name, error)
+        self._save_order(service_name, order)
+        self.clear_service_challenges(service_name)
+
+    def _get_order(self, order: Dict[str, Any], account: Dict[str, Any], directory: Dict[str, Any]) -> Dict[str, Any]:
+        order_url = order.get('order_url')
+        if not order_url:
+            raise ACMEProtocolError('Order record is missing order_url')
+        response, _ = self._post_jws(order_url, None, account, directory, expect_json=True)
+        if not isinstance(response, dict):
+            raise ACMEProtocolError('ACME order response is not an object')
+        return response
+
+    def _fetch_authorization(self, url: str, account: Dict[str, Any], directory: Dict[str, Any]) -> Dict[str, Any]:
+        response, _ = self._post_jws(url, None, account, directory, expect_json=True)
+        if not isinstance(response, dict):
+            raise ACMEProtocolError(f'ACME authorization response from {url} is not an object')
+        return response
+
+    def _create_and_start_order(self, order: Dict[str, Any]) -> None:
+        service_name = order['service_name']
+        directory = self._get_directory(order['directory_url'])
+        account = self._ensure_account(order, directory)
+        payload = {
+            'identifiers': [{'type': 'dns', 'value': d} for d in order['domains']]
+        }
+        response, headers = self._post_jws(directory['newOrder'], payload, account, directory, expect_json=True)
+        if not isinstance(response, dict):
+            raise ACMEProtocolError('ACME newOrder response is not an object')
+        order_url = headers.get('Location') or headers.get('location')
+        if not order_url:
+            raise ACMEProtocolError('ACME newOrder response did not include Location header')
+
+        order.update({
+            'order_url': order_url,
+            'finalize_url': response.get('finalize'),
+            'authorizations': response.get('authorizations', []),
+            'status': response.get('status', 'pending'),
+        })
+        if not order.get('finalize_url'):
+            raise ACMEProtocolError('ACME newOrder response did not include finalize URL')
+        if not isinstance(order.get('authorizations'), list):
+            raise ACMEProtocolError('ACME newOrder authorizations field is not a list')
+
+        thumbprint = account.get('jwk_thumbprint')
+        if not thumbprint:
+            key = self._load_private_key(account['private_key_pem'])
+            thumbprint = self._jwk_thumbprint(self._jwk_from_private_key(key))
+            account['jwk_thumbprint'] = thumbprint
+            self._save_account(order.get('account_name') or self.DEFAULT_ACCOUNT_NAME, account)
+
+        challenges: Dict[str, Dict[str, Any]] = {}
+        for authz_url in order['authorizations']:
+            authz = self._fetch_authorization(authz_url, account, directory)
+            if authz.get('status') == 'valid':
+                continue
+            http01 = None
+            for challenge in authz.get('challenges', []):
+                if isinstance(challenge, dict) and challenge.get('type') == 'http-01':
+                    http01 = challenge
+                    break
+            if not http01:
+                raise ACMEProtocolError(f'No http-01 challenge found for authorization {authz_url}')
+            token = http01.get('token')
+            challenge_url = http01.get('url')
+            if not isinstance(token, str) or not isinstance(challenge_url, str):
+                raise ACMEProtocolError(f'Invalid http-01 challenge object for authorization {authz_url}')
+            key_authorization = f'{token}.{thumbprint}'
+            self.set_http01_challenge(
+                token,
+                key_authorization,
+                service_name,
+                expires=authz.get('expires') if isinstance(authz.get('expires'), str) else None,
+                order_url=order_url,
+            )
+            # Tell the ACME server that the HTTP-01 resource is ready.
+            self._post_jws(challenge_url, {}, account, directory, expect_json=True)
+            challenges[token] = {
+                'url': challenge_url,
+                'authorization_url': authz_url,
+            }
+
+        order['challenges'] = challenges
+        order['status'] = 'validating'
+        self._save_order(service_name, order)
+        logger.info('ACME: started HTTP-01 validation for %s', service_name)
+
+    def _finalize_order(self, order: Dict[str, Any], account: Dict[str, Any], directory: Dict[str, Any]) -> Dict[str, Any]:
+        finalize_url = order.get('finalize_url')
+        if not finalize_url:
+            raise ACMEProtocolError('Order record is missing finalize_url')
+        csr_der = self._create_csr_der(order['private_key_pem'], order['domains'])
+        response, _ = self._post_jws(
+            finalize_url,
+            {'csr': self._b64url(csr_der)},
+            account,
+            directory,
+            expect_json=True,
+        )
+        if not isinstance(response, dict):
+            raise ACMEProtocolError('ACME finalize response is not an object')
+        return response
+
+    def _download_certificate(self, order: Dict[str, Any], account: Dict[str, Any], directory: Dict[str, Any]) -> str:
+        cert_url = order.get('certificate_url')
+        if not cert_url:
+            raise ACMEProtocolError('Order record is missing certificate_url')
+        response, _ = self._post_jws(cert_url, None, account, directory, expect_json=False)
+        if not isinstance(response, str) or 'BEGIN CERTIFICATE' not in response:
+            raise ACMEProtocolError('ACME certificate download did not return a PEM certificate chain')
+        return response
+
+    def _continue_order(self, order: Dict[str, Any]) -> Optional[str]:
+        service_name = order['service_name']
+        directory = self._get_directory(order['directory_url'])
+        account = self._ensure_account(order, directory)
+
+        current = self._get_order(order, account, directory)
+        status = current.get('status')
+        if status == 'invalid':
+            self._fail_order(service_name, order, json.dumps(current.get('error', current)))
+            return None
+        if status == 'pending':
+            order['status'] = 'validating'
+            self._save_order(service_name, order)
+            return None
+        if status == 'ready':
+            current = self._finalize_order(order, account, directory)
+            status = current.get('status')
+        if status == 'processing':
+            order['status'] = 'processing'
+            order['certificate_url'] = current.get('certificate') or order.get('certificate_url')
+            self._save_order(service_name, order)
+            return None
+        if status == 'valid':
+            order['status'] = 'valid'
+            order['certificate_url'] = current.get('certificate') or order.get('certificate_url')
+            if not order.get('certificate_url'):
+                self._save_order(service_name, order)
+                return None
+            cert_pem = self._download_certificate(order, account, directory)
+            tls_creds = TLSCredentials(cert=cert_pem, key=order['private_key_pem'])
+            self.mgr.cert_mgr.save_acme_cert_key_pair(service_name, tls_creds)
+            self.clear_service_challenges(service_name)
+            self.mgr.set_store(self._order_key(service_name), None)
+            logger.info('ACME: installed certificate for %s', service_name)
+            return service_name
+        order['status'] = str(status or 'unknown')
+        self._save_order(service_name, order)
+        return None
 
     def process_pending_orders(self) -> List[str]:
-        """
-        Process pending ACME orders.
+        """Process ACME orders queued by ensure_certificate()/ensure_renewal()."""
+        services_to_reconfig: List[str] = []
+        for key, raw in self.mgr.get_store_prefix(self.ORDER_STORE_PREFIX).items():
+            service_name = key[len(self.ORDER_STORE_PREFIX):]
+            try:
+                order = json.loads(raw)
+            except Exception as e:
+                logger.warning('ACME: cannot decode order %r: %s', service_name, e)
+                continue
+            if not isinstance(order, dict):
+                continue
+            if order.get('status') == 'failed':
+                continue
+            try:
+                if order.get('status') == 'needs-order':
+                    self._create_and_start_order(order)
+                    continue
 
-        This patch introduces the HTTP-01 serving/routing and metadata plumbing.
-        The ACME order/finalize client is intentionally left isolated here for a
-        follow-up implementation.
-        """
-        return []
+                # Poll a few times to collapse the common ready->valid path into
+                # a single serve-loop iteration, but keep the cap low so we do not
+                # block cephadm for long on slow CAs.
+                completed: Optional[str] = None
+                for _ in range(self.ORDER_POLL_ATTEMPTS):
+                    completed = self._continue_order(order)
+                    if completed:
+                        services_to_reconfig.append(completed)
+                        break
+                    updated = self._kv_get_json(self._order_key(service_name))
+                    if not updated or updated.get('status') in ['failed', 'needs-order']:
+                        break
+                    order = updated
+                    if order.get('status') not in ['validating', 'processing', 'ready', 'pending']:
+                        break
+                    time.sleep(self.ORDER_POLL_SECONDS)
+            except Exception as e:
+                self._fail_order(service_name, order, str(e))
+        return services_to_reconfig
 
     def ensure_renewal(self, cert_info: "CertInfo", cert_obj: "Cert") -> bool:
-        logger.warning(
-            'ACME: certificate %s is managed_by=%s but ACME order/finalize support is not implemented yet',
-            cert_info.cert_name,
-            TLSObjectManager.ACME.value,
+        svc = self.mgr.cert_mgr.get_associated_service(cert_info)
+        if not svc:
+            logger.error('ACME: cannot renew %s; no associated service found', cert_info.cert_name)
+            return False
+        metadata = self._load_cert_metadata(svc)
+        if not metadata:
+            logger.error('ACME: cannot renew %s; no ACME metadata found for %s', cert_info.cert_name, svc)
+            return False
+        self.ensure_certificate(
+            svc,
+            metadata['cert_name'],
+            metadata['key_name'],
+            metadata,
+            force=True,
         )
+        logger.info('ACME: queued renewal order for %s', svc)
         return False

--- a/src/pybind/mgr/cephadm/acme_challenges.py
+++ b/src/pybind/mgr/cephadm/acme_challenges.py
@@ -1,0 +1,48 @@
+import logging
+from typing import TYPE_CHECKING, Any, Dict, Tuple
+
+import cherrypy
+
+if TYPE_CHECKING:
+    from cephadm.module import CephadmOrchestrator
+
+logger = logging.getLogger(__name__)
+
+
+class ACMEChallengeRoot:
+    """CherryPy root serving ACME HTTP-01 challenge responses."""
+
+    def __init__(self, mgr: "CephadmOrchestrator") -> None:
+        self.mgr = mgr
+
+    @cherrypy.expose
+    def default(self, *args: str) -> str:
+        # Expected public path:
+        #   /.well-known/acme-challenge/<token>
+        if len(args) != 3 or args[0] != '.well-known' or args[1] != 'acme-challenge':
+            raise cherrypy.HTTPError(404)
+        token = args[2]
+        key_authorization = self.mgr.acme_mgr.get_http01_key_authorization(token)
+        if not key_authorization:
+            raise cherrypy.HTTPError(404)
+        cherrypy.response.headers['Content-Type'] = 'text/plain'
+        return key_authorization
+
+
+class ACMEChallengesServer:
+    """Small unauthenticated CherryPy server for ACME HTTP-01 challenges."""
+
+    def __init__(self, mgr: "CephadmOrchestrator") -> None:
+        self.mgr = mgr
+
+    def configure(self) -> Tuple[Dict[str, Any], None]:
+        config: Dict[str, Any] = {
+            '/': {
+                'environment': 'production',
+                'tools.trailing_slash.on': False,
+                'engine.autoreload.on': False,
+                'request.show_tracebacks': False,
+                'response.timeout': 30,
+            }
+        }
+        return config, None

--- a/src/pybind/mgr/cephadm/cert_mgr.py
+++ b/src/pybind/mgr/cephadm/cert_mgr.py
@@ -6,7 +6,15 @@ from enum import Enum
 from cephadm.ssl_cert_utils import SSLCerts, SSLConfigException
 from mgr_util import verify_tls, certificate_days_to_expire, ServerConfigException
 from cephadm.ssl_cert_utils import get_certificate_info, get_private_key_info
-from cephadm.tlsobject_types import Cert, PrivKey, TLSObjectScope, TLSObjectException, TLSObjectProtocol, TLSCredentials
+from cephadm.tlsobject_types import (
+    Cert,
+    PrivKey,
+    TLSObjectManager,
+    TLSObjectScope,
+    TLSObjectException,
+    TLSObjectProtocol,
+    TLSCredentials,
+)
 from cephadm.tlsobject_store import TLSObjectStore
 
 if TYPE_CHECKING:
@@ -49,8 +57,11 @@ class CertInfo:
                  is_valid: bool = False,
                  is_close_to_expiration: bool = False,
                  days_to_expiration: int = 0,
-                 error_info: str = ''):
-        self.user_made = user_made
+                 error_info: str = '',
+                 managed_by: Optional[str] = None):
+        self.managed_by = managed_by or (
+            TLSObjectManager.USER.value if user_made else TLSObjectManager.CEPHADM.value
+        )
         self.cert_name = cert_name
         self.target = target or ''
         self.is_valid = is_valid
@@ -59,8 +70,12 @@ class CertInfo:
         self.error_info = error_info
 
     @property
+    def user_made(self) -> bool:
+        return self.managed_by == TLSObjectManager.USER.value
+
+    @property
     def signed_by(self) -> str:
-        return "user" if self.user_made else "cephadm"
+        return self.managed_by
 
     @property
     def status(self) -> CertStatus:
@@ -78,7 +93,11 @@ class CertInfo:
         return self.is_valid and not self.is_close_to_expiration
 
     def get_status_description(self) -> str:
-        cert_source = 'user-made' if self.user_made else 'cephadm-signed'
+        cert_source = {
+            TLSObjectManager.USER.value: 'user-made',
+            TLSObjectManager.CEPHADM.value: 'cephadm-signed',
+            TLSObjectManager.ACME.value: 'acme-managed',
+        }.get(self.managed_by, self.managed_by)
         cert_target = f' ({self.target})' if self.target else ''
         cert_details = f"'{self.cert_name}{cert_target}' ({cert_source})"
         if not self.is_valid:
@@ -357,12 +376,12 @@ class CertMgr:
         return TLSCredentials(cert=cert, key=key, ca_cert=ca_cert)
 
     def save_cert(self, cert_name: str, cert: str, service_name: Optional[str] = None, host: Optional[str] = None,
-                  user_made: bool = False, editable: bool = False) -> None:
-        self.cert_store.save_tlsobject(cert_name, cert, service_name, host, user_made, editable)
+                  user_made: bool = False, editable: bool = False, managed_by: Optional[str] = None) -> None:
+        self.cert_store.save_tlsobject(cert_name, cert, service_name, host, user_made, editable, managed_by)
 
     def save_key(self, key_name: str, key: str, service_name: Optional[str] = None, host: Optional[str] = None,
-                 user_made: bool = False, editable: bool = False) -> None:
-        self.key_store.save_tlsobject(key_name, key, service_name, host, user_made, editable)
+                 user_made: bool = False, editable: bool = False, managed_by: Optional[str] = None) -> None:
+        self.key_store.save_tlsobject(key_name, key, service_name, host, user_made, editable, managed_by)
 
     def save_self_signed_cert_key_pair(self, service_name: str, tls_creds: TLSCredentials, host: str,
                                        label: Optional[str] = None) -> None:
@@ -372,8 +391,17 @@ class CertMgr:
         self.key_store.save_tlsobject(ss_key_name, tls_creds.key, host=host, user_made=False)
 
     def _is_inline_saved_tlsobject(self, obj: Optional[TLSObjectProtocol]) -> bool:
-        # Inline-saved credentials are persisted as user_made=True but editable=False.
-        return bool(obj and getattr(obj, 'user_made', False) and not getattr(obj, 'editable', True))
+        # Inline-saved credentials are user-managed but non-editable copies persisted by cephadm.
+        managed_by = getattr(
+            obj,
+            'managed_by',
+            TLSObjectManager.USER.value if getattr(obj, 'user_made', False) else TLSObjectManager.CEPHADM.value,
+        )
+        return bool(
+            obj
+            and managed_by == TLSObjectManager.USER.value
+            and not getattr(obj, 'editable', True)
+        )
 
     def rm_inline_saved_cert_key_pair(
         self,
@@ -450,14 +478,14 @@ class CertMgr:
 
         Defaults:
         - If `include_cephadm_signed` is False and no explicit `signed-by=` is provided,
-          we auto-filter to show only user-made certs (and always include the root CA).
+          we auto-filter out cephadm-managed certs (and always include the root CA).
         - If the caller explicitly filters by `signed-by=...`, that explicit filter wins.
 
         Behavior matrix:
           +------------------------+-----------------------------+----------------------------------------------+
           | include_cephadm_signed | 'signed-by=' in filter_by?  | Effective behavior on signed-by               |
           +------------------------+-----------------------------+----------------------------------------------+
-          | False                  | No                          | Auto-filter: signed-by=user  + root CA        |
+          | False                  | No                          | Auto-filter: signed-by!=cephadm + root CA     |
           | False                  | Yes                         | Use user's explicit selector                  |
           | True                   | No                          | No auto filter (include user + cephadm)       |
           | True                   | Yes                         | Use user's explicit selector                  |
@@ -507,7 +535,7 @@ class CertMgr:
             if not include_cephadm_signed and not explicit_signed_by:
                 cert_filters.append(
                     lambda cert_ctx:
-                    cert_ctx.get(CertFilterOption.SIGNED_BY) == 'user'
+                    cert_ctx.get(CertFilterOption.SIGNED_BY) != TLSObjectManager.CEPHADM.value
                     or cert_ctx[CertFilterOption.NAME] == self.CEPHADM_ROOT_CA_CERT
                 )
             return cert_filters
@@ -670,9 +698,25 @@ class CertMgr:
         try:
             days_to_expiration = verify_tls(cert.cert, key.key) if key else certificate_days_to_expire(cert.cert)
             is_close_to_expiration = days_to_expiration < self.mgr.certificate_renewal_threshold_days
-            return CertInfo(cert_name, target, cert.user_made, True, is_close_to_expiration, days_to_expiration, "")
+            return CertInfo(
+                cert_name,
+                target,
+                is_valid=True,
+                is_close_to_expiration=is_close_to_expiration,
+                days_to_expiration=days_to_expiration,
+                error_info="",
+                managed_by=cert.managed_by,
+            )
         except ServerConfigException as e:
-            return CertInfo(cert_name, target, cert.user_made, False, False, 0, str(e))
+            return CertInfo(
+                cert_name,
+                target,
+                is_valid=False,
+                is_close_to_expiration=False,
+                days_to_expiration=0,
+                error_info=str(e),
+                managed_by=cert.managed_by,
+            )
 
     def get_problematic_certificates(self) -> List[Tuple[CertInfo, Cert]]:
 
@@ -708,7 +752,7 @@ class CertMgr:
             elif any(key_name in ks for ks in self.known_keys.values()) or self.is_cephadm_signed_object(key_name):
                 # certificate is supposed to have a key but it's missing
                 logger.error(f"Key '{key_name}' is missing for certificate '{cert_name}'.")
-                cert_info = CertInfo(cert_name, target, cert_obj.user_made, False, False, 0, "missing key")
+                cert_info = CertInfo(cert_name, target, is_valid=False, error_info="missing key", managed_by=cert_obj.managed_by)
             else:
                 # certificate has no associated key
                 cert_info = self._check_certificate_state(cert_name, target, cert_obj)
@@ -747,12 +791,16 @@ class CertMgr:
         def requires_user_intervention(cert_info: CertInfo, cert_obj: Cert) -> bool:
             """Determines if a certificate requires manual user intervention."""
             close_to_expiry = (not cert_info.is_operationally_valid() and not self.mgr.certificate_automated_rotation_enabled)
-            user_made_and_invalid = cert_obj.user_made and not cert_info.is_operationally_valid()
-            return close_to_expiry or user_made_and_invalid
+            not_cephadm_managed = cert_obj.managed_by != TLSObjectManager.CEPHADM.value
+            external_or_unsupported_and_invalid = not_cephadm_managed and not cert_info.is_operationally_valid()
+            return close_to_expiry or external_or_unsupported_and_invalid
 
         def trigger_auto_fix(cert_info: CertInfo, cert_obj: Cert) -> bool:
             """Attempts to automatically fix certificate issues if possible."""
-            if not self.mgr.certificate_automated_rotation_enabled or cert_obj.user_made:
+            if (
+                not self.mgr.certificate_automated_rotation_enabled
+                or cert_obj.managed_by != TLSObjectManager.CEPHADM.value
+            ):
                 return False
 
             # This is a cephadm-signed certificate, let's try to fix it

--- a/src/pybind/mgr/cephadm/cert_mgr.py
+++ b/src/pybind/mgr/cephadm/cert_mgr.py
@@ -183,6 +183,7 @@ class CertMgr:
     CEPHADM_CERT_WARNING = 'CEPHADM_CERT_WARNING'
 
     CEPHADM_SIGNED = 'cephadm-signed'
+    ACME = 'acme'
     LABEL_SEPARATOR = "__lbl__"
 
     def __init__(self, mgr: "CephadmOrchestrator") -> None:
@@ -206,6 +207,19 @@ class CertMgr:
 
     def is_cephadm_signed_object(self, object_name: str) -> bool:
         return object_name.startswith(self.CEPHADM_SIGNED)
+
+    def is_acme_object(self, object_name: str) -> bool:
+        return object_name.startswith(f'{self.ACME}_')
+
+    def acme_cert(self, service_name: str, label: Optional[str] = None) -> str:
+        if label:
+            return f'{self.ACME}_{service_name}{self.LABEL_SEPARATOR}{label}_cert'
+        return f'{self.ACME}_{service_name}_cert'
+
+    def acme_key(self, service_name: str, label: Optional[str] = None) -> str:
+        if label:
+            return f'{self.ACME}_{service_name}{self.LABEL_SEPARATOR}{label}_key'
+        return f'{self.ACME}_{service_name}_key'
 
     def self_signed_cert(self, service_name: str, label: Optional[str] = None) -> str:
         if label:
@@ -257,6 +271,14 @@ class CertMgr:
 
     def get_root_ca(self) -> str:
         return self.ssl_certs.get_root_cert()
+
+    def register_acme_cert_key_pair(self, service_name: str, scope: TLSObjectScope, label: Optional[str] = None) -> None:
+        self.register_cert_key_pair(
+            service_name,
+            self.acme_cert(service_name, label),
+            self.acme_key(service_name, label),
+            scope,
+        )
 
     def register_self_signed_cert_key_pair(self, service_name: str, label: Optional[str] = None) -> None:
         """
@@ -382,6 +404,33 @@ class CertMgr:
     def save_key(self, key_name: str, key: str, service_name: Optional[str] = None, host: Optional[str] = None,
                  user_made: bool = False, editable: bool = False, managed_by: Optional[str] = None) -> None:
         self.key_store.save_tlsobject(key_name, key, service_name, host, user_made, editable, managed_by)
+
+    def save_acme_cert_key_pair(self, service_name: str, tls_creds: TLSCredentials,
+                                service_target: Optional[str] = None, host: Optional[str] = None,
+                                label: Optional[str] = None) -> None:
+        acme_cert_name = self.acme_cert(service_name, label)
+        acme_key_name = self.acme_key(service_name, label)
+        self.cert_store.save_tlsobject(
+            acme_cert_name,
+            tls_creds.cert,
+            service_name=service_target,
+            host=host,
+            editable=False,
+            managed_by=TLSObjectManager.ACME.value,
+        )
+        self.key_store.save_tlsobject(
+            acme_key_name,
+            tls_creds.key,
+            service_name=service_target,
+            host=host,
+            editable=False,
+            managed_by=TLSObjectManager.ACME.value,
+        )
+
+    def rm_acme_cert_key_pair(self, service_name: str, service_target: Optional[str] = None,
+                              host: Optional[str] = None, label: Optional[str] = None) -> None:
+        self.rm_cert_if_present(self.acme_cert(service_name, label), service_target, host)
+        self.rm_key_if_present(self.acme_key(service_name, label), service_target, host)
 
     def save_self_signed_cert_key_pair(self, service_name: str, tls_creds: TLSCredentials, host: str,
                                        label: Optional[str] = None) -> None:
@@ -834,6 +883,20 @@ class CertMgr:
         for cert_info, cert_obj in self.get_problematic_certificates():
 
             log_issue(cert_info)
+
+            if cert_obj.managed_by == TLSObjectManager.ACME.value:
+                fixed = False
+                if fix_issues and hasattr(self.mgr, 'acme_mgr'):
+                    fixed = self.mgr.acme_mgr.ensure_renewal(cert_info, cert_obj)
+                if fixed:
+                    svc = self.get_associated_service(cert_info)
+                    if svc:
+                        services_to_reconfig.add(svc)
+                    else:
+                        logger.error(f'Cannot find the service associated with the certificate {cert_info.cert_name}')
+                else:
+                    certs_with_issues.append(cert_info)
+                continue
 
             if requires_user_intervention(cert_info, cert_obj):
                 certs_with_issues.append(cert_info)

--- a/src/pybind/mgr/cephadm/http_server.py
+++ b/src/pybind/mgr/cephadm/http_server.py
@@ -7,6 +7,7 @@ from cherrypy.process.servers import ServerAdapter
 from cherrypy_mgr import CherryPyMgr
 
 from cephadm.agent import AgentEndpoint
+from cephadm.acme_challenges import ACMEChallengeRoot, ACMEChallengesServer
 from cephadm.services.service_discovery import ServiceDiscovery
 from mgr_util import test_port_allocation, PortAlreadyInUse
 from orchestrator import OrchestratorError
@@ -20,17 +21,21 @@ class CephadmHttpServer(threading.Thread):
         self.mgr = mgr
         self.agent = AgentEndpoint(mgr)
         self.service_discovery = ServiceDiscovery(mgr)
+        self.acme_challenges = ACMEChallengesServer(mgr)
         self.cherrypy_shutdown_event = threading.Event()
         self.cherrypy_restart_event = threading.Event()
         self._service_discovery_port = self.mgr.service_discovery_port
+        self._acme_challenge_port = self.mgr.acme_challenge_port
         security_enabled, _, _ = self.mgr._get_security_config()
         self.security_enabled = security_enabled
         self.agent_adapter = None
         self.sd_adapter = None
+        self.acme_adapter = None
         super().__init__(target=self.run)
 
     def config_update(self) -> None:
         self.service_discovery_port = self.mgr.service_discovery_port
+        self.acme_challenge_port = self.mgr.acme_challenge_port
         security_enabled, _, _ = self.mgr._get_security_config()
         if self.security_enabled != security_enabled:
             self.security_enabled = security_enabled
@@ -56,13 +61,35 @@ class CephadmHttpServer(threading.Thread):
         self._service_discovery_port = value
         self.restart()
 
+
+    @property
+    def acme_challenge_port(self) -> int:
+        return self._acme_challenge_port
+
+    @acme_challenge_port.setter
+    def acme_challenge_port(self, value: int) -> None:
+        if self._acme_challenge_port == value:
+            return
+
+        try:
+            test_port_allocation(self.mgr.get_mgr_ip(), value)
+        except PortAlreadyInUse:
+            raise OrchestratorError(f'ACME challenge port {value} is already in use. Listening on old port {self._acme_challenge_port}.')
+        except Exception as e:
+            raise OrchestratorError(f'Cannot check ACME challenge port ip:{self.mgr.get_mgr_ip()} port:{value} error:{e}')
+
+        self.mgr.log.info(f'Changing ACME challenge port from {self._acme_challenge_port} to {value}...')
+        self._acme_challenge_port = value
+        self.restart()
+
     def restart(self) -> None:
         self.cherrypy_restart_event.set()
 
     def _stop_adapters(self) -> None:
         adapters_to_stop = {
             'service-discovery': getattr(self, 'sd_adapter', None),
-            'cephadm-agent': getattr(self, 'agent_adapter', None)
+            'cephadm-agent': getattr(self, 'agent_adapter', None),
+            'acme-challenges': getattr(self, 'acme_adapter', None)
         }
         for name, adapter in adapters_to_stop.items():
             if adapter:
@@ -75,6 +102,7 @@ class CephadmHttpServer(threading.Thread):
 
         self.sd_adapter = None
         self.agent_adapter = None
+        self.acme_adapter = None
 
     def run(self) -> None:
         def _mount_server(
@@ -135,6 +163,20 @@ class CephadmHttpServer(threading.Thread):
                 extra_mounts=agent_mounts,
                 logger=self.mgr.log
             )
+
+
+            # start ACME HTTP-01 challenge server
+            acme_config, acme_ssl_info = self.acme_challenges.configure()
+            self.acme_adapter = _mount_server(
+                name='acme-challenges',
+                bind_addr=(self.mgr.get_mgr_ip(), self._acme_challenge_port),
+                main_app=ACMEChallengeRoot(self.mgr),
+                main_path='/',
+                main_config=acme_config,
+                ssl_info=acme_ssl_info,
+                logger=self.mgr.log
+            )
+
 
         try:
             start_servers()

--- a/src/pybind/mgr/cephadm/http_server.py
+++ b/src/pybind/mgr/cephadm/http_server.py
@@ -61,7 +61,6 @@ class CephadmHttpServer(threading.Thread):
         self._service_discovery_port = value
         self.restart()
 
-
     @property
     def acme_challenge_port(self) -> int:
         return self._acme_challenge_port
@@ -164,7 +163,6 @@ class CephadmHttpServer(threading.Thread):
                 logger=self.mgr.log
             )
 
-
             # start ACME HTTP-01 challenge server
             acme_config, acme_ssl_info = self.acme_challenges.configure()
             self.acme_adapter = _mount_server(
@@ -176,7 +174,6 @@ class CephadmHttpServer(threading.Thread):
                 ssl_info=acme_ssl_info,
                 logger=self.mgr.log
             )
-
 
         try:
             start_servers()

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -17,6 +17,7 @@ from threading import Event
 
 from ceph.deployment.service_spec import PrometheusSpec
 from cephadm.cert_mgr import CertMgr
+from cephadm.acme import ACMEManager
 from cephadm.tlsobject_store import TLSObjectScope, TLSObjectException
 
 import string
@@ -451,6 +452,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             desc='Cephadm service discovery port'
         ),
         Option(
+            'acme_challenge_port',
+            type='int',
+            default=8766,
+            desc='Cephadm ACME HTTP-01 challenge server port'
+        ),
+        Option(
             'cgroups_split',
             type='bool',
             default=True,
@@ -648,6 +655,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             self.hw_monitoring = False
             self.hw_monitoring_vendor = 'generic'
             self.service_discovery_port = 0
+            self.acme_challenge_port = 0
             self.secure_monitoring_stack = False
             self.apply_spec_fails: List[Tuple[str, str]] = []
             self.max_osd_draining_count = 10
@@ -733,6 +741,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
 
         service_registry.init_services(self)
         self._init_cert_mgr()
+        self.acme_mgr = ACMEManager(self)
 
         self.migration = Migrations(self)
 
@@ -802,6 +811,8 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         self.cert_mgr.register_cert('nvmeof', 'nvmeof_root_ca_cert', TLSObjectScope.SERVICE)
         # register haproxy monitor ssl cert and key
         self.cert_mgr.register_cert_key_pair('ingress', 'haproxy_monitor_ssl_cert', 'haproxy_monitor_ssl_key', TLSObjectScope.SERVICE)
+        # register ACME-managed certificate names for the first supported HTTP-01 consumer
+        self.cert_mgr.register_acme_cert_key_pair('mgmt-gateway', TLSObjectScope.GLOBAL)
         # register per-feature SMB TLS cert names
         for _smb_feature in ['remote_control', 'keybridge']:
             self.cert_mgr.register_cert_key_pair(

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -458,6 +458,16 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             desc='Cephadm ACME HTTP-01 challenge server port'
         ),
         Option(
+            'acme_profiles',
+            type='str',
+            default='',
+            desc=(
+                'JSON object describing cluster-level ACME profiles. Example: '
+                '{"profiles":{"default":{"directory_url":"https://acme-staging-v02.api.letsencrypt.org/directory",'
+                '"email":"admin@example.com","terms_of_service_agreed":true}}}'
+            )
+        ),
+        Option(
             'cgroups_split',
             type='bool',
             default=True,
@@ -656,6 +666,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             self.hw_monitoring_vendor = 'generic'
             self.service_discovery_port = 0
             self.acme_challenge_port = 0
+            self.acme_profiles = ''
             self.secure_monitoring_stack = False
             self.apply_spec_fails: List[Tuple[str, str]] = []
             self.max_osd_draining_count = 10

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -116,6 +116,8 @@ class CephadmServe:
 
                     self._check_certificates()
 
+                    self._process_acme_orders()
+
                     self._purge_deleted_services()
 
                     self._check_for_moved_osds()
@@ -166,6 +168,15 @@ class CephadmServe:
             for svc in services_to_reconfig:
                 self.log.info(f'certmgr: certificate has changed, reconfiguring service {svc}')
                 self.mgr.service_action('reconfig', svc)
+
+
+    def _process_acme_orders(self) -> None:
+        if not hasattr(self.mgr, 'acme_mgr'):
+            return
+        services_to_reconfig = self.mgr.acme_mgr.process_pending_orders()
+        for svc in services_to_reconfig:
+            self.log.info(f'acme: certificate has changed, reconfiguring service {svc}')
+            self.mgr.service_action('reconfig', svc)
 
     def _serve_sleep(self) -> None:
         sleep_interval = max(

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -169,7 +169,6 @@ class CephadmServe:
                 self.log.info(f'certmgr: certificate has changed, reconfiguring service {svc}')
                 self.mgr.service_action('reconfig', svc)
 
-
     def _process_acme_orders(self) -> None:
         if not hasattr(self.mgr, 'acme_mgr'):
             return

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -442,6 +442,8 @@ class CephadmService(metaclass=ABCMeta):
             return self._get_certificates_from_certmgr_store(svc_spec, fqdns, cert_name, key_name, ca_cert_name)
         elif cert_source == CertificateSource.CEPHADM_SIGNED.value:
             return self._get_cephadm_signed_certificates(svc_spec, daemon_spec, ips, fqdns, custom_sans)
+        elif cert_source == CertificateSource.ACME.value:
+            return self._get_acme_certificates(svc_spec, daemon_spec, ips, fqdns, custom_sans)
         else:
             logger.error(f'Invalid cert_source: {cert_source}')
             return EMPTY_TLS_CREDENTIALS
@@ -516,6 +518,38 @@ class CephadmService(metaclass=ABCMeta):
         else:
             logger.error(f'Failed to get cert/key {cert_name} for service {svc_spec.service_name()} host: {host} from the certmgr store.')
             return EMPTY_TLS_CREDENTIALS
+
+
+    def _get_acme_certificates(
+        self,
+        svc_spec: ServiceSpec,
+        daemon_spec: CephadmDaemonDeploySpec,
+        ips: List[str],
+        fqdns: List[str],
+        custom_sans: List[str],
+    ) -> TLSCredentials:
+        """Return an ACME-managed cert/key if present, else a temporary cephadm cert.
+
+        The HTTP-01 challenge server/routing is introduced separately from the
+        ACME order/finalize client. Until an issued ACME cert is stored by the
+        ACME manager, services still need a usable TLS pair to start, so we use
+        a cephadm-signed temporary certificate as bootstrap material.
+        """
+        service_name = svc_spec.service_name()
+        acme_cert_name = self.mgr.cert_mgr.acme_cert(service_name)
+        acme_key_name = self.mgr.cert_mgr.acme_key(service_name)
+        host = fqdns[0] if fqdns else None
+
+        cert = self.mgr.cert_mgr.get_cert(acme_cert_name, service_name, host)
+        key = self.mgr.cert_mgr.get_key(acme_key_name, service_name, host)
+        if cert and key:
+            return TLSCredentials(cert=cert, key=key)
+
+        logger.info(
+            "ACME certificate for service %s is not available yet; using temporary cephadm-signed certificate",
+            service_name,
+        )
+        return self._get_cephadm_signed_certificates(svc_spec, daemon_spec, ips, fqdns, custom_sans)
 
     def _get_cephadm_signed_certificates(
         self,
@@ -628,7 +662,7 @@ class CephadmService(metaclass=ABCMeta):
         # Inline-saved certs/keys are persisted in the certmgr store as user_made=True
         # but editable=False. These should be garbage-collected once the service no
         # longer uses INLINE.
-        if cert_source in (CertificateSource.REFERENCE.value, CertificateSource.CEPHADM_SIGNED.value):
+        if cert_source in (CertificateSource.REFERENCE.value, CertificateSource.CEPHADM_SIGNED.value, CertificateSource.ACME.value):
             self.mgr.cert_mgr.rm_inline_saved_cert_key_pair(
                 self.cert_name,
                 self.key_name,
@@ -639,8 +673,20 @@ class CephadmService(metaclass=ABCMeta):
 
         # Cephadm-signed certs/keys are stored under cephadm-signed_* entities and
         # should be removed when the service no longer uses CEPHADM_SIGNED.
+        # ACME is a special case: before the first ACME cert is issued we use a
+        # cephadm-signed temporary cert so the gateway can start and expose
+        # HTTP-01 on port 80. Keep that temporary pair until an ACME cert exists.
         if cert_source != CertificateSource.CEPHADM_SIGNED.value:
-            self.mgr.cert_mgr.try_rm_self_signed_cert_key_pair(svc_name, host)
+            acme_bootstrap = (
+                cert_source == CertificateSource.ACME.value
+                and not self.mgr.cert_mgr.cert_exists(self.mgr.cert_mgr.acme_cert(svc_name))
+            )
+            if not acme_bootstrap:
+                self.mgr.cert_mgr.try_rm_self_signed_cert_key_pair(svc_name, host)
+
+        if cert_source != CertificateSource.ACME.value and hasattr(self.mgr, 'acme_mgr'):
+            self.mgr.acme_mgr.cleanup_service(svc_name)
+            self.mgr.cert_mgr.rm_acme_cert_key_pair(svc_name)
 
     def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
         self.prepare_certificates(daemon_spec)

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -519,7 +519,6 @@ class CephadmService(metaclass=ABCMeta):
             logger.error(f'Failed to get cert/key {cert_name} for service {svc_spec.service_name()} host: {host} from the certmgr store.')
             return EMPTY_TLS_CREDENTIALS
 
-
     def _get_acme_certificates(
         self,
         svc_spec: ServiceSpec,
@@ -544,6 +543,14 @@ class CephadmService(metaclass=ABCMeta):
         key = self.mgr.cert_mgr.get_key(acme_key_name, service_name, host)
         if cert and key:
             return TLSCredentials(cert=cert, key=key)
+
+        if hasattr(self.mgr, 'acme_mgr'):
+            self.mgr.acme_mgr.ensure_certificate(
+                service_name,
+                acme_cert_name,
+                acme_key_name,
+                getattr(svc_spec, 'acme', {}),
+            )
 
         logger.info(
             "ACME certificate for service %s is not available yet; using temporary cephadm-signed certificate",

--- a/src/pybind/mgr/cephadm/services/mgmt_gateway.py
+++ b/src/pybind/mgr/cephadm/services/mgmt_gateway.py
@@ -4,7 +4,7 @@ from typing import List, Any, Tuple, Dict, cast, Optional, TYPE_CHECKING
 from ceph.deployment.utils import wrap_ipv6
 
 from orchestrator import DaemonDescription
-from ceph.deployment.service_spec import MgmtGatewaySpec, GrafanaSpec, ServiceSpec
+from ceph.deployment.service_spec import CertificateSource, MgmtGatewaySpec, GrafanaSpec, ServiceSpec
 from cephadm.services.cephadmservice import CephadmService, CephadmDaemonDeploySpec, get_dashboard_endpoints
 from .service_registry import register_cephadm_service
 
@@ -59,6 +59,14 @@ class MgmtGatewayService(CephadmService):
         self.mgr.set_module_option_ex('dashboard', 'standby_error_status_code', '503')
         self.mgr.set_module_option_ex('dashboard', 'standby_behaviour', 'error')
 
+    def get_acme_challenge_endpoints(self) -> List[str]:
+        acme_endpoints = []
+        for dd in self.mgr.cache.get_daemons_by_service('mgr'):
+            assert dd.hostname is not None
+            addr = dd.ip if dd.ip else self.mgr.inventory.get_addr(dd.hostname)
+            acme_endpoints.append(f"{wrap_ipv6(addr)}:{self.mgr.acme_challenge_port}")
+        return acme_endpoints
+
     def get_service_discovery_endpoints(self) -> List[str]:
         # the mgmt gateway uses this internally when generating its nginx
         # configuration and the URL prefixes that we publish to the world.
@@ -86,6 +94,11 @@ class MgmtGatewayService(CephadmService):
             for service in ['mgr']
             for d in mgr.cache.get_daemons_by_service(service)
         ]
+        if (
+            spec is not None
+            and getattr(spec, 'certificate_source', None) == CertificateSource.ACME.value
+        ):
+            deps.append(f'acme_challenge_port:{mgr.acme_challenge_port}')
         parent_deps = super().get_dependencies(mgr, spec, daemon_type)
         return sorted(deps + parent_deps)
 
@@ -99,6 +112,8 @@ class MgmtGatewayService(CephadmService):
         grafana_endpoints = self.get_service_endpoints('grafana')
         oauth2_proxy_endpoints = self.get_service_endpoints('oauth2-proxy')
         service_discovery_endpoints = self.get_service_discovery_endpoints()
+        acme_challenge_endpoints = self.get_acme_challenge_endpoints()
+        acme_enabled = svc_spec.certificate_source == CertificateSource.ACME.value
         try:
             grafana_spec = cast(GrafanaSpec, self.mgr.spec_store['grafana'].spec)
             grafana_protocol = grafana_spec.protocol
@@ -111,7 +126,8 @@ class MgmtGatewayService(CephadmService):
             'alertmanager_endpoints': alertmanager_endpoints,
             'grafana_endpoints': grafana_endpoints,
             'oauth2_proxy_endpoints': oauth2_proxy_endpoints,
-            'service_discovery_endpoints': service_discovery_endpoints
+            'service_discovery_endpoints': service_discovery_endpoints,
+            'acme_challenge_endpoints': acme_challenge_endpoints
         }
         server_context = {
             'spec': svc_spec,
@@ -125,6 +141,8 @@ class MgmtGatewayService(CephadmService):
             'alertmanager_endpoints': alertmanager_endpoints,
             'grafana_endpoints': grafana_endpoints,
             'service_discovery_endpoints': service_discovery_endpoints,
+            'acme_challenge_endpoints': acme_challenge_endpoints,
+            'acme_enabled': acme_enabled,
             'enable_oauth2_proxy': bool(oauth2_proxy_endpoints),
         }
 

--- a/src/pybind/mgr/cephadm/templates/services/mgmt-gateway/external_server.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/mgmt-gateway/external_server.conf.j2
@@ -1,3 +1,27 @@
+{% if acme_enabled and acme_challenge_endpoints %}
+server {
+    {% if spec.virtual_ip %}
+    listen                    {{ spec.virtual_ip }}:80;
+    {% else %}
+    listen                    0.0.0.0:80;
+    listen                    [::]:80;
+    {% endif %}
+
+    location ^~ /.well-known/acme-challenge/ {
+        proxy_pass http://acme_challenge_servers;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto http;
+        proxy_buffering off;
+    }
+
+    location / {
+        return 301 https://$host{% if spec.port and spec.port != 443 %}:{{ spec.port }}{% endif %}$request_uri;
+    }
+}
+{% endif %}
+
 
 server {
 {% if not spec.ssl %}

--- a/src/pybind/mgr/cephadm/templates/services/mgmt-gateway/nginx.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/mgmt-gateway/nginx.conf.j2
@@ -34,6 +34,14 @@ http {
     }
 {% endif %}
 
+{% if acme_challenge_endpoints %}
+    upstream acme_challenge_servers {
+     {% for ep in acme_challenge_endpoints %}
+     server {{ ep }};
+     {% endfor %}
+    }
+{% endif %}
+
 {% if dashboard_endpoints %}
     upstream dashboard_servers {
      {% for ep in dashboard_endpoints %}

--- a/src/pybind/mgr/cephadm/tests/test_acme.py
+++ b/src/pybind/mgr/cephadm/tests/test_acme.py
@@ -1,0 +1,181 @@
+import json
+
+from cephadm.acme import ACMEManager
+from cephadm.tlsobject_types import TLSCredentials
+
+
+class FakeCertMgr:
+    def __init__(self):
+        self.saved = []
+
+    def save_acme_cert_key_pair(self, service_name, tls_creds):
+        assert isinstance(tls_creds, TLSCredentials)
+        self.saved.append((service_name, tls_creds))
+
+    def get_associated_service(self, cert_info):
+        return 'mgmt-gateway'
+
+
+class FakeMgr:
+    def __init__(self):
+        self.store = {}
+        self.cert_mgr = FakeCertMgr()
+        self.acme_profiles = ''
+
+    def get_store(self, key):
+        return self.store.get(key)
+
+    def set_store(self, key, value):
+        if value is None:
+            self.store.pop(key, None)
+        else:
+            self.store[key] = value
+
+    def get_store_prefix(self, prefix):
+        return {k: v for k, v in self.store.items() if k.startswith(prefix)}
+
+
+class FakeACMEManager(ACMEManager):
+    def __init__(self, mgr):
+        super().__init__(mgr)
+        self.nonce = 0
+        self.order_gets = 0
+
+    def _http_request(self, url, method='GET', data=None, headers=None):
+        if url == 'https://ca.example/directory':
+            return 200, {}, json.dumps({
+                'newNonce': 'https://ca.example/new-nonce',
+                'newAccount': 'https://ca.example/new-account',
+                'newOrder': 'https://ca.example/new-order',
+            }).encode('utf-8')
+        if url == 'https://ca.example/new-nonce':
+            self.nonce += 1
+            return 200, {'Replay-Nonce': f'nonce-{self.nonce}'}, b''
+        if url == 'https://ca.example/new-account':
+            return 201, {'Location': 'https://ca.example/acct/1'}, b'{"status":"valid"}'
+        if url == 'https://ca.example/new-order':
+            return 201, {'Location': 'https://ca.example/order/1'}, json.dumps({
+                'status': 'pending',
+                'authorizations': ['https://ca.example/authz/1'],
+                'finalize': 'https://ca.example/finalize/1',
+            }).encode('utf-8')
+        if url == 'https://ca.example/authz/1':
+            return 200, {}, json.dumps({
+                'status': 'pending',
+                'identifier': {'type': 'dns', 'value': 'ceph.example.com'},
+                'challenges': [{
+                    'type': 'http-01',
+                    'token': 'tok123',
+                    'url': 'https://ca.example/challenge/1',
+                }],
+            }).encode('utf-8')
+        if url == 'https://ca.example/challenge/1':
+            return 200, {}, b'{"status":"pending"}'
+        if url == 'https://ca.example/order/1':
+            self.order_gets += 1
+            return 200, {}, json.dumps({
+                'status': 'ready' if self.order_gets == 1 else 'valid',
+                'authorizations': ['https://ca.example/authz/1'],
+                'finalize': 'https://ca.example/finalize/1',
+                'certificate': 'https://ca.example/cert/1',
+            }).encode('utf-8')
+        if url == 'https://ca.example/finalize/1':
+            return 200, {}, json.dumps({
+                'status': 'valid',
+                'certificate': 'https://ca.example/cert/1',
+            }).encode('utf-8')
+        if url == 'https://ca.example/cert/1':
+            return 200, {'Content-Type': 'application/pem-certificate-chain'}, (
+                '-----BEGIN CERTIFICATE-----\n'
+                'MIIB\n'
+                '-----END CERTIFICATE-----\n'
+            ).encode('utf-8')
+        raise AssertionError(f'unexpected ACME request: {method} {url}')
+
+
+def test_acme_order_flow_stores_challenge_then_certificate():
+    mgr = FakeMgr()
+    acme_mgr = FakeACMEManager(mgr)
+
+    acme_cfg = {
+        'domains': ['ceph.example.com'],
+        'directory_url': 'https://ca.example/directory',
+        'email': 'admin@example.com',
+        'terms_of_service_agreed': True,
+    }
+
+    acme_mgr.ensure_certificate(
+        'mgmt-gateway',
+        'acme_mgmt-gateway_cert',
+        'acme_mgmt-gateway_key',
+        acme_cfg,
+    )
+
+    assert acme_mgr.process_pending_orders() == []
+    assert acme_mgr.get_http01_key_authorization('tok123').startswith('tok123.')
+
+    assert acme_mgr.process_pending_orders() == ['mgmt-gateway']
+    assert mgr.cert_mgr.saved[0][0] == 'mgmt-gateway'
+    assert 'BEGIN CERTIFICATE' in mgr.cert_mgr.saved[0][1].cert
+    assert 'BEGIN RSA PRIVATE KEY' in mgr.cert_mgr.saved[0][1].key
+    assert acme_mgr.get_http01_key_authorization('tok123') is None
+
+
+def test_acme_config_uses_global_profile_defaults():
+    mgr = FakeMgr()
+    mgr.acme_profiles = json.dumps({
+        'profiles': {
+            'default': {
+                'directory_url': 'https://ca.example/directory',
+                'email': 'global@example.com',
+                'terms_of_service_agreed': True,
+                'account_name': 'global-account',
+            }
+        }
+    })
+    acme_mgr = FakeACMEManager(mgr)
+
+    acme_mgr.ensure_certificate(
+        'mgmt-gateway',
+        'acme_mgmt-gateway_cert',
+        'acme_mgmt-gateway_key',
+        {'domains': ['Ceph.EXAMPLE.com']},
+    )
+
+    order = json.loads(mgr.store[acme_mgr.ORDER_STORE_PREFIX + 'mgmt-gateway'])
+    assert order['domains'] == ['ceph.example.com']
+    assert order['profile'] == 'default'
+    assert order['directory_url'] == 'https://ca.example/directory'
+    assert order['email'] == 'global@example.com'
+    assert order['account_name'] == 'global-account'
+
+
+def test_acme_config_service_overrides_global_profile():
+    mgr = FakeMgr()
+    mgr.acme_profiles = json.dumps({
+        'profiles': {
+            'default': {
+                'directory_url': 'https://ca.example/directory',
+                'email': 'global@example.com',
+                'terms_of_service_agreed': True,
+                'account_name': 'global-account',
+            }
+        }
+    })
+    acme_mgr = FakeACMEManager(mgr)
+
+    acme_mgr.ensure_certificate(
+        'mgmt-gateway',
+        'acme_mgmt-gateway_cert',
+        'acme_mgmt-gateway_key',
+        {
+            'domains': ['ceph.example.com'],
+            'email': 'service@example.com',
+            'account_name': 'service-account',
+        },
+    )
+
+    order = json.loads(mgr.store[acme_mgr.ORDER_STORE_PREFIX + 'mgmt-gateway'])
+    assert order['directory_url'] == 'https://ca.example/directory'
+    assert order['email'] == 'service@example.com'
+    assert order['account_name'] == 'service-account'

--- a/src/pybind/mgr/cephadm/tests/test_certmgr.py
+++ b/src/pybind/mgr/cephadm/tests/test_certmgr.py
@@ -5,7 +5,7 @@ import json
 from tests import mock
 import logging
 
-from cephadm.tlsobject_types import Cert, PrivKey, TLSObjectException, TLSObjectProtocol, TLSCredentials
+from cephadm.tlsobject_types import Cert, PrivKey, TLSObjectException, TLSObjectManager, TLSObjectProtocol, TLSCredentials
 from cephadm.tlsobject_store import TLSOBJECT_STORE_PREFIX, TLSObjectStore, TLSObjectScope
 from cephadm.module import CephadmOrchestrator
 from cephadm.cert_mgr import CertInfo, CertMgr
@@ -293,6 +293,50 @@ TLSOBJECT_STORE_KEY_PREFIX = f'{TLSOBJECT_STORE_PREFIX}key.'
 
 
 class TestCertMgr(object):
+
+    def test_cert_managed_by_migration_from_user_made(self):
+        user_cert = Cert.from_json({'cert': 'user-cert', 'user_made': True, 'editable': False})
+        cephadm_cert = Cert.from_json({'cert': 'cephadm-cert', 'user_made': False, 'editable': False})
+
+        assert user_cert.managed_by == TLSObjectManager.USER.value
+        assert user_cert.user_made is True
+        assert user_cert.to_json()['managed_by'] == TLSObjectManager.USER.value
+        assert user_cert.to_json()['user_made'] is True
+
+        assert cephadm_cert.managed_by == TLSObjectManager.CEPHADM.value
+        assert cephadm_cert.user_made is False
+        assert cephadm_cert.to_json()['managed_by'] == TLSObjectManager.CEPHADM.value
+        assert cephadm_cert.to_json()['user_made'] is False
+
+    def test_key_managed_by_migration_from_user_made(self):
+        user_key = PrivKey.from_json({'key': 'user-key', 'user_made': True, 'editable': False})
+        cephadm_key = PrivKey.from_json({'key': 'cephadm-key', 'user_made': False, 'editable': False})
+
+        assert user_key.managed_by == TLSObjectManager.USER.value
+        assert user_key.user_made is True
+        assert cephadm_key.managed_by == TLSObjectManager.CEPHADM.value
+        assert cephadm_key.user_made is False
+
+    def test_tlsobject_managed_by_acme_round_trip(self):
+        cert = Cert('acme-cert', managed_by=TLSObjectManager.ACME.value, editable=False)
+        key = PrivKey('acme-key', managed_by=TLSObjectManager.ACME.value, editable=False)
+
+        assert cert.user_made is False
+        assert key.user_made is False
+        assert Cert.from_json(cert.to_json()).managed_by == TLSObjectManager.ACME.value
+        assert PrivKey.from_json(key.to_json()).managed_by == TLSObjectManager.ACME.value
+
+    def test_cert_info_uses_managed_by_for_signed_by_and_description(self):
+        cert_info = CertInfo(
+            'acme_cert',
+            'target',
+            is_valid=False,
+            error_info='expired',
+            managed_by=TLSObjectManager.ACME.value,
+        )
+
+        assert cert_info.signed_by == TLSObjectManager.ACME.value
+        assert 'acme-managed' in cert_info.get_status_description()
 
     @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
     def test_tlsobject_store_save_cert(self, _set_store, cephadm_module: CephadmOrchestrator):

--- a/src/pybind/mgr/cephadm/tlsobject_store.py
+++ b/src/pybind/mgr/cephadm/tlsobject_store.py
@@ -144,10 +144,19 @@ class TLSObjectStore():
                        service_name: Optional[str] = None,
                        host: Optional[str] = None,
                        user_made: bool = False,
-                       editable: bool = False) -> None:
+                       editable: bool = False,
+                       managed_by: Optional[str] = None) -> None:
 
         self._validate_tlsobject_name(obj_name, service_name, host)
-        tlsobject = self.tlsobject_class(tlsobject, user_made, editable)
+        if managed_by is None:
+            tlsobject = self.tlsobject_class(tlsobject, user_made, editable)
+        else:
+            tlsobject = self.tlsobject_class(
+                tlsobject,
+                user_made,
+                editable,
+                managed_by=managed_by,
+            )
         scope, target = self.get_tlsobject_scope_and_target(obj_name, service_name, host)
         if scope in (TLSObjectScope.SERVICE, TLSObjectScope.HOST):
             self.objects_by_name[obj_name][target] = tlsobject

--- a/src/pybind/mgr/cephadm/tlsobject_store.py
+++ b/src/pybind/mgr/cephadm/tlsobject_store.py
@@ -140,7 +140,7 @@ class TLSObjectStore():
             return self.objects_by_name.get(obj_name, {}).get(target)
 
     def save_tlsobject(self, obj_name: str,
-                       tlsobject: str,
+                       tlsobject_cls: str,
                        service_name: Optional[str] = None,
                        host: Optional[str] = None,
                        user_made: bool = False,
@@ -149,10 +149,10 @@ class TLSObjectStore():
 
         self._validate_tlsobject_name(obj_name, service_name, host)
         if managed_by is None:
-            tlsobject = self.tlsobject_class(tlsobject, user_made, editable)
+            tlsobject = self.tlsobject_class(tlsobject_cls, user_made, editable)
         else:
             tlsobject = self.tlsobject_class(
-                tlsobject,
+                tlsobject_cls,
                 user_made,
                 editable,
                 managed_by=managed_by,

--- a/src/pybind/mgr/cephadm/tlsobject_types.py
+++ b/src/pybind/mgr/cephadm/tlsobject_types.py
@@ -51,10 +51,48 @@ class TLSObjectTarget(NamedTuple):
 EMPTY_TLS_CREDENTIALS = TLSCredentials('', '', '')
 
 
+class TLSObjectManager(str, Enum):
+    """
+    Describes who owns the lifecycle of a stored TLS object.
+
+    This is intentionally separate from ServiceSpec.certificate_source:
+      - certificate_source describes how a service resolves certificate material.
+      - managed_by describes who owns the persisted cert/key lifecycle.
+
+    Legacy objects only have user_made; when managed_by is missing it is
+    derived as USER for user_made=True and CEPHADM otherwise.
+    """
+    USER = 'user'
+    CEPHADM = 'cephadm'
+    ACME = 'acme'
+
+
+def _managed_by_from_legacy(user_made: Optional[bool]) -> str:
+    return TLSObjectManager.USER.value if bool(user_made) else TLSObjectManager.CEPHADM.value
+
+
+def _validate_managed_by(managed_by: Any) -> str:
+    try:
+        return TLSObjectManager(str(managed_by)).value
+    except ValueError:
+        allowed = ', '.join(m.value for m in TLSObjectManager)
+        raise TLSObjectException(f'Invalid managed_by value {managed_by!r}. Must be one of: {allowed}')
+
+
+def _resolve_managed_by(managed_by: Optional[Any], user_made: Optional[bool]) -> str:
+    if managed_by is not None:
+        return _validate_managed_by(managed_by)
+    return _managed_by_from_legacy(user_made)
+
+
 class TLSObjectProtocol(Protocol):
     STORAGE_PREFIX: str
 
-    def __init__(self, cert: str = '', user_made: bool = False, editable: bool = False) -> None:
+    def __init__(self,
+                 cert: str = '',
+                 user_made: Optional[bool] = None,
+                 editable: bool = False,
+                 managed_by: Optional[str] = None) -> None:
         ...
 
     def __bool__(self) -> bool:
@@ -74,23 +112,36 @@ class TLSObjectProtocol(Protocol):
 class Cert(TLSObjectProtocol):
     STORAGE_PREFIX = 'cert'
 
-    def __init__(self, cert: str = '', user_made: bool = False, editable: bool = False) -> None:
+    def __init__(self,
+                 cert: str = '',
+                 user_made: Optional[bool] = None,
+                 editable: bool = False,
+                 managed_by: Optional[str] = None) -> None:
         self.cert = cert
-        self.user_made = user_made
+        self.managed_by = _resolve_managed_by(managed_by, user_made)
         self.editable = editable
+
+    @property
+    def user_made(self) -> bool:
+        return self.managed_by == TLSObjectManager.USER.value
+
+    @user_made.setter
+    def user_made(self, value: bool) -> None:
+        self.managed_by = _managed_by_from_legacy(value)
 
     def __bool__(self) -> bool:
         return bool(self.cert)
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, Cert):
-            return self.cert == other.cert and self.user_made == other.user_made
+            return self.cert == other.cert and self.managed_by == other.managed_by
         return NotImplemented
 
     def to_json(self) -> Dict[str, Union[str, bool]]:
         if (self):
             return {
                 'cert': self.cert,
+                'managed_by': self.managed_by,
                 'user_made': self.user_made,
                 'editable': self.editable
             }
@@ -104,38 +155,54 @@ class Cert(TLSObjectProtocol):
         cert = data['cert']
         if not isinstance(cert, str):
             raise TLSObjectException('Tried to make Cert object with non-string cert')
-        if any(k not in ['cert', 'user_made', 'editable'] for k in data.keys()):
+        if any(k not in ['cert', 'user_made', 'editable', 'managed_by'] for k in data.keys()):
             raise TLSObjectException(f'Got unknown field for Cert object. Fields: {data.keys()}')
 
         try:
-            user_made = parse_bool(data.get('user_made', False))
+            user_made = parse_bool(data.get('user_made', False)) if 'user_made' in data else None
             editable = parse_bool(data.get('editable', False))
         except ValueError as e:
             raise TLSObjectException(f'Expected field in Cert object to be bool but got another type: {e}')
 
-        return cls(cert=cert, user_made=user_made, editable=editable)
+        managed_by = data.get('managed_by')
+        if managed_by is not None and not isinstance(managed_by, str):
+            raise TLSObjectException('Expected managed_by field in Cert object to be a string')
+        return cls(cert=cert, user_made=user_made, editable=editable, managed_by=managed_by)
 
 
 class PrivKey(TLSObjectProtocol):
     STORAGE_PREFIX = 'key'
 
-    def __init__(self, key: str = '', user_made: bool = False, editable: bool = False) -> None:
+    def __init__(self,
+                 key: str = '',
+                 user_made: Optional[bool] = None,
+                 editable: bool = False,
+                 managed_by: Optional[str] = None) -> None:
         self.key = key
-        self.user_made = user_made
+        self.managed_by = _resolve_managed_by(managed_by, user_made)
         self.editable = editable
+
+    @property
+    def user_made(self) -> bool:
+        return self.managed_by == TLSObjectManager.USER.value
+
+    @user_made.setter
+    def user_made(self, value: bool) -> None:
+        self.managed_by = _managed_by_from_legacy(value)
 
     def __bool__(self) -> bool:
         return bool(self.key)
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, PrivKey):
-            return self.key == other.key and self.user_made == other.user_made
+            return self.key == other.key and self.managed_by == other.managed_by
         return NotImplemented
 
     def to_json(self) -> Dict[str, Union[str, bool]]:
         if bool(self):
             return {
                 'key': self.key,
+                'managed_by': self.managed_by,
                 'user_made': self.user_made,
                 'editable': self.editable
             }
@@ -143,19 +210,22 @@ class PrivKey(TLSObjectProtocol):
             return {}
 
     @classmethod
-    def from_json(cls, data: Dict[str, str]) -> 'PrivKey':
+    def from_json(cls, data: Dict[str, Union[str, bool]]) -> 'PrivKey':
         if 'key' not in data:
             return cls()
         key = data['key']
         if not isinstance(key, str):
             raise TLSObjectException('Tried to make PrivKey object with non-string key')
-        if any(k not in ['key', 'user_made', 'editable'] for k in data.keys()):
+        if any(k not in ['key', 'user_made', 'editable', 'managed_by'] for k in data.keys()):
             raise TLSObjectException(f'Got unknown field for PrivKey object. Fields: {data.keys()}')
 
         try:
-            user_made = parse_bool(data.get('user_made', False))
+            user_made = parse_bool(data.get('user_made', False)) if 'user_made' in data else None
             editable = parse_bool(data.get('editable', False))
         except ValueError as e:
             raise TLSObjectException(f'Expected field in PrivKey object to be bool but got another type: {e}')
 
-        return cls(key=key, user_made=user_made, editable=editable)
+        managed_by = data.get('managed_by')
+        if managed_by is not None and not isinstance(managed_by, str):
+            raise TLSObjectException('Expected managed_by field in PrivKey object to be a string')
+        return cls(key=key, user_made=user_made, editable=editable, managed_by=managed_by)

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1346,6 +1346,13 @@ class ServiceSpec(object):
                 raise SpecValidationError(
                     f"When using certificate_source '{CertificateSource.ACME.value}', an acme config block is required."
                 )
+
+            # Service-level ACME config intentionally only requires the domain
+            # list. CA/account settings such as directory_url, email, account_name
+            # and terms_of_service_agreed may come from a cluster-level ACME
+            # profile and can be overridden here when needed. Full profile
+            # resolution happens in cephadm.acme.ACMEManager, where mgr module
+            # options are available.
             domains = acme_cfg.get('domains')
             if not isinstance(domains, list) or not domains or not all(isinstance(d, str) and d.strip() for d in domains):
                 raise SpecValidationError(
@@ -1361,12 +1368,24 @@ class ServiceSpec(object):
                     pass
                 else:
                     raise SpecValidationError('ACME HTTP-01 domains must be DNS names, not IP addresses.')
+
+            profile = acme_cfg.get('profile')
+            if profile is not None and (not isinstance(profile, str) or not profile.strip()):
+                raise SpecValidationError("ACME 'profile' must be a non-empty string when provided.")
             directory_url = acme_cfg.get('directory_url')
-            if directory_url is not None and not isinstance(directory_url, str):
-                raise SpecValidationError("ACME 'directory_url' must be a string when provided.")
+            if directory_url is not None and (not isinstance(directory_url, str) or not directory_url.strip()):
+                raise SpecValidationError("ACME 'directory_url' must be a non-empty string when provided.")
             email = acme_cfg.get('email')
             if email is not None and not isinstance(email, str):
                 raise SpecValidationError("ACME 'email' must be a string when provided.")
+            terms_agreed = acme_cfg.get('terms_of_service_agreed')
+            if terms_agreed is not None and terms_agreed is not True:
+                raise SpecValidationError(
+                    "ACME 'terms_of_service_agreed' must be true when provided."
+                )
+            account_name = acme_cfg.get('account_name')
+            if account_name is not None and (not isinstance(account_name, str) or not account_name.strip()):
+                raise SpecValidationError("ACME 'account_name' must be a non-empty string when provided.")
 
 
     def validate(self) -> None:

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -58,6 +58,7 @@ class TLSBlock(TypedDict, total=False):
     ssl_cert: str
     ssl_key: str
     custom_sans: List[str]
+    acme: Dict[str, Any]
 
 
 class RequiresCertificatesEntry(TypedDict):
@@ -68,15 +69,20 @@ class RequiresCertificatesEntry(TypedDict):
 
 class CertificateSource(Enum):
     """
-    Describes the source of the certificate used by cephadm:
+    Describes how cephadm resolves certificate material.
 
-    - INLINE: Certificate is embedded inline in the spec.
-    - REFEFRENCE: Certificate is provided by the user through the certmgr.
-    - CEPHADM_SIGNED: Certificate is generated and signed by cephadm (via certmgr).
+    - INLINE: User provides cert/key inline in the service spec. Cephadm persists
+      the resolved material in certmgr as non-editable.
+    - REFERENCE: User points to an existing editable certmgr object. Cephadm consumes
+      it but does not own its lifecycle.
+    - CEPHADM_SIGNED: Cephadm generates and owns cert/key lifecycle using the cephadm CA.
+    - ACME: Cephadm obtains cert/key from an external ACME CA and owns renewal.
+      The resolved cert/key is persisted in certmgr, but it is not a user-managed reference.
     """
     INLINE = "inline"
     REFERENCE = "reference"
     CEPHADM_SIGNED = "cephadm-signed"
+    ACME = "acme"
 
 
 class MonitorCertSource(Enum):
@@ -1007,6 +1013,7 @@ class ServiceSpec(object):
                  custom_configs: Optional[List[CustomConfig]] = None,
                  ip_addrs: Optional[Dict[str, str]] = None,
                  ssl_ca_cert: Optional[str] = None,
+                 acme: Optional[Dict[str, Any]] = None,
                  termination_grace_period_seconds: Optional[int] = None,
                  ):
 
@@ -1032,6 +1039,7 @@ class ServiceSpec(object):
             self.ssl_key = ssl_key
             self.ssl_ca_cert = ssl_ca_cert
             self.custom_sans = custom_sans
+            self.acme = acme
 
         if self.service_type in self.REQUIRES_SERVICE_ID or self.service_type == 'osd':
             self.service_id = service_id
@@ -1254,6 +1262,8 @@ class ServiceSpec(object):
                 tls['ssl_key'] = self.ssl_key
             if self.custom_sans:
                 tls['custom_sans'] = self.custom_sans
+            if self.certificate_source == CertificateSource.ACME.value and self.acme:
+                tls['acme'] = self.acme
             c.update(tls)
 
         if c:
@@ -1277,6 +1287,7 @@ class ServiceSpec(object):
         has_key = bool(getattr(self, "ssl_key", None))
         has_ca_cert = bool(getattr(self, "ssl_ca_cert", None))
         has_cert_src = bool(getattr(self, "certificate_source", None))
+        acme_cfg = getattr(self, "acme", None)
 
         # Pairing rule for legacy inline specs
         if (has_cert or has_key) and not (has_cert and has_key):
@@ -1316,6 +1327,47 @@ class ServiceSpec(object):
                 f"When using certificate_source '{self.certificate_source}', custom "
                 "ssl_cert or ssl_key must not be provided."
             )
+
+        if self.certificate_source == CertificateSource.ACME.value:
+            if self.service_type != 'mgmt-gateway':
+                raise SpecValidationError(
+                    f"certificate_source '{CertificateSource.ACME.value}' is currently supported only for mgmt-gateway"
+                )
+            if has_cert or has_key or has_ca_cert:
+                raise SpecValidationError(
+                    f"When using certificate_source '{CertificateSource.ACME.value}', custom "
+                    "ssl_cert, ssl_key, or ssl_ca_cert must not be provided."
+                )
+            if getattr(self, 'custom_sans', None):
+                raise SpecValidationError(
+                    f"When using certificate_source '{CertificateSource.ACME.value}', use acme.domains instead of custom_sans."
+                )
+            if not isinstance(acme_cfg, dict):
+                raise SpecValidationError(
+                    f"When using certificate_source '{CertificateSource.ACME.value}', an acme config block is required."
+                )
+            domains = acme_cfg.get('domains')
+            if not isinstance(domains, list) or not domains or not all(isinstance(d, str) and d.strip() for d in domains):
+                raise SpecValidationError(
+                    "ACME config requires a non-empty 'domains' list of DNS names."
+                )
+            for domain in domains:
+                domain = domain.strip()
+                if domain.startswith('*.'):
+                    raise SpecValidationError('ACME HTTP-01 does not support wildcard domains.')
+                try:
+                    ip_address(domain)
+                except ValueError:
+                    pass
+                else:
+                    raise SpecValidationError('ACME HTTP-01 domains must be DNS names, not IP addresses.')
+            directory_url = acme_cfg.get('directory_url')
+            if directory_url is not None and not isinstance(directory_url, str):
+                raise SpecValidationError("ACME 'directory_url' must be a string when provided.")
+            email = acme_cfg.get('email')
+            if email is not None and not isinstance(email, str):
+                raise SpecValidationError("ACME 'email' must be a string when provided.")
+
 
     def validate(self) -> None:
         if not self.service_type:
@@ -2603,6 +2655,7 @@ class MgmtGatewaySpec(ServiceSpec):
                  ssl: Optional[bool] = True,
                  certificate_source: Optional[str] = None,
                  custom_sans: Optional[List[str]] = None,
+                 acme: Optional[Dict[str, Any]] = None,
                  ssl_prefer_server_ciphers: Optional[str] = None,
                  ssl_session_tickets: Optional[str] = None,
                  ssl_session_timeout: Optional[str] = None,
@@ -2631,6 +2684,7 @@ class MgmtGatewaySpec(ServiceSpec):
             ssl_key=ssl_key,
             certificate_source=certificate_source,
             custom_sans=custom_sans,
+            acme=acme,
             preview_only=preview_only,
             extra_container_args=extra_container_args,
             extra_entrypoint_args=extra_entrypoint_args,
@@ -2670,6 +2724,15 @@ class MgmtGatewaySpec(ServiceSpec):
             ports.append(cast(int, self.port))
         else:
             ports.append(443)  # default HTTPS port
+        if (
+            self.ssl
+            and self.certificate_source == CertificateSource.ACME.value
+            and 80 not in ports
+        ):
+            # HTTP-01 validation always starts on public TCP/80. Keep the
+            # HTTPS port first because other cephadm code treats ports[0] as
+            # the primary mgmt-gateway endpoint.
+            ports.append(80)
         return ports
 
     def validate(self) -> None:


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
