### PR TITLE
mgr: add heap admin socket command

### DIFF
--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -17,7 +17,10 @@
 
 #include "common/errno.h"
 #include "common/signal.h"
+#include "common/cmdparse.h"
 #include "include/compat.h"
+#include "include/str_list.h"
+#include "perfglue/heap_profiler.h"
 
 #include "include/stringify.h"
 #include "global/global_context.h"
@@ -42,6 +45,7 @@ using std::map;
 using std::string;
 using std::vector;
 using namespace std::literals;
+using ceph::common::cmd_getval;
 
 class MgrHook : public AdminSocketHook {
   MgrStandby* mgr;
@@ -55,7 +59,7 @@ public:
            bufferlist& outbl) override {
     int r = 0;
     try {
-      r = mgr->asok_command(admin_command, cmdmap, f, errss);
+      r = mgr->asok_command(admin_command, cmdmap, f, errss, outbl);
     } catch (const TOPNSPC::common::bad_cmd_get& e) {
       errss << e.what();
       r = -EINVAL;
@@ -141,12 +145,31 @@ void MgrStandby::handle_conf_change(
   }
 }
 
-int MgrStandby::asok_command(std::string_view cmd, const cmdmap_t& cmdmap, Formatter* f, std::ostream& errss)
+int MgrStandby::asok_command(std::string_view cmd, const cmdmap_t& cmdmap,
+			     Formatter* f, std::ostream& errss,
+			     ceph::buffer::list& outbl)
 {
   dout(10) << __func__ << ": " << cmd << dendl;
   if (cmd == "status") {
     f->open_object_section("status");
     f->close_section();
+    return 0;
+  } else if (cmd == "heap") {
+    if (!ceph_using_tcmalloc()) {
+      errss << "could not issue heap profiler command -- not using tcmalloc!";
+      return -EOPNOTSUPP;
+    }
+    std::string heapcmd;
+    cmd_getval(cmdmap, "heapcmd", heapcmd);
+    std::vector<std::string> cmd_vec;
+    get_str_vec(heapcmd, cmd_vec);
+    std::string val;
+    if (cmd_getval(cmdmap, "value", val)) {
+      cmd_vec.push_back(val);
+    }
+    std::ostringstream outss;
+    ceph_heap_profiler_handle_command(cmd_vec, outss);
+    outbl.append(outss.str());
     return 0;
   } else {
     return -ENOSYS;
@@ -181,6 +204,14 @@ int MgrStandby::init()
   asok_hook.reset(new MgrHook(this));
   {
     int r = admin_socket->register_command("status", asok_hook.get(), "show status");
+    ceph_assert(r == 0);
+    r = admin_socket->register_command(
+      "heap " \
+      "name=heapcmd,type=CephChoices,strings=" \
+      "dump|start_profiler|stop_profiler|release|get_release_rate|set_release_rate|stats " \
+      "name=value,type=CephString,req=false",
+      asok_hook.get(),
+      "show heap usage info (available only if compiled with tcmalloc)");
     ceph_assert(r == 0);
   }
 

--- a/src/mgr/MgrStandby.h
+++ b/src/mgr/MgrStandby.h
@@ -39,7 +39,8 @@ public:
   std::vector<std::string> get_tracked_keys() const noexcept override;
   void handle_conf_change(const ConfigProxy& conf,
 			  const std::set <std::string> &changed) override;
-  int asok_command(std::string_view cmd, const cmdmap_t& cmdmap, Formatter* f, std::ostream& errss);
+  int asok_command(std::string_view cmd, const cmdmap_t& cmdmap, Formatter* f,
+		   std::ostream& errss, ceph::buffer::list& outbl);
 
 protected:
   ceph::async::io_context_pool poolctx;


### PR DESCRIPTION
the mon, osd and mds register a "heap" asok command that forwards to ceph_heap_profiler_handle_command, but the mgr never did, so `ceph daemon mgr.<id> heap stats` returns "no valid command found". that leaves no way to tcmalloc-profile a leaking mgr through its admin socket, which is what chasing mgr memory growth needs.

register the same command on MgrStandby's admin socket. its hook lives for the whole process, so it works on both the standby and the active mgr. heap output goes to the bufferlist, as on the other daemons, while status keeps using the formatter.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
