### PR TITLE
osd: Assert on EC creating transactions that would incorrectly change size

### DIFF
--- a/src/osd/ECCommon.cc
+++ b/src/osd/ECCommon.cc
@@ -1146,6 +1146,7 @@ void ECCommon::RecoveryBackend::handle_recovery_push(
         &m->t);
     }
   }
+
   m->push_replies[get_parent()->primary_shard()].push_back(PushReplyOp());
   m->push_replies[get_parent()->primary_shard()].back().soid = op.soid;
 }

--- a/src/osd/ECTransaction.cc
+++ b/src/osd/ECTransaction.cc
@@ -563,6 +563,8 @@ ECTransaction::Generate::Generate(PGTransaction &t,
     encode_and_write();
   }
 
+  log_shard_size_analysis();
+
   written_map->emplace(oid, std::move(to_write));
 
   if (entry && plan.orig_size < plan.projected_size) {
@@ -1048,3 +1050,60 @@ void ECTransaction::generate_transactions(
       plans.plans.pop_front();
   });
 }
+
+void ECTransaction::Generate::log_shard_size_analysis() const {
+  // ----------------------------------------------------------------
+  // Step 1: Build per-shard sizes from the plan's orig/projected sizes.
+  //
+  // orig_shard_sizes[shard]  = on-disk shard size before this operation,
+  //                            derived from plan.orig_size via the stripe mapping.
+  // proj_shard_sizes[shard]  = expected on-disk shard size after the operation,
+  //                            as recorded in the projected object_info.
+  // ----------------------------------------------------------------
+  shard_id_map<uint64_t> orig_shard_sizes(sinfo.get_k_plus_m());
+  shard_id_map<uint64_t> proj_shard_sizes(sinfo.get_k_plus_m());
+
+  for (shard_id_t shard; shard < sinfo.get_k_plus_m(); ++shard) {
+    orig_shard_sizes[shard] = sinfo.object_size_to_shard_size(plan.orig_size, shard);
+    proj_shard_sizes[shard] = sinfo.object_size_to_shard_size(plan.projected_size, shard);
+  }
+
+  // ----------------------------------------------------------------
+  // Step 2: Compute the resulting per-shard size by replaying each
+  // shard's ObjectStore::Transaction via ECUtil::compute_shard_size_from_transaction().
+  // ----------------------------------------------------------------
+  shard_id_map<uint64_t> result_shard_sizes(sinfo.get_k_plus_m());
+
+  for (auto &&[shard, txn] : transactions) {
+    const ghobject_t target_goid(oid, ghobject_t::NO_GEN, shard);
+    result_shard_sizes[shard] = ECUtil::compute_shard_size_from_transaction(
+      txn, target_goid, orig_shard_sizes[shard]);
+  }
+
+  // ----------------------------------------------------------------
+  // Step 3: Assert that the transaction produces the projected shard size.
+  // Always log the summary so we can verify this code path is reached.
+  // ----------------------------------------------------------------
+  ldpp_dout(dpp, -1) << __func__ << ": oid=" << oid
+                     << " orig_size=" << plan.orig_size
+                     << " projected_size=" << plan.projected_size
+                     << dendl;
+  for (shard_id_t shard; shard < sinfo.get_k_plus_m(); ++shard) {
+    uint64_t orig_sz   = orig_shard_sizes[shard];
+    uint64_t proj_sz   = proj_shard_sizes[shard];
+    uint64_t result_sz = result_shard_sizes.count(shard)
+                           ? result_shard_sizes[shard]
+                           : orig_sz;
+
+    ldpp_dout(dpp, -1) << __func__ << ":   shard " << shard
+                       << " orig=" << orig_sz
+                       << " projected=" << proj_sz
+                       << " computed=" << result_sz
+                       << dendl;
+
+    if (result_sz != proj_sz) {
+      ceph_abort_msg("EC transaction produces wrong shard size");
+    }
+  }
+}
+

--- a/src/osd/ECTransaction.h
+++ b/src/osd/ECTransaction.h
@@ -109,6 +109,18 @@ class Generate {
   void written_shards();
   void attr_updates();
 
+  /**
+   * Log analysis of per-shard size changes implied by the write plan and
+   * compute the size the object will be after applying the transaction to
+   * orig_size.  Called at dout(20) for debug purposes.
+   *
+   * For every shard the function reports:
+   *   - orig_shard_size  : size derived from plan.orig_size
+   *   - proj_shard_size  : size derived from plan.projected_size
+   *   - result_shard_size: size derived by replaying op against orig_size
+   */
+  void log_shard_size_analysis() const;
+
  public:
   Generate(PGTransaction &t,
     ErasureCodeInterfaceRef &ec_impl, pg_t &pgid,

--- a/src/osd/ECUtil.cc
+++ b/src/osd/ECUtil.cc
@@ -1157,4 +1157,104 @@ bool is_hinfo_key_string(const string &key) {
 const string &get_hinfo_key() {
   return HINFO_KEY;
 }
+
+uint64_t compute_shard_size_from_transaction(
+  ceph::os::Transaction txn,
+  const ghobject_t &target,
+  uint64_t orig_size)
+{
+  ceph::os::Transaction::iterator it = txn.begin();
+  uint64_t size = orig_size;
+
+  while (it.have_op()) {
+    ceph::os::Transaction::Op *o = it.decode_op();
+
+    switch (o->op) {
+      case ceph::os::Transaction::OP_WRITE: {
+        bufferlist bl;
+        it.decode_bl(bl);
+        if (it.get_oid(o->oid) == target) {
+          uint64_t end = o->off + o->len;
+          if (end > size) size = end;
+        }
+        break;
+      }
+      case ceph::os::Transaction::OP_ZERO: {
+        // No data payload — off+len may extend the file.
+        if (it.get_oid(o->oid) == target) {
+          uint64_t end = o->off + o->len;
+          if (end > size) size = end;
+        }
+        break;
+      }
+      case ceph::os::Transaction::OP_TRUNCATE: {
+        // OP_TRUNCATE stores the target size in op->off.
+        // It is "set size" — can grow or shrink.
+        if (it.get_oid(o->oid) == target) {
+          size = o->off;
+        }
+        break;
+      }
+      // -------- ops with inline data payloads that must be consumed --------
+      case ceph::os::Transaction::OP_SETATTR: {
+        it.decode_string();       // attr name
+        bufferlist bl;
+        it.decode_bl(bl);
+        break;
+      }
+      case ceph::os::Transaction::OP_SETATTRS: {
+        map<string, bufferptr> aset;
+        it.decode_attrset(aset);
+        break;
+      }
+      case ceph::os::Transaction::OP_RMATTR: {
+        it.decode_string();       // attr name
+        break;
+      }
+      case ceph::os::Transaction::OP_OMAP_SETKEYS: {
+        map<string, bufferlist> aset;
+        it.decode_attrset(aset);
+        break;
+      }
+      case ceph::os::Transaction::OP_OMAP_RMKEYS: {
+        set<string> keys;
+        it.decode_keyset(keys);
+        break;
+      }
+      case ceph::os::Transaction::OP_OMAP_SETHEADER: {
+        bufferlist bl;
+        it.decode_bl(bl);
+        break;
+      }
+      case ceph::os::Transaction::OP_OMAP_RMKEYRANGE: {
+        it.decode_string();       // first key
+        it.decode_string();       // last key
+        break;
+      }
+      case ceph::os::Transaction::OP_COLL_HINT: {
+        bufferlist bl;
+        it.decode_bl(bl);
+        break;
+      }
+      case ceph::os::Transaction::OP_COLL_SETATTR: {
+        it.decode_string();       // attr name
+        bufferlist bl;
+        it.decode_bl(bl);
+        break;
+      }
+      case ceph::os::Transaction::OP_COLL_RMATTR: {
+        it.decode_string();       // attr name
+        break;
+      }
+      // All remaining ops carry no inline data payload and do not affect
+      // the target shard file size (NOP, CREATE, TOUCH, CLONE,
+      // CLONERANGE*, MKCOLL, RMCOLL, COLL_ADD/REMOVE/MOVE/RENAME/
+      // SET_BITS, SPLIT_COLLECTION*, MERGE_COLLECTION, COLL_MOVE_RENAME,
+      // TRY_RENAME, SETALLOCHINT, OMAP_CLEAR, REMOVE, RMATTRS).
+      default:
+        break;
+    }
+  }
+  return size;
+}
 }

--- a/src/osd/ECUtil.h
+++ b/src/osd/ECUtil.h
@@ -25,6 +25,7 @@
 #include "include/encoding.h"
 #include "common/interval_map.h"
 #include "common/mini_flat_map.h"
+#include "os/Transaction.h"
 
 #include "osd_types.h"
 
@@ -1152,5 +1153,28 @@ struct log_entry_t {
 
 bool is_hinfo_key_string(const std::string &key);
 const std::string &get_hinfo_key();
+
+/**
+ * Compute the on-disk file size of a shard object after applying the ops in
+ * a single shard's ObjectStore::Transaction.
+ *
+ * @param txn        The shard transaction to parse (taken by value; consumed).
+ * @param target     The ghobject_t whose size changes should be tracked.
+ *                   Only OP_WRITE, OP_ZERO and OP_TRUNCATE on this exact
+ *                   object affect the returned size; all other objects (e.g.
+ *                   rollback-stash gen-objects) are ignored.
+ * @param orig_size  Starting shard file size, used when the transaction
+ *                   contains no size-altering ops for @p target.
+ * @return           Resulting shard file size after replaying the transaction.
+ *
+ * Rules applied per op on @p target:
+ *   OP_WRITE / OP_ZERO  — extend if (off + len) > current size
+ *   OP_TRUNCATE         — set size to op->off  (grows or shrinks)
+ */
+uint64_t compute_shard_size_from_transaction(
+  ceph::os::Transaction txn,
+  const ghobject_t &target,
+  uint64_t orig_size);
+
 }
 


### PR DESCRIPTION
Attempt to catch why krbd appears to be triggering this known bug. 

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
