### PR TITLE
test: Add longer shared timeout for omap recovery tests

### DIFF
--- a/src/test/librados/omap_cxx.cc
+++ b/src/test/librados/omap_cxx.cc
@@ -33,10 +33,12 @@ class OmapTest : public ceph::test::PoolTypeTestFixture {
 protected:
   std::string nspace;
   uint64_t alignment = 0;
+  static std::chrono::seconds recovery_budget;
 
   static void SetUpTestSuite() {
     SKIP_IF_CRIMSON();
     ASSERT_EQ("", connect_cluster_pp(rados));
+    recovery_budget = std::chrono::minutes(15);
   }
 
   static void TearDownTestSuite() {
@@ -161,11 +163,10 @@ protected:
 
   int wait_for_upmap(
       std::string oid,
-      int desired_primary,
-      std::chrono::seconds timeout) {
+      int desired_primary) {
     bool upmap_in_effect = false;
     auto start_time = std::chrono::steady_clock::now();
-    while (!upmap_in_effect && (std::chrono::steady_clock::now() - start_time < timeout)) {
+    while (!upmap_in_effect && (std::chrono::steady_clock::now() - start_time < recovery_budget)) {
       ceph::messaging::osd::OSDMapReply reply;
       int res = request_osd_map(oid, &reply);
       EXPECT_TRUE(res == 0);
@@ -177,6 +178,14 @@ protected:
         std::this_thread::sleep_for(std::chrono::seconds(1));
       }
     }
+    // Deduct elapsed time so the next Recovery test inherits a reduced budget,
+    // but guarantee each test always has at least 60 seconds to work with.
+    auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+        std::chrono::steady_clock::now() - start_time);
+    static constexpr auto min_budget = std::chrono::seconds(60);
+    auto deductible = std::min(elapsed, recovery_budget - min_budget);
+    recovery_budget -= std::max(deductible, std::chrono::seconds(0));
+    std::cout << "New recovery_budget: " << recovery_budget << std::endl;
     return upmap_in_effect ? 0 : -ETIMEDOUT;
   }
 
@@ -219,6 +228,9 @@ protected:
   // Helper to get standard test omap data
   std::map<std::string, bufferlist> get_test_omap_data();
 };
+
+// Static member definitions for OmapTest
+std::chrono::seconds OmapTest::recovery_budget{0};
 
 // Helper method to create a test object with omap data
 void OmapTest::create_test_object_with_omap(
@@ -537,7 +549,7 @@ TEST_P(OmapTest, OmapRecovery) {
   EXPECT_TRUE(rc == 0);
 
   // 5. Wait for new upmap to appear as acting set of osds
-  int res2 = wait_for_upmap("change_upmap_oid", new_primary, 60s);
+  int res2 = wait_for_upmap("change_upmap_oid", new_primary);
   EXPECT_TRUE(res2 == 0);
   
   // 6. Read omap
@@ -580,7 +592,7 @@ TEST_P(OmapTest, NoOmapRecovery) {
   EXPECT_TRUE(rc == 0);
 
   // 5. Wait for new upmap to appear as acting set of osds
-  int res2 = wait_for_upmap("no_omap_oid", new_primary, 60s);
+  int res2 = wait_for_upmap("no_omap_oid", new_primary);
   EXPECT_TRUE(res2 == 0);
 
   // 6. Read data
@@ -657,7 +669,7 @@ TEST_P(OmapTest, LargeOmapRecovery) {
   EXPECT_TRUE(rc == 0);
 
   // 5. Wait for new upmap to appear as acting set of osds
-  int res2 = wait_for_upmap("large_oid", new_primary, 60s);
+  int res2 = wait_for_upmap("large_oid", new_primary);
   EXPECT_TRUE(res2 == 0);
 
   // 6. Read omap
@@ -1757,10 +1769,8 @@ TEST_P(OmapTest, GenerationalObjectRecovery) {
   std::cout << "Set new upmap to trigger recovery" << std::endl;
   
   // 6. Wait for recovery to complete
-  int res2 = wait_for_upmap(oid, new_primary, 60s);
+  int res2 = wait_for_upmap(oid, new_primary);
   EXPECT_TRUE(res2 == 0);
-  
-  std::cout << "Recovery completed" << std::endl;
   
   // 7. Read omap - verify we got the NEW head value, not old generation
   // If the bug exists, recovery might have retrieved data from wrong generation


### PR DESCRIPTION
test: Add longer shared timeout for omap recovery tests

Before, there were 60 second fixed timers per test. These were observed timing out in a smoke/basic teuthology job with osd thrashing.
Now, there is a 15 minute timeout shared between all the recovery tests so that the suite doesn't fail if some of the recovery tests take a few minutes to complete recovery.

Fixes: https://tracker.ceph.com/issues/77808


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
