### PR TITLE
mds: fix replay cap reconnect crash

### DIFF
--- a/qa/tasks/cephfs/test_client_recovery.py
+++ b/qa/tasks/cephfs/test_client_recovery.py
@@ -883,3 +883,122 @@ class TestClientOnLaggyOSD(CephFSTestCase):
             self.mount_a.mount_wait()
             self.mount_a.create_destroy()
             self.clear_laggy_params(osd)
+
+
+class TestMixedClientReconnect(CephFSTestCase):
+    """
+    Verify that MDS does not crash when a kernel client and a FUSE client,
+    both holding open file descriptors (and therefore caps) on the same file,
+    are killed simultaneously and then reconnect: first the kernel client
+    after a 60-second delay, and then both clients together.
+
+    Reproduces the scenario:
+
+        ClientA (kernel):  bash -c "exec 3>/mnt/cephfs_test/reconnect_test;
+                           sleep 300"
+        ClientB (fuse):    bash -c "exec 3>/mnt/cephfs_test/reconnect_test;
+                           sleep 300"
+        # kill both, wait 60s, reconnect A, then reconnect both
+        # assert no MDS crash
+    """
+
+    CLIENTS_REQUIRED = 2
+    MDSS_REQUIRED = 1
+
+    # Name of the shared test file inside the CephFS root.
+    TEST_FILE = "reconnect_test"
+
+    def test_mixed_client_reconnect_no_mds_crash(self):
+        """
+        Hold caps on the same file from a kernel client (mount_a) and a FUSE
+        client (mount_b), kill both, wait 60s, reconnect mount_a, then
+        reconnect mount_b, and confirm that the MDS is still up:active with
+        no crash.
+        """
+        from tasks.cephfs.kernel_mount import KernelMountBase
+
+        if not isinstance(self.mount_a, KernelMountBase):
+            self.skipTest("mount_a must be a kernel client for this test")
+        if not isinstance(self.mount_b, FuseMount):
+            self.skipTest("mount_b must be a FUSE client for this test")
+
+        # ------------------------------------------------------------------ #
+        # Step 1: Both clients open the file and hold an fd / caps.
+        # open_background() opens the file for writing and keeps it open
+        # until its stdin is closed, which is exactly what we need.
+        # ------------------------------------------------------------------ #
+        log.info("Step 1: open background file on both clients")
+        cap_holder_a = self.mount_a.open_background(
+            basename=self.TEST_FILE, write=True, content="client_a"
+        )
+        # Wait until mount_b can see the file (confirms mount_a has flushed
+        # the create to the MDS before we open from mount_b).
+        self.mount_b.wait_for_visible(self.TEST_FILE)
+
+        cap_holder_b = self.mount_b.open_background(
+            basename=self.TEST_FILE, write=False
+        )
+
+        # Both sessions must be active before we proceed.
+        self.assert_session_count(2)
+        mount_a_gid = self.mount_a.get_global_id()
+        mount_b_gid = self.mount_b.get_global_id()
+        log.info("mount_a gid=%s  mount_b gid=%s", mount_a_gid, mount_b_gid)
+
+        # ------------------------------------------------------------------ #
+        # Step 2: Kill both client processes (simulate abrupt disconnect).
+        # suspend_netns() drops network access without touching the process,
+        # which is the cleanest way to simulate a dead-network client while
+        # keeping the background process alive so we can resume it later.
+        # ------------------------------------------------------------------ #
+        log.info("Step 2: suspend network for both clients")
+        self.mount_a.suspend_netns()
+        self.mount_b.suspend_netns()
+
+        # Give the MDS time to notice the clients are gone (session_timeout).
+        session_timeout = self.fs.get_var("session_timeout")
+        log.info("Waiting %ss for sessions to go stale", session_timeout * 1.5)
+        time.sleep(session_timeout * 1.5)
+
+        # ------------------------------------------------------------------ #
+        # Step 3: Reconnect only mount_a (kernel client) after ~60s.
+        # ------------------------------------------------------------------ #
+        RECONNECT_DELAY = 60
+        log.info("Step 3: reconnect mount_a after %ss delay", RECONNECT_DELAY)
+        time.sleep(RECONNECT_DELAY)
+        self.mount_a.resume_netns()
+
+        # Allow mount_a time to complete its reconnect handshake with the MDS.
+        time.sleep(10)
+        self.assert_session_state(mount_a_gid, "open")
+        log.info("mount_a session is open after reconnect")
+
+        # ------------------------------------------------------------------ #
+        # Step 4: Reconnect mount_b (FUSE client).
+        # ------------------------------------------------------------------ #
+        log.info("Step 4: reconnect mount_b")
+        self.mount_b.resume_netns()
+        time.sleep(10)
+
+        # ------------------------------------------------------------------ #
+        # Step 5: Verify MDS is still up:active — no crash occurred.
+        # ------------------------------------------------------------------ #
+        log.info("Step 5: verify MDS state and session counts")
+        self.fs.wait_for_state('up:active', timeout=MDS_RESTART_GRACE)
+
+        # Both clients should now have active sessions again.
+        self.assert_session_count(2)
+        self.assert_session_state(mount_a_gid, "open")
+        self.assert_session_state(mount_b_gid, "open")
+
+        log.info("MDS is up:active and both sessions are open — no crash")
+
+        # ------------------------------------------------------------------ #
+        # Cleanup: close the background file holders.
+        # ------------------------------------------------------------------ #
+        self.mount_a._kill_background(cap_holder_a)
+        self.mount_b._kill_background(cap_holder_b)
+
+        # Confirm I/O still works on both mounts after reconnect.
+        self.mount_a.create_destroy()
+        self.mount_b.create_destroy()

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -5928,11 +5928,13 @@ Capability* MDCache::try_reconnect_cap(CInode *in, Session *session)
       dout(15) << " chose lock states on " << *in << dendl;
     }
 
-    auto it =
-      cap_reconnect_waiters.find(in->ino());
-    if (it != cap_reconnect_waiters.end()) {
-      mds->queue_waiters(it->second);
-      cap_reconnect_waiters.erase(it);
+    if (!cap_imports.count(in->ino())) {
+      auto it =
+        cap_reconnect_waiters.find(in->ino());
+      if (it != cap_reconnect_waiters.end()) {
+        mds->queue_waiters(it->second);
+        cap_reconnect_waiters.erase(it);
+      }
     }
   }
   return cap;

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -735,9 +735,16 @@ private:
     return NULL;
   }
   void remove_replay_cap_reconnect(inodeno_t ino, client_t client) {
-    ceph_assert(cap_imports[ino].size() == 1);
+    ceph_assert(cap_imports[ino].count(client));
     ceph_assert(cap_imports[ino][client].size() == 1);
-    cap_imports.erase(ino);
+    // remove only this client
+    cap_imports[ino].erase(client);
+
+    // clean up inode key only when all clients done
+    if (cap_imports[ino].empty())
+    {
+        cap_imports.erase(ino);
+    }
   }
   void wait_replay_cap_reconnect(inodeno_t ino, MDSContext *c) {
     cap_reconnect_waiters[ino].push_back(c);

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -735,15 +735,19 @@ private:
     return NULL;
   }
   void remove_replay_cap_reconnect(inodeno_t ino, client_t client) {
-    ceph_assert(cap_imports[ino].count(client));
-    ceph_assert(cap_imports[ino][client].size() == 1);
+    auto outer_it = cap_imports.find(ino);
+    ceph_assert(outer_it != cap_imports.end());
+
+    auto &inner = outer_it->second;
+    auto inner_it = inner.find(client);
+    ceph_assert(inner_it != inner.end());
+
     // remove only this client
-    cap_imports[ino].erase(client);
+    inner.erase(inner_it);
 
     // clean up inode key only when all clients done
-    if (cap_imports[ino].empty())
-    {
-        cap_imports.erase(ino);
+    if (inner.empty()) {
+      cap_imports.erase(outer_it);
     }
   }
   void wait_replay_cap_reconnect(inodeno_t ino, MDSContext *c) {


### PR DESCRIPTION
This commit resolves a crash in CephFS MDS recovery/replay caused by an assertion in MDCache::remove_replay_cap_reconnect() that assumed only a single reconnect entry per inode. In practice, multiple clients may legitimately reconnect to the same inode during restart or failover, triggering the assertion and aborting the MDS.

The fix ensures that reconnect entries are removed per client, and the inode key is cleaned up only when all reconnects are complete.

Fixes: https://tracker.ceph.com/issues/60014





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
