### PR TITLE
mgr/cephadm: track SMB rgw_creds_uri as a daemon dependency

### DIFF
--- a/src/pybind/mgr/cephadm/services/smb.py
+++ b/src/pybind/mgr/cephadm/services/smb.py
@@ -208,15 +208,19 @@ class SMBService(CephService):
             ca_cert=ssl_params.ssl_ca_cert or '',
         )
 
-    def _rgw_creds_uri(self, cluster_id: str) -> Optional[str]:
+    @classmethod
+    def _lookup_rgw_creds_uri(
+        cls, mgr: 'CephadmOrchestrator', cluster_id: str
+    ) -> Optional[str]:
         from smb.external import rgw_config_key as _smb_rgw_config_key
         from smb.mon_store import MonKeyConfigStore
-        _rgw_entry = MonKeyConfigStore(self.mgr)[
-            _smb_rgw_config_key(cluster_id)
-        ]
+        _rgw_entry = MonKeyConfigStore(mgr)[_smb_rgw_config_key(cluster_id)]
         if _rgw_entry.exists():
             return _rgw_entry.uri
         return None
+
+    def _rgw_creds_uri(self, cluster_id: str) -> Optional[str]:
+        return self._lookup_rgw_creds_uri(self.mgr, cluster_id)
 
     def generate_config(
         self, daemon_spec: CephadmDaemonDeploySpec
@@ -538,6 +542,8 @@ class SMBService(CephService):
             out.append(Dep.META(f'ceph_cluster_config.{ccc.alias}', value))
         # Add features as a dependency
         out.append(Dep.FIELD('features', ','.join(sorted(smb_spec.features or []))))
+        rgw_creds_uri = cls._lookup_rgw_creds_uri(mgr, smb_spec.cluster_id) or ''
+        out.append(Dep.FIELD('rgw_creds_uri', rgw_creds_uri))
         return out
 
     def choose_next_action(
@@ -553,7 +559,15 @@ class SMBService(CephService):
             scheduled_action, daemon_type, spec, curr_deps, last_deps)
         if step.action is utils.Action.RECONFIG:
             sym_diff = set(curr_deps).symmetric_difference(last_deps)
-            if any(d.startswith(Dep.FIELD('features', '')) for d in sym_diff):
+            needs_redeploy_prefixes = (
+                Dep.FIELD('features', ''),
+                Dep.FIELD('rgw_creds_uri', ''),
+            )
+            if any(
+                d.startswith(p)
+                for d in sym_diff
+                for p in needs_redeploy_prefixes
+            ):
                 return replace(step, action=utils.Action.REDEPLOY)
         return step
 

--- a/src/pybind/mgr/cephadm/tests/services/test_smb.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_smb.py
@@ -234,5 +234,6 @@ def test_smb_get_dependencies(cephadm_module):
     deps = SMBService.get_dependencies(cephadm_module, spec, spec.service_type)
     assert deps == [
         'smb+meta:ceph_cluster_config.exo=sha256:859b001f76df4d184b858b9c3e323ca8ff85a311414d0405f4484d17aa481ef3',
-        'smb+field:features=domain'
+        'smb+field:features=domain',
+        'smb+field:rgw_creds_uri=rados:mon-config-key:smb/config/foxtrot/config.smb.rgw',
     ]

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -1541,7 +1541,14 @@ def _save_pending_rgw_config(
         rgw = sc.resource.rgw
         assert rgw is not None
         assert rgw.credential_ref is not None
-        cred = cred_map[rgw.credential_ref]
+        cred = cred_map.get(rgw.credential_ref)
+        if cred is None:
+            log.error(
+                "share %r references missing RGW credential %r",
+                sc.resource.name,
+                rgw.credential_ref,
+            )
+            continue
         access_key = cred.access_key_id or ''
         secret_key = cred.secret_access_key or ''
         merge_shares[sc.resource.name] = {


### PR DESCRIPTION
Depends on https://github.com/ceph/ceph/pull/69907/

When an RGW share is added to a cluster that already has CephFS shares, RGW credentials show as empty in `net conf list` inside the container. The private-store URI carrying credentials is appended to `SAMBACC_CONFIG` via `extra_config_uris`, but was not tracked as a dependency for cephadm to redeploy the daemon. Thus `update-config --watch` sidecar
continues running with the stale `SAMBACC_CONFIG` and never receives the RGW credentials URI.

The PR intends to fix this issue by adding `rgw_creds_uri` as a dependency and include it in REDEPLOY action too.

Fixes: https://tracker.ceph.com/issues/77763

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
