### PR TITLE
mgr/snap_schedule: do not assume wall clock does not tick

### DIFF
--- a/src/pybind/mgr/snap_schedule/tests/fs/test_schedule.py
+++ b/src/pybind/mgr/snap_schedule/tests/fs/test_schedule.py
@@ -55,9 +55,9 @@ class TestSchedule(object):
         assert simple_schedule.start.second == 0
         assert simple_schedule.start.minute == 0
         assert simple_schedule.start.hour == 0
-        assert simple_schedule.start.day == now.day
-        assert simple_schedule.start.month == now.month
-        assert simple_schedule.start.year == now.year
+        assert simple_schedule.start.day == simple_schedule.created.day
+        assert simple_schedule.start.month == simple_schedule.created.month
+        assert simple_schedule.start.year == simple_schedule.created.year
         assert simple_schedule.start.tzinfo == now.tzinfo
 
     def test_created_now(self, simple_schedule):

--- a/src/pybind/mgr/snap_schedule/tests/fs/test_schedule.py
+++ b/src/pybind/mgr/snap_schedule/tests/fs/test_schedule.py
@@ -62,11 +62,7 @@ class TestSchedule(object):
 
     def test_created_now(self, simple_schedule):
         now = datetime.datetime.now(datetime.timezone.utc)
-        assert simple_schedule.created.minute == now.minute
-        assert simple_schedule.created.hour == now.hour
-        assert simple_schedule.created.day == now.day
-        assert simple_schedule.created.month == now.month
-        assert simple_schedule.created.year == now.year
+        assert abs((now - simple_schedule.created).total_seconds()) < 5
         assert simple_schedule.created.tzinfo == now.tzinfo
 
     def test_repeat_valid(self, simple_schedule):

--- a/src/pybind/mgr/snap_schedule/tests/fs/test_schedule.py
+++ b/src/pybind/mgr/snap_schedule/tests/fs/test_schedule.py
@@ -55,9 +55,7 @@ class TestSchedule(object):
         assert simple_schedule.start.second == 0
         assert simple_schedule.start.minute == 0
         assert simple_schedule.start.hour == 0
-        assert simple_schedule.start.day == now.day
-        assert simple_schedule.start.month == now.month
-        assert simple_schedule.start.year == now.year
+        assert simple_schedule.start.date() == simple_schedule.created.date()
         assert simple_schedule.start.tzinfo == now.tzinfo
 
     def test_created_now(self, simple_schedule):


### PR DESCRIPTION
previously, we assumed that the test ran so fast, that wall clock did not tick between when we noted down a time and compare the timestamp. but this does not hold, as wall clock does tick, and we are not always that lucky.

in this series we stop comparing two independently-read timestamps field by field, since a clock boundary crossing between the two reads breaks the comparison even though both readings are correct.

Fixes: https://tracker.ceph.com/issues/79957

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
