### PR TITLE
nvmeofgw: implement monitor command ok-to-stop

### DIFF
--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -120,6 +120,13 @@ options:
   desc: Number of beacons from MonClient before NVMeofGwMon sends ack-map to it
   services:
   - mon
+- name: mon_nvmeofgw_active_gw_percentage
+  type: uint
+  level: advanced
+  default: 75
+  desc: The minimal percent of active gateways to approve stop GW command
+  services:
+  - mon
 - name: mon_nvmeofgw_delete_grace
   type: secs
   level: advanced

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1585,6 +1585,12 @@ COMMAND("nvme-gw listeners"
 	" show all nvmeof gateways listeners within (pool, group)",
 	"mon", "r")
 
+COMMAND("nvme-gw ok-to-stop"
+	" name=pool,type=CephString"
+	" name=group,type=CephString",
+	" returns true if is it possible to stop one of gateways within (pool, group)",
+	"mon", "r")
+
 COMMAND("nvme-gw enable"
    " name=id,type=CephString"
    " name=pool,type=CephString"

--- a/src/mon/NVMeofGwMap.cc
+++ b/src/mon/NVMeofGwMap.cc
@@ -299,6 +299,33 @@ int NVMeofGwMap::cfg_admin_state_change(const NvmeGwId &gw_id,
   return 0;
 }
 
+bool NVMeofGwMap::is_ok_to_stop(const NvmeGroupKey& group_key)
+{
+  uint32_t num_gws = created_gws[group_key].size();
+  uint32_t num_active_gws = 0;
+  for (auto& gws_states: created_gws[group_key]) {
+    auto& state = gws_states.second;
+    auto gw_id = gws_states.first;
+    if (state.availability == gw_availability_t::GW_AVAILABLE) {
+      for (auto& state_itr: created_gws[group_key][gw_id].sm_state) {
+        if (state_itr.second == gw_states_per_group_t::GW_ACTIVE_STATE) {
+          num_active_gws ++;
+          break;
+        }
+      }
+    }
+  }
+  uint64_t percent_active_gws =
+           g_conf().get_val<uint64_t>("mon_nvmeofgw_active_gw_percentage");
+  dout(10) << "num gws " << num_gws << " num active gws " << num_active_gws
+           << " percentage " << percent_active_gws << dendl;
+  if (num_gws > 0 && (100 * num_active_gws >= percent_active_gws * num_gws)) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
 bool NVMeofGwMap::validate_number_locations(int num_gws, int num_locations)
 {
   return true; // TODO: add validation in the separate PR

--- a/src/mon/NVMeofGwMap.h
+++ b/src/mon/NVMeofGwMap.h
@@ -139,6 +139,7 @@ public:
          const NvmeGroupKey& group_key, uint64_t beacon_sequence);
   bool is_location_in_disaster(const NvmeGroupKey& group_key,
              NvmeLocation& location, bool &cleanup_in_process);
+  bool is_ok_to_stop(const NvmeGroupKey& group_key);
 private:
   int  do_delete_gw(const NvmeGwId &gw_id, const NvmeGroupKey& group_key);
   int  do_erase_gw_id(const NvmeGwId &gw_id,

--- a/src/mon/NVMeofGwMon.cc
+++ b/src/mon/NVMeofGwMon.cc
@@ -612,6 +612,24 @@ bool NVMeofGwMon::preprocess_command(MonOpRequestRef op)
     getline(sstrm, rs);
     mon.reply_command(op, err, rs, rdata, get_last_committed());
     return true;
+  } else if (prefix == "nvme-gw ok-to-stop") {
+    std::string  pool, group;
+    if (!f) {
+      f.reset(Formatter::create(format, "json-pretty", "json-pretty"));
+    }
+    cmd_getval(cmdmap, "pool", pool);
+    cmd_getval(cmdmap, "group", group);
+    auto group_key = std::make_pair(pool, group);
+    dout(10) << prefix << " pool " << pool << " group " << group << dendl;
+    f->open_object_section("common");
+    bool rc = map.is_ok_to_stop(group_key);
+    f->dump_bool("result", rc);
+    f->close_section();
+    f->flush(rdata);
+    sstrm.str("");
+    getline(sstrm, rs);
+    mon.reply_command(op, err, rs, rdata, get_last_committed());
+    return true;
   }
   return false;
 }


### PR DESCRIPTION
fixes: https://tracker.ceph.com/issues/77766

As response monitor allows or forbids to stop the GW.
For decision it uses the criteria  from the configuration 



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
