### PR TITLE
tentacle: mgr/dashboard: rbd-mirroring - hide create/import token buttons for read-only users

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/overview/overview.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/overview/overview.component.html
@@ -37,19 +37,24 @@
     <div cdsCol="{md:5}">
       <div class="d-flex flex-row-reverse gap-3">
         <ng-container *ngFor="let action of tableActions">
-          <button type="button"
-                  [cdsButton]="action.buttonKind"
-                  [title]="action.name"
-                  (click)="action.click($event)"
-                  [disabled]="action.disable()"
-                  [attr.aria-label]="action.name"
-                  [attr.data-testid]="action.name"
-                  [preserveFragment]="action.preserveFragment ? '' : null">
+        @if (!action.visible || action.visible(selection)) {
+          <button
+            type="button"
+            [cdsButton]="action.buttonKind"
+            [title]="action.name"
+            (click)="action.click($event)"
+            [disabled]="action.disable()"
+            [attr.aria-label]="action.name"
+            [attr.data-testid]="action.name"
+            [preserveFragment]="action.preserveFragment ? '' : null">
             <span i18n>{{ action.name }}</span>
-            <svg class="cds--btn__icon"
-                 [cdsIcon]="action.icon"
-                 size="16"></svg>
+            <svg
+              class="cds--btn__icon"
+              [cdsIcon]="action.icon"
+              size="16">
+            </svg>
           </button>
+        }
         </ng-container>
       </div>
     </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/overview/overview.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/overview/overview.component.ts
@@ -52,6 +52,7 @@ export class OverviewComponent implements OnInit, OnDestroy {
       name: $localize`Create Bootstrap Token`,
       canBePrimary: () => true,
       disable: () => false,
+      visible: () => this.permission.update,
       buttonKind: 'primary'
     };
     const importBootstrapAction: CdTableAction = {
@@ -60,6 +61,7 @@ export class OverviewComponent implements OnInit, OnDestroy {
       click: () => this.importBootstrapModal(),
       name: $localize`Import Bootstrap Token`,
       disable: () => false,
+      visible: () => this.permission.update,
       buttonKind: 'tertiary'
     };
     this.tableActions = [createBootstrapAction, importBootstrapAction];


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77942

---

backport of https://github.com/ceph/ceph/pull/69282
parent tracker: https://tracker.ceph.com/issues/77115

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh