### PR TITLE
monitoring/ceph-mixin: scope test queries per dashboard

### DIFF
--- a/monitoring/ceph-mixin/tests_dashboards/features/ceph-cluster.feature
+++ b/monitoring/ceph-mixin/tests_dashboards/features/ceph-cluster.feature
@@ -1,5 +1,8 @@
 Feature: Ceph Cluster Dashboard
 
+  Background:
+    Given the dashboard is `ceph-cluster-advanced`
+
   Scenario: "Test cluster health"
   Given the following series:
     | metrics                  | values |

--- a/monitoring/ceph-mixin/tests_dashboards/features/environment.py
+++ b/monitoring/ceph-mixin/tests_dashboards/features/environment.py
@@ -15,6 +15,7 @@ class GlobalContext:
         self.promql_expr_test = None
         self.data = get_dashboards_data()
         self.query_map = self.data['queries']
+        self.dashboard = None
 
     def reset_promql_test(self):
         self.promql_expr_test = PromqlTest()
@@ -53,6 +54,7 @@ global_context = GlobalContext()
 
 def before_scenario(context, scenario):
     global_context.reset_promql_test()
+    global_context.dashboard = None
 
 
 def after_scenario(context, scenario):
@@ -61,6 +63,14 @@ def after_scenario(context, scenario):
 
 def after_all(context):
     global_context.print_query_stats()
+
+
+@given('the dashboard is `{dashboard}`')
+def step_impl(context, dashboard):
+    if dashboard not in global_context.query_map:
+        raise KeyError(f'Unknown dashboard "{dashboard}". Known: '
+                       f'{sorted(global_context.query_map)}')
+    global_context.dashboard = dashboard
 
 
 @given("the following series")
@@ -111,19 +121,23 @@ def step_impl(context, panel_name, legend):
     """
     if legend == "EMPTY":
         legend = ''
+    if global_context.dashboard is None:
+        raise KeyError('No dashboard selected; add "Given the dashboard is '
+                       '`<name>`" to the feature Background')
     query_id = panel_name + '-' + legend
-    if query_id not in global_context.query_map:
-        print(f"QueryMap: {global_context.query_map}")
-        raise KeyError((f'Query with legend {legend} in panel "{panel_name}"'
-                           'couldn\'t be found'))
+    dashboard_queries = global_context.query_map[global_context.dashboard]
+    if query_id not in dashboard_queries:
+        raise KeyError(f'Query with legend {legend} in panel "{panel_name}" '
+                       f'couldn\'t be found in dashboard '
+                       f'"{global_context.dashboard}"')
 
-    expr = global_context.query_map[query_id]['query']
+    expr = dashboard_queries[query_id]['query']
     global_context.promql_expr_test.set_expression(expr)
     for row in context.table:
         metric = row['metrics']
         value = row['values']
         global_context.promql_expr_test.add_exp_samples(metric, float(value))
-    path = global_context.query_map[query_id]['path']
+    path = dashboard_queries[query_id]['path']
     global_context.data['stats'][path]['tested'] += 1
 
 

--- a/monitoring/ceph-mixin/tests_dashboards/features/host-details.feature
+++ b/monitoring/ceph-mixin/tests_dashboards/features/host-details.feature
@@ -1,5 +1,8 @@
 Feature: Host Details Dashboard
 
+  Background:
+    Given the dashboard is `host-details`
+
 Scenario: "Test OSD"
   Given the following series:
     | metrics | values |

--- a/monitoring/ceph-mixin/tests_dashboards/features/hosts_overview.feature
+++ b/monitoring/ceph-mixin/tests_dashboards/features/hosts_overview.feature
@@ -1,5 +1,8 @@
 Feature: Hosts Overview Dashboard
 
+  Background:
+    Given the dashboard is `hosts-overview`
+
 Scenario: "Test network load succeeds"
   Given the following series:
     | metrics | values |

--- a/monitoring/ceph-mixin/tests_dashboards/features/osd-device-details.feature
+++ b/monitoring/ceph-mixin/tests_dashboards/features/osd-device-details.feature
@@ -1,5 +1,8 @@
 Feature: OSD device details
 
+  Background:
+    Given the dashboard is `osd-device-details`
+
 Scenario: "Test Physical Device Latency for $osd - Reads"
   Given the following series:
     | metrics | values |

--- a/monitoring/ceph-mixin/tests_dashboards/features/osds-overview.feature
+++ b/monitoring/ceph-mixin/tests_dashboards/features/osds-overview.feature
@@ -1,5 +1,8 @@
 Feature: OSD Overview
 
+  Background:
+    Given the dashboard is `osds-overview`
+
 Scenario: "Test OSD onode Hits Ratio"
   Given the following series:
     | metrics | values |

--- a/monitoring/ceph-mixin/tests_dashboards/features/radosgw-detail.feature
+++ b/monitoring/ceph-mixin/tests_dashboards/features/radosgw-detail.feature
@@ -1,5 +1,8 @@
 Feature: RGW Host Detail Dashboard
 
+  Background:
+    Given the dashboard is `radosgw-detail`
+
 Scenario: "Test $rgw_servers GET/PUT Latencies - GET"
   Given the following series:
     | metrics | values |

--- a/monitoring/ceph-mixin/tests_dashboards/features/radosgw_overview.feature
+++ b/monitoring/ceph-mixin/tests_dashboards/features/radosgw_overview.feature
@@ -1,5 +1,8 @@
 Feature: RGW Overview Dashboard
 
+  Background:
+    Given the dashboard is `radosgw-overview`
+
 Scenario: "Test Average GET Latencies"
   Given the following series:
     | metrics | values |

--- a/monitoring/ceph-mixin/tests_dashboards/util.py
+++ b/monitoring/ceph-mixin/tests_dashboards/util.py
@@ -23,8 +23,8 @@ def resolve_time_and_unit(time: str) -> Union[Tuple[int, str], Tuple[None, None]
 
 def get_dashboards_data() -> Dict[str, Any]:
     data: Dict[str, Any] = {'queries': {}, 'variables': {}, 'stats': {}}
-    for file in Path(__file__).parent.parent \
-                              .joinpath('dashboards_out').glob('*.json'):
+    for file in sorted(Path(__file__).parent.parent
+                       .joinpath('dashboards_out').glob('*.json')):
         with open(file, 'r') as f:
             dashboard_data = json.load(f)
             data['stats'][str(file)] = {'total': 0, 'tested': 0}
@@ -39,9 +39,16 @@ def add_dashboard_queries(data: Dict[str, Any], dashboard_data: Dict[str, Any], 
     Grafana panels can have more than one target/query, in order to identify each
     query in the panel we append the "legendFormat" of the target to the panel name.
     format: panel_name-legendFormat
+
+    Queries are grouped per dashboard (data['queries'][<dashboard>]) so that
+    different dashboards reusing a panel title/legend, e.g. "IOPS-Read", stay in
+    separate namespaces. Each .feature picks its dashboard so the lookup is
+    unambiguous.
     """
     if 'panels' not in dashboard_data:
         return
+    dashboard = Path(path).stem
+    queries = data['queries'].setdefault(dashboard, {})
     error = 0
     panel_ids_in_file = set()
 
@@ -57,24 +64,15 @@ def add_dashboard_queries(data: Dict[str, Any], dashboard_data: Dict[str, Any], 
                 title = panel['title']
                 legend_format = target['legendFormat'] if 'legendFormat' in target else ""
                 query_id = f'{title}-{legend_format}'
-                # Skip duplicates within collapsed rows
-                # but error on duplicates at top-level or across different contexts
+                # a repeated id within one dashboard is expected for a collapsed
+                # row; at top level it means a missing legendFormat
                 if query_id in panel_ids_in_file:
                     if legend_format != '__auto' and not in_row:
                         cprint((f'ERROR: Query in panel "{title}" with legend "{legend_format}"'
                                 f' already exists in the same file: "{path}"'), 'red')
                         error = 1
-                    # Skip adding duplicate
                     continue
-                # Also check for duplicates across different files
-                # NOTE: This silently skips duplicate panel+legend combinations across dashboards,
-                # which means some queries never get tested. A better approach would be to include
-                # dashboard name in query_id (e.g., "dashboard:panel-legend"), but that requires
-                # updating all test .feature files to specify which dashboard they're testing.
-                if query_id in data['queries']:
-                    # Skip silently for duplicates across files (first one wins)
-                    continue
-                data['queries'][query_id] = {'query': target['expr'], 'path': path}
+                queries[query_id] = {'query': target['expr'], 'path': path}
                 data['stats'][path]['total'] += 1
                 panel_ids_in_file.add(query_id)
         # Recurse into row panels


### PR DESCRIPTION
`get_dashboards_data()` keeps every query in a single map keyed by "<panel title>-<legendFormat>", but that id is not unique: several dashboards have a panel titled "IOPS", "OSDs" or "Throughput". The dashboard read last overwrites the earlier entry, so one query shadows another and never gets tested. glob() walks the files in filesystem order, so which query survives, and whether the test passes, depends on readdir.

run-tox-promql-query-test hit this in "Test IOPS Read" (ceph-cluster.feature): the scenario feeds ceph_osd_op_r but the id resolved to a CephFS pool panel.
```
    FAILED:
      expr: "sum(rate(ceph_pool_rd{cluster=~"mycluster|",  pool_id=~"UNSET VARIABLE"}[1m]))", time: 1m,
          exp:"{} 2.5E+01"
          got:"nil"
    HOOK-ERROR in after_scenario: AssertionError:
```
pool_id is "UNSET VARIABLE" because the scenario does not set $mdatapool, and no ceph_pool_rd series were fed, so the query returns nil. It only fails when readdir returns `cephfsdashboard` after `ceph-cluster-advanced`, so the earlier change that walked nested rows and made the winner deterministic did not fix it; it fixed which query wins, not that the wrong one can win.

Key the queries per dashboard (`data['queries'][<dashboard>][<id>]`) and have each .feature name its dashboard in a Background step. The lookup is confined to that dashboard, so a title/legend used elsewhere no longer shadows it. A duplicate within one dashboard is still an error, unless it is in a collapsed row.

`ceph-cluster.feature` covers `ceph-cluster-advanced`; the rest map to one dashboard each.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
