### PR TITLE
test/subprocess: add missing space in SubshellKilled subcommand

### DIFF
--- a/src/test/test_subprocess.cc
+++ b/src/test/test_subprocess.cc
@@ -258,7 +258,7 @@ TEST(SubProcessTimed, SubshellNoTimeout)
 TEST(SubProcessTimed, SubshellKilled)
 {
   SubProcessTimed sh(SHELL, SubProcess::PIPE, SubProcess::PIPE, SubProcess::PIPE, 10);
-  sh.add_cmd_args("-c", SHELL "-c cat", NULL);
+  sh.add_cmd_args("-c", SHELL " -c cat", NULL);
   ASSERT_EQ(sh.spawn(), 0);
   std::string msg("etaoin shrdlu");
   int n = write(sh.get_stdin(), msg.c_str(), msg.size());


### PR DESCRIPTION
9abf2388f24 rewrote `sh -c cat` as `SHELL "-c cat"`, which concatenates to
`/bin/sh-c cat`, so the subshell execs a non-existent `/bin/sh-c`. The test
still passed because the SIGTERM from `kill()` usually wins the race against
shell startup; under CI load the shell occasionally prints
`/bin/sh: line 1: /bin/sh-c: No such file or directory` into the stderr pipe
first, `ASSERT_TRUE(buf.empty())` fails, and the skipped `join()` turns this
into a SIGABRT in `~SubProcess()`.

CI where this issue was hit: https://github.com/sunyuechi/ceph-ci/actions/runs/28764694459

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests