### PR TITLE
mgr/dashboard: NVMe-oF – Enable editing host access from the Subsystem Overview page

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-group-form/nvmeof-group-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-group-form/nvmeof-group-form.component.spec.ts
@@ -160,7 +160,7 @@ describe('NvmeofGroupFormComponent', () => {
       } as any;
 
       component.groupForm.get('groupName').setValue('encrypted-group');
-      component.groupForm.get('enableEncryption').setValue(true);
+      component.groupForm.get('enable_auth').setValue(true);
       component.groupForm.get('encryptionKey').setValue('encryption-key-123');
       component.onSubmit();
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-group-form/nvmeof-group-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-group-form/nvmeof-group-form.component.ts
@@ -68,6 +68,7 @@ export class NvmeofGroupFormComponent extends CdForm implements OnInit {
         [CdValidators.unique(this.nvmeofService.exists, this.nvmeofService)]
       ),
       unmanaged: new UntypedFormControl(false),
+      enable_auth: new UntypedFormControl(false),
       enableEncryption: new UntypedFormControl(false),
       encryptionConfig: new UntypedFormControl(null),
       encryptionKey: new UntypedFormControl(null),
@@ -158,7 +159,7 @@ export class NvmeofGroupFormComponent extends CdForm implements OnInit {
       unmanaged: formValues.unmanaged
     };
 
-    if (formValues.enableEncryption) {
+    if (formValues.enableEncryption || formValues.enable_auth) {
       const encryptionKey = formValues.encryptionKey || formValues.encryptionConfig;
       if (encryptionKey) {
         serviceSpec['encryption_key'] = encryptionKey;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.spec.ts
@@ -10,7 +10,7 @@ import { NgbActiveModal, NgbTypeaheadModule } from '@ng-bootstrap/ng-bootstrap';
 
 import { SharedModule } from '~/app/shared/shared.module';
 import { NvmeofService } from '~/app/shared/api/nvmeof.service';
-import { HOST_TYPE } from '~/app/shared/models/nvmeof';
+import { ALLOW_ALL_HOST, HOST_TYPE } from '~/app/shared/models/nvmeof';
 
 import { NvmeofInitiatorsFormComponent } from './nvmeof-initiators-form.component';
 
@@ -92,6 +92,7 @@ describe('NvmeofInitiatorsFormComponent', () => {
     beforeEach(() => {
       nvmeofService = TestBed.inject(NvmeofService);
       spyOn(nvmeofService, 'addSubsystemInitiators').and.returnValue(of({}));
+      spyOn(nvmeofService, 'removeInitiators').and.returnValue(of({}));
     });
 
     it('should be creating request correctly', () => {
@@ -146,6 +147,30 @@ describe('NvmeofInitiatorsFormComponent', () => {
 
       expect(nvmeofService.addSubsystemInitiators).not.toHaveBeenCalled();
       expect(component.isSubmitLoading).toBe(false);
+    });
+
+    it('should remove wildcard host before adding specific hosts', () => {
+      const subsystemNQN = 'nqn.test';
+      component.subsystemNQN = subsystemNQN;
+      component.group = 'test-group';
+      component.existingHosts = [ALLOW_ALL_HOST];
+
+      const payload: any = {
+        hostType: HOST_TYPE.SPECIFIC,
+        addedHosts: ['host3']
+      };
+
+      component.onSubmit(payload);
+
+      expect(nvmeofService.removeInitiators).toHaveBeenCalledWith(subsystemNQN, {
+        host_nqn: ALLOW_ALL_HOST,
+        gw_group: 'test-group'
+      });
+      expect(nvmeofService.addSubsystemInitiators).toHaveBeenCalledWith(subsystemNQN, {
+        allow_all: false,
+        gw_group: 'test-group',
+        hosts: [{ dhchap_key: '', host_nqn: 'host3' }]
+      });
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.ts
@@ -3,6 +3,7 @@ import { Step } from 'carbon-components-angular';
 import { NvmeofService, SubsystemInitiatorRequest } from '~/app/shared/api/nvmeof.service';
 import { FinishedTask } from '~/app/shared/models/finished-task';
 import {
+  ALLOW_ALL_HOST,
   AuthStepType,
   HOST_TYPE,
   HostStepType,
@@ -11,6 +12,8 @@ import {
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { TearsheetComponent } from '~/app/shared/components/tearsheet/tearsheet.component';
+import { Observable } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
 
 type InitiatorsFormPayload = Pick<HostStepType, 'hostType' | 'addedHosts'> &
   Partial<Pick<AuthStepType, 'hostDchapKeyList'>>;
@@ -149,12 +152,27 @@ export class NvmeofInitiatorsFormComponent implements OnInit {
       hosts,
       gw_group: this.group
     };
+
+    const shouldRemoveAllowAllHost =
+      payload.hostType === HOST_TYPE.SPECIFIC && this.existingHosts.includes(ALLOW_ALL_HOST);
+
+    const submitCall$: Observable<unknown> = shouldRemoveAllowAllHost
+      ? this.nvmeofService
+          .removeInitiators(this.subsystemNQN, {
+            host_nqn: ALLOW_ALL_HOST,
+            gw_group: this.group
+          })
+          .pipe(
+            switchMap(() => this.nvmeofService.addSubsystemInitiators(this.subsystemNQN, request))
+          )
+      : this.nvmeofService.addSubsystemInitiators(this.subsystemNQN, request);
+
     this.taskWrapperService
       .wrapTaskAroundCall({
         task: new FinishedTask(taskUrl, {
           nqn: this.subsystemNQN
         }),
-        call: this.nvmeofService.addSubsystemInitiators(this.subsystemNQN, request)
+        call: submitCall$
       })
       .subscribe({
         error: () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-list/nvmeof-initiators-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-list/nvmeof-initiators-list.component.html
@@ -1,42 +1,34 @@
 @if (allowAllHosts) {
   <cd-alert-panel
-    class="cds-mb-4"
-    type="info"
-    [showTitle]="false">
-    <div cdsStack="horizontal"
-         gap="2">
-      <div cdsStack="vertical"
-           gap="2">
-        <strong i18n>Host access: All hosts allowed</strong>
-        <p
-          class="cds-mb-0 cds-mt-1"
-          i18n
-        >
-          Allowing all hosts grants access to every initiator on the network. Authentication is not supported in this mode, which may expose the subsystem to unauthorized access.
-        </p>
-      </div>
-      <a cdsLink
-         class="cds-ml-3"
-         (click)="openAddInitiatorForm(true)"
-         i18n>Edit host access</a>
-    </div>
-  </cd-alert-panel>
-} @else {
-  <cd-table [data]="initiators"
-            columnMode="flex"
-            (fetchData)="listInitiators()"
-            [columns]="initiatorColumns"
-            selectionType="multiClick"
-            (updateSelection)="updateSelection($event)">
-    <div class="table-actions">
-      <cd-table-actions [permission]="permission"
-                        [selection]="selection"
-                        class="btn-group"
-                        [tableActions]="tableActions">
-      </cd-table-actions>
-    </div>
-  </cd-table>
+  class="cds-mb-4"
+  type="warning"
+  [showTitle]="false">
+  <div cdsStack="vertical"
+       gap="1">
+    <strong class="cds-mb-1"
+            i18n>All hosts allowed</strong>
+    <p class="cds-mb-0"
+       i18n>
+      Allowing all hosts grants access to every initiator on the network. Authentication is not supported in this mode, which may expose the subsystem to unauthorized access.
+    </p>
+  </div>
+</cd-alert-panel>
 }
+
+<cd-table [data]="initiators"
+          columnMode="flex"
+          (fetchData)="listInitiators()"
+          [columns]="initiatorColumns"
+          selectionType="multiClick"
+          (updateSelection)="updateSelection($event)">
+  <div class="table-actions">
+    <cd-table-actions [permission]="permission"
+                      [selection]="selection"
+                      class="btn-group"
+                      [tableActions]="tableActions">
+    </cd-table-actions>
+  </div>
+</cd-table>
 
 <ng-template #hostNqnTpl
              let-row="data.row">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-list/nvmeof-initiators-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-list/nvmeof-initiators-list.component.spec.ts
@@ -180,7 +180,7 @@ describe('NvmeofInitiatorsListComponent', () => {
     expect(getSubsystemSpy).toHaveBeenCalledTimes(2);
   });
 
-  it('should filter ALLOW_ALL_HOST from array response', fakeAsync(() => {
+  it('should include ALLOW_ALL_HOST from array response', fakeAsync(() => {
     spyOn(nvmeofService, 'getInitiators').and.returnValue(
       of([
         { nqn: ALLOW_ALL_HOST, use_dhchap: false },
@@ -191,7 +191,10 @@ describe('NvmeofInitiatorsListComponent', () => {
     component.listInitiators();
     tick();
 
-    expect(component.initiators).toEqual([{ nqn: 'nqn.2016-06.io.spdk:host2', use_dhchap: false }]);
+    expect(component.initiators).toEqual([
+      { nqn: ALLOW_ALL_HOST, use_dhchap: false },
+      { nqn: 'nqn.2016-06.io.spdk:host2', use_dhchap: false }
+    ]);
   }));
 
   it('should support hosts-wrapper response from getInitiators', fakeAsync(() => {
@@ -207,6 +210,23 @@ describe('NvmeofInitiatorsListComponent', () => {
     component.listInitiators();
     tick();
 
-    expect(component.initiators).toEqual([{ nqn: 'nqn.2016-06.io.spdk:host3', use_dhchap: true }]);
+    expect(component.initiators).toEqual([
+      { nqn: ALLOW_ALL_HOST, use_dhchap: false },
+      { nqn: 'nqn.2016-06.io.spdk:host3', use_dhchap: true }
+    ]);
+  }));
+
+  it('should set allowAllHosts to true when wildcard initiator exists', fakeAsync(() => {
+    const allowAllSubsystem = { ...mockSubsystem, allow_any_host: true };
+    spyOn(nvmeofService, 'getInitiators').and.returnValue(
+      of([{ nqn: ALLOW_ALL_HOST, use_dhchap: false }])
+    );
+    spyOn(nvmeofService, 'getSubsystem').and.returnValue(of(allowAllSubsystem));
+
+    component.listInitiators();
+    component.getSubsystem();
+    tick();
+
+    expect(component.allowAllHosts).toBe(true);
   }));
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-list/nvmeof-initiators-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-list/nvmeof-initiators-list.component.ts
@@ -183,7 +183,11 @@ export class NvmeofInitiatorsListComponent implements OnInit, OnDestroy {
   }
 
   hasAllHostsAllowed(): boolean {
-    return !!this.subsystem?.allow_any_host && this.initiators.length === 0;
+    return (
+      !!this.subsystem?.allow_any_host &&
+      (this.initiators.length === 0 ||
+        this.initiators.some((initiator) => initiator.nqn === ALLOW_ALL_HOST))
+    );
   }
 
   updateSelection(selection: CdTableSelection) {
@@ -195,7 +199,7 @@ export class NvmeofInitiatorsListComponent implements OnInit, OnDestroy {
       .getInitiators(this.subsystemNQN, this.group)
       .subscribe((response: NvmeofSubsystemInitiator[] | { hosts: NvmeofSubsystemInitiator[] }) => {
         const initiators = Array.isArray(response) ? response : response?.hosts || [];
-        this.initiators = initiators.filter((i) => i.nqn !== ALLOW_ALL_HOST);
+        this.initiators = initiators;
         this.updateAuthStatus();
       });
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystem-overview/nvmeof-subsystem-overview.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystem-overview/nvmeof-subsystem-overview.component.html
@@ -68,8 +68,7 @@
             <div class="cds--type-label-02">
               <span>{{ detail.value ? 'Allow all hosts' : 'Restrict to specific hosts' }}</span>
               <a cdsLink
-                 [routerLink]="['../hosts']"
-                 [queryParams]="{ group: groupName }"
+                 (click)="openEditHostAccessModal()"
                  [cdsStack]="'horizontal'"
                  class="cds-ml-2"
                  [gap]="1">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystem-overview/nvmeof-subsystem-overview.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystem-overview/nvmeof-subsystem-overview.component.spec.ts
@@ -1,14 +1,15 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { ActivatedRoute } from '@angular/router';
-import { of } from 'rxjs';
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
+import { of, Subject } from 'rxjs';
 
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { GridModule, TilesModule } from 'carbon-components-angular';
 
 import { NvmeofSubsystemOverviewComponent } from './nvmeof-subsystem-overview.component';
 import { NvmeofService } from '~/app/shared/api/nvmeof.service';
+import { URLVerbs } from '~/app/shared/constants/app.constants';
 import { SharedModule } from '~/app/shared/shared.module';
 import { NvmeofSubsystem, NvmeofSubsystemInitiator } from '~/app/shared/models/nvmeof';
 
@@ -16,6 +17,9 @@ describe('NvmeofSubsystemOverviewComponent', () => {
   let component: NvmeofSubsystemOverviewComponent;
   let fixture: ComponentFixture<NvmeofSubsystemOverviewComponent>;
   let nvmeofService: NvmeofService;
+  let router: Router;
+  let activatedRoute: ActivatedRoute;
+  let routerEvents$: Subject<any>;
 
   const mockSubsystem: NvmeofSubsystem = {
     nqn: 'nqn.2016-06.io.spdk:cnode1',
@@ -79,6 +83,8 @@ describe('NvmeofSubsystemOverviewComponent', () => {
   }
 
   beforeEach(async () => {
+    routerEvents$ = new Subject<any>();
+
     await TestBed.configureTestingModule({
       declarations: [NvmeofSubsystemOverviewComponent],
       imports: [
@@ -97,6 +103,13 @@ describe('NvmeofSubsystemOverviewComponent', () => {
             getSubsystem: jest.fn().mockReturnValue(of(mockSubsystem)),
             getInitiators: jest.fn().mockReturnValue(of([]))
           }
+        },
+        {
+          provide: Router,
+          useValue: {
+            events: routerEvents$.asObservable(),
+            navigate: jest.fn().mockResolvedValue(true)
+          }
         }
       ]
     }).compileComponents();
@@ -106,6 +119,8 @@ describe('NvmeofSubsystemOverviewComponent', () => {
     fixture = TestBed.createComponent(NvmeofSubsystemOverviewComponent);
     component = fixture.componentInstance;
     nvmeofService = TestBed.inject(NvmeofService);
+    router = TestBed.inject(Router);
+    activatedRoute = TestBed.inject(ActivatedRoute);
     fixture.detectChanges();
   });
 
@@ -189,4 +204,30 @@ describe('NvmeofSubsystemOverviewComponent', () => {
     });
     expect(f.nativeElement.textContent).toContain('Unidirectional');
   }));
+
+  it('should open host access edit modal route when edit is clicked', () => {
+    const navigateSpy = jest.spyOn(router, 'navigate').mockResolvedValue(true);
+    component.groupName = 'group1';
+    component.openEditHostAccessModal();
+
+    expect(navigateSpy).toHaveBeenCalledWith(
+      [{ outlets: { modal: [URLVerbs.ADD, 'initiator'] } }],
+      {
+        queryParams: { group: 'group1' },
+        relativeTo: activatedRoute.parent
+      }
+    );
+  });
+
+  it('should refresh subsystem on non-modal navigation end', () => {
+    (nvmeofService.getSubsystem as jest.Mock).mockClear();
+
+    routerEvents$.next(new NavigationEnd(1, '/nvmeof/(modal:add)', '/nvmeof/(modal:add)'));
+    expect(nvmeofService.getSubsystem).not.toHaveBeenCalled();
+
+    routerEvents$.next(
+      new NavigationEnd(2, '/nvmeof/subsystems/overview', '/nvmeof/subsystems/overview')
+    );
+    expect(nvmeofService.getSubsystem).toHaveBeenCalledWith('nqn.2016-06.io.spdk:cnode1', 'group1');
+  });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystem-overview/nvmeof-subsystem-overview.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystem-overview/nvmeof-subsystem-overview.component.ts
@@ -1,6 +1,7 @@
-import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
-import { forkJoin } from 'rxjs';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
+import { forkJoin, Subscription } from 'rxjs';
+import { filter } from 'rxjs/operators';
 
 import { NvmeofService } from '~/app/shared/api/nvmeof.service';
 import {
@@ -9,6 +10,7 @@ import {
   NO_AUTH,
   getSubsystemAuthStatus
 } from '~/app/shared/models/nvmeof';
+import { URLVerbs } from '~/app/shared/constants/app.constants';
 import { ICON_TYPE } from '~/app/shared/enum/icons.enum';
 import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 import { NvmeofEditAuthenticationComponent } from '../nvmeof-edit-authentication/nvmeof-edit-authentication.component';
@@ -27,27 +29,49 @@ export interface SubsystemDetail {
   styleUrls: ['./nvmeof-subsystem-overview.component.scss'],
   standalone: false
 })
-export class NvmeofSubsystemOverviewComponent implements OnInit {
+export class NvmeofSubsystemOverviewComponent implements OnInit, OnDestroy {
   subsystemNQN!: string;
   groupName!: string;
   subsystem!: NvmeofSubsystem;
   details: SubsystemDetail[] = [];
+  private subscriptions = new Subscription();
 
   constructor(
     private route: ActivatedRoute,
+    private router: Router,
     private nvmeofService: NvmeofService,
     private modalService: ModalCdsService
   ) {}
 
   ngOnInit() {
-    this.route.parent?.params.subscribe((params) => {
-      this.subsystemNQN = params['subsystem_nqn'];
-      this.fetchIfReady();
-    });
-    this.route.queryParams.subscribe((qp) => {
-      this.groupName = qp['group'];
-      this.fetchIfReady();
-    });
+    this.subscriptions.add(
+      this.route.parent?.params.subscribe((params) => {
+        this.subsystemNQN = params['subsystem_nqn'];
+        this.fetchIfReady();
+      })
+    );
+    this.subscriptions.add(
+      this.route.queryParams.subscribe((qp) => {
+        this.groupName = qp['group'];
+        this.fetchIfReady();
+      })
+    );
+    this.subscriptions.add(
+      this.router.events
+        .pipe(
+          filter(
+            (event): event is NavigationEnd =>
+              event instanceof NavigationEnd && !event.urlAfterRedirects.includes('(modal:')
+          )
+        )
+        .subscribe(() => {
+          this.fetchIfReady();
+        })
+    );
+  }
+
+  ngOnDestroy() {
+    this.subscriptions.unsubscribe();
   }
 
   private fetchIfReady() {
@@ -178,5 +202,12 @@ export class NvmeofSubsystemOverviewComponent implements OnInit {
     if (modalRef?.closeChange) {
       modalRef.closeChange.subscribe(() => this.fetchSubsystem());
     }
+  }
+
+  openEditHostAccessModal() {
+    this.router.navigate([{ outlets: { modal: [URLVerbs.ADD, 'initiator'] } }], {
+      queryParams: { group: this.groupName },
+      relativeTo: this.route.parent
+    });
   }
 }


### PR DESCRIPTION


https://github.com/user-attachments/assets/bfe63271-3445-4f7a-9496-450c4555ace2

Fixes: https://tracker.ceph.com/issues/77912

Signed-off-by: pujaoshahu <pshahu@redhat.com>

Summary:  

Added an Edit Host Access action to the Subsystem Overview page.
Enabled users to modify host access settings without leaving the overview page.
Reused the existing host access configuration workflow to ensure consistent behavior.
Updated the UI to reflect the latest host access configuration after changes are applied.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
