### PR TITLE
qa/crimson: ignore PG_NOT_DEEP_SCRUBBED in all crimson tests

### DIFF
--- a/qa/config/crimson_qa_overrides.yaml
+++ b/qa/config/crimson_qa_overrides.yaml
@@ -2,6 +2,8 @@ overrides:
   ceph:
     log-ignorelist:
     - \(POOL_APP_NOT_ENABLED\)
+    # \todo delete once scrub scheduling is enabled in Crimson:
+    - \(PG_NOT_DEEP_SCRUBBED\)
     conf:
       global:
         enable experimental unrecoverable data corrupting features: crimson


### PR DESCRIPTION
As we do not yet scrub scheduling in Crimson, the
OSDs do not perform deep scrubs. last_deep_scrub_stamp thus stays at epoch 0 for all PGs. The monitor flags these as overdue immediately, causing spurious test failures — particularly in tests that restart OSDs (e.g. crimson_fio_restart), where PGs reaching active+clean state trigger the health check.

Fixes: https://tracker.ceph.com/issues/77929
