### PR TITLE
mds: check lock contention before stray reintegration

### DIFF
--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -685,6 +685,48 @@ void StrayManager::reintegrate_stray(CDentry *straydn, CDentry *rdn)
     return;
   }
 
+  /*
+   * Check for lock contention on both the source stray dentry and the
+   * destination dentry before sending the internal rename.  The rename
+   * will try to xlock both source and dest dentries, and wrlock both
+   * parent directories' filelock/nestlock.  If a client operation
+   * (lookup, unlink) already holds or is waiting for a conflicting lock
+   * on either dentry, the rename will block and become a slow request.
+   * Defer the reintegration — it will be retried the next time a
+   * dentry link operation on the remote parent triggers eval_remote().
+   *
+   * Check both the current lock state (held) and the waiter queue
+   * (waiting).  A lock that is currently held but has no waiters yet
+   * would pass a waiter-only check, but the rename would still block
+   * trying to acquire it.  Likewise the source stray dentry may be
+   * under contention from a client holding caps on the stray inode.
+   */
+  auto has_lock_contention = [](CDentry *dn) -> bool {
+    if (!dn->is_auth())
+      return false;
+    // lock is currently held in a conflicting mode
+    if (dn->lock.is_rdlocked() ||
+        dn->lock.is_wrlocked() ||
+        dn->lock.is_xlocked())
+      return true;
+    // lock has waiters queued for conflicting modes
+    if (dn->lock.is_waiter_for(SimpleLock::WAIT_WR) ||
+        dn->lock.is_waiter_for(SimpleLock::WAIT_XLOCK))
+      return true;
+    return false;
+  };
+
+  if (has_lock_contention(rdn)) {
+    dout(10) << __func__ << ": dest dentry " << *rdn
+             << " has lock contention, deferring" << dendl;
+    return;
+  }
+  if (has_lock_contention(straydn)) {
+    dout(10) << __func__ << ": stray dentry " << *straydn
+             << " has lock contention, deferring" << dendl;
+    return;
+  }
+
   logger->inc(l_mdc_strays_reintegrated);
 
   // rename it to remote linkage .


### PR DESCRIPTION
Stray reintegration sends an internal CEPH_MDS_OP_RENAME to move the stray dentry back to one of its remote parents.  This rename must acquire xlock on both the source stray dentry and the destination dentry, plus wrlock on both parent directories filelock/nestlock.

When a client operation (lookup, unlink, setfilelock) concurrently holds or waits for a conflicting lock on either dentry, the internal rename blocks and becomes a slow request.  The blocked rename holds whatever locks it already acquired, stalling all subsequent traffic on that directory and causing cascaded slow requests across the MDS.

Add a has_lock_contention() check before sending the rename.  The check inspects both the current lock state (rdlock/wrlock/xlock held) and the waiter queue (WAIT_WR/WAIT_XLOCK) on both the destination dentry and the source stray dentry.  If contention is detected, defer the reintegration.  It will be retried when the next client operation on the same directory triggers notify_stray().

The check is inherently racy — the lock state can change between the check and the actual lock acquisition inside the rename.  This is acceptable: a false negative means we still block, which is the same behavior the patch mitigates, not a new bug.

Fixes: https://tracker.ceph.com/issues/77940





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
